### PR TITLE
Static node wide throughput limits

### DIFF
--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -335,6 +335,13 @@ struct configuration final : public config_store {
     property<std::optional<size_t>>
       controller_log_accummulation_rps_capacity_configuration_operations;
 
+    // node and cluster throughput limiting
+    bounded_property<std::optional<uint64_t>>
+      kafka_throughput_limit_node_in_bps;
+    bounded_property<std::optional<uint64_t>>
+      kafka_throughput_limit_node_out_bps;
+    bounded_property<std::chrono::milliseconds> kafka_quota_balancer_window;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -280,149 +280,153 @@ connection_context::reserve_request_units(api_key key, size_t size) {
 
 ss::future<>
 connection_context::dispatch_method_once(request_header hdr, size_t size) {
-    return throttle_request(hdr, size).then([this, hdr = std::move(hdr), size](
-                                              session_resources
-                                                sres_in) mutable {
-        if (_server.abort_requested()) {
-            // protect against shutdown behavior
-            return ss::make_ready_future<>();
-        }
+    return throttle_request(hdr, size)
+      .then([this, hdr = std::move(hdr), size](
+              session_resources sres_in) mutable {
+          if (_server.abort_requested()) {
+              // protect against shutdown behavior
+              return ss::make_ready_future<>();
+          }
 
-        auto sres = ss::make_lw_shared(std::move(sres_in));
+          auto sres = ss::make_lw_shared(std::move(sres_in));
 
-        auto remaining = size - request_header_size
-                         - hdr.client_id_buffer.size() - hdr.tags_size_bytes;
-        return read_iobuf_exactly(conn->input(), remaining)
-          .then([this, hdr = std::move(hdr), sres = std::move(sres)](
-                  iobuf buf) mutable {
-              if (_server.abort_requested()) {
-                  // _server._cntrl etc might not be alive
-                  return ss::now();
-              }
-              auto self = shared_from_this();
-              auto rctx = request_context(
-                self, std::move(hdr), std::move(buf), sres->backpressure_delay);
-              /*
-               * we process requests in order since all subsequent requests
-               * are dependent on authentication having completed.
-               *
-               * the other important reason for disabling pipeling is because
-               * when a sasl handshake with version=0 is processed, the next
-               * data on the wire is _not_ another request: it is a
-               * size-prefixed authentication payload without a request
-               * envelope, and requires special handling.
-               *
-               * a well behaved client should implicitly provide a data stream
-               * that invokes this behavior in the server: that is, it won't
-               * send auth data (or any other requests) until handshake or the
-               * full auth-process completes, etc... but representing these
-               * nuances of the protocol _explicitly_ in the server makes its
-               * behavior easier to understand and avoids misbehaving clients
-               * creating server-side errors that will appear as a corrupted
-               * stream at best and at worst some odd behavior.
-               */
+          auto remaining = size - request_header_size
+                           - hdr.client_id_buffer.size() - hdr.tags_size_bytes;
+          return read_iobuf_exactly(conn->input(), remaining)
+            .then([this, hdr = std::move(hdr), sres = std::move(sres)](
+                    iobuf buf) mutable {
+                if (_server.abort_requested()) {
+                    // _server._cntrl etc might not be alive
+                    return ss::now();
+                }
+                auto self = shared_from_this();
+                auto rctx = request_context(
+                  self,
+                  std::move(hdr),
+                  std::move(buf),
+                  sres->backpressure_delay);
+                /*
+                 * we process requests in order since all subsequent requests
+                 * are dependent on authentication having completed.
+                 *
+                 * the other important reason for disabling pipeling is because
+                 * when a sasl handshake with version=0 is processed, the next
+                 * data on the wire is _not_ another request: it is a
+                 * size-prefixed authentication payload without a request
+                 * envelope, and requires special handling.
+                 *
+                 * a well behaved client should implicitly provide a data stream
+                 * that invokes this behavior in the server: that is, it won't
+                 * send auth data (or any other requests) until handshake or the
+                 * full auth-process completes, etc... but representing these
+                 * nuances of the protocol _explicitly_ in the server makes its
+                 * behavior easier to understand and avoids misbehaving clients
+                 * creating server-side errors that will appear as a corrupted
+                 * stream at best and at worst some odd behavior.
+                 */
 
-              const auto correlation = rctx.header().correlation;
-              const sequence_id seq = _seq_idx;
-              _seq_idx = _seq_idx + sequence_id(1);
-              auto res = kafka::process_request(
-                std::move(rctx), _server.smp_group(), *sres);
-              /**
-               * first stage processed in a foreground.
-               */
-              return res.dispatched
-                .then_wrapped([this,
-                               f = std::move(res.response),
-                               seq,
-                               correlation,
-                               self,
-                               sres = std::move(sres)](ss::future<> d) mutable {
-                    /*
-                     * if the dispatch/first stage failed, then we need to
-                     * need to consume the second stage since it might be
-                     * an exceptional future. if we captured `f` in the
-                     * lambda but didn't use `then_wrapped` then the
-                     * lambda would be destroyed and an ignored
-                     * exceptional future would be caught by seastar.
-                     */
-                    if (d.failed()) {
-                        return f.discard_result()
-                          .handle_exception([](std::exception_ptr e) {
-                              vlog(
-                                klog.info,
-                                "Discarding second stage failure {}",
-                                e);
-                          })
-                          .finally([self, d = std::move(d)]() mutable {
-                              self->_server.probe().service_error();
-                              self->_server.probe().request_completed();
-                              return std::move(d);
-                          });
-                    }
-                    /**
-                     * second stage processed in background.
-                     */
-                    ssx::background
-                      = ssx::spawn_with_gate_then(
-                          _server.conn_gate(),
-                          [this,
-                           f = std::move(f),
-                           sres = std::move(sres),
-                           seq,
-                           correlation]() mutable {
-                              return f.then(
-                                [this,
-                                 sres = std::move(sres),
+                const auto correlation = rctx.header().correlation;
+                const sequence_id seq = _seq_idx;
+                _seq_idx = _seq_idx + sequence_id(1);
+                auto res = kafka::process_request(
+                  std::move(rctx), _server.smp_group(), *sres);
+                /**
+                 * first stage processed in a foreground.
+                 */
+                return res.dispatched
+                  .then_wrapped([this,
+                                 f = std::move(res.response),
                                  seq,
-                                 correlation](response_ptr r) mutable {
+                                 correlation,
+                                 self,
+                                 sres = std::move(sres)](
+                                  ss::future<> d) mutable {
+                      /*
+                       * if the dispatch/first stage failed, then we need to
+                       * need to consume the second stage since it might be
+                       * an exceptional future. if we captured `f` in the
+                       * lambda but didn't use `then_wrapped` then the
+                       * lambda would be destroyed and an ignored
+                       * exceptional future would be caught by seastar.
+                       */
+                      if (d.failed()) {
+                          return f.discard_result()
+                            .handle_exception([](std::exception_ptr e) {
+                                vlog(
+                                  klog.info,
+                                  "Discarding second stage failure {}",
+                                  e);
+                            })
+                            .finally([self, d = std::move(d)]() mutable {
+                                self->_server.probe().service_error();
+                                self->_server.probe().request_completed();
+                                return std::move(d);
+                            });
+                      }
+                      /**
+                       * second stage processed in background.
+                       */
+                      ssx::background
+                        = ssx::spawn_with_gate_then(
+                            _server.conn_gate(),
+                            [this,
+                             f = std::move(f),
+                             sres = std::move(sres),
+                             seq,
+                             correlation]() mutable {
+                                return f.then([this,
+                                               sres = std::move(sres),
+                                               seq,
+                                               correlation](
+                                                response_ptr r) mutable {
                                     r->set_correlation(correlation);
                                     response_and_resources randr{
                                       std::move(r), std::move(sres)};
                                     _responses.insert({seq, std::move(randr)});
                                     return maybe_process_responses();
                                 });
-                          })
-                          .handle_exception([self](std::exception_ptr e) {
-                              // ssx::spawn_with_gate already caught
-                              // shutdown-like exceptions, so we should only be
-                              // taking this path for real errors.  That also
-                              // means that on shutdown we don't bother to call
-                              // shutdown_input on the connection, so rely
-                              // on any future reader to check the abort
-                              // source before considering reading the
-                              // connection.
+                            })
+                            .handle_exception([self](std::exception_ptr e) {
+                                // ssx::spawn_with_gate already caught
+                                // shutdown-like exceptions, so we should only
+                                // be taking this path for real errors.  That
+                                // also means that on shutdown we don't bother
+                                // to call shutdown_input on the connection, so
+                                // rely on any future reader to check the abort
+                                // source before considering reading the
+                                // connection.
 
-                              auto disconnected = net::is_disconnect_exception(
-                                e);
-                              if (disconnected) {
-                                  vlog(
-                                    klog.info,
-                                    "Disconnected {} ({})",
-                                    self->conn->addr,
-                                    disconnected.value());
-                              } else {
-                                  vlog(
-                                    klog.warn,
-                                    "Error processing request: {}",
-                                    e);
-                              }
+                                auto disconnected
+                                  = net::is_disconnect_exception(e);
+                                if (disconnected) {
+                                    vlog(
+                                      klog.info,
+                                      "Disconnected {} ({})",
+                                      self->conn->addr,
+                                      disconnected.value());
+                                } else {
+                                    vlog(
+                                      klog.warn,
+                                      "Error processing request: {}",
+                                      e);
+                                }
 
-                              self->_server.probe().service_error();
-                              self->conn->shutdown_input();
-                          });
-                    return d;
-                })
-                .handle_exception([self](std::exception_ptr e) {
-                    vlog(
-                      klog.info, "Detected error dispatching request: {}", e);
-                    self->conn->shutdown_input();
-                });
-          });
-    })
-    .handle_exception_type([](const ss::sleep_aborted&) {
-        // shutdown started while force-throttling
-        return ss::make_ready_future<>();
-    });
+                                self->_server.probe().service_error();
+                                self->conn->shutdown_input();
+                            });
+                      return d;
+                  })
+                  .handle_exception([self](std::exception_ptr e) {
+                      vlog(
+                        klog.info, "Detected error dispatching request: {}", e);
+                      self->conn->shutdown_input();
+                  });
+            });
+      })
+      .handle_exception_type([](const ss::sleep_aborted&) {
+          // shutdown started while force-throttling
+          return ss::make_ready_future<>();
+      });
 }
 
 /**

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -199,9 +199,9 @@ ss::future<session_resources> connection_context::throttle_request(
     // size of the current request and return any computed delay
     // to apply for quota throttling.
     //
-    // note that when throttling is first applied the request is
-    // allowed to pass through and subsequent requests and
-    // delayed. this is a similar strategy used by kafka: the
+    // note that when throttling is first determined, the request is
+    // allowed to pass through, and only subsequent requests are
+    // delayed. this is a similar strategy used by kafka 2.0: the
     // response is important because it allows clients to
     // distinguish throttling delays from real delays. delays
     // applied to subsequent messages allow backpressure to take
@@ -218,8 +218,7 @@ ss::future<session_resources> connection_context::throttle_request(
       .client_id = ss::sstring{hdr.client_id.value_or("")}};
     auto tracker = std::make_unique<request_tracker>(_server.probe());
     auto fut = ss::now();
-    if (
-      delay.duration > std::chrono::milliseconds(0) && !delay.first_violation) {
+    if (delay.enforce && delay.duration > ss::lowres_clock::duration::zero()) {
         fut = ss::sleep_abortable(delay.duration, _server.abort_source());
     }
     auto track = track_latency(hdr.key);

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -418,6 +418,10 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                     self->conn->shutdown_input();
                 });
           });
+    })
+    .handle_exception_type([](const ss::sleep_aborted&) {
+        // shutdown started while force-throttling
+        return ss::make_ready_future<>();
     });
 }
 

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -36,11 +36,33 @@ quota_manager::quota_manager()
       config::shard_local_cfg().kafka_client_group_byte_rate_quota.bind())
   , _target_fetch_tp_rate_per_client_group(
       config::shard_local_cfg().kafka_client_group_fetch_byte_rate_quota.bind())
+  , _kafka_throughput_limit_node_in_bps(
+      config::shard_local_cfg().kafka_throughput_limit_node_in_bps.bind())
+  , _kafka_throughput_limit_node_out_bps(
+      config::shard_local_cfg().kafka_throughput_limit_node_out_bps.bind())
+  , _kafka_quota_balancer_window(
+      config::shard_local_cfg().kafka_quota_balancer_window.bind())
+  , _shard_ingress_quota(
+      get_shard_ingress_quota_default(), _kafka_quota_balancer_window())
+  , _shard_egress_quota(
+      get_shard_egress_quota_default(), _kafka_quota_balancer_window())
   , _gc_freq(config::shard_local_cfg().quota_manager_gc_sec())
   , _max_delay(config::shard_local_cfg().max_kafka_throttle_delay_ms.bind()) {
     _gc_timer.set_callback([this] {
         auto full_window = _default_num_windows() * _default_window_width();
         gc(full_window);
+    });
+    _kafka_throughput_limit_node_in_bps.watch([this] {
+        _shard_ingress_quota.set_quota(get_shard_ingress_quota_default());
+    });
+    _kafka_throughput_limit_node_out_bps.watch([this] {
+        _shard_egress_quota.set_quota(get_shard_egress_quota_default());
+    });
+    _kafka_quota_balancer_window.watch([this] {
+        const auto v = _kafka_quota_balancer_window();
+        vlog(klog.debug, "Set shard TP token bucket window {}", v);
+        _shard_ingress_quota.set_width(v);
+        _shard_egress_quota.set_width(v);
     });
 }
 
@@ -55,6 +77,10 @@ ss::future<> quota_manager::start() {
     _gc_timer.arm_periodic(_gc_freq);
     return ss::make_ready_future<>();
 }
+
+/*
+ * Per-Client and Per-Client-Group Quotas
+ */
 
 quota_manager::client_quotas_t::iterator
 quota_manager::maybe_add_and_retrieve_quota(
@@ -293,6 +319,92 @@ void quota_manager::gc(clock::duration full_window) {
       [now, expire_age](const std::pair<ss::sstring, client_quota>& q) {
           return (now - q.second.last_seen) > expire_age;
       });
+}
+
+/*
+ * Shard Global Quotas
+ */
+
+namespace {
+
+bottomless_token_bucket::quota_t get_default_quota_from_property(
+  const config::binding<std::optional<uint64_t>>& prop) {
+    if (prop()) {
+        const uint64_t v = *prop() / ss::smp::count;
+        if (v >= static_cast<uint64_t>(bottomless_token_bucket::max_quota)) {
+            return bottomless_token_bucket::max_quota;
+        }
+        if (v < 1) {
+            return 1;
+        }
+        return static_cast<bottomless_token_bucket::quota_t>(v);
+    } else {
+        return bottomless_token_bucket::max_quota;
+    }
+}
+
+using delay_t = std::chrono::milliseconds;
+
+/// Evaluate throttling delay required based on the state of a token bucket
+delay_t eval_delay(const bottomless_token_bucket& tb) noexcept {
+    // no delay if tokens are over the bottom
+    if (tb.tokens() >= 0) {
+        return delay_t::zero();
+    }
+    // quota is in [tokens/s], so we need to scale it to `delay_t` by dividing
+    // by the `delay_t` unit scale denominator (and multiplying by the numerator
+    // but that one has to be 1)
+    static_assert(delay_t::period::num == 1);
+    return delay_t(muldiv(-tb.tokens(), delay_t::period::den, tb.quota()));
+}
+
+} // namespace
+
+quota_manager::shard_quota_t
+quota_manager::get_shard_ingress_quota_default() const {
+    const shard_quota_t v = get_default_quota_from_property(
+      _kafka_throughput_limit_node_in_bps);
+    vlog(klog.debug, "Default shard TP ingress quota: {}", v);
+    return v;
+}
+
+quota_manager::shard_quota_t
+quota_manager::get_shard_egress_quota_default() const {
+    const shard_quota_t v = get_default_quota_from_property(
+      _kafka_throughput_limit_node_out_bps);
+    vlog(klog.debug, "Default shard TP egress quota {}", v);
+    return v;
+}
+
+quota_manager::shard_delays_t quota_manager::get_shard_delays(
+  clock::time_point& connection_throttle_until,
+  const clock::time_point now) const {
+    shard_delays_t res;
+
+    // force throttle whatever the client did not do on its side
+    if (now < connection_throttle_until) {
+        res.enforce = connection_throttle_until - now;
+    }
+
+    // throttling delay the connection should be requested to throttle
+    // this time
+    res.request = std::min(
+      _max_delay(),
+      std::max(
+        eval_delay(_shard_ingress_quota), eval_delay(_shard_egress_quota)));
+    connection_throttle_until = now + res.request;
+
+    return res;
+}
+
+void quota_manager::record_request_tp(
+  const size_t request_size, const clock::time_point now) noexcept {
+    _shard_ingress_quota.use(request_size, now);
+}
+
+void quota_manager::record_response_tp(
+  const size_t request_size, const clock::time_point now) noexcept {
+    _shard_egress_quota.use(request_size, now);
 }
 
 } // namespace kafka

--- a/src/v/utils/CMakeLists.txt
+++ b/src/v/utils/CMakeLists.txt
@@ -13,6 +13,7 @@ v_cc_library(
     directory_walker.cc
     uuid.cc
     request_auth.cc
+    bottomless_token_bucket.cc
   DEPS
     Seastar::seastar
     Hdrhistogram::hdr_histogram

--- a/src/v/utils/bottomless_token_bucket.cc
+++ b/src/v/utils/bottomless_token_bucket.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "utils/bottomless_token_bucket.h"
+
+#include "likely.h"
+#include "vassert.h"
+
+void bottomless_token_bucket::use(
+  const tokens_t n, const clock::time_point now) noexcept {
+    vassert(n >= 0, "Cannot use negative number of tokens");
+    refill(now);
+    _tokens -= n;
+}
+
+void bottomless_token_bucket::set_quota_impl(const quota_t quota) noexcept {
+    vassert(quota > 0, "Token bucket quota must be positive ({})", quota);
+    vassert(
+      quota <= max_quota,
+      "Token bucket quota too large ({} > {})",
+      quota,
+      max_quota);
+    _quota = quota;
+}
+
+void bottomless_token_bucket::set_width_impl(const time_res_t width) noexcept {
+    vassert(
+      width.count() > 0,
+      "Token bucket width must be positive ({})",
+      width.count());
+    vassert(
+      width <= max_width,
+      "Token bucket width too large ({} > {})",
+      width.count(),
+      max_width.count());
+    _width = width;
+}
+
+void bottomless_token_bucket::update_burst_tokens() noexcept {
+    _burst = muldiv(_quota, _width.count(), time_res_t::period::den);
+    _tokens = std::min(_burst, _tokens);
+}
+
+void bottomless_token_bucket::refill(const clock::time_point now) noexcept {
+    const auto delta = std::chrono::duration_cast<time_res_t>(
+      now - _last_check);
+    _last_check = now;
+    if (unlikely(delta >= max_width)) {
+        // avoid overflow on multiplication - the product will be greater
+        // than _burst anyway
+        _tokens = _burst;
+    } else {
+        const tokens_t add_tokens = muldiv(
+          _quota, delta.count(), time_res_t::period::den);
+        if (add_tokens >= _burst) {
+            _tokens = _burst;
+        } else {
+            _tokens = std::min<tokens_t>(_burst, _tokens + add_tokens);
+        }
+    }
+}

--- a/src/v/utils/bottomless_token_bucket.h
+++ b/src/v/utils/bottomless_token_bucket.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "seastar/core/lowres_clock.hh"
+#include "seastarx.h"
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+
+/// muldiv calculates \p x * \p mul / \p div in integer domain avoiding both
+/// integer overflow and loss of precision because of the intermediate result
+/// being the same integer type as the arguments.
+///
+/// There are still limits for the values where overflow can kick in:
+/// if \p x % \p div * \p mul fails to stay within type limits, the behaviour is
+/// undefined. That may happen when
+/// abs( \p mul * \p div ) >= numeric_limits<int64_t>::max()
+inline int64_t
+muldiv(const int64_t x, const int64_t mul, const int64_t div) noexcept {
+    const auto qr = std::div(x, div);
+    return qr.quot * mul + qr.rem * mul / div;
+}
+
+/// Variation of token bucket algorithm to allow bursty traffic.
+/// Tokens represent resource units (e.g. bytes of traffic) whose usage is
+/// controlled. Number of tokens in the bucket is capped by \ref quota *
+/// \ref width at the top, and can go negative without a bound.
+class bottomless_token_bucket {
+public:
+    /// Quota is measured in [tokens/s] and cannot be negative despite the
+    /// signed type
+    using quota_t = int64_t;  // [tokens/s]
+    using tokens_t = int64_t; // [tokens]
+    using clock = ss::lowres_clock;
+    using time_res_t = std::chrono::milliseconds;
+
+    // Algoritms rely on time_res_t to be subsecond
+    static_assert(time_res_t::period::num == 1);
+
+    // Maximum supported width of a bucket ~ 25 days
+    static constexpr time_res_t max_width{std::numeric_limits<int32_t>::max()};
+
+    // To avoid dynamic checking of acceptable width and quota maximums,
+    // quota is limited in the way to avoid integer overflows in any condition.
+    // This effectively maxes it to ~ 2 Ttokens/s. If that is ever found not
+    // enough, this maximum should be raised to full int64_t, and both
+    // set_quota() and set_width() should dynamically check that the calculated
+    // burst does not overflow.
+    static constexpr quota_t max_quota{
+      static_cast<quota_t>(std::numeric_limits<int32_t>::max())
+      * time_res_t::period::den};
+
+    /// Token bucket is initialized full of tokens
+    bottomless_token_bucket(
+      const quota_t quota, const time_res_t width) noexcept {
+        // do boundary checks on params and calculate _burst
+        set_quota_impl(quota);
+        set_width_impl(width);
+        update_burst_tokens();
+        refill(clock::time_point{});
+    }
+
+    void set_quota(const quota_t quota) noexcept {
+        set_quota_impl(quota);
+        update_burst_tokens();
+    }
+
+    /// @post 0 < return value <= max_quota
+    quota_t quota() const noexcept { return _quota; }
+
+    void set_width(const time_res_t width) noexcept {
+        set_width_impl(width);
+        update_burst_tokens();
+    }
+
+    /// Record usage of tokens
+    /// @param n Number of tokens used
+    /// @param now Time to record at
+    void use(tokens_t n, clock::time_point now) noexcept;
+
+    /// Current amount of tokens
+    tokens_t tokens() const noexcept { return _tokens; }
+
+private:
+    void set_quota_impl(const quota_t quota) noexcept;
+    void set_width_impl(const time_res_t width) noexcept;
+    void update_burst_tokens() noexcept;
+    void refill(const clock::time_point now) noexcept;
+
+private:
+    quota_t _quota{0};
+    time_res_t _width;
+    tokens_t _tokens{0};
+    tokens_t _burst{0}; // capacity of the bucket
+    clock::time_point _last_check{-max_width};
+};

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ rp_test(
     human_test.cc
     fragmented_vector_test.cc
     tracking_allocator_tests.cc
+    bottomless_token_bucket_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::utils absl::flat_hash_map
   LABELS utils

--- a/src/v/utils/tests/bottomless_token_bucket_test.cc
+++ b/src/v/utils/tests/bottomless_token_bucket_test.cc
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "utils/bottomless_token_bucket.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(muldiv_test) {
+    constexpr static auto mn = std::numeric_limits<int64_t>::min();
+    constexpr static auto mx = std::numeric_limits<int64_t>::max();
+    // straight samples
+    BOOST_CHECK_EQUAL(muldiv(98733, 9287, 6489), 98733 * 9287 / 6489);
+    BOOST_CHECK_EQUAL(muldiv(-494162, -654, -998), -494162 * -654 / -998);
+    // zeros
+    BOOST_CHECK_EQUAL(muldiv(0, -654, -998), 0);
+    BOOST_CHECK_EQUAL(muldiv(-494162, 0, -998), 0);
+    // near direct overflow
+    BOOST_CHECK_EQUAL(muldiv(6935552231102021794, 2, 3), 4623701487401347862);
+    BOOST_CHECK_EQUAL(
+      muldiv(10, -2305878194122661888, -3), 7686260647075539626);
+    // near intermediate overflow
+    BOOST_CHECK_EQUAL(
+      muldiv(1152921504606846976, 8495162354, 1085720514), 9020972926972920768);
+    // boundary values as 1st argument
+    BOOST_CHECK_EQUAL(muldiv(mx, 1, 1), mx);
+    BOOST_CHECK_EQUAL(muldiv(mn, 1, 1), mn);
+    BOOST_CHECK_EQUAL(muldiv(mx, 777, 1554), mx / 2);
+    BOOST_CHECK_EQUAL(muldiv(mn, -32767, 32768), (1ull << 63) - (1ull << 48));
+    // boundary values as 2nd argument
+    BOOST_CHECK_EQUAL(muldiv(1, mx, 1), mx);
+    BOOST_CHECK_EQUAL(muldiv(1, mn, 1), mn);
+    // boundary values as 3rd argument
+    BOOST_CHECK_EQUAL(muldiv(1, 1, mx), 0);
+    BOOST_CHECK_EQUAL(muldiv(1, 1, mn), 0);
+    BOOST_CHECK_EQUAL(muldiv(mx / 2, 2, mx), 0); // mx is odd, mx/2 is truncated
+    BOOST_CHECK_EQUAL(muldiv(mn / 2, 2, mn), 1); // mn is even
+}
+
+BOOST_AUTO_TEST_CASE(test_bottomless_token_bucket) {
+    using namespace std::chrono;
+
+    // === straight cases
+    bottomless_token_bucket b1(1, milliseconds(1)), b2(1000, seconds(1));
+    BOOST_CHECK_EQUAL(b1.quota(), 1);
+    BOOST_CHECK_EQUAL(b1.tokens(), 0); // == 1*0.001 truncated
+    BOOST_CHECK_EQUAL(b2.quota(), 1000);
+    BOOST_CHECK_EQUAL(b2.tokens(), 1000); // == 1000*1
+
+    ss::lowres_clock::time_point now;
+    b1.use(1, now);
+    b2.use(1, now);
+    // token count goes negative because the time is zero
+    BOOST_CHECK_EQUAL(b1.tokens(), -1);
+    BOOST_CHECK_EQUAL(b2.tokens(), 1000 - 1);
+
+    now += seconds(10);
+    b1.use(1, now);
+    b2.use(1, now);
+    BOOST_CHECK_LE(b1.tokens(), 0); // LE because burst is rounded internally
+    BOOST_CHECK_EQUAL(b2.tokens(), b2.quota() /* *1s */ - 1);
+
+    b2.use(11, now);
+    BOOST_CHECK_EQUAL(b2.tokens(), b2.quota() - 12);
+
+    now += seconds(1);
+    b2.use(1, now);
+    BOOST_CHECK_EQUAL(b2.tokens(), b2.quota() - 1);
+
+    b2.use(9999, now);
+    BOOST_CHECK_EQUAL(b2.tokens(), b2.quota() - 10000);
+
+    now += milliseconds(100);
+    b2.use(1, now);
+    BOOST_CHECK_EQUAL(b2.tokens(), b2.quota() - 10000 + 100 - 1);
+
+    // === boundary cases
+    bottomless_token_bucket b3(
+      bottomless_token_bucket::max_quota, bottomless_token_bucket::max_width);
+    BOOST_CHECK_EQUAL(b3.quota(), bottomless_token_bucket::max_quota);
+    const auto max_tokens = muldiv(
+      bottomless_token_bucket::max_quota,
+      bottomless_token_bucket::max_width.count(),
+      1000);
+    BOOST_CHECK_EQUAL(b3.tokens(), max_tokens);
+
+    // to zero
+    b3.use(max_tokens, bottomless_token_bucket::clock::time_point{});
+    BOOST_CHECK_EQUAL(b3.tokens(), 0);
+
+    // half way up
+    const auto halfwayup = duration_cast<ss::lowres_clock::duration>(
+                             bottomless_token_bucket::max_width)
+                           / 2;
+    now = ss::lowres_clock::time_point{} + halfwayup;
+    b3.use(1, now);
+    BOOST_CHECK_EQUAL(b3.tokens(), 2'305'843'005'992'468'481 - 1);
+
+    // another half way up
+    now += halfwayup;
+    b3.use(1, now);
+    BOOST_CHECK_EQUAL(b3.tokens(), 4'611'686'011'984'936'962 - 2);
+
+    // limited by burst this time
+    now += halfwayup;
+    b3.use(1, now);
+    BOOST_CHECK_EQUAL(b3.tokens(), 4'611'686'014'132'420'609 - 1);
+    // the value is different here due to `now` rounded to milliseconds in use()
+
+    // === setters
+    b3.set_quota(1'000'000);
+    BOOST_CHECK_EQUAL(
+      b3.tokens(),
+      bottomless_token_bucket::max_width.count() * 1'000'000
+        / 1000 /* ms->s */);
+    b3.set_width(milliseconds(3'000));
+    BOOST_CHECK_EQUAL(b3.tokens(), 3 * 1'000'000);
+
+    b3.use(1'000'000, now);
+    BOOST_CHECK_EQUAL(b3.tokens(), 3 * 1'000'000 - 1'000'000);
+
+    now += milliseconds(3'000);
+    b3.use(1, now);
+    BOOST_CHECK_EQUAL(b3.tokens(), 3 * 1'000'000 - 1);
+}


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

This PR introduces limiting of kafka traffic throughput to node wide ingress and egress limits, evenly distributed between shards. Connections served by each shard are counted towards the same quota. Total throughput of all connections served by the same shard is `limit/ss::smp::count`.

Intra-node quota balancing (sharing unused parts of shard quotas with other shards that need it more) is subject to a following PR.

Re #7855

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.
-->

New cluster configuration properties:
| Name | Description |
| --- | --- |
| kafka_throughput_limit_node_in_bps | Node wide throughput ingress limit - maximum kafka traffic throughput allowed on the ingress side of each node, in bytes/s. Default is no limit |
| kafka_throughput_limit_node_out_bps | Node wide throughput egress limit - maximum kafka traffic throughput allowed on the egress side of each node, in bytes/s. Default is no limit. |
| kafka_quota_balancer_window_ms | Time window used to average current throughput measurement for quota balancer, in milliseconds |

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

* none

(Release Notes will be provided in the next PR)
