### PR TITLE
Added validation of `segment.bytes` property when altering topic configuration

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -1044,6 +1044,7 @@ func setContainerModeCfgFields(cfg *config.Config) {
 	cfg.Redpanda.Other["topic_partitions_per_shard"] = 1000
 	cfg.Redpanda.Other["fetch_reads_debounce_timeout"] = 10
 	cfg.Redpanda.Other["group_initial_rebalance_delay"] = 0
+	cfg.Redpanda.Other["log_segment_size_min"] = 1
 }
 
 func getOrFindInstallDir(fs afero.Fs, installDir string) (string, error) {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -250,6 +250,7 @@ func TestStartCommand(t *testing.T) {
 				"topic_partitions_per_shard":    1000,
 				"fetch_reads_debounce_timeout":  10,
 				"group_initial_rebalance_delay": 0,
+				"log_segment_size_min":          1,
 			}
 
 			conf, err := new(config.Params).Load(fs)
@@ -1491,6 +1492,7 @@ func TestStartCommand(t *testing.T) {
 				"topic_partitions_per_shard":    1000,
 				"fetch_reads_debounce_timeout":  10,
 				"group_initial_rebalance_delay": 0,
+				"log_segment_size_min":          1,
 			}
 			require.Equal(st, expectedClusterFields, conf.Redpanda.Other)
 		},
@@ -1542,6 +1544,7 @@ func TestStartCommand(t *testing.T) {
 				"topic_partitions_per_shard":    1000,
 				"fetch_reads_debounce_timeout":  10,
 				"group_initial_rebalance_delay": 0,
+				"log_segment_size_min":          1,
 			}
 			require.Nil(st, conf.Redpanda.ID)
 			require.Equal(st, true, conf.Redpanda.DeveloperMode)
@@ -1584,6 +1587,7 @@ func TestStartCommand(t *testing.T) {
 				"topic_partitions_per_shard":    1000,
 				"fetch_reads_debounce_timeout":  10,
 				"group_initial_rebalance_delay": 0,
+				"log_segment_size_min":          1,
 			}
 			require.Exactly(st, expectedClusterFields, conf.Redpanda.Other)
 		},

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -44,7 +44,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "16777216",
        .visibility = visibility::tunable},
-      std::nullopt)
+      1_MiB)
   , log_segment_size_max(
       *this,
       "log_segment_size_max",

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -113,7 +113,8 @@ create_topic_properties_update(alter_configs_resource& resource) {
                 parse_and_set_optional(
                   update.properties.segment_size,
                   cfg.value,
-                  kafka::config_resource_operation::set);
+                  kafka::config_resource_operation::set,
+                  segment_size_validator{});
                 continue;
             }
             if (cfg.name == topic_property_timestamp_type) {

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -202,6 +202,10 @@ create_topic_properties_update(alter_configs_resource& resource) {
                 // Skip unsupported Kafka config
                 continue;
             };
+        } catch (const validation_error& e) {
+            return make_error_alter_config_resource_response<
+              alter_configs_resource_response>(
+              resource, error_code::invalid_config, e.what());
         } catch (const boost::bad_lexical_cast& e) {
             return make_error_alter_config_resource_response<
               alter_configs_resource_response>(

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -215,6 +215,25 @@ struct noop_validator {
     std::optional<ss::sstring> operator()(const T&) { return std::nullopt; }
 };
 
+struct segment_size_validator {
+    std::optional<ss::sstring> operator()(const size_t& value) {
+        // use reasonable defaults even if they are not set in configuration
+        size_t min
+          = config::shard_local_cfg().log_segment_size_min.value().value_or(1);
+        size_t max
+          = config::shard_local_cfg().log_segment_size_max.value().value_or(
+            std::numeric_limits<size_t>::max());
+
+        if (value < min || value > max) {
+            return fmt::format(
+              "segment size {} is outside of allowed range [{}, {}]",
+              value,
+              min,
+              max);
+        }
+        return std::nullopt;
+    }
+};
 
 template<typename T, typename Validator = noop_validator<T>>
 requires requires(const T& value, const ss::sstring& str, Validator validator) {

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -164,7 +164,10 @@ create_topic_properties_update(incremental_alter_configs_resource& resource) {
             }
             if (cfg.name == topic_property_segment_size) {
                 parse_and_set_optional(
-                  update.properties.segment_size, cfg.value, op);
+                  update.properties.segment_size,
+                  cfg.value,
+                  op,
+                  segment_size_validator{});
                 continue;
             }
             if (cfg.name == topic_property_timestamp_type) {

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -239,6 +239,10 @@ create_topic_properties_update(incremental_alter_configs_resource& resource) {
                 continue;
             }
 
+        } catch (const validation_error& e) {
+            return make_error_alter_config_resource_response<
+              incremental_alter_configs_resource_response>(
+              resource, error_code::invalid_config, e.what());
         } catch (const boost::bad_lexical_cast& e) {
             return make_error_alter_config_resource_response<
               incremental_alter_configs_resource_response>(

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "config/configuration.h"
 #include "finjector/hbadger.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -23,6 +24,7 @@
 #include <seastar/core/abort_source.hh>
 
 #include <filesystem>
+#include <optional>
 #include <system_error>
 #include <vector>
 
@@ -34,6 +36,8 @@ struct manual_deletion_fixture : public raft_test_fixture {
         storage::log_config::storage_type::disk,
         model::cleanup_policy_bitflags::deletion,
         1_KiB) {
+        config::shard_local_cfg().log_segment_size_min.set_value(
+          std::optional<uint64_t>());
         gr.enable_all();
     }
 

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -34,6 +34,9 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <fmt/core.h>
 
+#include <cstdint>
+#include <optional>
+
 using namespace std::chrono_literals; // NOLINT
 
 inline ss::logger tlog{"test_log"};
@@ -199,6 +202,9 @@ public:
         // avoid double metric registrations
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg().get("disable_metrics").set_value(true);
+            config::shard_local_cfg()
+              .get("log_segment_size_min")
+              .set_value(std::optional<uint64_t>{});
         }).get0();
         kvstore.start().get();
     }

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -148,9 +148,9 @@ class UpdateTopicOperation(Operation):
         TopicSpec.PROPERTY_TIMESTAMP_TYPE:
         lambda: random.choice(['CreateTime', 'LogAppendTime']),
         TopicSpec.PROPERTY_SEGMENT_SIZE:
-        lambda: random.randint(10 * 2 ^ 20, 512 * 2 ^ 20),
+        lambda: random.randint(10 * 2**20, 512 * 2**20),
         TopicSpec.PROPERTY_RETENTION_BYTES:
-        lambda: random.randint(10 * 2 ^ 20, 512 * 2 ^ 20),
+        lambda: random.randint(10 * 2**20, 512 * 2**20),
         TopicSpec.PROPERTY_RETENTION_TIME:
         lambda: random.randint(10000, 1000000)
     }

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -76,13 +76,13 @@ class AlterTopicConfiguration(RedpandaTest):
         kafka_tools = KafkaCliTools(self.redpanda)
         self.client().alter_topic_configs(
             topic, {
-                TopicSpec.PROPERTY_SEGMENT_SIZE: 1024,
+                TopicSpec.PROPERTY_SEGMENT_SIZE: 1024 * 1024,
                 TopicSpec.PROPERTY_RETENTION_TIME: 360000,
                 TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime"
             })
         spec = kafka_tools.describe_topic(topic)
 
-        assert spec.segment_bytes == 1024
+        assert spec.segment_bytes == 1024 * 1024
         assert spec.retention_ms == 360000
         assert spec.message_timestamp_type == "LogAppendTime"
 

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -9,6 +9,7 @@
 
 import random
 import string
+import subprocess
 from rptest.clients.kcl import RawKCL
 
 from rptest.services.cluster import cluster
@@ -131,6 +132,53 @@ class AlterTopicConfiguration(RedpandaTest):
         new_spec = kafka_tools.describe_topic(topic)
         # topic spec shouldn't change
         assert new_spec == spec
+
+    @cluster(num_nodes=3)
+    def test_segment_size_validation(self):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        initial_spec = kafka_tools.describe_topic(topic)
+        self.redpanda.set_cluster_config({"log_segment_size_min": 1024})
+        try:
+            self.client().alter_topic_configs(
+                topic, {TopicSpec.PROPERTY_SEGMENT_SIZE: 16})
+        except subprocess.CalledProcessError as e:
+            assert "is outside of allowed range" in e.output
+
+        assert initial_spec.segment_bytes == kafka_tools.describe_topic(
+            topic
+        ).segment_bytes, "segment.bytes shouldn't be changed to invalid value"
+
+        # change min segment bytes redpanda property
+        self.redpanda.set_cluster_config({"log_segment_size_min": 1024 * 1024})
+        # try setting value that is smaller than requested min
+        try:
+            self.client().alter_topic_configs(
+                topic, {TopicSpec.PROPERTY_SEGMENT_SIZE: 1024 * 1024 - 1})
+        except subprocess.CalledProcessError as e:
+            assert "is outside of allowed range" in e.output
+
+        assert initial_spec.segment_bytes == kafka_tools.describe_topic(
+            topic
+        ).segment_bytes, "segment.bytes shouldn't be changed to invalid value"
+        valid_segment_size = 1024 * 1024 + 1
+        self.client().alter_topic_configs(
+            topic, {TopicSpec.PROPERTY_SEGMENT_SIZE: valid_segment_size})
+        assert kafka_tools.describe_topic(
+            topic).segment_bytes == valid_segment_size
+
+        self.redpanda.set_cluster_config(
+            {"log_segment_size_max": 10 * 1024 * 1024})
+        # try to set value greater than max allowed segment size
+        try:
+            self.client().alter_topic_configs(
+                topic, {TopicSpec.PROPERTY_SEGMENT_SIZE: 20 * 1024 * 1024})
+        except subprocess.CalledProcessError as e:
+            assert "is outside of allowed range" in e.output
+
+        # check that segment size didn't change
+        assert kafka_tools.describe_topic(
+            topic).segment_bytes == valid_segment_size
 
     @cluster(num_nodes=3)
     def test_shadow_indexing_config(self):

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -153,7 +153,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         self.start_redpanda(num_nodes=5,
                             extra_rp_conf={
                                 "default_topic_replications": 3,
-                                "compacted_log_segment_size": 1 * (2 ^ 20)
+                                "compacted_log_segment_size": 1 * (2**20)
                             })
         # skip compacted topics tests in debug mode
         if compacted and self.debug_mode:
@@ -216,7 +216,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
                 "default_topic_replications": 3,
                 # make segments small to ensure that they are compacted during
                 # the test (only sealed i.e. not being written segments are compacted)
-                "compacted_log_segment_size": 1 * (2 ^ 20),
+                "compacted_log_segment_size": 1 * (2**20),
             })
 
         # skip compacted topics tests in debug mode


### PR DESCRIPTION
Introduced validation of `segment.bytes` topic property when set via `IncrementalAlterConfiguration` and `AlterConfiguration` requests. The validation checks if a property that is set by the user makes sense. 

## Additionally
Fixed incorrectly used bitwise `XOR` operator in tests. 

Fixes: #7990 
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->


  ### Improvements
- validation of `segments.bytes` property according to configured min/max values

