### PR TITLE
[v22.3.x] net: treat ENOTCONN as reconnect error

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -42,6 +42,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case ENETUNREACH:
         case ETIMEDOUT:
         case ECONNRESET:
+        case ENOTCONN:
         case ECONNABORTED:
         case EPIPE:
             return true;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8018
Fixes https://github.com/redpanda-data/redpanda/issues/8024,