### PR TITLE
tests: work around missing BUILD_TYPE variable

### DIFF
--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -81,7 +81,19 @@ class RedpandaTest(Test):
         the much slower debug builds of redpanda, which generally cannot
         keep up with significant quantities of data or partition counts.
         """
-        return os.environ.get('BUILD_TYPE', None) == 'debug'
+        build_type = os.environ.get('BUILD_TYPE', None)
+        if build_type is not None:
+            return build_type == 'debug'
+        else:
+            # Work around https://github.com/redpanda-data/devprod/issues/523
+            job_key = os.environ.get("BUILDKITE_STEP_KEY", None)
+            self.logger.warn(
+                f"BUILD_TYPE variable not set!  Trying buildkite step key '{job_key}'..."
+            )
+            if job_key is None:
+                return False
+            else:
+                return 'debug' in job_key
 
     @property
     def ci_mode(self):


### PR DESCRIPTION
This variable was mistakenly removed, and causes tests to be run in debug mode that shouldn't be.

Related: https://github.com/redpanda-data/devprod/issues/523

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
