### PR TITLE
archival: Fix archival metadata STM errors in read replica

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -144,7 +144,7 @@ ss::future<> ntp_archiver::upload_until_abort() {
     }
 
     while (!_as.abort_requested()) {
-        if (!_parent.is_elected_leader() || _paused) {
+        if (!_parent.is_leader() || _paused) {
             bool shutdown = false;
             try {
                 vlog(
@@ -197,7 +197,7 @@ ss::future<> ntp_archiver::sync_manifest_until_abort() {
     }
 
     while (!_as.abort_requested()) {
-        if (!_parent.is_elected_leader() || _paused) {
+        if (!_parent.is_leader() || _paused) {
             bool shutdown = false;
             try {
                 vlog(
@@ -569,8 +569,8 @@ void ntp_archiver::update_probe() {
 }
 
 bool ntp_archiver::can_update_archival_metadata() const {
-    return !_as.abort_requested() && !_gate.is_closed()
-           && _parent.is_elected_leader() && _parent.term() == _start_term;
+    return !_as.abort_requested() && !_gate.is_closed() && _parent.is_leader()
+           && _parent.term() == _start_term;
 }
 
 bool ntp_archiver::may_begin_uploads() const {
@@ -719,7 +719,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
 
 std::optional<ss::sstring> ntp_archiver::upload_should_abort() {
     auto original_term = _parent.term();
-    auto lost_leadership = !_parent.is_elected_leader()
+    auto lost_leadership = !_parent.is_leader()
                            || _parent.term() != original_term;
     if (unlikely(lost_leadership)) {
         return fmt::format(
@@ -727,7 +727,7 @@ std::optional<ss::sstring> ntp_archiver::upload_should_abort() {
           "current leadership status: {}, "
           "current term: {}, "
           "original term: {}",
-          _parent.is_elected_leader(),
+          _parent.is_leader(),
           _parent.term(),
           original_term);
     } else {

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -529,9 +529,8 @@ ss::future<cloud_storage::download_result> ntp_archiver::sync_manifest() {
         auto builder = _parent.archival_meta_stm()->batch_start(deadline, _as);
         builder.add_segments(std::move(mdiff));
         if (
-          new_start_offset.has_value()
-          && old_start_offset.value_or(model::offset())
-               != new_start_offset.value()) {
+          new_start_offset.has_value() && old_start_offset.has_value()
+          && old_start_offset.value() != new_start_offset.value()) {
             builder.truncate(new_start_offset.value());
             needs_cleanup = true;
         }

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -759,7 +759,7 @@ void archival_metadata_stm::apply_update_start_offset(const start_offset& so) {
       so.start_offset);
     if (!_manifest->advance_start_offset(so.start_offset)) {
         vlog(
-          _logger.warn,
+          _logger.error,
           "Can't truncate manifest up to offset {}, offset out of range",
           so.start_offset);
     } else {

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -683,6 +683,7 @@ model::offset archival_metadata_stm::max_collectible_offset() {
     // From Redpanda 22.3 up, the ntp_config's impression of whether archival
     // is enabled is authoritative.
     bool collect_all = !_raft->log_config().is_archival_enabled();
+    bool is_read_replica = _raft->log_config().is_read_replica_mode_enabled();
 
     // In earlier versions, we should assume every topic is archival enabled
     // if the global cloud_storage_enable_remote_write is true.
@@ -692,9 +693,12 @@ model::offset archival_metadata_stm::max_collectible_offset() {
         collect_all = false;
     }
 
-    if (collect_all) {
+    if (collect_all || is_read_replica) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
+        // In read-replicas the state machine exists and stores segments from
+        // the remote manifest. Since nothing is uploaded there is no need to
+        // interact with local retention.
         return model::offset::max();
     }
     auto lo = get_last_offset();

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -291,7 +291,7 @@ class SISettings:
                  cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
                      int] = None,
                  bypass_bucket_creation: bool = False,
-                 cloud_storage_housekeeping_interval_ms=None):
+                 cloud_storage_housekeeping_interval_ms: Optional[int] = None):
         self.cloud_storage_type = CloudStorageType.S3
         if hasattr(test_context, 'injected_args') \
         and test_context.injected_args is not None \
@@ -451,7 +451,6 @@ class SISettings:
         if self.cloud_storage_housekeeping_interval_ms:
             conf[
                 'cloud_storage_housekeeping_interval_ms'] = self.cloud_storage_housekeeping_interval_ms
-
         return conf
 
 

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -23,6 +23,7 @@ from rptest.util import (
     produce_until_segments,
     wait_for_segments_removal,
 )
+from random import choice
 
 # Log errors expected when connectivity between redpanda and the S3
 # backend is disrupted
@@ -120,10 +121,10 @@ class SIAdminApiTest(RedpandaTest):
                                                 segment_to_remove, True)
 
         self.logger.info("trying to sync remote partition")
-        for node in self.redpanda.nodes:
-            validation_result = self.admin.si_sync_local_state(
-                self.topic, 0, node)
-            self.logger.info(f"sync result {validation_result}")
+
+        node = choice(self.redpanda.nodes)
+        validation_result = self.admin.si_sync_local_state(self.topic, 0, node)
+        self.logger.info(f"sync result {validation_result}")
 
         def start_offset_not_zero():
             for partition in rpk.describe_topic(self.topic):


### PR DESCRIPTION
There are two main problems
- Initial start offset of the read replica archival STM was different from the downloaded manifest. This caused the code to invoke truncation command on archival STM which was incorrect and triggered an error in the log.
- Another problem is that background fibers in `ntp_archiver` are running if `cluster::partition::is_elected_leader` is true but `cluster::partition::is_leader` is false. In this state the archival metadata STM can't replicate a message and read replica manifest sync can fail.

Fixes #8045


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->

  ### Bug Fixes

  * Fix archival metadata STM replication error in read replicas
