### PR TITLE
tests: faster, parallelizable unit tests

### DIFF
--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -56,7 +56,7 @@ inline ss::logger tstlog("raft_test");
 
 using namespace std::chrono_literals; // NOLINT
 
-inline static std::chrono::milliseconds heartbeat_interval = 40ms;
+inline static std::chrono::milliseconds heartbeat_interval = 20ms;
 inline static const raft::replicate_options
   default_replicate_opts(raft::consistency_level::quorum_ack);
 
@@ -413,7 +413,7 @@ struct raft_group {
           make_broker(node_id),
           _id,
           raft::group_configuration(_initial_brokers, model::revision_id(0)),
-          raft::timeout_jitter(heartbeat_interval * 10),
+          raft::timeout_jitter(heartbeat_interval * 5),
           ssx::sformat("{}/{}", _storage_dir, node_id()),
           _storage_type,
           [this, node_id](raft::leadership_status st) {
@@ -434,7 +434,7 @@ struct raft_group {
           broker,
           _id,
           raft::group_configuration({}, model::revision_id(0)),
-          raft::timeout_jitter(heartbeat_interval * 10),
+          raft::timeout_jitter(heartbeat_interval * 5),
           ssx::sformat("{}/{}", _storage_dir, node_id()),
           _storage_type,
           [this, node_id](raft::leadership_status st) {

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -194,8 +194,8 @@ class TestRunner():
 
         if "rpunit" in binary or "rpfixture" in binary:
             unit_args = [
-                "--overprovisioned", "--unsafe-bypass-fsync 1",
-                "--default-log-level=trace", "--logger-log-level='io=debug'",
+                "--unsafe-bypass-fsync 1", "--default-log-level=info",
+                "--logger-log-level='io=debug'",
                 "--logger-log-level='exception=debug'"
             ] + COMMON_TEST_ARGS
             if "--" in args:

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -192,9 +192,14 @@ class TestRunner():
         else:
             args = list(map(str, args))
 
+        # If in CI, run with trace because we need the evidence if something
+        # fails.  Locally, use INFO to improve runtime: the developer can
+        # selectively re-run failing tests with more logging if needed.
+        log_level = 'trace' if self.ci else 'info'
+
         if "rpunit" in binary or "rpfixture" in binary:
             unit_args = [
-                "--unsafe-bypass-fsync 1", "--default-log-level=info",
+                "--unsafe-bypass-fsync 1", f"--default-log-level={log_level}",
                 "--logger-log-level='io=debug'",
                 "--logger-log-level='exception=debug'"
             ] + COMMON_TEST_ARGS
@@ -213,6 +218,10 @@ class TestRunner():
     def _gen_testdir(self):
         return tempfile.mkdtemp(suffix=self._gen_alphanum(),
                                 prefix="%s/test." % self.root)
+
+    @property
+    def ci(self):
+        return 'CI' in os.environ
 
     def run(self):
         # Execute the requested number of times, terminate on the first failure.
@@ -234,7 +243,7 @@ class TestRunner():
         env = os.environ.copy()
         env["TEST_DIR"] = test_dir
         env["BOOST_TEST_LOG_LEVEL"] = "test_suite"
-        if "CI" in env:
+        if self.ci:
             env["BOOST_TEST_COLOR_OUTPUT"] = "0"
         env["BOOST_TEST_CATCH_SYSTEM_ERRORS"] = "no"
         env["BOOST_TEST_REPORT_LEVEL"] = "no"


### PR DESCRIPTION
(Preceded by #7962)

Historically, our "unit" tests were a mixture of actual unit tests, and tests that instantiated whole redpanda `application` stacks for doing integration testing inside a single process.  There is no entry for "unit test" in the dictionary, but for our purposes let's say it's a test which only instantiates the particular part of the application under test, rather than instantiating a whole application and testing the component in that context (the latter is an integration test).

These categories of test are meaningfully different:
- fixture tests are much longer running
- fixture tests listen on default redpanda TCP ports and therefore cannot be run in parallel with one another.
- fixture tests are huge 1.5GB+ binaries, unit tests are tiny binaries that build much faster
- when looking at coverage, when a unit test covers a line of code, it's a strong signal that the code in question is being properly tested (i.e. calling a function and checking the result).  Whereas when a fixture test covers a line, it may well be doing so as a pure side effect as a result of instantiating the whole redpanda application.

Splitting these out enables developers to run the unit tests quickly: running unit and fixture tests takes >10 minutes and cannot easily be parallelised, whereas running the unit tests with parallelism enabled is more like 1 minute or less.


## Backports Required


- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes


  * none
