### PR TITLE
treewide: Fix ostream error handling

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_storage_clients/s3_client.h"
 
+#include "bytes/bytes.h"
 #include "cloud_storage_clients/logger.h"
 #include "cloud_storage_clients/s3_error.h"
 #include "cloud_storage_clients/util.h"
@@ -36,6 +37,7 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <gnutls/crypto.h>
 
+#include <bit>
 #include <exception>
 #include <utility>
 
@@ -293,9 +295,7 @@ request_creator::make_delete_objects_request(
         auto hash = internal::hash<GNUTLS_DIG_MD5, 16>{};
         hash.update(body);
         auto bin_digest = hash.reset();
-        return bytes_to_base64(
-          {reinterpret_cast<const uint8_t*>(bin_digest.data()),
-           bin_digest.size()});
+        return bytes_to_base64(to_bytes_view(bin_digest));
     }();
 
     auto header = http::client::request_header{};

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -279,6 +279,12 @@ request_creator::make_delete_objects_request(
 
         auto out = std::ostringstream{};
         boost::property_tree::write_xml(out, delete_tree);
+        if (!out.good()) {
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format,
+              "failed to create delete request, state: {}",
+              out.rdstate()));
+        }
         return out.str();
     }();
 

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -442,6 +442,12 @@ inline void rjson_serialize(
     std::stringstream ss;
     vassert(host.address(), "Unset optional address unexpected.");
     ss << host.address().value();
+    if (!ss.good()) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "failed to serialize acl_host, state: {}",
+          ss.rdstate()));
+    }
     w.Key("address");
     rjson_serialize(w, ss.str());
     w.EndObject();

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -63,6 +63,12 @@ struct convert<ss::socket_address> {
         Node node;
         std::ostringstream o;
         o << rhs.addr();
+        if (!o.good()) {
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format,
+              "failed to format socket_address, state: {}",
+              o.rdstate()));
+        }
         node["address"] = o.str();
         node["port"] = rhs.port();
         return node;

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -47,6 +47,12 @@ void rjson_serialize(
 
     std::ostringstream a;
     a << v.addr();
+    if (!a.good()) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "failed to format socket_address, state: {}",
+          a.rdstate()));
+    }
 
     w.Key("address");
     w.String(a.str());


### PR DESCRIPTION
The `ostream` handles exceptions internally and in case if any exception is getting thrown it sets the fail bit. The code must use `good` or `fail` methods to check if the formatting operation is successful. The errors like that are rare so it doesn't make much sense to fix every use of `ostream`. If the `std::stringstream` is used to format a log message, it's OK to ignore a failbit. But there are cases when it's necessary to check. For instance, when we serialize partition manifest. If the `bad_alloc` is thrown during formatting process the manifest will be truncated.

This PR fixes several cases of such `ostream` use. For instance, inside s3 client the `stringstream` is used to format XML request. Without checking the stream we may end up sending corrupted request. In this case we will get a cryptic error message from AWS S3.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

  ### Bug Fixes

  * Fix an issue that can cause redpanda to send ill-formed DeleteObjects request to AWS S3
