### PR TITLE
gha/lint: bump shfmt from 3.5.1 to 3.6.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Install shfmt
       env:
-        SHFMT_VER: 3.5.1
+        SHFMT_VER: 3.6.0
       run: |
         mkdir -v -p "$HOME/.local/bin"
         wget -O "$HOME/.local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/v${SHFMT_VER}/shfmt_v${SHFMT_VER}_linux_amd64"


### PR DESCRIPTION
Bump to latest release [v3.6.0](https://github.com/mvdan/sh/releases/tag/v3.6.0). Brings in some `shfmt` bug fixes. Fortunately, no formatting changes needed as a result of this bump.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none