### PR TITLE
DNM [v22.3.x] async manifest serialization

### DIFF
--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -449,7 +449,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 
     std::stringstream st;
-    stm_manifest.serialize(st);
+    stm_manifest.serialize(st).get();
     vlog(test_log.debug, "manifest: {}", st.str());
     verify_segment_request("500-1-v1.log", stm_manifest);
 

--- a/src/v/cloud_storage/base_manifest.h
+++ b/src/v/cloud_storage/base_manifest.h
@@ -39,7 +39,7 @@ public:
     /// Serialize manifest object
     ///
     /// \return asynchronous input_stream with the serialized json
-    virtual serialized_json_stream serialize() const = 0;
+    virtual ss::future<serialized_json_stream> serialize() const = 0;
 
     /// Manifest object name in S3
     virtual remote_manifest_path get_manifest_path() const = 0;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -252,12 +252,12 @@ public:
     /// Serialize manifest object
     ///
     /// \return asynchronous input_stream with the serialized json
-    serialized_json_stream serialize() const override;
+    ss::future<serialized_json_stream> serialize() const override;
 
     /// Serialize manifest object
     ///
     /// \param out output stream that should be used to output the json
-    void serialize(std::ostream& out) const;
+    ss::future<> serialize(std::ostream& out) const;
 
     /// Compare two manifests for equality
     bool operator==(const partition_manifest& other) const = default;

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -274,7 +274,7 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
     auto offset_map = co_await build_offset_map(mat);
     if (cst_log.is_enabled(ss::log_level::debug)) {
         std::stringstream ostr;
-        mat.partition_manifest.serialize(ostr);
+        co_await mat.partition_manifest.serialize(ostr);
         vlog(
           _ctxlog.debug,
           "Partition manifest used for recovery: {}",

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -325,7 +325,7 @@ ss::future<upload_result> remote::upload_manifest(
     while (!_gate.is_closed() && permit.is_allowed && !result.has_value()) {
         std::exception_ptr eptr = nullptr;
         try {
-            auto [is, size] = manifest.serialize();
+            auto [is, size] = co_await manifest.serialize();
             co_await lease.client->put_object(
               bucket, path, size, std::move(is), tags, fib.get_timeout());
             vlog(ctxlog.debug, "Successfuly uploaded manifest to {}", path);

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -345,7 +345,7 @@ ss::future<> remote_segment::do_hydrate_txrange() {
         throw download_exception(res, _path);
     }
 
-    auto [stream, size] = manifest.serialize();
+    auto [stream, size] = co_await manifest.serialize();
     co_await _cache.put(manifest.get_manifest_path(), stream)
       .finally([&s = stream]() mutable { return s.close(); });
 

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -655,7 +655,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
         .ntp_revision = model::initial_revision_id(3),
         .segment_term = model::term_id(1),
       });
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();
@@ -906,7 +906,7 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_serialization_roundtrip) {
           &m, segment_name(segment.first), segment.second);
     }
 
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();
@@ -1062,7 +1062,7 @@ SEASTAR_THREAD_TEST_CASE(
     }
     m.advance_start_offset(model::offset(100));
 
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -406,7 +406,7 @@ make_imposter_expectations(
     }
     m.advance_insync_offset(m.get_last_offset());
     std::stringstream ostr;
-    m.serialize(ostr);
+    m.serialize(ostr).get();
     results.push_back(cloud_storage_fixture::expectation{
       .url = "/" + m.get_manifest_path()().string(),
       .body = ss::sstring(ostr.str())});

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -141,7 +141,7 @@ SEASTAR_THREAD_TEST_CASE(update_topic_manifest_correct_path) {
 
 SEASTAR_THREAD_TEST_CASE(construct_serialize_update_same_object) {
     topic_manifest m(cfg, model::initial_revision_id(0));
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();
@@ -156,7 +156,7 @@ SEASTAR_THREAD_TEST_CASE(construct_serialize_update_same_object) {
 SEASTAR_THREAD_TEST_CASE(update_serialize_update_same_object) {
     topic_manifest m;
     m.update(make_manifest_stream(min_topic_manifest_json)).get();
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();
@@ -268,7 +268,7 @@ SEASTAR_THREAD_TEST_CASE(full_update_serialize_update_same_object) {
     topic_manifest m;
     m.update(make_manifest_stream(full_topic_manifest_json)).get();
 
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();
@@ -283,7 +283,7 @@ SEASTAR_THREAD_TEST_CASE(full_update_serialize_update_same_object) {
 SEASTAR_THREAD_TEST_CASE(update_non_empty_manifest) {
     topic_manifest m(cfg, model::initial_revision_id(0));
     m.update(make_manifest_stream(full_topic_manifest_json)).get();
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();

--- a/src/v/cloud_storage/tests/tx_range_manifest_test.cc
+++ b/src/v/cloud_storage/tests/tx_range_manifest_test.cc
@@ -66,7 +66,7 @@ SEASTAR_THREAD_TEST_CASE(create_tx_manifest) {
 
 SEASTAR_THREAD_TEST_CASE(empty_serialization_roundtrip_test) {
     tx_range_manifest m(segment_path);
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();
@@ -79,7 +79,7 @@ SEASTAR_THREAD_TEST_CASE(empty_serialization_roundtrip_test) {
 
 SEASTAR_THREAD_TEST_CASE(serialization_roundtrip_test) {
     tx_range_manifest m(segment_path, ranges);
-    auto [is, size] = m.serialize();
+    auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
     ss::copy(is, os).get();

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -309,7 +309,7 @@ ss::future<> topic_manifest::update(ss::input_stream<char> is) {
     co_return;
 }
 
-serialized_json_stream topic_manifest::serialize() const {
+ss::future<serialized_json_stream> topic_manifest::serialize() const {
     iobuf serialized;
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
@@ -321,7 +321,7 @@ serialized_json_stream topic_manifest::serialize() const {
           get_manifest_path()));
     }
     size_t size_bytes = serialized.size_bytes();
-    return {
+    co_return serialized_json_stream{
       .stream = make_iobuf_input_stream(std::move(serialized)),
       .size_bytes = size_bytes};
 }

--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -34,7 +34,7 @@ public:
     /// Serialize manifest object
     ///
     /// \return asynchronous input_stream with the serialized json
-    serialized_json_stream serialize() const override;
+    ss::future<serialized_json_stream> serialize() const override;
 
     /// Manifest object name in S3
     remote_manifest_path get_manifest_path() const override;

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -87,7 +87,7 @@ void tx_range_manifest::update(const rapidjson::Document& doc) {
     _ranges.shrink_to_fit();
 }
 
-serialized_json_stream tx_range_manifest::serialize() const {
+ss::future<serialized_json_stream> tx_range_manifest::serialize() const {
     iobuf serialized;
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
@@ -99,7 +99,7 @@ serialized_json_stream tx_range_manifest::serialize() const {
           get_manifest_path()));
     }
     size_t size_bytes = serialized.size_bytes();
-    return {
+    co_return serialized_json_stream{
       .stream = make_iobuf_input_stream(std::move(serialized)),
       .size_bytes = size_bytes};
 }

--- a/src/v/cloud_storage/tx_range_manifest.h
+++ b/src/v/cloud_storage/tx_range_manifest.h
@@ -46,7 +46,7 @@ public:
     /// Serialize manifest object
     ///
     /// \return asynchronous input_stream with the serialized json
-    serialized_json_stream serialize() const override;
+    ss::future<serialized_json_stream> serialize() const override;
 
     /// Manifest object name in S3
     remote_manifest_path get_manifest_path() const override;

--- a/src/v/cluster/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/tests/archival_metadata_stm_test.cc
@@ -254,8 +254,8 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
 
     {
         std::stringstream s1, s2;
-        m.serialize(s1);
-        archival_stm.manifest().serialize(s2);
+        m.serialize(s1).get();
+        archival_stm.manifest().serialize(s2).get();
         vlog(logger.info, "original manifest: {}", s1.str());
         vlog(logger.info, "restored manifest: {}", s2.str());
     }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3178,7 +3178,7 @@ ss::future<ss::json::json_return_type> admin_server::sync_local_state_handler(
         vlog(logger.info, "Requested bucket syncup completed");
         if (result) {
             std::stringstream sts;
-            result->serialize(sts);
+            co_await result->serialize(sts);
             vlog(logger.info, "Requested bucket syncup result {}", sts.str());
         } else {
             vlog(logger.info, "Requested bucket syncup result empty");

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -109,7 +109,7 @@ ss::future<> segment::remove_persistent_state() {
         rm.push_back(
           internal::compacted_index_path(reader().filename().c_str()));
     }
-    vlog(stlog.info, "removing: {}", rm);
+    vlog(stlog.debug, "removing: {}", rm);
     return ss::do_with(
       std::move(rm), [](const std::vector<std::filesystem::path>& to_remove) {
           return ss::do_for_each(


### PR DESCRIPTION

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #7751 

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

None

## Release Notes


### Improvements

* Improved tail latency when one partition has many segments in cloud storage