### PR TITLE
Prevent isolated/decommissioned nodes handle kafka API requests

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -154,6 +154,7 @@ v_cc_library(
     ephemeral_credential_service.cc
     topic_recovery_status_rpc_handler.cc
     topic_recovery_status_frontend.cc
+    node_isolation_watcher.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -56,6 +56,7 @@ class ephemeral_credential_frontend;
 class self_test_backend;
 class self_test_frontend;
 class topic_recovery_status_frontend;
+class node_isolation_watcher;
 
 namespace node {
 class local_monitor;

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -788,4 +788,9 @@ health_monitor_backend::get_cluster_health_overview(
 
     co_return ret;
 }
+
+bool health_monitor_backend::does_raft0_have_leader() {
+    return _raft0->get_leader_id().has_value();
+}
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -77,6 +77,8 @@ public:
     ss::future<cluster_health_overview>
       get_cluster_health_overview(model::timeout_clock::time_point);
 
+    bool does_raft0_have_leader();
+
 private:
     /**
      * Struct used to track pending refresh request, it gives ability

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -137,4 +137,9 @@ void health_monitor_frontend::disk_health_tick() {
     });
 }
 
+ss::future<bool> health_monitor_frontend::does_raft0_have_leader() {
+    return dispatch_to_backend(
+      [](health_monitor_backend& be) { return be.does_raft0_have_leader(); });
+}
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -82,6 +82,8 @@ public:
     ss::future<cluster_health_overview>
       get_cluster_health_overview(model::timeout_clock::time_point);
 
+    ss::future<bool> does_raft0_have_leader();
+
 private:
     template<typename Func>
     auto dispatch_to_backend(Func&& f) {

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -157,6 +157,10 @@ ss::future<std::vector<node_metadata>> metadata_cache::alive_nodes() const {
     co_return !brokers.empty() ? brokers : _members_table.local().node_list();
 }
 
+std::vector<node_metadata> metadata_cache::all_nodes() const {
+    return _members_table.local().node_list();
+}
+
 std::vector<model::node_id> metadata_cache::node_ids() const {
     return _members_table.local().node_ids();
 }

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -16,6 +16,7 @@
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "config/node_config.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -216,6 +217,12 @@ cluster::partition_leaders_table::leaders_info_t
 metadata_cache::get_leaders() const {
     return _leaders.local().get_leaders();
 }
+
+void metadata_cache::set_is_node_isolated_status(bool is_node_isolated) {
+    _is_node_isolated = is_node_isolated;
+}
+
+bool metadata_cache::is_node_isolated() { return _is_node_isolated; }
 
 /**
  * hard coded defaults

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -162,6 +162,9 @@ public:
     void reset_leaders();
     cluster::partition_leaders_table::leaders_info_t get_leaders() const;
 
+    void set_is_node_isolated_status(bool is_node_isolated);
+    bool is_node_isolated();
+
     model::compression get_default_compression() const;
     model::cleanup_policy_bitflags get_default_cleanup_policy_bitflags() const;
     model::compaction_strategy get_default_compaction_strategy() const;
@@ -188,5 +191,7 @@ private:
     ss::sharded<members_table>& _members_table;
     ss::sharded<partition_leaders_table>& _leaders;
     ss::sharded<health_monitor_frontend>& _health_monitor;
+
+    bool _is_node_isolated{false};
 };
 } // namespace cluster

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -114,6 +114,9 @@ public:
     /// Returns all brokers, returns copy as the content of broker can change
     ss::future<std::vector<node_metadata>> alive_nodes() const;
 
+    /// Return all brokers
+    std::vector<node_metadata> all_nodes() const;
+
     /// Returns all broker ids
     std::vector<model::node_id> node_ids() const;
 

--- a/src/v/cluster/node_isolation_watcher.cc
+++ b/src/v/cluster/node_isolation_watcher.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/node_isolation_watcher.h"
+
+#include "cluster/metadata_cache.h"
+#include "config/node_config.h"
+#include "ssx/future-util.h"
+
+namespace cluster {
+
+node_isolation_watcher::node_isolation_watcher(
+  ss::sharded<metadata_cache>& metadata_cache,
+  ss::sharded<health_monitor_frontend>& health_monitor,
+  ss::sharded<node_status_table>& node_status_table)
+  : _metadata_cache(metadata_cache)
+  , _health_monitor(health_monitor)
+  , _node_status_table(node_status_table) {
+    start_isolation_watch_timer();
+}
+
+ss::future<> node_isolation_watcher::stop() {
+    _isolation_watch_timer.cancel();
+    return _gate.close();
+}
+
+void node_isolation_watcher::start_isolation_watch_timer() {
+    _isolation_watch_timer.set_callback([this] { update_isolation_status(); });
+    rearm_isolation_watch_timer();
+}
+
+void node_isolation_watcher::rearm_isolation_watch_timer() {
+    _isolation_watch_timer.arm(
+      model::timeout_clock::now() + _isolation_check_ms);
+}
+
+void node_isolation_watcher::update_isolation_status() {
+    ssx::spawn_with_gate(
+      _gate, [this] { return do_update_isolation_status(); });
+}
+
+ss::future<> node_isolation_watcher::do_update_isolation_status() {
+    bool isolated_status = co_await is_node_isolated();
+    if (isolated_status != _last_is_isolated_status) {
+        vlog(
+          clusterlog.warn,
+          "Change is_isolated status. Is node isolated: {}",
+          isolated_status);
+        co_await _metadata_cache.invoke_on_all(
+          [isolated_status](cluster::metadata_cache& mc) {
+              mc.set_is_node_isolated_status(isolated_status);
+          });
+        _last_is_isolated_status = isolated_status;
+    }
+    rearm_isolation_watch_timer();
+}
+
+ss::future<bool> node_isolation_watcher::is_node_isolated() {
+    if (!_node_status_table.local().is_isolated()) {
+        co_return false;
+    }
+
+    bool does_raft0_have_leader
+      = co_await _health_monitor.local().does_raft0_have_leader();
+    if (does_raft0_have_leader) {
+        co_return false;
+    }
+
+    auto nodes_status_res = co_await _health_monitor.local().get_nodes_status(
+      config::shard_local_cfg().metadata_status_wait_timeout_ms()
+      + model::timeout_clock::now());
+
+    if (nodes_status_res.has_value()) {
+        auto& nodes_status = nodes_status_res.value();
+
+        // All nodes from health report should be not alive for isolation
+        bool is_one_of_node_not_alive = std::any_of(
+          nodes_status.begin(),
+          nodes_status.end(),
+          [](const node_state& node_state) {
+              // Current node should not influence on answer.
+              if (config::node().node_id() == node_state.id) {
+                  return cluster::alive::no;
+              }
+              return node_state.is_alive;
+          });
+
+        if (is_one_of_node_not_alive) {
+            co_return false;
+        }
+    }
+
+    co_return true;
+}
+
+} // namespace cluster

--- a/src/v/cluster/node_isolation_watcher.h
+++ b/src/v/cluster/node_isolation_watcher.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/health_monitor_frontend.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/node_status_table.h"
+#include "seastarx.h"
+
+namespace cluster {
+
+class node_isolation_watcher {
+public:
+    node_isolation_watcher(
+      ss::sharded<metadata_cache>& metadata_cache,
+      ss::sharded<health_monitor_frontend>& health_monitor,
+      ss::sharded<node_status_table>& node_status_table);
+
+    ss::future<> stop();
+
+private:
+    void start_isolation_watch_timer();
+    void rearm_isolation_watch_timer();
+
+    void update_isolation_status();
+    ss::future<> do_update_isolation_status();
+    ss::future<bool> is_node_isolated();
+
+    ss::gate _gate;
+    ss::timer<model::timeout_clock> _isolation_watch_timer;
+    std::chrono::milliseconds _isolation_check_ms{700};
+
+    ss::sharded<metadata_cache>& _metadata_cache;
+    ss::sharded<health_monitor_frontend>& _health_monitor;
+    ss::sharded<node_status_table>& _node_status_table;
+
+    bool _last_is_isolated_status{false};
+};
+
+} // namespace cluster

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1730,7 +1730,15 @@ configuration::configuration()
       "balancer, in milliseconds",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       5000ms,
-      {.min = 1ms, .max = bottomless_token_bucket::max_width}) {}
+      {.min = 1ms, .max = bottomless_token_bucket::max_width})
+  , node_isolation_heartbeat_timeout(
+      *this,
+      "node_isolation_heartbeat_timeout",
+      "How long after the last heartbeat request a node will wait before "
+      "considering itself to be isolated",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      3000,
+      {.min = 100, .max = 10000}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -365,6 +365,8 @@ struct configuration final : public config_store {
       kafka_throughput_limit_node_out_bps;
     bounded_property<std::chrono::milliseconds> kafka_quota_balancer_window;
 
+    bounded_property<int64_t> node_isolation_heartbeat_timeout;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -59,6 +59,8 @@ std::string_view to_string_view(feature f) {
         return "kafka_gssapi";
     case feature::partition_move_revert_cancel:
         return "partition_move_cancel_revert";
+    case feature::node_isolation:
+        return "node_isolation";
     case feature::test_alpha:
         return "__test_alpha";
     case feature::test_bravo:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -50,6 +50,7 @@ enum class feature : std::uint64_t {
     tm_stm_cache = 1ULL << 16U,
     kafka_gssapi = 1ULL << 17U,
     partition_move_revert_cancel = 1ULL << 18U,
+    node_isolation = 1ULL << 19U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 62U,
@@ -219,6 +220,12 @@ constexpr static std::array feature_schema{
     feature_spec::prepare_policy::always},
 
   // For testing, a feature that does not auto-activate
+  feature_spec{
+    cluster::cluster_version{9},
+    "node_isolation",
+    feature::node_isolation,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{2001},
     "__test_alpha",

--- a/src/v/kafka/server/handlers/details/isolated_node_utils.h
+++ b/src/v/kafka/server/handlers/details/isolated_node_utils.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/metadata_cache.h"
+#include "features/feature_table.h"
+#include "kafka/server/request_context.h"
+
+#include <seastarx.h>
+
+namespace kafka {
+
+using is_node_isolated_or_decommissioned
+  = ss::bool_class<struct is_node_isolated_or_decommissioned_tag>;
+
+inline is_node_isolated_or_decommissioned
+node_isolated_or_decommissioned(request_context& ctx) {
+    auto isoalted_or_decommissioned = is_node_isolated_or_decommissioned::no;
+    if (ctx.feature_table().local().is_active(
+          features::feature::node_isolation)) {
+        isoalted_or_decommissioned = ctx.metadata_cache().is_node_isolated()
+                                       ? is_node_isolated_or_decommissioned::yes
+                                       : is_node_isolated_or_decommissioned::no;
+    }
+
+    return isoalted_or_decommissioned;
+}
+
+} // namespace kafka

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -117,6 +117,21 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/is_node_isolated",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get is node isolated",
+                    "type": "boolean",
+                    "nickname": "is_node_isolated",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3303,6 +3303,13 @@ void admin_server::register_debug_routes() {
 
           return ss::make_ready_future<ss::json::json_return_type>(ret);
       });
+
+    register_route<user>(
+      seastar::httpd::debug_json::is_node_isolated,
+      [this](std::unique_ptr<ss::httpd::request>) {
+          return ss::make_ready_future<ss::json::json_return_type>(
+            _metadata_cache.local().is_node_isolated());
+      });
 }
 ss::future<ss::json::json_return_type>
 admin_server::get_partition_balancer_status_handler(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -33,6 +33,7 @@
 #include "cluster/metadata_dissemination_handler.h"
 #include "cluster/metadata_dissemination_service.h"
 #include "cluster/node/local_monitor.h"
+#include "cluster/node_isolation_watcher.h"
 #include "cluster/node_status_rpc_handler.h"
 #include "cluster/partition_balancer_rpc_handler.h"
 #include "cluster/partition_manager.h"
@@ -1112,6 +1113,13 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(controller->get_partition_leaders()),
       std::ref(controller->get_health_monitor()))
       .get();
+
+    syschecks::systemd_message("Creating isolation node watcher").get();
+    construct_single_service(
+      _node_isolation_watcher,
+      metadata_cache,
+      controller->get_health_monitor(),
+      node_status_table);
 
     // metrics and quota management
     syschecks::systemd_message("Adding kafka quota manager").get();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -245,6 +245,8 @@ private:
     ss::sharded<ssx::metrics::public_metrics_group> _public_metrics;
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
 
+    std::unique_ptr<cluster::node_isolation_watcher> _node_isolation_watcher;
+
     // Small helpers to execute one-time upgrade actions
     std::vector<std::unique_ptr<features::feature_migrator>> _migrators;
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -811,3 +811,6 @@ class Admin:
         service_param = f"service={rp_service if rp_service is not None else ''}"
         return self._request("PUT",
                              f"redpanda-services/restart?{service_param}")
+
+    def is_node_isolated(self, node):
+        return self._request("GET", "debug/is_node_isolated", node=node).json()

--- a/tests/rptest/tests/isolated_decommissioned_node_test.py
+++ b/tests/rptest/tests/isolated_decommissioned_node_test.py
@@ -1,0 +1,170 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
+from ducktape.utils.util import wait_until
+from rptest.clients.types import TopicSpec
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.util import firewall_blocked
+from rptest.clients.rpk import RpkTool
+from confluent_kafka import (admin, Producer, KafkaException, Consumer)
+from ducktape.mark import parametrize
+
+import time
+import uuid
+import time
+
+
+def on_delivery(err, msg):
+    if err is not None:
+        raise KafkaException(err)
+
+
+class IsolatedDecommissionedNodeTest(PreallocNodesTest):
+    topics = (TopicSpec(partition_count=1, replication_factor=3), )
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_leader_balancer": False,
+        }
+
+        super(IsolatedDecommissionedNodeTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             node_prealloc_count=3,
+                             extra_rp_conf=extra_rp_conf)
+
+        self.internal_port = 33145
+        self.admin = Admin(self.redpanda)
+        self.isolated_node = None
+        self.max_records = 40
+
+    def is_node_isolated(self):
+        return self.admin.is_node_isolated(self.isolated_node)
+
+    def check_consume(self, isolation_handler_mode):
+        topic_name = self.topics[0].name
+        max_retries = 5
+        retries_count = 0
+
+        consumer = Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': f"consumer-{uuid.uuid4()}",
+            'auto.offset.reset': 'earliest',
+            'isolation.level': 'read_committed',
+        })
+
+        consumer.subscribe([topic_name])
+        num_consumed = 0
+        prev_rec = bytes("0", 'UTF-8')
+
+        while num_consumed != self.max_records and retries_count < max_retries:
+            max_consume_records = 10
+            timeout = 10
+            records = consumer.consume(max_consume_records, timeout)
+
+            if len(records) == 0:
+                retries_count += 1
+                time.sleep(3)
+
+            for record in records:
+                retries_count = 0
+                assert prev_rec == record.key(), f"{prev_rec}, {record.key()}"
+                prev_rec = bytes(str(int(prev_rec) + 1), 'UTF-8')
+
+            num_consumed += len(records)
+
+        consumer.close()
+
+        assert num_consumed == self.max_records, f"Can not consume all data. Consumed: {num_consumed}, expected: {self.max_records}"
+
+    @cluster(num_nodes=3)
+    def create_topic_on_isolated_node_test(self):
+        # Idea of this test it to pass only isolated broker to client and expect that client will get another brokers list and will communicate with them
+        topic = self.topics[0]
+        self.isolated_node = self.redpanda.nodes[0]
+        with firewall_blocked([self.isolated_node], self.internal_port, True):
+            wait_until(self.is_node_isolated, timeout_sec=20, backoff_sec=1)
+
+            confluent_admin = admin.AdminClient({
+                "bootstrap.servers":
+                self.redpanda.broker_address(self.isolated_node),
+            })
+
+            confluent_admin.create_topics([
+                admin.NewTopic("123", replication_factor=1, num_partitions=1)
+            ])
+
+    @cluster(num_nodes=3)
+    @parametrize(isolation_handler_mode=True)
+    @parametrize(isolation_handler_mode=False)
+    def discover_leader_for_topic_test(self, isolation_handler_mode):
+        # Idea of this test is check that producer can descover partition leader if we pass only isolated node
+        if not isolation_handler_mode:
+            feature_name = "node_isolation"
+            self.admin.put_feature(feature_name, {"state": "disabled"})
+
+        topic = self.topics[0]
+
+        self.leader_for_all = None
+
+        def wait_leader():
+            try:
+                self.leader_for_all = self.admin.get_partition_leader(
+                    namespace="kafka", topic=str(topic), partition=0)
+                return True
+            except:
+                return False
+
+        wait_until(wait_leader,
+                   timeout_sec=10,
+                   backoff_sec=1,
+                   err_msg="Can not get leader for first topic")
+
+        self.admin.partition_transfer_leadership('redpanda', 'controller', 0,
+                                                 self.leader_for_all)
+        wait_until(lambda: self.admin.get_partition_leader(
+            namespace="redpanda", topic="controller", partition=0) == self.
+                   leader_for_all,
+                   timeout_sec=10,
+                   backoff_sec=1,
+                   err_msg="Leadership did not stabilize")
+
+        self.not_isolated_node = None
+        for node in self.redpanda.nodes:
+            if self.redpanda.idx(node) == self.leader_for_all:
+                self.isolated_node = node
+            else:
+                self.not_isolated_node = node
+
+        with firewall_blocked([self.isolated_node], self.internal_port, True):
+
+            wait_until(self.is_node_isolated, timeout_sec=20, backoff_sec=1)
+
+            producer = Producer({
+                "bootstrap.servers":
+                self.redpanda.broker_address(self.isolated_node),
+            })
+
+            for i in range(self.max_records):
+                producer.produce(str(topic),
+                                 key=str(i),
+                                 value=str(i),
+                                 callback=on_delivery)
+            try:
+                producer.flush(10.0)
+            except ck.cimpl.KafkaException as e:
+                # We can get timeout only with switched off handler for isolation node
+                assert isolation_handler_mode == False
+                kafka_error = e.args[0]
+                assert kafka_error.code() == ck.cimpl.KafkaError._MSG_TIMED_OUT
+
+        if isolation_handler_mode:
+            self.check_consume(isolation_handler_mode)


### PR DESCRIPTION
## Ideas
The main idea of this pr:
* Add new state for redpanda node - isolated, how redpanda process should "discover" that it is isolated
* Create way to say clients “Do not communicate with me and send your request to another node”

We need to signal to clients that node can not get any requests anymore. The simplest way  to do it is by using Kafka RPC. Clients send metadata requests to get info about the cluster, so we do not want to return wrong information from isolated nodes. So we can do it by using metadata response.

For now we have several types of pings for nodes.
* Health_monitor
* Node_status_table
* Append_entries request from controller leader

So for beginning we can just check that we do not communicate with another nodes from Health_monitor, also we do not get append_entries requests from controller leader + node does not have outside raft heartbits. So after it we can decide that we are isolated and signal client to reconnect to another node.

[RFC](https://docs.google.com/document/d/1IYztXGunVHWSJXOKbHodbKtVigT7AQ_6l-XiwLkkOyc/edit?usp=sharing)
[Ticket](https://github.com/redpanda-data/core-internal/issues/271)

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

### Features

* Redpanda nodes now automatically decline Kafka API requests when they detect that they are isolated from the cluster
* Cluster configuration properties are added to control node isolation detection: `node_isolation_raft_timeout` and `node_isolation_heartbeat_timeout`.  Both are 3 seconds by default.

