### PR TITLE
r/recovery_stm: logging request size and available throttle units

### DIFF
--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -248,6 +248,11 @@ recovery_stm::read_range_for_recovery(
           [](size_t acc, const auto& batch) {
               return acc + batch.size_bytes();
           });
+        vlog(
+          _ctxlog.trace,
+          "Requesting throttle for {} bytes, available in throttle: {}",
+          size,
+          _ptr->_recovery_throttle->get().available());
         co_await _ptr->_recovery_throttle->get()
           .throttle(size, _ptr->_as)
           .handle_exception_type([this](const ss::broken_semaphore&) {

--- a/src/v/raft/recovery_throttle.h
+++ b/src/v/raft/recovery_throttle.h
@@ -48,6 +48,8 @@ public:
         return _throttler.throttle(size, as);
     }
 
+    size_t available() { return _throttler.available(); }
+
     void shutdown() { _throttler.shutdown(); }
 
 private:


### PR DESCRIPTION
Added logging of a requested throttle size and available throttle units to make it easier to debug recovery that didn't finished.


<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
  * none