### PR TITLE
tests: allow setting of `cloud_storage_credentials_source`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -393,7 +393,7 @@ class SISettings:
                 logger.info(msg)
                 raise Exception(msg)
             else:
-                logger.debug(
+                logger.info(
                     'No AWS credentials supplied, assuming minio defaults')
 
     @property


### PR DESCRIPTION
When running ducktape tests on EC2 machines, some tests require access to S3 and the credentials are currently passed in as global config settings `s3_access_key` and `s3_secret_key`.

This PR adds a new ducktape global config setting `cloud_store_cred_source` which is used to set the cloud storage property [cloud_storage_credentials_source](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_credentials_source) for tests.

Set the value to `aws_instance_metadata` to configure ducktape tests to [use IAM roles](https://docs.redpanda.com/docs/platform/security/iam-roles/#configuring-iam-roles), as an alternative to setting `s3_access_key ` and `s3_secret_key`.

Prerequisite: EC2 machines must have an IAM role attached that has access to S3.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none