### PR TITLE
net: eliminate indirection through `net::server:resources` type

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -236,7 +236,7 @@ ss::future<session_resources> connection_context::throttle_request(
                   .tracker = std::move(tracker),
                 };
                 if (track) {
-                    r.method_latency = _rs.hist().auto_measure();
+                    r.method_latency = _server.hist().auto_measure();
                 }
                 return r;
             });

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -353,7 +353,7 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                      */
                     ssx::background
                       = ssx::spawn_with_gate_then(
-                          _rs.conn_gate(),
+                          _server.conn_gate(),
                           [this,
                            f = std::move(f),
                            sres = std::move(sres),

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -260,8 +260,8 @@ connection_context::reserve_request_units(api_key key, size_t size) {
           mem_estimate,
           handler ? (*handler)->name() : "<bad key>"));
     }
-    auto fut = ss::get_units(_rs.memory(), mem_estimate);
-    if (_rs.memory().waiters()) {
+    auto fut = ss::get_units(_server.memory(), mem_estimate);
+    if (_server.memory().waiters()) {
         _rs.probe().waiting_for_available_memory();
     }
     return fut;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -86,16 +86,16 @@ class connection_context final
 public:
     connection_context(
       server& s,
-      net::server::resources&& r,
+      ss::lw_shared_ptr<net::connection> conn,
       std::optional<security::sasl_server> sasl,
       bool enable_authorizer,
       std::optional<security::tls::mtls_state> mtls_state,
       config::binding<uint32_t> max_request_size) noexcept
       : _server(s)
-      , _rs(std::move(r))
+      , conn(conn)
       , _sasl(std::move(sasl))
       // tests may build a context without a live connection
-      , _client_addr(_rs.conn ? _rs.conn->addr.addr() : ss::net::inet_address{})
+      , _client_addr(conn ? conn->addr.addr() : ss::net::inet_address{})
       , _enable_authorizer(enable_authorizer)
       , _authlog(_client_addr, client_port())
       , _mtls_state(std::move(mtls_state))
@@ -108,7 +108,7 @@ public:
     connection_context& operator=(connection_context&&) = delete;
 
     server& server() { return _server; }
-    const ss::sstring& listener() const { return _rs.conn->name(); }
+    const ss::sstring& listener() const { return conn->name(); }
     std::optional<security::sasl_server>& sasl() { return _sasl; }
 
     template<typename T>
@@ -191,7 +191,7 @@ public:
     bool is_finished_parsing() const;
     ss::net::inet_address client_host() const { return _client_addr; }
     uint16_t client_port() const {
-        return _rs.conn ? _rs.conn->addr.port() : 0;
+        return conn ? conn->addr.port() : 0;
     }
 
 private:
@@ -293,7 +293,7 @@ private:
     };
 
     class server& _server;
-    net::server::resources _rs;
+    ss::lw_shared_ptr<net::connection> conn;
     sequence_id _next_response;
     sequence_id _seq_idx;
     map_t _responses;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -190,9 +190,7 @@ public:
     ss::future<> process_one_request();
     bool is_finished_parsing() const;
     ss::net::inet_address client_host() const { return _client_addr; }
-    uint16_t client_port() const {
-        return conn ? conn->addr.port() : 0;
-    }
+    uint16_t client_port() const { return conn ? conn->addr.port() : 0; }
 
 private:
     // Reserve units from memory from the memory semaphore in proportion

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -86,7 +86,7 @@ public:
 
     request_reader& reader() { return _reader; }
 
-    latency_probe& probe() { return _conn->server().probe(); }
+    latency_probe& probe() { return _conn->server().latency_probe(); }
 
     const cluster::metadata_cache& metadata_cache() const {
         return _conn->server().metadata_cache();

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -137,7 +137,7 @@ public:
         return _fetch_metadata_cache;
     }
 
-    latency_probe& probe() { return _probe; }
+    latency_probe& latency_probe() { return _probe; }
 
 private:
     ss::smp_service_group _smp_group;
@@ -164,7 +164,7 @@ private:
     kafka::fetch_metadata_cache _fetch_metadata_cache;
     security::tls::principal_mapper _mtls_principal_mapper;
 
-    latency_probe _probe;
+    class latency_probe _probe;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -65,7 +65,7 @@ public:
     std::string_view name() const final { return "kafka rpc protocol"; }
     // the lifetime of all references here are guaranteed to live
     // until the end of the server (container/parent)
-    ss::future<> apply(net::server::resources) final;
+    ss::future<> apply(ss::lw_shared_ptr<net::connection>) final;
 
     ss::smp_service_group smp_group() const { return _smp_group; }
     cluster::topics_frontend& topics_frontend() {

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -135,8 +135,8 @@ static inline void print_exceptional_future(
     }
 }
 
-ss::future<>
-server::apply_proto(ss::lw_shared_ptr<net::connection> conn, conn_quota::units cq_units) {
+ss::future<> server::apply_proto(
+  ss::lw_shared_ptr<net::connection> conn, conn_quota::units cq_units) {
     return apply(conn)
       .then_wrapped(
         [this, conn, cq_units = std::move(cq_units)](ss::future<> f) {

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -109,8 +109,6 @@ public:
 
         server_probe& probe() { return _s->_probe; }
         ssx::semaphore& memory() { return _s->_memory; }
-        ss::abort_source& abort_source() { return _s->_as; }
-        bool abort_requested() const { return _s->_as.abort_requested(); }
 
     private:
         server* _s;
@@ -150,6 +148,8 @@ public:
 
     ss::gate& conn_gate() { return _conn_gate; }
     hdr_hist& hist() { return _hist; }
+    ss::abort_source& abort_source() { return _as; }
+    bool abort_requested() const { return _as.abort_requested(); }
 
 private:
     struct listener {

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -100,17 +100,11 @@ public:
     // always guaranteed non-null
     class resources final {
     public:
-        resources(server* s, ss::lw_shared_ptr<net::connection> c)
-          : conn(std::move(c))
-          , _s(s) {}
+        resources(server*, ss::lw_shared_ptr<net::connection> c)
+          : conn(std::move(c)) {}
 
         // NOLINTNEXTLINE
         ss::lw_shared_ptr<net::connection> conn;
-
-        server_probe& probe() { return _s->_probe; }
-
-    private:
-        server* _s;
     };
 
     explicit server(server_configuration);
@@ -145,6 +139,7 @@ public:
     virtual std::string_view name() const = 0;
     virtual ss::future<> apply(resources) = 0;
 
+    server_probe& probe() { return _probe; }
     ssx::semaphore& memory() { return _memory; }
     ss::gate& conn_gate() { return _conn_gate; }
     hdr_hist& hist() { return _hist; }

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -108,7 +108,6 @@ public:
         ss::lw_shared_ptr<net::connection> conn;
 
         server_probe& probe() { return _s->_probe; }
-        ssx::semaphore& memory() { return _s->_memory; }
 
     private:
         server* _s;
@@ -146,6 +145,7 @@ public:
     virtual std::string_view name() const = 0;
     virtual ss::future<> apply(resources) = 0;
 
+    ssx::semaphore& memory() { return _memory; }
     ss::gate& conn_gate() { return _conn_gate; }
     hdr_hist& hist() { return _hist; }
     ss::abort_source& abort_source() { return _as; }

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -109,7 +109,6 @@ public:
 
         server_probe& probe() { return _s->_probe; }
         ssx::semaphore& memory() { return _s->_memory; }
-        hdr_hist& hist() { return _s->_hist; }
         ss::abort_source& abort_source() { return _s->_as; }
         bool abort_requested() const { return _s->_as.abort_requested(); }
 
@@ -150,6 +149,7 @@ public:
     virtual ss::future<> apply(resources) = 0;
 
     ss::gate& conn_gate() { return _conn_gate; }
+    hdr_hist& hist() { return _hist; }
 
 private:
     struct listener {

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -110,7 +110,6 @@ public:
         server_probe& probe() { return _s->_probe; }
         ssx::semaphore& memory() { return _s->_memory; }
         hdr_hist& hist() { return _s->_hist; }
-        ss::gate& conn_gate() { return _s->_conn_gate; }
         ss::abort_source& abort_source() { return _s->_as; }
         bool abort_requested() const { return _s->_as.abort_requested(); }
 
@@ -149,6 +148,8 @@ public:
 
     virtual std::string_view name() const = 0;
     virtual ss::future<> apply(resources) = 0;
+
+    ss::gate& conn_gate() { return _conn_gate; }
 
 private:
     struct listener {

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -149,7 +149,8 @@ private:
     ss::future<> accept(listener&);
     ss::future<ss::stop_iteration>
       accept_finish(ss::sstring, ss::future<ss::accept_result>);
-    ss::future<> apply_proto(ss::lw_shared_ptr<net::connection>, conn_quota::units);
+    ss::future<>
+      apply_proto(ss::lw_shared_ptr<net::connection>, conn_quota::units);
     void setup_metrics();
     void setup_public_metrics();
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -568,7 +568,7 @@ public:
         security::sasl_server sasl(security::sasl_server::sasl_state::complete);
         auto conn = ss::make_lw_shared<kafka::connection_context>(
           *proto,
-          net::server::resources(nullptr, nullptr),
+          nullptr,
           std::move(sasl),
           false,
           std::nullopt,

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -52,7 +52,7 @@ struct server_context_impl final : streaming_context {
 
 ss::future<> rpc_server::apply(net::server::resources rs) {
     return ss::do_until(
-      [rs] { return rs.conn->input().eof() || rs.abort_requested(); },
+      [this, rs] { return rs.conn->input().eof() || abort_requested(); },
       [this, rs]() mutable {
           return parse_header(rs.conn->input())
             .then([this, rs](std::optional<header> h) mutable {

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -27,7 +27,8 @@ namespace rpc {
 static constexpr size_t reply_min_compression_bytes = 1024;
 
 struct server_context_impl final : streaming_context {
-    server_context_impl(net::server& server, ss::lw_shared_ptr<net::connection> conn, header h)
+    server_context_impl(
+      net::server& server, ss::lw_shared_ptr<net::connection> conn, header h)
       : server(server)
       , conn(conn)
       , hdr(h) {
@@ -107,8 +108,8 @@ ss::future<> rpc_server::send_reply_skip_payload(
     co_await send_reply(std::move(ctx), std::move(buf));
 }
 
-ss::future<>
-rpc_server::dispatch_method_once(header h, ss::lw_shared_ptr<net::connection> conn) {
+ss::future<> rpc_server::dispatch_method_once(
+  header h, ss::lw_shared_ptr<net::connection> conn) {
     const auto method_id = h.meta;
     auto ctx = ss::make_lw_shared<server_context_impl>(*this, conn, h);
     probe().add_bytes_received(size_of_rpc_header + h.payload_size);

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -165,7 +165,7 @@ rpc_server::dispatch_method_once(header h, net::server::resources rs) {
               method* m = it->get()->method_from_id(method_id);
 
               return m->handle(ctx->res.conn->input(), *ctx)
-                .then_wrapped([this, ctx, m, l = ctx->res.hist().auto_measure(), rs](
+                .then_wrapped([this, ctx, m, l = hist().auto_measure(), rs](
                                 ss::future<netbuf> fut) mutable {
                     bool error = true;
                     netbuf reply_buf;

--- a/src/v/rpc/rpc_server.h
+++ b/src/v/rpc/rpc_server.h
@@ -59,7 +59,8 @@ public:
     }
 
 private:
-    ss::future<> dispatch_method_once(header, ss::lw_shared_ptr<net::connection>);
+    ss::future<>
+      dispatch_method_once(header, ss::lw_shared_ptr<net::connection>);
     ss::future<> send_reply(ss::lw_shared_ptr<server_context_impl>, netbuf);
     ss::future<>
       send_reply_skip_payload(ss::lw_shared_ptr<server_context_impl>, netbuf);

--- a/src/v/rpc/rpc_server.h
+++ b/src/v/rpc/rpc_server.h
@@ -16,6 +16,7 @@
 namespace rpc {
 
 struct service;
+struct server_context_impl;
 
 // Wrapper around net::server that serves the internal RPC protocol. It allows
 // new services to be registered while the server is running.
@@ -59,6 +60,9 @@ public:
 
 private:
     ss::future<> dispatch_method_once(header, net::server::resources);
+    ss::future<> send_reply(ss::lw_shared_ptr<server_context_impl>, netbuf);
+    ss::future<>
+      send_reply_skip_payload(ss::lw_shared_ptr<server_context_impl>, netbuf);
     std::vector<std::unique_ptr<service>> _services;
 };
 

--- a/src/v/rpc/rpc_server.h
+++ b/src/v/rpc/rpc_server.h
@@ -51,7 +51,7 @@ public:
         return "vectorized internal rpc protocol";
     }
 
-    ss::future<> apply(net::server::resources rs) final;
+    ss::future<> apply(ss::lw_shared_ptr<net::connection>) final;
 
     template<std::derived_from<service> T, typename... Args>
     void register_service(Args&&... args) {
@@ -59,7 +59,7 @@ public:
     }
 
 private:
-    ss::future<> dispatch_method_once(header, net::server::resources);
+    ss::future<> dispatch_method_once(header, ss::lw_shared_ptr<net::connection>);
     ss::future<> send_reply(ss::lw_shared_ptr<server_context_impl>, netbuf);
     ss::future<>
       send_reply_skip_payload(ss::lw_shared_ptr<server_context_impl>, netbuf);

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -739,7 +739,7 @@ public:
 
     ss::future<> apply(net::server::resources rs) final {
         return ss::do_until(
-          [rs] { return rs.conn->input().eof() || rs.abort_requested(); },
+          [this, rs] { return rs.conn->input().eof() || abort_requested(); },
           [rs]() mutable {
               return ss::make_exception_future<>(
                 erroneous_protocol_exception());

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -737,10 +737,10 @@ public:
 
     std::string_view name() const final { return "redpanda erraneous proto"; };
 
-    ss::future<> apply(net::server::resources rs) final {
+    ss::future<> apply(ss::lw_shared_ptr<net::connection> conn) final {
         return ss::do_until(
-          [this, rs] { return rs.conn->input().eof() || abort_requested(); },
-          [rs]() mutable {
+          [this, conn] { return conn->input().eof() || abort_requested(); },
+          [] {
               return ss::make_exception_future<>(
                 erroneous_protocol_exception());
           });


### PR DESCRIPTION
The structure `net::server:resources` was a container for a `shared_ptr<net::connection>` and a reference to the underlying server and a selection of accessors for server resources.

Where https://github.com/redpanda-data/redpanda/pull/7860 flattened the `net::protocol` into `net::server`, this change flattens connection handling. For example, in many cases accesses to the server through the `net::server:resources` object is made in the context the `net::server` subclass, and these resources can be accessed directly rather than requiring the extra hop through the resources object.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.
-->
  * none
