### PR TITLE
lsan: ignore memory leak

### DIFF
--- a/lsan_suppressions.txt
+++ b/lsan_suppressions.txt
@@ -1,0 +1,1 @@
+leak:seastar::net::conntrack::handle::~handle

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -279,6 +279,15 @@ class TestRunner():
             env["ASAN_SYMBOLIZER_PATH"] = llvm_symbolizer
         logger.info(f"Using llvm-symbolizer: {llvm_symbolizer}")
 
+        # setup lsan suppressions
+        src_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                               "..")
+        lsan_suppressions = os.path.join(src_dir, "lsan_suppressions.txt")
+        assert os.path.isfile(
+            lsan_suppressions
+        ), f"cannot find lsan suppressions at {lsan_suppressions}"
+        env["LSAN_OPTIONS"] = f"suppressions={lsan_suppressions}"
+
         # We only capture stderr because that's where backtraces go
         p = subprocess.Popen(cmd,
                              env=env,


### PR DESCRIPTION
A memory leak pops up in our CI from time to time
(https://github.com/redpanda-data/redpanda/issues/3338). It is caused by
a very narrow race within Seastar when incoming connections arrive while
a socket server is being shutdown.

I've posted a "fix" for this in upstream Seastar (link below) which is
effectively rejected because it doesn't really fix the leak, but merely
cleans up on exit to make LSAN happy. AFAICT this leak can only happen
when a socket server is being shut down, and in Redpanda, this only
happens when Redpanda is shutting down. So in this case it would seem to be harmless,
but annoying because it will occassionally fail our CI.

This PR adds an LSAN suppressions file allows us to instruct LSAN to ignore
this particular leak when it occassionally does trigger.

An alternative to this PR is to merge the "fix" into our Seastar fork. Presumably this
leak will be fixed at some point and we can remove the suppression.

Fixes: https://github.com/redpanda-data/redpanda/issues/3338

See https://github.com/scylladb/seastar/pull/1265 for more discussion
and a link to an issue with a reproducer.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.
-->
  * none
