### PR TITLE
net: treat ENOTCONN as reconnect error

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -42,6 +42,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case ENETUNREACH:
         case ETIMEDOUT:
         case ECONNRESET:
+        case ENOTCONN:
         case ECONNABORTED:
         case EPIPE:
             return true;


### PR DESCRIPTION
This has peculiarly only shown up on ARM testing,
but it belongs in the category of "ways a connection can die" that should be treated as non-error reconnects.

Fixes https://github.com/redpanda-data/redpanda/issues/7984


## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  ### Improvements

  * Transient "Transport endpoint not connected" errors to S3 are no longer logged at ERROR severity.