### PR TITLE
k8s: broker_tls is enabled only if internal listener has tls

### DIFF
--- a/src/go/k8s/pkg/resources/certmanager/type_helpers.go
+++ b/src/go/k8s/pkg/resources/certmanager/type_helpers.go
@@ -138,6 +138,7 @@ type apiCertificates struct {
 	clientCertificates []resources.Resource
 	rootResources      []resources.Resource
 	tlsEnabled         bool
+	internalTlsEnabled bool
 	// true if api is using our own generated self-signed issuer
 	selfSignedNodeCertificate bool
 
@@ -251,6 +252,9 @@ func (cc *ClusterCertificates) prepareAPI(
 		return tlsDisabledAPICertificates(), nil
 	}
 	result := tlsEnabledAPICertificates(cc.pandaCluster.Namespace)
+	if internalTLSListener != nil {
+		result.internalTlsEnabled = true
+	}
 
 	// TODO(#3550): Do not create rootIssuer if nodeSecretRef is passed and mTLS is disabled
 	toApplyRoot, rootIssuerRef := prepareRoot(rootCertSuffix, cc.client, cc.pandaCluster, cc.scheme, cc.logger)
@@ -669,7 +673,7 @@ func (cc *ClusterCertificates) GetTLSConfig(
 
 // KafkaClientBrokerTLS returns configuration to connect to kafka api with tls
 func (cc *ClusterCertificates) KafkaClientBrokerTLS(mountPoints *resourcetypes.TLSMountPoints) *config.ServerTLS {
-	if !cc.kafkaAPI.tlsEnabled {
+	if !cc.kafkaAPI.internalTlsEnabled {
 		return nil
 	}
 	result := config.ServerTLS{

--- a/src/go/k8s/pkg/resources/certmanager/type_helpers.go
+++ b/src/go/k8s/pkg/resources/certmanager/type_helpers.go
@@ -138,7 +138,7 @@ type apiCertificates struct {
 	clientCertificates []resources.Resource
 	rootResources      []resources.Resource
 	tlsEnabled         bool
-	internalTlsEnabled bool
+	internalTLSEnabled bool
 	// true if api is using our own generated self-signed issuer
 	selfSignedNodeCertificate bool
 
@@ -253,7 +253,7 @@ func (cc *ClusterCertificates) prepareAPI(
 	}
 	result := tlsEnabledAPICertificates(cc.pandaCluster.Namespace)
 	if internalTLSListener != nil {
-		result.internalTlsEnabled = true
+		result.internalTLSEnabled = true
 	}
 
 	// TODO(#3550): Do not create rootIssuer if nodeSecretRef is passed and mTLS is disabled
@@ -673,7 +673,7 @@ func (cc *ClusterCertificates) GetTLSConfig(
 
 // KafkaClientBrokerTLS returns configuration to connect to kafka api with tls
 func (cc *ClusterCertificates) KafkaClientBrokerTLS(mountPoints *resourcetypes.TLSMountPoints) *config.ServerTLS {
-	if !cc.kafkaAPI.internalTlsEnabled {
+	if !cc.kafkaAPI.internalTLSEnabled {
 		return nil
 	}
 	result := config.ServerTLS{

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -194,7 +194,7 @@ func (r *StatefulSetResource) Ensure(ctx context.Context) error {
 	return r.handleScaling(ctx)
 }
 
-// GetCentralizedConfigurationHashFromCluster retrieves the current centralized configuratino hash from the statefulset
+// GetCentralizedConfigurationHashFromCluster retrieves the current centralized configuration hash from the statefulset
 func (r *StatefulSetResource) GetCentralizedConfigurationHashFromCluster(
 	ctx context.Context,
 ) (string, error) {


### PR DESCRIPTION
currently we set broker_tls to enabled even if internal listener does not have tls.

```
broker_tls:
        enabled: true
```

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

None

## Release Notes

  ### Bug Fixes

  * Fix for unreleased feature https://github.com/redpanda-data/redpanda/pull/7820
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
