### PR TITLE
Fix race condition in the eviction loop

### DIFF
--- a/src/v/cloud_storage/materialized_segments.h
+++ b/src/v/cloud_storage/materialized_segments.h
@@ -106,7 +106,8 @@ private:
 
     /// List of segments and readers waiting to have their stop() method
     /// called before destruction
-    eviction_list_t _eviction_list;
+    eviction_list_t _eviction_pending;
+    eviction_list_t _eviction_in_flight;
 
     // We need to quickly look up readers by segment, to find any readers
     // for a segment that is targeted by a read.  Within those readers,

--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -164,7 +164,11 @@ const ss::abort_source* retry_chain_node::get_abort_source() const {
 }
 
 retry_chain_node::~retry_chain_node() {
-    vassert(_num_children == 0, "Fiber stopped before its dependencies");
+    vassert(
+      _num_children == 0,
+      "{} Fiber stopped before its dependencies, num children {}",
+      (*this)(),
+      _num_children);
     if (auto parent = get_parent(); parent != nullptr) {
         parent->rem_child();
     }


### PR DESCRIPTION
With large number of segments it is possible to run into the following
situation. When the partition is stopped we're waiting for the eviction
loop to process all segments scheduled for eviction. The list of evicted
segments is moved to the temporary variable and then the eviction loop
processes it.

The 'stop' method uses 'flush_evicted' method which checks the size of
the eviction list. The 'flush_evicted' method pushes eviction barrier to
the list only if the eviction list is not empty. But it is possible that
the 'flush_evicted' method will be called right after the eviction list
is moved to the temporary. In this case the 'flush_evicted' will return
early and wouldn't create a barrier. This will lead to a situation when
the 'remote_parititon' could be deleted before all segments stored in
the temporary eviction list are processed.

This commit splits the eviction list into two parts. The pending list
and in-flight list. New items are added to the pending list. Then the
eviction loop moves it to the in-flight list and processes it. The items
in the in-flight list are processed in FIFO order and removed right
after processing. This is because the list might contain a lot of
segments from multiple partitions. In this case when the eviction loop
will evict the eviction barrier the in-flight list won't be cleared yet
(because there are other segments remaining). The eviciton of the
barrier will let the 'remote_partition::stop' method to exit and and
'remote_partition' to be deleted despite the fact that the evicted
'remote_segment' instances that belongs to it are not deleted yet. This
will trigger an assertion.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

* none