### PR TITLE
[v22.3.x] cluster: initialize node ID assignment counter

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -361,6 +361,16 @@ void members_manager::apply_initial_node_uuid_map(uuid_map_t id_by_uuid) {
     if (!id_by_uuid.empty()) {
         vlog(clusterlog.debug, "Initial node UUID map: {}", id_by_uuid);
     }
+    // Start the node ID assignment counter just past the highest node ID. This
+    // helps ensure removed seed servers are accounted for when auto-assigning
+    // node IDs, since seed servers don't call get_or_assign_node_id().
+    for (const auto& [uuid, id] : id_by_uuid) {
+        if (id == INT_MAX) {
+            _next_assigned_id = id;
+            break;
+        }
+        _next_assigned_id = std::max(_next_assigned_id, id + 1);
+    }
     _id_by_uuid = std::move(id_by_uuid);
 }
 
@@ -520,6 +530,9 @@ members_manager::get_or_assign_node_id(const model::node_uuid& node_uuid) {
                 return std::nullopt;
             }
             ++_next_assigned_id;
+        }
+        if (_next_assigned_id == INT_MAX) {
+            return std::nullopt;
         }
         _id_by_uuid.emplace(node_uuid, _next_assigned_id);
         vlog(

--- a/tests/rptest/tests/node_id_assignment_test.py
+++ b/tests/rptest/tests/node_id_assignment_test.py
@@ -42,6 +42,14 @@ def check_node_ids_persist(redpanda):
         assert new_node_id == original_node_id, f"{new_node_id} vs {original_node_id}"
 
 
+def wait_for_node_removed(admin, node_id):
+    def node_removed():
+        brokers = admin.get_brokers()
+        return not any(b["node_id"] == node_id for b in brokers)
+
+    wait_until(node_removed, timeout_sec=30, backoff_sec=1)
+
+
 class NodeIdAssignment(RedpandaTest):
     """
     Test that exercises cluster formation when node IDs are automatically
@@ -53,8 +61,13 @@ class NodeIdAssignment(RedpandaTest):
         self.admin = self.redpanda._admin
 
     def setUp(self):
-        self.redpanda.start(auto_assign_node_id=True)
+        self.redpanda.set_seed_servers(self.redpanda.nodes)
+        self.redpanda.start(auto_assign_node_id=True,
+                            omit_seeds_on_idx_one=False)
         self._create_initial_topics()
+
+    def node_ids(self):
+        return [self.redpanda.node_id(n) for n in self.redpanda.nodes]
 
     @cluster(num_nodes=3)
     def test_basic_assignment(self):
@@ -68,12 +81,16 @@ class NodeIdAssignment(RedpandaTest):
         We should be able to get a new node ID after wiping and decommissioning
         a node.
         """
+        original_node_ids = self.node_ids()
         replaced_node = self.redpanda.nodes[-1]
         replaced_node_id = self.redpanda.node_id(replaced_node)
+
         self.admin.decommission_broker(replaced_node_id)
+        wait_for_node_removed(self.admin, replaced_node_id)
+
         wipe_and_restart(self.redpanda, replaced_node)
         new_node_id = self.redpanda.node_id(replaced_node, force_refresh=True)
-        assert replaced_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"
+        assert new_node_id not in original_node_ids, f"Cleaned node came back with node ID {new_node_id}"
 
     @cluster(num_nodes=3)
     def test_rejoin_after_decommission(self):
@@ -83,7 +100,10 @@ class NodeIdAssignment(RedpandaTest):
         """
         original_node = self.redpanda.nodes[-1]
         original_node_id = self.redpanda.node_id(original_node)
+
         self.admin.decommission_broker(original_node_id)
+        wait_for_node_removed(self.admin, original_node_id)
+
         new_node_id = self.redpanda.node_id(original_node, force_refresh=True)
         assert original_node_id == new_node_id, f"Node came back with different node ID {new_node_id}"
 
@@ -93,17 +113,17 @@ class NodeIdAssignment(RedpandaTest):
         Wiping a node that doesn't have a configured node ID should result in a
         new node ID being assigned to that node.
         """
+        original_node_ids = self.node_ids()
         brokers = self.admin.get_brokers()
         assert 3 == len(brokers), f"Got {len(brokers)} brokers"
 
         clean_node = self.redpanda.nodes[-1]
-        original_node_id = self.redpanda.node_id(clean_node)
         wipe_and_restart(self.redpanda, clean_node)
 
         brokers = self.admin.get_brokers()
         assert 4 == len(brokers), f"Got {len(brokers)} brokers"
         new_node_id = self.redpanda.node_id(clean_node, force_refresh=True)
-        assert original_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"
+        assert new_node_id not in original_node_ids, f"Cleaned node came back with node ID {new_node_id}"
         check_node_ids_persist(self.redpanda)
 
     @cluster(num_nodes=3, log_allow_list=["doesn't match stored node ID"])
@@ -149,6 +169,9 @@ class NodeIdAssignmentUpgrade(RedpandaTest):
         Upgrade a cluster and then immediately start using the node ID
         assignment feature.
         """
+        original_node_ids = [
+            self.redpanda.node_id(n) for n in self.redpanda.nodes
+        ]
         self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
         self.redpanda.restart_nodes(self.redpanda.nodes,
                                     auto_assign_node_id=True)
@@ -159,10 +182,9 @@ class NodeIdAssignmentUpgrade(RedpandaTest):
             err_msg="Timeout waiting for cluster to support 'license' feature")
 
         clean_node = self.redpanda.nodes[-1]
-        original_node_id = self.redpanda.node_id(clean_node)
         wipe_and_restart(self.redpanda, clean_node)
 
         brokers = self.admin.get_brokers()
         assert 4 == len(brokers), f"Got {len(brokers)} brokers"
         new_node_id = self.redpanda.node_id(clean_node, force_refresh=True)
-        assert original_node_id != new_node_id, f"Cleaned node came back with node ID {new_node_id}"
+        assert new_node_id not in original_node_ids, f"Cleaned node came back with node ID {new_node_id}"


### PR DESCRIPTION
CONFLICT: added the missing bits of end_to_end.py to support auto-assigned node IDs and the new bootstrapping

We previously weren't initializing the node ID assignment counter with the node IDs assigned to the cluster founders. This PR bumps the counter with the node IDs available at initial cluster bootstrap. This fix is adjacent to the one in #7789 -- it's just another layer of protection.

This PR also adds a test that restacks a cluster in random order, ensuring that no node IDs are reused, which would have caught this issue.
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

 

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
 ### Bug Fixes

* Node ID assignment will now use node IDs higher than those used by the initial seed servers, avoiding a potential node ID re-use in cases where a seed server is fully decommissioned before adding a new node.