### PR TITLE
k8s: Fix wrong WithValues invocation

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -435,7 +435,7 @@ func (r *ClusterReconciler) handlePodFinalizer(
 		// if it's not gone
 		if broker != nil {
 			// decommission it
-			log.WithValues(nodeID).Info("decommissioning broker")
+			log.WithValues("node-id", nodeID).Info("decommissioning broker")
 			if err = adminClient.DecommissionBroker(ctx, nodeID); err != nil {
 				return fmt.Errorf(`unable to decommission node "%d": %w`, nodeID, err)
 			}
@@ -464,7 +464,7 @@ func (r *ClusterReconciler) handlePodFinalizer(
 					}
 					continue
 				}
-				log.WithValues(key).Info("deleting PersistentVolumeClaim")
+				log.WithValues("persistent-volume-claim", key).Info("deleting PersistentVolumeClaim")
 				if err := r.Delete(ctx, &pvc, &client.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 					return fmt.Errorf(`unable to delete PersistentVolumeClaim "%s/%s": %w`, key.Name, key.Namespace, err)
 				}
@@ -482,7 +482,7 @@ func (r *ClusterReconciler) removePodFinalizer(
 	ctx context.Context, pod *corev1.Pod, log logr.Logger,
 ) error {
 	if controllerutil.ContainsFinalizer(pod, FinalizerKey) {
-		log.V(7).WithValues(pod.Namespace, pod.Name).Info("removing finalizer")
+		log.V(7).WithValues("namespace", pod.Namespace, "name", pod.Name).Info("removing finalizer")
 		controllerutil.RemoveFinalizer(pod, FinalizerKey)
 		if err := r.Update(ctx, pod); err != nil {
 			return err
@@ -495,7 +495,7 @@ func (r *ClusterReconciler) setPodFinalizer(
 	ctx context.Context, pod *corev1.Pod, log logr.Logger,
 ) error {
 	if !controllerutil.ContainsFinalizer(pod, FinalizerKey) {
-		log.V(7).WithValues(pod.Namespace, pod.Name).Info("adding finalizer")
+		log.V(7).WithValues("namespace", pod.Namespace, "name", pod.Name).Info("adding finalizer")
 		controllerutil.AddFinalizer(pod, FinalizerKey)
 		if err := r.Update(ctx, pod); err != nil {
 			return err
@@ -524,7 +524,7 @@ func (r *ClusterReconciler) setPodNodeIDAnnotation(
 		if err != nil {
 			return fmt.Errorf("cannot fetch node id for node-id annotation: %w", err)
 		}
-		log.WithValues(pod.Name, nodeID).Info("setting node-id annotation")
+		log.WithValues("pod-name", pod.Name, "node-id", nodeID).Info("setting node-id annotation")
 		pod.Annotations[PodAnnotationNodeIDKey] = fmt.Sprintf("%d", nodeID)
 		if err := r.Update(ctx, pod, &client.UpdateOptions{}); err != nil {
 			return fmt.Errorf(`unable to update pod "%s" with node-id annotation: %w`, pod.Name, err)


### PR DESCRIPTION
The `WithValues` requires to have pairs of key and value fileds for logger to report any additional context.

Fixes #7818 
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

### Bug Fixes

  * Fix operator panic during decommissioning logging
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
