### PR TITLE
docs: fix k8s doc link

### DIFF
--- a/src/go/k8s/README.md
+++ b/src/go/k8s/README.md
@@ -11,7 +11,7 @@ Use all your favorite open source tooling - 10x faster.
 ## Getting started
 
 Official Kubernetes quick start documentation can be found at
-[https://vectorized.io/docs/](https://vectorized.io/docs/quick-start-kubernetes)
+[https://docs.redpanda.com/docs/](https://docs.redpanda.com/docs/platform/quickstart/kubernetes-qs-dev/)
 
 ### Requirements
 


### PR DESCRIPTION
This fixes a link to the kubernetes documentation for redpanda.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

* none
