### PR TITLE
configurable net::server logger

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -47,18 +47,9 @@ ss::future<> connection_context::process_one_request() {
               return ss::make_ready_future<>();
           }
           if (sz > _max_request_size()) {
-              vlog(
-                klog.warn,
-                "request from {} is larger ({} bytes) than configured max "
-                "request size {}",
-                conn->addr,
-                sz,
-                _max_request_size());
               return ss::make_exception_future<>(
                 net::invalid_request_error(fmt::format(
-                  "request is larger ({} bytes) than configured max request "
-                  "size "
-                  "{}",
+                  "request size {} is larger than the configured max {}",
                   sz,
                   _max_request_size())));
           }

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -64,7 +64,7 @@ server::server(
   ss::sharded<coproc::partition_manager>& coproc_partition_manager,
   ss::sharded<v8_engine::data_policy_table>& data_policy_table,
   std::optional<qdc_monitor::config> qdc_config) noexcept
-  : net::server(cfg)
+  : net::server(cfg, klog)
   , _smp_group(smp)
   , _topics_frontend(tf)
   , _config_frontend(cf)

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -77,6 +77,9 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
         // an out_of_range
         return "parse error";
     } catch (const invalid_request_error& e) {
+        if (std::strlen(e.what())) {
+            return fmt::format("invalid request: {}", e.what());
+        }
         return "invalid request";
     } catch (...) {
         // Global catch-all prevents stranded/non-handled exceptional futures.

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -104,7 +104,6 @@ void server::start() {
 
 static inline void print_exceptional_future(
   ss::logger& log,
-  std::string_view name,
   ss::future<> f,
   const char* ctx,
   ss::socket_address address) {
@@ -117,18 +116,11 @@ static inline void print_exceptional_future(
     auto disconnected = is_disconnect_exception(ex);
 
     if (!disconnected) {
-        vlog(
-          log.error,
-          "{} - Error[{}] remote address: {} - {}",
-          name,
-          ctx,
-          address,
-          ex);
+        vlog(log.error, "Error[{}] remote address: {} - {}", ctx, address, ex);
     } else {
         vlog(
           log.info,
-          "{} - Disconnected {} ({}, {})",
-          name,
+          "Disconnected {} ({}, {})",
           address,
           ctx,
           disconnected.value());
@@ -141,11 +133,11 @@ ss::future<> server::apply_proto(
       .then_wrapped(
         [this, conn, cq_units = std::move(cq_units)](ss::future<> f) {
             print_exceptional_future(
-              _log, name(), std::move(f), "applying protocol", conn->addr);
+              _log, std::move(f), "applying protocol", conn->addr);
             return conn->shutdown().then_wrapped(
               [this, addr = conn->addr](ss::future<> f) {
                   print_exceptional_future(
-                    _log, name(), std::move(f), "shutting down", addr);
+                    _log, std::move(f), "shutting down", addr);
               });
         })
       .finally([conn] {});

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -97,8 +97,8 @@ struct server_configuration {
 
 class server {
 public:
-    explicit server(server_configuration);
-    explicit server(ss::sharded<server_configuration>* s);
+    explicit server(server_configuration, ss::logger&);
+    explicit server(ss::sharded<server_configuration>* s, ss::logger&);
     server(server&&) noexcept = default;
     server& operator=(server&&) noexcept = delete;
     server(const server&) = delete;
@@ -154,6 +154,7 @@ private:
     void setup_metrics();
     void setup_public_metrics();
 
+    ss::logger& _log;
     ssx::semaphore _memory;
     std::vector<std::unique_ptr<listener>> _listeners;
     boost::intrusive::list<net::connection> _connections;

--- a/src/v/rpc/rpc_server.h
+++ b/src/v/rpc/rpc_server.h
@@ -23,10 +23,10 @@ struct server_context_impl;
 class rpc_server : public net::server {
 public:
     explicit rpc_server(net::server_configuration s)
-      : net::server(std::move(s)) {}
+      : net::server(std::move(s), rpclog) {}
 
     explicit rpc_server(ss::sharded<net::server_configuration>* s)
-      : net::server(s) {}
+      : net::server(s, rpclog) {}
 
     rpc_server(rpc_server&&) noexcept = default;
     ~rpc_server() = default;

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -97,7 +97,11 @@ public:
             : nullptr);
         scfg.max_service_memory_per_core = static_cast<int64_t>(
           ss::memory::stats().total_memory() / 10);
-        _server = std::make_unique<T>(std::move(scfg));
+        if constexpr (std::is_same_v<T, rpc::rpc_server>) {
+            _server = std::make_unique<T>(std::move(scfg));
+        } else {
+            _server = std::make_unique<T>(std::move(scfg), rpc::rpclog);
+        }
     }
 
     template<typename Service, typename... Args>


### PR DESCRIPTION
PR lets net::server log to a configured logger (e.g. rpc or kafka). Prior to this net::server only logged to the rpc logger. This lead to awkward error messages where kafka errors were printed through the rpc logger. To counter that kafka might duplicate the error message: once in an exception and once in a logged message, like this:

```
WARN  2022-12-21 21:09:58,281 [shard 0] kafka - connection_context.cc:56 - request from 127.0.0.1:36846 is larger ({56} bytes) than configured max request size 104857600                                                                                                                                                                                                            
INFO  2022-12-21 21:09:58,281 [shard 0] rpc - server.cc:134 - kafka rpc protocol - Disconnected 127.0.0.1:36846 (applying protocol, invalid request)
```

now we can rely eat exceptions in net::server and log them into the correct scope so that they make sense:

```
INFO  2022-12-21 22:23:40,762 [shard 0] kafka - server.cc:126 - Disconnected 127.0.0.1:49606 (applying protocol, invalid request: request size {56} is larger than the configured max 104857600)                                                                                                                                                                                     
```

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

-->
  * none

