### PR TITLE
cloud_storage: Manifest compression

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -24,6 +24,7 @@ v_cc_library(
     recovery_request.cc
     topic_recovery_service.cc
     recovery_utils.cc
+    segment_meta_cstore.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -406,13 +406,14 @@ partition_manifest::const_iterator partition_manifest::end() const {
     return _segments.end();
 }
 
-partition_manifest::const_reverse_iterator partition_manifest::rbegin() const {
-    return _segments.rbegin();
+std::optional<segment_meta> partition_manifest::last_segment() const {
+    if (_segments.empty()) {
+        return std::nullopt;
+    }
+    return _segments.rbegin()->second;
 }
 
-partition_manifest::const_reverse_iterator partition_manifest::rend() const {
-    return _segments.rend();
-}
+bool partition_manifest::empty() const { return _segments.size() == 0; }
 
 size_t partition_manifest::size() const { return _segments.size(); }
 

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -212,9 +212,9 @@ public:
     /// Return iterator to the begining(end) of the segments list
     const_iterator begin() const;
     const_iterator end() const;
-    const_reverse_iterator rbegin() const;
-    const_reverse_iterator rend() const;
+    std::optional<segment_meta> last_segment() const;
     size_t size() const;
+    bool empty() const;
 
     // Return the tracked amount of memory associated with the segments in this
     // manifest, or 0 if the memory is not being tracked.

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -534,8 +534,13 @@ remote_partition::get_term_last_offset(model::term_id term) const {
         }
     }
     // if last segment term is equal to the one we look for return it
-    if (_manifest.rbegin()->second.segment_term == term) {
-        return _manifest.rbegin()->second.committed_kafka_offset();
+    auto last = _manifest.last_segment();
+    vassert(
+      last.has_value(),
+      "The manifest for {} is not expected to be empty",
+      _manifest.get_ntp());
+    if (last->segment_term == term) {
+        return last->committed_kafka_offset();
     }
 
     return std::nullopt;

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -307,7 +307,8 @@ public:
     auto at_with_hint(
       const col_t& c, uint32_t ix, const std::optional<hint_vec_t>& h) const {
         vassert(h.has_value(), "Invalid access at index {}", ix);
-        return c.at(ix, std::get<static_cast<size_t>(col_index)>(h.value()));
+        return c.at_index(
+          ix, std::get<static_cast<size_t>(col_index)>(h.value()));
     }
 
     /// Materialize 'segment_meta' struct from column iterator
@@ -322,18 +323,18 @@ public:
         auto hint_it = _hints.lower_bound(bo);
         if (hint_it == _hints.end() || hint_it->second == std::nullopt) {
             return iterators_t(
-              _is_compacted.at(ix),
-              _size_bytes.at(ix),
+              _is_compacted.at_index(ix),
+              _size_bytes.at_index(ix),
               std::move(base_offset_iter),
-              _committed_offset.at(ix),
-              _base_timestamp.at(ix),
-              _max_timestamp.at(ix),
-              _delta_offset.at(ix),
-              _ntp_revision.at(ix),
-              _archiver_term.at(ix),
-              _segment_term.at(ix),
-              _delta_offset_end.at(ix),
-              _sname_format.at(ix));
+              _committed_offset.at_index(ix),
+              _base_timestamp.at_index(ix),
+              _max_timestamp.at_index(ix),
+              _delta_offset.at_index(ix),
+              _ntp_revision.at_index(ix),
+              _archiver_term.at_index(ix),
+              _segment_term.at_index(ix),
+              _delta_offset_end.at_index(ix),
+              _sname_format.at_index(ix));
         }
 
         auto hint = hint_it->second;
@@ -376,8 +377,8 @@ public:
     }
 
     /// Search by index
-    auto at(size_t ix) const {
-        auto it = _base_offset.at(ix);
+    auto at_index(size_t ix) const {
+        auto it = _base_offset.at_index(ix);
         return materialize(std::move(it));
     }
 
@@ -553,9 +554,9 @@ public:
     }
 
     std::unique_ptr<segment_meta_materializing_iterator::impl>
-    at(size_t ix) const {
+    at_index(size_t ix) const {
         return std::make_unique<segment_meta_materializing_iterator::impl>(
-          _col.at(ix));
+          _col.at_index(ix));
     }
 
 private:
@@ -612,8 +613,9 @@ void segment_meta_cstore::prefix_truncate(model::offset new_start_offset) {
     return _impl->prefix_truncate(new_start_offset);
 }
 
-segment_meta_cstore::const_iterator segment_meta_cstore::at(size_t ix) const {
-    return const_iterator(_impl->at(ix));
+segment_meta_cstore::const_iterator
+segment_meta_cstore::at_index(size_t ix) const {
+    return const_iterator(_impl->at_index(ix));
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -10,49 +10,554 @@
 
 #include "cloud_storage/segment_meta_cstore.h"
 
+#include "cloud_storage/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timestamp.h"
+#include "utils/delta_for.h"
+
+#include <bitset>
+#include <functional>
+#include <tuple>
+
 namespace cloud_storage {
 
-class segment_meta_cstore::impl {
-public:
-private:
+using int64_delta_alg = details::delta_delta<int64_t>;
+using int64_xor_alg = details::delta_xor;
+// Column for monotonically increaseing data
+using counter_col_t = segment_meta_column<int64_t, int64_delta_alg>;
+// Column for varying data
+using gauge_col_t = segment_meta_column<int64_t, int64_xor_alg>;
+
+/// Samping rate of the indexer inside the column store, if
+/// sampling_rate == 1 every row is indexed, 2 - every secod row, etc
+/// The value 8 with max_frame_size set to 64 will give us 8 hints per
+/// frame (frame has 64 rows). There is no measureable difference between
+/// value 8 and smaller values.
+static constexpr uint32_t sampling_rate = 8;
+
+// Sampling rate shold be proportional to max_frame_size so we will
+// sample first row of every frame.
+static_assert(
+  gauge_col_t::max_frame_size % sampling_rate == 0, "Invalid sampling rate");
+
+enum class segment_meta_ix {
+    is_compacted,
+    size_bytes,
+    base_offset,
+    committed_offset,
+    base_timestamp,
+    max_timestamp,
+    delta_offset,
+    ntp_revision,
+    archiver_term,
+    segment_term,
+    delta_offset_end,
+    sname_format,
 };
 
-segment_meta_cstore::const_iterator segment_meta_cstore::begin() {
-    throw "not implemented";
+namespace details {
+template<class T>
+void commit_one(T&& tx) {
+    if (tx.has_value()) {
+        tx->commit();
+    }
 }
 
-segment_meta_cstore::const_iterator segment_meta_cstore::end() {
-    throw "not implemented";
+template<class... Args>
+void commit_all_impl(Args&&... args) {
+    (commit_one(args), ...);
 }
 
-std::optional<segment_meta> segment_meta_cstore::last_segment() {
-    throw "not implemented";
+template<class... Args>
+void commit_all(std::tuple<Args...>&& tup) {
+    std::apply(commit_all_impl<Args...>, std::move(tup));
+}
+
+template<class... Args>
+void maybe_increment_impl(Args&... args) {
+    (++args, ...);
+}
+
+// Increment tuple of iterators
+template<class... Args>
+void increment_all(std::tuple<Args...>& tup) {
+    std::apply(maybe_increment_impl<Args...>, tup);
+}
+
+/// The iters tuple is a tuple of std::optional<iterator-type>. The method
+/// checks if the optoinal referenced by index is not none and dereferences.
+template<segment_meta_ix ix, class T, class... Args>
+void value_or(const std::tuple<Args...>& iters, T& res) {
+    const auto& it = std::get<static_cast<size_t>(ix)>(iters);
+    res = T(*it);
+}
+
+} // namespace details
+
+/// The aggregated columnar storage for segment_meta.
+/// The data structure contains several columns, one per
+/// field in the segment_meta struct. All columns have the same
+/// number of elements at any point in time.
+class column_store {
+    using hint_t = deltafor_stream_pos_t<int64_t>;
+    using hint_vec_t = std::tuple<
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t,
+      hint_t>;
+
+    static constexpr size_t hint_array_size = sizeof(hint_vec_t); // (192 bytes)
+
+    // The data type is used to store a map of 'hint' objects which
+    // are stream pos objects. We're optimizing memory usage by not
+    // storing index of the element as part of the hint_array_t because
+    // all elements of the hint_array_t has the same index and it's the
+    // same as the key.
+    // The nullopt values act as a dividers between different frames.
+    // Without them it will be possible to fetch hint that corresponds
+    // to previoius frame using lower_bound method. This will lead to
+    // assertion. To prevent this we need to insert a nullopt when the
+    // frame starts.
+
+    using hint_map_t = absl::
+      btree_map<uint32_t, std::optional<hint_vec_t>, std::greater<uint32_t>>;
+
+public:
+    using iterators_t = std::tuple<
+      gauge_col_t::const_iterator,
+      gauge_col_t::const_iterator,
+      counter_col_t::const_iterator,
+      gauge_col_t::const_iterator,
+      gauge_col_t::const_iterator,
+      gauge_col_t::const_iterator,
+      counter_col_t::const_iterator,
+      counter_col_t::const_iterator,
+      gauge_col_t::const_iterator,
+      counter_col_t::const_iterator,
+      counter_col_t::const_iterator,
+      counter_col_t::const_iterator>;
+
+    column_store()
+      : _is_compacted(int64_xor_alg())
+      , _size_bytes(int64_xor_alg())
+      , _base_offset(int64_delta_alg(0))
+      , _committed_offset(int64_xor_alg())
+      , _base_timestamp(int64_xor_alg())
+      , _max_timestamp(int64_xor_alg())
+      , _delta_offset(int64_delta_alg(0))
+      , _ntp_revision(int64_delta_alg(0))
+      , _archiver_term(int64_xor_alg())
+      , _segment_term(int64_delta_alg(0))
+      , _delta_offset_end(int64_delta_alg(0))
+      , _sname_format(int64_delta_alg(0)) {}
+
+    /// Add element to the store. The operation is transactional.
+    void append(const segment_meta& meta) {
+        auto ix = _base_offset.size();
+        // C++ guarantees that all parameters of the function are
+        // computed before the function is called. Here, every 'append_tx'
+        // call returns a transaction that has to be committed. The 'append_tx'
+        // is a transactional append operation and it's 'commit' method is
+        // guaranteed to not throw exceptions. Because of that all 'append_tx'
+        // calls will be completed before the 'commit_all' function will be
+        // called. The 'commit_all' calls 'commit' method on all transactions,
+        // committing them. If any 'append_tx' call will throw no column will be
+        // updated and all transactions will be aborted. Because of that the
+        // update is all or nothing even in presence of bad_alloc exceptions.
+        details::commit_all(std::make_tuple(
+          _is_compacted.append_tx(static_cast<int64_t>(meta.is_compacted)),
+          _size_bytes.append_tx(static_cast<int64_t>(meta.size_bytes)),
+          _base_offset.append_tx(meta.base_offset()),
+          _committed_offset.append_tx(meta.committed_offset()),
+          _base_timestamp.append_tx(meta.base_timestamp.value()),
+          _max_timestamp.append_tx(meta.max_timestamp.value()),
+          _delta_offset.append_tx(meta.delta_offset()),
+          _ntp_revision.append_tx(meta.ntp_revision()),
+          _archiver_term.append_tx(meta.archiver_term()),
+          _segment_term.append_tx(meta.segment_term()),
+          _delta_offset_end.append_tx(meta.delta_offset_end()),
+          _sname_format.append_tx(static_cast<int64_t>(meta.sname_format))));
+
+        if (
+          ix
+            % static_cast<uint32_t>(::details::FOR_buffer_depth * sampling_rate)
+          == 0) {
+            // At the begining of every row we need to collect
+            // a set of hints to speed up the subsequent random
+            // reads.
+            auto base_offset_hint = _base_offset.get_current_stream_pos();
+            // Invariant: it's guaranteed that if we will get nullopt from
+            // one column we will get nullopt from other columns. The opposite
+            // is also true.
+            if (base_offset_hint.has_value()) {
+                auto tup = std::make_tuple(
+                  *_is_compacted.get_current_stream_pos(),
+                  *_size_bytes.get_current_stream_pos(),
+                  *base_offset_hint,
+                  *_committed_offset.get_current_stream_pos(),
+                  *_base_timestamp.get_current_stream_pos(),
+                  *_max_timestamp.get_current_stream_pos(),
+                  *_delta_offset.get_current_stream_pos(),
+                  *_ntp_revision.get_current_stream_pos(),
+                  *_archiver_term.get_current_stream_pos(),
+                  *_segment_term.get_current_stream_pos(),
+                  *_delta_offset_end.get_current_stream_pos(),
+                  *_sname_format.get_current_stream_pos());
+                _hints.insert(std::make_pair(ix, tup));
+            } else {
+                _hints.insert(std::make_pair(ix, std::nullopt));
+            }
+        }
+    }
+
+    static segment_meta dereference(const iterators_t& it) {
+        segment_meta meta = {};
+        details::value_or<segment_meta_ix::is_compacted>(it, meta.is_compacted);
+        details::value_or<segment_meta_ix::size_bytes>(it, meta.size_bytes);
+        details::value_or<segment_meta_ix::base_offset>(it, meta.base_offset);
+        details::value_or<segment_meta_ix::committed_offset>(
+          it, meta.committed_offset);
+        details::value_or<segment_meta_ix::base_timestamp>(
+          it, meta.base_timestamp);
+        details::value_or<segment_meta_ix::max_timestamp>(
+          it, meta.max_timestamp);
+        details::value_or<segment_meta_ix::delta_offset>(it, meta.delta_offset);
+        details::value_or<segment_meta_ix::ntp_revision>(it, meta.ntp_revision);
+        details::value_or<segment_meta_ix::archiver_term>(
+          it, meta.archiver_term);
+        details::value_or<segment_meta_ix::segment_term>(it, meta.segment_term);
+        details::value_or<segment_meta_ix::delta_offset_end>(
+          it, meta.delta_offset_end);
+        details::value_or<segment_meta_ix::sname_format>(it, meta.sname_format);
+        return meta;
+    }
+
+    /// Return last element in the sequence or nullopt
+    std::optional<segment_meta> last_segment() const {
+        if (_base_offset.size() == 0) {
+            return std::nullopt;
+        }
+        segment_meta meta = {
+          .is_compacted = static_cast<bool>(*_is_compacted.last_value()),
+          .size_bytes = static_cast<size_t>(*_size_bytes.last_value()),
+          .base_offset = model::offset(*_base_offset.last_value()),
+          .committed_offset = model::offset(*_committed_offset.last_value()),
+          .base_timestamp = model::timestamp(*_base_timestamp.last_value()),
+          .max_timestamp = model::timestamp(*_max_timestamp.last_value()),
+          .delta_offset = model::offset_delta(*_delta_offset.last_value()),
+          .ntp_revision = model::initial_revision_id(
+            *_ntp_revision.last_value()),
+          .archiver_term = model::term_id(*_archiver_term.last_value()),
+          .segment_term = model::term_id(*_segment_term.last_value()),
+          .delta_offset_end = model::offset_delta(
+            *_delta_offset_end.last_value()),
+          .sname_format = static_cast<segment_name_format>(
+            *_sname_format.last_value()),
+        };
+        return meta;
+    }
+
+    /// Return iterator to the end of the sequence
+    auto begin() const {
+        // Individual iterators can be accessed using
+        // segment_meta_ix values as tuple indexes.
+        return iterators_t(
+          _is_compacted.begin(),
+          _size_bytes.begin(),
+          _base_offset.begin(),
+          _committed_offset.begin(),
+          _base_timestamp.begin(),
+          _max_timestamp.begin(),
+          _delta_offset.begin(),
+          _ntp_revision.begin(),
+          _archiver_term.begin(),
+          _segment_term.begin(),
+          _delta_offset_end.begin(),
+          _sname_format.begin());
+    }
+
+    /// Return iterator to the first element after the end of the sequence
+    auto end() const {
+        return iterators_t(
+          _is_compacted.end(),
+          _size_bytes.end(),
+          _base_offset.end(),
+          _committed_offset.end(),
+          _base_timestamp.end(),
+          _max_timestamp.end(),
+          _delta_offset.end(),
+          _ntp_revision.end(),
+          _archiver_term.end(),
+          _segment_term.end(),
+          _delta_offset_end.end(),
+          _sname_format.end());
+    }
+
+    template<segment_meta_ix col_index, class col_t>
+    auto at_with_hint(
+      const col_t& c, uint32_t ix, const std::optional<hint_vec_t>& h) const {
+        vassert(h.has_value(), "Invalid access at index {}", ix);
+        return c.at(ix, std::get<static_cast<size_t>(col_index)>(h.value()));
+    }
+
+    /// Materialize 'segment_meta' struct from column iterator
+    ///
+    ///
+    auto materialize(counter_col_t::const_iterator base_offset_iter) const {
+        if (base_offset_iter == _base_offset.end()) {
+            return end();
+        }
+        uint32_t ix = base_offset_iter.index();
+        auto hint_it = _hints.lower_bound(ix);
+        if (hint_it == _hints.end() || hint_it->second == std::nullopt) {
+            return iterators_t(
+              _is_compacted.at(ix),
+              _size_bytes.at(ix),
+              std::move(base_offset_iter),
+              _committed_offset.at(ix),
+              _base_timestamp.at(ix),
+              _max_timestamp.at(ix),
+              _delta_offset.at(ix),
+              _ntp_revision.at(ix),
+              _archiver_term.at(ix),
+              _segment_term.at(ix),
+              _delta_offset_end.at(ix),
+              _sname_format.at(ix));
+        }
+
+        auto hint = hint_it->second;
+        return iterators_t(
+          at_with_hint<segment_meta_ix::is_compacted>(_is_compacted, ix, hint),
+          at_with_hint<segment_meta_ix::size_bytes>(_size_bytes, ix, hint),
+          std::move(base_offset_iter),
+          at_with_hint<segment_meta_ix::committed_offset>(
+            _committed_offset, ix, hint),
+          at_with_hint<segment_meta_ix::base_timestamp>(
+            _base_timestamp, ix, hint),
+          at_with_hint<segment_meta_ix::max_timestamp>(
+            _max_timestamp, ix, hint),
+          at_with_hint<segment_meta_ix::delta_offset>(_delta_offset, ix, hint),
+          at_with_hint<segment_meta_ix::ntp_revision>(_ntp_revision, ix, hint),
+          at_with_hint<segment_meta_ix::archiver_term>(
+            _archiver_term, ix, hint),
+          at_with_hint<segment_meta_ix::segment_term>(_segment_term, ix, hint),
+          at_with_hint<segment_meta_ix::delta_offset_end>(
+            _delta_offset_end, ix, hint),
+          at_with_hint<segment_meta_ix::sname_format>(_sname_format, ix, hint));
+    }
+
+    /// Search by base_offset
+    auto find(int64_t bo) const {
+        auto it = _base_offset.find(bo);
+        return materialize(std::move(it));
+    }
+
+    /// Search by base_offset
+    auto lower_bound(int64_t bo) const {
+        auto it = _base_offset.lower_bound(bo);
+        return materialize(std::move(it));
+    }
+
+    /// Search by base_offset
+    auto upper_bound(int64_t bo) const {
+        auto it = _base_offset.upper_bound(bo);
+        return materialize(std::move(it));
+    }
+
+    /// Return two values: inflated size (size without compression) followed
+    /// by the actual size that takes compression into account.
+    std::pair<size_t, size_t> inflated_actual_size() const {
+        auto inflated_size = _base_offset.size() * sizeof(segment_meta);
+        auto actual_size = _is_compacted.mem_use() + _size_bytes.mem_use()
+                           + _base_offset.mem_use()
+                           + _committed_offset.mem_use()
+                           + _base_timestamp.mem_use()
+                           + _max_timestamp.mem_use() + _delta_offset.mem_use()
+                           + _ntp_revision.mem_use() + _archiver_term.mem_use()
+                           + _segment_term.mem_use()
+                           + _delta_offset_end.mem_use()
+                           + _sname_format.mem_use();
+        auto index_size = static_cast<size_t>(
+          _hints.size() * sizeof(hint_map_t::value_type)
+          * 1.4); // The size of the _hints is an estimate based on absl docs
+        return std::make_pair(inflated_size, actual_size + index_size);
+    }
+
+    size_t size() const { return _base_offset.size(); }
+
+    bool contains(int64_t o) const {
+        auto it = _base_offset.find(o);
+        return it != _base_offset.end();
+    }
+
+    bool empty() const { return size() == 0; }
+
+private:
+    gauge_col_t _is_compacted;
+    gauge_col_t _size_bytes;
+    counter_col_t _base_offset;
+    gauge_col_t _committed_offset;
+    gauge_col_t _base_timestamp;
+    gauge_col_t _max_timestamp;
+    counter_col_t _delta_offset;
+    counter_col_t _ntp_revision;
+    /// The archiver term is not strictly monotonic in manifests
+    /// generated by old redpanda versions
+    gauge_col_t _archiver_term;
+    counter_col_t _segment_term;
+    counter_col_t _delta_offset_end;
+    counter_col_t _sname_format;
+
+    hint_map_t _hints;
+};
+
+/// Materializing iterator implementation
+class segment_meta_materializing_iterator::impl {
+public:
+    explicit impl(column_store::iterators_t iters)
+      : _iters(std::move(iters))
+      , _curr(std::nullopt) {}
+
+    const segment_meta& dereference() const {
+        if (!_curr.has_value()) {
+            _curr = column_store::dereference(_iters);
+        }
+        return _curr.value();
+    }
+
+    void increment() {
+        _curr = std::nullopt;
+        details::increment_all(_iters);
+    }
+
+    bool equal(const impl& other) const { return _iters == other._iters; }
+
+private:
+    column_store::iterators_t _iters;
+    mutable std::optional<segment_meta> _curr;
+};
+
+segment_meta_materializing_iterator::segment_meta_materializing_iterator(
+  std::unique_ptr<impl> i)
+  : _impl(std::move(i)) {}
+
+segment_meta_materializing_iterator::~segment_meta_materializing_iterator() {}
+
+const segment_meta& segment_meta_materializing_iterator::dereference() const {
+    return _impl->dereference();
+}
+
+void segment_meta_materializing_iterator::increment() { _impl->increment(); }
+
+bool segment_meta_materializing_iterator::equal(
+  const segment_meta_materializing_iterator& other) const {
+    return _impl->equal(*other._impl);
+}
+
+/// Column store implementation
+class segment_meta_cstore::impl {
+public:
+    void append(const segment_meta& meta) { _col.append(meta); }
+
+    std::unique_ptr<segment_meta_materializing_iterator::impl> begin() const {
+        return std::make_unique<segment_meta_materializing_iterator::impl>(
+          _col.begin());
+    }
+
+    std::unique_ptr<segment_meta_materializing_iterator::impl> end() const {
+        return std::make_unique<segment_meta_materializing_iterator::impl>(
+          _col.end());
+    }
+
+    std::unique_ptr<segment_meta_materializing_iterator::impl>
+    find(model::offset o) const {
+        return std::make_unique<segment_meta_materializing_iterator::impl>(
+          _col.find(o()));
+    }
+
+    std::unique_ptr<segment_meta_materializing_iterator::impl>
+    lower_bound(model::offset o) const {
+        return std::make_unique<segment_meta_materializing_iterator::impl>(
+          _col.lower_bound(o()));
+    }
+
+    std::unique_ptr<segment_meta_materializing_iterator::impl>
+    upper_bound(model::offset o) const {
+        return std::make_unique<segment_meta_materializing_iterator::impl>(
+          _col.upper_bound(o()));
+    }
+
+    std::optional<segment_meta> last_segment() const {
+        return _col.last_segment();
+    }
+
+    void insert(const segment_meta& m) { _col.append(m); }
+
+    auto inflated_actual_size() const { return _col.inflated_actual_size(); }
+
+    size_t size() const { return _col.size(); }
+
+    bool empty() const { return _col.empty(); }
+
+    bool contains(model::offset o) { return _col.contains(o()); }
+
+private:
+    column_store _col;
+};
+
+segment_meta_cstore::segment_meta_cstore()
+  : _impl(std::make_unique<impl>()) {}
+
+segment_meta_cstore::~segment_meta_cstore() {}
+
+segment_meta_cstore::const_iterator segment_meta_cstore::begin() const {
+    return const_iterator(_impl->begin());
+}
+
+std::pair<size_t, size_t> segment_meta_cstore::inflated_actual_size() const {
+    return _impl->inflated_actual_size();
+}
+
+segment_meta_cstore::const_iterator segment_meta_cstore::end() const {
+    return const_iterator(_impl->end());
+}
+
+std::optional<segment_meta> segment_meta_cstore::last_segment() const {
+    return _impl->last_segment();
 }
 
 segment_meta_cstore::const_iterator
-segment_meta_cstore::find(model::offset) const {
-    throw "not implemented";
+segment_meta_cstore::find(model::offset o) const {
+    return const_iterator(_impl->find(o));
 }
 
-bool segment_meta_cstore::contains(model::offset) const {
-    throw "not implemented";
+bool segment_meta_cstore::contains(model::offset o) const {
+    return _impl->contains(o);
 }
 
-bool segment_meta_cstore::empty() const { throw "not implemented"; }
+bool segment_meta_cstore::empty() const { return _impl->empty(); }
 
-segment_meta_cstore::const_iterator
-segment_meta_cstore::upper_bound(model::offset) const {
-    throw "not implemented";
-}
+size_t segment_meta_cstore::size() const { return _impl->size(); }
 
 segment_meta_cstore::const_iterator
-segment_meta_cstore::lower_bound(model::offset) const {
-    throw "not implemented";
+segment_meta_cstore::upper_bound(model::offset o) const {
+    return const_iterator(_impl->upper_bound(o));
 }
 
-std::pair<segment_meta_cstore::const_iterator, bool>
-segment_meta_cstore::insert(std::pair<model::offset, segment_meta>) {
-    throw "not implemented";
+segment_meta_cstore::const_iterator
+segment_meta_cstore::lower_bound(model::offset o) const {
+    return const_iterator(_impl->lower_bound(o));
 }
+
+void segment_meta_cstore::insert(const segment_meta& s) { _impl->insert(s); }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/segment_meta_cstore.h"
+
+namespace cloud_storage {
+
+class segment_meta_cstore::impl {
+public:
+private:
+};
+
+segment_meta_cstore::const_iterator segment_meta_cstore::begin() {
+    throw "not implemented";
+}
+
+segment_meta_cstore::const_iterator segment_meta_cstore::end() {
+    throw "not implemented";
+}
+
+std::optional<segment_meta> segment_meta_cstore::last_segment() {
+    throw "not implemented";
+}
+
+segment_meta_cstore::const_iterator
+segment_meta_cstore::find(model::offset) const {
+    throw "not implemented";
+}
+
+bool segment_meta_cstore::contains(model::offset) const {
+    throw "not implemented";
+}
+
+bool segment_meta_cstore::empty() const { throw "not implemented"; }
+
+segment_meta_cstore::const_iterator
+segment_meta_cstore::upper_bound(model::offset) const {
+    throw "not implemented";
+}
+
+segment_meta_cstore::const_iterator
+segment_meta_cstore::lower_bound(model::offset) const {
+    throw "not implemented";
+}
+
+std::pair<segment_meta_cstore::const_iterator, bool>
+segment_meta_cstore::insert(std::pair<model::offset, segment_meta>) {
+    throw "not implemented";
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -60,7 +60,7 @@ namespace details {
 template<class T>
 void commit_one(T&& tx) {
     if (tx.has_value()) {
-        tx->commit();
+        std::move(*tx).commit();
     }
 }
 

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -276,7 +276,7 @@ private:
     }
 
     std::array<value_t, buffer_depth> _head{};
-    mutable std::optional<encoder_t> _tail{std::nullopt};
+    std::optional<encoder_t> _tail{std::nullopt};
     const delta_t _delta_alg;
     size_t _size{0};
     std::optional<hint_t> _last_row;

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -171,7 +171,7 @@ public:
     /// index lookup operations.
     std::optional<hint_t> get_current_stream_pos() const { return _last_row; }
 
-    const_iterator at(size_t index) const {
+    const_iterator at_index(size_t index) const {
         if (index >= _size) {
             return end();
         }
@@ -184,7 +184,7 @@ public:
     ///
     /// The 'hint' has to correspond to any index lower or equal to
     /// 'index'. The 'hint' values has to be stored externally.
-    const_iterator at(size_t index, const hint_t& hint) const {
+    const_iterator at_index(size_t index, const hint_t& hint) const {
         if (index >= _size) {
             return end();
         }
@@ -263,7 +263,7 @@ public:
 
     void prefix_truncate_ix(uint32_t ix) {
         segment_meta_column_frame<value_t, delta_t> tmp(_delta_alg);
-        for (auto it = at(ix); it != end(); ++it) {
+        for (auto it = at_index(ix); it != end(); ++it) {
             tmp.append(*it);
         }
         _head = tmp._head;
@@ -330,7 +330,7 @@ private:
     template<class iter_t>
     static iter_list_t make_snapshot_at(iter_t begin, iter_t end, size_t ix) {
         iter_list_t snap;
-        auto intr = begin->at(ix);
+        auto intr = begin->at_index(ix);
         snap.push_back(std::move(intr));
         std::advance(begin, 1);
         for (auto it = begin; it != end; ++it) {
@@ -344,7 +344,7 @@ private:
     static iter_list_t
     make_snapshot_at(iter_t begin, iter_t end, size_t ix, const hint_t& row) {
         iter_list_t snap;
-        auto intr = begin->at(ix, row);
+        auto intr = begin->at_index(ix, row);
         snap.push_back(std::move(intr));
         std::advance(begin, 1);
         for (auto it = begin; it != end; ++it) {
@@ -553,7 +553,7 @@ public:
         return tx;
     }
 
-    const_iterator at(size_t index) const {
+    const_iterator at_index(size_t index) const {
         auto inner = index;
         for (auto it = _frames.begin(); it != _frames.end(); ++it) {
             if (it->size() <= inner) {
@@ -569,7 +569,7 @@ public:
     ///
     /// The 'hint' has to correspond to any index lower or equal to
     /// 'index'. The 'hint' values has to be stored externally.
-    const_iterator at(size_t index, const hint_t& hint) const {
+    const_iterator at_index(size_t index, const hint_t& hint) const {
         auto inner = index;
         for (auto it = _frames.begin(); it != _frames.end(); ++it) {
             if (it->size() <= inner) {
@@ -833,7 +833,7 @@ public:
     /// Upper/lower bound search operations
     const_iterator upper_bound(model::offset) const;
     const_iterator lower_bound(model::offset) const;
-    const_iterator at(size_t ix) const;
+    const_iterator at_index(size_t ix) const;
 
     void insert(const segment_meta&);
 

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -17,6 +17,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <functional>
+#include <iterator>
 
 namespace cloud_storage {
 
@@ -112,6 +113,15 @@ public:
             }
             _tail->add(_head);
         }
+    }
+
+    const_iterator at(size_t index) const {
+        if (index >= _size) {
+            return end();
+        }
+        auto it = begin();
+        std::advance(it, index);
+        return it;
     }
 
     size_t size() const { return _size; }

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -140,7 +140,7 @@ public:
         void add(const std::array<value_t, buffer_depth>& row) {
             inner.add(row);
         }
-        void commit() noexcept { self._tail->tx_commit(std::move(inner)); }
+        void commit() && noexcept { self._tail->tx_commit(std::move(inner)); }
     };
 
     // Transactional append operation
@@ -503,9 +503,9 @@ public:
             std::get<frame_list_t>(inner).push_back(std::move(frame));
         }
 
-        void commit() noexcept {
+        void commit() && noexcept {
             if (std::holds_alternative<frame_tx_t>(inner)) {
-                std::get<frame_tx_t>(inner).commit();
+                std::move(std::get<frame_tx_t>(inner)).commit();
             } else {
                 self._frames.splice(
                   self._frames.end(), std::get<frame_list_t>(inner));

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -168,6 +168,16 @@ public:
 
     bool contains(value_t value) const { return find(value) != end(); }
 
+    void prefix_truncate(value_t new_start) {
+        segment_meta_column_frame<value_t, delta_t> tmp(_delta_alg);
+        for (auto it = find(new_start); it != end(); ++it) {
+            tmp.append(*it);
+        }
+        _head = tmp._head;
+        _tail = std::move(tmp._tail);
+        _size = tmp._size;
+    }
+
 private:
     template<class PredT>
     const_iterator pred_search(value_t value) const {

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -18,6 +18,7 @@
 
 #include <functional>
 #include <iterator>
+#include <memory>
 #include <variant>
 
 namespace cloud_storage {
@@ -168,6 +169,13 @@ public:
     }
 
     size_t size() const { return _size; }
+
+    size_t mem_use() const {
+        if (!_tail.has_value()) {
+            return sizeof(*this);
+        }
+        return sizeof(*this) + _tail.value().mem_use();
+    }
 
     const_iterator begin() const {
         if (_tail.has_value()) {
@@ -449,6 +457,14 @@ public:
             return 0;
         }
         return max_frame_size * (_frames.size() - 1) + _frames.back().size();
+    }
+
+    size_t mem_use() const {
+        size_t total = 0;
+        for (const auto& p : _frames) {
+            total += p.mem_use();
+        }
+        return sizeof(*this) + total;
     }
 
     const_iterator begin() const { return const_iterator(_frames); }

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/types.h"
+#include "utils/delta_for.h"
+
+#include <boost/iterator/iterator_categories.hpp>
+#include <boost/iterator/iterator_facade.hpp>
+
+#include <functional>
+
+namespace cloud_storage {
+
+template<class value_t, class decoder_t>
+class frame_iterator_impl
+  : public boost::iterator_facade<
+      frame_iterator_impl<value_t, decoder_t>,
+      value_t const,
+      boost::iterators::forward_traversal_tag> {
+    constexpr static uint32_t buffer_depth = details::FOR_buffer_depth;
+    constexpr static uint32_t index_mask = buffer_depth - 1;
+
+    friend class boost::iterator_core_access;
+    using self_t = frame_iterator_impl<value_t, decoder_t>;
+
+public:
+    /// Create iterator that points to the begining
+    explicit frame_iterator_impl(
+      decoder_t decoder,
+      const std::array<value_t, buffer_depth>& head,
+      uint32_t size)
+      : _head(head)
+      , _decoder(std::move(decoder))
+      , _size(size) {
+        if (!_decoder->read(_read_buf)) {
+            _read_buf = _head;
+        }
+    }
+
+    /// Create iterator that points to the end
+    frame_iterator_impl() = default;
+
+    uint32_t index() const { return _pos; }
+
+private:
+    const value_t& dereference() const {
+        auto ix = _pos & index_mask;
+        return _read_buf.at(ix);
+    }
+
+    void increment() {
+        _pos++;
+        if ((_pos & index_mask) == 0) {
+            // Read next buffer from the decoder
+            _read_buf = {};
+            if (!_decoder->read(_read_buf)) {
+                // If the decoder is empty we need to continue reading data from
+                // the head of the column.
+                _read_buf = _head;
+            }
+        }
+    }
+
+    bool equal(const self_t& other) const {
+        if (other._pos == other._size) {
+            // All 'end' iterators are equal
+            return _pos == _size;
+        }
+        return other._pos == _pos && other._size == _size;
+    }
+
+    std::array<value_t, buffer_depth> _read_buf{};
+    std::array<value_t, buffer_depth> _head{};
+    std::optional<decoder_t> _decoder{std::nullopt};
+    uint32_t _pos{0};
+    uint32_t _size{0};
+};
+
+template<class value_t, class delta_t = details::delta_xor>
+class frame {
+    constexpr static uint32_t buffer_depth = details::FOR_buffer_depth;
+    constexpr static uint32_t index_mask = buffer_depth - 1;
+    using encoder_t = deltafor_encoder<value_t, delta_t>;
+    using decoder_t = deltafor_decoder<value_t, delta_t>;
+
+    struct index_value {
+        size_t ix;
+        value_t value;
+    };
+
+public:
+    using const_iterator = frame_iterator_impl<value_t, decoder_t>;
+
+    explicit frame(delta_t d)
+      : _delta_alg(std::move(d)) {}
+
+    void append(value_t value) {
+        auto ix = index_mask & _size++;
+        _head.at(ix) = value;
+        if ((_size & index_mask) == 0) {
+            if (!_tail.has_value()) {
+                _tail.emplace(_head.at(0), _delta_alg);
+            }
+            _tail->add(_head);
+        }
+    }
+
+    size_t size() const { return _size; }
+
+    const_iterator begin() const {
+        if (_tail.has_value()) {
+            decoder_t decoder(
+              _tail->get_initial_value(),
+              _tail->get_row_count(),
+              _tail->share(),
+              _delta_alg);
+            return const_iterator(std::move(decoder), _head, _size);
+        } else if (_size != 0) {
+            // special case, data is only stored in the buffer
+            // not in the compressed column
+            decoder_t decoder(0, 0, iobuf(), _delta_alg);
+            return const_iterator(std::move(decoder), _head, _size);
+        }
+        return end();
+    }
+
+    const_iterator end() const { return const_iterator(); }
+
+    const_iterator find(value_t value) const {
+        return pred_search<std::equal_to<value_t>>(value);
+    }
+
+    const_iterator upper_bound(value_t value) const {
+        return pred_search<std::greater<value_t>>(value);
+    }
+
+    const_iterator lower_bound(value_t value) const {
+        return pred_search<std::greater_equal<value_t>>(value);
+    }
+
+    std::optional<value_t> last_value() const {
+        if (_size == 0) {
+            return std::nullopt;
+        }
+        auto ix = (_size - 1) & index_mask;
+        return _head.at(ix);
+    }
+
+    bool contains(value_t value) const { return find(value) != end(); }
+
+private:
+    template<class PredT>
+    const_iterator pred_search(value_t value) const {
+        PredT pred;
+        for (auto it = begin(); it != end(); ++it) {
+            if (pred(*it, value)) {
+                return it;
+            }
+        }
+        return end();
+    }
+
+    std::array<value_t, buffer_depth> _head{};
+    mutable std::optional<encoder_t> _tail{std::nullopt};
+    const delta_t _delta_alg;
+    size_t _size{0};
+};
+
+class segment_meta_cstore {
+    class impl;
+
+public:
+    using const_iterator = int;
+    using const_reverse_iterator = int;
+
+    const_iterator begin();
+    const_iterator end();
+
+    std::optional<segment_meta> last_segment();
+
+    const_iterator find(model::offset) const;
+    bool contains(model::offset) const;
+    bool empty() const;
+    const_iterator upper_bound(model::offset) const;
+    const_iterator lower_bound(model::offset) const;
+
+    std::pair<const_iterator, bool>
+      insert(std::pair<model::offset, segment_meta>);
+
+private:
+    std::unique_ptr<impl> _impl;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -22,20 +22,20 @@
 namespace cloud_storage {
 
 template<class value_t, class decoder_t>
-class frame_iterator_impl
+class segment_meta_frame_const_iterator
   : public boost::iterator_facade<
-      frame_iterator_impl<value_t, decoder_t>,
+      segment_meta_frame_const_iterator<value_t, decoder_t>,
       value_t const,
       boost::iterators::forward_traversal_tag> {
     constexpr static uint32_t buffer_depth = details::FOR_buffer_depth;
     constexpr static uint32_t index_mask = buffer_depth - 1;
 
     friend class boost::iterator_core_access;
-    using self_t = frame_iterator_impl<value_t, decoder_t>;
+    using self_t = segment_meta_frame_const_iterator<value_t, decoder_t>;
 
 public:
     /// Create iterator that points to the begining
-    explicit frame_iterator_impl(
+    explicit segment_meta_frame_const_iterator(
       decoder_t decoder,
       const std::array<value_t, buffer_depth>& head,
       uint32_t size)
@@ -48,7 +48,7 @@ public:
     }
 
     /// Create iterator that points to the end
-    frame_iterator_impl() = default;
+    segment_meta_frame_const_iterator() = default;
 
     uint32_t index() const { return _pos; }
 
@@ -87,7 +87,7 @@ private:
 };
 
 template<class value_t, class delta_t = details::delta_xor>
-class frame {
+class segment_meta_column_frame {
     constexpr static uint32_t buffer_depth = details::FOR_buffer_depth;
     constexpr static uint32_t index_mask = buffer_depth - 1;
     using encoder_t = deltafor_encoder<value_t, delta_t>;
@@ -99,9 +99,10 @@ class frame {
     };
 
 public:
-    using const_iterator = frame_iterator_impl<value_t, decoder_t>;
+    using const_iterator
+      = segment_meta_frame_const_iterator<value_t, decoder_t>;
 
-    explicit frame(delta_t d)
+    explicit segment_meta_column_frame(delta_t d)
       : _delta_alg(std::move(d)) {}
 
     void append(value_t value) {

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ rp_test(
 rp_test(
   BENCHMARK_TEST
   BINARY_NAME cloud_storage_bench
-  SOURCES cache_bench.cc
+  SOURCES cache_bench.cc segment_meta_cstore_bench.cc
   LIBRARIES Seastar::seastar_perf_testing v::cloud_storage
   LABELS cloud_storage
 )

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ rp_test(
     offset_translation_layer_test.cc
     remote_segment_index_test.cc
     recovery_request_test.cc
+    segment_meta_cstore_test.cc 
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cloud_storage v::storage_test_utils v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -1518,7 +1518,7 @@ void scan_ts_segments_general(partition_manifest const& m) {
 
     // After range: should get null
     reference_check_timequery(
-      m, model::timestamp{m.rbegin()->second.max_timestamp() + 1});
+      m, model::timestamp{m.last_segment()->max_timestamp() + 1});
 }
 /**
  * For a timequery() result, assert it is non-null and equal to the expected
@@ -1554,7 +1554,7 @@ void scan_ts_segments(partition_manifest const& m) {
 
     // After range: should get null
     BOOST_REQUIRE(
-      m.timequery(model::timestamp{m.rbegin()->second.max_timestamp() + 1})
+      m.timequery(model::timestamp{m.last_segment()->max_timestamp() + 1})
       == std::nullopt);
 
     // Also compare all results with reference implementation.
@@ -1774,7 +1774,7 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_out_of_order) {
 
     // After range: should get null
     BOOST_REQUIRE(
-      m.timequery(model::timestamp{m.rbegin()->second.max_timestamp() + 1})
+      m.timequery(model::timestamp{m.last_segment()->max_timestamp() + 1})
       == std::nullopt);
 }
 

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -126,7 +126,7 @@ void append_tx_test(StoreT& store, int test_scale) {
     perf_tests::start_measuring_time();
     auto tx = store.append_tx(tail);
     if (tx) {
-        tx->commit();
+        std::move(*tx).commit();
     } else {
         assert(false);
     }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -106,6 +106,29 @@ void append_test(StoreT& store, int test_scale) {
 }
 
 template<class StoreT>
+void append_tx_test(StoreT& store, int test_scale) {
+    std::vector<int64_t> head;
+    int64_t tail;
+    int64_t value = 0;
+    for (int64_t i = 0; i < test_scale - 1; i++) {
+        value += random_generators::get_int(1, 100);
+        head.push_back(value);
+    }
+    tail = value + random_generators::get_int(1, 100);
+    for (auto x : head) {
+        store.append(x);
+    }
+    perf_tests::start_measuring_time();
+    auto tx = store.append_tx(tail);
+    if (tx) {
+        tx->commit();
+    } else {
+        assert(false);
+    }
+    perf_tests::stop_measuring_time();
+}
+
+template<class StoreT>
 void find_test(StoreT& store) {
     perf_tests::start_measuring_time();
     auto it = store.find(*store.last_value());
@@ -126,9 +149,25 @@ PERF_TEST(cstore_bench, xor_frame_append) {
     append_test(frame, 4096);
 }
 
+PERF_TEST(cstore_bench, xor_frame_append_tx) {
+    delta_xor_frame frame(initial_xor);
+    append_tx_test(frame, 4096);
+}
+
 PERF_TEST(cstore_bench, xor_column_append) {
     delta_xor_column column(initial_xor);
     append_test(column, 4096);
+}
+
+PERF_TEST(cstore_bench, xor_column_append_tx) {
+    delta_xor_column column(initial_xor);
+    append_tx_test(column, 4096);
+}
+
+PERF_TEST(cstore_bench, xor_column_append_tx2) {
+    // trigger code path that commits by splicing the list
+    delta_xor_column column(initial_xor);
+    append_tx_test(column, 4097);
 }
 
 PERF_TEST(cstore_bench, xor_frame_find_4K) { find_test(xor_frame_4K); }
@@ -146,9 +185,25 @@ PERF_TEST(cstore_bench, delta_frame_append) {
     append_test(frame, 4096);
 }
 
+PERF_TEST(cstore_bench, delta_frame_append_tx) {
+    delta_delta_frame frame(initial_delta);
+    append_tx_test(frame, 4096);
+}
+
 PERF_TEST(cstore_bench, delta_column_append) {
     delta_delta_column column(initial_delta);
     append_test(column, 4096);
+}
+
+PERF_TEST(cstore_bench, delta_column_append_tx) {
+    delta_delta_column column(initial_delta);
+    append_tx_test(column, 4096);
+}
+
+PERF_TEST(cstore_bench, delta_column_append_tx2) {
+    // trigger code path that commits by splicing the list
+    delta_delta_column column(initial_delta);
+    append_tx_test(column, 4097);
 }
 
 PERF_TEST(cstore_bench, delta_frame_find_4K) { find_test(delta_frame_4K); }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -9,11 +9,16 @@
  */
 
 #include "cloud_storage/segment_meta_cstore.h"
+#include "model/fundamental.h"
 #include "random/generators.h"
 #include "seastarx.h"
 #include "utils/delta_for.h"
 
 #include <seastar/testing/perf_tests.hh>
+
+#include <absl/container/btree_map.h>
+
+#include <vector>
 
 using namespace cloud_storage;
 

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -222,3 +222,301 @@ PERF_TEST(cstore_bench, delta_frame_at_4K) { at_test(delta_frame_4K); }
 PERF_TEST(cstore_bench, delta_column_at_4K) { at_test(delta_column_4K); }
 
 PERF_TEST(cstore_bench, delta_column_at_4M) { at_test(delta_column_4M); }
+
+PERF_TEST(cstore_bench, xor_frame_at_with_index_4K) {
+    std::map<int32_t, delta_xor_frame::hint_t> index;
+    delta_xor_frame frame(initial_xor);
+    int64_t value = random_generators::get_int(1000);
+    for (int64_t i = 0; i < 4096; i++) {
+        value += random_generators::get_int(1, 100);
+        frame.append(value);
+        if (i % 16 == 0) {
+            auto row = frame.get_current_stream_pos();
+            if (row) {
+                index.insert(std::make_pair(i, row.value()));
+            }
+        }
+    }
+    auto it = index.at(4000);
+    perf_tests::start_measuring_time();
+    frame.at(4000, it);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(cstore_bench, xor_column_at_with_index_4K) {
+    std::map<int32_t, delta_xor_column::hint_t> index;
+    delta_xor_column column(initial_xor);
+    int64_t value = random_generators::get_int(1000);
+    for (int64_t i = 0; i < 4096; i++) {
+        value += random_generators::get_int(1, 100);
+        column.append(value);
+        if (i % 16 == 0) {
+            auto row = column.get_current_stream_pos();
+            if (row) {
+                index.insert(std::make_pair(i, row.value()));
+            }
+        }
+    }
+    auto it = index.at(4000);
+    perf_tests::start_measuring_time();
+    column.at(4000, it);
+    perf_tests::stop_measuring_time();
+}
+
+std::vector<segment_meta> generate_metadata(size_t sz) {
+    namespace rg = random_generators;
+    std::vector<segment_meta> manifest;
+    segment_meta curr{
+      .is_compacted = false,
+      .size_bytes = 812,
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(0),
+      .base_timestamp = model::timestamp(1646430092103),
+      .max_timestamp = model::timestamp(1646430092103),
+      .delta_offset = model::offset_delta(0),
+      .archiver_term = model::term_id(2),
+      .segment_term = model::term_id(0),
+      .delta_offset_end = model::offset_delta(0),
+      .sname_format = segment_name_format::v2,
+    };
+    bool short_segment_run = false;
+    for (size_t i = 0; i < sz; i++) {
+        auto s = curr;
+        manifest.push_back(s);
+        if (short_segment_run) {
+            curr.base_offset = model::next_offset(curr.committed_offset);
+            curr.committed_offset = curr.committed_offset
+                                    + model::offset(rg::get_int(1, 10));
+            curr.size_bytes = rg::get_int(1, 200);
+            curr.base_timestamp = curr.max_timestamp;
+            curr.max_timestamp = model::timestamp(
+              curr.max_timestamp.value() + rg::get_int(0, 1000));
+            curr.delta_offset = curr.delta_offset_end;
+            curr.delta_offset_end = curr.delta_offset_end
+                                    + model::offset_delta(rg::get_int(5));
+            if (rg::get_int(50) == 0) {
+                curr.segment_term = curr.segment_term
+                                    + model::term_id(rg::get_int(1, 20));
+                curr.archiver_term = curr.archiver_term
+                                     + model::term_id(rg::get_int(1, 20));
+            }
+        } else {
+            curr.base_offset = model::next_offset(curr.committed_offset);
+            curr.committed_offset = curr.committed_offset
+                                    + model::offset(rg::get_int(1, 1000));
+            curr.size_bytes = rg::get_int(1, 200000);
+            curr.base_timestamp = curr.max_timestamp;
+            curr.max_timestamp = model::timestamp(
+              curr.max_timestamp.value() + rg::get_int(0, 100000));
+            curr.delta_offset = curr.delta_offset_end;
+            curr.delta_offset_end = curr.delta_offset_end
+                                    + model::offset_delta(rg::get_int(15));
+            if (rg::get_int(50) == 0) {
+                curr.segment_term = curr.segment_term
+                                    + model::term_id(rg::get_int(1, 20));
+                curr.archiver_term = curr.archiver_term
+                                     + model::term_id(rg::get_int(1, 20));
+            }
+        }
+        if (rg::get_int(200) == 0) {
+            short_segment_run = !short_segment_run;
+        }
+    }
+    return manifest;
+}
+
+class baseline_column_store {
+public:
+    using const_iterator
+      = absl::btree_map<model::offset, segment_meta>::const_iterator;
+
+    /// Return iterator
+    const_iterator begin() const { return _data.begin(); }
+
+    const_iterator end() const { return _data.end(); }
+
+    /// Return last segment's metadata (or nullopt if empty)
+    std::optional<segment_meta> last_segment() const {
+        if (_data.empty()) {
+            return std::nullopt;
+        }
+        auto it = _data.end();
+        it = std::prev(it);
+        return it->second;
+    }
+
+    /// Find element and return its iterator
+    const_iterator find(model::offset o) const { return _data.find(o); }
+
+    /// Check if the offset is present
+    bool contains(model::offset o) const { return _data.contains(o); }
+
+    /// Return true if data structure is empty
+    bool empty() const { return _data.empty(); }
+
+    /// Return size of the collection
+    size_t size() const { return _data.size(); }
+
+    /// Upper/lower bound search operations
+    const_iterator upper_bound(model::offset o) const {
+        return _data.upper_bound(o);
+    }
+    const_iterator lower_bound(model::offset o) const {
+        return _data.lower_bound(o);
+    }
+
+    void insert(const segment_meta& meta) { _data[meta.base_offset] = meta; }
+
+private:
+    absl::btree_map<model::offset, segment_meta> _data;
+};
+
+template<class StoreT>
+void cs_append_test(StoreT& store, size_t sz) {
+    auto manifest = generate_metadata(sz);
+
+    size_t i = 0;
+    for (const auto& s : manifest) {
+        store.insert(s);
+        i++;
+        if (i == sz) {
+            // Do not add last element
+            break;
+        }
+    }
+
+    perf_tests::start_measuring_time();
+    store.insert(manifest.back());
+    perf_tests::stop_measuring_time();
+}
+
+template<class StoreT>
+void cs_scan_test(StoreT& store, size_t sz) {
+    auto manifest = generate_metadata(sz);
+
+    for (const auto& s : manifest) {
+        store.insert(s);
+    }
+
+    perf_tests::start_measuring_time();
+    for (const auto& i : store) {
+        perf_tests::do_not_optimize(i);
+    }
+    perf_tests::stop_measuring_time();
+}
+
+template<class StoreT>
+void cs_find_test(StoreT& store, size_t sz) {
+    auto manifest = generate_metadata(sz);
+
+    for (const auto& s : manifest) {
+        store.insert(s);
+    }
+
+    perf_tests::start_measuring_time();
+    auto i = store.find(manifest.back().base_offset);
+    perf_tests::do_not_optimize(i);
+    perf_tests::stop_measuring_time();
+}
+
+template<class StoreT>
+void cs_lower_bound_test(StoreT& store, size_t sz) {
+    auto manifest = generate_metadata(sz);
+
+    for (const auto& s : manifest) {
+        store.insert(s);
+    }
+
+    perf_tests::start_measuring_time();
+    auto i = store.lower_bound(manifest.back().base_offset);
+    perf_tests::do_not_optimize(i);
+    perf_tests::stop_measuring_time();
+}
+
+template<class StoreT>
+void cs_upper_bound_test(StoreT& store, size_t sz) {
+    auto manifest = generate_metadata(sz);
+
+    for (const auto& s : manifest) {
+        store.insert(s);
+    }
+
+    perf_tests::start_measuring_time();
+    auto i = store.upper_bound(manifest.back().base_offset);
+    perf_tests::do_not_optimize(i);
+    perf_tests::stop_measuring_time();
+}
+
+template<class StoreT>
+void cs_last_segment_test(StoreT& store, size_t sz) {
+    auto manifest = generate_metadata(sz);
+
+    for (const auto& s : manifest) {
+        store.insert(s);
+    }
+
+    perf_tests::start_measuring_time();
+    auto s = store.last_segment();
+    perf_tests::do_not_optimize(s);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(cstore_bench, column_store_append_baseline) {
+    baseline_column_store store;
+    cs_append_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_append_result) {
+    segment_meta_cstore store;
+    cs_append_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_scan_baseline) {
+    baseline_column_store store;
+    cs_scan_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_scan_result) {
+    segment_meta_cstore store;
+    cs_scan_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_find_baseline) {
+    baseline_column_store store;
+    cs_find_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_find_result) {
+    segment_meta_cstore store;
+    cs_find_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_lower_bound_baseline) {
+    baseline_column_store store;
+    cs_lower_bound_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_lower_bound_result) {
+    segment_meta_cstore store;
+    cs_lower_bound_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_upper_bound_baseline) {
+    baseline_column_store store;
+    cs_upper_bound_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_upper_bound_result) {
+    segment_meta_cstore store;
+    cs_upper_bound_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_last_segment_baseline) {
+    baseline_column_store store;
+    cs_last_segment_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, column_store_last_segment_result) {
+    segment_meta_cstore store;
+    cs_last_segment_test(store, 10000);
+}

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/segment_meta_cstore.h"
+#include "random/generators.h"
+#include "seastarx.h"
+#include "utils/delta_for.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+using namespace cloud_storage;
+
+using delta_xor_alg = details::delta_xor;
+using delta_xor_frame = segment_meta_column_frame<int64_t, delta_xor_alg>;
+using delta_delta_alg = details::delta_delta<int64_t>;
+using delta_delta_frame = segment_meta_column_frame<int64_t, delta_delta_alg>;
+using delta_xor_column = segment_meta_column<int64_t, delta_xor_alg>;
+using delta_delta_column = segment_meta_column<int64_t, delta_delta_alg>;
+
+static const delta_xor_alg initial_xor{};
+static const delta_delta_alg initial_delta{0};
+
+static const delta_xor_frame xor_frame_4K = []() {
+    delta_xor_frame frame(initial_xor);
+    int64_t value = random_generators::get_int(1000);
+    for (int64_t i = 0; i < 4096; i++) {
+        value += random_generators::get_int(1, 100);
+        frame.append(value);
+    }
+    return frame;
+}();
+
+static const delta_xor_column xor_column_4K = []() {
+    delta_xor_column column(initial_xor);
+    int64_t value = random_generators::get_int(1000);
+    for (int64_t i = 0; i < 4096; i++) {
+        value += random_generators::get_int(1, 100);
+        column.append(value);
+    }
+    return column;
+}();
+
+static const delta_xor_column xor_column_4M = []() {
+    delta_xor_column column(initial_xor);
+    int64_t value = random_generators::get_int(1000);
+    for (int64_t i = 0; i < 4096000; i++) {
+        value += random_generators::get_int(1, 100);
+        column.append(value);
+    }
+    return column;
+}();
+
+static const delta_delta_frame delta_frame_4K = []() {
+    delta_delta_frame frame(initial_delta);
+    int64_t value = random_generators::get_int(1000);
+    for (int64_t i = 0; i < 4096; i++) {
+        value += random_generators::get_int(1, 100);
+        frame.append(value);
+    }
+    return frame;
+}();
+
+static const delta_delta_column delta_column_4K = []() {
+    delta_delta_column column(initial_delta);
+    int64_t value = random_generators::get_int(1000);
+    for (int64_t i = 0; i < 4096; i++) {
+        value += random_generators::get_int(1, 100);
+        column.append(value);
+    }
+    return column;
+}();
+
+static const delta_delta_column delta_column_4M = []() {
+    delta_delta_column column(initial_delta);
+    int64_t value = random_generators::get_int(1000);
+    for (int64_t i = 0; i < 4096000; i++) {
+        value += random_generators::get_int(1, 100);
+        column.append(value);
+    }
+    return column;
+}();
+
+template<class StoreT>
+void append_test(StoreT& store, int test_scale) {
+    std::vector<int64_t> head;
+    int64_t tail;
+    int64_t value = 0;
+    for (int64_t i = 0; i < test_scale - 1; i++) {
+        value += random_generators::get_int(1, 100);
+        head.push_back(value);
+    }
+    tail = value + random_generators::get_int(1, 100);
+    for (auto x : head) {
+        store.append(x);
+    }
+    perf_tests::start_measuring_time();
+    store.append(tail);
+    perf_tests::stop_measuring_time();
+}
+
+template<class StoreT>
+void find_test(StoreT& store) {
+    perf_tests::start_measuring_time();
+    auto it = store.find(*store.last_value());
+    perf_tests::do_not_optimize(it);
+    perf_tests::stop_measuring_time();
+}
+
+template<class StoreT>
+void at_test(StoreT& store) {
+    perf_tests::start_measuring_time();
+    auto it = store.at(store.size() - 1);
+    perf_tests::do_not_optimize(it);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(cstore_bench, xor_frame_append) {
+    delta_xor_frame frame(initial_xor);
+    append_test(frame, 4096);
+}
+
+PERF_TEST(cstore_bench, xor_column_append) {
+    delta_xor_column column(initial_xor);
+    append_test(column, 4096);
+}
+
+PERF_TEST(cstore_bench, xor_frame_find_4K) { find_test(xor_frame_4K); }
+
+PERF_TEST(cstore_bench, xor_column_find_4K) { find_test(xor_column_4K); }
+
+PERF_TEST(cstore_bench, xor_frame_at_4K) { at_test(xor_frame_4K); }
+
+PERF_TEST(cstore_bench, xor_column_at_4K) { at_test(xor_column_4K); }
+
+PERF_TEST(cstore_bench, xor_column_at_4M) { at_test(xor_column_4M); }
+
+PERF_TEST(cstore_bench, delta_frame_append) {
+    delta_delta_frame frame(initial_delta);
+    append_test(frame, 4096);
+}
+
+PERF_TEST(cstore_bench, delta_column_append) {
+    delta_delta_column column(initial_delta);
+    append_test(column, 4096);
+}
+
+PERF_TEST(cstore_bench, delta_frame_find_4K) { find_test(delta_frame_4K); }
+
+PERF_TEST(cstore_bench, delta_column_find_4K) { find_test(delta_column_4K); }
+
+PERF_TEST(cstore_bench, delta_column_find_4M) { at_test(delta_column_4M); }
+
+PERF_TEST(cstore_bench, delta_frame_at_4K) { at_test(delta_frame_4K); }
+
+PERF_TEST(cstore_bench, delta_column_at_4K) { at_test(delta_column_4K); }
+
+PERF_TEST(cstore_bench, delta_column_at_4M) { at_test(delta_column_4M); }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -144,7 +144,7 @@ void find_test(StoreT& store) {
 template<class StoreT>
 void at_test(StoreT& store) {
     perf_tests::start_measuring_time();
-    auto it = store.at(store.size() - 1);
+    auto it = store.at_index(store.size() - 1);
     perf_tests::do_not_optimize(it);
     perf_tests::stop_measuring_time();
 }
@@ -239,7 +239,7 @@ PERF_TEST(cstore_bench, xor_frame_at_with_index_4K) {
     }
     auto it = index.at(4000);
     perf_tests::start_measuring_time();
-    frame.at(4000, it);
+    frame.at_index(4000, it);
     perf_tests::stop_measuring_time();
 }
 
@@ -259,7 +259,7 @@ PERF_TEST(cstore_bench, xor_column_at_with_index_4K) {
     }
     auto it = index.at(4000);
     perf_tests::start_measuring_time();
-    column.at(4000, it);
+    column.at_index(4000, it);
     perf_tests::stop_measuring_time();
 }
 

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -30,6 +30,7 @@ using delta_xor_frame = segment_meta_column_frame<int64_t, delta_xor_alg>;
 using delta_delta_alg = details::delta_delta<int64_t>;
 using delta_delta_frame = segment_meta_column_frame<int64_t, delta_delta_alg>;
 using delta_xor_column = segment_meta_column<int64_t, delta_xor_alg>;
+using delta_delta_column = segment_meta_column<int64_t, delta_delta_alg>;
 
 static const delta_xor_alg initial_xor{};
 static const delta_delta_alg initial_delta{0};
@@ -59,6 +60,11 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_delta) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_xor) {
     delta_xor_column col(initial_xor);
+    append_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_delta) {
+    delta_delta_column col(initial_delta);
     append_test_case(100000, col);
 }
 
@@ -93,6 +99,11 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_iter_delta) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_iter_xor) {
     delta_xor_column col(initial_xor);
+    iter_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_iter_delta) {
+    delta_delta_column col(initial_delta);
     iter_test_case(100000, col);
 }
 
@@ -149,6 +160,16 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor_small) {
     delta_xor_column col(initial_xor);
+    find_test_case(random_generators::get_int(1, 16), col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_delta) {
+    delta_delta_column col(initial_delta);
+    find_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_delta_small) {
+    delta_delta_column col(initial_delta);
     find_test_case(random_generators::get_int(1, 16), col);
 }
 
@@ -217,6 +238,16 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_xor_small) {
     lower_bound_test_case(random_generators::get_int(1, 16), col);
 }
 
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_delta) {
+    delta_delta_column col(initial_delta);
+    lower_bound_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_delta_small) {
+    delta_delta_column col(initial_delta);
+    lower_bound_test_case(random_generators::get_int(1, 16), col);
+}
+
 template<class column_t>
 void upper_bound_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
@@ -280,6 +311,16 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_xor_small) {
     upper_bound_test_case(random_generators::get_int(1, 16), col);
 }
 
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_delta) {
+    delta_delta_column col(initial_delta);
+    upper_bound_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_delta_small) {
+    delta_delta_column col(initial_delta);
+    upper_bound_test_case(random_generators::get_int(1, 16), col);
+}
+
 template<class column_t>
 void at_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
@@ -336,6 +377,16 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_xor_small) {
     at_test_case(random_generators::get_int(16), col);
 }
 
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_delta) {
+    delta_delta_column col(initial_delta);
+    at_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_delta_small) {
+    delta_delta_column col(initial_delta);
+    at_test_case(random_generators::get_int(16), col);
+}
+
 template<class column_t>
 void prefix_truncate_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
@@ -372,5 +423,10 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_prefix_truncate_delta) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_prefix_truncate_xor) {
     delta_xor_column col(initial_xor);
+    prefix_truncate_test_case(10, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_prefix_truncate_delta) {
+    delta_delta_column col(initial_delta);
     prefix_truncate_test_case(10, col);
 }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -118,8 +118,9 @@ void iter_test_case(const int64_t num_elements, column_t& column) {
     BOOST_REQUIRE_EQUAL(total_size, column.size());
 
     int i = 0;
-    for (auto actual : column) {
-        BOOST_REQUIRE_EQUAL(actual, expected[i++]);
+    for (auto it = column.begin(); it != column.end(); ++it) {
+        BOOST_REQUIRE_EQUAL(it.index(), i);
+        BOOST_REQUIRE_EQUAL(*it, expected[i++]);
     }
 }
 
@@ -380,6 +381,7 @@ void at_test_case(const int64_t num_elements, column_t& column) {
         BOOST_REQUIRE(it != column.end());
         auto actual = *it;
         BOOST_REQUIRE_EQUAL(actual, expected);
+        BOOST_REQUIRE_EQUAL(it.index(), index);
     }
 }
 

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -381,7 +381,7 @@ void at_test_case(const int64_t num_elements, column_t& column) {
     std::shuffle(samples.begin(), samples.end(), g);
 
     for (auto [expected, index] : samples) {
-        auto it = column.at(index);
+        auto it = column.at_index(index);
         BOOST_REQUIRE(it != column.end());
         auto actual = *it;
         BOOST_REQUIRE_EQUAL(actual, expected);
@@ -517,8 +517,9 @@ void at_with_hint_test_case(const int64_t num_elements, column_t& column) {
             num_skips++;
             continue;
         }
-        auto it = h_it->pos.has_value() ? column.at(index, h_it->pos.value())
-                                        : column.at(index);
+        auto it = h_it->pos.has_value()
+                    ? column.at_index(index, h_it->pos.value())
+                    : column.at_index(index);
         BOOST_REQUIRE(it != column.end());
         auto actual = *it;
         BOOST_REQUIRE_EQUAL(actual, expected);
@@ -736,7 +737,7 @@ void test_cstore_prefix_truncate(size_t test_size, size_t max_truncate_ix) {
     for (size_t i = 0; i < store.size(); i++) {
         BOOST_REQUIRE(store.contains(manifest[i].base_offset));
         BOOST_REQUIRE_EQUAL(*store.find(manifest[i].base_offset), manifest[i]);
-        BOOST_REQUIRE_EQUAL(*store.at(i), manifest[i]);
+        BOOST_REQUIRE_EQUAL(*store.at_index(i), manifest[i]);
     }
 }
 

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/segment_meta_cstore.h"
+#include "common_def.h"
+#include "random/generators.h"
+#include "utils/delta_for.h"
+#include "vlog.h"
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <limits>
+
+using namespace cloud_storage;
+
+template<class delta_alg>
+void append_test_case(const int64_t max_value, delta_alg initial) {
+    using frame_t = frame<int64_t, delta_alg>;
+    frame_t frame(std::move(initial));
+    size_t total_size = 0;
+    for (int64_t ix = 0; ix < max_value;
+         ix += random_generators::get_int(1, 100)) {
+        frame.append(ix);
+        total_size++;
+        BOOST_REQUIRE_EQUAL(ix, frame.last_value());
+    }
+    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_append_xor) {
+    append_test_case<details::delta_xor>(10000000, {});
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_append_delta) {
+    append_test_case<details::delta_delta<int64_t>>(
+      10000000, details::delta_delta<int64_t>(0));
+}
+
+template<class delta_alg>
+void iter_test_case(const int64_t max_value, delta_alg initial) {
+    using frame_t = frame<int64_t, delta_alg>;
+    frame_t frame(std::move(initial));
+    size_t total_size = 0;
+    std::vector<int64_t> expected;
+    for (int64_t ix = 0; ix < max_value;
+         ix += random_generators::get_int(1, 100)) {
+        frame.append(ix);
+        expected.push_back(ix);
+        total_size++;
+    }
+    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+
+    int i = 0;
+    for (auto actual : frame) {
+        BOOST_REQUIRE_EQUAL(actual, expected[i++]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_iter_xor) {
+    iter_test_case<details::delta_xor>(10000000, {});
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_iter_delta) {
+    iter_test_case<details::delta_delta<int64_t>>(
+      10000000, details::delta_delta<int64_t>(0));
+}
+
+template<class delta_alg>
+void find_test_case(const int64_t max_value, delta_alg initial) {
+    using frame_t = frame<int64_t, delta_alg>;
+    frame_t frame(std::move(initial));
+    size_t total_size = 0;
+    std::vector<int64_t> samples;
+    for (int64_t ix = 0; ix < max_value;
+         ix += random_generators::get_int(1, 100)) {
+        frame.append(ix);
+        if (samples.empty() || random_generators::get_int(10) == 0) {
+            samples.push_back(ix);
+        }
+        total_size++;
+    }
+    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(samples.begin(), samples.end(), g);
+
+    for (auto expected : samples) {
+        auto it = frame.find(expected);
+        BOOST_REQUIRE(it != frame.end());
+        auto actual = *it;
+        BOOST_REQUIRE_EQUAL(actual, expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_xor) {
+    find_test_case<details::delta_xor>(10000000, {});
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_delta) {
+    find_test_case<details::delta_delta<int64_t>>(
+      10000000, details::delta_delta<int64_t>(0));
+}
+
+template<class delta_alg>
+void lower_bound_test_case(const int64_t max_value, delta_alg initial) {
+    using frame_t = frame<int64_t, delta_alg>;
+    frame_t frame(std::move(initial));
+    size_t total_size = 0;
+    std::vector<int64_t> samples;
+    int64_t last = 0;
+    for (int64_t ix = 10000; ix < max_value;
+         ix += random_generators::get_int(1, 100)) {
+        frame.append(ix);
+        last = ix;
+        if (samples.empty() || random_generators::get_int(10) == 0) {
+            samples.push_back(ix);
+        }
+        total_size++;
+    }
+    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(samples.begin(), samples.end(), g);
+
+    {
+        auto it = frame.lower_bound(last);
+        BOOST_REQUIRE_EQUAL(last, *it);
+        it = frame.lower_bound(last + 1);
+        BOOST_REQUIRE(it == frame.end());
+    }
+
+    for (auto expected : samples) {
+        auto it = frame.lower_bound(expected);
+        BOOST_REQUIRE(it != frame.end());
+        auto actual = *it;
+        BOOST_REQUIRE_EQUAL(actual, expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_xor) {
+    lower_bound_test_case<details::delta_xor>(10000000, {});
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_delta) {
+    lower_bound_test_case<details::delta_delta<int64_t>>(
+      10000000, details::delta_delta<int64_t>(0));
+}
+
+template<class delta_alg>
+void upper_bound_test_case(const int64_t max_value, delta_alg initial) {
+    using frame_t = frame<int64_t, delta_alg>;
+    frame_t frame(std::move(initial));
+    size_t total_size = 0;
+    std::vector<int64_t> samples;
+    int64_t last = 0;
+    for (int64_t ix = 10000; ix < max_value;
+         ix += random_generators::get_int(1, 100)) {
+        frame.append(ix);
+        if (samples.empty() || random_generators::get_int(10) == 0) {
+            samples.push_back(ix);
+        }
+        last = ix;
+        total_size++;
+    }
+    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(samples.begin(), samples.end(), g);
+
+    {
+        auto it = frame.upper_bound(last);
+        BOOST_REQUIRE(it == frame.end());
+    }
+
+    for (auto expected : samples) {
+        auto it = frame.upper_bound(expected - 1);
+        BOOST_REQUIRE(it != frame.end());
+        auto actual = *it;
+        BOOST_REQUIRE_EQUAL(actual, expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_xor) {
+    upper_bound_test_case<details::delta_xor>(10000000, {});
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_delta) {
+    upper_bound_test_case<details::delta_delta<int64_t>>(
+      10000000, details::delta_delta<int64_t>(0));
+}
+

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -9,9 +9,13 @@
  */
 
 #include "cloud_storage/segment_meta_cstore.h"
+#include "cloud_storage/types.h"
 #include "common_def.h"
+#include "model/fundamental.h"
+#include "model/timestamp.h"
 #include "random/generators.h"
 #include "utils/delta_for.h"
+#include "utils/human.h"
 #include "vlog.h"
 
 #include <seastar/testing/test_case.hh>

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -29,15 +29,17 @@ using delta_xor_alg = details::delta_xor;
 using delta_xor_frame = segment_meta_column_frame<int64_t, delta_xor_alg>;
 using delta_delta_alg = details::delta_delta<int64_t>;
 using delta_delta_frame = segment_meta_column_frame<int64_t, delta_delta_alg>;
+using delta_xor_column = segment_meta_column<int64_t, delta_xor_alg>;
 
 static const delta_xor_alg initial_xor{};
 static const delta_delta_alg initial_delta{0};
 
 template<class column_t>
-void append_test_case(const int64_t max_value, column_t& column) {
+void append_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
-    for (int64_t ix = 0; ix < max_value;
-         ix += random_generators::get_int(1, 100)) {
+    int64_t ix = 0;
+    for (int64_t i = 0; i < num_elements; i++) {
+        ix += random_generators::get_int(1, 100);
         column.append(ix);
         total_size++;
         BOOST_REQUIRE_EQUAL(ix, column.last_value());
@@ -45,22 +47,28 @@ void append_test_case(const int64_t max_value, column_t& column) {
     BOOST_REQUIRE_EQUAL(total_size, column.size());
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_append_xor) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_xor) {
     delta_xor_frame frame(initial_xor);
-    append_test_case(10000000, frame);
+    append_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_append_delta) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_delta) {
     delta_delta_frame frame(initial_delta);
-    append_test_case(10000000, frame);
+    append_test_case(100000, frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_xor) {
+    delta_xor_column col(initial_xor);
+    append_test_case(100000, col);
 }
 
 template<class column_t>
-void iter_test_case(const int64_t max_value, column_t& column) {
+void iter_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> expected;
-    for (int64_t ix = 0; ix < max_value;
-         ix += random_generators::get_int(1, 100)) {
+    int64_t ix = 0;
+    for (int64_t i = 0; i < num_elements; i++) {
+        ix += random_generators::get_int(1, 100);
         column.append(ix);
         expected.push_back(ix);
         total_size++;
@@ -73,22 +81,28 @@ void iter_test_case(const int64_t max_value, column_t& column) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_iter_xor) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_iter_xor) {
     delta_xor_frame frame(initial_xor);
-    iter_test_case(10000000, frame);
+    iter_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_iter_delta) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_iter_delta) {
     delta_delta_frame frame(initial_delta);
-    iter_test_case(10000000, frame);
+    iter_test_case(100000, frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_iter_xor) {
+    delta_xor_column col(initial_xor);
+    iter_test_case(100000, col);
 }
 
 template<class column_t>
-void find_test_case(const int64_t max_value, column_t& column) {
+void find_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> samples;
-    for (int64_t ix = 0; ix < max_value;
-         ix += random_generators::get_int(1, 100)) {
+    int64_t ix = 0;
+    for (auto i = 0; i < num_elements; i++) {
+        ix += random_generators::get_int(1, 100);
         column.append(ix);
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.push_back(ix);
@@ -108,33 +122,44 @@ void find_test_case(const int64_t max_value, column_t& column) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_xor) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_xor) {
     delta_xor_frame frame(initial_xor);
-    find_test_case(10000000, frame);
+    find_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_xor_small) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_xor_small) {
     delta_xor_frame frame(initial_xor);
-    find_test_case(random_generators::get_int(16), frame);
+    find_test_case(random_generators::get_int(1, 16), frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_delta) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_delta) {
     delta_delta_frame frame(initial_delta);
-    find_test_case(10000000, frame);
+    find_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_delta_small) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_delta_small) {
     delta_delta_frame frame(initial_delta);
-    find_test_case(random_generators::get_int(16), frame);
+    find_test_case(random_generators::get_int(1, 16), frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor) {
+    delta_xor_column col(initial_xor);
+    find_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor_small) {
+    delta_xor_column col(initial_xor);
+    find_test_case(random_generators::get_int(1, 16), col);
 }
 
 template<class column_t>
-void lower_bound_test_case(const int64_t max_value, column_t& column) {
+void lower_bound_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> samples;
     int64_t last = 0;
-    for (int64_t ix = 10000; ix < max_value;
-         ix += random_generators::get_int(1, 100)) {
+    int64_t ix = 10000;
+    for (auto i = 0; i < num_elements; i++) {
+        ix += random_generators::get_int(1, 100);
         column.append(ix);
         last = ix;
         if (samples.empty() || random_generators::get_int(10) == 0) {
@@ -162,33 +187,44 @@ void lower_bound_test_case(const int64_t max_value, column_t& column) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_xor) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_xor) {
     delta_xor_frame frame(initial_xor);
-    lower_bound_test_case(10000000, frame);
+    lower_bound_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_xor_small) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_xor_small) {
     delta_xor_frame frame(initial_xor);
-    lower_bound_test_case(random_generators::get_int(16), frame);
+    lower_bound_test_case(random_generators::get_int(1, 16), frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_delta) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_delta) {
     delta_delta_frame frame(initial_delta);
-    lower_bound_test_case(10000000, frame);
+    lower_bound_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_delta_small) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_delta_small) {
     delta_delta_frame frame(initial_delta);
-    lower_bound_test_case(random_generators::get_int(16), frame);
+    lower_bound_test_case(random_generators::get_int(1, 16), frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_xor) {
+    delta_xor_column col(initial_xor);
+    lower_bound_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_xor_small) {
+    delta_xor_column col(initial_xor);
+    lower_bound_test_case(random_generators::get_int(1, 16), col);
 }
 
 template<class column_t>
-void upper_bound_test_case(const int64_t max_value, column_t& column) {
+void upper_bound_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> samples;
     int64_t last = 0;
-    for (int64_t ix = 10000; ix < max_value;
-         ix += random_generators::get_int(1, 100)) {
+    int64_t ix = 10000;
+    for (auto i = 0; i < num_elements; i++) {
+        ix += random_generators::get_int(1, 100);
         column.append(ix);
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.push_back(ix);
@@ -214,32 +250,43 @@ void upper_bound_test_case(const int64_t max_value, column_t& column) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_xor) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_xor) {
     delta_xor_frame frame(initial_xor);
-    upper_bound_test_case(10000000, frame);
+    upper_bound_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_xor_small) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_xor_small) {
     delta_xor_frame frame(initial_xor);
-    upper_bound_test_case(random_generators::get_int(16), frame);
+    upper_bound_test_case(random_generators::get_int(1, 16), frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_delta) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_delta) {
     delta_delta_frame frame(initial_delta);
-    upper_bound_test_case(10000000, frame);
+    upper_bound_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_delta_small) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_delta_small) {
     delta_delta_frame frame(initial_delta);
-    upper_bound_test_case(random_generators::get_int(16), frame);
+    upper_bound_test_case(random_generators::get_int(1, 16), frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_xor) {
+    delta_xor_column col(initial_xor);
+    upper_bound_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_xor_small) {
+    delta_xor_column col(initial_xor);
+    upper_bound_test_case(random_generators::get_int(1, 16), col);
 }
 
 template<class column_t>
-void at_test_case(const int64_t max_value, column_t& column) {
+void at_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
     std::vector<std::pair<int64_t, size_t>> samples;
-    for (int64_t value = 0; value < max_value;
-         value += random_generators::get_int(1, 100)) {
+    int64_t value = 0;
+    for (int64_t i = 0; i < num_elements; i++) {
+        value += random_generators::get_int(1, 100);
         column.append(value);
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.emplace_back(value, total_size);
@@ -259,32 +306,43 @@ void at_test_case(const int64_t max_value, column_t& column) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_xor) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_xor) {
     delta_xor_frame frame(initial_xor);
-    at_test_case(10000000, frame);
+    at_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_xor_small) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_xor_small) {
     delta_xor_frame frame(initial_xor);
     at_test_case(random_generators::get_int(16), frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_delta) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_delta) {
     delta_delta_frame frame(initial_delta);
-    at_test_case(10000000, frame);
+    at_test_case(100000, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_delta_small) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_delta_small) {
     delta_delta_frame frame(initial_delta);
     at_test_case(random_generators::get_int(16), frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_xor) {
+    delta_xor_column col(initial_xor);
+    at_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_xor_small) {
+    delta_xor_column col(initial_xor);
+    at_test_case(random_generators::get_int(16), col);
 }
 
 template<class column_t>
-void prefix_truncate_test_case(const int64_t max_value, column_t& column) {
+void prefix_truncate_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> samples;
-    for (int64_t value = 0; value < max_value;
-         value += random_generators::get_int(1, 100)) {
+    int64_t value = 0;
+    for (int64_t i = 0; i < num_elements; i++) {
+        value += random_generators::get_int(1, 100);
         column.append(value);
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.push_back(value);
@@ -302,12 +360,17 @@ void prefix_truncate_test_case(const int64_t max_value, column_t& column) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_xor) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_prefix_truncate_xor) {
     delta_xor_frame frame(initial_xor);
     prefix_truncate_test_case(10, frame);
 }
 
-BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_delta) {
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_prefix_truncate_delta) {
     delta_delta_frame frame(initial_delta);
     prefix_truncate_test_case(10, frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_prefix_truncate_xor) {
+    delta_xor_column col(initial_xor);
+    prefix_truncate_test_case(10, col);
 }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -25,286 +25,289 @@
 
 using namespace cloud_storage;
 
-template<class delta_alg>
-void append_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
-    frame_t frame(std::move(initial));
+using delta_xor_alg = details::delta_xor;
+using delta_xor_frame = segment_meta_column_frame<int64_t, delta_xor_alg>;
+using delta_delta_alg = details::delta_delta<int64_t>;
+using delta_delta_frame = segment_meta_column_frame<int64_t, delta_delta_alg>;
+
+static const delta_xor_alg initial_xor{};
+static const delta_delta_alg initial_delta{0};
+
+template<class column_t>
+void append_test_case(const int64_t max_value, column_t& column) {
     size_t total_size = 0;
     for (int64_t ix = 0; ix < max_value;
          ix += random_generators::get_int(1, 100)) {
-        frame.append(ix);
+        column.append(ix);
         total_size++;
-        BOOST_REQUIRE_EQUAL(ix, frame.last_value());
+        BOOST_REQUIRE_EQUAL(ix, column.last_value());
     }
-    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    BOOST_REQUIRE_EQUAL(total_size, column.size());
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_append_xor) {
-    append_test_case<details::delta_xor>(10000000, {});
+    delta_xor_frame frame(initial_xor);
+    append_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_append_delta) {
-    append_test_case<details::delta_delta<int64_t>>(
-      10000000, details::delta_delta<int64_t>(0));
+    delta_delta_frame frame(initial_delta);
+    append_test_case(10000000, frame);
 }
 
-template<class delta_alg>
-void iter_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
-    frame_t frame(std::move(initial));
+template<class column_t>
+void iter_test_case(const int64_t max_value, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> expected;
     for (int64_t ix = 0; ix < max_value;
          ix += random_generators::get_int(1, 100)) {
-        frame.append(ix);
+        column.append(ix);
         expected.push_back(ix);
         total_size++;
     }
-    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    BOOST_REQUIRE_EQUAL(total_size, column.size());
 
     int i = 0;
-    for (auto actual : frame) {
+    for (auto actual : column) {
         BOOST_REQUIRE_EQUAL(actual, expected[i++]);
     }
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_iter_xor) {
-    iter_test_case<details::delta_xor>(10000000, {});
+    delta_xor_frame frame(initial_xor);
+    iter_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_iter_delta) {
-    iter_test_case<details::delta_delta<int64_t>>(
-      10000000, details::delta_delta<int64_t>(0));
+    delta_delta_frame frame(initial_delta);
+    iter_test_case(10000000, frame);
 }
 
-template<class delta_alg>
-void find_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
-    frame_t frame(std::move(initial));
+template<class column_t>
+void find_test_case(const int64_t max_value, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> samples;
     for (int64_t ix = 0; ix < max_value;
          ix += random_generators::get_int(1, 100)) {
-        frame.append(ix);
+        column.append(ix);
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.push_back(ix);
         }
         total_size++;
     }
-    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    BOOST_REQUIRE_EQUAL(total_size, column.size());
     std::random_device rd;
     std::mt19937 g(rd());
     std::shuffle(samples.begin(), samples.end(), g);
 
     for (auto expected : samples) {
-        auto it = frame.find(expected);
-        BOOST_REQUIRE(it != frame.end());
+        auto it = column.find(expected);
+        BOOST_REQUIRE(it != column.end());
         auto actual = *it;
         BOOST_REQUIRE_EQUAL(actual, expected);
     }
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_xor) {
-    find_test_case<details::delta_xor>(10000000, {});
+    delta_xor_frame frame(initial_xor);
+    find_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_xor_small) {
-    find_test_case<details::delta_xor>(random_generators::get_int(16), {});
+    delta_xor_frame frame(initial_xor);
+    find_test_case(random_generators::get_int(16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_delta) {
-    find_test_case<details::delta_delta<int64_t>>(
-      10000000, details::delta_delta<int64_t>(0));
+    delta_delta_frame frame(initial_delta);
+    find_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_delta_small) {
-    find_test_case<details::delta_delta<int64_t>>(
-      random_generators::get_int(16), details::delta_delta<int64_t>(0));
+    delta_delta_frame frame(initial_delta);
+    find_test_case(random_generators::get_int(16), frame);
 }
 
-template<class delta_alg>
-void lower_bound_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
-    frame_t frame(std::move(initial));
+template<class column_t>
+void lower_bound_test_case(const int64_t max_value, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> samples;
     int64_t last = 0;
     for (int64_t ix = 10000; ix < max_value;
          ix += random_generators::get_int(1, 100)) {
-        frame.append(ix);
+        column.append(ix);
         last = ix;
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.push_back(ix);
         }
         total_size++;
     }
-    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    BOOST_REQUIRE_EQUAL(total_size, column.size());
     std::random_device rd;
     std::mt19937 g(rd());
     std::shuffle(samples.begin(), samples.end(), g);
 
     {
-        auto it = frame.lower_bound(last);
+        auto it = column.lower_bound(last);
         BOOST_REQUIRE_EQUAL(last, *it);
-        it = frame.lower_bound(last + 1);
-        BOOST_REQUIRE(it == frame.end());
+        it = column.lower_bound(last + 1);
+        BOOST_REQUIRE(it == column.end());
     }
 
     for (auto expected : samples) {
-        auto it = frame.lower_bound(expected);
-        BOOST_REQUIRE(it != frame.end());
+        auto it = column.lower_bound(expected);
+        BOOST_REQUIRE(it != column.end());
         auto actual = *it;
         BOOST_REQUIRE_EQUAL(actual, expected);
     }
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_xor) {
-    lower_bound_test_case<details::delta_xor>(10000000, {});
+    delta_xor_frame frame(initial_xor);
+    lower_bound_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_xor_small) {
-    lower_bound_test_case<details::delta_xor>(
-      random_generators::get_int(16), {});
+    delta_xor_frame frame(initial_xor);
+    lower_bound_test_case(random_generators::get_int(16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_delta) {
-    lower_bound_test_case<details::delta_delta<int64_t>>(
-      10000000, details::delta_delta<int64_t>(0));
+    delta_delta_frame frame(initial_delta);
+    lower_bound_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_delta_small) {
-    lower_bound_test_case<details::delta_delta<int64_t>>(
-      random_generators::get_int(16), details::delta_delta<int64_t>(0));
+    delta_delta_frame frame(initial_delta);
+    lower_bound_test_case(random_generators::get_int(16), frame);
 }
 
-template<class delta_alg>
-void upper_bound_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
-    frame_t frame(std::move(initial));
+template<class column_t>
+void upper_bound_test_case(const int64_t max_value, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> samples;
     int64_t last = 0;
     for (int64_t ix = 10000; ix < max_value;
          ix += random_generators::get_int(1, 100)) {
-        frame.append(ix);
+        column.append(ix);
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.push_back(ix);
         }
         last = ix;
         total_size++;
     }
-    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    BOOST_REQUIRE_EQUAL(total_size, column.size());
     std::random_device rd;
     std::mt19937 g(rd());
     std::shuffle(samples.begin(), samples.end(), g);
 
     {
-        auto it = frame.upper_bound(last);
-        BOOST_REQUIRE(it == frame.end());
+        auto it = column.upper_bound(last);
+        BOOST_REQUIRE(it == column.end());
     }
 
     for (auto expected : samples) {
-        auto it = frame.upper_bound(expected - 1);
-        BOOST_REQUIRE(it != frame.end());
+        auto it = column.upper_bound(expected - 1);
+        BOOST_REQUIRE(it != column.end());
         auto actual = *it;
         BOOST_REQUIRE_EQUAL(actual, expected);
     }
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_xor) {
-    upper_bound_test_case<details::delta_xor>(10000000, {});
+    delta_xor_frame frame(initial_xor);
+    upper_bound_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_xor_small) {
-    upper_bound_test_case<details::delta_xor>(
-      random_generators::get_int(16), {});
+    delta_xor_frame frame(initial_xor);
+    upper_bound_test_case(random_generators::get_int(16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_delta) {
-    upper_bound_test_case<details::delta_delta<int64_t>>(
-      10000000, details::delta_delta<int64_t>(0));
+    delta_delta_frame frame(initial_delta);
+    upper_bound_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_delta_small) {
-    upper_bound_test_case<details::delta_delta<int64_t>>(
-      random_generators::get_int(16), details::delta_delta<int64_t>(0));
+    delta_delta_frame frame(initial_delta);
+    upper_bound_test_case(random_generators::get_int(16), frame);
 }
 
-template<class delta_alg>
-void at_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
-    frame_t frame(std::move(initial));
+template<class column_t>
+void at_test_case(const int64_t max_value, column_t& column) {
     size_t total_size = 0;
     std::vector<std::pair<int64_t, size_t>> samples;
     for (int64_t value = 0; value < max_value;
          value += random_generators::get_int(1, 100)) {
-        frame.append(value);
+        column.append(value);
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.emplace_back(value, total_size);
         }
         total_size++;
     }
-    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    BOOST_REQUIRE_EQUAL(total_size, column.size());
     std::random_device rd;
     std::mt19937 g(rd());
     std::shuffle(samples.begin(), samples.end(), g);
 
     for (auto [expected, index] : samples) {
-        auto it = frame.at(index);
-        BOOST_REQUIRE(it != frame.end());
+        auto it = column.at(index);
+        BOOST_REQUIRE(it != column.end());
         auto actual = *it;
         BOOST_REQUIRE_EQUAL(actual, expected);
     }
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_xor) {
-    at_test_case<details::delta_xor>(10000000, {});
+    delta_xor_frame frame(initial_xor);
+    at_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_xor_small) {
-    at_test_case<details::delta_xor>(random_generators::get_int(16), {});
+    delta_xor_frame frame(initial_xor);
+    at_test_case(random_generators::get_int(16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_delta) {
-    at_test_case<details::delta_delta<int64_t>>(
-      10000000, details::delta_delta<int64_t>{0});
+    delta_delta_frame frame(initial_delta);
+    at_test_case(10000000, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_delta_small) {
-    at_test_case<details::delta_delta<int64_t>>(
-      random_generators::get_int(16), details::delta_delta<int64_t>{0});
+    delta_delta_frame frame(initial_delta);
+    at_test_case(random_generators::get_int(16), frame);
 }
 
-template<class delta_alg>
-void prefix_truncate_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
-    frame_t frame(std::move(initial));
+template<class column_t>
+void prefix_truncate_test_case(const int64_t max_value, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> samples;
     for (int64_t value = 0; value < max_value;
          value += random_generators::get_int(1, 100)) {
-        frame.append(value);
+        column.append(value);
         if (samples.empty() || random_generators::get_int(10) == 0) {
             samples.push_back(value);
         }
         total_size++;
     }
-    BOOST_REQUIRE_EQUAL(total_size, frame.size());
+    BOOST_REQUIRE_EQUAL(total_size, column.size());
 
     for (auto value : samples) {
-        frame.prefix_truncate(value);
-        auto it = frame.begin();
-        BOOST_REQUIRE(it != frame.end());
+        column.prefix_truncate(value);
+        auto it = column.begin();
+        BOOST_REQUIRE(it != column.end());
         auto actual = *it;
         BOOST_REQUIRE_EQUAL(actual, value);
     }
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_xor) {
-    prefix_truncate_test_case<details::delta_xor>(10, {});
+    delta_xor_frame frame(initial_xor);
+    prefix_truncate_test_case(10, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_delta) {
-    prefix_truncate_test_case<details::delta_delta<int64_t>>(
-      10, details::delta_delta<int64_t>{0});
+    delta_delta_frame frame(initial_delta);
+    prefix_truncate_test_case(10, frame);
 }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -69,6 +69,42 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_delta) {
 }
 
 template<class column_t>
+void append_tx_test_case(const int64_t num_elements, column_t& column) {
+    size_t total_size = 0;
+    int64_t ix = 0;
+    for (int64_t i = 0; i < num_elements; i++) {
+        ix += random_generators::get_int(1, 100);
+        auto tx = column.append_tx(ix);
+        if (tx) {
+            tx->commit();
+        }
+        total_size++;
+        BOOST_REQUIRE_EQUAL(ix, column.last_value());
+    }
+    BOOST_REQUIRE_EQUAL(total_size, column.size());
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_tx_xor) {
+    delta_xor_frame frame(initial_xor);
+    append_tx_test_case(100000, frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_tx_delta) {
+    delta_delta_frame frame(initial_delta);
+    append_tx_test_case(100000, frame);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_tx_xor) {
+    delta_xor_column col(initial_xor);
+    append_tx_test_case(100000, col);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_tx_delta) {
+    delta_delta_column col(initial_delta);
+    append_tx_test_case(100000, col);
+}
+
+template<class column_t>
 void iter_test_case(const int64_t num_elements, column_t& column) {
     size_t total_size = 0;
     std::vector<int64_t> expected;

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -108,9 +108,18 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_xor) {
     find_test_case<details::delta_xor>(10000000, {});
 }
 
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_xor_small) {
+    find_test_case<details::delta_xor>(random_generators::get_int(16), {});
+}
+
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_delta) {
     find_test_case<details::delta_delta<int64_t>>(
       10000000, details::delta_delta<int64_t>(0));
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_delta_small) {
+    find_test_case<details::delta_delta<int64_t>>(
+      random_generators::get_int(16), details::delta_delta<int64_t>(0));
 }
 
 template<class delta_alg>
@@ -153,9 +162,19 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_xor) {
     lower_bound_test_case<details::delta_xor>(10000000, {});
 }
 
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_xor_small) {
+    lower_bound_test_case<details::delta_xor>(
+      random_generators::get_int(16), {});
+}
+
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_delta) {
     lower_bound_test_case<details::delta_delta<int64_t>>(
       10000000, details::delta_delta<int64_t>(0));
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_delta_small) {
+    lower_bound_test_case<details::delta_delta<int64_t>>(
+      random_generators::get_int(16), details::delta_delta<int64_t>(0));
 }
 
 template<class delta_alg>
@@ -196,9 +215,19 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_xor) {
     upper_bound_test_case<details::delta_xor>(10000000, {});
 }
 
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_xor_small) {
+    upper_bound_test_case<details::delta_xor>(
+      random_generators::get_int(16), {});
+}
+
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_delta) {
     upper_bound_test_case<details::delta_delta<int64_t>>(
       10000000, details::delta_delta<int64_t>(0));
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_delta_small) {
+    upper_bound_test_case<details::delta_delta<int64_t>>(
+      random_generators::get_int(16), details::delta_delta<int64_t>(0));
 }
 
 template<class delta_alg>
@@ -230,6 +259,10 @@ void at_test_case(const int64_t max_value, delta_alg initial) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_xor) {
     at_test_case<details::delta_xor>(10000000, {});
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_xor_small) {
+    at_test_case<details::delta_xor>(random_generators::get_int(16), {});
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_at_delta) {

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -81,7 +81,7 @@ void append_tx_test_case(const int64_t num_elements, column_t& column) {
         ix += random_generators::get_int(1, 100);
         auto tx = column.append_tx(ix);
         if (tx) {
-            tx->commit();
+            std::move(*tx).commit();
         }
         total_size++;
         BOOST_REQUIRE_EQUAL(ix, column.last_value());

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -27,7 +27,7 @@ using namespace cloud_storage;
 
 template<class delta_alg>
 void append_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = frame<int64_t, delta_alg>;
+    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
     frame_t frame(std::move(initial));
     size_t total_size = 0;
     for (int64_t ix = 0; ix < max_value;
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_append_delta) {
 
 template<class delta_alg>
 void iter_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = frame<int64_t, delta_alg>;
+    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
     frame_t frame(std::move(initial));
     size_t total_size = 0;
     std::vector<int64_t> expected;
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_iter_delta) {
 
 template<class delta_alg>
 void find_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = frame<int64_t, delta_alg>;
+    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
     frame_t frame(std::move(initial));
     size_t total_size = 0;
     std::vector<int64_t> samples;
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_find_delta_small) {
 
 template<class delta_alg>
 void lower_bound_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = frame<int64_t, delta_alg>;
+    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
     frame_t frame(std::move(initial));
     size_t total_size = 0;
     std::vector<int64_t> samples;
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_lower_bound_delta_small) {
 
 template<class delta_alg>
 void upper_bound_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = frame<int64_t, delta_alg>;
+    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
     frame_t frame(std::move(initial));
     size_t total_size = 0;
     std::vector<int64_t> samples;
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_upper_bound_delta_small) {
 
 template<class delta_alg>
 void at_test_case(const int64_t max_value, delta_alg initial) {
-    using frame_t = frame<int64_t, delta_alg>;
+    using frame_t = segment_meta_column_frame<int64_t, delta_alg>;
     frame_t frame(std::move(initial));
     size_t total_size = 0;
     std::vector<std::pair<int64_t, size_t>> samples;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -137,9 +137,9 @@ ss::future<consensus_ptr> partition_manager::manage(
         } else {
             // Manifest is not empty since we were able to recovery
             // some data.
-            vassert(manifest.size() != 0, "Manifest is empty");
-            auto last_segm_it = manifest.rbegin();
-            auto last_included_term = last_segm_it->second.archiver_term;
+            auto last_segment = manifest.last_segment();
+            vassert(last_segment.has_value(), "Manifest is empty");
+            auto last_included_term = last_segment->archiver_term;
 
             vlog(
               clusterlog.info,

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -281,7 +281,7 @@ public:
     iobuf copy() const { return _data.copy(); }
 
     /// Share the underlying iobuf
-    iobuf share() { return _data.share(0, _data.size_bytes()); }
+    iobuf share() const { return _data.share(0, _data.size_bytes()); }
 
     /// Return number of rows stored in the underlying iobuf instance
     uint32_t get_row_count() const noexcept { return _cnt; }
@@ -715,7 +715,7 @@ private:
 
     TVal _initial;
     TVal _last;
-    iobuf _data;
+    mutable iobuf _data;
     uint32_t _cnt;
     DeltaStep _delta;
 };

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -272,6 +272,8 @@ public:
     /// Get last value used to create the encoder
     TVal get_last_value() const noexcept { return _last; }
 
+    size_t mem_use() const { return _data.size_bytes(); }
+
 private:
     template<typename T>
     void _pack_as(const row_t& input) {

--- a/src/v/utils/tests/delta_for_test.cc
+++ b/src/v/utils/tests/delta_for_test.cc
@@ -254,3 +254,154 @@ BOOST_AUTO_TEST_CASE(test_compression_ratio) {
     auto num_bytes_per_val = num_elements;
     BOOST_REQUIRE(enc_delta.share().size_bytes() < num_bytes_per_val);
 }
+
+template<class TVal, class DeltaT>
+std::vector<std::array<TVal, details::FOR_buffer_depth>> populate_encoder(
+  deltafor_encoder<TVal, DeltaT>& c,
+  std::vector<deltafor_stream_pos_t<TVal>>& pos,
+  uint64_t initial_value,
+  const std::vector<std::pair<TVal, TVal>>& deltas) {
+    std::vector<std::array<TVal, details::FOR_buffer_depth>> result;
+    auto p = initial_value + deltas.front().first;
+    for (auto [min_delta, max_delta] : deltas) {
+        std::array<TVal, details::FOR_buffer_depth> buf = {};
+        for (int x = 0; x < details::FOR_buffer_depth; x++) {
+            buf.at(x) = p;
+            p += random_generators::get_int(min_delta, max_delta);
+            if (p < buf.at(x)) {
+                throw std::out_of_range("delta can't be represented");
+            }
+        }
+        result.push_back(buf);
+        pos.push_back(c.get_position());
+        c.add(buf);
+    }
+    return result;
+}
+
+template<class TVal, class DeltaT>
+void skip_test(const std::vector<std::pair<TVal, TVal>>& deltas, DeltaT delta) {
+    static constexpr TVal initial_value = 0;
+    deltafor_encoder<TVal, DeltaT> enc(initial_value, delta);
+    std::vector<deltafor_stream_pos_t<TVal>> positions;
+    auto expected = populate_encoder(enc, positions, initial_value, deltas);
+
+    BOOST_REQUIRE_EQUAL(positions.size(), expected.size());
+
+    for (auto i = 0; i < expected.size(); i++) {
+        auto row = expected.at(i);
+        auto pos = positions.at(i);
+        deltafor_decoder<TVal, DeltaT> dec(
+          initial_value, enc.get_row_count(), enc.copy(), delta);
+        dec.skip(pos);
+        std::array<TVal, details::FOR_buffer_depth> buf{};
+        auto success = dec.read(buf);
+        BOOST_REQUIRE(success);
+        BOOST_REQUIRE(row == buf);
+
+        // maybe read another item
+        if (i != expected.size() - 1) {
+            row = expected.at(i + 1);
+            buf = {};
+            success = dec.read(buf);
+            BOOST_REQUIRE(success);
+            BOOST_REQUIRE(row == buf);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(skip_test_1) {
+    std::vector<std::pair<int64_t, int64_t>> deltas = {
+      std::make_pair(0LL, 0LL),
+      std::make_pair(0LL, 10LL),
+      std::make_pair(0LL, 100LL),
+      std::make_pair(0LL, 1000LL),
+      std::make_pair(0LL, 10000LL),
+      std::make_pair(0LL, 100000LL),
+      std::make_pair(0LL, 1000000LL),
+      std::make_pair(0LL, 10000000LL),
+      std::make_pair(0LL, 100000000LL),
+      std::make_pair(0LL, 1000000000LL),
+      std::make_pair(0LL, 10000000000LL),
+      std::make_pair(0LL, 100000000000LL),
+      std::make_pair(0LL, 1000000000000LL),
+      std::make_pair(0LL, 10000000000000LL),
+      std::make_pair(0LL, 100000000000000LL),
+      std::make_pair(0LL, 1000000000000000LL),
+      std::make_pair(0LL, 10000000000000000LL),
+      std::make_pair(0LL, 100000000000000000LL),
+      std::make_pair(0LL, 1000000000000000000LL),
+    };
+    skip_test<int64_t>(deltas, details::delta_xor());
+}
+
+BOOST_AUTO_TEST_CASE(skip_test_2) {
+    std::vector<std::pair<uint64_t, uint64_t>> deltas = {
+      std::make_pair(0ULL, 0ULL),
+      std::make_pair(0ULL, 10ULL),
+      std::make_pair(0ULL, 100ULL),
+      std::make_pair(0ULL, 1000ULL),
+      std::make_pair(0ULL, 10000ULL),
+      std::make_pair(0ULL, 100000ULL),
+      std::make_pair(0ULL, 1000000ULL),
+      std::make_pair(0ULL, 10000000ULL),
+      std::make_pair(0ULL, 100000000ULL),
+      std::make_pair(0ULL, 1000000000ULL),
+      std::make_pair(0ULL, 10000000000ULL),
+      std::make_pair(0ULL, 100000000000ULL),
+      std::make_pair(0ULL, 1000000000000ULL),
+      std::make_pair(0ULL, 10000000000000ULL),
+      std::make_pair(0ULL, 100000000000000ULL),
+      std::make_pair(0ULL, 1000000000000000ULL),
+      std::make_pair(0ULL, 10000000000000000ULL),
+      std::make_pair(0ULL, 100000000000000000ULL),
+      std::make_pair(0ULL, 1000000000000000000ULL),
+    };
+    skip_test<uint64_t>(deltas, details::delta_xor());
+}
+
+BOOST_AUTO_TEST_CASE(skip_test_3) {
+    std::vector<std::pair<int64_t, int64_t>> deltas = {
+      std::make_pair(10LL, 10LL),
+      std::make_pair(10LL, 100LL),
+      std::make_pair(10LL, 1000LL),
+      std::make_pair(10LL, 10000LL),
+      std::make_pair(10LL, 100000LL),
+      std::make_pair(10LL, 1000000LL),
+      std::make_pair(10LL, 10000000LL),
+      std::make_pair(10LL, 100000000LL),
+      std::make_pair(10LL, 1000000000LL),
+      std::make_pair(10LL, 10000000000LL),
+      std::make_pair(10LL, 100000000000LL),
+      std::make_pair(10LL, 1000000000000LL),
+      std::make_pair(10LL, 10000000000000LL),
+      std::make_pair(10LL, 100000000000000LL),
+      std::make_pair(10LL, 1000000000000000LL),
+      std::make_pair(10LL, 10000000000000000LL),
+      std::make_pair(10LL, 100000000000000000LL),
+    };
+    skip_test<int64_t>(deltas, details::delta_delta<int64_t>(10));
+}
+
+BOOST_AUTO_TEST_CASE(skip_test_4) {
+    std::vector<std::pair<uint64_t, uint64_t>> deltas = {
+      std::make_pair(10ULL, 10ULL),
+      std::make_pair(10ULL, 100ULL),
+      std::make_pair(10ULL, 1000ULL),
+      std::make_pair(10ULL, 10000ULL),
+      std::make_pair(10ULL, 100000ULL),
+      std::make_pair(10ULL, 1000000ULL),
+      std::make_pair(10ULL, 10000000ULL),
+      std::make_pair(10ULL, 100000000ULL),
+      std::make_pair(10ULL, 1000000000ULL),
+      std::make_pair(10ULL, 10000000000ULL),
+      std::make_pair(10ULL, 100000000000ULL),
+      std::make_pair(10ULL, 1000000000000ULL),
+      std::make_pair(10ULL, 10000000000000ULL),
+      std::make_pair(10ULL, 100000000000000ULL),
+      std::make_pair(10ULL, 1000000000000000ULL),
+      std::make_pair(10ULL, 10000000000000000ULL),
+      std::make_pair(10ULL, 100000000000000000ULL),
+    };
+    skip_test<uint64_t>(deltas, details::delta_delta<uint64_t>(10));
+}


### PR DESCRIPTION
Implement columnar compression for manifests.

This is a first part of a series of pull requests that just adds data structures without using them to implement the `cloud_storage::partition_manifest`.

Currently, the manifest is implemented using `absl::btree_map` that uses `model::offset` as a key and `cloud_storage::segment_meta` as a value. The `segment_meta` is a relatively large struct  around 100 bytes that contain only integer/boolean/enum fields. This consumes a lot of memory.

To minimize memory usage the structure can be converted to the columnar format. In this case every field is represented using its own column. So essentially, instead of having a collection of `segment_meta` objects the manifest will contain a set of columns, one column per field in `segment_meta`. When new object is added to the collection new value will be added to every column.  The search could be performed on one column and the full `segment_meta` struct could be reconstructed by querying the remaining columns by index.

This storage format is more compact because every column can be compressed efficiently using simple encoding (delta-delta + frame of reference or delta xor + frame of reference).

**Column structure**

Every column consist of series of frames. Every frame has size limit. Currently, it can only contain 1024 elements or 64 rows. The frames are organized into a linked list. The frame contains a `deltafor_encoder<int64_t, delta_alg>` instance. The `delta_alg` can be either `delta_xor` for columns that contains non-monotonic data or `delta_delta` for monotonic data. The example of monotonic column is `base_offset` field. The `base_offset` values can only grow. The monotonic fields can be used to search specific values quickly because search alg. can quickly skip irrelevant frames. The non-monotonic columns can also be used for searches but it's not as efficient. 

**Iterators**

The frame iterator contains a full copy of data so it is stable. It can even outlive the parent container. This implemented by sharing an underlying `iobuf` of the `deltafor_encoder` with the iterator. The iterator has its own copy of `deltafor_decoder` and can be used to decode data. The decoder can only decode full rows of data (every row has 16 elements) and frame iterator is hiding this from the user. This means that you can iterate through elements and not rows.

The column iterator contains a snapshot of the column. The snapshot is just a list of frame iterators. It maintains an outer iterator that tracks list elements and current inner iterator which is a frame iterator which is currently being read.

Both iterators are moveable but not copyable. Also, both iterators can only be used to traverse column forward.

**Column store**

The column store contains 12 columns. One per field inside `segment_meta`. It can be used to iterate though all elements, supports prefix truncation and quickly search by base offset. The search is performed in two steps. First, the `base_offset` column is used to locate the value and get its index (offset inside the column). Then the index is used to materialize the struct. The struct is generated  by getting a value by index in every column. This requires random access into 12 different columns. Index access requires scanning one frame of the column. Combined scans of 12 frames can be relatively heavy.

**Random access**

To speedup random access the new mechanism was introduced. The `deltafor_encoder` was extended to allow the user to save a position inside the stream. This position is called a 'hint' in the code. The `deltafor_decoder` can be constructed to start decoding from the stored position bypassing all previous content of the frame. In column store we're storing this hints per every 8 rows. The hints are stored in the `btree_map`. During the materialization step the hints are extracted and are used to speedup the materialization. This allows column store to be only moderately slower than baseline implementation which uses `btree_map`.

```
test                                            iterations      median         mad         min         max      allocs       tasks        inst
cstore_bench.column_store_upper_bound_baseline        1752   615.536ns     2.455ns   612.075ns   630.194ns       0.000       0.000       448.0
cstore_bench.column_store_upper_bound_result           222     5.717us    22.221ns     5.660us     5.739us      53.000       0.000     74101.7
```

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

* none