### PR TITLE
tests: fixed incorrectly used ^ operator in scale tests

### DIFF
--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -85,7 +85,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
         extra_rp_conf = {
             # make segments small to ensure that they are compacted during
             # the test (only sealed i.e. not being written segments are compacted)
-            "compacted_log_segment_size": 5 * (2 ^ 20),
+            "compacted_log_segment_size": 5 * (2**20),
             "raft_learner_recovery_rate": 512 * (1024 * 1024)
         }
         if num_to_upgrade > 0:

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -112,7 +112,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             # FIXME: this is not enough data to keep up a background load through
             # the test.
             # https://github.com/redpanda-data/redpanda/issues/6245
-            message_size = 128 * (2 ^ 10)
+            message_size = 128 * (2**10)
             message_cnt = 2000000
             consumers = 8
             partitions_count = 18000
@@ -120,7 +120,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             # FIXME: this is not enough data to keep up a background load through
             # the test.
             # https://github.com/redpanda-data/redpanda/issues/6245
-            message_size = 512 * (2 ^ 10)
+            message_size = 512 * (2**10)
             message_cnt = 5000000
             consumers = 8
             partitions_count = 200
@@ -182,14 +182,14 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             max_concurrent_moves = 5
             timeout = 80
         elif type == self.MANY_PARTITIONS:
-            message_size = 128 * (2 ^ 10)
+            message_size = 128 * (2**10)
             message_cnt = 2000000
             consumers = 8
             partitions_count = 18000
             max_concurrent_moves = 400
             timeout = 300
         else:
-            message_size = 512 * (2 ^ 10)
+            message_size = 512 * (2**10)
             message_cnt = 5000000
             consumers = 8
             partitions_count = 200

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -36,7 +36,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
                 self.NODE_AVAILABILITY_TIMEOUT,
                 "partition_autobalancing_tick_interval_ms": 5000,
                 "members_backend_retry_ms": 1000,
-                "raft_learner_recovery_rate": 1073741824,
+                "raft_learner_recovery_rate": 10 * 1073741824,
                 "group_topic_partitions": self.GROUP_TOPIC_PARTITIONS
             },
             *args,
@@ -109,21 +109,18 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             consumers = 1
             partitions_count = 16
         elif type == self.MANY_PARTITIONS:
-            # FIXME: this is not enough data to keep up a background load through
-            # the test.
-            # https://github.com/redpanda-data/redpanda/issues/6245
+
             message_size = 128 * (2**10)
-            message_cnt = 2000000
+            message_cnt = 819200
             consumers = 8
             partitions_count = 18000
+            timeout = 500
         else:
-            # FIXME: this is not enough data to keep up a background load through
-            # the test.
-            # https://github.com/redpanda-data/redpanda/issues/6245
-            message_size = 512 * (2**10)
-            message_cnt = 5000000
+            message_size = 128 * (2**10)
+            message_cnt = 819200
             consumers = 8
             partitions_count = 200
+            timeout = 500
 
         topic = TopicSpec(partition_count=partitions_count,
                           replication_factor=replication_factor)
@@ -137,7 +134,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
         )
         # wait for the partitions to be filled with data
         self.producer.wait_for_acks(message_cnt // 2,
-                                    timeout_sec=300,
+                                    timeout_sec=timeout,
                                     backoff_sec=5)
 
         # stop one of the nodes to trigger partition balancer
@@ -152,7 +149,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
                 f"stopped node {stopped_id} hosts {len(replicas)} replicas")
             return len(replicas) == 0
 
-        wait_until(stopped_node_is_empty, 120, 5)
+        wait_until(stopped_node_is_empty, timeout, 5)
         admin = Admin(self.redpanda)
 
         def all_reconfigurations_done():
@@ -163,7 +160,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
 
             return len(ongoing) == 0
 
-        wait_until(all_reconfigurations_done, 300, 5)
+        wait_until(all_reconfigurations_done, timeout, 5)
 
         self.verify(topic.name, message_size, consumers)
 
@@ -182,19 +179,19 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             max_concurrent_moves = 5
             timeout = 80
         elif type == self.MANY_PARTITIONS:
-            message_size = 128 * (2**10)
-            message_cnt = 2000000
+            message_size = 256 * (2**10)
+            message_cnt = 819200
             consumers = 8
             partitions_count = 18000
             max_concurrent_moves = 400
-            timeout = 300
+            timeout = 500
         else:
-            message_size = 512 * (2**10)
-            message_cnt = 5000000
+            message_size = 256 * (2**10)
+            message_cnt = 819200
             consumers = 8
             partitions_count = 200
             max_concurrent_moves = 200
-            timeout = 300
+            timeout = 500
 
         # set max number of concurrent moves
         self.redpanda.set_cluster_config(


### PR DESCRIPTION
In python the `^` character is not the power operator but bitwise XOR. Replaced all `^` occurrences where the `^` was meant to be used as power with `**` which is a power operator.

Fixes: #6245

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

  * none

