### PR TITLE
tools: fix dev_cluster without `--`

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -128,7 +128,7 @@ async def main():
                         default="0.0.0.0")
     args, extra_args = parser.parse_known_args()
 
-    if extra_args[0] == "--":
+    if extra_args and extra_args[0] == "--":
         extra_args = extra_args[1:]
     elif extra_args:
         # Re-do with strict parse: this will surface unknown argument errors


### PR DESCRIPTION
Broke this in https://github.com/redpanda-data/redpanda/pull/7926

## Backports Required



- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
