### PR TITLE
[v22.2.x] ducktape: Update docker image

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:jammy-20220531
+FROM ubuntu:jammy-20221130
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Hoping this will fix:
```
The following packages have unmet dependencies:

 libsasl2-dev : Depends: libsasl2-2 (= 2.1.27+dfsg2-3ubuntu1) but 2.1.27+dfsg2-3ubuntu1.1 is to be installed

[91mE: Unable to correct problems, you have held broken packages.
```

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [x] v22.1.x

## UX Changes

* none

## Release Notes

* none
