### PR TITLE
cloud_storage: Set limits on segments and readers in tests

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -21,6 +21,7 @@
 #include "cloud_storage/tests/s3_imposter.h"
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/types.h"
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
@@ -625,9 +626,22 @@ static model::record_batch_header read_single_batch_from_remote_partition(
 /// Similar to prev function but scans the range of offsets instead of
 /// returning a single one
 static std::vector<model::record_batch_header> scan_remote_partition(
-  cloud_storage_fixture& imposter, model::offset base, model::offset max) {
+  cloud_storage_fixture& imposter,
+  model::offset base,
+  model::offset max,
+  size_t maybe_max_segments = 0,
+  size_t maybe_max_readers = 0) {
     auto conf = imposter.get_configuration();
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    if (maybe_max_segments) {
+        config::shard_local_cfg()
+          .cloud_storage_max_materialized_segments_per_shard(
+            maybe_max_segments);
+    }
+    if (maybe_max_readers) {
+        config::shard_local_cfg().cloud_storage_max_readers_per_shard(
+          maybe_max_readers);
+    }
     remote api(s3_connection_limit(10), conf, config_file);
     api.start().get();
     auto action = ss::defer([&api] { api.stop().get(); });
@@ -1149,7 +1163,12 @@ FIXTURE_TEST(
     auto base = segments[0].base_offset;
     auto max = segments[num_segments - 1].max_offset;
     vlog(test_log.debug, "offset range: {}-{}", base, max);
-    auto headers_read = scan_remote_partition(*this, base, max);
+    auto headers_read = scan_remote_partition(
+      *this,
+      base,
+      max,
+      random_generators::get_int(5, 20),
+      random_generators::get_int(5, 20));
     model::offset expected_offset{0};
     for (const auto& header : headers_read) {
         BOOST_REQUIRE_EQUAL(expected_offset, header.base_offset);
@@ -1165,9 +1184,20 @@ scan_remote_partition_incrementally(
   cloud_storage_fixture& imposter,
   model::offset base,
   model::offset max,
-  size_t maybe_max_bytes = 0) {
+  size_t maybe_max_bytes = 0,
+  size_t maybe_max_segments = 0,
+  size_t maybe_max_readers = 0) {
     auto conf = imposter.get_configuration();
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    if (maybe_max_segments) {
+        config::shard_local_cfg()
+          .cloud_storage_max_materialized_segments_per_shard(
+            maybe_max_segments);
+    }
+    if (maybe_max_readers) {
+        config::shard_local_cfg().cloud_storage_max_readers_per_shard(
+          maybe_max_readers);
+    }
     remote api(s3_connection_limit(10), conf, config_file);
     api.start().get();
     auto action = ss::defer([&api] { api.stop().get(); });
@@ -1231,7 +1261,13 @@ FIXTURE_TEST(
     auto base = segments[0].base_offset;
     auto max = segments[num_segments - 1].max_offset;
     vlog(test_log.debug, "offset range: {}-{}", base, max);
-    auto headers_read = scan_remote_partition_incrementally(*this, base, max);
+    auto headers_read = scan_remote_partition_incrementally(
+      *this,
+      base,
+      max,
+      0,
+      random_generators::get_int(5, 20),
+      random_generators::get_int(5, 20));
     model::offset expected_offset{0};
     for (const auto& header : headers_read) {
         BOOST_REQUIRE_EQUAL(expected_offset, header.base_offset);
@@ -1645,9 +1681,20 @@ scan_remote_partition_incrementally_with_reuploads(
   cloud_storage_fixture& imposter,
   model::offset base,
   model::offset max,
-  std::vector<in_memory_segment> segments) {
+  std::vector<in_memory_segment> segments,
+  size_t maybe_max_segments = 0,
+  size_t maybe_max_readers = 0) {
     auto conf = imposter.get_configuration();
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    if (maybe_max_segments) {
+        config::shard_local_cfg()
+          .cloud_storage_max_materialized_segments_per_shard(
+            maybe_max_segments);
+    }
+    if (maybe_max_readers) {
+        config::shard_local_cfg().cloud_storage_max_readers_per_shard(
+          maybe_max_readers);
+    }
     remote api(s3_connection_limit(10), conf, config_file);
     api.start().get();
     auto action = ss::defer([&api] { api.stop().get(); });
@@ -1810,7 +1857,12 @@ FIXTURE_TEST(
     auto max = segments[num_segments - 1].max_offset;
     vlog(test_log.debug, "full offset range: {}-{}", base, max);
     auto headers_read = scan_remote_partition_incrementally_with_reuploads(
-      *this, base, max, std::move(segments));
+      *this,
+      base,
+      max,
+      std::move(segments),
+      random_generators::get_int(5, 20),
+      random_generators::get_int(5, 20));
     model::offset expected_offset{0};
     for (const auto& header : headers_read) {
         BOOST_REQUIRE_EQUAL(expected_offset, header.base_offset);
@@ -1885,7 +1937,7 @@ FIXTURE_TEST(
 
     for (size_t sz : client_batch_sizes) {
         auto headers_read = scan_remote_partition_incrementally(
-          *this, base, max, sz);
+          *this, base, max, sz, 5, 5);
 
         BOOST_REQUIRE_EQUAL(
           headers_read.size(),
@@ -1904,7 +1956,8 @@ FIXTURE_TEST(
     auto max = segments.back().max_offset;
     vlog(test_log.debug, "offset range: {}-{}", base, max);
 
-    auto headers_read = scan_remote_partition_incrementally(*this, base, max);
+    auto headers_read = scan_remote_partition_incrementally(
+      *this, base, max, 0, 20, 20);
     model::offset expected_offset{0};
     size_t ix_header = 0;
     for (size_t ix_seg = 0; ix_seg < segment_layout.size(); ix_seg++) {


### PR DESCRIPTION
The default for `cloud_storage_max_readers_per_shard` and `cloud_storage_max_materialized_segments_per_shard` depends on `topic_partitions_per_shard` which has relatively high default value (7000). This will allow 7000 readers and 14000 materialized segments to be created during the test.

The random tests are creating only 1000 segments so we will never hit the code path that starts clean up because certain number of segments are materialized. This commit lowers these parameters for randomized tests.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

* none