### PR TITLE
Track consumer subscriptions

### DIFF
--- a/src/v/kafka/protocol/request_reader.h
+++ b/src/v/kafka/protocol/request_reader.h
@@ -58,6 +58,9 @@ public:
     }
 
     ss::sstring read_string() { return do_read_string(read_int16()); }
+    ss::sstring read_string_unchecked(int16_t len) {
+        return do_read_string(len);
+    }
 
     ss::sstring read_flex_string() {
         return do_read_flex_string(read_unsigned_varint());

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -346,7 +346,7 @@ std::vector<member_config> group::member_metadata() const {
       std::back_inserter(out),
       [this](const member_map::value_type& m) {
           auto& group_inst = m.second->group_instance_id();
-          auto metadata = m.second->get_protocol_metadata(*_protocol);
+          auto metadata = m.second->get_protocol_metadata(_protocol.value());
           return member_config{
             .member_id = m.first,
             .group_instance_id = group_inst,

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -258,6 +258,11 @@ public:
         return _pending_members.find(member) != _pending_members.end();
     }
 
+    bool subscribed(const model::topic&) const;
+
+    static absl::node_hash_set<model::topic>
+      decode_consumer_subscriptions(iobuf);
+
     /// Reschedule all members' heartbeat expiration
     void reschedule_all_member_heartbeats() {
         for (auto& e : _members) {
@@ -819,6 +824,9 @@ private:
         return _feature_table.local().is_active(
           features::feature::transaction_ga);
     }
+
+    void update_subscriptions();
+    std::optional<absl::node_hash_set<model::topic>> _subscriptions;
 
     kafka::group_id _id;
     group_state _state;

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -106,3 +106,17 @@ FIXTURE_TEST(join_empty_group_static_member, consumer_offsets_fixture) {
           });
     }).get();
 }
+
+SEASTAR_THREAD_TEST_CASE(consumer_group_decode) {
+    {
+        // snatched from a log message after a franz-go client joined
+        auto data = bytes_to_iobuf(
+          base64_to_bytes("AAEAAAADAAJ0MAACdDEAAnQyAAAACAAAAAAAAAAAAAAAAA=="));
+        const auto topics = group::decode_consumer_subscriptions(
+          std::move(data));
+        BOOST_REQUIRE(
+          topics
+          == absl::node_hash_set<model::topic>(
+            {model::topic("t0"), model::topic("t1"), model::topic("t2")}));
+    }
+}


### PR DESCRIPTION
In a few features like offset deletion and offset retention GC the
set of subscribed consumer topics are checked by the broker. However,
this set of topics is encoded in binary data produced by the client and
normally never inspected by the server.

However, for the well-known "consumer" type of consumer group the format
is standardized and the broker can decode this data to track the
subscriptions.

Related to https://github.com/redpanda-data/redpanda/issues/7624, https://github.com/redpanda-data/core-internal/issues/294

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

-->

  * none
