### PR TITLE
storage: clean up staging files on deletion

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -29,8 +29,8 @@
 #include "storage/segment_set.h"
 #include "storage/segment_utils.h"
 #include "storage/storage_resources.h"
-#include "utils/directory_walker.h"
 #include "utils/file_sanitizer.h"
+#include "utils/gate_guard.h"
 #include "vlog.h"
 
 #include <seastar/core/abort_source.hh>
@@ -372,31 +372,27 @@ ss::future<> log_manager::shutdown(model::ntp ntp) {
 
 ss::future<> log_manager::remove(model::ntp ntp) {
     vlog(stlog.info, "Asked to remove: {}", ntp);
-    return ss::with_gate(_open_gate, [this, ntp = std::move(ntp)] {
-        auto handle = _logs.extract(ntp);
-        _resources.update_partition_count(_logs.size());
-        if (handle.empty()) {
-            return ss::make_ready_future<>();
-        }
-        // 'ss::shared_ptr<>' make a copy
-        storage::log lg = handle.mapped()->handle;
-        vlog(stlog.info, "Removing: {}", lg);
-        // NOTE: it is ok to *not* externally synchronize the log here
-        // because remove, takes a write lock on each individual segments
-        // waiting for all of them to be closed before actually removing the
-        // underlying log. If there is a background operation like
-        // compaction or so, it will block correctly.
-        auto ntp_dir = lg.config().work_directory();
-        ss::sstring topic_dir = lg.config().topic_directory().string();
-        return lg.remove()
-          .then([dir = std::move(ntp_dir)] { return ss::remove_file(dir); })
-          .then([this, dir = std::move(topic_dir)]() mutable {
-              // We always dispatch topic directory deletion to core 0 as
-              // requests may come from different cores
-              return dispatch_topic_dir_deletion(std::move(dir));
-          })
-          .finally([lg] {});
-    });
+    gate_guard g(_open_gate);
+    auto handle = _logs.extract(ntp);
+    _resources.update_partition_count(_logs.size());
+    if (handle.empty()) {
+        co_return;
+    }
+    // 'ss::shared_ptr<>' make a copy
+    storage::log lg = handle.mapped()->handle;
+    vlog(stlog.info, "Removing: {}", lg);
+    // NOTE: it is ok to *not* externally synchronize the log here
+    // because remove, takes a write lock on each individual segments
+    // waiting for all of them to be closed before actually removing the
+    // underlying log. If there is a background operation like
+    // compaction or so, it will block correctly.
+    auto ntp_dir = lg.config().work_directory();
+    ss::sstring topic_dir = lg.config().topic_directory().string();
+    co_await lg.remove();
+    co_await remove_file(ntp_dir);
+    // We always dispatch topic directory deletion to core 0 as requests may
+    // come from different cores
+    co_await dispatch_topic_dir_deletion(topic_dir);
 }
 
 ss::future<> log_manager::dispatch_topic_dir_deletion(ss::sstring dir) {

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -29,6 +29,7 @@
 #include "storage/segment_set.h"
 #include "storage/segment_utils.h"
 #include "storage/storage_resources.h"
+#include "utils/directory_walker.h"
 #include "utils/file_sanitizer.h"
 #include "utils/gate_guard.h"
 #include "vlog.h"
@@ -46,6 +47,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <fmt/format.h>
 
 #include <chrono>
@@ -389,6 +391,30 @@ ss::future<> log_manager::remove(model::ntp ntp) {
     auto ntp_dir = lg.config().work_directory();
     ss::sstring topic_dir = lg.config().topic_directory().string();
     co_await lg.remove();
+    directory_walker walker;
+    co_await walker.walk(
+      ntp_dir, [&ntp_dir](const ss::directory_entry& de) -> ss::future<> {
+          // Concurrent truncations and compactions may conflict with each
+          // other, resulting in a mutual inability to use their staging files.
+          // If this has happened, clean up all staging files so we can fully
+          // remove the NTP directory.
+          //
+          // TODO: we should more consistently clean up the staging operations
+          // to clean up after themselves on failure.
+          if (boost::algorithm::ends_with(de.name, ".staging")) {
+              // It isn't necessarily problematic to get here since we can
+              // proceed with removal, but it points to a missing cleanup which
+              // can be problematic for users, as it needlessly consumes space.
+              // Log verbosely to make it easier to catch.
+              auto file_path = fmt::format("{}/{}", ntp_dir, de.name);
+              vlog(
+                stlog.error,
+                "Leftover staging file found, removing: {}",
+                file_path);
+              return ss::remove_file(file_path);
+          }
+          return ss::make_ready_future<>();
+      });
     co_await remove_file(ntp_dir);
     // We always dispatch topic directory deletion to core 0 as requests may
     // come from different cores

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -470,6 +470,10 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
           "generation: {}, skipping compaction",
           s->get_generation_id(),
           segment_generation);
+        const ss::sstring staging_file = s->reader().path().to_staging();
+        if (co_await ss::file_exists(staging_file)) {
+            co_await ss::remove_file(staging_file);
+        }
         co_return std::nullopt;
     }
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2620,6 +2620,12 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
     info("produce_done");
     truncate.get();
     info("truncate_done");
+
+    // Ensure we've cleaned up all our staging segments such that a removal of
+    // the log results in nothing leftover.
+    auto dir_path = log.config().work_directory();
+    mgr.remove(ntp).get();
+    BOOST_REQUIRE_EQUAL(false, ss::file_exists(dir_path).get());
 };
 
 FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {


### PR DESCRIPTION
If the generation_id is updated while we write the compaction output, we
end up returning early without keeping track of the staging files. This
could result in files being left over, even after removal of the
partition since we currently don't allow removing the NTP directory
while any unexpected files exist.

This PR addresses this in two ways:
- by removing all files suffixed with ".staging" when a partition is deleted
- by immediately removing staging files if exiting out of compaction early

The latter approach as implemented by this PR doesn't completely cover every instance of aborted compactions, just the ones seen in the wild and commonly seen in the storage unit test. Tackling this more holistically will be a broader change that will take more time and be harder to backport.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Bug Fixes

* Files left over from aborted compactions will now be cleaned up more robustly.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
