### PR TITLE
cluster: initialize node ID assignment counter

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -356,6 +356,16 @@ void members_manager::apply_initial_node_uuid_map(uuid_map_t id_by_uuid) {
     if (!id_by_uuid.empty()) {
         vlog(clusterlog.debug, "Initial node UUID map: {}", id_by_uuid);
     }
+    // Start the node ID assignment counter just past the highest node ID. This
+    // helps ensure removed seed servers are accounted for when auto-assigning
+    // node IDs, since seed servers don't call get_or_assign_node_id().
+    for (const auto& [uuid, id] : id_by_uuid) {
+        if (id == INT_MAX) {
+            _next_assigned_id = id;
+            break;
+        }
+        _next_assigned_id = std::max(_next_assigned_id, id + 1);
+    }
     _id_by_uuid = std::move(id_by_uuid);
 }
 
@@ -524,6 +534,9 @@ members_manager::get_or_assign_node_id(const model::node_uuid& node_uuid) {
                 return std::nullopt;
             }
             ++_next_assigned_id;
+        }
+        if (_next_assigned_id == INT_MAX) {
+            return std::nullopt;
         }
         _id_by_uuid.emplace(node_uuid, _next_assigned_id);
         vlog(

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -83,7 +83,8 @@ class EndToEndTest(Test):
                        si_settings=None,
                        environment=None,
                        install_opts: Optional[InstallOptions] = None,
-                       new_bootstrap=False):
+                       new_bootstrap=False,
+                       max_num_seeds=3):
         if si_settings is not None:
             self.si_settings = si_settings
 
@@ -105,7 +106,7 @@ class EndToEndTest(Test):
         if new_bootstrap:
             seeds = [
                 self.redpanda.nodes[i]
-                for i in range(0, min(len(self.redpanda.nodes), 3))
+                for i in range(0, min(len(self.redpanda.nodes), max_num_seeds))
             ]
             self.redpanda.set_seed_servers(seeds)
         version_to_install = None


### PR DESCRIPTION
We previously weren't initializing the node ID assignment counter with the node IDs assigned to the cluster founders. This PR bumps the counter with the node IDs available at initial cluster bootstrap. This fix is adjacent to the one in #7789 -- it's just another layer of protection.

This PR also adds a test that restacks a cluster in random order, ensuring that no node IDs are reused, which would have caught this issue.
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

 

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
 ### Bug Fixes

* Node ID assignment will now use node IDs higher than those used by the initial seed servers, avoiding a potential node ID re-use in cases where a seed server is fully decommissioned before adding a new node.