### PR TITLE
archival: change start offset related warning in segment collector to debug

### DIFF
--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -44,7 +44,7 @@ void segment_collector::collect_segments() {
 
     if (_begin_inclusive >= _manifest.get_last_offset()) {
         vlog(
-          archival_log.warn,
+          archival_log.debug,
           "Start offset {} is ahead of manifest last offset {} for ntp {}",
           _begin_inclusive,
           _manifest.get_last_offset(),


### PR DESCRIPTION
When start offset is ahead of manifest a warning is issued. However this is a fairly common occurrence in practice and does not warrant a warning appearing in logs. The log entry is demoted to debug.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

  * none

## Release Notes

  * none
