### PR TITLE
RPC timeout diagnosis improvements

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -196,6 +196,7 @@ ss::future<ss::temporary_buffer<char>> client::receive() {
 ss::future<> client::send(ss::scattered_message<char> msg) {
     _probe->add_outbound_bytes(msg.size());
     return _out.write(std::move(msg))
+      .discard_result()
       .handle_exception([this](std::exception_ptr e) {
           _probe->register_transport_error();
           return ss::make_exception_future<>(e);

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -80,7 +80,7 @@ private:
         ph.write(raw_size, sizeof(be_total_size));
 
         return _out.write(iobuf_as_scattered(std::move(buf)))
-          .then([this, is_flexible] {
+          .then([this, is_flexible](bool) {
               return parse_size(_in).then([this, is_flexible](
                                             std::optional<size_t> sz) {
                   if (!sz) {

--- a/src/v/net/batched_output_stream.cc
+++ b/src/v/net/batched_output_stream.cc
@@ -30,13 +30,13 @@ batched_output_stream::batched_output_stream(
     vassert(_cache_size > 0, "Size must be > 0");
 }
 
-[[gnu::cold]] static ss::future<>
+[[gnu::cold]] static ss::future<bool>
 already_closed_error(ss::scattered_message<char>& msg) {
-    return ss::make_exception_future<>(
+    return ss::make_exception_future<bool>(
       batched_output_stream_closed(msg.size()));
 }
 
-ss::future<> batched_output_stream::write(ss::scattered_message<char> msg) {
+ss::future<bool> batched_output_stream::write(ss::scattered_message<char> msg) {
     if (unlikely(_closed)) {
         return already_closed_error(msg);
     }
@@ -50,9 +50,9 @@ ss::future<> batched_output_stream::write(ss::scattered_message<char> msg) {
               _unflushed_bytes += vbytes;
               if (
                 _write_sem->waiters() == 0 || _unflushed_bytes >= _cache_size) {
-                  return do_flush();
+                  return do_flush().then([] { return true; });
               }
-              return ss::make_ready_future<>();
+              return ss::make_ready_future<bool>(false);
           });
       });
 }

--- a/src/v/net/batched_output_stream.h
+++ b/src/v/net/batched_output_stream.h
@@ -59,7 +59,19 @@ public:
     batched_output_stream(const batched_output_stream&) = delete;
     batched_output_stream& operator=(const batched_output_stream&) = delete;
 
-    ss::future<> write(ss::scattered_message<char> msg);
+    /**
+     * @brief Write the given payload to the underlying stream and maybe flush.
+     *
+     * Writes the scattered message to the underlying output stream, flushing if
+     * this is the only (last) writer trying to write to this stream or if the
+     * _cache_size has been reached.
+     *
+     * @param msg the message to write to the underlying stream
+     * @return ss::future<bool> a future which resolves when the flush, if any,
+     * completes with the wrapped value indicating wheter a flush occurred on
+     * this write (true) or not (false)
+     */
+    ss::future<bool> write(ss::scattered_message<char> msg);
     ss::future<> flush();
 
     /// \brief calls output_stream<char>::close()

--- a/src/v/net/batched_output_stream.h
+++ b/src/v/net/batched_output_stream.h
@@ -33,7 +33,17 @@ private:
     std::string msg;
 };
 
-/// \brief batch operations for zero copy interface of an output_stream<char>
+/**
+ * @brief Wrap a seastar output stream to provide batching of flush calls.
+ *
+ * When used for zero-copy operations, a seastar output stream does not send
+ * data further downstream to the sink (i.e., the kernel) until flush() is
+ * called. Rather than calling flush after every write (e.g., a full rpc request
+ * payload), class attempts to reduce the number of flush calls by supressing
+ * flushes when multiple writes are in progress on the stream: a flush occurs
+ * only when the last pending writer completes or when a configured amount of
+ * unflushed bytes have accumulated.
+ */
 class batched_output_stream {
 public:
     static constexpr size_t default_max_unflushed_bytes = 1024 * 1024;

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -152,7 +152,7 @@ ss::future<> connection::shutdown() {
 
 ss::future<> connection::write(ss::scattered_message<char> msg) {
     _probe.add_bytes_sent(msg.size());
-    return _out.write(std::move(msg));
+    return _out.write(std::move(msg)).discard_result();
 }
 
 } // namespace net

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -602,16 +602,16 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
         update_node_append_timestamp(target);
         vlog(
           _ctxlog.trace, "Sending empty append entries request to {}", target);
-        auto f
-          = _client_protocol
-              .append_entries(
-                target.id(),
-                std::move(req),
-                rpc::client_opts(_replicate_append_timeout + clock_type::now()))
-              .then([this, id = target.id(), seq, dirty_offset](
-                      result<append_entries_reply> reply) {
-                  process_append_entries_reply(id, reply, seq, dirty_offset);
-              });
+        auto f = _client_protocol
+                   .append_entries(
+                     target.id(),
+                     std::move(req),
+                     rpc::client_opts(_replicate_append_timeout))
+                   .then([this, id = target.id(), seq, dirty_offset](
+                           result<append_entries_reply> reply) {
+                       process_append_entries_reply(
+                         id, reply, seq, dirty_offset);
+                   });
 
         send_futures.push_back(std::move(f));
     });

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -244,7 +244,7 @@ ss::future<> heartbeat_manager::do_heartbeat(node_heartbeat&& r) {
                  r.target,
                  std::move(r.request),
                  rpc::client_opts(
-                   clock_type::now() + _heartbeat_timeout(),
+                   rpc::timeout_spec::from_now(_heartbeat_timeout()),
                    rpc::compression_type::zstd,
                    512))
                .then([node = r.target,

--- a/src/v/raft/prevote_stm.h
+++ b/src/v/raft/prevote_stm.h
@@ -15,6 +15,7 @@
 #include "raft/logger.h"
 #include "raft/types.h"
 #include "raft/vote_stm.h"
+#include "rpc/types.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_future.hh>
@@ -58,7 +59,7 @@ private:
     // for sequentiality/progress
     ssx::semaphore _sem;
     std::optional<raft::group_configuration> _config;
-    clock_type::time_point _prevote_timeout;
+    rpc::timeout_spec _prevote_timeout;
     // for safety to wait for all bg ops
     ss::gate _vote_bg;
     absl::flat_hash_map<vnode, vmeta> _replies;

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -48,8 +48,8 @@ vote_stm::~vote_stm() {
       "Must call vote_stm::wait()");
 }
 ss::future<result<vote_reply>> vote_stm::do_dispatch_one(vnode n) {
-    vlog(_ctxlog.trace, "Sending vote request to {}", n);
-    auto tout = clock_type::now() + _ptr->_jit.base_duration();
+    auto tout = _ptr->_jit.base_duration();
+    vlog(_ctxlog.info, "Sending vote request to {} with timeout {}", n, tout);
 
     auto r = _req;
     _ptr->_probe.vote_request_sent();

--- a/src/v/rpc/response_handler.h
+++ b/src/v/rpc/response_handler.h
@@ -35,13 +35,12 @@ public:
     requires requires(Func f) {
         { f() } -> std::same_as<void>;
     }
-    void
-    with_timeout(rpc::clock_type::time_point timeout, Func&& timeout_action) {
+    void with_timeout(rpc::timeout_spec timeout, Func&& timeout_action) {
         _timeout_timer = std::make_unique<rpc::timer_type>(
           [this, f = std::forward<Func>(timeout_action)]() mutable {
               complete_with_timeout(std::forward<Func>(f));
           });
-        _timeout_timer->arm(timeout);
+        _timeout_timer->arm(timeout.timeout_at());
     }
 
     ss::future<response_ptr> get_future() { return _promise.get_future(); }

--- a/src/v/rpc/test/netbuf_tests.cc
+++ b/src/v/rpc/test/netbuf_tests.cc
@@ -35,7 +35,7 @@ SEASTAR_THREAD_TEST_CASE(netbuf_pod) {
     src.y = 88;
     src.z = 88;
     n.set_correlation_id(42);
-    n.set_service_method_id(66);
+    n.set_service_method({"test::test", 66});
     reflection::async_adl<pod>{}.to(n.buffer(), src).get();
     // forces the computation of the header
     auto bufs = std::move(n).as_scattered().get().release().release();

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -456,7 +456,7 @@ FIXTURE_TEST(rpc_mixed_compression, rpc_integration_fixture) {
                   .echo(
                     echo::echo_req{.str = data},
                     rpc::client_opts(
-                      rpc::no_timeout,
+                      rpc::timeout_spec::none,
                       rpc::compression_type::zstd,
                       0 /*min bytes compress*/))
                   .get0();

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -45,6 +45,58 @@ namespace rpc {
 struct client_context_impl;
 
 /**
+ * @brief A structure for tracking various points in time associated with a
+ * specific RPC request, for more detailed diagnosis when an RPC times out.
+ */
+struct timing_info {
+    using clock_type = rpc::clock_type;
+    using time_point = clock_type::time_point;
+
+    constexpr static time_point unset = time_point::min();
+
+    /**
+     * The originally configured timeout, usually created when the client_opts
+     * object is constructed.
+     */
+    timeout_spec timeout = timeout_spec::none;
+
+    /**
+     * The moment in time the request was enqueued in the _requests array, i.e.,
+     * now waiting in line to be sent. This
+     * is often immediately followed by being dispatched, though not always:
+     * since we dispatch in-order, any lower-sequence number requests which
+     * haven't been dispatched yet will prevent this from being dispatched.
+     */
+    time_point enqueued_at = unset;
+
+    /**
+     * The moment in time we dispatched the request: that is, it was the next
+     * request to be sent and we called .write on the output stream: note that
+     * this does not perform the write (since that's an async method), but it
+     * means that the task responsible for doing the write has been set up.
+     */
+    time_point dispatched_at = unset;
+
+    /**
+     * The moment in time the future associated with the write to the output
+     * stream completes. As this is a buffered_output_stream, it does not
+     * necessarily mean the underlying stream has been flushed (as this happens
+     * only sometimes), so doesn't even mean the kernel has been notified of the
+     * buffers yet.
+     */
+    time_point written_at = unset;
+
+    /**
+     * True if the batched output stream write associated with this request was
+     * flushed at the time of writing. That is, the written_at timestamp is set
+     * when the write occurs, but the output stream will internally decide
+     * whether to flush not depending on concurrent writers
+     *
+     */
+    bool flushed = false;
+};
+
+/**
  * Transport implementation used for internal RPC traffic.
  *
  * As callers send buffers over the wire, the transport associates each with an
@@ -88,6 +140,7 @@ private:
     struct entry {
         std::unique_ptr<ss::scattered_message<char>> scattered_message;
         client_opts::resource_units_t resource_units;
+        uint32_t correlation_id;
     };
     using requests_queue_t
       = absl::btree_map<sequence_t, std::unique_ptr<entry>>;
@@ -107,14 +160,37 @@ private:
     make_response_handler(netbuf&, const rpc::client_opts&, sequence_t);
 
     ssx::semaphore _memory;
+
     /**
-     * Map of response handlers to use when processing a buffer read from the
-     * wire.
+     * @brief Get the timing info for the request with the given correlation ID.
+     *
+     * A pointer to the timing info object embedded in the _correlations map, or
+     * nullptr the correlation no longer exists (e.g., because the request has
+     * completed).
+     *
+     * This pointer is only valid until the next suspension point, since the
+     * entry may be deleted at any point if the current fiber suspends.
+     */
+    timing_info* get_timing(uint32_t correlation);
+
+    /**
+     * @brief Holds the response handler and timing information for an
+     * outstanding request.
+     */
+    struct response_entry {
+        internal::response_handler handler;
+        timing_info timing;
+    };
+
+    /**
+     * Map of correlation IDs to response handlers to use when processing a
+     * response read from the wire. We also track the timing info for the
+     * request in this map.
      *
      * NOTE: _correlation_idx is unrelated to the sequence type used to define
      * on-wire ordering below.
      */
-    absl::flat_hash_map<uint32_t, std::unique_ptr<internal::response_handler>>
+    absl::flat_hash_map<uint32_t, std::unique_ptr<response_entry>>
       _correlations;
     uint32_t _correlation_idx{0};
     ss::metrics::metric_groups _metrics;


### PR DESCRIPTION
This series of changes intends to improve the logging for RPC timeouts.

Specifically we want to know _what_ RPC timed out, and _why_ it timed out.

The _what_ is the RPC name, and the _why_ is more complicated, but in this
series of changes we record the point in time certain important events happen,
so that we can understand if the RPC was ever sent to the remote side, or if it
suffered from a stall, or if it wasn't flushed due to concurrent writers to the batched
output stream.

This requires changes to plumb through timeout information as well as record the
RPC name in each generated protocol.

It should help to diagnose #7853 and similar issues.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x


## Release Notes

  * none