### PR TITLE
tests: deflake partition_balancer_test.test_decommission

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -860,8 +860,23 @@ class PartitionBalancerTest(PartitionBalancerService):
             # back to normal recovery speed
             self.logger.info("bringing back recovery speed")
             # use raw admin interface to avoid waiting for the killed node
-            admin.patch_cluster_config(
-                {"raft_learner_recovery_rate": 100_000_000})
+            new_version = admin.patch_cluster_config(
+                {"raft_learner_recovery_rate": 100_000_000})['config_version']
+
+            alive_nodes = [
+                n for n in self.redpanda.nodes
+                if self.redpanda.idx(n) is not to_kill_id
+            ]
+
+            def config_applied():
+                status = admin.get_cluster_config_status(node=survivor_node)
+                self.logger.debug(
+                    f"cluster status: {status}, checking for live nodes: {alive_nodes}"
+                )
+                return all(k["config_version"] >= new_version for k in status
+                           if k["node_id"] in alive_nodes)
+
+            wait_until(config_applied, timeout_sec=60, backoff_sec=2)
 
         # Check that the node has been successfully decommissioned.
         # We have to bring back failed node because otherwise decommission won't finish.

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -40,6 +40,11 @@ RACE_BETWEEN_DELETION_AND_ADDING_PARTITION = [
     "cluster - .*std::__1::__fs::filesystem::filesystem_error \(error system:2, filesystem error: mkdir failed: No such file or directory"
 ]
 
+STARTUP_SEQUENCE_ABORTED = [
+    # Example: main - application.cc:335 - Failure during startup: seastar::abort_requested_exception (abort requested)
+    "Failure during startup: seastar::abort_requested_exception \(abort requested\)"
+]
+
 
 class PartitionBalancerService(EndToEndTest):
     def __init__(self, ctx, *args, **kwargs):
@@ -779,7 +784,8 @@ class PartitionBalancerTest(PartitionBalancerService):
         self.run_validation(enable_idempotence=False,
                             consumer_timeout_sec=CONSUMER_TIMEOUT)
 
-    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=7,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST + STARTUP_SEQUENCE_ABORTED)
     @matrix(kill_same_node=[True, False], decommission_first=[True, False])
     def test_decommission(self, kill_same_node, decommission_first):
         """


### PR DESCRIPTION
When a broker kill command races with applying a new config delta, partial configuration file is written to disk and the subsequent start fails. This is a known issue in the current implementation.

```
try {
        // TODO: do a clean write tmp + mv, to
        // avoid possibility of torn writes.  Note
        // that an fsync is not necessary as long
        // as the write is atomic: it is safe for
        // the cache to be a little behind.
        iobuf buf;
        buf.append(out.c_str(), out.size());
        co_await write_fully(cache_path(), std::move(buf));
    } catch (...) {
        // Failure to write the cache (maybe we're
        // out of disk space?) is not fatal.  It
        // just means that on next restart we'll
        // apply the deltas since the last time we
        // successfully wrote it.
        vlog(
          clusterlog.warn,
          "Failed writing config cache: {}",
          std::current_exception());
    }
```

In this test, when the NodeStopper attempts to kill the broker, it is racing with application of `raft_learner_recovery_rate` configuration. This patch doesn't fix the underlying root cause but rather adapts the test to this behavior by waiting for the config_version to be applied on the nodes that are not killed.

Fixes #7854, Fixes #7856

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
