### PR TITLE
[v22.3.x] cloud_storage: filter stopped segments on trim

### DIFF
--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -314,8 +314,19 @@ void materialized_segments::maybe_trim_segment(
         // this will delete and unlink the object from
         // _materialized collection
         if (st.parent) {
-            to_offload.push_back(
-              std::make_pair(st.parent.get(), st.base_rp_offset()));
+            if (
+              st.parent->state()
+              == remote_partition::partition_state::running) {
+                to_offload.push_back(
+                  std::make_pair(st.parent.get(), st.base_rp_offset()));
+            } else {
+                vlog(
+                  cst_log.info,
+                  "Materialized segment {} offset {} not offloaded, partition "
+                  "is stopping",
+                  st.ntp(),
+                  st.base_rp_offset());
+            }
         } else {
             // This cannot happen, because materialized_segment_state
             // is only instantiated by remote_partition and will

--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -295,6 +295,10 @@ void materialized_segments::trim_segments(std::optional<size_t> target_free) {
  */
 void materialized_segments::maybe_trim_segment(
   materialized_segment_state& st, offload_list_t& to_offload) {
+    if (st.segment->is_stopped()) {
+        return;
+    }
+
     if (st.segment->download_in_progress()) {
         return;
     }

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -605,6 +605,7 @@ remote_partition::aborted_transactions(offset_range offsets) {
 }
 
 ss::future<> remote_partition::stop() {
+    _state = partition_state::stopping;
     vlog(_ctxlog.debug, "remote partition stop {} segments", _segments.size());
 
     co_await _gate.close();
@@ -624,6 +625,7 @@ ss::future<> remote_partition::stop() {
     // stopping readers is fast, the queue is not usually long, and destroying
     // partitions is relatively infrequent.
     co_await materialized().flush_evicted();
+    _state = partition_state::stopped;
 }
 
 /// Return reader back to segment_state

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -122,6 +122,9 @@ public:
     /// Hook for materialized_segment to notify us when a segment is evicted
     void offload_segment(model::offset);
 
+    enum class partition_state { running, stopping, stopped };
+    partition_state state() const { return _state; }
+
 private:
     ss::future<> run_eviction_loop();
 
@@ -188,6 +191,8 @@ private:
 
     segment_map_t _segments;
     partition_probe _probe;
+
+    partition_state _state{partition_state::running};
 };
 
 } // namespace cloud_storage


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7832
Fixes https://github.com/redpanda-data/redpanda/issues/7864,