### PR TITLE
tests: check if decommission finished before recommissioning

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1376,7 +1376,8 @@ class RedpandaService(Service):
     def set_cluster_config(self,
                            values: dict,
                            expect_restart: bool = False,
-                           admin_client: Admin = None):
+                           admin_client: Admin = None,
+                           timeout: int = 10):
         """
         Update cluster configuration and wait for all nodes to report that they
         have seen the new config.
@@ -1403,7 +1404,7 @@ class RedpandaService(Service):
         # early in the cluster's lifetime
         config_status = wait_until_result(
             is_ready,
-            timeout_sec=10,
+            timeout_sec=timeout,
             backoff_sec=0.5,
             err_msg=f"Config status versions did not converge on {new_version}"
         )

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -548,7 +548,8 @@ class NodesDecommissioningTest(EndToEndTest):
             self.logger.info(f"decommissioning node: {node_id}")
             # set recovery rate to small value to prevent node
             # from finishing decommission operation
-            self._set_recovery_rate(64)
+            self.redpanda.set_cluster_config({"raft_learner_recovery_rate": 1},
+                                             timeout=30)
             admin.decommission_broker(id=node_id)
             wait_until(lambda: self._partitions_moving(node=survivor_node) or
                        self._node_removed(node_id, survivor_node),
@@ -558,7 +559,8 @@ class NodesDecommissioningTest(EndToEndTest):
                 break
             self.logger.info(f"recommissioning node: {node_id}", )
             admin.recommission_broker(id=node_id)
-            self._set_recovery_rate(1024 * 1024 * 1024)
+            self.redpanda.set_cluster_config(
+                {"raft_learner_recovery_rate": 1024 * 1024 * 1024}, timeout=30)
 
         if not self._node_removed(node_id, survivor_node):
             # finally decommission node

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -550,20 +550,24 @@ class NodesDecommissioningTest(EndToEndTest):
             # from finishing decommission operation
             self._set_recovery_rate(64)
             admin.decommission_broker(id=node_id)
-            wait_until(lambda: self._partitions_moving(node=survivor_node),
-                       timeout_sec=15,
+            wait_until(lambda: self._partitions_moving(node=survivor_node) or
+                       self._node_removed(node_id, survivor_node),
+                       timeout_sec=60,
                        backoff_sec=1)
+            if self._node_removed(node_id, survivor_node):
+                break
             self.logger.info(f"recommissioning node: {node_id}", )
             admin.recommission_broker(id=node_id)
             self._set_recovery_rate(1024 * 1024 * 1024)
 
-        # finally decommission node
-        self.logger.info(f"decommissioning node: {node_id}", )
-        admin.decommission_broker(id=node_id)
+        if not self._node_removed(node_id, survivor_node):
+            # finally decommission node
+            self.logger.info(f"decommissioning node: {node_id}", )
+            admin.decommission_broker(id=node_id)
 
-        wait_until(lambda: self._node_removed(node_id, survivor_node),
-                   timeout_sec=120,
-                   backoff_sec=2)
+            wait_until(lambda: self._node_removed(node_id, survivor_node),
+                       timeout_sec=120,
+                       backoff_sec=2)
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=240)
 

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -21,7 +21,6 @@ from rptest.clients.types import TopicSpec
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
 from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RESTART_LOG_ALLOW_LIST, RedpandaService
-from ducktape.mark import ok_to_fail
 
 
 class NodesDecommissioningTest(EndToEndTest):
@@ -526,8 +525,6 @@ class NodesDecommissioningTest(EndToEndTest):
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=240)
 
-    # https://github.com/redpanda-data/redpanda/issues/7874
-    @ok_to_fail
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_flipping_decommission_recommission(self):
 


### PR DESCRIPTION
Added check if the decommissioning finished before requesting recommission. If the node was already delete it is fine and we can pass the test.

Fixes: #7874

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
  * none
