### PR TITLE
kafka: fix handling redpanda.remote.delete in AlterConfigs

### DIFF
--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -190,6 +190,7 @@ create_topic_properties_update(alter_configs_resource& resource) {
                   update.properties.remote_delete,
                   cfg.value,
                   storage::ntp_config::default_remote_delete);
+                continue;
             }
             if (cfg.name == topic_property_remote_write) {
                 auto set_value = update.properties.shadow_indexing.value

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -8,7 +8,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from enum import Enum
 import random
 import string
 import itertools
@@ -24,7 +23,8 @@ from rptest.services.redpanda import ResourceSettings, SISettings
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.services.rpk_producer import RpkProducer
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.util import wait_for_segments_removal
+from rptest.util import wait_for_segments_removal, expect_exception
+from rptest.clients.kcl import KCL
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix, parametrize
@@ -330,6 +330,36 @@ class CreateSITopicsTest(RedpandaTest):
             "true", "DYNAMIC_TOPIC_CONFIG")
         assert explicit_si_configs["redpanda.remote.write"] == (
             "false", "DYNAMIC_TOPIC_CONFIG")
+
+    @cluster(num_nodes=1)
+    def topic_alter_config_test(self):
+        """
+        Intentionally use the legacy (deprecated in Kafka 2.3.0) AlterConfig
+        admin RPC, to check it works with our custom topic properties
+        """
+        rpk = RpkTool(self.redpanda)
+        topic = topic_name()
+        rpk.create_topic(topic=topic, partitions=1, replicas=1)
+
+        # Older KCL has support for the legacy AlterConfig RPC: latest rpk and kafka CLI do not.
+        kcl = KCL(self.redpanda)
+
+        examples = {
+            'redpanda.remote.delete': 'true',
+            'redpanda.remote.write': 'true',
+            'redpanda.remote.read': 'true',
+            'retention.local.target.bytes': '123456',
+            'retention.local.target.ms': '123456'
+        }
+
+        for k, v in examples.items():
+            kcl.alter_topic_config({k: v}, incremental=False, topic=topic)
+
+        # As a control, confirm that if we did pass an invalid property, we would have got an error
+        with expect_exception(RuntimeError, lambda e: "invalid" in str(e)):
+            kcl.alter_topic_config({"redpanda.invalid.property": 'true'},
+                                   incremental=False,
+                                   topic=topic)
 
 
 # When quickly recreating topics after deleting them, redpanda's topic


### PR DESCRIPTION
This was being matched, but a missing `continue` meant we fell through to the unmatched error path.

Fixes https://github.com/redpanda-data/redpanda/issues/7921

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

  ### Bug Fixes

  * Fix setting `redpanda.remote.delete` topic property via the legacy AlterConfig API (this API was deprecated in Kafka 2.3.0, but is supported for backward compatibility)
