### PR TITLE
kafka: fix transactional reads on tiered storage recovered partitions

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -256,7 +256,10 @@ ss::future<> cache::clean_up_cache() {
                 // leak
                 _access_time_tracker.remove_timestamp(
                   std::string_view(filename_to_remove));
-            } catch (std::exception& e) {
+            } catch (const ss::gate_closed_exception&) {
+                // We are shutting down, stop iterating and propagate
+                throw;
+            } catch (const std::exception& e) {
                 vlog(
                   cst_log.error,
                   "Cache eviction couldn't delete {}: {}.",

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -123,8 +123,6 @@ public:
     void offload_segment(model::offset);
 
 private:
-    ss::future<> run_eviction_loop();
-
     friend struct materialized_segment_state;
 
     using materialized_segment_ptr

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -215,7 +215,8 @@ replicated_partition::aborted_transactions(
     }
     if (
       _partition->cloud_data_available()
-      && offsets.begin_rp < _partition->start_offset()) {
+      && offsets.begin
+           < _translator->from_log_offset(_partition->start_offset())) {
         // The fetch request was satisfied using shadow indexing.
         auto tx_remote = co_await aborted_transactions_remote(
           offsets, ot_state);

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -49,12 +49,8 @@ ss::future<storage::translating_reader> replicated_partition::make_reader(
         co_return co_await _partition->make_cloud_reader(cfg);
     }
 
-    auto local_kafka_start_offset = _translator->from_log_offset(
-      _partition->start_offset());
     if (
-      _partition->is_remote_fetch_enabled()
-      && _partition->cloud_data_available()
-      && cfg.start_offset < local_kafka_start_offset
+      may_read_from_cloud(model::offset_cast(cfg.start_offset))
       && cfg.start_offset >= _partition->start_cloud_offset()) {
         cfg.type_filter = {model::record_batch_type::raft_data};
         co_return co_await _partition->make_cloud_reader(cfg, deadline);
@@ -174,6 +170,16 @@ replicated_partition::aborted_transactions_remote(
     co_return target;
 }
 
+/**
+ * Based on the lower offset of an incoming request, decide whether it should
+ * be sent to cloud storage (return true), or local raft storage (return false)
+ */
+bool replicated_partition::may_read_from_cloud(kafka::offset start_offset) {
+    return _partition->is_remote_fetch_enabled()
+           && _partition->cloud_data_available()
+           && (start_offset < _translator->from_log_offset(_partition->start_offset()));
+}
+
 ss::future<std::vector<cluster::rm_stm::tx_range>>
 replicated_partition::aborted_transactions(
   model::offset base,
@@ -213,10 +219,7 @@ replicated_partition::aborted_transactions(
         // Always use SI for read replicas
         co_return co_await aborted_transactions_remote(offsets, ot_state);
     }
-    if (
-      _partition->cloud_data_available()
-      && offsets.begin
-           < _translator->from_log_offset(_partition->start_offset())) {
+    if (may_read_from_cloud(model::offset_cast(base))) {
         // The fetch request was satisfied using shadow indexing.
         auto tx_remote = co_await aborted_transactions_remote(
           offsets, ot_state);

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -139,6 +139,8 @@ private:
       cloud_storage::offset_range offsets,
       ss::lw_shared_ptr<const storage::offset_translator_state> ot_state);
 
+    bool may_read_from_cloud(kafka::offset);
+
     ss::lw_shared_ptr<cluster::partition> _partition;
     ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
 };

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -146,7 +146,7 @@ RUN go install github.com/twmb/kcl@v0.8.0 && \
 
 # Install the kgo-verifier tool
 RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard 3c01706276bb08bed90839d38c5f1e95437d8e78 && \
+    cd /opt/kgo-verifier && git reset --hard a2b3ae780b0dc0bc1b4cf2aa33a9d43d10578b0b && \
     go mod tidy && make
 
 # Expose port 8080 for any http examples within clients

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -318,7 +318,10 @@ class RpkTool:
 
     def alter_topic_config(self, topic, set_key, set_value):
         cmd = ['alter-config', topic, "--set", f"{set_key}={set_value}"]
-        self._run_topic(cmd)
+        out = self._run_topic(cmd)
+        if 'INVALID' in out:
+            raise RpkException(
+                f"Invalid topic config {topic} {set_key}={set_value}")
 
     def delete_topic_config(self, topic, key):
         cmd = ['alter-config', topic, "--delete", key]

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -422,13 +422,15 @@ class KgoVerifierSeqConsumer(KgoVerifierService):
                  max_throughput_mb=None,
                  nodes=None,
                  debug_logs=False,
-                 trace_logs=False):
+                 trace_logs=False,
+                 loop=True):
         super(KgoVerifierSeqConsumer,
               self).__init__(context, redpanda, topic, msg_size, nodes,
                              debug_logs, trace_logs)
         self._max_msgs = max_msgs
         self._max_throughput_mb = max_throughput_mb
         self._status = ConsumerStatus()
+        self._loop = loop
 
     @property
     def consumer_status(self):
@@ -438,7 +440,8 @@ class KgoVerifierSeqConsumer(KgoVerifierService):
         if clean:
             self.clean_node(node)
 
-        cmd = f"{TESTS_DIR}/kgo-verifier --brokers {self._redpanda.brokers()} --topic {self._topic} --produce_msgs 0 --rand_read_msgs 0 --seq_read=1 --loop --client-name {self.who_am_i()}"
+        loop = "--loop" if self._loop else ""
+        cmd = f"{TESTS_DIR}/kgo-verifier --brokers {self._redpanda.brokers()} --topic {self._topic} --produce_msgs 0 --rand_read_msgs 0 --seq_read=1 {loop} --client-name {self.who_am_i()}"
         if self._max_msgs is not None:
             cmd += f" --seq_read_msgs {self._max_msgs}"
         if self._max_throughput_mb is not None:

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -535,7 +535,8 @@ class ProduceStatus:
                  restarts=0,
                  latency=None,
                  active=False,
-                 failed_transactions=0):
+                 failed_transactions=0,
+                 aborted_transaction_msgs=0):
         self.sent = sent
         self.acked = acked
         self.bad_offsets = bad_offsets
@@ -545,10 +546,11 @@ class ProduceStatus:
         self.latency = latency
         self.active = active
         self.failed_transactions = failed_transactions
+        self.aborted_transaction_messages = aborted_transaction_msgs
 
     def __str__(self):
         l = self.latency
-        return f"ProduceStatus<{self.sent} {self.acked} {self.bad_offsets} {self.restarts} {self.failed_transactions} {l['p50']}/{l['p90']}/{l['p99']}>"
+        return f"ProduceStatus<{self.sent} {self.acked} {self.bad_offsets} {self.restarts} {self.failed_transactions} {self.aborted_transaction_messages} {l['p50']}/{l['p90']}/{l['p99']}>"
 
 
 class KgoVerifierProducer(KgoVerifierService):

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -28,7 +28,7 @@ class KgoVerifierService(Service):
     Use ctx.cluster.alloc(ClusterSpec.simple_linux(1)) to allocate node and pass it to constructor
     """
     def __init__(self, context, redpanda, topic, msg_size, custom_node,
-                 debug_logs):
+                 debug_logs, trace_logs):
         self.use_custom_node = custom_node is not None
 
         # We should pass num_nodes to allocate for our service in BackgroundThreadService,
@@ -52,6 +52,7 @@ class KgoVerifierService(Service):
         self._pid = None
         self._remote_port = None
         self._debug_logs = debug_logs
+        self._trace_logs = trace_logs
 
         for node in self.nodes:
             if not hasattr(node, "kgo_verifier_ports"):
@@ -95,7 +96,9 @@ class KgoVerifierService(Service):
 
         self._remote_port = self._select_port(node)
 
-        wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} {'--debug' if self._debug_logs else ''}> {self.log_path} 2>&1 & echo $!"
+        debug = '--debug' if self._debug_logs else ''
+        trace = '--trace' if self._trace_logs else ''
+        wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} {debug} {trace}> {self.log_path} 2>&1 & echo $!"
         self.logger.debug(f"spawn {self.who_am_i()}: {wrapped_cmd}")
         pid_str = node.account.ssh_output(wrapped_cmd)
         self.logger.debug(
@@ -418,10 +421,11 @@ class KgoVerifierSeqConsumer(KgoVerifierService):
                  max_msgs=None,
                  max_throughput_mb=None,
                  nodes=None,
-                 debug_logs=False):
+                 debug_logs=False,
+                 trace_logs=False):
         super(KgoVerifierSeqConsumer,
               self).__init__(context, redpanda, topic, msg_size, nodes,
-                             debug_logs)
+                             debug_logs, trace_logs)
         self._max_msgs = max_msgs
         self._max_throughput_mb = max_throughput_mb
         self._status = ConsumerStatus()
@@ -454,8 +458,10 @@ class KgoVerifierRandomConsumer(KgoVerifierService):
                  rand_read_msgs,
                  parallel,
                  nodes=None,
-                 debug_logs=False):
-        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs)
+                 debug_logs=False,
+                 trace_logs=False):
+        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs,
+                         trace_logs)
         self._rand_read_msgs = rand_read_msgs
         self._parallel = parallel
         self._status = ConsumerStatus()
@@ -486,8 +492,10 @@ class KgoVerifierConsumerGroupConsumer(KgoVerifierService):
                  max_msgs=None,
                  max_throughput_mb=None,
                  nodes=None,
-                 debug_logs=False):
-        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs)
+                 debug_logs=False,
+                 trace_logs=False):
+        super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs,
+                         trace_logs)
 
         self._readers = readers
         self._loop = loop
@@ -550,13 +558,14 @@ class KgoVerifierProducer(KgoVerifierService):
                  custom_node=None,
                  batch_max_bytes=None,
                  debug_logs=False,
+                 trace_logs=False,
                  fake_timestamp_ms=None,
                  use_transactions=False,
                  transaction_abort_rate=None,
                  msgs_per_transaction=None):
         super(KgoVerifierProducer,
               self).__init__(context, redpanda, topic, msg_size, custom_node,
-                             debug_logs)
+                             debug_logs, trace_logs)
         self._msg_count = msg_count
         self._status = ProduceStatus()
         self._batch_max_bytes = batch_max_bytes

--- a/tests/rptest/tests/replication_factor_change_test.py
+++ b/tests/rptest/tests/replication_factor_change_test.py
@@ -10,6 +10,7 @@
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
+from rptest.util import expect_exception
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool, RpkException
@@ -59,16 +60,24 @@ class ReplicationFactorChangeTest(RedpandaTest):
     def check_error_test(self):
         self.replication_factor = 3
         new_rf = -1
-        self._rpk.alter_topic_config(self.topic_name, self.rf_property, new_rf)
+
+        with expect_exception(RpkException, lambda e: "Invalid" in e.msg):
+            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                         new_rf)
+
         assert len(self.admin.list_reconfigurations()) == 0
         self.check_rf(self.replication_factor)
 
         new_rf = 0
-        self._rpk.alter_topic_config(self.topic_name, self.rf_property, new_rf)
+        with expect_exception(RpkException, lambda e: "Invalid" in e.msg):
+            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                         new_rf)
         assert len(self.admin.list_reconfigurations()) == 0
         self.check_rf(self.replication_factor)
 
         new_rf = 10000
-        self._rpk.alter_topic_config(self.topic_name, self.rf_property, new_rf)
+        with expect_exception(RpkException, lambda e: "Invalid" in e.msg):
+            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                         new_rf)
         assert len(self.admin.list_reconfigurations()) == 0
         self.check_rf(self.replication_factor)

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -13,19 +13,12 @@ from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.utils.mode_checks import skip_debug_mode
 from rptest.util import (
     segments_count,
     wait_for_segments_removal,
 )
-from rptest.utils.si_utils import Producer
-
-from ducktape.utils.util import wait_until
-
-import confluent_kafka as ck
-
-import uuid
-import random
-from itertools import zip_longest
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
 
 
 class ShadowIndexingTxTest(RedpandaTest):
@@ -56,37 +49,33 @@ class ShadowIndexingTxTest(RedpandaTest):
             rpk.alter_topic_config(topic.name, 'redpanda.remote.write', 'true')
             rpk.alter_topic_config(topic.name, 'redpanda.remote.read', 'true')
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=4)
+    @skip_debug_mode
     def test_shadow_indexing_aborted_txs(self):
         """Check that messages belonging to aborted transaction are not seen by clients
         when fetching from remote segments."""
-        topic = self.topics[0]
+        msg_size = 16384
+        msg_count = 10000
+        per_transaction = 10
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=msg_size,
+                                       msg_count=msg_count,
+                                       use_transactions=True,
+                                       transaction_abort_rate=0.1,
+                                       msgs_per_transaction=per_transaction,
+                                       debug_logs=True)
+        producer.start()
+        producer.wait()
+        pstatus = producer.produce_status
+        self.logger.info(f"Produce status: {pstatus}")
+        committed_messages = pstatus.acked - pstatus.aborted_transaction_messages
+        assert pstatus.acked == msg_count
+        assert 0 < committed_messages < msg_count
 
-        producer = Producer(self.redpanda.brokers(), "shadow-indexing-tx-test",
-                            self.logger)
-
-        def done():
-            for _ in range(100):
-                try:
-                    producer.produce(topic.name)
-                except ck.KafkaException as err:
-                    self.logger.warn(f"producer error: {err}")
-                    producer.reconnect()
-            self.logger.info("producer iteration complete")
-            topic_partitions = segments_count(self.redpanda,
-                                              topic.name,
-                                              partition_idx=0)
-            partitions = []
-            for p in topic_partitions:
-                partitions.append(p >= 10)
-            return all(partitions)
-
-        wait_until(done,
-                   timeout_sec=120,
-                   backoff_sec=1,
-                   err_msg="producing failed")
-
-        assert producer.num_aborted > 0
+        # Re-use node for consumer later
+        traffic_node = producer.nodes[0]
 
         kafka_tools = KafkaCliTools(self.redpanda)
         kafka_tools.alter_topic_config(
@@ -101,35 +90,16 @@ class ShadowIndexingTxTest(RedpandaTest):
                                   partition_idx=0,
                                   count=6)
 
-        consumer = ck.Consumer(
-            {
-                'bootstrap.servers': self.redpanda.brokers(),
-                'group.id': 'shadow-indexing-tx-test',
-                'auto.offset.reset': 'earliest',
-            },
-            logger=self.logger)
-        consumer.subscribe([topic.name])
+        consumer = KgoVerifierSeqConsumer(self.test_context,
+                                          self.redpanda,
+                                          self.topic,
+                                          msg_size,
+                                          loop=False,
+                                          nodes=[traffic_node])
+        consumer.start(clean=False)
+        consumer.wait()
+        status = consumer.consumer_status
 
-        consumed = []
-        while True:
-            msgs = consumer.consume(timeout=5.0)
-            if len(msgs) == 0:
-                break
-            consumed.extend([(m.key(), m.offset()) for m in msgs])
-
-        self.logger.info(
-            f"consumed {len(consumed)} records, expected {len(producer.keys)} keys"
-        )
-
-        first_mismatch = ''
-        for p_key, (c_key, c_offset) in zip_longest(producer.keys,
-                                                    consumed,
-                                                    fillvalue=(None, -1)):
-            if p_key != c_key:
-                first_mismatch = f"produced: {p_key}, consumed: {c_key} (offset: {c_offset})"
-                break
-
-        assert (not first_mismatch), (
-            f"produced and consumed messages differ, "
-            f"produced length: {len(producer.keys)}, consumed length: {len(consumed)}, "
-            f"first mismatch: {first_mismatch}")
+        assert status.validator.valid_reads == committed_messages
+        assert status.validator.invalid_reads == 0
+        assert status.validator.out_of_scope_invalid_reads == 0


### PR DESCRIPTION

In this PR:
- Tests for tiered storage+transactions are improved to use substantially more data, via external kgo-verifier processes instead of the low-throughput embedded rdkafka path.  This reproduces the issues from #7043 much more reliably than the old version of the test.
- The cause of the bad reads in #7043 is fixed: this was happening when the code in the kafka layer used inconsistent logic to decide where to read data (raft or cloud storage), vs. where to read aborted transactions.  When reading close to the seam between the cloud storage data and the data recovered to raft during topic recovery, it would read batches from cloud storage, and then read aborted transactions list from raft (which was empty), resulting in those aborted batches becoming visible to the client.
- Two separate bug fixes are also included, because they destabilized the improved test:
  - an issue is fixed where recovery could sometimes fail if a segment contained just one batch: this was noticed when running the test iteratively to diagnose #7043
  - an issue is fixed where ERROR messages could be logged from cache service during shutdown.

Fixes: #7043 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Bug Fixes

* An issue is fixed where after certain disaster recovery procedures (tiered storage topic recovery), data in aborted transactions within a small range of offsets could become visible to consumers.
