### PR TITLE
[v22.3.x] cloud_storage: log headers as single line messages

### DIFF
--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -294,3 +294,29 @@ struct fmt::formatter<http::client::request_header> {
         return fmt::format_to(ctx.out(), "{}", s.str());
     }
 };
+
+template<>
+struct fmt::formatter<http::client::response_header> {
+    char presentation = 'u'; // 'u' for unchanged, 'l' for one line
+    constexpr auto parse(format_parse_context& ctx) {
+        auto it = ctx.begin();
+        auto end = ctx.end();
+        if (it != end && (*it == 'l' || *it == 'u')) presentation = *it++;
+        if (it != end && *it != '}') throw format_error("invalid format");
+        return it;
+    }
+
+    auto format(http::client::response_header& h, auto& ctx) const {
+        if (presentation == 'u') {
+            std::stringstream s;
+            s << h;
+            return fmt::format_to(ctx.out(), "{}", s.str());
+        }
+        // format one line
+        auto out = ctx.out();
+        for (auto& f : h) {
+            out = fmt::format_to(out, "[{}: {}];", f.name_string(), f.value());
+        }
+        return out;
+    }
+};

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -524,12 +524,12 @@ ss::future<http::client::response_stream_ref> client::get_object(
                       && result == boost::beast::http::status::not_found) {
                         vlog(
                           s3_log.debug,
-                          "S3 replied with expected error: {}",
+                          "S3 replied with expected error: {:l}",
                           ref->get_headers());
                     } else {
                         vlog(
                           s3_log.warn,
-                          "S3 replied with error: {}",
+                          "S3 replied with error: {:l}",
                           ref->get_headers());
                     }
                     return drain_response_stream(std::move(ref))
@@ -565,14 +565,14 @@ ss::future<client::head_object_result> client::head_object(
                   if (status == boost::beast::http::status::not_found) {
                       vlog(
                         s3_log.debug,
-                        "Object not available, error: {}",
+                        "Object not available, error: {:l}",
                         ref->get_headers());
                       return parse_head_error_response<head_object_result>(
                         ref->get_headers(), key);
                   } else if (status != boost::beast::http::status::ok) {
                       vlog(
                         s3_log.warn,
-                        "S3 replied with error: {}",
+                        "S3 replied with error: {:l}",
                         ref->get_headers());
                       return parse_head_error_response<head_object_result>(
                         ref->get_headers(), key);
@@ -627,7 +627,7 @@ ss::future<> client::put_object(
                     if (status != boost::beast::http::status::ok) {
                         vlog(
                           s3_log.warn,
-                          "S3 replied with error: {}",
+                          "S3 replied with error: {:l}",
                           ref->get_headers());
                         return parse_rest_error_response<>(
                           status, std::move(res));
@@ -684,7 +684,7 @@ ss::future<client::list_bucket_result> client::list_objects_v2(
                           // We received error response so the outbuf contains
                           // error digest instead of the result of the query
                           vlog(
-                            s3_log.warn, "S3 replied with error: {}", header);
+                            s3_log.warn, "S3 replied with error: {:l}", header);
                           return parse_rest_error_response<
                             client::list_bucket_result>(
                             header.result(), std::move(outbuf));
@@ -716,7 +716,7 @@ ss::future<> client::delete_object(
                      != boost::beast::http::status::no_content) { // expect 204
                   vlog(
                     s3_log.warn,
-                    "S3 replied with error: {}",
+                    "S3 replied with error: {:l}",
                     ref->get_headers());
                   return parse_rest_error_response<>(status, std::move(res));
               }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7947

