### PR TITLE
Make `rpk debug bundle` environment-aware

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_k8s_linux.go
@@ -1,0 +1,86 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build linux
+
+package debug
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func executeK8SBundle(
+	ctx context.Context,
+	fs afero.Fs,
+	conf *config.Config,
+	cl *kgo.Client,
+	admin *admin.AdminAPI,
+	timeout time.Duration,
+	path string,
+) error {
+	fmt.Println("Creating bundle file...")
+	mode := os.FileMode(0o755)
+	f, err := fs.OpenFile(
+		path,
+		os.O_CREATE|os.O_WRONLY,
+		mode,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create bundle file: %v", err)
+	}
+	defer f.Close()
+
+	grp := multierror.Group{}
+
+	w := zip.NewWriter(f)
+	defer w.Close()
+
+	ps := &stepParams{
+		fs:      fs,
+		w:       w,
+		timeout: timeout,
+	}
+
+	steps := []step{
+		saveKafkaMetadata(ctx, ps, cl),
+		saveDataDirStructure(ps, conf),
+		saveConfig(ps, conf),
+		saveCPUInfo(ps),
+		saveInterrupts(ps),
+		saveResourceUsageData(ps, conf),
+		saveNTPDrift(ps),
+		savePrometheusMetrics(ctx, ps, admin),
+		saveDiskUsage(ctx, ps, conf),
+	}
+	for _, s := range steps {
+		grp.Go(s)
+	}
+
+	errs := grp.Wait()
+	if errs != nil {
+		err := writeFileToZip(ps, "errors.txt", []byte(errs.Error()))
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
+		fmt.Println(errs.Error())
+	}
+
+	fmt.Printf("Debug bundle saved to %q\n", f.Name())
+	return nil
+}

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle_linux.go
@@ -113,7 +113,7 @@ func executeBundle(
 		mode,
 	)
 	if err != nil {
-		return fmt.Errorf("couldn't create bundle file: %w", err)
+		return fmt.Errorf("unable to create bundle file: %v", err)
 	}
 	defer f.Close()
 


### PR DESCRIPTION
This commit introduces an environment check in `rpk debug bundle` to know if the bundle request is coming from a k8s environment, the idea, for now, is just bundling a subset of files from the bare-metal approach but in upcoming PRs we will introduce more k8s-oriented debugging files:

Tested in a k8s cluster:
```yaml
$ k exec -it -n redpanda redpanda-0 -- /tmp/rpk debug bundle
Defaulted container "redpanda" out of: redpanda, set-datadir-ownership (init), redpanda-configurator (init)
Creating bundle file...
Permission denied to create the file in "", using "/var/lib/redpanda/1671823179-bundle.zip" instead
Debug bundle saved to "/var/lib/redpanda/1671823179-bundle.zip"
```

Content of the zip:
```yaml
$ ls -al ./1671823179-bundle
total 344
drwxr-xr-x. 3 rvasquez rvasquez    163 Dec 23 14:23 .
drwxr-xr-x. 7 rvasquez rvasquez   4096 Dec 23 14:23 ..
-rw-rw-r--. 1 rvasquez rvasquez   1613 Nov 30  1979 data-dir.txt
-rw-rw-r--. 1 rvasquez rvasquez    253 Nov 30  1979 du.txt
-rw-rw-r--. 1 rvasquez rvasquez   7179 Nov 30  1979 kafka.json
-rw-rw-r--. 1 rvasquez rvasquez    174 Nov 30  1979 ntp.txt
drwxr-xr-x. 2 rvasquez rvasquez     39 Dec 23 14:23 proc
-rw-rw-r--. 1 rvasquez rvasquez 318307 Nov 30  1979 prometheus-metrics.txt
-rw-rw-r--. 1 rvasquez rvasquez   1732 Nov 30  1979 redpanda.yaml
-rw-rw-r--. 1 rvasquez rvasquez     91 Nov 30  1979 resource-usage.json

```

Fixes https://github.com/redpanda-data/redpanda/issues/7927

Next step is collecting information available from the k8s API. 

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix


## Release Notes
  ### Improvements

  * rpk debug bundle now recognizes if it's being called from a k8s environment and collects the information available in a containerized environment

