### PR TITLE
Draft: Approximate histogram for tracking allocator

### DIFF
--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -84,4 +84,22 @@ T random_choice(std::initializer_list<T> choices) {
     return std::move(choice);
 }
 
+template<typename T>
+T get_real() {
+    std::uniform_real_distribution<T> dist;
+    return dist(internal::gen);
+}
+
+template<typename T>
+T get_real(T min, T max) {
+    std::uniform_real_distribution<T> dist(min, max);
+    return dist(internal::gen);
+}
+
+template<typename T>
+T get_real(T max) {
+    std::uniform_real_distribution<T> dist(0, max);
+    return dist(internal::gen);
+}
+
 } // namespace random_generators

--- a/src/v/utils/approximate_histogram.h
+++ b/src/v/utils/approximate_histogram.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "random/generators.h"
+#include "vassert.h"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cmath>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+
+/*
+ * An implementation of a Morris counter. The general idea is that the
+ * closer the constant 'a' is to infinity the more accurate the count will be
+ * at the cost of a much lower 'max_count'.
+ *
+ * Bounds for variance and space can be found at:
+ * https://www.cs.princeton.edu/~hy2/files/approx_counting.pdf
+ */
+template<std::unsigned_integral count_t, size_t a>
+class approximate_count {
+    static constexpr long double inv_a = 1.0L / a;
+    static constexpr long double factor = 1.0L + inv_a;
+
+    static constexpr uint64_t get_count(count_t n) {
+        long double val_d = (std::pow(factor, n) - 1.0) / inv_a;
+        return std::llroundl(val_d);
+    }
+
+public:
+    // The highest value this counter can count to for a given value of 'a'.
+    // TODO: in C++23 this should be a constexpr.
+    static uint64_t max_count() {
+        return get_count(std::numeric_limits<count_t>::max());
+    }
+
+    approximate_count& operator++() {
+        // Cap exponent at upper limit for count_t to avoid overflowing.
+        if (_exp == std::numeric_limits<count_t>::max()) {
+            return *this;
+        }
+
+        long double p = std::pow(factor, -1 * _exp);
+        auto r = random_generators::get_real<long double>(
+          0.0, std::nextafter(1.0, std::numeric_limits<long double>::max()));
+
+        if (r < p) {
+            _exp += 1;
+        }
+
+        return *this;
+    }
+
+    uint64_t get() const { return get_count(_exp); }
+
+private:
+    count_t _exp{0};
+};
+
+/*
+ * The constant factor from the original Morris
+ * paper. Allows for a max count of ~130k.
+ */
+constexpr size_t a_const_default = 30;
+
+/*
+ * Defines a histogram with a fixed number of buckets each of
+ * which a even value is mapped to via the hash function.
+ */
+template<
+  typename key_t,
+  std::unsigned_integral bucket_t,
+  size_t number_of_buckets,
+  size_t a = a_const_default,
+  class hash_t = std::hash<key_t>>
+class approximate_histogram {
+public:
+    approximate_histogram& operator+=(const key_t& val) {
+        auto bucket = hash_t{}(val);
+        vassert(0 <= bucket < number_of_buckets, "out of range");
+
+        ++_hist[bucket];
+
+        return *this;
+    }
+
+    constexpr uint64_t operator[](size_t bucket) const {
+        return _hist[bucket].get();
+    }
+
+private:
+    std::array<approximate_count<bucket_t, a>, number_of_buckets> _hist{};
+};
+
+template<size_t number_of_buckets, size_t min_pow_2>
+class size_to_buckets {
+    static constexpr size_t max_pow_2 = number_of_buckets + min_pow_2 - 1;
+
+public:
+    size_t operator()(size_t bytes) const noexcept {
+        auto pow_2 = std::bit_width(bytes) - 1;
+
+        return std::clamp(pow_2, min_pow_2, max_pow_2) - min_pow_2;
+    }
+};
+
+/*
+ * Creates a histogram with 16 buckets each representing
+ * a count of allocations of size [2^(i-1), 2^i) bytes i.e,
+ * [0, 2^5), [2^5, 2^6), [2^6, 2^7), ... , [2^19, inf)
+ *
+ * Each bucket can count up to 6.12 × 10^8 allocations.
+ *
+ * sizeof(memory_histogram_t) == 16
+ */
+using memory_histogram_t
+  = approximate_histogram<size_t, uint8_t, 16, 14, size_to_buckets<16, 4>>;

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -44,7 +44,17 @@ rp_test(
     human_test.cc
     fragmented_vector_test.cc
     tracking_allocator_tests.cc
+    approximate_histogram_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::utils absl::flat_hash_map
+  LABELS utils
+)
+
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME approximate_histogram_bench
+  SOURCES approximate_histogram_bench.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES Seastar::seastar_perf_testing v::utils
   LABELS utils
 )

--- a/src/v/utils/tests/approximate_histogram_bench.cc
+++ b/src/v/utils/tests/approximate_histogram_bench.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "utils/approximate_histogram.h"
+#include "vassert.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <cstdint>
+
+constexpr uint64_t iterations = 10000000;
+
+void adding_basic() {
+    uint64_t i = 0, j = 0;
+    perf_tests::start_measuring_time();
+    for (; i < iterations; i++) {
+        j += 1;
+        perf_tests::do_not_optimize(j);
+    }
+    perf_tests::stop_measuring_time();
+    vassert(j == iterations, "j != iterations");
+}
+
+void adding_histogram() {
+    using approx_hist_t
+      = approximate_histogram<size_t, uint8_t, 16, 30, size_to_buckets<16, 4>>;
+    approx_hist_t hist;
+    size_t val = 1 << 3;
+
+    uint64_t i = 0;
+    perf_tests::start_measuring_time();
+    for (; i < iterations; i++) {
+        hist += val;
+        perf_tests::do_not_optimize(i);
+    }
+    perf_tests::stop_measuring_time();
+
+    perf_tests::do_not_optimize(hist);
+}
+
+PERF_TEST(approximate_histogram, adding_basic) { adding_basic(); }
+PERF_TEST(approximate_histogram, adding_histogram) { adding_histogram(); }

--- a/src/v/utils/tests/approximate_histogram_tests.cc
+++ b/src/v/utils/tests/approximate_histogram_tests.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "utils/approximate_histogram.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+
+BOOST_AUTO_TEST_CASE(hist_basic_test) {
+    using approx_hist_t = memory_histogram_t;
+    approx_hist_t hist;
+
+    for (uint64_t i = 0; i < 100000; i++) {
+        for (auto j = 4; j < 20; j++) {
+            hist += (size_t)1 << j;
+        }
+    }
+
+    for (size_t i = 0; i < 16; i++) {
+        BOOST_REQUIRE(hist[i] >= 1000);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(counter_max_counts) {
+    auto count_1 = approximate_count<uint8_t, 30>::max_count();
+    BOOST_REQUIRE(count_1 == 128331);
+    auto count_2 = approximate_count<uint8_t, 20>::max_count();
+    BOOST_REQUIRE(count_2 == 5061737);
+    auto count_3 = approximate_count<uint16_t, 5000>::max_count();
+    BOOST_REQUIRE(count_3 == 2458655844);
+}
+
+BOOST_AUTO_TEST_CASE(counter_min_counts) {
+    // The first increment to any counter should always be counted.
+
+    approximate_count<uint8_t, 30> counter_1;
+    ++counter_1;
+    BOOST_REQUIRE(counter_1.get() >= 1);
+
+    approximate_count<uint8_t, 20> counter_2;
+    ++counter_2;
+    BOOST_REQUIRE(counter_2.get() >= 1);
+
+    approximate_count<uint16_t, 5000> counter_3;
+    ++counter_3;
+    BOOST_REQUIRE(counter_3.get() >= 1);
+}
+
+BOOST_AUTO_TEST_CASE(size_to_buckets_test) {
+    size_to_buckets<16, 4> hash{};
+    for (auto i = 4; i < 16 + 4; i++) {
+        BOOST_REQUIRE(hash(1 << i) == i - 4);
+    }
+
+    BOOST_REQUIRE(hash(1) == 0);
+    BOOST_REQUIRE(hash((size_t)1 << 60) == 15);
+}
+
+BOOST_AUTO_TEST_CASE(memory_histogram_t_size) {
+    BOOST_REQUIRE(sizeof(memory_histogram_t) == 16);
+}


### PR DESCRIPTION
This is a draft PR. Implemented is a fixed bucket histogram where the count of each bucket is approximated via a Morris counter. This results in a low memory overhead for a rather large histogram(1 byte per bucket).  

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
* none