### PR TITLE
add segments.ms support

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -277,6 +277,10 @@ metadata_cache::get_default_shadow_indexing_mode() const {
     return m;
 }
 
+std::optional<std::chrono::milliseconds>
+metadata_cache::get_default_segment_ms() const {
+    return config::shard_local_cfg().log_segment_ms();
+}
 topic_properties metadata_cache::get_default_properties() const {
     topic_properties tp;
     tp.compression = {get_default_compression()};

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -175,6 +175,7 @@ public:
     std::chrono::milliseconds get_default_retention_local_target_ms() const;
     model::shadow_indexing_mode get_default_shadow_indexing_mode() const;
     uint32_t get_default_batch_max_bytes() const;
+    std::optional<std::chrono::milliseconds> get_default_segment_ms() const;
     topic_properties get_default_properties() const;
     std::optional<partition_assignment>
     get_partition_assignment(const model::ntp& ntp) const;

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -330,6 +330,7 @@ struct compat_check<cluster::topic_properties> {
         json_write(retention_local_target_bytes);
         json_write(retention_local_target_ms);
         json_write(remote_delete);
+        json_write(segment_ms);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -350,6 +351,7 @@ struct compat_check<cluster::topic_properties> {
         json_read(retention_local_target_bytes);
         json_read(retention_local_target_ms);
         json_read(remote_delete);
+        json_read(segment_ms);
         return obj;
     }
 
@@ -370,6 +372,8 @@ struct compat_check<cluster::topic_properties> {
         obj.retention_local_target_bytes = tristate<size_t>{std::nullopt};
         obj.retention_local_target_ms = tristate<std::chrono::milliseconds>{
           std::nullopt};
+
+        obj.segment_ms = tristate<std::chrono::milliseconds>{std::nullopt};
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -437,6 +441,9 @@ struct compat_check<cluster::topic_configuration> {
         // ADL will always squash remote_delete to false
         obj.properties.remote_delete = false;
 
+        obj.properties.segment_ms = tristate<std::chrono::milliseconds>{
+          std::nullopt};
+
         if (cfg != obj) {
             throw compat_error(fmt::format(
               "Verify of {{cluster::topic_property}} decoding "
@@ -491,6 +498,9 @@ struct compat_check<cluster::create_topics_request> {
               std::nullopt};
             topic.properties.retention_local_target_ms
               = tristate<std::chrono::milliseconds>{std::nullopt};
+
+            topic.properties.segment_ms = tristate<std::chrono::milliseconds>{
+              std::nullopt};
         }
         if (req != obj) {
             throw compat_error(fmt::format(
@@ -547,6 +557,8 @@ struct compat_check<cluster::create_topics_reply> {
               std::nullopt};
             topic.properties.retention_local_target_ms
               = tristate<std::chrono::milliseconds>{std::nullopt};
+            topic.properties.segment_ms = tristate<std::chrono::milliseconds>{
+              std::nullopt};
         }
         if (reply != obj) {
             throw compat_error(fmt::format(

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -690,7 +690,8 @@ struct instance_generator<cluster::topic_properties> {
           tests::random_tristate([] { return tests::random_duration_ms(); }),
           // Remote delete always false to enable ADL roundtrip (ADL
           // always decodes to false for legacy topics)
-          false};
+          false,
+          tests::random_tristate([] { return tests::random_duration_ms(); })};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -586,6 +586,7 @@ inline void rjson_serialize(
       w, "retention_local_target_bytes", tps.retention_local_target_bytes);
     write_member(w, "retention_local_target_ms", tps.retention_local_target_ms);
     write_member(w, "remote_delete", tps.remote_delete);
+    write_member(w, "segment_ms", tps.segment_ms);
     w.EndObject();
 }
 
@@ -607,6 +608,7 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
       rd, "retention_local_target_bytes", obj.retention_local_target_bytes);
     read_member(rd, "retention_local_target_ms", obj.retention_local_target_ms);
     read_member(rd, "remote_delete", obj.remote_delete);
+    read_member(rd, "segment_ms", obj.segment_ms);
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -81,6 +81,34 @@ configuration::configuration()
       "Duration after which inactive readers will be evicted from cache",
       {.visibility = visibility::tunable},
       30s)
+  , log_segment_ms(
+      *this,
+      "log_segment_ms",
+      "Default log segment lifetime in ms for topics which do not set "
+      "segment.ms",
+      {.needs_restart = needs_restart::no,
+       .example = "3600000",
+       .visibility = visibility::user},
+      std::nullopt,
+      {.min = 60s})
+  , log_segment_ms_min(
+      *this,
+      "log_segment_ms_min",
+      "Lower bound on topic segment.ms: lower values will be clamped to this "
+      "value",
+      {.needs_restart = needs_restart::no,
+       .example = "60000",
+       .visibility = visibility::tunable},
+      60s)
+  , log_segment_ms_max(
+      *this,
+      "log_segment_ms_max",
+      "Upper bound on topic segment.ms: higher values will be clamped to this "
+      "value",
+      {.needs_restart = needs_restart::no,
+       .example = "31536000000",
+       .visibility = visibility::tunable},
+      24h * 365)
   , rpc_server_listen_backlog(
       *this,
       "rpc_server_listen_backlog",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -48,6 +48,10 @@ struct configuration final : public config_store {
     bounded_property<uint16_t> log_segment_size_jitter_percent;
     bounded_property<uint64_t> compacted_log_segment_size;
     property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;
+    bounded_property<std::optional<std::chrono::milliseconds>> log_segment_ms;
+    property<std::chrono::milliseconds> log_segment_ms_min;
+    property<std::chrono::milliseconds> log_segment_ms_max;
+
     // Network
     bounded_property<std::optional<int>> rpc_server_listen_backlog;
     bounded_property<std::optional<int>> rpc_server_tcp_recv_buf;

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -139,6 +139,13 @@ create_topic_properties_update(alter_configs_resource& resource) {
                   storage::ntp_config::default_remote_delete);
                 continue;
             }
+            if (cfg.name == topic_property_segment_ms) {
+                parse_and_set_tristate(
+                  update.properties.segment_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set);
+                continue;
+            }
             if (cfg.name == topic_property_remote_write) {
                 auto set_value = update.properties.shadow_indexing.value
                                    ? model::add_shadow_indexing_flag(

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -34,7 +34,7 @@
 
 namespace kafka {
 
-static constexpr std::array<std::string_view, 15> supported_configs{
+static constexpr std::array<std::string_view, 16> supported_configs{
   topic_property_compression,
   topic_property_cleanup_policy,
   topic_property_timestamp_type,
@@ -49,7 +49,8 @@ static constexpr std::array<std::string_view, 15> supported_configs{
   topic_property_read_replica,
   topic_property_max_message_bytes,
   topic_property_retention_local_target_bytes,
-  topic_property_retention_local_target_ms};
+  topic_property_retention_local_target_ms,
+  topic_property_segment_ms};
 
 bool is_supported(std::string_view name) {
     return std::any_of(

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -796,6 +796,17 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   [](const bool& b) { return b ? "true" : "false"; });
             }
 
+            add_topic_config_if_requested(
+              resource,
+              result,
+              topic_property_segment_ms,
+              ctx.metadata_cache().get_default_segment_ms(),
+              topic_property_segment_ms,
+              topic_config->properties.segment_ms,
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg().log_segment_ms.desc()));
             break;
         }
 

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -232,13 +232,18 @@ create_topic_properties_update(incremental_alter_configs_resource& resource) {
                   update.custom_properties.replication_factor, cfg.value, op);
                 continue;
             }
+            if (cfg.name == topic_property_segment_ms) {
+                parse_and_set_tristate(
+                  update.properties.segment_ms, cfg.value, op);
+                continue;
+            }
             if (
               std::find(
                 std::begin(allowlist_topic_noop_confs),
                 std::end(allowlist_topic_noop_confs),
                 cfg.name)
               != std::end(allowlist_topic_noop_confs)) {
-                // Skip unusupported Kafka config
+                // Skip unsupported Kafka config
                 continue;
             }
 
@@ -284,6 +289,7 @@ inline std::string_view map_config_name(std::string_view input) {
       .match("log.cleanup.policy", "log_cleanup_policy")
       .match("log.message.timestamp.type", "log_message_timestamp_type")
       .match("log.compression.type", "log_compression_type")
+      .match("log.roll.ms", "log_segment_ms")
       .default_match(input);
 }
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -182,6 +182,9 @@ to_cluster_type(const creatable_topic& t) {
       = get_bool_value(config_entries, topic_property_remote_delete)
           .value_or(storage::ntp_config::default_remote_delete);
 
+    cfg.properties.segment_ms = get_tristate_value<std::chrono::milliseconds>(
+      config_entries, topic_property_segment_ms);
+
     /// Final topic_property not decoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
 
@@ -294,6 +297,10 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
     config_entries[topic_property_remote_delete] = from_config_type(
       properties.remote_delete);
 
+    if (properties.segment_ms.has_value()) {
+        config_entries[topic_property_segment_ms] = from_config_type(
+          properties.segment_ms.value());
+    }
     /// Final topic_property not encoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
     return config_entries;

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -65,6 +65,7 @@ static constexpr std::string_view topic_property_replication_factor
   = "replication.factor";
 static constexpr std::string_view topic_property_remote_delete
   = "redpanda.remote.delete";
+static constexpr std::string_view topic_property_segment_ms = "segment.ms";
 
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
@@ -73,7 +74,6 @@ static constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {
   // Not used in Redpanda
   "unclean.leader.election.enable",
   "message.downconversion.enable",
-  "segment.ms",
   "segment.index.bytes",
   "segment.jitter.ms",
   "min.insync.replicas",

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -345,16 +345,17 @@ FIXTURE_TEST(
       "max.message.bytes",
       "retention.local.target.bytes",
       "retention.local.target.ms",
-      "redpanda.remote.delete"};
+      "redpanda.remote.delete",
+      "segment.ms"};
 
-    // All properies_request
+    // All properties_request
     auto all_describe_resp = describe_configs(test_tp);
     assert_properties_amount(test_tp, all_describe_resp, all_properties.size());
     for (const auto& property : all_properties) {
         assert_property_presented(test_tp, property, all_describe_resp, true);
     }
 
-    // Single properies_request
+    // Single properties_request
     for (const auto& request_property : all_properties) {
         std::vector<ss::sstring> request_properties = {request_property};
         auto single_describe_resp = describe_configs(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1028,6 +1028,7 @@ ss::future<> disk_log_impl::maybe_roll(
 
 ss::future<> disk_log_impl::do_housekeeping(
   std::chrono::system_clock::time_point system_time) {
+    auto gate = _compaction_gate.hold();
     // do_housekeeping races with maybe_roll to use new_segment.
     // take a lock to prevent problems
     auto lock = _segments_rolling_lock.get_units();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1026,8 +1026,7 @@ ss::future<> disk_log_impl::maybe_roll(
     }
 }
 
-ss::future<> disk_log_impl::do_housekeeping(
-  std::chrono::system_clock::time_point system_time) {
+ss::future<> disk_log_impl::do_housekeeping() {
     auto gate = _compaction_gate.hold();
     // do_housekeeping races with maybe_roll to use new_segment.
     // take a lock to prevent problems
@@ -1062,7 +1061,7 @@ ss::future<> disk_log_impl::do_housekeeping(
           seg_ms.value(),
           local_config.log_segment_ms_min(),
           local_config.log_segment_ms_max())
-      > system_time) {
+      > ss::lowres_clock::now()) {
         // skip, time hasn't expired
         co_return;
     }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -206,6 +206,10 @@ private:
 
     // Bytes written since last time we requested stm snapshot
     ssx::semaphore_units _stm_dirty_bytes_units;
+
+    // Mutually exclude operations that will cause segment rolling
+    // do_housekeeping and maybe_roll
+    mutex _segments_rolling_lock;
 };
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -142,7 +142,9 @@ private:
       ss::io_priority_class prio);
 
     ss::future<> do_truncate(
-      truncate_config, std::optional<ssx::semaphore_units> lock_guard);
+      truncate_config,
+      std::optional<std::pair<ssx::semaphore_units, ssx::semaphore_units>>
+        lock_guards);
     ss::future<> remove_full_segments(model::offset o);
 
     ss::future<> do_truncate_prefix(truncate_prefix_config);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -179,7 +179,7 @@ private:
         ss::abort_source::subscription subscription;
     };
     bool _closed{false};
-    ss::gate _compaction_gate;
+    ss::gate _compaction_housekeeping_gate;
     log_manager& _manager;
     float _segment_size_jitter;
     segment_set _segs;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -66,6 +66,8 @@ public:
     ss::future<> truncate(truncate_config) final;
     ss::future<> truncate_prefix(truncate_prefix_config) final;
     ss::future<> compact(compaction_config) final;
+    ss::future<>
+      do_housekeeping(std::chrono::system_clock::time_point) final override;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;
     void set_collectible_offset(model::offset) final;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -66,8 +66,7 @@ public:
     ss::future<> truncate(truncate_config) final;
     ss::future<> truncate_prefix(truncate_prefix_config) final;
     ss::future<> compact(compaction_config) final;
-    ss::future<>
-      do_housekeeping(std::chrono::system_clock::time_point) final override;
+    ss::future<> do_housekeeping() final override;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;
     void set_collectible_offset(model::offset) final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -52,6 +52,11 @@ public:
         virtual ss::future<> truncate(truncate_config) = 0;
         virtual ss::future<> truncate_prefix(truncate_prefix_config) = 0;
 
+        // TODO should compact be merged in this?
+        // run housekeeping task, like rolling segments
+        virtual ss::future<>
+        do_housekeeping(std::chrono::system_clock::time_point server_time) = 0;
+
         virtual ss::future<model::record_batch_reader>
           make_reader(log_reader_config) = 0;
         virtual log_appender make_appender(log_append_config) = 0;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -175,6 +175,10 @@ public:
 
     ss::future<> compact(compaction_config cfg) { return _impl->compact(cfg); }
 
+    ss::future<>
+    housekeeping(std::chrono::system_clock::time_point system_time) {
+        return _impl->do_housekeeping(system_time);
+    }
     /**
      * \brief Returns a future that resolves when log eviction is scheduled
      *

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -54,8 +54,7 @@ public:
 
         // TODO should compact be merged in this?
         // run housekeeping task, like rolling segments
-        virtual ss::future<>
-        do_housekeeping(std::chrono::system_clock::time_point server_time) = 0;
+        virtual ss::future<> do_housekeeping() = 0;
 
         virtual ss::future<model::record_batch_reader>
           make_reader(log_reader_config) = 0;
@@ -175,10 +174,7 @@ public:
 
     ss::future<> compact(compaction_config cfg) { return _impl->compact(cfg); }
 
-    ss::future<>
-    housekeeping(std::chrono::system_clock::time_point system_time) {
-        return _impl->do_housekeeping(system_time);
-    }
+    ss::future<> housekeeping() { return _impl->do_housekeeping(); }
     /**
      * \brief Returns a future that resolves when log eviction is scheduled
      *

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -201,6 +201,15 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         co_return;
     }
 
+    // TODO handle this after compaction?
+    // handle segment.ms sequentially, since compaction is already sequential
+    // when this will be unified with compaction, the whole task could be made
+    // concurrent
+    for (auto now = std::chrono::system_clock::now();
+         auto& log_meta : _logs_list) {
+        co_await log_meta.handle.housekeeping(now);
+    }
+
     for (auto& log_meta : _logs_list) {
         log_meta.flags &= ~bflags::compacted;
     }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -205,9 +205,8 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     // handle segment.ms sequentially, since compaction is already sequential
     // when this will be unified with compaction, the whole task could be made
     // concurrent
-    for (auto now = std::chrono::system_clock::now();
-         auto& log_meta : _logs_list) {
-        co_await log_meta.handle.housekeeping(now);
+    for (auto& log_meta : _logs_list) {
+        co_await log_meta.handle.housekeeping();
     }
 
     for (auto& log_meta : _logs_list) {

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -205,7 +205,7 @@ public:
 private:
     using logs_type
       = absl::flat_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;
-    using housekeeping_list_type
+    using compaction_list_type
       = intrusive_list<log_housekeeping_meta, &log_housekeeping_meta::link>;
 
     ss::future<log> do_manage(ntp_config);
@@ -232,7 +232,7 @@ private:
     simple_time_jitter<ss::lowres_clock> _jitter;
     ss::timer<ss::lowres_clock> _housekeeping_timer;
     logs_type _logs;
-    housekeeping_list_type _logs_list;
+    compaction_list_type _logs_list;
     batch_cache _batch_cache;
     ss::gate _open_gate;
     ss::abort_source _abort_source;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -205,7 +205,7 @@ public:
 private:
     using logs_type
       = absl::flat_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;
-    using compaction_list_type
+    using housekeeping_list_type
       = intrusive_list<log_housekeeping_meta, &log_housekeeping_meta::link>;
 
     ss::future<log> do_manage(ntp_config);
@@ -230,9 +230,9 @@ private:
     kvstore& _kvstore;
     storage_resources& _resources;
     simple_time_jitter<ss::lowres_clock> _jitter;
-    ss::timer<ss::lowres_clock> _compaction_timer;
+    ss::timer<ss::lowres_clock> _housekeeping_timer;
     logs_type _logs;
-    compaction_list_type _logs_list;
+    housekeeping_list_type _logs_list;
     batch_cache _batch_cache;
     ss::gate _open_gate;
     ss::abort_source _abort_source;

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -163,10 +163,7 @@ struct mem_log_impl final : log::impl {
         return gc(cfg.eviction_time, cfg.max_bytes);
     }
 
-    ss::future<>
-    do_housekeeping(std::chrono::system_clock::time_point) final override {
-        return ss::now();
-    }
+    ss::future<> do_housekeeping() final override { return ss::now(); }
     std::ostream& print(std::ostream& o) const final {
         fmt::print(o, "{{mem_log_impl:{}}}", offsets());
         return o;

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -162,6 +162,11 @@ struct mem_log_impl final : log::impl {
     ss::future<> compact(compaction_config cfg) final {
         return gc(cfg.eviction_time, cfg.max_bytes);
     }
+
+    ss::future<>
+    do_housekeeping(std::chrono::system_clock::time_point) final override {
+        return ss::now();
+    }
     std::ostream& print(std::ostream& o) const final {
         fmt::print(o, "{{mem_log_impl:{}}}", offsets());
         return o;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -59,7 +59,8 @@ segment::segment(
   , _idx(std::move(i))
   , _appender(std::move(a))
   , _compaction_index(std::move(ci))
-  , _cache(std::move(c)) {
+  , _cache(std::move(c))
+  , _first_write(std::nullopt) {
     if (_appender) {
         _appender->set_callbacks(&_appender_callbacks);
     }
@@ -442,12 +443,19 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
         });
     auto index_fut = compaction_index_batch(b);
     return ss::when_all(std::move(write_fut), std::move(index_fut))
-      .then([this](std::tuple<ss::future<append_result>, ss::future<>> p) {
+      .then([this, batch_type = b.header().type](
+              std::tuple<ss::future<append_result>, ss::future<>> p) {
           auto& [append_fut, index_fut] = p;
           const bool index_append_failed = index_fut.failed()
                                            && has_compaction_index();
           const bool has_error = append_fut.failed() || index_append_failed;
           if (!has_error) {
+              if (
+                !this->_first_write.has_value()
+                && batch_type == model::record_batch_type::raft_data) {
+                  // record time of first write of data batch
+                  this->_first_write = std::chrono::system_clock::now();
+              }
               index_fut.get();
               return std::move(append_fut);
           }

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -454,7 +454,7 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
                 !this->_first_write.has_value()
                 && batch_type == model::record_batch_type::raft_data) {
                   // record time of first write of data batch
-                  this->_first_write = std::chrono::system_clock::now();
+                  this->_first_write = ss::lowres_clock::now();
               }
               index_fut.get();
               return std::move(append_fut);

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -163,6 +163,11 @@ public:
     generation_id get_generation_id() const { return _generation_id; }
     void advance_generation() { _generation_id++; }
 
+    auto first_write_ts()
+      -> std::optional<std::chrono::system_clock::time_point> {
+        return _first_write;
+    }
+
 private:
     void set_close();
     void cache_truncate(model::offset offset);
@@ -219,6 +224,11 @@ private:
     ss::gate _gate;
 
     absl::btree_map<size_t, model::offset> _inflight;
+
+    // Timestamp from server time of first data written to this segment,
+    // field is set when a raft_data batch is appended.
+    // Used to implement segment.ms
+    std::optional<std::chrono::system_clock::time_point> _first_write;
 
     friend std::ostream& operator<<(std::ostream&, const segment&);
 };

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -163,8 +163,16 @@ public:
     generation_id get_generation_id() const { return _generation_id; }
     void advance_generation() { _generation_id++; }
 
-    auto first_write_ts()
-      -> std::optional<std::chrono::system_clock::time_point> {
+    /**
+     * Timestamp of the first data batch written to this segment.
+     * Note that this isn't the first timestamp of a data batch in the log,
+     * and is only set if the segment was appended to while this segment was
+     * active. I.e. a closed segment following a restart wouldn't have this
+     * value set, because we only intend on using this in the context of an
+     * active segment.
+     */
+    constexpr std::optional<ss::lowres_clock::time_point>
+    first_write_ts() const {
         return _first_write;
     }
 
@@ -227,8 +235,8 @@ private:
 
     // Timestamp from server time of first data written to this segment,
     // field is set when a raft_data batch is appended.
-    // Used to implement segment.ms
-    std::optional<std::chrono::system_clock::time_point> _first_write;
+    // Used to implement segment.ms rolling
+    std::optional<ss::lowres_clock::time_point> _first_write;
 
     friend std::ostream& operator<<(std::ostream&, const segment&);
 };

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -100,6 +100,10 @@ public:
         }
     }
 
+    constexpr ss::io_priority_class get_priority_class() const {
+        return _opts.priority;
+    }
+
 private:
     void dispatch_background_head_write();
     ss::future<> do_next_adaptive_fallocation();

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -93,7 +93,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "{{compaction_strategy: {}, cleanup_policy_bitflags: {}, segment_size: "
       "{}, retention_bytes: {}, retention_time_ms: {}, recovery_enabled: {}, "
       "retention_local_target_bytes: {}, retention_local_target_ms: {}, "
-      "remote_delete: {}}}",
+      "remote_delete: {}, segment_ms: {}}}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -102,7 +102,8 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.recovery_enabled,
       v.retention_local_target_bytes,
       v.retention_local_target_ms,
-      v.remote_delete);
+      v.remote_delete,
+      v.segment_ms);
 
     return o;
 }

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -92,7 +92,8 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       o,
       "{{compaction_strategy: {}, cleanup_policy_bitflags: {}, segment_size: "
       "{}, retention_bytes: {}, retention_time_ms: {}, recovery_enabled: {}, "
-      "retention_local_target_bytes: {}, retention_local_target_ms: {}}}",
+      "retention_local_target_bytes: {}, retention_local_target_ms: {}, "
+      "remote_delete: {}}}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -100,7 +101,8 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.retention_time,
       v.recovery_enabled,
       v.retention_local_target_bytes,
-      v.retention_local_target_ms);
+      v.retention_local_target_ms,
+      v.remote_delete);
 
     return o;
 }

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -32,6 +32,7 @@ class TopicSpec:
     PROPERTY_RETENTION_LOCAL_TARGET_BYTES = "retention.local.target.bytes"
     PROPERTY_RETENTION_LOCAL_TARGET_MS = "retention.local.target.ms"
     PROPERTY_REMOTE_DELETE = "redpanda.remote.delete"
+    PROPERTY_SEGMENT_MS = "segment.ms"
 
     # compression types
     COMPRESSION_NONE = "none"
@@ -59,7 +60,8 @@ class TopicSpec:
                  redpanda_datapolicy=None,
                  redpanda_remote_read=None,
                  redpanda_remote_write=None,
-                 redpanda_remote_delete=None):
+                 redpanda_remote_delete=None,
+                 segment_ms=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -73,6 +75,7 @@ class TopicSpec:
         self.redpanda_remote_read = redpanda_remote_read
         self.redpanda_remote_write = redpanda_remote_write
         self.redpanda_remote_delete = redpanda_remote_delete
+        self.segment_ms = segment_ms
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -141,6 +141,13 @@ class DescribeTopicsTest(RedpandaTest):
                 value="1073741824",
                 doc_string=
                 "Default log segment size in bytes for topics which do not set segment.bytes"
+            ),
+            "segment.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="-1",
+                doc_string=
+                "Default log segment lifetime in ms for topics which do not set segment.ms"
             )
         }
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -189,7 +189,9 @@ class CreateTopicsTest(RedpandaTest):
         'max.message.bytes':
         lambda: random.randint(1024 * 1024, 10 * 1024 * 1024),
         'redpanda.remote.delete':
-        lambda: "true" if random.randint(0, 1) else "false"
+        lambda: "true" if random.randint(0, 1) else "false",
+        'segment.ms':
+        lambda: random.randint(10000, 10000000),
     }
 
     def __init__(self, test_context):
@@ -217,7 +219,8 @@ class CreateTopicsTest(RedpandaTest):
                              config={p: property_value})
 
             cfgs = rpk.describe_topic_configs(topic=name)
-            assert str(cfgs[p][0]) == str(property_value)
+            assert str(cfgs[p][0]) == str(
+                property_value), f"{cfgs[p][0]=} != {property_value=}"
 
 
 class CreateSITopicsTest(RedpandaTest):

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -105,8 +105,8 @@ def read_property_update_serde(rdr: Reader, type_reader):
 
 
 def read_incremental_topic_update_serde(rdr: Reader):
-    return rdr.read_envelope(
-        lambda rdr, _: {
+    def incr_topic_upd(rdr: Reader, version):
+        incr_obj = {
             'compression':
             read_property_update_serde(
                 rdr, lambda r: r.read_optional(Reader.read_serde_enum)),
@@ -131,7 +131,10 @@ def read_incremental_topic_update_serde(rdr: Reader):
             'shadow_indexing':
             read_property_update_serde(
                 rdr, lambda r: r.read_optional(Reader.read_serde_enum)),
-        })
+        }
+        return incr_obj
+
+    return rdr.read_envelope(incr_topic_upd)
 
 
 def read_create_partitions_serde(rdr: Reader):


### PR DESCRIPTION
PR to add support for segment.ms, following discussion on RFC

tasks:
- [x] configuration variables
  - [x] internally
  - [x] externally visible
- [x] infra
  - [x] log::housekeeping and implementation
  - [x] log_manager::housekeeping integration
- [ ] ducktape tests
  - [ ] a low segment.ms with a heavy workload,
  - [ ] Upgrade test with a topic created before segment.ms
  - [ ] Silent modification of dangerous user-provided values
  - [ ] Simultaneous time roll of multiple segments, the cluster should be well-behaved
  
open TODO:
- log_manager::housekeeping
  - should segment.ms housekeeping be done after compaction 
- log
  - should log::compact be merged in log::housekeeping

Fixes https://github.com/redpanda-data/redpanda/issues/4438
     
## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

See release notes

## Release Notes

### Features

* Implement a Kafka-compatible `segment.ms` topic property. This controls the maximum time between the first write to a segment, and later closing the segment.  This is sometimes useful when one needs topic retention limits to apply within a known time period, rather than at the next segment roll.  This is disabled by default.
* Add `log_segment_ms` cluster configuration property, which is the default value for `segment.ms` on topics that do not override it.  This is also accessible via the Kafka API under its Kafka-compatible alias `log.roll.ms`.  The lowest permitted value for this property is 60 seconds.
* Add `log_segment_ms_min` and `log_segment_ms_max` cluster configuration properties.  These limits are applied to `segment.ms` and `log_segment_ms`, to protect systems from pathologically small segment roll periods.


