### PR TITLE
ducktape: update allowed lists for server logger

### DIFF
--- a/tests/rptest/tests/controller_upgrade_test.py
+++ b/tests/rptest/tests/controller_upgrade_test.py
@@ -26,11 +26,11 @@ ALLOWED_LOGS = [
 
     # < 22.2 versions may log bare std::exception error
     # (https://github.com/redpanda-data/redpanda/issues/5886)
-    re.compile("rpc - .*std::exception"),
+    re.compile("(kafka|rpc) - .*std::exception"),
 
     #  <= 22.2 versions may log bare seastar::condition_variable_timed_out error
     re.compile(
-        "rpc - Service handler threw an exception: seastar::condition_variable_timed_out"
+        "(kafka|rpc) - Service handler threw an exception: seastar::condition_variable_timed_out"
     ),
 
     # < 22.2 versions may log a "cannot find consensus group" error message

--- a/tests/rptest/tests/partition_movement_upgrade_test.py
+++ b/tests/rptest/tests/partition_movement_upgrade_test.py
@@ -104,8 +104,7 @@ class PartitionMovementUpgradeTest(PreallocNodesTest, PartitionMovementMixin):
     #
     # This log entry may be logged by version up to v22.1.x
     unsupported_api_version_log_entry = re.compile(
-        "kafka rpc protocol - Error\[applying protocol\] .*Unsupported version \d+ for .*"
-    )
+        "Error\[applying protocol\] .*Unsupported version \d+ for .*")
 
     @cluster(num_nodes=6,
              log_allow_list=RESTART_LOG_ALLOW_LIST +

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -36,7 +36,7 @@ ELECTION_TIMEOUT = 10
 # Logs that may appear when a node is network-isolated
 ISOLATION_LOG_ALLOW_LIST = [
     # rpc - server.cc:91 - vectorized internal rpc protocol - Error[shutting down] remote address: 10.89.0.16:60960 - std::__1::system_error (error system:32, sendmsg: Broken pipe)
-    "rpc - .*Broken pipe",
+    "(kafka|rpc) - .*Broken pipe",
 ]
 
 

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -123,10 +123,10 @@ PREV_VERSION_LOG_ALLOW_LIST = [
     # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exists on target broker
     "raft - .*raft group does not exists on target broker",
     # e.g. rpc - Service handler thrown an exception - seastar::gate_closed_exception (gate closed)
-    "rpc - .*gate_closed_exception.*",
+    "(kafka|rpc) - .*gate_closed_exception.*",
     # Tests on mixed versions will start out with an unclean restart before
     # starting a workload.
-    "(raft|rpc) - .*(disconnected_endpoint|Broken pipe|Connection reset by peer)",
+    "(raft|kafka|rpc) - .*(disconnected_endpoint|Broken pipe|Connection reset by peer)",
 ]
 
 


### PR DESCRIPTION
rpc -> (kafka|rpc) for generic errors that might bubble up from simple rpc protocol server or kafka server.

Also checked metrics and they seem ok.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

-->
  * none

