### PR TITLE
[v22.3.x] Backport 7656 v22.3.x 670

### DIFF
--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -70,4 +70,9 @@ ss::future<> api::stop() {
     }
 }
 
+ss::future<> api::restart() {
+    co_await stop();
+    co_await start();
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/api.h
+++ b/src/v/pandaproxy/schema_registry/api.h
@@ -42,6 +42,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    ss::future<> restart();
 
 private:
     model::node_id _node_id;

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -11,7 +11,8 @@ set(swags
   transaction
   cluster
   debug
-  shadow_indexing)
+  shadow_indexing
+  redpanda_services_restart)
 
 set(swag_files)
 foreach(swag ${swags})

--- a/src/v/redpanda/admin/api-doc/redpanda_services_restart.json
+++ b/src/v/redpanda/admin/api-doc/redpanda_services_restart.json
@@ -1,0 +1,31 @@
+"/v1/redpanda-services/restart": {
+  "put": {
+    "summary": "Restart a redpanda service.",
+    "operationId": "redpanda_services_restart",
+    "parameters": [
+      {
+        "name": "service",
+        "in": "query",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "200": {
+        "description": "Restart success"
+      },
+      "400": {
+        "description": "Service name is required"
+      },
+      "404": {
+        "description": "Service not found"
+      },
+      "500": {
+        "description": "Internal Server error"
+      }
+    }
+  }
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -53,6 +53,7 @@
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "net/dns.h"
+#include "pandaproxy/schema_registry/api.h"
 #include "raft/types.h"
 #include "redpanda/admin/api-doc/broker.json.h"
 #include "redpanda/admin/api-doc/cluster.json.h"
@@ -63,6 +64,7 @@
 #include "redpanda/admin/api-doc/hbadger.json.h"
 #include "redpanda/admin/api-doc/partition.json.h"
 #include "redpanda/admin/api-doc/raft.json.h"
+#include "redpanda/admin/api-doc/redpanda_services_restart.json.h"
 #include "redpanda/admin/api-doc/security.json.h"
 #include "redpanda/admin/api-doc/shadow_indexing.json.h"
 #include "redpanda/admin/api-doc/status.json.h"
@@ -110,7 +112,8 @@ admin_server::admin_server(
   ss::sharded<cluster::metadata_cache>& metadata_cache,
   ss::sharded<archival::scheduler_service>& archival_service,
   ss::sharded<rpc::connection_cache>& connection_cache,
-  ss::sharded<cluster::node_status_table>& node_status_table)
+  ss::sharded<cluster::node_status_table>& node_status_table,
+  pandaproxy::schema_registry::api* schema_registry)
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
@@ -122,7 +125,8 @@ admin_server::admin_server(
   , _connection_cache(connection_cache)
   , _auth(config::shard_local_cfg().admin_api_require_auth.bind(), _controller)
   , _archival_service(archival_service)
-  , _node_status_table(node_status_table) {}
+  , _node_status_table(node_status_table)
+  , _schema_registry(schema_registry) {}
 
 ss::future<> admin_server::start() {
     configure_metrics_route();
@@ -172,6 +176,8 @@ void admin_server::configure_admin_routes() {
     rb->register_api_file(_server._routes, "debug");
     rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "cluster");
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "redpanda_services_restart");
     register_config_routes();
     register_cluster_config_routes();
     register_raft_routes();
@@ -186,6 +192,7 @@ void admin_server::configure_admin_routes() {
     register_debug_routes();
     register_cluster_routes();
     register_shadow_indexing_routes();
+    register_redpanda_service_restart_routes();
 }
 
 static json::validator make_set_replicas_validator() {
@@ -3192,5 +3199,47 @@ void admin_server::register_shadow_indexing_routes() {
       ss::httpd::shadow_indexing_json::sync_local_state,
       [this](std::unique_ptr<ss::httpd::request> req) {
           return sync_local_state_handler(std::move(req));
+      });
+}
+
+ss::future<> admin_server::restart_redpanda_service(service_kind service) {
+    if (service == service_kind::schema_registry) {
+        // Checks specific to schema registry
+        if (_schema_registry == nullptr) {
+            throw ss::httpd::server_error_exception(
+              "Schema Registry is undefined. Is it set in the .yaml config "
+              "file?");
+        }
+
+        try {
+            co_await _schema_registry->restart();
+        } catch (...) {
+            throw ss::httpd::server_error_exception(
+              "Unknown issue restarting schema_registry");
+        }
+    }
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::redpanda_services_restart_handler(
+  std::unique_ptr<ss::httpd::request> req) {
+    auto service_param = req->get_query_param("service");
+    std::optional<service_kind> service = from_string_view<service_kind>(
+      service_param);
+    if (!service.has_value()) {
+        throw ss::httpd::not_found_exception(
+          fmt::format("Invalid service: {}", service));
+    }
+
+    vlog(logger.info, "Restart redpanda service: {}", service);
+    co_await restart_redpanda_service(*service);
+    co_return ss::json::json_return_type(ss::json::json_void());
+}
+
+void admin_server::register_redpanda_service_restart_routes() {
+    register_route<superuser>(
+      ss::httpd::redpanda_services_restart_json::redpanda_services_restart,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return redpanda_services_restart_handler(std::move(req));
       });
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -15,7 +15,9 @@
 #include "config/endpoint_tls_config.h"
 #include "coproc/partition_manager.h"
 #include "model/metadata.h"
+#include "pandaproxy/schema_registry/fwd.h"
 #include "request_auth.h"
+#include "rp_services.h"
 #include "rpc/connection_cache.h"
 #include "seastarx.h"
 
@@ -54,7 +56,8 @@ public:
       ss::sharded<cluster::metadata_cache>&,
       ss::sharded<archival::scheduler_service>&,
       ss::sharded<rpc::connection_cache>&,
-      ss::sharded<cluster::node_status_table>&);
+      ss::sharded<cluster::node_status_table>&,
+      pandaproxy::schema_registry::api*);
 
     ss::future<> start();
     ss::future<> stop();
@@ -231,6 +234,7 @@ private:
     void register_debug_routes();
     void register_cluster_routes();
     void register_shadow_indexing_routes();
+    void register_redpanda_service_restart_routes();
 
     ss::future<ss::json::json_return_type> patch_cluster_config_handler(
       std::unique_ptr<ss::httpd::request>, const request_auth_result&);
@@ -306,6 +310,9 @@ private:
     ss::future<ss::json::json_return_type>
       sync_local_state_handler(std::unique_ptr<ss::httpd::request>);
 
+    ss::future<ss::json::json_return_type>
+      redpanda_services_restart_handler(std::unique_ptr<ss::httpd::request>);
+
     ss::future<> throw_on_error(
       ss::httpd::request& req,
       std::error_code ec,
@@ -334,6 +341,8 @@ private:
     void rearm_log_level_timer();
     void log_level_timer_handler();
 
+    ss::future<> restart_redpanda_service(service_kind service);
+
     ss::http_server _server;
     admin_server_cfg _cfg;
     ss::sharded<cluster::partition_manager>& _partition_manager;
@@ -346,4 +355,5 @@ private:
     bool _ready{false};
     ss::sharded<archival::scheduler_service>& _archival_service;
     ss::sharded<cluster::node_status_table>& _node_status_table;
+    pandaproxy::schema_registry::api* _schema_registry;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -637,7 +637,8 @@ void application::configure_admin_server() {
       std::ref(metadata_cache),
       std::ref(archival_scheduler),
       std::ref(_connection_cache),
-      std::ref(node_status_table))
+      std::ref(node_status_table),
+      _schema_registry.get())
       .get();
 }
 

--- a/src/v/redpanda/rp_services.h
+++ b/src/v/redpanda/rp_services.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/string_switch.h"
+
+#include <type_traits>
+
+enum class service_kind {
+    schema_registry,
+};
+
+constexpr std::string_view to_string_view(service_kind kind) {
+    switch (kind) {
+    case service_kind::schema_registry:
+        return "schema-registry";
+    }
+    return "invalid";
+}
+
+template<typename E>
+std::enable_if_t<std::is_enum_v<E>, std::optional<E>>
+  from_string_view(std::string_view);
+
+template<>
+constexpr std::optional<service_kind>
+from_string_view<service_kind>(std::string_view sv) {
+    return string_switch<std::optional<service_kind>>(sv)
+      .match(
+        to_string_view(service_kind::schema_registry),
+        service_kind::schema_registry)
+      .default_match(std::nullopt);
+}

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -776,3 +776,8 @@ class Admin:
             raise
         if len(r.text) > 0:
             return r.json()["cluster_uuid"]
+
+    def redpanda_services_restart(self, rp_service: Optional[str] = None):
+        service_param = f"service={rp_service if rp_service is not None else ''}"
+        return self._request("PUT",
+                             f"redpanda-services/restart?{service_param}")

--- a/tests/rptest/tests/restart_services_test.py
+++ b/tests/rptest/tests/restart_services_test.py
@@ -1,0 +1,62 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import requests
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+from rptest.services.redpanda import ResourceSettings, LoggingConfig
+
+log_config = LoggingConfig('info',
+                           logger_levels={
+                               'admin_api_server': 'trace',
+                               'security': 'trace',
+                               'pandaproxy': 'trace',
+                               'kafka/client': 'trace'
+                           })
+
+
+class RestartServicesTest(RedpandaTest):
+    #
+    # Smoke test the redpanda-services/restart Admin API endpoint
+    #
+    def __init__(self, context, **kwargs):
+        super(RestartServicesTest, self).__init__(
+            context,
+            extra_rp_conf={"auto_create_topics_enabled": False},
+            resource_settings=ResourceSettings(num_cpus=1),
+            log_config=log_config,
+            enable_sr=True,
+            **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_restart_services(self):
+        admin = Admin(self.redpanda)
+
+        # Failure checks
+        self.logger.debug("Check restart with no service name")
+        try:
+            admin.redpanda_services_restart()
+        except requests.exceptions.HTTPError as ex:
+            self.logger.debug(ex)
+            assert ex.response.status_code == requests.codes.bad_request
+
+        self.logger.debug("Check restart with invalid service name")
+        try:
+            admin.redpanda_services_restart(rp_service='foobar')
+        except requests.exceptions.HTTPError as ex:
+            self.logger.debug(ex)
+            assert ex.response.status_code == requests.codes.not_found
+
+        self.logger.debug("Check schema registry restart")
+        result_raw = admin.redpanda_services_restart(
+            rp_service='schema-registry')
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -61,6 +61,7 @@ message Test2 {
 
 log_config = LoggingConfig('info',
                            logger_levels={
+                               'admin_api_server': 'trace',
                                'security': 'trace',
                                'pandaproxy': 'trace',
                                'kafka/client': 'trace'
@@ -1205,6 +1206,118 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             for n in self.redpanda.nodes:
                 check_connection(n.account.hostname)
             move_leader()
+
+    @cluster(num_nodes=3)
+    def test_restart_schema_registry(self):
+        # Create several schemas on one subject and return the list schemas and schema ids
+        def register_schemas(subject: str):
+            schemas = [
+                json.dumps({"schema": schema1_def}),
+                json.dumps({"schema": schema2_def}),
+                json.dumps({"schema": schema3_def})
+            ]
+            schema_ids = []
+
+            for schema in schemas:
+                self.logger.debug(f"Post schema {json.loads(schema)}")
+                result_raw = self._post_subjects_subject_versions(
+                    subject=subject, data=schema)
+                self.logger.debug(result_raw)
+                assert result_raw.status_code == requests.codes.ok
+                res = result_raw.json()
+                self.logger.debug(res)
+                assert "id" in res
+                schema_ids.append(result_raw.json()["id"])
+
+            return schemas, schema_ids
+
+        # Given a list of subjects, check that they exist on the registry
+        def check_subjects(subjects: list[str]):
+            result_raw = self._get_subjects()
+            self.logger.debug(result_raw)
+            assert result_raw.status_code == requests.codes.ok
+            res_subjects = result_raw.json()
+            self.logger.debug(res_subjects)
+            assert type(res_subjects) == type([])
+            res_subjects.sort()
+            subjects.sort()
+            assert res_subjects == subjects
+
+        # Given the subject and list of versions, check that the version numbers match
+        def check_subject_versions(subject: str, subject_versions: list[int]):
+            result_raw = self._get_subjects_subject_versions(subject=subject)
+            self.logger.debug(result_raw)
+            assert result_raw.status_code == requests.codes.ok
+            res_versions = result_raw.json()
+            self.logger.debug(res_versions)
+            assert type(res_versions) == type([])
+            res_versions.sort()
+            subject_versions.sort()
+            assert res_versions == subject_versions
+
+        # Given the subject, list of schemas, list of versions, and list of ids,
+        # check the schema that maps to the id
+        def check_each_schema(subject: str, schemas: list[str],
+                              schema_ids: list[int],
+                              subject_versions: list[int]):
+            for version in subject_versions:
+                self.logger.debug(
+                    f"Fetch schema version {version} on subject {subject}")
+                result_raw = self._get_subjects_subject_versions_version(
+                    subject=subject, version=version)
+                self.logger.debug(result_raw)
+                assert result_raw.status_code == requests.codes.ok
+                res = result_raw.json()
+                self.logger.debug(res)
+                assert type(res) == type({})
+                assert "subject" in res
+                assert "version" in res
+                assert "id" in res
+                assert "schema" in res
+                assert res["subject"] == subject
+                assert res["version"] == version
+                assert res["id"] in schema_ids
+                schema = json.loads(schemas[version - 1])
+                assert res["schema"] == schema["schema"]
+
+        admin = Admin(self.redpanda)
+
+        num_subjects = 3
+        subjects = {}
+        for _ in range(num_subjects):
+            subjects[f"{create_topic_names(1)[0]}-key"] = {
+                "schemas": [],
+                "schema_ids": [],
+                "subject_versions": []
+            }
+
+        self.logger.debug("Register and check schemas before restart")
+        for subject in subjects:
+            schemas, schema_ids = register_schemas(subject)
+            result_raw = self._get_subjects_subject_versions(subject=subject)
+            self.logger.debug(result_raw)
+            assert result_raw.status_code == requests.codes.ok
+            subject_versions = result_raw.json()
+            check_subject_versions(subject, subject_versions)
+            check_each_schema(subject, schemas, schema_ids, subject_versions)
+            subjects[subject]["schemas"] = schemas
+            subjects[subject]["schema_ids"] = schema_ids
+            subjects[subject]["subject_versions"] = subject_versions
+        check_subjects(list(subjects.keys()))
+
+        self.logger.debug("Restart the schema registry")
+        result_raw = admin.redpanda_services_restart(
+            rp_service='schema-registry')
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug("Check schemas after restart")
+        check_subjects(list(subjects.keys()))
+        for subject in subjects:
+            check_subject_versions(subject, subjects[subject]["schema_ids"])
+            check_each_schema(subject, subjects[subject]["schemas"],
+                              subjects[subject]["schema_ids"],
+                              subjects[subject]["subject_versions"])
 
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):


### PR DESCRIPTION
## Cover letter

Backport PR #7765 

To resolve backport conflicts, the following changes were made:
- Removed `self_test_frontend`, `register_self_test_routes`, and `self_test_get_results_handler` in admin_server.cc (See commit 5091a615361e335eff36704673e3cd3bd0f2affd)
- Removed `self_test_start_handler`, `self_test_stop_handler`, and `self_test_get_results_handler` in the admin_server (See commit 2c58ed0833b9620cc57fd5f4732197d4086d6173)
- Removed `self_test_start`, `self_test_stop`, and `self_test_status` in `tests/rptest/services/admin.py` (See commit b6f05cdcada5d12cde871bb4d143c9b5d6a1914a)

Changes from force-push `b976687`:
- Fix linter problems

Changes from force-push `6645fbc`:
- Fix syntax errors

Changes from force-push `409942e`:
- Remove `SchemaRegistryConfig` from DT tests

Fixes: #8080


## UX Changes

* Users can now restart the schema registry by issuing a PUT request to `admin/redpanda-services/restart?service=schema-registry`. This request will wipe schema registry state.

## Release Notes

### Improvements

* Adds a new endpoint to the schema registry that clears the in-memory data.