### PR TITLE
cloud_storage: filter stopped segments on trim

### DIFF
--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -314,8 +314,19 @@ void materialized_segments::maybe_trim_segment(
         // this will delete and unlink the object from
         // _materialized collection
         if (st.parent) {
-            to_offload.push_back(
-              std::make_pair(st.parent.get(), st.base_rp_offset()));
+            if (
+              st.parent->state()
+              == remote_partition::partition_state::running) {
+                to_offload.push_back(
+                  std::make_pair(st.parent.get(), st.base_rp_offset()));
+            } else {
+                vlog(
+                  cst_log.info,
+                  "Materialized segment {} offset {} not offloaded, partition "
+                  "is stopping",
+                  st.ntp(),
+                  st.base_rp_offset());
+            }
         } else {
             // This cannot happen, because materialized_segment_state
             // is only instantiated by remote_partition and will

--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -295,6 +295,10 @@ void materialized_segments::trim_segments(std::optional<size_t> target_free) {
  */
 void materialized_segments::maybe_trim_segment(
   materialized_segment_state& st, offload_list_t& to_offload) {
+    if (st.segment->is_stopped()) {
+        return;
+    }
+
     if (st.segment->download_in_progress()) {
         return;
     }

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -608,6 +608,7 @@ remote_partition::aborted_transactions(offset_range offsets) {
 }
 
 ss::future<> remote_partition::stop() {
+    _state = partition_state::stopping;
     vlog(_ctxlog.debug, "remote partition stop {} segments", _segments.size());
 
     co_await _gate.close();
@@ -627,6 +628,7 @@ ss::future<> remote_partition::stop() {
     // stopping readers is fast, the queue is not usually long, and destroying
     // partitions is relatively infrequent.
     co_await materialized().flush_evicted();
+    _state = partition_state::stopped;
 }
 
 /// Return reader back to segment_state

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -122,6 +122,9 @@ public:
     /// Hook for materialized_segment to notify us when a segment is evicted
     void offload_segment(model::offset);
 
+    enum class partition_state { running, stopping, stopped };
+    partition_state state() const { return _state; }
+
 private:
     ss::future<> run_eviction_loop();
 
@@ -188,6 +191,8 @@ private:
 
     segment_map_t _segments;
     partition_probe _probe;
+
+    partition_state _state{partition_state::running};
 };
 
 } // namespace cloud_storage


### PR DESCRIPTION
When trimming segments in `materialized_segments`, we should ignore segments which are already stopped. This avoids the following issues:

* A stopped segment is offloaded by `materialized_segments`. If the `remote_partition` is stopping at the same time, it is iterating over it's segment map (`_segments`) while an entry from the map is erased by the segment offload, causing an iterator invalidation.

* A segment is marked for eviction and later attempted to stop by `materialized_segments`, but it has already been stopped by the partition. This is also avoided now due to checks inside the segment #7800, but if the segment is filtered out early we avoid this issue later.

Fixes #7830


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

  * none

## Release Notes

  * none
