### PR TITLE
cloud_storage: Evict segments based on heuristic

### DIFF
--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -148,6 +148,9 @@ private:
     /// Return reader back to segment_state
     void return_reader(std::unique_ptr<remote_segment_batch_reader>);
 
+    /// Evict reader (add to the eviction list)
+    void evict_reader(std::unique_ptr<remote_segment_batch_reader>);
+
     /// Iterators used by the partition_record_batch_reader_impl class
     iterator seek_by_timestamp(model::timestamp);
 


### PR DESCRIPTION
If the client is doing batch job the segments are scanned one by one and never reused by the same client. Previously, the remote_partition didn't take client behavior into account and this resulted in materialization of large number of partitions.

To avoid this this commit adds a heuristic which is invoked when the reader is complted scanning a segment. In this case the, if the reader is the only user of the segment the segment will be evicted without waiting 60s (our hardcoded idle timeout).

Currently, most severe memory pressure is caused by materialized segments which are created en masse during scans. The idle timeout for materialized segment is 60s and active consumer can hydrate/materialize large number of segments during this time interval.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.



If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

  ### Improvements

  * Improve tiered-storage performance during batch read operations