### PR TITLE
coud_storage: Fix timequery in read-replica

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -339,13 +339,14 @@ ss::future<> partition::stop() {
 ss::future<std::optional<storage::timequery_result>>
 partition::timequery(storage::timequery_config cfg) {
     std::optional<storage::timequery_result> result;
+    bool is_read_replica = _raft->log_config().is_read_replica_mode_enabled();
     if (
-      _cloud_storage_partition && _raft->log().start_timestamp() >= cfg.time
-      && _cloud_storage_partition->is_data_available()) {
+      _cloud_storage_partition && _cloud_storage_partition->is_data_available()
+      && (is_read_replica || _raft->log().start_timestamp() >= cfg.time)) {
         // We have data in the remote partition, and all the data in the raft
-        // log is ahead of the query timestamp, so proceed to query the
-        // remote partition to try and find the earliest data that has timestamp
-        // >= the query time.
+        // log is ahead of the query timestamp or the topic is a read replica,
+        // so proceed to query the remote partition to try and find the earliest
+        // data that has timestamp >= the query time.
         vlog(
           clusterlog.debug,
           "timequery (cloud) {} t={} max_offset(k)={}",


### PR DESCRIPTION
Do not take local raft group into account in timequery in read replica. In read replica local raft group stores only configuration batches so it doesn't make sense to use it.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

  ### Bug Fixes

  * Fix timequery in read-replica