### PR TITLE
Topic-aware leadership balancing

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -125,6 +125,7 @@ v_cc_library(
     scheduling/constraints.cc
     scheduling/leader_balancer.cc
     scheduling/leader_balancer_probe.cc
+    scheduling/leader_balancer_constraints.cc
     health_monitor_types.cc
     health_monitor_backend.cc
     health_monitor_frontend.cc

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -13,6 +13,7 @@
 #include "cluster/partition_manager.h"
 #include "cluster/scheduling/leader_balancer_probe.h"
 #include "cluster/scheduling/leader_balancer_strategy.h"
+#include "cluster/scheduling/leader_balancer_types.h"
 #include "cluster/types.h"
 #include "raft/consensus.h"
 #include "raft/consensus_client_protocol.h"
@@ -92,6 +93,8 @@ private:
     using index_type = leader_balancer_strategy::index_type;
     using reassignment = leader_balancer_strategy::reassignment;
 
+    leader_balancer_types::group_id_to_topic_revision_t
+    build_group_id_to_topic_rev() const;
     index_type build_index();
     absl::flat_hash_set<raft::group_id> muted_groups() const;
     absl::flat_hash_set<model::node_id> muted_nodes() const;

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -120,6 +120,8 @@ private:
     void trigger_balance();
     ss::future<ss::stop_iteration> balance();
 
+    bool should_stop_balance() const;
+
     // On/off switch: when off, leader balancer tick will run
     // but do nothing
     config::binding<bool> _enabled;

--- a/src/v/cluster/scheduling/leader_balancer_constraints.cc
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.cc
@@ -10,15 +10,254 @@
  */
 #include "cluster/scheduling/leader_balancer_constraints.h"
 
+#include "model/metadata.h"
+#include "vassert.h"
+
 namespace cluster::leader_balancer_types {
+
+even_topic_distributon_constraint::even_topic_distributon_constraint(
+  group_id_to_topic_revision_t group_to_topic_rev,
+  shard_index si,
+  const muted_index& mi)
+  : _si(std::move(si))
+  , _mi(mi)
+  , _group_to_topic_rev(std::move(group_to_topic_rev)) {
+    rebuild_indexes();
+    calc_topic_skew();
+    calculate_error();
+}
+
+void even_topic_distributon_constraint::update_index(const reassignment& r) {
+    // _topic_partition_index, _topic_replica_index, and _topic_opt_leaders
+    // will not change from moving leadership. They will only change if the
+    // replicas themselves are moved. Hence no need to update them here.
+
+    auto topic_id = group_to_topic_id().at(r.group);
+
+    // Update _topic_skew and _error
+
+    auto& skew = _topic_skew.at(topic_id);
+    _error -= skew;
+    skew = adjusted_error(skew, topic_id, r.from, r.to);
+    _error += skew;
+
+    // Update _topic_node_index
+
+    auto& groups_from_node = _topic_node_index.at(topic_id).at(r.from.node_id);
+    auto it = std::find_if(
+      groups_from_node.begin(),
+      groups_from_node.end(),
+      [&r](const auto& g_info) { return r.group == g_info.group_id; });
+
+    vassert(it != groups_from_node.end(), "reassigning non-existent group");
+
+    auto moved_group_info = std::move(*it);
+    groups_from_node.erase(it);
+
+    _topic_node_index[topic_id][r.to.node_id].emplace_back(
+      moved_group_info.group_id, r.to, std::move(moved_group_info.replicas));
+
+    // Update _si
+
+    _si.update_index(r);
+}
+
+std::optional<reassignment>
+even_topic_distributon_constraint::recommended_reassignment() {
+    // Sort topics based on topic error here
+    std::vector<decltype(_topic_node_index)::const_iterator> sorted_topics;
+    sorted_topics.reserve(_topic_node_index.size());
+
+    for (auto it = _topic_node_index.cbegin(); it != _topic_node_index.cend();
+         ++it) {
+        sorted_topics.push_back(it);
+    }
+
+    std::sort(
+      sorted_topics.begin(),
+      sorted_topics.end(),
+      [this](const auto& a, const auto& b) {
+          return _topic_skew[a->first] > _topic_skew[b->first];
+      });
+
+    // Look for a topic with the most skew
+    for (const auto& topic : sorted_topics) {
+        const auto& nodes = topic->second;
+
+        if (nodes.size() == 0) {
+            continue;
+        }
+
+        std::vector<decltype(nodes.cbegin())> nodes_sorted;
+        nodes_sorted.reserve(nodes.size());
+
+        for (auto it = nodes.cbegin(); it != nodes.cend(); ++it) {
+            nodes_sorted.push_back(it);
+        }
+
+        std::sort(
+          nodes_sorted.begin(),
+          nodes_sorted.end(),
+          [](const auto& a, const auto& b) {
+              return a->second.size() > b->second.size();
+          });
+
+        // Try to move leadership off the node with the most leadership.
+        for (const auto& node : nodes_sorted) {
+            // Don't try moving a group from a muted node.
+            if (mi().muted_nodes().contains(node->first)) {
+                continue;
+            }
+
+            for (const auto& g_info : node->second) {
+                const auto& leader = g_info.leader;
+                const auto& group = g_info.group_id;
+                const auto& replicas = g_info.replicas;
+
+                // Don't try moving any groups that are currently muted.
+                if (mi().muted_groups().contains(group)) {
+                    continue;
+                }
+
+                for (const auto& replica : replicas) {
+                    // Don't try a move to a different shard to on the same
+                    // node. As it won't decrease error
+                    if (replica.node_id == node->first || leader == replica) {
+                        continue;
+                    }
+
+                    // Don't try moving group to a muted node.
+                    if (mi().muted_nodes().contains(replica.node_id)) {
+                        continue;
+                    }
+
+                    reassignment r{group, leader, replica};
+
+                    if (evaluate_internal(r) > error_jitter) {
+                        return r;
+                    }
+                }
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+void even_topic_distributon_constraint::rebuild_indexes() {
+    _topic_node_index.clear();
+    _topic_replica_index.clear();
+    _topic_partition_index.clear();
+
+    for (const auto& broker_shard : si().shards()) {
+        for (const auto& group_p : broker_shard.second) {
+            auto topic_id = group_to_topic_id().at(group_p.first);
+            const auto& node_id = broker_shard.first.node_id;
+
+            _topic_node_index[topic_id][node_id].emplace_back(
+              group_p.first, broker_shard.first, group_p.second);
+            _topic_partition_index[topic_id] += 1;
+
+            // Some of the replicas may not have leadership. So add
+            // all replica nodes here.
+            for (const auto& replica_bs : group_p.second) {
+                _topic_replica_index[topic_id].insert(replica_bs.node_id);
+                _topic_node_index[topic_id].try_emplace(replica_bs.node_id);
+            }
+        }
+    }
+}
+
+/**
+ *  Used to calculate the initial values for the error this constraint
+ *  is trying to minimize. The goal here is to calculate a per topic
+ *  error(or skew) where the error is zero if the leaders of a topic's
+ *  partitions are evenly distributed on every node. And where the error
+ *  grows to +infinity the more skewed the leadership assignment is to a
+ *  subset of nodes. The equations used can be summarized as;
+ *
+ *  skew[topic_i] = SUM(leaders[node_i, topic_i] - opt[topic_i])^2
+ *  opt[topic_i]  = total_partitions[topic_i] / total_nodes[topic_i]
+ *  where total_nodes is the number of nodes a topic has replicas on.
+ *        total_partitions is the number of partitions the topic has.
+ */
+void even_topic_distributon_constraint::calc_topic_skew() {
+    _topic_skew.clear();
+    _topic_opt_leaders.clear();
+
+    for (const auto& topic : _topic_node_index) {
+        auto topic_partitions = static_cast<double>(
+          _topic_partition_index.at(topic.first));
+        auto topic_replicas = static_cast<double>(
+          _topic_replica_index.at(topic.first).size());
+        auto opt_leaders = topic_partitions
+                           / std::min(topic_replicas, topic_partitions);
+        _topic_opt_leaders[topic.first] = opt_leaders;
+
+        auto& skew = _topic_skew[topic.first];
+        skew = 0;
+
+        for (const auto& node : topic.second) {
+            auto leaders = static_cast<double>(node.second.size());
+
+            skew += pow(leaders - opt_leaders, 2);
+        }
+    }
+}
+
+/*
+ * Compute new error for the given reassignment.
+ */
+double even_topic_distributon_constraint::adjusted_error(
+  double current_error,
+  const topic_id_t& topic_id,
+  const model::broker_shard& from,
+  const model::broker_shard& to) const {
+    // Moving leadership between shards on the same node doesn't change
+    // error for this constraint.
+    if (from.node_id == to.node_id) {
+        return current_error;
+    }
+
+    auto opt_leaders = _topic_opt_leaders.at(topic_id);
+
+    const auto& topic_leaders = _topic_node_index.at(topic_id);
+
+    double from_node_leaders = 0;
+    const auto from_it = topic_leaders.find(from.node_id);
+    if (from_it != topic_leaders.cend()) {
+        from_node_leaders = static_cast<double>(from_it->second.size());
+    } else {
+        // If there are no leaders for the topic on the from node
+        // then there is nothing to move and no change to the error.
+        return current_error;
+    }
+
+    double to_node_leaders = 0;
+    const auto to_it = topic_leaders.find(to.node_id);
+    if (to_it != topic_leaders.cend()) {
+        to_node_leaders = static_cast<double>(to_it->second.size());
+    }
+
+    // Subtract old weights
+    current_error -= pow(from_node_leaders - opt_leaders, 2);
+    current_error -= pow(to_node_leaders - opt_leaders, 2);
+
+    // Add new weights
+    current_error += pow((from_node_leaders - 1) - opt_leaders, 2);
+    current_error += pow((to_node_leaders + 1) - opt_leaders, 2);
+
+    return current_error;
+}
 
 std::optional<reassignment>
 even_shard_load_constraint::recommended_reassignment() {
+    auto [load, load_map] = build_load_indexes();
     const auto curr_error = error();
 
     // Consider each group from high load core, and record the reassignment
     // involving the lowest load "to" core.
-    for (const auto& from : boost::adaptors::reverse(_load)) {
+    for (const auto& from : boost::adaptors::reverse(load)) {
         if (mi().muted_nodes().contains(from->first.node_id)) {
             continue;
         }
@@ -37,7 +276,7 @@ even_shard_load_constraint::recommended_reassignment() {
             // iterate over all the replicas and look for the lowest load
             // shard in the replica list
             for (const auto& to_shard : group.second) {
-                auto load = _load_map.at(to_shard);
+                auto load = load_map.at(to_shard);
                 if (likely(load >= lowest_load)) {
                     // there is no point in evaluating this move, it is
                     // worse than the best one we've found so far.
@@ -113,26 +352,32 @@ size_t even_shard_load_constraint::num_cores() const {
       });
 }
 
-void even_shard_load_constraint::rebuild_load_index() {
-    _load.clear();
-    _load_map.clear();
+std::pair<
+  even_shard_load_constraint::load_t,
+  even_shard_load_constraint::load_map_t>
+even_shard_load_constraint::build_load_indexes() const {
+    load_t load;
+    load_map_t load_map;
 
-    _load.reserve(si().shards().size());
-    _load_map.reserve(si().shards().size());
+    load.reserve(si().shards().size());
+    load_map.reserve(si().shards().size());
     for (auto it = si().shards().cbegin(); it != si().shards().cend(); ++it) {
-        _load.push_back(it);
-        _load_map.emplace(it->first, it->second.size());
+        load.push_back(it);
+        load_map.emplace(it->first, it->second.size());
     }
-    std::sort(_load.begin(), _load.end(), [](const auto& a, const auto& b) {
+    std::sort(load.begin(), load.end(), [](const auto& a, const auto& b) {
         return a->second.size() < b->second.size();
     });
+
+    return {load, load_map};
 }
 
 std::vector<shard_load> even_shard_load_constraint::stats() const {
+    auto [load, _] = build_load_indexes();
     std::vector<shard_load> ret;
-    ret.reserve(_load.size());
+    ret.reserve(load.size());
     std::transform(
-      _load.cbegin(), _load.cend(), std::back_inserter(ret), [](const auto& e) {
+      load.cbegin(), load.cend(), std::back_inserter(ret), [](const auto& e) {
           // oddly, absl::btree::size returns a signed type
           return shard_load{e->first, static_cast<size_t>(e->second.size())};
       });

--- a/src/v/cluster/scheduling/leader_balancer_constraints.cc
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.cc
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/scheduling/leader_balancer_constraints.h"
+
+namespace cluster::leader_balancer_types {
+
+std::optional<reassignment>
+even_shard_load_constraint::recommended_reassignment() {
+    const auto curr_error = error();
+
+    // Consider each group from high load core, and record the reassignment
+    // involving the lowest load "to" core.
+    for (const auto& from : boost::adaptors::reverse(_load)) {
+        if (mi().muted_nodes().contains(from->first.node_id)) {
+            continue;
+        }
+
+        constexpr size_t load_unset = std::numeric_limits<size_t>::max();
+        size_t lowest_load = load_unset;
+        reassignment lowest_reassign{};
+
+        // Consider each group from high load core, and record the
+        // reassignment involving the lowest load "to" core.
+        for (const auto& group : from->second) {
+            if (mi().muted_groups().contains(group.first)) {
+                continue;
+            }
+
+            // iterate over all the replicas and look for the lowest load
+            // shard in the replica list
+            for (const auto& to_shard : group.second) {
+                auto load = _load_map.at(to_shard);
+                if (likely(load >= lowest_load)) {
+                    // there is no point in evaluating this move, it is
+                    // worse than the best one we've found so far.
+                    continue;
+                }
+
+                if (mi().muted_nodes().contains(to_shard.node_id)) {
+                    continue;
+                }
+
+                lowest_load = load;
+                lowest_reassign = {group.first, from->first, to_shard};
+            }
+        }
+
+        if (lowest_load != load_unset) {
+            // We found a possible reassignment while looking at the current
+            // "from" shard, and while it is the best possible reassignment
+            // found it may not improve the error
+            auto new_error = adjusted_error(
+              curr_error, lowest_reassign.from, lowest_reassign.to);
+            if (new_error + error_jitter < curr_error) {
+                return lowest_reassign;
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+double even_shard_load_constraint::adjusted_error(
+  double current_error,
+  const model::broker_shard& from,
+  const model::broker_shard& to) const {
+    auto target_load = calc_target_load();
+    const auto from_count = static_cast<double>(si().shards().at(from).size());
+    const auto to_count = static_cast<double>(si().shards().at(to).size());
+    // subtract original contribution
+    current_error -= pow(from_count - target_load, 2);
+    current_error -= pow(to_count - target_load, 2);
+    // add back in the adjusted amount
+    current_error += pow(from_count - 1 - target_load, 2);
+    current_error += pow(to_count + 1 - target_load, 2);
+    return current_error;
+}
+
+size_t even_shard_load_constraint::num_groups() const {
+    return std::accumulate(
+      si().shards().cbegin(),
+      si().shards().cend(),
+      size_t{0},
+      [this](auto acc, const auto& e) {
+          /*
+           * we aren't going to attempt to move leadership between muted
+           * nodes, so we only count groups with leaders on non-muted nodes
+           * when calculating error / target load.
+           */
+          if (mi().muted_nodes().contains(e.first.node_id)) {
+              return acc;
+          }
+          return acc + e.second.size();
+      });
+}
+
+double even_shard_load_constraint::calc_target_load() const {
+    return static_cast<double>(_num_groups) / static_cast<double>(_num_cores);
+}
+
+size_t even_shard_load_constraint::num_cores() const {
+    return std::count_if(
+      si().shards().cbegin(), si().shards().cend(), [this](const auto& core) {
+          return !mi().muted_nodes().contains(core.first.node_id);
+      });
+}
+
+void even_shard_load_constraint::rebuild_load_index() {
+    _load.clear();
+    _load_map.clear();
+
+    _load.reserve(si().shards().size());
+    _load_map.reserve(si().shards().size());
+    for (auto it = si().shards().cbegin(); it != si().shards().cend(); ++it) {
+        _load.push_back(it);
+        _load_map.emplace(it->first, it->second.size());
+    }
+    std::sort(_load.begin(), _load.end(), [](const auto& a, const auto& b) {
+        return a->second.size() < b->second.size();
+    });
+}
+
+std::vector<shard_load> even_shard_load_constraint::stats() const {
+    std::vector<shard_load> ret;
+    ret.reserve(_load.size());
+    std::transform(
+      _load.cbegin(), _load.cend(), std::back_inserter(ret), [](const auto& e) {
+          // oddly, absl::btree::size returns a signed type
+          return shard_load{e->first, static_cast<size_t>(e->second.size())};
+      });
+    return ret;
+}
+
+} // namespace cluster::leader_balancer_types

--- a/src/v/cluster/scheduling/leader_balancer_constraints.h
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/scheduling/leader_balancer_types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "raft/types.h"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/sstring.hh>
+
+#include <absl/container/btree_map.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <boost/range/adaptor/reversed.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <optional>
+#include <unordered_map>
+
+namespace cluster::leader_balancer_types {
+
+class shard_index final : public index {
+public:
+    explicit shard_index(index_type index)
+      : _index(std::move(index)) {}
+
+    shard_index(shard_index&& si) noexcept = default;
+    shard_index(const shard_index& si) noexcept = default;
+
+    shard_index& operator=(shard_index&&) = default;
+    shard_index& operator=(const shard_index&) = default;
+
+    ~shard_index() override = default;
+
+    void update_index(const reassignment& r) override {
+        auto replicas = std::move(_index[r.from][r.group]);
+        _index[r.to].try_emplace(r.group, std::move(replicas));
+        _index[r.from].erase(r.group);
+    }
+
+    const index_type& shards() const { return _index; }
+
+private:
+    index_type _index;
+};
+
+/*
+ * Tracks nodes and groups being `muted` by the leader balancer.
+ * Reassignments to and from muted nodes and groups should be avoided.
+ */
+class muted_index final : public index {
+public:
+    muted_index(
+      absl::flat_hash_set<model::node_id> muted_nodes,
+      absl::flat_hash_set<raft::group_id> muted_groups)
+      : _muted_nodes(std::move(muted_nodes))
+      , _muted_groups(std::move(muted_groups)) {}
+
+    muted_index(muted_index&& mi) noexcept = default;
+    muted_index& operator=(muted_index&&) = default;
+    ~muted_index() override = default;
+
+    const absl::flat_hash_set<model::node_id>& muted_nodes() const {
+        return _muted_nodes;
+    }
+
+    const absl::flat_hash_set<raft::group_id>& muted_groups() const {
+        return _muted_groups;
+    }
+
+    absl::flat_hash_set<raft::group_id>& muted_groups() {
+        return _muted_groups;
+    }
+
+    void update_index(const reassignment&) override {
+        // nothing to do here.
+    }
+
+    void update_muted_groups(absl::flat_hash_set<raft::group_id> new_groups) {
+        _muted_groups = std::move(new_groups);
+    }
+
+private:
+    absl::flat_hash_set<model::node_id> _muted_nodes;
+    absl::flat_hash_set<raft::group_id> _muted_groups;
+};
+
+/*
+ * Greedy shard balancer strategy is to move leaders from the most loaded core
+ * to the least loaded core. The strategy treats all cores equally, ignoring
+ * node-level balancing.
+ */
+class even_shard_load_constraint final
+  : public soft_constraint
+  , public index {
+    /*
+     * avoid rounding errors when determining if a move improves balance by
+     * adding a small amount of jitter. effectively a move needs to improve by
+     * more than this value.
+     */
+    static constexpr double error_jitter = 0.000001;
+
+public:
+    even_shard_load_constraint(shard_index si, const muted_index& mi)
+      : _si(std::move(si))
+      , _mi(mi)
+      , _num_cores(num_cores())
+      , _num_groups(num_groups()) {
+        rebuild_load_index();
+        calculate_error();
+    }
+
+    even_shard_load_constraint(even_shard_load_constraint&&) noexcept = default;
+    even_shard_load_constraint&
+    operator=(even_shard_load_constraint&&) noexcept = default;
+
+    even_shard_load_constraint(const even_shard_load_constraint&) = delete;
+    even_shard_load_constraint& operator=(const even_shard_load_constraint&)
+      = delete;
+
+    ~even_shard_load_constraint() override = default;
+
+    double error() const { return _error; }
+    void update_index(const reassignment& r) override {
+        _error = adjusted_error(_error, r.from, r.to);
+        _si.update_index(r);
+    }
+
+    /*
+     * Find a group reassignment that improves overall error. The general
+     * approach is to select a group from the highest loaded shard and move
+     * leadership for that group to the least loaded shard that the group is
+     * compatible with.
+     *
+     * Clearly this is a costly method in terms of runtime complexity.
+     * Measurements for clusters with several thousand partitions indicate a
+     * real time execution cost of at most a couple hundred micros. Other
+     * strategies are sure to improve this as we tackle larger configurations.
+     *
+     * Muted nodes are nodes that should be treated as if they have no available
+     * capacity. So do not move leadership to a muted node, but any leaders on a
+     * muted node should not be touched in case the mute is temporary.
+     */
+    std::optional<reassignment> recommended_reassignment() override;
+
+    std::vector<shard_load> stats() const;
+
+    double calc_target_load() const;
+
+private:
+    shard_index _si;
+    std::reference_wrapper<const muted_index> _mi;
+    size_t _num_cores;
+    size_t _num_groups;
+    std::vector<index_type::const_iterator> _load;
+    absl::flat_hash_map<model::broker_shard, size_t> _load_map;
+    double _error{0};
+
+    const shard_index& si() const { return _si; }
+    const muted_index& mi() const { return _mi.get(); }
+
+    /*
+     * Compute new error for the given reassignment.
+     */
+    double adjusted_error(
+      double current_error,
+      const model::broker_shard& from,
+      const model::broker_shard& to) const;
+
+    void calculate_error() {
+        _error = std::accumulate(
+          si().shards().cbegin(),
+          si().shards().cend(),
+          double{0},
+          [target_load = calc_target_load()](auto acc, const auto& e) {
+              double num_groups = e.second.size();
+              return acc + pow(num_groups - target_load, 2);
+          });
+    }
+
+    double evaluate_internal(const reassignment& r) override {
+        double err = error();
+        return err - adjusted_error(err, r.from, r.to);
+    }
+
+    size_t num_groups() const;
+    size_t num_cores() const;
+    /*
+     * build the load index, which is a vector of iterators to each element in
+     * the core index, where the iterators in the load index are sorted by the
+     * number of groups having their leader on a given core.
+     */
+    void rebuild_load_index();
+};
+
+} // namespace cluster::leader_balancer_types

--- a/src/v/cluster/scheduling/leader_balancer_greedy.h
+++ b/src/v/cluster/scheduling/leader_balancer_greedy.h
@@ -10,13 +10,16 @@
  */
 #pragma once
 
+#include "cluster/scheduling/leader_balancer_constraints.h"
 #include "cluster/scheduling/leader_balancer_strategy.h"
+#include "cluster/scheduling/leader_balancer_types.h"
 #include "model/metadata.h"
 
 #include <absl/container/flat_hash_map.h>
 #include <boost/range/adaptor/reversed.hpp>
 
 #include <limits>
+#include <memory>
 
 /*
  * Greedy shard balancer strategy is to move leaders from the most loaded core
@@ -26,57 +29,15 @@
 namespace cluster {
 
 class greedy_balanced_shards final : private leader_balancer_strategy {
-    /*
-     * avoid rounding errors when determining if a move improves balance by
-     * adding a small amount of jitter. effectively a move needs to improve by
-     * more than this value.
-     */
-    static constexpr double error_jitter = 0.000001;
-
 public:
     explicit greedy_balanced_shards(
       index_type cores, absl::flat_hash_set<model::node_id> muted_nodes)
-      : _cores(std::move(cores))
-      , _muted_nodes(std::move(muted_nodes))
-      , _num_cores(num_cores())
-      , _num_groups(num_groups()) {
-        rebuild_load_index();
-    }
+      : _mi(std::make_unique<leader_balancer_types::muted_index>(
+        std::move(muted_nodes), absl::flat_hash_set<raft::group_id>{}))
+      , _even_shard_load_c(
+          leader_balancer_types::shard_index{std::move(cores)}, *_mi) {}
 
-    double calc_target_load() const {
-        return static_cast<double>(_num_groups)
-               / static_cast<double>(_num_cores);
-    }
-
-    double error() const final {
-        return std::accumulate(
-          _cores.cbegin(),
-          _cores.cend(),
-          double{0},
-          [target_load = calc_target_load()](auto acc, const auto& e) {
-              double num_groups = e.second.size();
-              return acc + pow(num_groups - target_load, 2);
-          });
-    }
-
-    /*
-     * Compute new error for the given reassignment.
-     */
-    double adjusted_error(
-      double current_error,
-      const model::broker_shard& from,
-      const model::broker_shard& to) const {
-        auto target_load = calc_target_load();
-        const auto from_count = static_cast<double>(_cores.at(from).size());
-        const auto to_count = static_cast<double>(_cores.at(to).size());
-        // subtract original contribution
-        current_error -= pow(from_count - target_load, 2);
-        current_error -= pow(to_count - target_load, 2);
-        // add back in the adjusted amount
-        current_error += pow(from_count - 1 - target_load, 2);
-        current_error += pow(to_count + 1 - target_load, 2);
-        return current_error;
-    }
+    double error() const final { return _even_shard_load_c.error(); }
 
     /*
      * Find a group reassignment that improves overall error. The general
@@ -94,126 +55,22 @@ public:
      * muted node should not be touched in case the mute is temporary.
      */
     std::optional<reassignment>
-    find_movement(const absl::flat_hash_set<raft::group_id>& skip) const final {
-        const auto curr_error = error();
+    find_movement(const absl::flat_hash_set<raft::group_id>& skip) final {
+        _mi->update_muted_groups(skip);
+        return _even_shard_load_c.recommended_reassignment();
+    }
 
-        // Consider each group from high load core, and record the reassignment
-        // involving the lowest load "to" core.
-        for (const auto& from : boost::adaptors::reverse(_load)) {
-            if (_muted_nodes.contains(from->first.node_id)) {
-                continue;
-            }
-
-            constexpr size_t load_unset = std::numeric_limits<size_t>::max();
-            size_t lowest_load = load_unset;
-            reassignment lowest_reassign{};
-
-            // Consider each group from high load core, and record the
-            // reassignment involving the lowest load "to" core.
-            for (const auto& group : from->second) {
-                if (skip.contains(group.first)) {
-                    continue;
-                }
-
-                // iterate over all the replicas and look for the lowest load
-                // shard in the replica list
-                for (const auto& to_shard : group.second) {
-                    auto load = _load_map.at(to_shard);
-                    if (likely(load >= lowest_load)) {
-                        // there is no point in evaluating this move, it is
-                        // worse than the best one we've found so far.
-                        continue;
-                    }
-
-                    if (_muted_nodes.contains(to_shard.node_id)) {
-                        continue;
-                    }
-
-                    lowest_load = load;
-                    lowest_reassign = {group.first, from->first, to_shard};
-                }
-            }
-
-            if (lowest_load != load_unset) {
-                // We found a possible reassignment while looking at the current
-                // "from" shard, and while it is the best possible reassignment
-                // found it may not improve the error
-                auto new_error = adjusted_error(
-                  curr_error, lowest_reassign.from, lowest_reassign.to);
-                if (new_error + error_jitter < curr_error) {
-                    return lowest_reassign;
-                }
-            }
-        }
-
-        return std::nullopt;
+    void apply_movement(const reassignment& r) final {
+        _even_shard_load_c.update_index(r);
     }
 
     std::vector<shard_load> stats() const final {
-        std::vector<shard_load> ret;
-        ret.reserve(_load.size());
-        std::transform(
-          _load.cbegin(),
-          _load.cend(),
-          std::back_inserter(ret),
-          [](const auto& e) {
-              // oddly, absl::btree::size returns a signed type
-              return shard_load{
-                e->first, static_cast<size_t>(e->second.size())};
-          });
-        return ret;
+        return _even_shard_load_c.stats();
     }
 
 private:
-    size_t num_groups() const {
-        return std::accumulate(
-          _cores.cbegin(),
-          _cores.cend(),
-          size_t{0},
-          [this](auto acc, const auto& e) {
-              /*
-               * we aren't going to attempt to move leadership between muted
-               * nodes, so we only count groups with leaders on non-muted nodes
-               * when calculating error / target load.
-               */
-              if (_muted_nodes.contains(e.first.node_id)) {
-                  return acc;
-              }
-              return acc + e.second.size();
-          });
-    }
-
-    size_t num_cores() const {
-        return std::count_if(
-          _cores.cbegin(), _cores.cend(), [this](const auto& core) {
-              return !_muted_nodes.contains(core.first.node_id);
-          });
-    }
-
-    /*
-     * build the load index, which is a vector of iterators to each element in
-     * the core index, where the iterators in the load index are sorted by the
-     * number of groups having their leader on a given core.
-     */
-    void rebuild_load_index() {
-        _load.clear();
-        _load.reserve(_cores.size());
-        _load_map.reserve(_cores.size());
-        for (auto it = _cores.cbegin(); it != _cores.cend(); ++it) {
-            _load.push_back(it);
-            _load_map.emplace(it->first, it->second.size());
-        }
-        std::sort(_load.begin(), _load.end(), [](const auto& a, const auto& b) {
-            return a->second.size() < b->second.size();
-        });
-    }
-
-    index_type _cores;
-    absl::flat_hash_set<model::node_id> _muted_nodes;
-    size_t _num_cores;
-    size_t _num_groups;
-    std::vector<index_type::const_iterator> _load;
-    absl::flat_hash_map<model::broker_shard, size_t> _load_map;
+    std::unique_ptr<leader_balancer_types::muted_index> _mi;
+    leader_balancer_types::even_shard_load_constraint _even_shard_load_c;
 };
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer_greedy.h
+++ b/src/v/cluster/scheduling/leader_balancer_greedy.h
@@ -28,7 +28,7 @@
  */
 namespace cluster {
 
-class greedy_balanced_shards final : private leader_balancer_strategy {
+class greedy_balanced_shards final : public leader_balancer_strategy {
 public:
     explicit greedy_balanced_shards(
       index_type cores, absl::flat_hash_set<model::node_id> muted_nodes)

--- a/src/v/cluster/scheduling/leader_balancer_random.h
+++ b/src/v/cluster/scheduling/leader_balancer_random.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/scheduling/leader_balancer_constraints.h"
+#include "cluster/scheduling/leader_balancer_strategy.h"
+#include "cluster/scheduling/leader_balancer_types.h"
+#include "model/metadata.h"
+#include "raft/types.h"
+#include "random/generators.h"
+#include "utils/fragmented_vector.h"
+#include "vassert.h"
+
+#include <absl/container/flat_hash_map.h>
+
+#include <cmath>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <optional>
+
+namespace cluster::leader_balancer_types {
+
+/*
+ * Given a `shard_index` this class will generate every possible reassignment.
+ */
+class random_reassignments {
+public:
+    explicit random_reassignments(const index_type& si)
+      : _replicas() {
+        for (const auto& [bs, leaders] : si) {
+            for (const auto& [group, replicas] : leaders) {
+                _current_leaders[group] = bs;
+
+                for (const auto& replica : replicas) {
+                    _replicas.push_back({group, replica});
+                }
+            }
+        }
+    }
+
+    /*
+     * This function randomly selects a reassignment from the set of all
+     * possible reassignments for a given shard_index. It will only return
+     * a given reassignment once, and when all possible reassignments have
+     * been returned it'll return a std::nullopt.
+     */
+    std::optional<reassignment> generate_reassignment() {
+        while (_replicas_begin < _replicas.size()) {
+            // If all reassignments are consumed doing the random shuffling
+            // incrementally is slower than using std::shuffle in the
+            // constructor. However, its assumed that only a small minority
+            // of the reassignments will be consumed. Hence the incremental
+            // approach is taken.
+
+            auto ri = random_generators::get_int<size_t>(
+              _replicas_begin, _replicas.size() - 1);
+
+            std::swap(_replicas[_replicas_begin], _replicas[ri]);
+
+            const auto& replica = _replicas[_replicas_begin];
+            _replicas_begin += 1;
+
+            auto replica_leader_it = _current_leaders.find(replica.group_id);
+            vassert(
+              replica_leader_it != _current_leaders.end(),
+              "replica_leader_it == _current_leaders.end()");
+            const auto& replica_leader = replica_leader_it->second;
+            if (replica_leader == replica.broker_shard) {
+                continue;
+            }
+
+            return {{replica.group_id, replica_leader, replica.broker_shard}};
+        }
+
+        return std::nullopt;
+    }
+
+    void update_index(const reassignment& r) {
+        _current_leaders[r.group] = r.to;
+        _replicas_begin = 0;
+    }
+
+private:
+    struct replica {
+        raft::group_id group_id;
+        model::broker_shard broker_shard;
+    };
+    absl::flat_hash_map<raft::group_id, model::broker_shard> _current_leaders;
+
+    using replicas_t = fragmented_vector<replica>;
+    replicas_t _replicas;
+    size_t _replicas_begin{0};
+};
+
+class random_hill_climbing_strategy final : public leader_balancer_strategy {
+public:
+    random_hill_climbing_strategy(
+      index_type index, group_id_to_topic_revision_t g_to_ntp, muted_index mi)
+      : _mi(std::make_unique<muted_index>(std::move(mi)))
+      , _reassignments(index)
+      , _etdc(std::move(g_to_ntp), shard_index(index), *_mi)
+      , _eslc(shard_index(std::move(index)), *_mi) {}
+
+    double error() const override { return _eslc.error() + _etdc.error(); }
+
+    /*
+     * Find a group reassignment that reduces total error.
+     */
+    std::optional<reassignment>
+    find_movement(const absl::flat_hash_set<raft::group_id>& skip) override {
+        for (;;) {
+            auto reassignment_opt = _reassignments.generate_reassignment();
+
+            if (!reassignment_opt) {
+                break;
+            }
+
+            auto reassignment = *reassignment_opt;
+            if (
+              skip.contains(reassignment.group)
+              || _mi->muted_nodes().contains(reassignment.from.node_id)
+              || _mi->muted_nodes().contains(reassignment.to.node_id)) {
+                continue;
+            }
+
+            auto eval = _etdc.evaluate(reassignment)
+                        + _eslc.evaluate(reassignment);
+
+            if (eval <= error_jitter) {
+                continue;
+            }
+
+            return reassignment_opt;
+        }
+
+        return std::nullopt;
+    }
+
+    void apply_movement(const reassignment& reassignment) override {
+        _etdc.update_index(reassignment);
+        _eslc.update_index(reassignment);
+        _mi->update_index(reassignment);
+        _reassignments.update_index(reassignment);
+    }
+
+    /*
+     * Return current strategy stats.
+     */
+    std::vector<shard_load> stats() const override { return _eslc.stats(); }
+
+private:
+    static constexpr double error_jitter = 0.000001;
+
+    std::unique_ptr<muted_index> _mi;
+    random_reassignments _reassignments;
+
+    even_topic_distributon_constraint _etdc;
+    even_shard_load_constraint _eslc;
+};
+
+} // namespace cluster::leader_balancer_types

--- a/src/v/cluster/scheduling/leader_balancer_strategy.h
+++ b/src/v/cluster/scheduling/leader_balancer_strategy.h
@@ -10,9 +10,9 @@
  */
 #pragma once
 
-#include "cluster/scheduling/leader_balancer_types.h"
 #include "absl/container/btree_map.h"
 #include "absl/container/node_hash_map.h"
+#include "cluster/scheduling/leader_balancer_types.h"
 #include "cluster/types.h"
 #include "raft/types.h"
 
@@ -58,7 +58,9 @@ public:
      * Find a group reassignment that reduces total error.
      */
     virtual std::optional<reassignment>
-    find_movement(const absl::flat_hash_set<raft::group_id>& skip) const = 0;
+    find_movement(const absl::flat_hash_set<raft::group_id>& skip) = 0;
+
+    virtual void apply_movement(const reassignment& reassignment) = 0;
 
     /*
      * Return current strategy stats.

--- a/src/v/cluster/scheduling/leader_balancer_strategy.h
+++ b/src/v/cluster/scheduling/leader_balancer_strategy.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "cluster/scheduling/leader_balancer_types.h"
 #include "absl/container/btree_map.h"
 #include "absl/container/node_hash_map.h"
 #include "cluster/types.h"
@@ -31,28 +32,19 @@ public:
      * a leader of the group. For convenience, the data structure also contains
      * the replica set of each group.
      */
-    using index_type = absl::node_hash_map<
-      model::broker_shard,
-      absl::btree_map<raft::group_id, std::vector<model::broker_shard>>>;
+    using index_type = leader_balancer_types::index_type;
 
     virtual ~leader_balancer_strategy() = default;
 
     /*
      * Represent leadership transfer for a group.
      */
-    struct reassignment {
-        raft::group_id group;
-        model::broker_shard from;
-        model::broker_shard to;
-    };
+    using reassignment = leader_balancer_types::reassignment;
 
     /*
      * Leaders per shard.
      */
-    struct shard_load {
-        model::broker_shard shard;
-        size_t leaders;
-    };
+    using shard_load = leader_balancer_types::shard_load;
 
     /*
      * Compute error for the current leadership configuration.

--- a/src/v/cluster/scheduling/leader_balancer_types.h
+++ b/src/v/cluster/scheduling/leader_balancer_types.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "raft/types.h"
+
+#include <absl/container/btree_map.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+
+namespace cluster::leader_balancer_types {
+
+struct reassignment {
+    raft::group_id group;
+    model::broker_shard from;
+    model::broker_shard to;
+
+    reassignment(
+      const raft::group_id& g,
+      const model::broker_shard& f,
+      const model::broker_shard& t)
+      : group(g)
+      , from(f)
+      , to(t) {}
+
+    reassignment() = default;
+};
+
+using index_type = absl::node_hash_map<
+  model::broker_shard,
+  absl::btree_map<raft::group_id, std::vector<model::broker_shard>>>;
+
+using group_id_to_topic_revision_t
+  = absl::flat_hash_map<raft::group_id, model::revision_id>;
+
+/*
+ * Leaders per shard.
+ */
+struct shard_load {
+    model::broker_shard shard;
+    size_t leaders{0};
+};
+
+} // namespace cluster::leader_balancer_types

--- a/src/v/cluster/scheduling/leader_balancer_types.h
+++ b/src/v/cluster/scheduling/leader_balancer_types.h
@@ -51,4 +51,23 @@ struct shard_load {
     size_t leaders{0};
 };
 
+class index {
+public:
+    virtual ~index() = default;
+    virtual void update_index(const reassignment&) = 0;
+};
+
+class soft_constraint {
+    virtual double evaluate_internal(const reassignment&) = 0;
+
+public:
+    virtual ~soft_constraint() = default;
+    double evaluate(const reassignment& r) {
+        auto ret = evaluate_internal(r);
+        return ret;
+    }
+
+    virtual std::optional<reassignment> recommended_reassignment() = 0;
+};
+
 } // namespace cluster::leader_balancer_types

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -80,6 +80,15 @@ rp_test(
 )
 
 rp_test(
+  UNIT_TEST
+  BINARY_NAME leader_balancer_constraints_test
+  SOURCES leader_balancer_constraints_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES Boost::unit_test_framework v::cluster
+  LABELS cluster
+)
+
+rp_test(
   BENCHMARK_TEST
   BINARY_NAME leader_balancer_bench
   SOURCES leader_balancer_bench.cc

--- a/src/v/cluster/tests/leader_balancer_bench.cc
+++ b/src/v/cluster/tests/leader_balancer_bench.cc
@@ -8,7 +8,10 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
+#include "cluster/scheduling/leader_balancer_constraints.h"
 #include "cluster/scheduling/leader_balancer_greedy.h"
+#include "cluster/scheduling/leader_balancer_random.h"
+#include "cluster/scheduling/leader_balancer_types.h"
 #include "leader_balancer_test_utils.h"
 
 #include <seastar/testing/perf_tests.hh>
@@ -17,12 +20,135 @@
 
 namespace {
 
-void balancer_bench(bool measure_all) {
-    constexpr int node_count = 72;
-    constexpr int shards_per_node = 16;  // i.e., cores per node
-    constexpr int groups_per_shard = 80; // group == partition in this context
-    constexpr int replicas = 3;          // number of replicas
+constexpr int node_count = 72;
+constexpr int shards_per_node = 16;  // i.e., cores per node
+constexpr int groups_per_shard = 80; // group == partition in this context
+constexpr int replicas = 3;          // number of replicas
 
+cluster::leader_balancer_types::group_id_to_topic_revision_t
+make_gid_to_topic_index(
+  const cluster::leader_balancer_types::index_type& index) {
+    cluster::leader_balancer_types::group_id_to_topic_revision_t ret;
+
+    for (const auto& [bs, leaders] : index) {
+        for (const auto& [group, replicas] : leaders) {
+            ret[group] = model::revision_id(0);
+        }
+    }
+
+    return ret;
+}
+
+/*
+ * Measures the time it takes to randomly generate and evaluate every possible
+ * reassignment for a given cluster. The reassignments are evaluated by the
+ * `even_shard_load_constraint` and the `even_topic_distributon_constraint`.
+ */
+template<typename random_t>
+void random_search_eval_bench(bool measure_all) {
+    constexpr int total_reassignments = groups_per_shard * shards_per_node
+                                        * node_count * (replicas - 1);
+
+    auto index = leader_balancer_test_utils::make_cluster_index(
+      node_count, shards_per_node, groups_per_shard, replicas);
+
+    cluster::leader_balancer_types::muted_index mi{{}, {}};
+    cluster::leader_balancer_types::shard_index si(index);
+    auto gid_topic = make_gid_to_topic_index(si.shards());
+
+    if (measure_all) {
+        perf_tests::start_measuring_time();
+    }
+
+    random_t rt{index};
+    cluster::leader_balancer_types::even_topic_distributon_constraint tdc(
+      gid_topic, si, mi);
+    cluster::leader_balancer_types::even_shard_load_constraint slc(
+      std::move(si), mi);
+
+    if (!measure_all) {
+        perf_tests::start_measuring_time();
+    }
+
+    for (auto i = 0; i < total_reassignments; i++) {
+        auto reassignment = rt.generate_reassignment();
+        vassert(reassignment.has_value(), "movemement");
+
+        double eval = tdc.evaluate(*reassignment);
+        vassert(eval <= 0.001, "eval != 0");
+
+        eval = slc.evaluate(*reassignment);
+        vassert(eval <= 0.001, "eval != 0");
+
+        perf_tests::do_not_optimize(eval);
+    }
+
+    perf_tests::stop_measuring_time();
+}
+
+/*
+ * Measures the time the even_topic_distributon_constraint takes to generate
+ * a recommend reassignment in the worst case where it has to iterate through
+ * every possible reassignment.
+ */
+void even_topic_c_bench(bool measure_all) {
+    auto index = leader_balancer_test_utils::make_cluster_index(
+      node_count, shards_per_node, groups_per_shard, replicas);
+
+    cluster::leader_balancer_types::muted_index mi{{}, {}};
+    cluster::leader_balancer_types::shard_index si(std::move(index));
+    auto gid_topic = make_gid_to_topic_index(si.shards());
+
+    if (measure_all) {
+        perf_tests::start_measuring_time();
+    }
+
+    cluster::leader_balancer_types::even_topic_distributon_constraint tdc(
+      gid_topic, si, mi);
+
+    if (!measure_all) {
+        perf_tests::start_measuring_time();
+    }
+
+    auto movement = tdc.recommended_reassignment();
+    vassert(!movement, "movemement");
+
+    perf_tests::do_not_optimize(movement);
+
+    perf_tests::stop_measuring_time();
+}
+
+/*
+ * Measures the time needed to randomly generate every possible reassignment for
+ * a cluster.
+ */
+template<typename random_t>
+void random_bench() {
+    constexpr int total_reassignments = groups_per_shard * shards_per_node
+                                        * node_count * (replicas - 1);
+
+    cluster::leader_balancer_strategy::index_type index
+      = leader_balancer_test_utils::make_cluster_index(
+        node_count, shards_per_node, groups_per_shard, replicas);
+
+    cluster::leader_balancer_types::muted_index mi{{}, {}};
+
+    perf_tests::start_measuring_time();
+    random_t rt{index};
+
+    perf_tests::do_not_optimize(rt);
+    for (auto i = 0; i < total_reassignments; i++) {
+        auto reassignment = rt.generate_reassignment();
+        vassert(reassignment.has_value(), "movemement ");
+
+        perf_tests::do_not_optimize(reassignment);
+        perf_tests::do_not_optimize(i);
+    }
+
+    perf_tests::stop_measuring_time();
+}
+
+void balancer_bench(bool measure_all) {
     cluster::leader_balancer_strategy::index_type index
       = leader_balancer_test_utils::make_cluster_index(
         node_count, shards_per_node, groups_per_shard, replicas);
@@ -47,6 +173,21 @@ void balancer_bench(bool measure_all) {
 
 } // namespace
 
-PERF_TEST(leader_balancing, bench_movement) { balancer_bench(false); }
+PERF_TEST(lb, even_shard_load_movement) { balancer_bench(false); }
+PERF_TEST(lb, even_shard_load_all) { balancer_bench(true); }
 
-PERF_TEST(leader_balancing, bench_all) { balancer_bench(true); }
+PERF_TEST(lb, even_topic_distribution_movement) { even_topic_c_bench(false); }
+PERF_TEST(lb, even_topic_distribution_all) { even_topic_c_bench(true); }
+
+PERF_TEST(lb, random_eval_movement) {
+    random_search_eval_bench<
+      cluster::leader_balancer_types::random_reassignments>(false);
+}
+PERF_TEST(lb, random_eval_all) {
+    random_search_eval_bench<
+      cluster::leader_balancer_types::random_reassignments>(true);
+}
+
+PERF_TEST(lb, random_generator) {
+    random_bench<cluster::leader_balancer_types::random_reassignments>();
+}

--- a/src/v/cluster/tests/leader_balancer_constraints_test.cc
+++ b/src/v/cluster/tests/leader_balancer_constraints_test.cc
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#define BOOST_TEST_MODULE leader_balancer_constraints
+
+#include "cluster/scheduling/leader_balancer_constraints.h"
+#include "cluster/scheduling/leader_balancer_types.h"
+#include "leader_balancer_constraints_utils.h"
+#include "leader_balancer_test_utils.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "raft/types.h"
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <sstream>
+#include <tuple>
+#include <vector>
+
+BOOST_AUTO_TEST_CASE(greedy_empty) {
+    // empty spec, expect no movement
+    BOOST_REQUIRE(no_movement({}));
+}
+
+BOOST_AUTO_TEST_CASE(greedy_balanced) {
+    // single node is already balanced, expect no movement
+    BOOST_REQUIRE(no_movement({
+      {{1, 2, 3}, {}},
+    }));
+    BOOST_REQUIRE(no_movement({
+      {{1}, {2}},
+      {{2}, {1}},
+    }));
+
+    // not exactly balanced, but as balanced as possible,
+    // i.e., lead loaded node has 1 less than the most loaded node
+    BOOST_REQUIRE(no_movement({
+      {{1, 3}, {2}},
+      {{2}, {1, 3}},
+    }));
+}
+
+BOOST_AUTO_TEST_CASE(greedy_movement) {
+    // 10 nodes
+    // 2 cores x node
+    // 10 partitions per shard
+    // r=3 (3 replicas)
+    auto index = leader_balancer_test_utils::make_cluster_index(10, 2, 10, 3);
+    auto shard_index = lbt::shard_index(index);
+    auto mute_index = lbt::muted_index({}, {});
+
+    auto greed = lbt::even_shard_load_constraint(shard_index, mute_index);
+    BOOST_REQUIRE_EQUAL(greed.error(), 0);
+
+    // new groups on shard {2, 0}
+    auto shard20 = model::broker_shard{model::node_id{2}, 0};
+    index[shard20][raft::group_id(20)] = index[shard20][raft::group_id(3)];
+    index[shard20][raft::group_id(21)] = index[shard20][raft::group_id(3)];
+    index[shard20][raft::group_id(22)] = index[shard20][raft::group_id(3)];
+
+    auto shard_index2 = lbt::shard_index(index);
+    auto greed2 = lbt::even_shard_load_constraint(shard_index2, mute_index);
+    BOOST_REQUIRE_GT(greed2.error(), 0);
+
+    // movement should be _from_ the overloaded shard
+    auto movement = greed2.recommended_reassignment();
+    BOOST_REQUIRE(movement);
+    check_valid(shard_index2.shards(), *movement);
+    BOOST_REQUIRE_EQUAL(movement->from, shard20);
+}
+
+BOOST_AUTO_TEST_CASE(greedy_obeys_replica) {
+    // unbalanced, but the overloaded node has no replicas it can
+    // send its groups to
+    BOOST_REQUIRE(no_movement({{{1, 2, 3}, {}}, {{4}, {}}, {{}, {4}}}));
+}
+
+BOOST_AUTO_TEST_CASE(greedy_simple_movement) {
+    // simple balancing from {2, 0} leader counts to {1, 1}
+    BOOST_REQUIRE_EQUAL(
+      expect_movement(
+        {
+          // clang-format off
+          {{1, 2}, {}},
+          {{}, {1, 2}}
+          // clang-format on
+        },
+        re(1, 0, 1)),
+      "");
+}
+
+BOOST_AUTO_TEST_CASE(greedy_highest_to_lowest) {
+    // balancing should occur from the most to least loaded node if that is
+    // possible
+    BOOST_REQUIRE_EQUAL(
+      expect_movement(
+        {
+          // clang-format off
+            {{1, 2},    {-1}},
+            {{3, 4, 5}, {-1}},                  // from 1
+            {{6, 7},    {-1}},
+            {{},        {1, 2, 3, 4, 5, 6, 7}}  // to 3
+
+          // clang-format on
+        },
+        re(3, 1, 3)),
+      "");
+
+    // like the previous case but group 3 is not replicated on the to node, so
+    // we check that group 4 goes instead
+    BOOST_REQUIRE_EQUAL(
+      expect_movement(
+        {
+          // clang-format off
+          {{1, 2},    {-1}},
+          {{3, 4, 5}, {-1}}, // from 1
+          {{6, 7},    {-1}},
+          {{},        {1, 2, 4, 5, 6, 7}} // to 3
+
+          // clang-format on
+        },
+        re(4, 1, 3)),
+      "");
+}
+
+BOOST_AUTO_TEST_CASE(greedy_low_to_lower) {
+    // balancing can occur even from a shard with less than average load,
+    // if there is a shard with even lower load and the higher loaded shards
+    // cannot be rebalanced from because of a lack of replicas for their
+    // groups on the lower load nodes
+    BOOST_REQUIRE_EQUAL(
+      expect_movement(
+        {
+          // clang-format off
+          {{1, 2, 3, 10}, {}},
+          {{4, 5, 6, 11}, {}},
+          {{7, 8},        {}},  // from 2
+          {{},            {8}}  // to 3
+
+          // clang-format on
+        },
+        re(8, 2, 3)),
+      "");
+}
+
+BOOST_AUTO_TEST_CASE(greedy_muted) {
+    // base spec without high, medium and low (zero) load nodes
+    auto spec = cluster_spec{
+      // clang-format off
+      {{1, 2, 3, 4}, {-1}},
+      {{5, 6},       {-1}},
+      {{},           {-1}},
+      // clang-format on
+    };
+
+    // base case, move from high to low
+    BOOST_REQUIRE_EQUAL(expect_movement(spec, re(1, 0, 2)), "");
+
+    // mute from the "from" node (high), so moves from mid to low
+    BOOST_REQUIRE_EQUAL(expect_movement(spec, re(5, 1, 2), {0}), "");
+
+    // mute from the "to" node (low), so moves from high to mid
+    BOOST_REQUIRE_EQUAL(expect_movement(spec, re(1, 0, 1), {2}), "");
+
+    // mute any 2 nodes and there should be no movement
+    BOOST_REQUIRE(no_movement(spec, {0, 1}));
+    BOOST_REQUIRE(no_movement(spec, {0, 2}));
+    BOOST_REQUIRE(no_movement(spec, {1, 2}));
+}
+
+BOOST_AUTO_TEST_CASE(greedy_skip) {
+    // base spec without high, medium and low load nodes
+
+    auto spec = cluster_spec{
+      // clang-format off
+      {{1, 2, 3, 4}, {-1}},
+      {{5, 6},       {-1}},
+      {{},           {-1}},
+      // clang-format on
+    };
+
+    // base case, move from high to low
+    BOOST_REQUIRE_EQUAL(expect_movement(spec, re(1, 0, 2)), "");
+
+    // skip group 1, we move group 2 instead from same node
+    BOOST_REQUIRE_EQUAL(expect_movement(spec, re(2, 0, 2), {}, {1}), "");
+
+    // skip all groups on node 0, we move mid to low
+    BOOST_REQUIRE_EQUAL(
+      expect_movement(spec, re(5, 1, 2), {}, {1, 2, 3, 4}), "");
+
+    // mute node 0 and skip all groups on node 1, no movement
+    absl::flat_hash_set<raft::group_id> skip{
+      raft::group_id(5), raft::group_id(6)};
+    BOOST_REQUIRE(no_movement(spec, {0}, skip));
+}
+
+BOOST_AUTO_TEST_CASE(even_topic_distribution_empty) {
+    auto gntp_i = group_to_topic_from_spec({});
+    auto [shard_index, muted_index] = from_spec({});
+
+    auto even_topic_con = lbt::even_topic_distributon_constraint(
+      gntp_i, shard_index, muted_index);
+
+    BOOST_REQUIRE(even_topic_con.error() == 0);
+    BOOST_REQUIRE(!even_topic_con.recommended_reassignment());
+}
+
+BOOST_AUTO_TEST_CASE(even_topic_distribution_constraint_no_error) {
+    // In this case leadership for the topic "test" is evenly
+    // distributed on every node. Hence the even topic constraint
+    // should report no error.
+
+    auto g_id_to_t_id = group_to_topic_from_spec({
+      {0, {1, 2}},
+    });
+
+    auto spec = cluster_spec{
+      {{1}, {2}},
+      {{2}, {1}},
+    };
+
+    auto [index_cl, gbs] = from_spec(spec);
+    auto mute_i = lbt::muted_index({}, {});
+
+    auto topic_constraint = lbt::even_topic_distributon_constraint(
+      g_id_to_t_id, index_cl, mute_i);
+
+    BOOST_REQUIRE(topic_constraint.error() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(even_topic_distributon_constraint_uniform_move) {
+    // In this case all leadership for the "test" topic
+    // is on a single node. This test checks if the even
+    // topic constraints correctly reports an error.
+
+    auto g_id_to_t_id = group_to_topic_from_spec({
+      {0, {1, 2}},
+    });
+
+    auto [index_cl, _] = from_spec({
+      {{1, 2}, {}},
+      {{}, {1, 2}},
+    });
+
+    auto mute_i = lbt::muted_index({}, {});
+
+    auto topic_constraint = lbt::even_topic_distributon_constraint(
+      g_id_to_t_id, index_cl, mute_i);
+    auto reassignment = re(1, 0, 1);
+
+    BOOST_REQUIRE(topic_constraint.error() != 0);
+    BOOST_REQUIRE(
+      topic_constraint.error() == topic_constraint.evaluate(reassignment));
+
+    index_cl.update_index(reassignment);
+    topic_constraint.update_index(reassignment);
+
+    BOOST_REQUIRE(topic_constraint.error() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(even_topic_constraint_too_many_replicas) {
+    // In this case although a topic's partitions are replicated
+    // on many nodes there is only 2 possible leadership assignments.
+    // Hence the cluster spec should be as optimial as possible and
+    // the even topic constraint shouldn't recommend any reassignments.
+
+    auto g_id_to_t_id = group_to_topic_from_spec({
+      {0, {1, 2}},
+    });
+
+    auto [index_cl, _] = from_spec({
+      {{1}, {2}},
+      {{2}, {1}},
+      {{}, {1}},
+      {{}, {2}},
+      {{}, {1, 2}},
+    });
+
+    auto mute_i = lbt::muted_index({}, {});
+
+    auto topic_constraint = lbt::even_topic_distributon_constraint(
+      g_id_to_t_id, index_cl, mute_i);
+}
+
+BOOST_AUTO_TEST_CASE(even_topic_distributon_constraint_find_reassignment) {
+    // In this case all leadership for the "tst1" topic
+    // is on a single node. This test checks if the even
+    // topic constraints correctly reports an error and
+    // finds a reassignment.
+
+    auto g_id_to_t_id = group_to_topic_from_spec({
+      {0, {1, 2}},
+      {1, {3, 4}},
+    });
+
+    auto [index_cl, _] = from_spec({
+      {{1, 2}, {}},
+      {{4}, {1, 2, 3}},
+      {{3}, {4}},
+    });
+
+    auto mute_i = lbt::muted_index({}, {});
+
+    auto topic_constraint = lbt::even_topic_distributon_constraint(
+      g_id_to_t_id, index_cl, mute_i);
+    auto reassignment = re(1, 0, 1);
+
+    BOOST_REQUIRE(topic_constraint.error() != 0);
+    BOOST_REQUIRE(
+      topic_constraint.error() == topic_constraint.evaluate(reassignment));
+
+    auto rreassignment = topic_constraint.recommended_reassignment();
+    BOOST_REQUIRE(rreassignment.has_value());
+
+    index_cl.update_index(rreassignment.value());
+    topic_constraint.update_index(rreassignment.value());
+
+    BOOST_REQUIRE(topic_constraint.error() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(even_topic_odd_partition_cnt) {
+    // In cases where a topic as a partition count that
+    // is not even divisible by the nodes they are replicated on.
+    // In these cases its not possible for every node to has_value
+    // equal leadership for the topic.
+    //
+    // This tests that in those cases the even topic constraint
+    // correctly recommends no further reassignments.
+
+    auto g_id_to_t_id = group_to_topic_from_spec({
+      {0, {1, 2, 3}},
+    });
+
+    auto [shard_index, muted_index] = from_spec(
+      {
+        {{1, 2}, {3}},
+        {{3}, {1, 2}},
+      },
+      {});
+
+    auto even_topic_con = lbt::even_topic_distributon_constraint(
+      g_id_to_t_id, shard_index, muted_index);
+
+    BOOST_REQUIRE(!even_topic_con.recommended_reassignment());
+}
+
+BOOST_AUTO_TEST_CASE(even_shard_no_error_even_topic_error) {
+    // Here even_shard_load_constraint.error = 0, but
+    // even_topic_distributon_constraint.error > 0 and any move will increase
+    // the first error.
+    //
+    // In this case optimizing for even shard distribution first will get
+    // us stuck in a local minima where any attempt to optimze for even
+    // topic distribution will increase total error.
+
+    auto g_id_to_t_id = group_to_topic_from_spec({
+      {0, {1, 2}},
+      {1, {3, 4}},
+    });
+
+    auto [shard_index, muted_index] = from_spec(
+      {
+        {{1, 2}, {3, 4}},
+        {{3, 4}, {1, 2}},
+      },
+      {});
+
+    auto even_shard_con = lbt::even_shard_load_constraint(
+      shard_index, muted_index);
+    auto even_topic_con = lbt::even_topic_distributon_constraint(
+      g_id_to_t_id, shard_index, muted_index);
+
+    BOOST_REQUIRE(even_shard_con.error() == 0);
+    BOOST_REQUIRE(even_topic_con.error() > 0);
+
+    auto rea = even_topic_con.recommended_reassignment();
+    BOOST_REQUIRE(rea.has_value());
+
+    BOOST_REQUIRE(even_shard_con.evaluate(*rea) < 0);
+    BOOST_REQUIRE(even_topic_con.evaluate(*rea) > 0);
+}
+
+BOOST_AUTO_TEST_CASE(even_topic_no_error_even_shard_error) {
+    // Here even_topic_distributon_constraint.error = min, but
+    // even_shard_load_constraint.error > 0
+    //
+    // In this case optimizing for even topic distribution first will
+    // result in error for the even shard being greater than zero. However,
+    // unlike when optimzing for even shard constraint first we are not
+    // stuck in a low minima. Hence we can optimize for the even shard
+    // constraint without increasing global error.
+
+    auto g_id_to_t_id = group_to_topic_from_spec({
+      {0, {1, 2, 3}},
+      {1, {4, 5, 6}},
+    });
+
+    auto [shard_index, muted_index] = from_spec(
+      {
+        {{6}, {4, 5}},
+        {{1, 2, 4, 5}, {3, 6}},
+        {{3}, {1, 2}},
+      },
+      {});
+
+    auto even_shard_con = lbt::even_shard_load_constraint(
+      shard_index, muted_index);
+    auto even_topic_con = lbt::even_topic_distributon_constraint(
+      g_id_to_t_id, shard_index, muted_index);
+
+    BOOST_REQUIRE(even_shard_con.error() > 0);
+
+    BOOST_REQUIRE(!even_topic_con.recommended_reassignment());
+    BOOST_REQUIRE(even_shard_con.recommended_reassignment().has_value());
+}

--- a/src/v/cluster/tests/leader_balancer_constraints_utils.h
+++ b/src/v/cluster/tests/leader_balancer_constraints_utils.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/scheduling/leader_balancer.h"
+#include "cluster/scheduling/leader_balancer_constraints.h"
+#include "cluster/scheduling/leader_balancer_greedy.h"
+#include "cluster/scheduling/leader_balancer_types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "raft/types.h"
+#include "vassert.h"
+
+#include <algorithm>
+#include <iterator>
+#include <tuple>
+#include <vector>
+
+using index_type = cluster::leader_balancer_strategy::index_type;
+
+struct node_spec {
+    std::vector<int> groups_led, groups_followed;
+};
+
+// a cluster_spec is a vector of node_specs, i.e., one element
+// per node, and each node_spec is two vectors: the list of groups
+// for this node is a leader, followed by those for which it is a follower
+using cluster_spec = std::vector<node_spec>;
+
+namespace lbt = cluster::leader_balancer_types;
+using reassignment = lbt::reassignment;
+
+/**
+ * @brief Create a greedy balancer from a cluster_spec and set of muted nodes.
+ */
+static auto from_spec(
+  const cluster_spec& spec, const absl::flat_hash_set<int>& muted = {}) {
+    index_type index;
+
+    absl::flat_hash_map<raft::group_id, model::broker_shard> group_to_leader;
+
+    model::node_id node_counter{0};
+    for (const node_spec& node : spec) {
+        model::broker_shard shard{node_counter, 0};
+
+        index[shard]; // always create the shard entry even if it leads nothing
+
+        for (auto& lg : node.groups_led) {
+            auto leader_group = raft::group_id{lg};
+            vassert(
+              !group_to_leader.contains(leader_group),
+              "multiple leaders for same group");
+            group_to_leader.insert({leader_group, shard});
+            index[shard][leader_group] = {shard};
+        }
+
+        node_counter++;
+    }
+
+    node_counter = model::node_id{0};
+    for (const node_spec& node : spec) {
+        model::broker_shard shard{node_counter, 0};
+
+        auto followed = node.groups_followed;
+
+        if (followed.size() == 1 && followed.front() == -1) {
+            // following only the -1 group is a special flag which means follow
+            // all groups
+            followed.clear();
+            for (auto& gl : group_to_leader) {
+                if (gl.second != shard) {
+                    followed.push_back(static_cast<int>(gl.first));
+                }
+            }
+        }
+
+        for (auto& fg : followed) {
+            auto followed = raft::group_id{fg};
+            vassert(group_to_leader.contains(followed), "");
+            auto leader = group_to_leader.at(followed);
+            vassert(index[leader].contains(followed), "");
+            index[leader][followed].push_back(shard);
+        }
+
+        node_counter++;
+    }
+
+    // transform muted from int to broker_shard (we assume the shard is always
+    // zero)
+    absl::flat_hash_set<model::node_id> muted_bs;
+    std::transform(
+      muted.begin(),
+      muted.end(),
+      std::inserter(muted_bs, muted_bs.begin()),
+      [](auto id) { return model::node_id{id}; });
+
+    auto shard_index = lbt::shard_index(std::move(index));
+    auto muted_index = lbt::muted_index(std::move(muted_bs), {});
+
+    return std::make_tuple(std::move(shard_index), std::move(muted_index));
+};
+
+// Each element of this vector is a topic and the raft groups that are
+// associated with that topic's partition. This spec can be used to generate
+// a mapping of group_id to ntp.
+using group_to_ntp_spec
+  = std::vector<std::pair<model::revision_id::type, std::vector<int>>>;
+static auto group_to_topic_from_spec(const group_to_ntp_spec& spec) {
+    lbt::group_id_to_topic_revision_t group_to_topic;
+
+    for (const auto& [topic, groups] : spec) {
+        for (const auto& group : groups) {
+            group_to_topic.try_emplace(raft::group_id(group), topic);
+        }
+    }
+
+    return group_to_topic;
+}
+
+/**
+ * @brief Basic validity checks on a reassignment.
+ */
+static void check_valid(const index_type& index, const reassignment& movement) {
+    // from == to is not valid (error should not decrease)
+    vassert(movement.from != movement.to, "");
+
+    auto& from_groups = index.at(movement.from);
+    // check that the from shard was the leader
+    vassert(from_groups.contains(movement.group), "");
+
+    // check that the to shard is in the replica set
+    auto& replicas = from_groups.at(movement.group);
+    vassert(std::count(replicas.begin(), replicas.end(), movement.to) == 1, "");
+}
+
+/**
+ * @brief returns true iff the passed spec had no movement on balance
+ */
+static bool no_movement(
+  const cluster_spec& spec,
+  const absl::flat_hash_set<int>& muted = {},
+  const absl::flat_hash_set<raft::group_id>& skip = {}) {
+    auto [shard_index, muted_index] = from_spec(spec, muted);
+    muted_index.update_muted_groups(skip);
+    auto balancer = lbt::even_shard_load_constraint(shard_index, muted_index);
+
+    return !balancer.recommended_reassignment();
+}
+
+static bool operator==(const lbt::reassignment& l, const lbt::reassignment& r) {
+    return l.group == r.group && l.from == r.from && l.to == r.to;
+}
+
+static ss::sstring to_string(const reassignment& r) {
+    return fmt::format("{{group: {} from: {} to: {}}}", r.group, r.from, r.to);
+}
+
+/**
+ * @brief Test helper which checks that the given spec and other parameters
+ * result in the expected resassignment.
+ */
+static ss::sstring expect_movement(
+  const cluster_spec& spec,
+  const reassignment& expected_reassignment,
+  const absl::flat_hash_set<int>& muted = {},
+  const absl::flat_hash_set<int>& skip = {}) {
+    auto [shard_index, mute_index] = from_spec(spec, muted);
+
+    absl::flat_hash_set<raft::group_id> skip_typed;
+    std::transform(
+      skip.begin(),
+      skip.end(),
+      std::inserter(skip_typed, skip_typed.begin()),
+      [](auto groupid) { return raft::group_id{groupid}; });
+
+    mute_index.update_muted_groups(std::move(skip_typed));
+    auto balancer = lbt::even_shard_load_constraint(shard_index, mute_index);
+
+    auto reassignment = balancer.recommended_reassignment();
+
+    if (!reassignment) {
+        return "no reassignment occurred";
+    }
+
+    check_valid(shard_index.shards(), *reassignment);
+
+    if (!(*reassignment == expected_reassignment)) {
+        return fmt::format(
+          "Reassignment not as expected.\nExpected: {}\nActual:   {}\n",
+          to_string(expected_reassignment),
+          to_string(*reassignment));
+    }
+
+    return "";
+}
+
+/**
+ * @brief Helper to create a reassignment from group, from and to passed as
+ * integers.
+ */
+static reassignment re(unsigned group, int from, int to) {
+    return {
+      raft::group_id(group),
+      model::broker_shard{model::node_id(from)},
+      model::broker_shard{model::node_id(to)}};
+}

--- a/src/v/cluster/tests/leader_balancer_test_utils.h
+++ b/src/v/cluster/tests/leader_balancer_test_utils.h
@@ -10,9 +10,9 @@
  */
 
 #include "cluster/scheduling/leader_balancer_greedy.h"
+#include "cluster/scheduling/leader_balancer_types.h"
 
 namespace leader_balancer_test_utils {
-
 /**
  * @brief Create an artificial cluster index object with the given
  * number of nodes, shards, groups and replica count.

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1614,6 +1614,19 @@ configuration::configuration()
       "Enable automatic leadership rebalancing",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
+  , leader_balancer_mode(
+      *this,
+      "leader_balancer_mode",
+      "Leader balancer mode",
+      {.needs_restart = needs_restart::no,
+       .example = model::leader_balancer_mode_to_string(
+         model::leader_balancer_mode::random_hill_climbing),
+       .visibility = visibility::user},
+      model::leader_balancer_mode::random_hill_climbing,
+      {
+        model::leader_balancer_mode::greedy_balanced_shards,
+        model::leader_balancer_mode::random_hill_climbing,
+      })
   , leader_balancer_idle_timeout(
       *this,
       "leader_balancer_idle_timeout",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -329,6 +329,7 @@ struct configuration final : public config_store {
     property<size_t> partition_autobalancing_concurrent_moves;
 
     property<bool> enable_leader_balancer;
+    enum_property<model::leader_balancer_mode> leader_balancer_mode;
     property<std::chrono::milliseconds> leader_balancer_idle_timeout;
     property<std::chrono::milliseconds> leader_balancer_mute_timeout;
     property<std::chrono::milliseconds> leader_balancer_node_mute_timeout;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -360,4 +360,37 @@ struct convert<model::cloud_storage_backend> {
     }
 };
 
+template<>
+struct convert<model::leader_balancer_mode> {
+    using type = model::leader_balancer_mode;
+
+    static constexpr auto acceptable_values = std::to_array(
+      {model::leader_balancer_mode_to_string(type::random_hill_climbing),
+       model::leader_balancer_mode_to_string(type::greedy_balanced_shards)});
+
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+
+        if (
+          std::find(acceptable_values.begin(), acceptable_values.end(), value)
+          == acceptable_values.end()) {
+            return false;
+        }
+
+        rhs = string_switch<type>(std::string_view{value})
+                .match(
+                  model::leader_balancer_mode_to_string(
+                    type::random_hill_climbing),
+                  type::random_hill_climbing)
+                .match(
+                  model::leader_balancer_mode_to_string(
+                    type::greedy_balanced_shards),
+                  type::greedy_balanced_shards);
+
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -489,6 +489,8 @@ consteval std::string_view property_type_name() {
         return "string";
     } else if constexpr (std::is_same_v<type, model::cloud_storage_backend>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, model::leader_balancer_mode>) {
+        return "string";
     } else {
         static_assert(dependent_false<T>::value, "Type name not defined");
     }

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -155,4 +155,9 @@ void rjson_serialize(
     stringize(w, v);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::leader_balancer_mode& v) {
+    stringize(w, v);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -71,4 +71,7 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::cloud_storage_backend& v);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::leader_balancer_mode& v);
+
 } // namespace json

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -25,6 +25,7 @@
 
 #include <compare>
 #include <optional>
+#include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -446,6 +447,26 @@ inline std::ostream& operator<<(std::ostream& os, cloud_storage_backend csb) {
         return os << "unknown";
     }
 }
+
+enum class leader_balancer_mode : uint8_t {
+    greedy_balanced_shards = 0,
+    random_hill_climbing = 1,
+};
+
+constexpr const char*
+leader_balancer_mode_to_string(leader_balancer_mode mode) {
+    switch (mode) {
+    case leader_balancer_mode::greedy_balanced_shards:
+        return "greedy_balanced_shards";
+    case leader_balancer_mode::random_hill_climbing:
+        return "random_hill_climbing";
+    default:
+        throw std::invalid_argument("unknown leader_balancer_mode");
+    }
+}
+
+std::ostream& operator<<(std::ostream&, leader_balancer_mode);
+std::istream& operator>>(std::istream&, leader_balancer_mode&);
 
 namespace internal {
 /*

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -423,4 +423,24 @@ std::ostream& operator<<(std::ostream& o, const shadow_indexing_mode& si) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, leader_balancer_mode lbt) {
+    o << leader_balancer_mode_to_string(lbt);
+    return o;
+}
+
+std::istream& operator>>(std::istream& i, leader_balancer_mode& lbt) {
+    ss::sstring s;
+    i >> s;
+    lbt = string_switch<leader_balancer_mode>(s)
+            .match(
+              leader_balancer_mode_to_string(
+                leader_balancer_mode::random_hill_climbing),
+              leader_balancer_mode::random_hill_climbing)
+            .match(
+              leader_balancer_mode_to_string(
+                leader_balancer_mode::greedy_balanced_shards),
+              leader_balancer_mode::greedy_balanced_shards);
+    return i;
+}
+
 } // namespace model

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -86,4 +86,22 @@ T random_choice(std::initializer_list<T> choices) {
     return std::move(choice);
 }
 
+template<typename T>
+T get_real() {
+    std::uniform_real_distribution<T> dist;
+    return dist(internal::gen);
+}
+
+template<typename T>
+T get_real(T min, T max) {
+    std::uniform_real_distribution<T> dist(min, max);
+    return dist(internal::gen);
+}
+
+template<typename T>
+T get_real(T max) {
+    std::uniform_real_distribution<T> dist(0, max);
+    return dist(internal::gen);
+}
+
 } // namespace random_generators


### PR DESCRIPTION
This PR changes the leader balancer to use randomized hill climbing to minimize a set of constraints. Currently two constraints are implemented;
- A constraint to ensure that each shard in a cluster has an equal number of partitions.
- A constraint to ensure that a topic's partitions are even distributed over each node in the cluster.

An analysis of the performance of randomized hill climbing over simulated annealing and a heuristic-based approach are summarized in a Google document [here](https://docs.google.com/document/d/1gCHYsVBBB92dMcLcsaIcZZsR2MpnnsKav_h-nogHkXE/edit?usp=sharing). 

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
* Changes the leader balancer to ensure a topic's partitions are even distributed across all nodes in a cluster.
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR. 
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
