### PR TITLE
Loading consumer groups asynchronously and in parallel

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -87,7 +87,13 @@ group::group(
   group_metadata_serializer serializer,
   enable_group_metrics group_metrics)
   : _id(std::move(id))
+  , _state(md.members.empty() ? group_state::empty : group_state::stable)
+  , _state_timestamp(md.state_timestamp)
+  , _generation(md.generation)
   , _num_members_joining(0)
+  , _protocol_type(md.protocol_type)
+  , _protocol(md.protocol)
+  , _leader(md.leader)
   , _new_member_added(false)
   , _conf(conf)
   , _partition(std::move(partition))
@@ -100,12 +106,6 @@ group::group(
                          .abort_timed_out_transactions_interval_ms.value())
   , _tx_frontend(tx_frontend)
   , _feature_table(feature_table) {
-    _state = md.members.empty() ? group_state::empty : group_state::stable;
-    _generation = md.generation;
-    _protocol_type = md.protocol_type;
-    _protocol = md.protocol;
-    _leader = md.leader;
-    _state_timestamp = md.state_timestamp;
     for (auto& m : md.members) {
         auto member = ss::make_lw_shared<group_member>(
           std::move(m),

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -234,6 +234,12 @@ private:
       ss::lw_shared_ptr<attached_partition>,
       group_recovery_consumer_state);
 
+    ss::future<> do_recover_group(
+      model::term_id,
+      ss::lw_shared_ptr<attached_partition>,
+      group_id,
+      group_stm);
+
     ss::future<> gc_partition_state(ss::lw_shared_ptr<attached_partition>);
 
     ss::future<> inject_noop(


### PR DESCRIPTION
Since all the groups managed by groups_manager are independent they may
be recovered in parallel. Using `max_concurrent_for_each` prevents
memory pressure when group count is really large.

Fixes: #7629 
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
 ### Improvements
- improved startup time and eliminated reactor stalls with large number of consumer groups
