### PR TITLE
cloud_storage: Limit number of materialized segments

### DIFF
--- a/src/v/cloud_storage/materialized_segments.h
+++ b/src/v/cloud_storage/materialized_segments.h
@@ -70,6 +70,8 @@ private:
     simple_time_jitter<ss::lowres_clock> _stm_jitter;
 
     config::binding<uint32_t> _max_partitions_per_shard;
+    config::binding<uint64_t> _log_segment_size;
+    const size_t _cache_size;
     config::binding<std::optional<uint32_t>> _max_readers_per_shard;
     config::binding<std::optional<uint32_t>> _max_segments_per_shard;
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1195,7 +1195,8 @@ configuration::configuration()
       *this,
       "cloud_storage_max_materialized_segments_per_shard",
       "Maximum concurrent readers of remote data per CPU core.  If unset, "
-      "value of `topic_partitions_per_shard` multiplied by 2 is used.",
+      "value of `cloud_storage_cache_size` divided by the 'log_segment_size' "
+      "is used.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
   , superusers(


### PR DESCRIPTION
Prevoiously, number of materialized segments in the 'remote_partition' was limited by the 'topic_partitions_per_shard' value. The limit is calculated as 'topic_partitions_per_shard' * 2. The default value for 'topic_partitions_per_shard' is 7000 which gives us 14K materialized segments per shard. This is way too high. The idle time for materialized segment is 60s which is enough time to materialize a lot of segments if they're cached and not too big.

The 'remote_segment' instance is relatively heavyweight. It contains materialized segment index which could be relatively large (several kilobytes). If we have a lot of cached small segments in cache the client could materialize very large number of segments consuming a lot of memory.

This commit changes the default to 'cache-size/segment-size' value. E.g. if the cache size is 10GiB and segment size is 512MiB we will be able to materialize 20 segments.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

* none