### PR TITLE
rpk: set destination directory in rpk debug bundle

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle.go
@@ -82,10 +82,13 @@ func newBundleCommand(fs afero.Fs) *cobra.Command {
 	}
 	command.Flags().StringVar(
 		&adminURL,
-		"admin-url",
+		config.FlagAdminHosts2,
 		"",
-		"The address to the broker's admin API. Defaults to the one in the config file",
+		"Comma-separated list of admin API addresses (<IP>:<port>)",
 	)
+	command.Flags().StringVar(&adminURL, "admin-url", "", "")
+	command.Flags().MarkDeprecated("admin-url", "use --"+config.FlagAdminHosts2)
+
 	command.Flags().DurationVar(
 		&timeout,
 		"timeout",

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_all.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_all.go
@@ -32,5 +32,9 @@ func executeBundle(
 	int,
 	time.Duration,
 ) error {
-	return errors.New("rpk debug bundle is unsupported on your operating system")
+	return errors.New("rpk debug bundle is not supported on your operating system")
+}
+
+func determineFilepath(fs afero.Fs, path string, isFlag bool) (finalPath string, err error) {
+	return "", errors.New("rpk debug bundle is not supported on your operating system")
 }

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
@@ -56,6 +56,7 @@ func executeBundle(
 	logsLimitBytes int,
 	timeout time.Duration,
 ) error {
+	fmt.Println("Creating bundle file...")
 	mode := os.FileMode(0o755)
 	timestamp := time.Now().Unix()
 	filename := fmt.Sprintf("%d-bundle.zip", timestamp)

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
@@ -55,13 +55,12 @@ func executeBundle(
 	logsSince, logsUntil string,
 	logsLimitBytes int,
 	timeout time.Duration,
+	filepath string,
 ) error {
 	fmt.Println("Creating bundle file...")
 	mode := os.FileMode(0o755)
-	timestamp := time.Now().Unix()
-	filename := fmt.Sprintf("%d-bundle.zip", timestamp)
 	f, err := fs.OpenFile(
-		filename,
+		filepath,
 		os.O_CREATE|os.O_WRONLY,
 		mode,
 	)
@@ -115,7 +114,7 @@ func executeBundle(
 		log.Info(errs.Error())
 	}
 
-	log.Infof("Debug bundle saved to '%s'", filename)
+	log.Infof("Debug bundle saved to '%s'", filepath)
 	return nil
 }
 

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_test.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_test.go
@@ -82,7 +82,7 @@ func TestWalkDirMissingRoot(t *testing.T) {
 	require.Contains(t, files[root].Error, "/etc/its_highly_unlikely_that_a_dir_named_like_this_exists_anywhere")
 }
 
-func TestProcessFilepath(t *testing.T) {
+func TestDetermineFilepath(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		filepath string
@@ -90,7 +90,7 @@ func TestProcessFilepath(t *testing.T) {
 		expErr   bool
 	}{
 		{"empty filepath", "", "-bundle.zip", false},
-		{"correct filepath", "/some/dir/customDebugName.zip", "/some/dir/customDebugName.zip", false},
+		{"correct filepath", "/tmp/customDebugName.zip", "/tmp/customDebugName.zip", false},
 		{"filepath with no extension", "/tmp/file", "/tmp/file.zip", false},
 		{"filepath is a directory", "/tmp", "", true},
 		{"unsupported extension", "customDebugName.tar.gz", "", true},
@@ -101,7 +101,7 @@ func TestProcessFilepath(t *testing.T) {
 			err := fs.Mkdir("/tmp", 0o755)
 			require.NoError(t, err)
 
-			filepath, err := processFilepath(fs, test.filepath)
+			filepath, err := determineFilepath(fs, test.filepath, false)
 			if test.expErr {
 				require.Error(t, err)
 				return

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -32,11 +32,15 @@ class RpkRemoteTool:
 
         return self._run_config(cmd, path=path, timeout=timeout)
 
-    def debug_bundle(self, working_dir):
+    def debug_bundle(self, output_file):
         # Run the bundle command.  It outputs into pwd, so switch to working dir first
-        return self._execute(
-            ["cd", working_dir, ";",
-             self._rpk_binary(), "debug", "bundle"])
+        return self._execute([
+            self._rpk_binary(),
+            'debug',
+            'bundle',
+            "--output",
+            output_file,
+        ])
 
     def cluster_config_force_reset(self, property_name):
         return self._execute([

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -59,10 +59,11 @@ class RpkClusterTest(RedpandaTest):
         # commands are run on redpanda nodes.
 
         working_dir = "/tmp"
+        file_path = os.path.join(working_dir, "bundle.zip")
         node = self.redpanda.nodes[0]
 
         rpk_remote = RpkRemoteTool(self.redpanda, node)
-        output = rpk_remote.debug_bundle(working_dir)
+        output = rpk_remote.debug_bundle(file_path)
         lines = output.split("\n")
 
         # On error, rpk bundle returns 0 but writes error description to stdout
@@ -98,12 +99,11 @@ class RpkClusterTest(RedpandaTest):
                 filtered_errors.append(l)
 
         assert not filtered_errors
-        assert output_file is not None
+        assert output_file == file_path
 
-        output_path = os.path.join(working_dir, output_file)
-        node.account.copy_from(output_path, working_dir)
+        node.account.copy_from(output_file, working_dir)
 
-        zf = zipfile.ZipFile(output_path)
+        zf = zipfile.ZipFile(output_file)
         files = zf.namelist()
         assert 'redpanda.yaml' in files
         assert 'redpanda.log' in files


### PR DESCRIPTION
The first step towards enabling debug bundle in our k8s deployments.

This PR introduces:
- `--output` flag that let you pick where you want to write the debug file
- Defaulting to $HOME if the user doesn't have permission to write in the directory

Fixes #7847 
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  ### Improvements

  * `rpk debug bundle` now have a `--output` flag that let you select the pathname where the debug file will be written.
  * `rpk debug bundle` will default to write the debug file in $HOME if the user doesn't have write permissions (only when --output flag is not set).
