### PR TITLE
[v22.1.x] prefix_truncate_recovery_test: retry leadership transfers

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -567,7 +567,7 @@ class Admin:
         Looks up current ntp leader and transfer leadership to target node, 
         this operations is NOP when current leader is the same as target.
         If user pass None for target this function will choose next replica for new leader.
-        If leadership transfer was performed this function return True
+        Returns true if leadership was transferred to the target node.
         """
         def _get_details():
             p = self.get_partitions(topic=topic,
@@ -590,7 +590,7 @@ class Admin:
 
         if target_id is not None:
             if leader_id == target_id:
-                return False
+                return True
             path = f"raft/{details['raft_group_id']}/transfer_leadership?target={target_id}"
         else:
             path = f"raft/{details['raft_group_id']}/transfer_leadership"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7193

I dropped the changes to the tests as they aren't on v22.1.x

## Release notes

* none