### PR TITLE
rpk/os: remove unnecessary yaml extension

### DIFF
--- a/src/go/rpk/pkg/os/file.go
+++ b/src/go/rpk/pkg/os/file.go
@@ -27,7 +27,7 @@ func ReplaceFile(fs afero.Fs, filename string, contents []byte, newPerms os.File
 	}
 	// Create a temp file first.
 	layout := "20060102150405" // year-month-day-hour-min-sec
-	bFilename := "redpanda-" + time.Now().Format(layout) + ".yaml"
+	bFilename := "redpanda-" + time.Now().Format(layout)
 	temp := filepath.Join(filepath.Dir(filename), bFilename)
 
 	err = afero.WriteFile(fs, temp, contents, newPerms)


### PR DESCRIPTION
Probably a carryover from the previous implementation that was used just for the `redpanda.yaml`.

Now, this method is used for other files such as the byoc plugin binary so having the .yaml extension here is wrong.

## Backports Required
- [ ] v22.3.x


## Release Notes
  * none
