### PR TITLE
tools/offline_log_viewer: fix read_serde_map

### DIFF
--- a/tools/offline_log_viewer/reader.py
+++ b/tools/offline_log_viewer/reader.py
@@ -143,5 +143,7 @@ class Reader:
     def read_serde_map(self, k_reader, v_reader):
         ret = {}
         for _ in range(self.read_uint32()):
-            ret[k_reader(self)] = v_reader(self)
+            key = k_reader(self)
+            val = v_reader(self)
+            ret[key] = val
         return ret


### PR DESCRIPTION
From https://docs.python.org/3/reference/expressions.html#evaluation-order :

> Notice that while evaluating an assignment, the right-hand side is
evaluated before the left-hand side.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - papercut/not impactful enough to backport

## UX Changes


## Release Notes
  * none