### PR TITLE
Increase timeout in graceful_leadership_transfer_test to fix 7827

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1887,17 +1887,11 @@ tx_gateway_frontend::do_abort_tm_tx(
     }
 
     if (!is_fetch_tx_supported()) {
-        if (
-          tx.status != tm_transaction::tx_status::ongoing
-          && tx.status != tm_transaction::tx_status::killed) {
+        if (tx.status != tm_transaction::tx_status::ongoing) {
             co_return tx_errc::invalid_txn_state;
         }
-    } else if (
-      tx.status == tm_transaction::tx_status::aborting
-      || tx.status == tm_transaction::tx_status::killed) {
-        if (tx.etag == expected_term) {
-            // a retried abort
-        } else {
+    } else if (tx.status == tm_transaction::tx_status::aborting) {
+        if (tx.etag != expected_term) {
             vlog(
               txlog.trace,
               "abort encountered old aborted tx:{} etag:{} pid:{} tx_seq:{} "
@@ -1927,9 +1921,7 @@ tx_gateway_frontend::do_abort_tm_tx(
                       tx.pid);
                     co_return tx_errc::unknown_server_error;
                 }
-                if (
-                  old_tx.status == tm_transaction::tx_status::aborting
-                  || tx.status == tm_transaction::tx_status::killed) {
+                if (old_tx.status == tm_transaction::tx_status::aborting) {
                     if (old_tx.tx_seq != tx.tx_seq) {
                         vlog(
                           txlog.warn,
@@ -1960,7 +1952,7 @@ tx_gateway_frontend::do_abort_tm_tx(
                 } else {
                     vlog(
                       txlog.warn,
-                      "fetched status:{} isn't aborting, killed nor ongoing",
+                      "fetched status:{} isn't aborting nor ongoing",
                       old_tx.status);
                     co_return tx_errc::unknown_server_error;
                 }
@@ -2104,8 +2096,7 @@ tx_gateway_frontend::do_abort_tm_tx(
 
     if (
       tx.status != tm_transaction::tx_status::ongoing
-      && tx.status != tm_transaction::tx_status::aborting
-      && tx.status != tm_transaction::tx_status::killed) {
+      && tx.status != tm_transaction::tx_status::aborting) {
         vlog(
           txlog.warn,
           "abort encontered a tx with unexpected status:{} (tx:{} etag:{} "

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -291,7 +291,7 @@ class TransactionsTest(RedpandaTest):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
+            'transaction.timeout.ms': 60000,
         })
 
         producer.init_transactions()

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -10,6 +10,7 @@
 from rptest.services.cluster import cluster
 from rptest.util import wait_until_result
 from rptest.clients.types import TopicSpec
+from time import sleep
 
 import uuid
 
@@ -194,7 +195,7 @@ class TransactionsTest(RedpandaTest):
             assert False, "send_offsetes should fail"
         except ck.cimpl.KafkaException as e:
             kafka_error = e.args[0]
-            assert kafka_error.code() == ck.cimpl.KafkaError.INVALID_TXN_STATE
+            assert kafka_error.code() == ck.cimpl.KafkaError._FENCED
 
         try:
             # if abort fails an app should recreate a producer otherwise
@@ -202,7 +203,7 @@ class TransactionsTest(RedpandaTest):
             producer.abort_transaction()
         except ck.cimpl.KafkaException as e:
             kafka_error = e.args[0]
-            assert kafka_error.code() == ck.cimpl.KafkaError.INVALID_TXN_STATE
+            assert kafka_error.code() == ck.cimpl.KafkaError._FENCED
 
     @cluster(num_nodes=3)
     def change_static_member_test(self):
@@ -257,6 +258,32 @@ class TransactionsTest(RedpandaTest):
             assert kafka_error.code() == ck.cimpl.KafkaError.FENCED_INSTANCE_ID
 
         producer.abort_transaction()
+
+    @cluster(num_nodes=3)
+    def expired_tx_test(self):
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': 5000,
+        })
+
+        producer.init_transactions()
+        producer.begin_transaction()
+
+        for i in range(0, 10):
+            producer.produce(self.input_t.name,
+                             str(i),
+                             str(i),
+                             partition=0,
+                             on_delivery=self.on_delivery)
+        producer.flush()
+        sleep(10)
+        try:
+            producer.commit_transaction()
+            assert False, "tx is expected to be expired"
+        except ck.cimpl.KafkaException as e:
+            kafka_error = e.args[0]
+            assert kafka_error.code() == ck.cimpl.KafkaError._FENCED
 
     @cluster(num_nodes=3)
     def graceful_leadership_transfer_test(self):


### PR DESCRIPTION
Updates Redpanda to use the same error code for an expired transaction as Kafka does. Fixes #7827 by creasing tx timeout in graceful_leadership_transfer_test. Adds new txn expiration test. 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

 * none

## Release Notes

### Features

  * Updates Redpanda to use the same error code for an expired transaction as Kafka does