### PR TITLE
Raise recovery rate in partition balancer test

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -49,7 +49,7 @@ class PartitionBalancerService(EndToEndTest):
                 "partition_autobalancing_mode": "continuous",
                 "partition_autobalancing_node_availability_timeout_sec": 10,
                 "partition_autobalancing_tick_interval_ms": 5000,
-                "raft_learner_recovery_rate": 1_000_000,
+                "raft_learner_recovery_rate": 100_000_000,
             },
             **kwargs,
         )
@@ -698,7 +698,7 @@ class PartitionBalancerTest(PartitionBalancerService):
             rpk.cluster_maintenance_disable(node)
             # use raw admin interface to avoid waiting for the killed node
             admin.patch_cluster_config(
-                {"raft_learner_recovery_rate": 1_000_000})
+                {"raft_learner_recovery_rate": 100_000_000})
 
             if kill_same_node:
                 self.wait_until_ready()
@@ -791,7 +791,7 @@ class PartitionBalancerTest(PartitionBalancerService):
             self.logger.info("bringing back recovery speed")
             # use raw admin interface to avoid waiting for the killed node
             admin.patch_cluster_config(
-                {"raft_learner_recovery_rate": 1_000_000})
+                {"raft_learner_recovery_rate": 100_000_000})
 
         # Check that the node has been successfully decommissioned.
         # We have to bring back failed node because otherwise decommission won't finish.


### PR DESCRIPTION
Previous recovery rate was not enough for cdt
Fixes #7253

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
  * none