### PR TITLE
Fixes expired_tx_test by retring on NOT_COORDINATOR

### DIFF
--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -10,7 +10,7 @@
 from rptest.services.cluster import cluster
 from rptest.util import wait_until_result
 from rptest.clients.types import TopicSpec
-from time import sleep
+from time import sleep, time
 
 import uuid
 
@@ -261,13 +261,40 @@ class TransactionsTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def expired_tx_test(self):
-        producer = ck.Producer({
-            'bootstrap.servers': self.redpanda.brokers(),
-            'transactional.id': '0',
-            'transaction.timeout.ms': 5000,
-        })
+        # confluent_kafka client uses the same timeout both for init_transactions
+        # and produce; we want to test expiration on produce so we need to keep
+        # the timeout low to avoid long sleeps in the test but when we set it too
+        # low init_transactions throws NOT_COORDINATOR. using explicit reties on
+        # it to overcome the problem
+        #
+        # for explanation see
+        # https://github.com/redpanda-data/redpanda/issues/7991
 
-        producer.init_transactions()
+        timeout_s = 30
+        begin = time()
+        while True:
+            assert time(
+            ) - begin <= timeout_s, f"Can't init transactions within {timeout_s} sec"
+            try:
+                producer = ck.Producer({
+                    'bootstrap.servers':
+                    self.redpanda.brokers(),
+                    'transactional.id':
+                    '0',
+                    'transaction.timeout.ms':
+                    5000,
+                })
+                producer.init_transactions()
+                break
+            except ck.cimpl.KafkaException as e:
+                self.redpanda.logger.debug(f"error on init_transactions",
+                                           exc_info=True)
+                kafka_error = e.args[0]
+                assert kafka_error.code() in [
+                    ck.cimpl.KafkaError.NOT_COORDINATOR,
+                    ck.cimpl.KafkaError._TIMED_OUT
+                ]
+
         producer.begin_transaction()
 
         for i in range(0, 10):


### PR DESCRIPTION
When transaction.timeout.ms is low and `init_transactions` times out `confluent_kafka` client may throw NOT_COORDINATOR; retrying explicitly to prevent flaky test

Fixes #7991

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

 * none