### PR TITLE
[v22.3.x] kafka: fix handling redpanda.remote.delete in AlterConfigs

### DIFF
--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -190,6 +190,7 @@ create_topic_properties_update(alter_configs_resource& resource) {
                   update.properties.remote_delete,
                   cfg.value,
                   storage::ntp_config::default_remote_delete);
+                continue;
             }
             if (cfg.name == topic_property_remote_write) {
                 auto set_value = update.properties.shadow_indexing.value


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7922
Fixes https://github.com/redpanda-data/redpanda/issues/7959,