### PR TITLE
[v22.3.x] backport unlink segment states on remote part stop

### DIFF
--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -248,6 +248,11 @@ void materialized_segments::trim_readers(size_t target_free) {
  * anything if no segments have an atime older than the TTL.  Ssee trim_readers
  * for how to trim the reader population back to a specific size
  *
+ * NOTE: This method must never be made async or yield while iterating over
+ * segments. If it does yield and remote_partition::stop runs, remote_partition
+ * can clear out the segments map, and a subsequent offload of that segment will
+ * cause a vassert failure.
+ *
  * @param target_free: if set, the trim will remove segments until the
  *        number of units available in segments_semaphore reaches the
  *        target, or until it runs out of candidates for eviction.  This

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -578,6 +578,13 @@ ss::future<> remote_partition::stop() {
     vlog(_ctxlog.debug, "remote partition stop {} segments", _segments.size());
 
     co_await _gate.close();
+    // Remove materialized_segment_state from the list that contains it, to
+    // avoid it getting registered for eviction and stop.
+    for (auto& pair : _segments) {
+        vlog(
+          _ctxlog.debug, "unlinking segment {}", pair.second->base_rp_offset());
+        pair.second->unlink();
+    }
 
     for (auto& s : _segments) {
         vlog(

--- a/src/v/cloud_storage/segment_state.h
+++ b/src/v/cloud_storage/segment_state.h
@@ -60,6 +60,11 @@ struct materialized_segment_state {
     /// List hook for the list of all materalized segments
     intrusive_list_hook _hook;
 
+    /// Removes object from list that it is part of. Used to isolate the object
+    /// before stopping it, so that the stop method is only called from one
+    /// place.
+    void unlink() { _hook.unlink(); }
+
     /// Record which partition this segment relates to.  This weak_ptr should
     /// never be broken, because our lifetime is shorter than our parent, but
     /// a weak_ptr is preferable to a reference (crash on bug) or a shared_ptr


### PR DESCRIPTION
Manual backport for https://github.com/redpanda-data/redpanda/pull/7868 - necessary because the automated backport failed, a commit `137e0de453dc8166a26e15d46dbd68c41ef57601` became empty on cherry-pick because this commit was essentially a revert of some intermediate code, so it had to be skipped:

The failed cherry pick attempt:
https://github.com/redpanda-data/redpanda/actions/runs/3848862980
```
git cherry-pick -x 147d40f2874085f0f67219bccd45f7160ee28c34 137e0de453dc8166a26e15d46dbd68c41ef57601 e4d566d4e3dee666b66cedb557053244aec18e42
```

Skipped 137e0de453dc8166a26e15d46dbd68c41ef57601

## UX Changes

  * none

## Release Notes

  * none