### PR TITLE
Avoid unnecessary move in topic_table::apply

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -575,18 +575,15 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
       storage::ntp_config::default_remote_delete);
 
     // generate deltas for controller backend
-    std::vector<topic_table_delta> deltas;
-    deltas.reserve(tp->second.get_assignments().size());
-    for (const auto& p_as : tp->second.get_assignments()) {
-        deltas.emplace_back(
+    const auto& assignments = tp->second.get_assignments();
+    _pending_deltas.reserve(_pending_deltas.size() + assignments.size());
+    for (auto& p_as : assignments) {
+        _pending_deltas.emplace_back(
           model::ntp(cmd.key.ns, cmd.key.tp, p_as.id),
           p_as,
           o,
           delta::op_type::update_properties);
     }
-
-    std::move(
-      deltas.begin(), deltas.end(), std::back_inserter(_pending_deltas));
 
     notify_waiters();
 


### PR DESCRIPTION
In that method we created a deltas container and emplaced values into it, then moved this value to the end of the pending deltas member. This results in an extra move versus simply emplacing the deltas directly in the member.

The deltas are non-trivial objects and the moves are in some cases relatively expensive (since e.g., they have to copy all the bytes of ss::string which has a small-string optimization).

Instead, just emplace the values directly in the pending deltas array. There are no suspension points so this is safe and equivalent to the old behavior.

Fixes #7669.


## Backports Required


- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

 * none
