### PR TITLE
Fix #7671: Timeout in PartitionBalancerTest.test_fuzz_admin_ops

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -577,8 +577,10 @@ class RpkTool:
 
     def _admin_host(self, node=None):
         if node is None:
-            return ",".join(
-                [f"{n.account.hostname}:9644" for n in self._redpanda.nodes])
+            return ",".join([
+                f"{n.account.hostname}:9644"
+                for n in self._redpanda.started_nodes()
+            ])
         else:
             return f"{node.account.hostname}:9644"
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -285,7 +285,7 @@ class Admin:
         elif node is None:
             # Pick a random node to run this request on.  If that node gives
             # connection errors we will retry on other nodes.
-            node = random.choice(self.redpanda.nodes)
+            node = random.choice(self.redpanda.started_nodes())
             retry_connection = True
         else:
             # We were called with a specific node to run on -- do no retry on

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -456,7 +456,7 @@ class AdminOperationsFuzzer():
 
             def validate_result():
                 try:
-                    op.validate(self.operation_ctx)
+                    return op.validate(self.operation_ctx)
                 except Exception as e:
                     self.redpanda.logger.debug(
                         f"Error validating operation {op_type} - {e}")
@@ -464,7 +464,7 @@ class AdminOperationsFuzzer():
 
             try:
                 if self.execute_with_retries(op_type, op):
-                    wait_until(lambda: validate_result,
+                    wait_until(validate_result,
                                timeout_sec=self.operation_timeout,
                                backoff_sec=1)
                     self.executed += 1
@@ -551,5 +551,6 @@ class AdminOperationsFuzzer():
                 raise RuntimeError(
                     f"Stopped without reaching target ({self.executed}/{count})"
                 )
+            return False
 
         wait_until(check, timeout_sec=timeout, backoff_sec=2)

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -459,7 +459,7 @@ class AdminOperationsFuzzer():
                     return op.validate(self.operation_ctx)
                 except Exception as e:
                     self.redpanda.logger.debug(
-                        f"Error validating operation {op_type} - {e}")
+                        f"Error validating operation {op_type}", exc_info=True)
                     return False
 
             try:
@@ -474,7 +474,8 @@ class AdminOperationsFuzzer():
                         f"Skipped operation: {op_type}, current cluster state does not allow executing the operation"
                     )
             except Exception as e:
-                self.redpanda.logger.error(f"Operation: {op_type} error: {e}")
+                self.redpanda.logger.debug(f"Operation: {op_type}",
+                                           exc_info=True)
                 self.error = e
                 self._stopping.set()
 
@@ -498,8 +499,8 @@ class AdminOperationsFuzzer():
             except Exception as e:
                 error = e
                 self.redpanda.logger.info(
-                    f"Operation: {op_type} error: {error}, retries left: {self.retries-retry}/{self.retries}"
-                )
+                    f"Operation: {op_type}, retries left: {self.retries-retry}/{self.retries}",
+                    exc_info=True)
                 sleep(self.retries_interval)
         raise error
 

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -210,7 +210,7 @@ class AddPartitionsOperation(Operation):
             return False
 
         rpk = ctx.rpk()
-        current = len(list(rpk.describe_topic(self.topic)))
+        current = len(list(rpk.describe_topic(self.topic, tolerant=True)))
         to_add = random.randint(1, 5)
         self.total = current + to_add
         ctx.redpanda.logger.info(

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -586,8 +586,8 @@ class PartitionBalancerTest(PartitionBalancerService):
                     assert self.redpanda.idx(node) not in node2partition_count
                 finally:
                     admin_fuzz.unpause()
+                admin_fuzz.ensure_progress()
 
-            admin_fuzz.wait(count=10, timeout=240)
             admin_fuzz.stop()
 
             ns.make_available()

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -545,7 +545,9 @@ class PartitionBalancerTest(PartitionBalancerService):
         self.start_consumer(1)
         self.await_startup()
 
-        admin_fuzz = AdminOperationsFuzzer(self.redpanda, min_replication=3)
+        admin_fuzz = AdminOperationsFuzzer(self.redpanda,
+                                           min_replication=3,
+                                           retries=0)
         admin_fuzz.start()
 
         def describe_topics(retries=5, retries_interval=5):

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -584,7 +584,7 @@ class PartitionBalancerTest(PartitionBalancerService):
         with self.NodeStopper(self) as ns:
             for n in range(7):
                 node = self.redpanda.nodes[n % len(self.redpanda.nodes)]
-                ns.make_unavailable(node)
+                ns.make_unavailable(node, wait_for_previous_node=True)
                 try:
                     admin_fuzz.pause()
                     self.wait_until_ready(expected_unavailable_node=node)

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -202,6 +202,7 @@ class PartitionBalancerService(EndToEndTest):
             self.test = test
             self.f_injector = FailureInjector(test.redpanda)
             self.cur_failure = None
+            self.logger = test.logger
 
         def __enter__(self):
             return self
@@ -229,6 +230,9 @@ class PartitionBalancerService(EndToEndTest):
                         lambda: self.wait_for_node_to_be_ready(
                             self.test.redpanda.idx(self.cur_failure.node)), 30,
                         1)
+                    self.logger.info(
+                        f"made {self.cur_failure.node.account.hostname} available"
+                    )
                 self.cur_failure = None
 
         def make_unavailable(self,
@@ -236,6 +240,7 @@ class PartitionBalancerService(EndToEndTest):
                              failure_types=None,
                              wait_for_previous_node=False):
             self.make_available(wait_for_previous_node)
+            self.logger.info(f"making {node.account.hostname} unavailable")
 
             if failure_types == None:
                 failure_types = [
@@ -250,6 +255,7 @@ class PartitionBalancerService(EndToEndTest):
             self.cur_failure = FailureSpec(random.choice(failure_types), node)
             self.f_injector._start_func(self.cur_failure.type)(
                 self.cur_failure.node)
+            self.logger.info(f"made {node.account.hostname} unavailable")
 
 
 class PartitionBalancerTest(PartitionBalancerService):

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -584,9 +584,9 @@ class PartitionBalancerTest(PartitionBalancerService):
         with self.NodeStopper(self) as ns:
             for n in range(7):
                 node = self.redpanda.nodes[n % len(self.redpanda.nodes)]
-                ns.make_unavailable(node, wait_for_previous_node=True)
                 try:
                     admin_fuzz.pause()
+                    ns.make_unavailable(node, wait_for_previous_node=True)
                     self.wait_until_ready(expected_unavailable_node=node)
                     node2partition_count = get_node2partition_count()
                     assert self.redpanda.idx(node) not in node2partition_count


### PR DESCRIPTION
Fixes several typos, improve logging, heal fault injection before introducing the next on, make sure we intermix admin ops with fault injections and make rpk & admin to connect only to started nodes.

Fixes https://github.com/redpanda-data/redpanda/issues/7671

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

 * none

## Release Notes

  * none

----

Force pushes:
 - [responded to comments, add new commit](https://github.com/redpanda-data/redpanda/compare/5e7e6786575d04112fc613bb0729f4b0b9821592..d5a4c806c8639ca59917c2c5bbb8de3ff4b9b5d2)
 - [rebase on dev](https://github.com/redpanda-data/redpanda/compare/d5a4c806c8639ca59917c2c5bbb8de3ff4b9b5d2..7e6bcdce3228606206f40e02a6d8d0cd8623a324)
 - [fix bugs](https://github.com/redpanda-data/redpanda/compare/7e6bcdce3228606206f40e02a6d8d0cd8623a324..340ecd27d8e4157f1c572e99b74f53a50901233d)
 - [minor things](https://github.com/redpanda-data/redpanda/compare/60b7c813505aa53705da06e883f888b663929195..7cb7cc87497d5dc8a9ead2ef2aea4f0d38cb52dd)