### PR TITLE
Update schemas and bump Kafka APIs that are one version away from flex

### DIFF
--- a/src/v/kafka/protocol/schemata/alter_configs_request.json
+++ b/src/v/kafka/protocol/schemata/alter_configs_request.json
@@ -16,12 +16,14 @@
 {
   "apiKey": 33,
   "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "AlterConfigsRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 enables flexible versions.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
-    { "name": "Resources", "type": "[]AlterConfigsResource", "versions": "0+", 
+    { "name": "Resources", "type": "[]AlterConfigsResource", "versions": "0+",
       "about": "The updates for each resource.", "fields": [
       { "name": "ResourceType", "type": "int8", "versions": "0+", "mapKey": true,
         "about": "The resource type." },

--- a/src/v/kafka/protocol/schemata/alter_configs_response.json
+++ b/src/v/kafka/protocol/schemata/alter_configs_response.json
@@ -18,8 +18,9 @@
   "type": "response",
   "name": "AlterConfigsResponse",
   // Starting in version 1, on quota violation brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 enables flexible versions.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/src/v/kafka/protocol/schemata/create_acls_request.json
+++ b/src/v/kafka/protocol/schemata/create_acls_request.json
@@ -16,12 +16,15 @@
 {
   "apiKey": 30,
   "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "CreateAclsRequest",
   // Version 1 adds resource pattern type.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 enables flexible versions.
+  // Version 3 adds user resource type.
+  "validVersions": "0-3",
+  "flexibleVersions": "2+",
   "fields": [
-    { "name": "Creations", "type": "[]CreatableAcl", "versions": "0+", 
+    { "name": "Creations", "type": "[]CreatableAcl", "versions": "0+",
       "about": "The ACLs that we want to create.", "fields": [
       { "name": "ResourceType", "type": "int8", "versions": "0+",
         "about": "The type of the resource." },

--- a/src/v/kafka/protocol/schemata/create_acls_response.json
+++ b/src/v/kafka/protocol/schemata/create_acls_response.json
@@ -18,8 +18,10 @@
   "type": "response",
   "name": "CreateAclsResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 enables flexible versions.
+  // Version 3 adds user resource type.
+  "validVersions": "0-3",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/src/v/kafka/protocol/schemata/delete_acls_request.json
+++ b/src/v/kafka/protocol/schemata/delete_acls_request.json
@@ -16,10 +16,13 @@
 {
   "apiKey": 31,
   "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "DeleteAclsRequest",
   // Version 1 adds the pattern type.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 enables flexible versions.
+  // Version 3 adds the user resource type.
+  "validVersions": "0-3",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Filters", "type": "[]DeleteAclsFilter", "versions": "0+",
       "about": "The filters to use when deleting ACLs.", "fields": [

--- a/src/v/kafka/protocol/schemata/delete_acls_response.json
+++ b/src/v/kafka/protocol/schemata/delete_acls_response.json
@@ -19,8 +19,10 @@
   "name": "DeleteAclsResponse",
   // Version 1 adds the resource pattern type.
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 enables flexible versions.
+  // Version 3 adds the user resource type.
+  "validVersions": "0-3",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/src/v/kafka/protocol/schemata/describe_acls_request.json
+++ b/src/v/kafka/protocol/schemata/describe_acls_request.json
@@ -16,10 +16,13 @@
 {
   "apiKey": 29,
   "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "DescribeAclsRequest",
   // Version 1 adds resource pattern type.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 enables flexible versions.
+  // Version 3 adds user resource type.
+  "validVersions": "0-3",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ResourceType", "type": "int8", "versions": "0+",
       "about": "The resource type." },

--- a/src/v/kafka/protocol/schemata/describe_acls_response.json
+++ b/src/v/kafka/protocol/schemata/describe_acls_response.json
@@ -19,8 +19,10 @@
   "name": "DescribeAclsResponse",
   // Version 1 adds PatternType.
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 enables flexible versions.
+  // Version 3 adds user resource type.
+  "validVersions": "0-3",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/src/v/kafka/protocol/schemata/describe_log_dirs_request.json
+++ b/src/v/kafka/protocol/schemata/describe_log_dirs_request.json
@@ -16,17 +16,21 @@
 {
   "apiKey": 35,
   "type": "request",
+  "listeners": ["zkBroker", "broker"],
   "name": "DescribeLogDirsRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  "validVersions": "0-4",
+  // Version 2 is the first flexible version.
+  // Version 3 is the same as version 2 (new field in response).
+  // Version 4 is the same as version 2 (new fields in response).
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Topics", "type": "[]DescribableLogDirTopic", "versions": "0+", "nullableVersions": "0+",
       "about": "Each topic that we want to describe log directories for, or null for all topics.", "fields": [
-      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName", "mapKey": true,
         "about": "The topic name" },
       { "name": "PartitionIndex", "type": "[]int32", "versions": "0+",
-        "about": "The partition indxes." }
+        "about": "The partition indexes." }
     ]}
   ]
 }

--- a/src/v/kafka/protocol/schemata/describe_log_dirs_response.json
+++ b/src/v/kafka/protocol/schemata/describe_log_dirs_response.json
@@ -18,11 +18,16 @@
   "type": "response",
   "name": "DescribeLogDirsResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  "validVersions": "0-4",
+  // Version 2 is the first flexible version.
+  // Version 3 adds the top-level ErrorCode field
+  // Version 4 adds the TotalBytes and UsableBytes fields
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "3+",
+      "ignorable": true, "about": "The error code, or 0 if there was no error." },
     { "name": "Results", "type": "[]DescribeLogDirsResult", "versions": "0+",
       "about": "The log directories.", "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
@@ -43,7 +48,13 @@
           { "name": "IsFutureKey", "type": "bool", "versions": "0+",
             "about": "True if this log is created by AlterReplicaLogDirsRequest and will replace the current log of the replica in the future." }
         ]}
-      ]}
+      ]},
+      { "name": "TotalBytes", "type": "int64", "versions": "4+", "ignorable": true, "default": "-1",
+        "about": "The total size in bytes of the volume the log directory is in."
+      },
+      { "name": "UsableBytes", "type": "int64", "versions": "4+", "ignorable": true, "default": "-1",
+        "about": "The usable size in bytes of the volume the log directory is in."
+      }
     ]}
   ]
 }

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1428,11 +1428,38 @@ void {{ struct.name }}::decode(iobuf buf, [[maybe_unused]] api_version version) 
 {%- endif %}
 {%- else %}
 {%- if op_type == "request" %}
+{%- if first_flex > 0 %}
+void {{ struct.name }}::encode(response_writer& writer, api_version version) {
+    if (version >= api_version({{ first_flex }})) {
+        writer.write_tags(std::move(unknown_tags));
+    }
+}
+void {{ struct.name }}::decode(request_reader& reader, api_version version) {
+    if (version >= api_version({{ first_flex }})) {
+        unknown_tags = reader.read_tags();
+    }
+}
+{%- else %}
 void {{ struct.name }}::encode(response_writer&, api_version) {}
 void {{ struct.name }}::decode(request_reader&, api_version) {}
+{%- endif %}
 {%- else %}
-void {{ struct.name }}::encode(response_writer&, api_version&) {}
+{%- if first_flex > 0 %}
+void {{ struct.name }}::encode(response_writer& writer, api_version version) {
+    if (version >= api_version({{ first_flex }})) {
+        write.write_tags(std::move(unknown_tags));
+    }
+}
+void {{ struct.name }}::decode(iobuf buf, api_version version) {
+    if (version >= api_version({{ first_flex }})) {
+        request_reader reader(std::move(buf));
+        unknown_tags = reader.read_tags();
+    }
+}
+{%- else %}
+void {{ struct.name }}::encode(response_writer&, api_version) {}
 void {{ struct.name }}::decode(iobuf, api_version) {}
+{%- endif %}
 {%- endif %}
 {%- endif %}
 

--- a/src/v/kafka/protocol/schemata/sasl_authenticate_request.json
+++ b/src/v/kafka/protocol/schemata/sasl_authenticate_request.json
@@ -16,10 +16,12 @@
 {
   "apiKey": 36,
   "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "SaslAuthenticateRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "AuthBytes", "type": "bytes", "versions": "0+",
       "about": "The SASL authentication bytes from the client, as defined by the SASL mechanism." }

--- a/src/v/kafka/protocol/schemata/sasl_authenticate_response.json
+++ b/src/v/kafka/protocol/schemata/sasl_authenticate_response.json
@@ -18,8 +18,9 @@
   "type": "response",
   "name": "SaslAuthenticateResponse",
   // Version 1 adds the session lifetime.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  // Version 2 adds flexible version support
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
@@ -27,7 +28,7 @@
       "about": "The error message, or null if there was no error." },
     { "name": "AuthBytes", "type": "bytes", "versions": "0+",
       "about": "The SASL authentication bytes from the server, as defined by the SASL mechanism." },
-    { "name": "SessionLifetimeMs", "type": "int64", "versions": "1+", "default": "0",
+    { "name": "SessionLifetimeMs", "type": "int64", "versions": "1+", "default": "0", "ignorable": true,
       "about": "The SASL authentication bytes from the server, as defined by the SASL mechanism." }
   ]
 }

--- a/src/v/kafka/protocol/tests/protocol_test.cc
+++ b/src/v/kafka/protocol/tests/protocol_test.cc
@@ -154,10 +154,12 @@ void check_kafka_binary_format(
       b == result,
       fmt::format(
         "Mismatched binary data detected for api: {} at version: {} "
-        "is_request: {}",
+        "is_request: {} re-encoded size_bytes: {} expected size_bytes: {}",
         key,
         version,
-        is_request));
+        is_request,
+        b.size(),
+        result.size()));
 }
 
 template<kafka::KafkaApiHandlerAny H>

--- a/src/v/kafka/server/handlers/add_partitions_to_txn.h
+++ b/src/v/kafka/server/handlers/add_partitions_to_txn.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using add_partitions_to_txn_handler
-  = single_stage_handler<add_partitions_to_txn_api, 0, 2>;
+  = single_stage_handler<add_partitions_to_txn_api, 0, 3>;
 
 }

--- a/src/v/kafka/server/handlers/alter_configs.h
+++ b/src/v/kafka/server/handlers/alter_configs.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using alter_configs_handler = single_stage_handler<alter_configs_api, 0, 1>;
+using alter_configs_handler = single_stage_handler<alter_configs_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/create_acls.h
+++ b/src/v/kafka/server/handlers/create_acls.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using create_acls_handler = single_stage_handler<create_acls_api, 0, 1>;
+using create_acls_handler = single_stage_handler<create_acls_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/delete_acls.h
+++ b/src/v/kafka/server/handlers/delete_acls.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using delete_acls_handler = single_stage_handler<delete_acls_api, 0, 1>;
+using delete_acls_handler = single_stage_handler<delete_acls_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/delete_groups.h
+++ b/src/v/kafka/server/handlers/delete_groups.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using delete_groups_handler = single_stage_handler<delete_groups_api, 0, 1>;
+using delete_groups_handler = single_stage_handler<delete_groups_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/describe_acls.h
+++ b/src/v/kafka/server/handlers/describe_acls.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using describe_acls_handler = single_stage_handler<describe_acls_api, 0, 1>;
+using describe_acls_handler = single_stage_handler<describe_acls_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/describe_groups.h
+++ b/src/v/kafka/server/handlers/describe_groups.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using describe_groups_handler = single_stage_handler<describe_groups_api, 0, 4>;
+using describe_groups_handler = single_stage_handler<describe_groups_api, 0, 5>;
 
 }

--- a/src/v/kafka/server/handlers/describe_log_dirs.h
+++ b/src/v/kafka/server/handlers/describe_log_dirs.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using describe_log_dirs_handler
-  = single_stage_handler<describe_log_dirs_api, 0, 1>;
+  = single_stage_handler<describe_log_dirs_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/end_txn.h
+++ b/src/v/kafka/server/handlers/end_txn.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using end_txn_handler = single_stage_handler<end_txn_api, 0, 2>;
+using end_txn_handler = single_stage_handler<end_txn_api, 0, 3>;
 
 }

--- a/src/v/kafka/server/handlers/find_coordinator.h
+++ b/src/v/kafka/server/handlers/find_coordinator.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using find_coordinator_handler
-  = single_stage_handler<find_coordinator_api, 0, 2>;
+  = single_stage_handler<find_coordinator_api, 0, 3>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/heartbeat.h
+++ b/src/v/kafka/server/handlers/heartbeat.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using heartbeat_handler = single_stage_handler<heartbeat_api, 0, 3>;
+using heartbeat_handler = single_stage_handler<heartbeat_api, 0, 4>;
 
 }

--- a/src/v/kafka/server/handlers/incremental_alter_configs.h
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using incremental_alter_configs_handler
-  = single_stage_handler<incremental_alter_configs_api, 0, 0>;
+  = single_stage_handler<incremental_alter_configs_api, 0, 1>;
 
 }

--- a/src/v/kafka/server/handlers/join_group.h
+++ b/src/v/kafka/server/handlers/join_group.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using join_group_handler = two_phase_handler<join_group_api, 0, 5>;
+using join_group_handler = two_phase_handler<join_group_api, 0, 6>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/leave_group.h
+++ b/src/v/kafka/server/handlers/leave_group.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using leave_group_handler = single_stage_handler<leave_group_api, 0, 3>;
+using leave_group_handler = single_stage_handler<leave_group_api, 0, 4>;
 
 }

--- a/src/v/kafka/server/handlers/list_groups.h
+++ b/src/v/kafka/server/handlers/list_groups.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using list_groups_handler = single_stage_handler<list_groups_api, 0, 2>;
+using list_groups_handler = single_stage_handler<list_groups_api, 0, 3>;
 
 }

--- a/src/v/kafka/server/handlers/offset_commit.h
+++ b/src/v/kafka/server/handlers/offset_commit.h
@@ -18,6 +18,6 @@ namespace kafka {
 // in version 0 kafka stores offsets in zookeeper. if we ever need to
 // support version 0 then we need to do some code review to see if this has
 // any implications on semantics.
-using offset_commit_handler = two_phase_handler<offset_commit_api, 1, 7>;
+using offset_commit_handler = two_phase_handler<offset_commit_api, 1, 8>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.h
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.h
@@ -15,5 +15,5 @@
 namespace kafka {
 
 using offset_for_leader_epoch_handler
-  = single_stage_handler<offset_for_leader_epoch_api, 0, 3>;
+  = single_stage_handler<offset_for_leader_epoch_api, 0, 4>;
 }

--- a/src/v/kafka/server/handlers/sasl_authenticate.h
+++ b/src/v/kafka/server/handlers/sasl_authenticate.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using sasl_authenticate_handler
-  = single_stage_handler<sasl_authenticate_api, 0, 1>;
+  = single_stage_handler<sasl_authenticate_api, 0, 2>;
 
 }

--- a/src/v/kafka/server/handlers/sync_group.h
+++ b/src/v/kafka/server/handlers/sync_group.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using sync_group_handler = two_phase_handler<sync_group_api, 0, 3>;
+using sync_group_handler = two_phase_handler<sync_group_api, 0, 4>;
 
 } // namespace kafka


### PR DESCRIPTION
## Cover letter

This PR bumps the APIs and requests of request handlers that are one level away from their respective first_flex levels. This should not affect the behavior of redpanda or of any clients that interact with it. Enabling flex is a strictly protocol level change with all fields remaining as they were.

## Force Pushes
- Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/633412226c7871e3cc4e084d08e7f0d18785c527..3ac786326bd09b482a4fcdba0baa2fef95a7110e): Bumped describe_log_dirs as well

## Release Notes

### Bugfixes
* Fixed a bug that prevented correct serialization and deserialization of types that have no fields at the flexible level (currently only ListGroupsv3)

### Improvements

* Bumps API version by one to enable flex support for add_partitions_to_txn, offset_commit, delete_groups, describe_groups, end_txn_request, find_coordinator, heartbeat, incremental_alter_configs, join_group,  leave_group,  list_groups, offset_for_leader_epoch, alter_configs, create_acls, delete_acls, describe_acls, describe_log_dirs, and sasl_authenticate APIs


