### PR TITLE
cloud_storage: add Azure Blob Storage Support for Tiered Storage

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -68,8 +68,8 @@ struct archival_metadata_stm_base_fixture
         conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
           net::metrics_disabled::yes,
           net::public_metrics_disabled::yes,
-          "us-east-1",
-          ss::sstring(httpd_host_name));
+          cloud_roles::aws_region_name{"us-east-1"},
+          cloud_storage_clients::endpoint_url{httpd_host_name});
         return conf;
     }
 

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -163,7 +163,10 @@ archiver_fixture::get_configurations() {
     s3conf.secret_key = cloud_roles::private_key_str("secret-key");
     s3conf.region = cloud_roles::aws_region_name("us-east-1");
     s3conf._probe = ss::make_shared(cloud_storage_clients::client_probe(
-      net::metrics_disabled::yes, net::public_metrics_disabled::yes, "", ""));
+      net::metrics_disabled::yes,
+      net::public_metrics_disabled::yes,
+      cloud_roles::aws_region_name{},
+      cloud_storage_clients::endpoint_url{}));
     s3conf.server_addr = server_addr;
 
     archival::configuration aconf;

--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -49,7 +49,8 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
 }
 
 static ss::sstring get_value_or_throw(
-  const config::property<std::optional<ss::sstring>>& prop, const char* name) {
+  const config::property<std::optional<ss::sstring>>& prop,
+  std::string_view name) {
     auto opt = prop.value();
     if (!opt) {
         vlog(
@@ -81,10 +82,12 @@ get_archival_service_config(ss::scheduling_group sg, ss::io_priority_class p) {
     auto time_limit_opt = time_limit ? std::make_optional(
                             segment_time_limit(*time_limit))
                                      : std::nullopt;
+
+    const auto& bucket_config
+      = cloud_storage::configuration::get_bucket_config();
     archival::configuration cfg{
-      .bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
-        config::shard_local_cfg().cloud_storage_bucket,
-        "cloud_storage_bucket")),
+      .bucket_name = cloud_storage_clients::bucket_name(
+        get_value_or_throw(bucket_config, bucket_config.name())),
       .cloud_storage_initial_backoff
       = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value(),
       .segment_upload_timeout

--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -516,8 +516,7 @@ std::error_code
 signature_abs::sign_header(http::client::request_header& header) const {
     auto ms_date = _sig_time.format_http_datetime();
     header.set("x-ms-date", {ms_date.data(), ms_date.size()});
-    // TODO(vlad): Support more versions?
-    header.set("x-ms-version", "2021-08-06");
+    header.set("x-ms-version", azure_storage_api_version);
 
     const auto to_sign = get_string_to_sign(header);
     if (!to_sign) {

--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -149,6 +149,14 @@ public:
     std::error_code sign_header(http::client::request_header& header) const;
 
 private:
+    // Azure expects every request to Blob Storage to contain an
+    // 'x-ms-version' header that specifies the API version to use.
+    // This version is hardcoded in Redpanda to ensure that an API
+    // version that we've tested with is used in field.
+    //
+    // Update this version to use a different storage API version.
+    static constexpr auto azure_storage_api_version = "2021-08-06";
+
     result<ss::sstring>
     get_string_to_sign(http::client::request_header& header) const;
 

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -924,6 +924,12 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
                                   cloud_storage_clients::s3_configuration,
                                   cfg_type>) {
                       return cloud_roles::aws_region_name{cfg.region};
+                  } else if constexpr (std::is_same_v<
+                                         cloud_storage_clients::
+                                           abs_configuration,
+                                         cfg_type>) {
+                      vassert(false, "Attempt to create refresh creds for ABS");
+                      return cloud_roles::aws_region_name{};
                   } else {
                       static_assert(
                         cloud_storage_clients::always_false_v<cfg_type>,
@@ -962,7 +968,7 @@ bool auth_refresh_bg_op::is_static_config() const {
 
 cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
     return std::visit(
-      [](const auto& cfg) {
+      [](const auto& cfg) -> cloud_roles::credentials {
           using cfg_type = std::decay_t<decltype(cfg)>;
           if constexpr (std::is_same_v<
                           cloud_storage_clients::s3_configuration,
@@ -972,6 +978,11 @@ cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
                 cfg.secret_key.value(),
                 std::nullopt,
                 cfg.region};
+          } else if constexpr (std::is_same_v<
+                                 cloud_storage_clients::abs_configuration,
+                                 cfg_type>) {
+              return cloud_roles::abs_credentials{
+                cfg.storage_account_name, cfg.shared_key.value()};
           } else {
               static_assert(
                 cloud_storage_clients::always_false_v<cfg_type>,

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -344,7 +344,6 @@ ss::future<upload_result> remote::upload_segment(
         if (res) {
             _probe.successful_upload();
             _probe.register_upload_size(content_length);
-            co_await reader_handle->close();
             co_return upload_result::success;
         }
 

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -50,8 +50,8 @@ s3_imposter_fixture::get_configuration() {
     conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,
       net::public_metrics_disabled::yes,
-      "us-east-1",
-      httpd_host_name);
+      cloud_roles::aws_region_name{"us-east-1"},
+      cloud_storage_clients::endpoint_url{httpd_host_name});
     return conf;
 }
 

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -11,8 +11,31 @@
 #include "cloud_storage/types.h"
 
 #include "cloud_storage/logger.h"
-#include "config/configuration.h"
 #include "vlog.h"
+
+namespace {
+cloud_storage_clients::default_overrides get_default_overrides() {
+    // Set default overrides
+    cloud_storage_clients::default_overrides overrides;
+    overrides.max_idle_time
+      = config::shard_local_cfg()
+          .cloud_storage_max_connection_idle_time_ms.value();
+    if (auto optep
+        = config::shard_local_cfg().cloud_storage_api_endpoint.value();
+        optep.has_value()) {
+        overrides.endpoint = cloud_storage_clients::endpoint_url(*optep);
+    }
+    overrides.disable_tls = config::shard_local_cfg().cloud_storage_disable_tls;
+    if (auto cert = config::shard_local_cfg().cloud_storage_trust_file.value();
+        cert.has_value()) {
+        overrides.trust_file = cloud_storage_clients::ca_trust_file(
+          std::filesystem::path(*cert));
+    }
+    overrides.port = config::shard_local_cfg().cloud_storage_api_endpoint_port;
+
+    return overrides;
+}
+} // namespace
 
 namespace cloud_storage {
 
@@ -114,7 +137,15 @@ static ss::sstring get_value_or_throw(
 }
 
 ss::future<configuration> configuration::get_config() {
-    vlog(cst_log.debug, "Generating archival configuration");
+    if (config::shard_local_cfg().cloud_storage_azure_storage_account()) {
+        co_return co_await get_abs_config();
+    } else {
+        co_return co_await get_s3_config();
+    }
+}
+
+ss::future<configuration> configuration::get_s3_config() {
+    vlog(cst_log.debug, "Generating S3 cloud storage configuration");
 
     auto cloud_credentials_source
       = config::shard_local_cfg().cloud_storage_credentials_source.value();
@@ -145,30 +176,12 @@ ss::future<configuration> configuration::get_config() {
     auto disable_public_metrics = net::public_metrics_disabled(
       config::shard_local_cfg().disable_public_metrics());
 
-    // Set default overrides
-    cloud_storage_clients::default_overrides overrides;
-    overrides.max_idle_time
-      = config::shard_local_cfg()
-          .cloud_storage_max_connection_idle_time_ms.value();
-    if (auto optep
-        = config::shard_local_cfg().cloud_storage_api_endpoint.value();
-        optep.has_value()) {
-        overrides.endpoint = cloud_storage_clients::endpoint_url(*optep);
-    }
-    overrides.disable_tls = config::shard_local_cfg().cloud_storage_disable_tls;
-    if (auto cert = config::shard_local_cfg().cloud_storage_trust_file.value();
-        cert.has_value()) {
-        overrides.trust_file = cloud_storage_clients::ca_trust_file(
-          std::filesystem::path(*cert));
-    }
-    overrides.port = config::shard_local_cfg().cloud_storage_api_endpoint_port;
-
     auto s3_conf
       = co_await cloud_storage_clients::s3_configuration::make_configuration(
         access_key,
         secret_key,
         region,
-        overrides,
+        get_default_overrides(),
         disable_metrics,
         disable_public_metrics);
 
@@ -183,8 +196,76 @@ ss::future<configuration> configuration::get_config() {
         "cloud_storage_bucket")),
       .cloud_credentials_source = cloud_credentials_source,
     };
-    vlog(cst_log.debug, "Cloud storage configuration generated: {}", cfg);
+
+    vlog(cst_log.debug, "S3 cloud storage configuration generated: {}", cfg);
     co_return cfg;
+}
+
+ss::future<configuration> configuration::get_abs_config() {
+    vlog(cst_log.debug, "Generating ABS cloud storage configuration");
+
+    const auto storage_account = cloud_roles::storage_account{
+      get_value_or_throw(
+        config::shard_local_cfg().cloud_storage_azure_storage_account,
+        "cloud_storage_azure_storage_account")};
+    const auto container = get_value_or_throw(
+      config::shard_local_cfg().cloud_storage_azure_container,
+      "cloud_storage_azure_container");
+    const auto shared_key = cloud_roles::private_key_str{get_value_or_throw(
+      config::shard_local_cfg().cloud_storage_azure_shared_key,
+      "cloud_storage_azure_shared_key")};
+
+    const auto cloud_credentials_source
+      = config::shard_local_cfg().cloud_storage_credentials_source.value();
+    if (
+      cloud_credentials_source
+      != model::cloud_credentials_source::config_file) {
+        vlog(
+          cst_log.error,
+          "Configuration property cloud_storage_credentials_source must be set "
+          "to 'config_file' as only Shared Key Authorization is supported for "
+          "now.");
+        throw std::runtime_error(
+          "configuration property cloud_storage_credentials_source is not "
+          "equal to 'config_file'");
+    }
+
+    auto disable_metrics = net::metrics_disabled(
+      config::shard_local_cfg().disable_metrics());
+    auto disable_public_metrics = net::public_metrics_disabled(
+      config::shard_local_cfg().disable_public_metrics());
+
+    auto abs_conf
+      = co_await cloud_storage_clients::abs_configuration::make_configuration(
+        shared_key,
+        storage_account,
+        get_default_overrides(),
+        disable_metrics,
+        disable_public_metrics);
+
+    configuration cfg{
+      .client_config = std::move(abs_conf),
+      .connection_limit = cloud_storage::connection_limit(
+        config::shard_local_cfg().cloud_storage_max_connections.value()),
+      .metrics_disabled = remote_metrics_disabled(
+        static_cast<bool>(disable_metrics)),
+      .bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
+        config::shard_local_cfg().cloud_storage_azure_container,
+        "cloud_storage_azure_container")),
+      .cloud_credentials_source = cloud_credentials_source,
+    };
+
+    vlog(cst_log.debug, "ABS cloud storage configuration generated: {}", cfg);
+    co_return cfg;
+}
+
+const config::property<std::optional<ss::sstring>>&
+configuration::get_bucket_config() {
+    if (config::shard_local_cfg().cloud_storage_azure_storage_account()) {
+        return config::shard_local_cfg().cloud_storage_azure_container;
+    } else {
+        return config::shard_local_cfg().cloud_storage_bucket;
+    }
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage_clients/configuration.h"
+#include "config/configuration.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -82,13 +83,13 @@ std::ostream& operator<<(std::ostream& o, const download_result& r);
 std::ostream& operator<<(std::ostream& o, const upload_result& r);
 
 struct configuration {
-    /// S3 configuration
+    /// Client configuration
     cloud_storage_clients::client_configuration client_config;
-    /// Number of simultaneous S3 uploads
+    /// Number of simultaneous client uploads
     connection_limit connection_limit;
     /// Disable metrics in the remote
     remote_metrics_disabled metrics_disabled;
-    /// The bucket to use
+    /// The S3 bucket or ABS container to use
     cloud_storage_clients::bucket_name bucket_name;
 
     model::cloud_credentials_source cloud_credentials_source;
@@ -96,6 +97,10 @@ struct configuration {
     friend std::ostream& operator<<(std::ostream& o, const configuration& cfg);
 
     static ss::future<configuration> get_config();
+    static ss::future<configuration> get_s3_config();
+    static ss::future<configuration> get_abs_config();
+    static const config::property<std::optional<ss::sstring>>&
+    get_bucket_config();
 };
 
 struct offset_range {

--- a/src/v/cloud_storage_clients/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/CMakeLists.txt
@@ -2,6 +2,7 @@
 v_cc_library(
   NAME cloud_storage_clients
   SRCS
+    abs_client.cc
     abs_error.cc
     client_pool.cc
     client_probe.cc

--- a/src/v/cloud_storage_clients/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/CMakeLists.txt
@@ -2,6 +2,7 @@
 v_cc_library(
   NAME cloud_storage_clients
   SRCS
+    abs_error.cc
     client_pool.cc
     client_probe.cc
     configuration.cc

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -1,0 +1,634 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/abs_client.h"
+
+#include "cloud_storage_clients/abs_error.h"
+#include "cloud_storage_clients/configuration.h"
+#include "cloud_storage_clients/logger.h"
+#include "cloud_storage_clients/util.h"
+#include "vlog.h"
+
+#include <utility>
+
+namespace {
+
+// These are the HTTP codes on which Microsoft's SDKs retry requests.
+// The mapping to ABS error codes is:
+// [500 -> "InternalError", 500 ->, "OperationTimedOut", 503 -> "ServerBusy"].
+// Note how some of these HTTP codes don't have a corresponding ABS error code,
+// and, hence shouldn't be returned by the server. It's likely that these extra
+// HTTP codes were used by older versions of the server, and since we can't
+// verify that, we keep them here.
+constexpr std::array<boost::beast::http::status, 6> retryable_http_codes = {
+  boost::beast::http::status::request_timeout,       // 408
+  boost::beast::http::status::too_many_requests,     // 429
+  boost::beast::http::status::internal_server_error, // 500
+  boost::beast::http::status::bad_gateway,           // 502
+  boost::beast::http::status::service_unavailable,   // 503
+  boost::beast::http::status::gateway_timeout,       // 504
+};
+
+constexpr boost::beast::string_view content_type_value = "text/plain";
+constexpr boost::beast::string_view blob_type_value = "BlockBlob";
+constexpr boost::beast::string_view blob_type_name = "x-ms-blob-type";
+constexpr boost::beast::string_view tags_name = "x-ms-tags";
+constexpr boost::beast::string_view delete_snapshot_name
+  = "x-ms-delete-snapshots";
+constexpr boost::beast::string_view delete_snapshot_value = "include";
+
+cloud_storage_clients::abs_client::list_bucket_result
+iobuf_to_list_bucket_result(iobuf buf) {
+    using namespace cloud_storage_clients;
+
+    try {
+        abs_client::list_bucket_result result;
+        auto root = util::iobuf_to_ptree(std::move(buf), abs_log);
+        auto enum_results = root.get_child("EnumerationResults");
+
+        if (auto prefix = enum_results.get_child_optional("Prefix"); prefix) {
+            result.prefix = prefix->get_value<ss::sstring>();
+        }
+
+        if (auto marker = enum_results.get_child_optional("Marker"); marker) {
+            result.is_truncated = true;
+        } else {
+            result.is_truncated = false;
+        }
+
+        auto blobs = enum_results.get_child("Blobs");
+        for (auto& [tag, blob] : blobs) {
+            abs_client::list_bucket_item item;
+            item.key = blob.get<ss::sstring>("Name");
+            item.size_bytes = blob.get<size_t>("Properties.Content-Length");
+            item.etag = blob.get<ss::sstring>("Properties.Etag");
+            // TODO(vlad): Why doesn't ss::sstring work here?
+            const auto last_modified = blob.get<std::string>(
+              "Properties.Last-Modified");
+            item.last_modified = util::parse_timestamp(last_modified);
+
+            result.contents.push_back(std::move(item));
+        }
+
+        return result;
+    } catch (...) {
+        vlog(
+          abs_log.error,
+          "Failed to parse List Container response: ",
+          std::current_exception());
+        throw;
+    }
+}
+
+bool is_error_retryable(
+  const cloud_storage_clients::abs_rest_error_response& err) {
+    return std::find(
+             retryable_http_codes.begin(),
+             retryable_http_codes.end(),
+             err.http_code())
+           != retryable_http_codes.end();
+}
+} // namespace
+
+namespace cloud_storage_clients {
+
+static abs_rest_error_response
+parse_rest_error_response(boost::beast::http::status result, iobuf buf) {
+    using namespace cloud_storage_clients;
+
+    try {
+        auto resp = util::iobuf_to_ptree(std::move(buf), abs_log);
+        auto code = resp.get<ss::sstring>("Error.Code", "");
+        auto msg = resp.get<ss::sstring>("Error.Message", "");
+        return {std::move(code), std::move(msg), result};
+    } catch (...) {
+        vlog(
+          cloud_storage_clients::abs_log.error,
+          "Failed to parse ABS error response {}",
+          std::current_exception());
+        throw;
+    }
+}
+
+static abs_rest_error_response
+parse_header_error_response(const http::http_response::header_type& hdr) {
+    ss::sstring code;
+    ss::sstring msg;
+    if (hdr.result() == boost::beast::http::status::not_found) {
+        code = "BlobNotFound";
+        msg = "Not found";
+    } else {
+        code = "Unknown";
+        msg = ss::sstring(hdr.reason().data(), hdr.reason().size());
+    }
+
+    return {std::move(code), std::move(msg), hdr.result()};
+}
+
+abs_request_creator::abs_request_creator(
+  const abs_configuration& conf,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
+  : _ap{conf.uri}
+  , _apply_credentials{std::move(apply_credentials)} {}
+
+result<http::client::request_header> abs_request_creator::make_get_blob_request(
+  bucket_name const& name, object_key const& key) {
+    // GET /{container-id}/{blob-id} HTTP/1.1
+    // Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
+    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // Authorization:{signature}           # added by 'add_auth'
+    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::get);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+result<http::client::request_header> abs_request_creator::make_put_blob_request(
+  bucket_name const& name,
+  object_key const& key,
+  size_t payload_size_bytes,
+  const object_tag_formatter& tags) {
+    // PUT /{container-id}/{blob-id} HTTP/1.1
+    // Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
+    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-tags:{object-formatter-tags}
+    // Authorization:{signature}           # added by 'add_auth'
+    // Content-Length:{payload-size}
+    // Content-Type: text/plain
+    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::put);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+    header.insert(boost::beast::http::field::content_type, content_type_value);
+    header.insert(
+      boost::beast::http::field::content_length,
+      std::to_string(payload_size_bytes));
+    header.insert(blob_type_name, blob_type_value);
+
+    if (!tags.empty()) {
+        header.insert(tags_name, tags.str());
+    }
+
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+result<http::client::request_header>
+abs_request_creator::make_get_blob_metadata_request(
+  bucket_name const& name, object_key const& key) {
+    // HEAD /{container-id}/{blob-id}?comp=metadata HTTP/1.1
+    // Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
+    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // Authorization:{signature}           # added by 'add_auth'
+    const auto target = fmt::format(
+      "/{}/{}?comp=metadata", name(), key().string());
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::head);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+result<http::client::request_header>
+abs_request_creator::make_delete_blob_request(
+  bucket_name const& name, object_key const& key) {
+    // DELETE /{container-id}/{blob-id} HTTP/1.1
+    // Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
+    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // Authorization:{signature}           # added by 'add_auth'
+    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::delete_);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+    header.insert(delete_snapshot_name, delete_snapshot_value);
+
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+result<http::client::request_header>
+abs_request_creator::make_list_blobs_request(
+  const bucket_name& name,
+  std::optional<object_key> prefix,
+  [[maybe_unused]] std::optional<object_key> start_after,
+  std::optional<size_t> max_keys) {
+    // GET /{container-id}?restype=container&comp=list&prefix={prefix}...
+    // ...&max_results{max_keys}
+    // HTTP/1.1 Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
+    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // Authorization:{signature}           # added by 'add_auth'
+    auto target = fmt::format("/{}?restype=container&comp=list", name());
+    if (prefix) {
+        target += fmt::format("&prefix={}", prefix.value()().string());
+    }
+
+    if (max_keys) {
+        target += fmt::format("&max_results={}", max_keys.value());
+    }
+
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::get);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+abs_client::abs_client(
+  const abs_configuration& conf,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
+  : _requestor(conf, std::move(apply_credentials))
+  , _client(conf)
+  , _probe(conf._probe) {}
+
+abs_client::abs_client(
+  const abs_configuration& conf,
+  const ss::abort_source& as,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
+  : _requestor(conf, std::move(apply_credentials))
+  , _client(conf, &as, conf._probe, conf.max_idle_time)
+  , _probe(conf._probe) {}
+
+ss::future<> abs_client::stop() { return _client.stop(); }
+
+void abs_client::shutdown() { _client.shutdown(); }
+
+template<typename T>
+ss::future<result<T, error_outcome>> abs_client::send_request(
+  ss::future<T> request_future,
+  const bucket_name& bucket,
+  const object_key& key) {
+    using namespace boost::beast::http;
+
+    auto outcome = error_outcome::fail;
+
+    try {
+        co_return co_await std::move(request_future);
+    } catch (const abs_rest_error_response& err) {
+        if (is_error_retryable(err)) {
+            vlog(
+              abs_log.warn,
+              "Received [{}] {} retryable error response from ABS: {}",
+              err.http_code(),
+              err.code_string(),
+              err.message());
+            outcome = error_outcome::retry_slowdown;
+            _probe->register_retryable_failure();
+        } else if (
+          err.http_code() == status::forbidden
+          || err.http_code() == status::unauthorized) {
+            vlog(
+              abs_log.error,
+              "Received [{}] {} error response from ABS. This indicates "
+              "misconfiguration of ABS and/or Redpanda: {}",
+              err.http_code(),
+              err.code_string(),
+              err.message());
+            outcome = error_outcome::fail;
+            _probe->register_failure(err.code());
+        } else if (
+          err.code() == abs_error_code::container_being_disabled
+          || err.code() == abs_error_code::container_being_deleted
+          || err.code() == abs_error_code::container_not_found) {
+            vlog(
+              abs_log.error,
+              "Received [{}] {} error response from ABS. This indicates "
+              "that your container is not available. Remediate the issue for "
+              "uploads to resume: {}",
+              err.http_code(),
+              err.code_string(),
+              err.message());
+            outcome = error_outcome::fail;
+            _probe->register_failure(err.code());
+        } else if (err.code() == abs_error_code::blob_not_found) {
+            // Unexpected 404s are logged by 'request_future' at warn
+            // level, so only log at debug level here.
+            vlog(abs_log.debug, "BlobNotFound response received {}", key);
+            outcome = error_outcome::key_not_found;
+            _probe->register_failure(err.code());
+        } else {
+            vlog(
+              abs_log.error,
+              "Received [{}] {} unexpected error response for storage account "
+              "{} from ABS: {}",
+              err.http_code(),
+              err.code_string(),
+              err.message());
+            outcome = error_outcome::fail;
+            _probe->register_failure(err.code());
+        }
+    } catch (...) {
+        _probe->register_failure(abs_error_code::_unknown);
+
+        outcome = util::handle_client_transport_error(
+          std::current_exception(), abs_log);
+    }
+
+    co_return outcome;
+}
+
+ss::future<result<http::client::response_stream_ref, error_outcome>>
+abs_client::get_object(
+  bucket_name const& name,
+  object_key const& key,
+  ss::lowres_clock::duration timeout,
+  bool expect_no_such_key) {
+    return send_request(
+      do_get_object(name, key, timeout, expect_no_such_key), name, key);
+}
+
+ss::future<http::client::response_stream_ref> abs_client::do_get_object(
+  bucket_name const& name,
+  object_key const& key,
+  ss::lowres_clock::duration timeout,
+  bool expect_no_such_key) {
+    auto header = _requestor.make_get_blob_request(name, key);
+    if (!header) {
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    vlog(abs_log.trace, "send https request:\n{}", header.value());
+
+    auto response_stream = co_await _client.request(
+      std::move(header.value()), timeout);
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+
+    const auto status = response_stream->get_headers().result();
+    if (status != boost::beast::http::status::ok) {
+        if (
+          expect_no_such_key
+          && status == boost::beast::http::status::not_found) {
+            vlog(
+              abs_log.debug,
+              "ABS replied with expected error: {:l}",
+              response_stream->get_headers());
+        } else {
+            vlog(
+              abs_log.warn,
+              "ABS replied with error: {:l}",
+              response_stream->get_headers());
+        }
+
+        auto buf = co_await util::drain_response_stream(
+          std::move(response_stream));
+        throw parse_rest_error_response(status, std::move(buf));
+    }
+
+    co_return response_stream;
+}
+
+ss::future<result<abs_client::no_response, error_outcome>>
+abs_client::put_object(
+  bucket_name const& name,
+  object_key const& key,
+  size_t payload_size,
+  ss::input_stream<char> body,
+  const object_tag_formatter& tags,
+  ss::lowres_clock::duration timeout) {
+    return send_request(
+      do_put_object(name, key, payload_size, std::move(body), tags, timeout)
+        .then(
+          []() { return ss::make_ready_future<no_response>(no_response{}); }),
+      name,
+      key);
+}
+
+ss::future<> abs_client::do_put_object(
+  bucket_name const& name,
+  object_key const& key,
+  size_t payload_size,
+  ss::input_stream<char> body,
+  const object_tag_formatter& tags,
+  ss::lowres_clock::duration timeout) {
+    auto header = _requestor.make_put_blob_request(
+      name, key, payload_size, tags);
+    if (!header) {
+        co_await body.close();
+
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    vlog(abs_log.trace, "send https request:\n{}", header.value());
+
+    auto response_stream = co_await _client
+                             .request(std::move(header.value()), body, timeout)
+                             .finally([&body] { return body.close(); });
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+
+    const auto status = response_stream->get_headers().result();
+    if (status != boost::beast::http::status::created) {
+        auto buf = co_await util::drain_response_stream(
+          std::move(response_stream));
+        throw parse_rest_error_response(status, std::move(buf));
+    }
+}
+
+ss::future<result<abs_client::head_object_result, error_outcome>>
+abs_client::head_object(
+  bucket_name const& name,
+  object_key const& key,
+  ss::lowres_clock::duration timeout) {
+    return send_request(do_head_object(name, key, timeout), name, key);
+}
+
+ss::future<abs_client::head_object_result> abs_client::do_head_object(
+  bucket_name const& name,
+  object_key const& key,
+  ss::lowres_clock::duration timeout) {
+    auto header = _requestor.make_get_blob_metadata_request(name, key);
+    if (!header) {
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    vlog(abs_log.trace, "send https request:\n{}", header.value());
+
+    auto response_stream = co_await _client.request(
+      std::move(header.value()), timeout);
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+
+    const auto status = response_stream->get_headers().result();
+    if (status == boost::beast::http::status::ok) {
+        const auto etag = response_stream->get_headers().at(
+          boost::beast::http::field::etag);
+        const auto size = boost::lexical_cast<uint64_t>(
+          response_stream->get_headers().at(
+            boost::beast::http::field::content_length));
+        co_return head_object_result{
+          .object_size = size, .etag = ss::sstring{etag.data(), etag.length()}};
+    } else {
+        throw parse_header_error_response(response_stream->get_headers());
+    }
+}
+
+ss::future<result<abs_client::no_response, error_outcome>>
+abs_client::delete_object(
+  const bucket_name& name,
+  const object_key& key,
+  ss::lowres_clock::duration timeout) {
+    using ret_t = result<no_response, error_outcome>;
+    return send_request(
+             do_delete_object(name, key, timeout).then([]() {
+                 return ss::make_ready_future<no_response>(no_response{});
+             }),
+             name,
+             key)
+      .then([&name, &key](const ret_t& result) {
+          // ABS returns a 404 for attempts to delete a blob that doesn't exist.
+          // The remote doesn't expect this, so we map 404s to a successful
+          // response.
+          if (!result && result.error() == error_outcome::key_not_found) {
+              vlog(
+                abs_log.debug,
+                "Object to be deleted was not found in cloud storage: "
+                "object={}, bucket={}. Ignoring ...",
+                name,
+                key);
+              return ss::make_ready_future<ret_t>(no_response{});
+          } else {
+              return ss::make_ready_future<ret_t>(result);
+          }
+      });
+}
+
+ss::future<> abs_client::do_delete_object(
+  const bucket_name& name,
+  const object_key& key,
+  ss::lowres_clock::duration timeout) {
+    auto header = _requestor.make_delete_blob_request(name, key);
+    if (!header) {
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    vlog(abs_log.trace, "send https request:\n{}", header.value());
+
+    auto response_stream = co_await _client.request(
+      std::move(header.value()), timeout);
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+
+    const auto status = response_stream->get_headers().result();
+    if (status != boost::beast::http::status::accepted) {
+        auto buf = co_await util::drain_response_stream(
+          std::move(response_stream));
+        throw parse_rest_error_response(status, std::move(buf));
+    }
+}
+
+ss::future<result<abs_client::list_bucket_result, error_outcome>>
+abs_client::list_objects(
+  const bucket_name& name,
+  std::optional<object_key> prefix,
+  std::optional<object_key> start_after,
+  std::optional<size_t> max_keys,
+  std::optional<ss::sstring> continuation_token,
+  ss::lowres_clock::duration timeout) {
+    return send_request(
+      do_list_objects(
+        name,
+        std::move(prefix),
+        std::move(start_after),
+        max_keys,
+        std::move(continuation_token),
+        timeout),
+      name,
+      object_key{""});
+}
+
+ss::future<abs_client::list_bucket_result> abs_client::do_list_objects(
+  const bucket_name& name,
+  std::optional<object_key> prefix,
+  std::optional<object_key> start_after,
+  std::optional<size_t> max_keys,
+  [[maybe_unused]] std::optional<ss::sstring> continuation_token,
+  ss::lowres_clock::duration timeout) {
+    auto header = _requestor.make_list_blobs_request(
+      name, std::move(prefix), std::move(start_after), max_keys);
+    if (!header) {
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    vlog(abs_log.trace, "send https request:\n{}", header.value());
+
+    auto response_stream = co_await _client.request(
+      std::move(header.value()), timeout);
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+    const auto status = response_stream->get_headers().result();
+
+    iobuf buf = co_await util::drain_response_stream(response_stream);
+    if (status != boost::beast::http::status::ok) {
+        throw parse_rest_error_response(status, std::move(buf));
+    } else {
+        co_return iobuf_to_list_bucket_result(std::move(buf));
+    }
+}
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/apply_credentials.h"
+#include "cloud_storage_clients/client.h"
+#include "cloud_storage_clients/client_probe.h"
+#include "http/client.h"
+
+namespace cloud_storage_clients {
+
+/// Request formatter for Azure Blob Storage
+class abs_request_creator {
+public:
+    /// C-tor
+    /// \param conf is a configuration container
+    explicit abs_request_creator(
+      const abs_configuration& conf,
+      ss::lw_shared_ptr<const cloud_roles::apply_credentials>
+        apply_credentials);
+
+    /// \brief Create 'Put Blob' request header
+    ///
+    /// \param name is container name
+    /// \param key is the blob identifier
+    /// \param payload_size_bytes is a size of the object in bytes
+    /// \param payload_size_bytes is a size of the object in bytes
+    /// \param tags are formatted tags for 'x-ms-tags'
+    /// \return initialized and signed http header or error
+    result<http::client::request_header> make_put_blob_request(
+      bucket_name const& name,
+      object_key const& key,
+      size_t payload_size_bytes,
+      const object_tag_formatter& tags);
+
+    /// \brief Create a 'Get Blob' request header
+    ///
+    /// \param name is container name
+    /// \param key is the blob identifier
+    /// \return initialized and signed http header or error
+    result<http::client::request_header>
+    make_get_blob_request(bucket_name const& name, object_key const& key);
+
+    /// \brief Create a 'Get Blob Metadata' request header
+    ///
+    /// \param name is a container
+    /// \param key is a blob name
+    /// \return initialized and signed http header or error
+    result<http::client::request_header> make_get_blob_metadata_request(
+      bucket_name const& name, object_key const& key);
+
+    /// \brief Create a 'Delete Blob' request header
+    ///
+    /// \param name is a container
+    /// \param key is an blob name
+    /// \return initialized and signed http header or error
+    result<http::client::request_header>
+    make_delete_blob_request(bucket_name const& name, object_key const& key);
+
+    /// \brief Initialize http header for 'List Blobs' request
+    ///
+    /// \param name of the container
+    /// \param prefix prefix of returned blob's names
+    /// \param start_after is always ignored
+    /// \param max_keys is the max number of returned objects
+    /// \return initialized and signed http header or error
+    result<http::client::request_header> make_list_blobs_request(
+      const bucket_name& name,
+      std::optional<object_key> prefix,
+      std::optional<object_key> start_after,
+      std::optional<size_t> max_keys);
+
+private:
+    access_point_uri _ap;
+    /// Applies credentials to http requests by adding headers and signing
+    /// request payload. Shared pointer so that the credentials can be
+    /// rotated through the client pool.
+    ss::lw_shared_ptr<const cloud_roles::apply_credentials> _apply_credentials;
+};
+
+/// S3 REST-API client
+class abs_client : public client {
+public:
+    abs_client(
+      const abs_configuration& conf,
+      ss::lw_shared_ptr<const cloud_roles::apply_credentials>
+        apply_credentials);
+
+    abs_client(
+      const abs_configuration& conf,
+      const ss::abort_source& as,
+      ss::lw_shared_ptr<const cloud_roles::apply_credentials>
+        apply_credentials);
+
+    /// Stop the client
+    ss::future<> stop() override;
+
+    /// Shutdown the underlying connection
+    void shutdown() override;
+
+    /// Download object from ABS container
+    ///
+    /// \param name is a container name
+    /// \param key is a blob identifier
+    /// \param timeout is a timeout of the operation
+    /// \param expect_no_such_key log 404 as warning if set to false
+    /// \return future that becomes ready after request was sent
+    ss::future<result<http::client::response_stream_ref, error_outcome>>
+    get_object(
+      bucket_name const& name,
+      object_key const& key,
+      ss::lowres_clock::duration timeout,
+      bool expect_no_such_key = false) override;
+
+    /// Send Get Blob Metadata request.
+    /// \param name is a container name
+    /// \param key is an id of the blob
+    /// \param timeout is a timeout of the operation
+    /// \return future that becomes ready when the request is completed
+    ss::future<result<head_object_result, error_outcome>> head_object(
+      bucket_name const& name,
+      object_key const& key,
+      ss::lowres_clock::duration timeout) override;
+
+    /// Put blob to ABS container.
+    /// \param name is a container name
+    /// \param key is an id of the blob
+    /// \param payload_size is a size of the object in bytes
+    /// \param body is an input_stream that can be used to read body
+    /// \param timeout is a timeout of the operation
+    /// \return future that becomes ready when the upload is completed
+    ss::future<result<no_response, error_outcome>> put_object(
+      bucket_name const& name,
+      object_key const& key,
+      size_t payload_size,
+      ss::input_stream<char> body,
+      const object_tag_formatter& tags,
+      ss::lowres_clock::duration timeout) override;
+
+    /// Send List Blobs request
+    /// \param name is a container name
+    /// \param prefix is an optional blob prefix to match
+    /// \param start_after
+    /// \param body is an input_stream that can be used to read body
+    /// \param timeout is a timeout of the operation
+    /// \return future that becomes ready when the request is completed
+    ss::future<result<list_bucket_result, error_outcome>> list_objects(
+      const bucket_name& name,
+      std::optional<object_key> prefix = std::nullopt,
+      std::optional<object_key> start_after = std::nullopt,
+      std::optional<size_t> max_keys = std::nullopt,
+      std::optional<ss::sstring> continuation_token = std::nullopt,
+      ss::lowres_clock::duration timeout
+      = http::default_connect_timeout) override;
+
+    /// Send Delete Blob request
+    /// \param name is a container name
+    /// \param key is an id of the blob
+    /// \param timeout is a timeout of the operation
+    ss::future<result<no_response, error_outcome>> delete_object(
+      const bucket_name& bucket,
+      const object_key& key,
+      ss::lowres_clock::duration timeout) override;
+
+    ss::future<result<delete_objects_result, error_outcome>> delete_objects(
+      const bucket_name& bucket,
+      std::vector<object_key> keys,
+      ss::lowres_clock::duration timeout) override {
+        vassert(false, "abs_client::delete_objects is not implemented");
+        co_return error_outcome::fail;
+    }
+
+private:
+    template<typename T>
+    ss::future<result<T, error_outcome>> send_request(
+      ss::future<T> request_future,
+      const bucket_name& bucket,
+      const object_key& key);
+
+    ss::future<http::client::response_stream_ref> do_get_object(
+      bucket_name const& name,
+      object_key const& key,
+      ss::lowres_clock::duration timeout,
+      bool expect_no_such_key = false);
+
+    ss::future<> do_put_object(
+      bucket_name const& name,
+      object_key const& key,
+      size_t payload_size,
+      ss::input_stream<char> body,
+      const object_tag_formatter& tags,
+      ss::lowres_clock::duration timeout);
+
+    ss::future<head_object_result> do_head_object(
+      bucket_name const& name,
+      object_key const& key,
+      ss::lowres_clock::duration timeout);
+
+    ss::future<> do_delete_object(
+      const bucket_name& name,
+      const object_key& key,
+      ss::lowres_clock::duration timeout);
+
+    ss::future<list_bucket_result> do_list_objects(
+      const bucket_name& name,
+      std::optional<object_key> prefix,
+      std::optional<object_key> start_after,
+      std::optional<size_t> max_keys,
+      std::optional<ss::sstring> continuation_token,
+      ss::lowres_clock::duration timeout);
+
+    abs_request_creator _requestor;
+    http::client _client;
+    ss::shared_ptr<client_probe> _probe;
+};
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -183,7 +183,8 @@ private:
     ss::future<result<T, error_outcome>> send_request(
       ss::future<T> request_future,
       const bucket_name& bucket,
-      const object_key& key);
+      const object_key& key,
+      std::optional<op_type_tag> op_type = std::nullopt);
 
     ss::future<http::client::response_stream_ref> do_get_object(
       bucket_name const& name,

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/abs_error.h"
+
+#include "utils/string_switch.h"
+
+#include <boost/lexical_cast.hpp>
+
+#include <map>
+
+namespace cloud_storage_clients {
+
+// Documentation for ABS error codes can be found at:
+// * https://learn.microsoft.com/en-us/rest/api/storageservices/common-rest-api-error-codes
+// * https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-error-codes
+std::istream& operator>>(std::istream& i, abs_error_code& code) {
+    ss::sstring c;
+    i >> c;
+
+    code
+      = string_switch<abs_error_code>(c)
+          .match("BlobNotFound", abs_error_code::blob_not_found)
+          .match("ServerBusy", abs_error_code::server_busy)
+          .match("InternalError", abs_error_code::internal_error)
+          .match("OperationTimedOut", abs_error_code::operation_timed_out)
+          .match("SystemInUse", abs_error_code::system_in_use)
+          .match("BlobNotFound", abs_error_code::blob_not_found)
+          .match("AccountBeingCreated", abs_error_code::account_being_created)
+          .match(
+            "ResourceAlreadyExists", abs_error_code::resource_already_exists)
+          .match("BlobAlreadyExists", abs_error_code::blob_already_exists)
+          .match("InvalidBlobOrBlock", abs_error_code::invalid_blob)
+          .match("PendingCopyOperation", abs_error_code::pending_copy_operation)
+          .match("SnapshotPresent", abs_error_code::snapshot_present)
+          .match("BlobBeingRehydrated", abs_error_code::blob_being_rehydrated)
+          .match("ContainerDisabled", abs_error_code::container_being_disabled)
+          .match(
+            "ContainerBeingDeleted", abs_error_code::container_being_deleted)
+          .match("ContainerNotFound", abs_error_code::container_not_found)
+          .default_match(abs_error_code::_unknown);
+
+    return i;
+}
+
+abs_rest_error_response::abs_rest_error_response(
+  ss::sstring code, ss::sstring message, boost::beast::http::status http_code)
+  : _code(boost::lexical_cast<abs_error_code>(code))
+  , _code_str(std::move(code))
+  , _message(std::move(message))
+  , _http_code(http_code) {}
+
+const char* abs_rest_error_response::what() const noexcept {
+    return _message.c_str();
+}
+
+abs_error_code abs_rest_error_response::code() const noexcept { return _code; }
+
+std::string_view abs_rest_error_response::code_string() const noexcept {
+    return _code_str;
+}
+
+std::string_view abs_rest_error_response::message() const noexcept {
+    return _message;
+}
+
+boost::beast::http::status abs_rest_error_response::http_code() const noexcept {
+    return _http_code;
+}
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/abs_error.h
+++ b/src/v/cloud_storage_clients/abs_error.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <boost/beast/http/status.hpp>
+
+#include <exception>
+
+namespace cloud_storage_clients {
+
+/// \brief Azure Blob Storage error codes
+enum class abs_error_code {
+    _unknown,
+    blob_not_found,
+    authentication_failed,
+    server_busy,
+    internal_error,
+    operation_timed_out,
+    system_in_use,
+    account_being_created,
+    resource_already_exists,
+    blob_already_exists,
+    invalid_blob,
+    pending_copy_operation,
+    snapshot_present,
+    blob_being_rehydrated,
+    container_being_disabled,
+    container_being_deleted,
+    container_not_found
+};
+
+/// Operators to use with lexical_cast
+std::istream& operator>>(std::istream& i, abs_error_code& code);
+
+/// Error received in a response from the server
+class abs_rest_error_response : std::exception {
+public:
+    abs_rest_error_response(
+      ss::sstring code,
+      ss::sstring message,
+      boost::beast::http::status http_code);
+
+    const char* what() const noexcept override;
+
+    abs_error_code code() const noexcept;
+    std::string_view code_string() const noexcept;
+    std::string_view message() const noexcept;
+    boost::beast::http::status http_code() const noexcept;
+
+private:
+    abs_error_code _code;
+    /// Error code string representation, this string is almost always short
+    /// enough for short string optimisation.
+    ss::sstring _code_str;
+    ss::sstring _message;
+    boost::beast::http::status _http_code;
+};
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -81,7 +81,7 @@ public:
     get_object(
       bucket_name const& name,
       object_key const& key,
-      const ss::lowres_clock::duration& timeout,
+      ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false)
       = 0;
 
@@ -99,7 +99,7 @@ public:
     virtual ss::future<result<head_object_result, error_outcome>> head_object(
       bucket_name const& name,
       object_key const& key,
-      const ss::lowres_clock::duration& timeout)
+      ss::lowres_clock::duration timeout)
       = 0;
 
     /// Upload object to cloud storage
@@ -115,9 +115,9 @@ public:
       bucket_name const& name,
       object_key const& key,
       size_t payload_size,
-      ss::input_stream<char>&& body,
+      ss::input_stream<char> body,
       const object_tag_formatter& tags,
-      const ss::lowres_clock::duration& timeout)
+      ss::lowres_clock::duration timeout)
       = 0;
 
     struct list_bucket_item {
@@ -147,7 +147,7 @@ public:
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
-      const ss::lowres_clock::duration& timeout = http::default_connect_timeout)
+      ss::lowres_clock::duration timeout = http::default_connect_timeout)
       = 0;
 
     /// Delete object from cloud storage
@@ -159,7 +159,7 @@ public:
     virtual ss::future<result<no_response, error_outcome>> delete_object(
       const bucket_name& bucket,
       const object_key& key,
-      const ss::lowres_clock::duration& timeout)
+      ss::lowres_clock::duration timeout)
       = 0;
 
     struct delete_objects_result {

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -1,5 +1,6 @@
 #include "cloud_storage_clients/client_pool.h"
 
+#include "cloud_storage_clients/abs_client.h"
 #include "cloud_storage_clients/s3_client.h"
 
 namespace cloud_storage_clients {
@@ -87,10 +88,12 @@ void client_pool::populate_client_pool() {
 
 client_pool::http_client_ptr client_pool::make_client() const {
     return std::visit(
-      [this](const auto& cfg) {
+      [this](const auto& cfg) -> http_client_ptr {
           using cfg_type = std::decay_t<decltype(cfg)>;
           if constexpr (std::is_same_v<s3_configuration, cfg_type>) {
               return ss::make_shared<s3_client>(cfg, _as, _apply_credentials);
+          } else if constexpr (std::is_same_v<abs_configuration, cfg_type>) {
+              return ss::make_shared<abs_client>(cfg, _as, _apply_credentials);
           } else {
               static_assert(always_false_v<cfg_type>, "Unknown client type");
           }

--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -70,6 +70,18 @@ void client_probe::register_failure(s3_error_code err) {
     _total_rpc_errors += 1;
 }
 
+void client_probe::register_failure(abs_error_code err) {
+    if (err == abs_error_code::blob_not_found) {
+        _total_nosuchkeys += 1;
+    }
+    _total_rpc_errors += 1;
+}
+
+void client_probe::register_retryable_failure() {
+    _total_slowdowns += 1;
+    _total_rpc_errors += 1;
+}
+
 void client_probe::setup_internal_metrics(
   net::metrics_disabled disable, std::span<raw_label> raw_labels) {
     namespace sm = ss::metrics;

--- a/src/v/cloud_storage_clients/client_probe.h
+++ b/src/v/cloud_storage_clients/client_probe.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_roles/types.h"
+#include "cloud_storage_clients/abs_error.h"
 #include "cloud_storage_clients/s3_error.h"
 #include "cloud_storage_clients/types.h"
 #include "http/probe.h"
@@ -67,6 +68,9 @@ public:
 
     /// Register S3 rpc error
     void register_failure(s3_error_code err);
+    /// Register ABS rpc error
+    void register_failure(abs_error_code err);
+    void register_retryable_failure();
 
 private:
     struct raw_label {

--- a/src/v/cloud_storage_clients/client_probe.h
+++ b/src/v/cloud_storage_clients/client_probe.h
@@ -26,6 +26,8 @@
 
 namespace cloud_storage_clients {
 
+enum class op_type_tag { upload, download };
+
 /// \brief Cloud storage client probe
 ///
 /// \note The goal of this is to measure billable traffic
@@ -67,10 +69,11 @@ public:
       endpoint_url endpoint);
 
     /// Register S3 rpc error
-    void register_failure(s3_error_code err);
+    void register_failure(
+      s3_error_code err, std::optional<op_type_tag> op_type = std::nullopt);
     /// Register ABS rpc error
     void register_failure(abs_error_code err);
-    void register_retryable_failure();
+    void register_retryable_failure(std::optional<op_type_tag> op_type);
 
 private:
     struct raw_label {
@@ -89,6 +92,10 @@ private:
     uint64_t _total_slowdowns;
     /// Total number of NoSuchKey responses
     uint64_t _total_nosuchkeys;
+    /// Total number of NoSuchKey responses
+    uint64_t _total_upload_slowdowns;
+    /// Total number of NoSuchKey responses
+    uint64_t _total_download_slowdowns;
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics{
       ssx::metrics::public_metrics_handle};

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -71,6 +71,22 @@ struct s3_configuration : common_configuration {
     friend std::ostream& operator<<(std::ostream& o, const s3_configuration& c);
 };
 
+struct abs_configuration : common_configuration {
+    cloud_roles::storage_account storage_account_name;
+    std::optional<cloud_roles::private_key_str> shared_key;
+
+    static ss::future<abs_configuration> make_configuration(
+      const std::optional<cloud_roles::private_key_str>& shared_key,
+      const cloud_roles::storage_account& storage_account_name,
+      const default_overrides& overrides = {},
+      net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
+      net::public_metrics_disabled disable_public_metrics
+      = net::public_metrics_disabled::yes);
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const abs_configuration& c);
+};
+
 template<typename T>
 concept storage_client_configuration
   = std::is_base_of_v<common_configuration, T>;

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -94,7 +94,8 @@ concept storage_client_configuration
 template<storage_client_configuration... Ts>
 using client_configuration_variant = std::variant<Ts...>;
 
-using client_configuration = client_configuration_variant<s3_configuration>;
+using client_configuration
+  = client_configuration_variant<abs_configuration, s3_configuration>;
 
 template<typename>
 inline constexpr bool always_false_v = false;

--- a/src/v/cloud_storage_clients/logger.h
+++ b/src/v/cloud_storage_clients/logger.h
@@ -16,4 +16,5 @@
 
 namespace cloud_storage_clients {
 inline ss::logger s3_log("s3");
+inline ss::logger abs_log("abs");
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -610,7 +610,7 @@ ss::future<s3_client::head_object_result> s3_client::do_head_object(
               });
         })
       .handle_exception_type([this](const rest_error_response& err) {
-          _probe->register_failure(err.code());
+          _probe->register_failure(err.code(), op_type_tag::download);
           return ss::make_exception_future<head_object_result>(err);
       });
 }
@@ -673,7 +673,7 @@ ss::future<> s3_client::do_put_object(
             .handle_exception_type(
               [](const ss::abort_requested_exception&) { return ss::now(); })
             .handle_exception_type([this](const rest_error_response& err) {
-                _probe->register_failure(err.code());
+                _probe->register_failure(err.code(), op_type_tag::upload);
                 return ss::make_exception_future<>(err);
             })
             .handle_exception([](std::exception_ptr eptr) {

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -510,7 +510,7 @@ ss::future<result<http::client::response_stream_ref, error_outcome>>
 s3_client::get_object(
   bucket_name const& name,
   object_key const& key,
-  const ss::lowres_clock::duration& timeout,
+  ss::lowres_clock::duration timeout,
   bool expect_no_such_key) {
     return send_request(
       do_get_object(name, key, timeout, expect_no_such_key), name, key);
@@ -519,7 +519,7 @@ s3_client::get_object(
 ss::future<http::client::response_stream_ref> s3_client::do_get_object(
   bucket_name const& name,
   object_key const& key,
-  const ss::lowres_clock::duration& timeout,
+  ss::lowres_clock::duration timeout,
   bool expect_no_such_key) {
     auto header = _requestor.make_get_object_request(name, key);
     if (!header) {
@@ -569,14 +569,14 @@ ss::future<result<s3_client::head_object_result, error_outcome>>
 s3_client::head_object(
   bucket_name const& name,
   object_key const& key,
-  const ss::lowres_clock::duration& timeout) {
+  ss::lowres_clock::duration timeout) {
     return send_request(do_head_object(name, key, timeout), name, key);
 }
 
 ss::future<s3_client::head_object_result> s3_client::do_head_object(
   bucket_name const& name,
   object_key const& key,
-  const ss::lowres_clock::duration& timeout) {
+  ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_head_object_request(name, key);
     if (!header) {
         return ss::make_exception_future<s3_client::head_object_result>(
@@ -628,9 +628,9 @@ ss::future<result<s3_client::no_response, error_outcome>> s3_client::put_object(
   bucket_name const& name,
   object_key const& key,
   size_t payload_size,
-  ss::input_stream<char>&& body,
+  ss::input_stream<char> body,
   const object_tag_formatter& tags,
-  const ss::lowres_clock::duration& timeout) {
+  ss::lowres_clock::duration timeout) {
     return send_request(
       do_put_object(name, key, payload_size, std::move(body), tags, timeout)
         .then(
@@ -643,9 +643,9 @@ ss::future<> s3_client::do_put_object(
   bucket_name const& name,
   object_key const& id,
   size_t payload_size,
-  ss::input_stream<char>&& body,
+  ss::input_stream<char> body,
   const object_tag_formatter& tags,
-  const ss::lowres_clock::duration& timeout) {
+  ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_unsigned_put_object_request(
       name, id, payload_size, tags);
     if (!header) {
@@ -700,7 +700,7 @@ s3_client::list_objects(
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
   std::optional<ss::sstring> continuation_token,
-  const ss::lowres_clock::duration& timeout) {
+  ss::lowres_clock::duration timeout) {
     const object_key dummy{""};
     co_return co_await send_request(
       do_list_objects_v2(
@@ -715,7 +715,7 @@ ss::future<s3_client::list_bucket_result> s3_client::do_list_objects_v2(
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
   std::optional<ss::sstring> continuation_token,
-  const ss::lowres_clock::duration& timeout) {
+  ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_list_objects_v2_request(
       name,
       std::move(prefix),
@@ -766,7 +766,7 @@ ss::future<result<s3_client::no_response, error_outcome>>
 s3_client::delete_object(
   const bucket_name& bucket,
   const object_key& key,
-  const ss::lowres_clock::duration& timeout) {
+  ss::lowres_clock::duration timeout) {
     using ret_t = result<s3_client::no_response, error_outcome>;
 
     return send_request(
@@ -800,7 +800,7 @@ s3_client::delete_object(
 ss::future<> s3_client::do_delete_object(
   const bucket_name& bucket,
   const object_key& key,
-  const ss::lowres_clock::duration& timeout) {
+  ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_delete_object_request(bucket, key);
     if (!header) {
         return ss::make_exception_future<>(std::system_error(header.error()));

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -138,7 +138,7 @@ public:
     get_object(
       bucket_name const& name,
       object_key const& key,
-      const ss::lowres_clock::duration& timeout,
+      ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false) override;
 
     /// HeadObject request.
@@ -148,7 +148,7 @@ public:
     ss::future<result<head_object_result, error_outcome>> head_object(
       bucket_name const& name,
       object_key const& key,
-      const ss::lowres_clock::duration& timeout) override;
+      ss::lowres_clock::duration timeout) override;
 
     /// Put object to S3 bucket.
     /// \param name is a bucket name
@@ -160,9 +160,9 @@ public:
       bucket_name const& name,
       object_key const& key,
       size_t payload_size,
-      ss::input_stream<char>&& body,
+      ss::input_stream<char> body,
       const object_tag_formatter& tags,
-      const ss::lowres_clock::duration& timeout) override;
+      ss::lowres_clock::duration timeout) override;
 
     ss::future<result<list_bucket_result, error_outcome>> list_objects(
       const bucket_name& name,
@@ -170,13 +170,13 @@ public:
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
-      const ss::lowres_clock::duration& timeout
+      ss::lowres_clock::duration timeout
       = http::default_connect_timeout) override;
 
     ss::future<result<no_response, error_outcome>> delete_object(
       const bucket_name& bucket,
       const object_key& key,
-      const ss::lowres_clock::duration& timeout) override;
+      ss::lowres_clock::duration timeout) override;
 
     ss::future<result<delete_objects_result, error_outcome>> delete_objects(
       const bucket_name& bucket,
@@ -187,21 +187,21 @@ private:
     ss::future<head_object_result> do_head_object(
       bucket_name const& name,
       object_key const& key,
-      const ss::lowres_clock::duration& timeout);
+      ss::lowres_clock::duration timeout);
 
     ss::future<http::client::response_stream_ref> do_get_object(
       bucket_name const& name,
       object_key const& key,
-      const ss::lowres_clock::duration& timeout,
+      ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false);
 
     ss::future<> do_put_object(
       bucket_name const& name,
       object_key const& key,
       size_t payload_size,
-      ss::input_stream<char>&& body,
+      ss::input_stream<char> body,
       const object_tag_formatter& tags,
-      const ss::lowres_clock::duration& timeout);
+      ss::lowres_clock::duration timeout);
 
     ss::future<list_bucket_result> do_list_objects_v2(
       const bucket_name& name,
@@ -209,13 +209,12 @@ private:
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
-      const ss::lowres_clock::duration& timeout
-      = http::default_connect_timeout);
+      ss::lowres_clock::duration timeout = http::default_connect_timeout);
 
     ss::future<> do_delete_object(
       const bucket_name& bucket,
       const object_key& key,
-      const ss::lowres_clock::duration& timeout);
+      ss::lowres_clock::duration timeout);
 
     ss::future<delete_objects_result> do_delete_objects(
       const bucket_name& bucket,

--- a/src/v/cloud_storage_clients/test_client/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/test_client/CMakeLists.txt
@@ -1,5 +1,9 @@
-# client
+# s3_client
 add_executable(s3_test_client s3_test_client_main.cc)
 target_link_libraries(s3_test_client PUBLIC v::model v::net v::http v::cloud_storage_clients v::cloud_roles)
 set_property(TARGET s3_test_client PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+# abs_client
+add_executable(abs_test_client abs_test_client_main.cc)
+target_link_libraries(abs_test_client PUBLIC v::model v::net v::http v::cloud_storage_clients v::cloud_roles)
+set_property(TARGET abs_test_client PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "cloud_roles/types.h"
+#include "cloud_storage_clients/abs_client.h"
+#include "http/client.h"
+#include "seastarx.h"
+#include "syschecks/syschecks.h"
+#include "utils/hdr_hist.h"
+#include "vlog.h"
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/memory.hh>
+#include <seastar/core/report_exception.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/net/dns.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/net/tls.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/optional/optional.hpp>
+#include <boost/outcome/detail/value_storage.hpp>
+#include <boost/system/system_error.hpp>
+#include <gnutls/gnutls.h>
+
+#include <chrono>
+#include <exception>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+static ss::logger test_log{"test"};
+
+void cli_opts(boost::program_options::options_description_easy_init opt) {
+    namespace po = boost::program_options;
+
+    opt(
+      "blob",
+      po::value<std::vector<std::string>>()->default_value({"test.txt"}),
+      "ABS blob id");
+
+    opt(
+      "storage-account",
+      po::value<std::string>()->default_value("test-storage-account"),
+      "ABS Storage Account");
+
+    opt(
+      "container",
+      po::value<std::string>()->default_value("test-container"),
+      "ABS Container");
+
+    opt(
+      "shared-key",
+      po::value<std::string>()->default_value(""),
+      "ABS Shared Key");
+
+    opt(
+      "in",
+      po::value<std::string>()->default_value(""),
+      "file to read data for ABS blob");
+
+    opt(
+      "out",
+      po::value<std::string>()->default_value(""),
+      "file to receive data from ABS blob");
+
+    opt(
+      "list-with-prefix",
+      po::value<std::string>(),
+      "list blobs in a container");
+
+    opt("delete", po::value<std::string>(), "delete object in container");
+    opt(
+      "get-metadata",
+      po::value<std::string>(),
+      "get metadata for object in container");
+
+    opt(
+      "uri", po::value<std::string>(), "alternative uri for the api endpoint");
+
+    opt("port", po::value<uint16_t>(), "alternative port for the api endpoint");
+
+    opt("disable-tls", "disable tls for this connection");
+}
+
+struct test_conf {
+    cloud_roles::storage_account storage_account;
+    cloud_storage_clients::bucket_name container;
+
+    std::vector<cloud_storage_clients::object_key> blobs;
+
+    cloud_storage_clients::abs_configuration client_cfg;
+
+    std::string in;
+    std::string out;
+
+    bool delete_blob;
+    bool get_metadata;
+
+    std::optional<cloud_storage_clients::object_key> list_with_prefix;
+};
+
+template<>
+struct fmt::formatter<test_conf> : public fmt::formatter<std::string_view> {
+    auto format(const test_conf& cfg, auto& ctx) const {
+        // make the output json-able so we can consume it in python for analysis
+        return formatter<std::string_view>::format(
+          fmt::format(
+            "[ 'storage-account': '{}', 'container': '{}', 'blobs': ['{}'] ]",
+            cfg.storage_account,
+            cfg.container,
+            fmt::join(cfg.blobs, "', '")),
+          ctx);
+    }
+};
+
+test_conf cfg_from(boost::program_options::variables_map& m) {
+    auto shared_key = cloud_roles::private_key_str(
+      m["shared-key"].as<std::string>());
+    auto storage_acc = cloud_roles::storage_account(
+      m["storage-account"].as<std::string>());
+    auto container = cloud_storage_clients::bucket_name(
+      m["container"].as<std::string>());
+
+    std::optional<cloud_storage_clients::object_key> prefix = std::nullopt;
+    if (m.contains("list-with-prefix")) {
+        prefix = cloud_storage_clients::object_key{
+          m["list-with-prefix"].as<std::string>()};
+    }
+
+    cloud_storage_clients::abs_configuration client_cfg
+      = cloud_storage_clients::abs_configuration::make_configuration(
+          shared_key,
+          storage_acc,
+          cloud_storage_clients::default_overrides{
+            .endpoint =
+              [&]() -> std::optional<cloud_storage_clients::endpoint_url> {
+                if (m.count("uri") > 0) {
+                    return cloud_storage_clients::endpoint_url{
+                      m["uri"].as<std::string>()};
+                }
+                return std::nullopt;
+            }(),
+            .port = [&]() -> std::optional<uint16_t> {
+                if (m.contains("port") > 0) {
+                    return m["port"].as<uint16_t>();
+                }
+                return std::nullopt;
+            }(),
+            .disable_tls = m.contains("disable-tls") > 0,
+          })
+          .get0();
+    vlog(test_log.info, "connecting to {}", client_cfg.server_addr);
+    return test_conf{
+      .storage_account = storage_acc,
+      .container = container,
+      .blobs =
+        [&] {
+            auto keys = m["blob"].as<std::vector<std::string>>();
+            auto out = std::vector<cloud_storage_clients::object_key>{};
+            std::transform(
+              keys.begin(),
+              keys.end(),
+              std::back_inserter(out),
+              [](auto const& ks) {
+                  return cloud_storage_clients::object_key(ks);
+              });
+            return out;
+        }(),
+      .client_cfg = std::move(client_cfg),
+      .in = m["in"].as<std::string>(),
+      .out = m["out"].as<std::string>(),
+      .delete_blob = m.count("delete") > 0,
+      .get_metadata = m.count("get-metadata") > 0,
+      .list_with_prefix = prefix};
+}
+
+// TODO(vlad): factor this out
+static std::pair<ss::input_stream<char>, uint64_t>
+get_input_file_as_stream(const std::filesystem::path& path) {
+    auto file = ss::open_file_dma(path.native(), ss::open_flags::ro).get0();
+    auto size = file.size().get0();
+    return std::make_pair(ss::make_file_input_stream(std::move(file), 0), size);
+}
+
+static ss::sstring time_to_string(std::chrono::system_clock::time_point tp) {
+    std::stringstream s;
+    auto tt = std::chrono::system_clock::to_time_t(tp);
+    auto tm = *std::gmtime(&tt);
+    s << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S");
+    return s.str();
+}
+
+static ss::lw_shared_ptr<cloud_roles::apply_credentials>
+make_credentials(const cloud_storage_clients::abs_configuration& cfg) {
+    return ss::make_lw_shared(
+      cloud_roles::make_credentials_applier(cloud_roles::abs_credentials{
+        cfg.storage_account_name, cfg.shared_key.value()}));
+}
+
+static ss::output_stream<char>
+get_output_file_as_stream(const std::filesystem::path& path) {
+    auto file = ss::open_file_dma(
+                  path.native(), ss::open_flags::rw | ss::open_flags::create)
+                  .get0();
+    return ss::make_file_output_stream(std::move(file)).get0();
+}
+
+int main(int args, char** argv, char** env) {
+    syschecks::initialize_intrinsics();
+    std::setvbuf(stdout, nullptr, _IOLBF, 1024);
+    ss::app_template app;
+    cli_opts(app.add_options());
+    ss::sharded<cloud_storage_clients::abs_client> client;
+
+    return app.run(args, argv, [&] {
+        auto& cfg = app.configuration();
+        return ss::async([&] {
+            test_conf lcfg = cfg_from(cfg);
+            cloud_storage_clients::abs_configuration abs_cfg = lcfg.client_cfg;
+            vlog(test_log.info, "config:{}", lcfg);
+            vlog(test_log.info, "constructing client");
+            auto credentials_applier = make_credentials(abs_cfg);
+            client.start(abs_cfg, credentials_applier).get();
+            vlog(test_log.info, "connecting");
+            client
+              .invoke_on(
+                0,
+                [lcfg = std::move(lcfg)](
+                  cloud_storage_clients::abs_client& cli) mutable {
+                    vlog(test_log.info, "sending request");
+                    if (!lcfg.out.empty()) {
+                        // Get Blob
+                        vlog(test_log.info, "receiving file {}", lcfg.out);
+                        auto out_file = get_output_file_as_stream(lcfg.out);
+                        const auto result = cli
+                                              .get_object(
+                                                lcfg.container,
+                                                lcfg.blobs.front(),
+                                                http::default_connect_timeout)
+                                              .get0();
+                        if (result) {
+                            auto resp = result.value()->as_input_stream();
+                            vlog(test_log.info, "response: OK");
+                            ss::copy(resp, out_file).get();
+                            vlog(test_log.info, "file write done");
+                            resp.close().get();
+                        } else {
+                            vlog(
+                              test_log.error,
+                              "GET request failed: {}",
+                              result.error());
+                        }
+                        out_file.flush().get();
+                        out_file.close().get();
+                    } else if (!lcfg.in.empty()) {
+                        // Put Blob
+                        vlog(test_log.info, "sending file {}", lcfg.in);
+                        auto [payload, payload_size] = get_input_file_as_stream(
+                          lcfg.in);
+                        const auto result = cli
+                                              .put_object(
+                                                lcfg.container,
+                                                lcfg.blobs.front(),
+                                                payload_size,
+                                                std::move(payload),
+                                                {},
+                                                http::default_connect_timeout)
+                                              .get0();
+                        if (!result) {
+                            vlog(
+                              test_log.error,
+                              "PUT request failed: {}",
+                              result.error());
+                        }
+                    } else if (lcfg.delete_blob) {
+                        // Delete Blob
+                        vlog(test_log.info, "Deleting blob");
+                        const auto result = cli
+                                              .delete_object(
+                                                lcfg.container,
+                                                lcfg.blobs.front(),
+                                                http::default_connect_timeout)
+                                              .get();
+
+                        if (result) {
+                            vlog(test_log.info, "Delete Blob completed");
+                        } else {
+                            vlog(
+                              test_log.error,
+                              "Delete request failed: {}",
+                              result.error());
+                        }
+                    } else if (lcfg.get_metadata) {
+                        // Get Blob Metadata
+                        vlog(test_log.info, "Getting blob metadata");
+                        const auto result = cli
+                                              .head_object(
+                                                lcfg.container,
+                                                lcfg.blobs.front(),
+                                                http::default_connect_timeout)
+                                              .get();
+                        if (result) {
+                            vlog(
+                              test_log.info,
+                              "Get Blob Metadata completed: etag={}",
+                              result.value().etag);
+                        } else {
+                            vlog(
+                              test_log.error,
+                              "Get Blob Metadata request failed: {}",
+                              result.error());
+                        }
+                    } else if (lcfg.list_with_prefix.has_value()) {
+                        vlog(test_log.info, "Listing blobs");
+
+                        if (lcfg.list_with_prefix.value()() == "none") {
+                            lcfg.list_with_prefix.reset();
+                        }
+
+                        const auto result = cli
+                                              .list_objects(
+                                                lcfg.container,
+                                                lcfg.list_with_prefix)
+                                              .get();
+                        if (result) {
+                            const auto& val = result.value();
+                            vlog(
+                              test_log.info,
+                              "List Blobs result, prefix: {}, "
+                              "is-truncated: "
+                              "{}, "
+                              "contents:",
+                              val.prefix,
+                              val.is_truncated);
+                            for (const auto& item : val.contents) {
+                                vlog(
+                                  test_log.info,
+                                  "\tkey: {}, last_modified: {}, "
+                                  "size_bytes: "
+                                  "{}",
+                                  item.key,
+                                  time_to_string(item.last_modified),
+                                  item.size_bytes);
+                            }
+                        } else {
+                            vlog(
+                              test_log.error,
+                              "Get Blob Metadata request failed: {}",
+                              result.error());
+                        }
+                    }
+                })
+              .get();
+            client.stop().get();
+            vlog(test_log.info, "done");
+            ss::sleep(std::chrono::seconds(1)).get();
+        });
+    });
+}

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -308,8 +308,8 @@ cloud_storage_clients::s3_configuration transport_configuration() {
     conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,
       net::public_metrics_disabled::yes,
-      "region",
-      "endpoint");
+      cloud_roles::aws_region_name{"region"},
+      cloud_storage_clients::endpoint_url{"endpoint"});
     return conf;
 }
 

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -31,8 +31,16 @@ error_outcome handle_client_transport_error(
 /// iobuf
 ss::future<iobuf> drain_response_stream(http::client::response_stream_ref resp);
 
+/// \brief: Drain the reponse stream pointed to by the 'resp' handle into an
+/// iobuf
+ss::future<iobuf>
+drain_chunked_response_stream(http::client::response_stream_ref resp);
+
 /// \brief: Convert iobuf that contains xml data to boost::property_tree
 boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf, ss::logger& logger);
+
+/// \brief: Parse timestamp in format that S3 and ABS use
+std::chrono::system_clock::time_point parse_timestamp(std::string_view sv);
 
 void log_buffer_with_rate_limiting(
   const char* msg, iobuf& buf, ss::logger& logger);

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -542,8 +542,11 @@ ss::future<> archival_metadata_stm::apply(model::record_batch b) {
 ss::future<> archival_metadata_stm::handle_eviction() {
     cloud_storage::partition_manifest manifest;
 
-    auto bucket = config::shard_local_cfg().cloud_storage_bucket.value();
-    vassert(bucket, "configuration property cloud_storage_bucket must be set");
+    const auto& bucket_config
+      = cloud_storage::configuration::get_bucket_config();
+    auto bucket = bucket_config.value();
+    vassert(
+      bucket, "configuration property {} must be set", bucket_config.name());
 
     auto timeout
       = config::shard_local_cfg().cloud_storage_manifest_upload_timeout_ms();

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -103,8 +103,9 @@ partition::partition(
             stm_manager->add_stm(_archival_meta_stm);
 
             if (cloud_storage_cache.local_is_initialized()) {
-                auto bucket
-                  = config::shard_local_cfg().cloud_storage_bucket.value();
+                const auto& bucket_config
+                  = cloud_storage::configuration::get_bucket_config();
+                auto bucket = bucket_config.value();
                 if (
                   read_replica_bucket
                   && _raft->log_config().is_read_replica_mode_enabled()) {
@@ -118,8 +119,9 @@ partition::partition(
                     bucket = read_replica_bucket;
                 }
                 if (!bucket) {
-                    throw std::runtime_error{
-                      "configuration property cloud_storage_bucket is not set"};
+                    throw std::runtime_error{fmt::format(
+                      "configuration property {} is not set",
+                      bucket_config.name())};
                 }
                 _cloud_storage_partition
                   = ss::make_shared<cloud_storage::remote_partition>(

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -494,12 +494,15 @@ ss::future<topic_result> topics_frontend::do_create_topic(
     if (assignable_config.is_recovery_enabled()) {
         // Before running the recovery we need to download topic_manifest.
 
-        auto bucket = config::shard_local_cfg().cloud_storage_bucket.value();
+        const auto& bucket_config
+          = cloud_storage::configuration::get_bucket_config();
+        auto bucket = bucket_config.value();
         if (!bucket.has_value()) {
             vlog(
               clusterlog.error,
-              "Can't run topic recovery for the topic {}, bucket is not set",
-              assignable_config.cfg.tp_ns);
+              "Can't run topic recovery for the topic {}, {} is not set",
+              assignable_config.cfg.tp_ns,
+              bucket_config.name());
             co_return make_error_result(
               assignable_config.cfg.tp_ns, errc::topic_operation_error);
         }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1160,6 +1160,30 @@ configuration::configuration()
       "Enable re-uploading data for compacted topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , cloud_storage_azure_storage_account(
+      *this,
+      "cloud_storage_azure_storage_account",
+      "The name of the Azure storage account to use with Tiered Storage",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt)
+  , cloud_storage_azure_container(
+      *this,
+      "cloud_storage_azure_container",
+      "The name of the Azure container to use with Tiered Storage. Note that "
+      "the container must belong to 'cloud_storage_azure_storage_account'",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt)
+  , cloud_storage_azure_shared_key(
+      *this,
+      "cloud_storage_azure_shared_key",
+      "The shared key to be used for Azure Shared Key authentication with the "
+      "configured Azure storage account (see "
+      "'cloud_storage_azure_storage_account)'. Note that Redpanda expects this "
+      "string to be Base64 encoded.",
+      {.needs_restart = needs_restart::yes,
+       .visibility = visibility::user,
+       .secret = is_secret::yes},
+      std::nullopt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -240,6 +240,10 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> cloud_storage_housekeeping_interval_ms;
     property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;
     property<bool> cloud_storage_enable_compacted_topic_reupload;
+    // Azure Blob Storage
+    property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;
+    property<std::optional<ss::sstring>> cloud_storage_azure_container;
+    property<std::optional<ss::sstring>> cloud_storage_azure_shared_key;
 
     // Archival upload controller
     property<std::chrono::milliseconds>

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1024,6 +1024,23 @@ static json::validator make_cluster_config_validator() {
     return json::validator(schema);
 }
 
+ss::sstring
+join_properties(const std::vector<std::reference_wrapper<
+                  const config::property<std::optional<ss::sstring>>>>& props) {
+    ss::sstring result = "";
+    for (size_t idx = 0; const auto& prop : props) {
+        if (idx == props.size() - 1) {
+            result += ss::sstring{prop.get().name()};
+        } else {
+            result += ssx::sformat("{}, ", prop.get().name());
+        }
+
+        ++idx;
+    };
+
+    return result;
+}
+
 /**
  * This function provides special case validation for configuration
  * properties that need to check other properties' values as well
@@ -1078,23 +1095,53 @@ void config_multi_property_validation(
         if (
           updated_config.cloud_storage_credentials_source
           == model::cloud_credentials_source::config_file) {
-            properties = {
+            config_properties_seq s3_properties = {
               std::ref(updated_config.cloud_storage_region),
               std::ref(updated_config.cloud_storage_bucket),
               std::ref(updated_config.cloud_storage_access_key),
               std::ref(updated_config.cloud_storage_secret_key),
             };
+
+            config_properties_seq abs_properties = {
+              std::ref(updated_config.cloud_storage_azure_storage_account),
+              std::ref(updated_config.cloud_storage_azure_container),
+              std::ref(updated_config.cloud_storage_azure_shared_key),
+            };
+
+            std::array<config_properties_seq, 2> valid_configurations = {
+              s3_properties, abs_properties};
+
+            bool is_valid_configuration = std::any_of(
+              valid_configurations.begin(),
+              valid_configurations.end(),
+              [](const auto& config) {
+                  return std::none_of(
+                    config.begin(), config.end(), [](const auto& prop) {
+                        return prop() == std::nullopt;
+                    });
+              });
+
+            if (!is_valid_configuration) {
+                errors["cloud_storage_enabled"] = ssx::sformat(
+                  "To enable cloud storage you need to configure S3 or Azure "
+                  "Blob Storage access. For S3 {} must be set. For ABS {} "
+                  "must be set",
+                  join_properties(s3_properties),
+                  join_properties(abs_properties));
+            }
         } else {
-            properties = {
+            // TODO(vlad): When we add support for non-config file auth
+            // methods for ABS, handling here should be updated too.
+            config_properties_seq properties = {
               std::ref(updated_config.cloud_storage_region),
               std::ref(updated_config.cloud_storage_bucket),
             };
-        }
 
-        for (auto& p : properties) {
-            if (p() == std::nullopt) {
-                errors[ss::sstring(p.get().name())]
-                  = "Must be set when cloud storage enabled";
+            for (auto& p : properties) {
+                if (p() == std::nullopt) {
+                    errors[ss::sstring(p.get().name())]
+                      = "Must be set when cloud storage enabled";
+                }
             }
         }
     }

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -28,6 +28,15 @@ services:
     image: minio/minio:RELEASE.2021-03-26T00-00-41Z
     networks:
     - redpanda-test
+  azurite:
+    container_name: azurite
+    hostname: devstoreaccount1.blob.localhost
+    restart: always
+    ports:
+    - 10000:10000
+    image: mcr.microsoft.com/azure-storage/azurite:3.21.0
+    networks:
+    - redpanda-test
   rp:
     image: vectorized/redpanda-test-node
     privileged: true

--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -1,0 +1,140 @@
+from rptest.archival.s3_client import ObjectMetadata
+from rptest.archival.shared_client_utils import key_to_topic
+
+from azure.storage.blob import BlobClient, BlobServiceClient, BlobType, ContainerClient
+from itertools import chain, islice
+
+import time
+import datetime
+from logging import Logger
+from typing import Iterator, NamedTuple, Optional
+from base64 import standard_b64decode
+
+
+def build_connection_string(proto: str, endpoint: Optional[str],
+                            storage_account: str, key: str) -> str:
+    assert proto in ["http", "https"
+                     ], f"Invalid protocol supplied to ABS client: {proto}"
+
+    parts = [
+        f"DefaultEndpointsProtocol={proto}", f"AccountName={storage_account}",
+        f"AccountKey={key}"
+    ]
+
+    if proto == "http":
+        parts += [f"BlobEndpoint={endpoint}"]
+    else:
+        parts += ["EndpointSuffix=core.windows.net"]
+
+    return ";".join(parts)
+
+
+class ABSClient:
+    def __init__(self,
+                 logger: Logger,
+                 storage_account: str,
+                 shared_key: str,
+                 endpoint: Optional[str] = None):
+        self.logger = logger
+
+        if endpoint is None:
+            proto = "https"
+        else:
+            proto = "http"
+
+        self.conn_str = build_connection_string(proto, endpoint,
+                                                storage_account, shared_key)
+
+    def _wait_no_key(self,
+                     blob_client: BlobServiceClient,
+                     timeout_sec: float = 10):
+        deadline = datetime.datetime.now() + datetime.timedelta(
+            seconds=timeout_sec)
+
+        try:
+            while blob_client.exists():
+                now = datetime.datetime.now()
+                if now > deadline:
+                    raise TimeoutError(
+                        f"Blob was not deleted within {timeout_sec}s")
+                time.sleep(2)
+        except Exception as err:
+            if isinstance(err, TimeoutError):
+                raise err
+
+            self.logger.debug(f"error ocurred while polling blob {err}")
+
+    def create_bucket(self, name: str):
+        blob_service = BlobServiceClient.from_connection_string(self.conn_str)
+        blob_service.create_container(name)
+
+    def delete_bucket(self, name: str):
+        blob_service = BlobServiceClient.from_connection_string(self.conn_str)
+        blob_service.delete_container(name)
+
+    def empty_bucket(self, name: str):
+        container_client = ContainerClient.from_connection_string(
+            self.conn_str, container_name=name)
+        blob_names_generator = container_client.list_blob_names()
+
+        for blob in blob_names_generator:
+            container_client.delete_blob(blob)
+
+    def delete_object(self, bucket: str, key: str, verify=False):
+        blob_client = BlobClient.from_connection_string(self.conn_str,
+                                                        container_name=bucket,
+                                                        blob_name=key)
+        blob_client.delete_blob()
+
+        if verify:
+            self._wait_no_key(blob_client)
+
+    def get_object_data(self, bucket: str, key: str) -> bytes:
+        blob_client = BlobClient.from_connection_string(self.conn_str,
+                                                        container_name=bucket,
+                                                        blob_name=key)
+        return blob_client.download_blob().content_as_bytes()
+
+    def put_object(self, bucket: str, key: str, data: str):
+        container_client = ContainerClient.from_connection_string(
+            self.conn_str, container_name=bucket)
+        blob_client = container_client.upload_blob(
+            name=key,
+            data=bytes(data, encoding="utf-8"),
+            blob_type=BlobType.BLOCKBLOB,
+            overwrite=True)
+
+        assert blob_client.exists(), f"Failed to upload blob {key}"
+
+    def get_object_meta(self, bucket: str, key: str) -> ObjectMetadata:
+        blob_client = BlobClient.from_connection_string(self.conn_str,
+                                                        container_name=bucket,
+                                                        blob_name=key)
+        props = blob_client.get_blob_properties()
+
+        assert props.deleted == False
+
+        # Note that we return the hexified md5 hash computed by Azure
+        # as the 'etag'. This is done in order to mimic the S3 behaviour
+        # and keep parametrised tests passing without making them aware
+        # of the cloud storage client being used.
+        return ObjectMetadata(bucket=props.container,
+                              key=props.name,
+                              etag=props.content_settings.content_md5.hex(),
+                              content_length=props.size)
+
+    def list_objects(self,
+                     bucket: str,
+                     topic: Optional[str] = None) -> Iterator[ObjectMetadata]:
+        container_client = ContainerClient.from_connection_string(
+            self.conn_str, container_name=bucket)
+        for blob_props in container_client.list_blobs():
+            if topic is not None and key_to_topic(blob_props.name) != topic:
+                self.logger.debug(f"Skip {blob_props.name} for {topic}")
+                continue
+
+            yield ObjectMetadata(
+                bucket=blob_props.container,
+                key=blob_props.name,
+                etag=blob_props.content_settings.content_md5.hex(),
+                content_length=blob_props.size)

--- a/tests/rptest/archival/shared_client_utils.py
+++ b/tests/rptest/archival/shared_client_utils.py
@@ -1,0 +1,13 @@
+import re
+from typing import Optional
+
+
+def key_to_topic(key: str) -> Optional[str]:
+    # Segment objects: <hash>/<ns>/<topic>/<partition>_<revision>/...
+    # Manifest objects: <hash>/meta/<ns>/<topic>/<partition>_<revision>/...
+    # Topic manifest objects: <hash>/meta/<ns>/<topic>/topic_manifest.json
+    m = re.search(".+/(.+)/(.+)/(\d+_\d+/|topic_manifest.json)", key)
+    if m is None:
+        return None
+    else:
+        return m.group(2)

--- a/tests/rptest/scale_tests/cloud_retention_test.py
+++ b/tests/rptest/scale_tests/cloud_retention_test.py
@@ -111,7 +111,7 @@ class CloudRetentionTest(PreallocNodesTest):
 
         def check_bucket_size():
             try:
-                size = sum(obj.ContentLength
+                size = sum(obj.content_length
                            for obj in self.s3_client.list_objects(
                                self.si_settings.cloud_storage_bucket))
                 self.logger.info(f"bucket size: {size}")

--- a/tests/rptest/scale_tests/cloud_retention_test.py
+++ b/tests/rptest/scale_tests/cloud_retention_test.py
@@ -112,7 +112,7 @@ class CloudRetentionTest(PreallocNodesTest):
         def check_bucket_size():
             try:
                 size = sum(obj.content_length
-                           for obj in self.s3_client.list_objects(
+                           for obj in self.cloud_storage_client.list_objects(
                                self.si_settings.cloud_storage_bucket))
                 self.logger.info(f"bucket size: {size}")
                 # check that for each partition there is more than 1

--- a/tests/rptest/scale_tests/cloud_retention_test.py
+++ b/tests/rptest/scale_tests/cloud_retention_test.py
@@ -35,7 +35,8 @@ class CloudRetentionTest(PreallocNodesTest):
             test_context=test_context,
             node_prealloc_count=1,
             num_brokers=3,
-            si_settings=SISettings(log_segment_size=self.segment_size),
+            si_settings=SISettings(test_context,
+                                   log_segment_size=self.segment_size),
             extra_rp_conf=extra_rp_conf)
 
     @cluster(num_nodes=4)

--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -65,6 +65,7 @@ class CloudStorageCompactionTest(EndToEndTest):
 
     def _init_redpanda(self, test_context, extra_rp_conf, environment):
         self.si_settings = SISettings(
+            test_context,
             cloud_storage_max_connections=5,
             log_segment_size=self.configuration["segment_size"],
             cloud_storage_readreplica_manifest_sync_timeout_ms=500,
@@ -126,6 +127,7 @@ class CloudStorageCompactionTest(EndToEndTest):
 
     def _init_redpanda_read_replica(self):
         self.rr_si_settings = SISettings(
+            self.test_context,
             bypass_bucket_creation=True,
             cloud_storage_max_connections=5,
             log_segment_size=self.configuration["segment_size"],

--- a/tests/rptest/scale_tests/extreme_recovery_test.py
+++ b/tests/rptest/scale_tests/extreme_recovery_test.py
@@ -174,14 +174,15 @@ class ExtremeRecoveryTest(TopicRecoveryTest):
         # This test requires dedicated system resources
         assert self.redpanda.dedicated_nodes
 
-        assert self.s3_client
+        assert self.cloud_storage_client
         topics = [
             TopicSpec(partition_count=RecoveryScale.part_per_topic,
                       replication_factor=3)
             for i in range(RecoveryScale.NUM_TOPICS)
         ]
 
-        extreme_recovery = RecoveryScale(self.test_context, self.s3_client,
+        extreme_recovery = RecoveryScale(self.test_context,
+                                         self.cloud_storage_client,
                                          self.kafka_tools, self.rpk,
                                          self.s3_bucket, self.logger, topics,
                                          self.rpk_producer_maker)

--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -183,7 +183,7 @@ class KgoVerifierWithSiTest(KgoVerifierBase):
         objects = list(self.redpanda.get_objects_from_si())
         assert len(objects) > 0
         for o in objects:
-            self.logger.info(f"S3 object: {o.Key}, {o.ContentLength}")
+            self.logger.info(f"S3 object: {o.key}, {o.content_length}")
 
         wrote_at_least = self._producer.produce_status.acked
 

--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -144,9 +144,11 @@ class KgoVerifierWithSiTest(KgoVerifierBase):
 
     def __init__(self, ctx):
         # Allow enough space for each parallel random read to be able to evict a segment
-        si_settings = SISettings(cloud_storage_cache_size=(
-            self.cloud_storage_cache_size or self.RANDOM_READ_PARALLEL *
-            self.segment_size))
+        si_settings = SISettings(
+            ctx,
+            cloud_storage_cache_size=(self.cloud_storage_cache_size
+                                      or self.RANDOM_READ_PARALLEL *
+                                      self.segment_size))
 
         super(KgoVerifierWithSiTest, self).__init__(
             test_context=ctx,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -347,6 +347,15 @@ class SISettings:
 
             self.endpoint_url = None
             self.cloud_storage_disable_tls = False
+            self.cloud_storage_api_endpoint_port = 443
+        if test_context.globals.get(self.GLOBAL_S3_SECRET_KEY, None):
+            test_context.ok_to_fail = True
+
+            msg = (
+                "Test requested ABS cloud storage, but provided globals for Azure."
+                " Stopping and marking as OFAIL.")
+            logger.info(msg)
+            raise Exception(msg)
         else:
             logger.debug("Running in Dockerised env against Azurite. "
                          "Using Azurite defualt credentials.")
@@ -373,8 +382,17 @@ class SISettings:
             self.cloud_storage_region = cloud_storage_region
             self.cloud_storage_api_endpoint_port = 443
         else:
-            logger.debug(
-                'No AWS credentials supplied, assuming minio defaults')
+            if test_context.globals.get(self.GLOBAL_ABS_SHARED_KEY, None):
+                test_context.ok_to_fail = True
+
+                msg = (
+                    "Test requested S3 cloud storage, but provided globals for Azure."
+                    " Stopping and marking as OFAIL.")
+                logger.info(msg)
+                raise Exception(msg)
+            else:
+                logger.debug(
+                    'No AWS credentials supplied, assuming minio defaults')
 
     @property
     def cloud_storage_bucket(self):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -22,13 +22,14 @@ import collections
 import re
 import uuid
 import zipfile
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Mapping, Optional, Tuple, Union, Any
 
 import yaml
 from ducktape.services.service import Service
 from ducktape.tests.test import TestContext
 from rptest.archival.s3_client import S3Client
+from rptest.archival.abs_client import ABSClient
 from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.utils.local_filesystem_utils import mkdir_p
 from ducktape.utils.util import wait_until
@@ -147,6 +148,11 @@ class MetricsEndpoint(Enum):
     PUBLIC_METRICS = 2
 
 
+class CloudStorageType(IntEnum):
+    S3 = 1
+    ABS = 2
+
+
 def one_or_many(value):
     """
     Helper for reading `one_or_many_property` configs when
@@ -253,14 +259,21 @@ class ResourceSettings:
 class SISettings:
     """
     Settings for shadow indexing stuff.
-    The defaults are for use with the default minio docker container, these
-    settings are altered in RedpandaTest if running on AWS.
+    The defaults are for use with the default minio docker container,
+    but if the test was parametrised with 'cloud_storage_type==CloudStorageType.ABS',
+    then the resulting settings will be for use with Azurite.
+
+    These settings are altered in RedpandaTest if running on AWS.
     """
     GLOBAL_S3_ACCESS_KEY = "s3_access_key"
     GLOBAL_S3_SECRET_KEY = "s3_secret_key"
     GLOBAL_S3_REGION_KEY = "s3_region"
 
+    GLOBAL_ABS_STORAGE_ACCOUNT = "abs_storage_account"
+    GLOBAL_ABS_SHARED_KEY = "abs_shared_key"
+
     def __init__(self,
+                 test_context,
                  *,
                  log_segment_size: int = 16 * 1000000,
                  cloud_storage_access_key: str = 'panda-user',
@@ -278,13 +291,34 @@ class SISettings:
                  cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
                      int] = None,
                  bypass_bucket_creation: bool = False):
+        self.cloud_storage_type = CloudStorageType.S3
+        if hasattr(test_context, 'injected_args') \
+        and test_context.injected_args is not None \
+        and 'cloud_storage_type' in test_context.injected_args:
+            self.cloud_storage_type = test_context.injected_args[
+                'cloud_storage_type']
+
+        if self.cloud_storage_type == CloudStorageType.S3:
+            self.cloud_storage_access_key = cloud_storage_access_key
+            self.cloud_storage_secret_key = cloud_storage_secret_key
+            self.cloud_storage_region = cloud_storage_region
+            self._cloud_storage_bucket = f'panda-bucket-{uuid.uuid1()}'
+
+            self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
+            self.cloud_storage_api_endpoint_port = cloud_storage_api_endpoint_port
+        elif self.cloud_storage_type == CloudStorageType.ABS:
+            # These are the default Azurite (Azure emulator) storage account and shared key.
+            # Both are readily available in the docs.
+            self.cloud_storage_azure_shared_key = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
+            self.cloud_storage_azure_storage_account = 'devstoreaccount1'
+
+            self._cloud_storage_azure_container = f'panda-container-{uuid.uuid1()}'
+            self.cloud_storage_api_endpoint = f'{self.cloud_storage_azure_storage_account}.blob.localhost'
+            self.cloud_storage_api_endpoint_port = 10000
+        else:
+            assert False, f"Unexpected value provided for 'cloud_storage_type' injected arg: {self.cloud_storage_type}"
+
         self.log_segment_size = log_segment_size
-        self.cloud_storage_access_key = cloud_storage_access_key
-        self.cloud_storage_secret_key = cloud_storage_secret_key
-        self.cloud_storage_region = cloud_storage_region
-        self.cloud_storage_bucket = f'panda-bucket-{uuid.uuid1()}'
-        self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
-        self.cloud_storage_api_endpoint_port = cloud_storage_api_endpoint_port
         self.cloud_storage_cache_size = cloud_storage_cache_size
         self.cloud_storage_enable_remote_read = cloud_storage_enable_remote_read
         self.cloud_storage_enable_remote_write = cloud_storage_enable_remote_write
@@ -296,6 +330,28 @@ class SISettings:
         self.bypass_bucket_creation = bypass_bucket_creation
 
     def load_context(self, logger, test_context):
+        if self.cloud_storage_type == CloudStorageType.S3:
+            self._load_s3_context(logger, test_context)
+        elif self.cloud_storage_type == CloudStorageType.ABS:
+            self._load_abs_context(logger, test_context)
+
+    def _load_abs_context(self, logger, test_context):
+        storage_account = test_context.globals.get(
+            self.GLOBAL_ABS_STORAGE_ACCOUNT, None)
+        shared_key = test_context.globals.get(self.GLOBAL_ABS_SHARED_KEY, None)
+
+        if storage_account and shared_key:
+            logger.info("Running on Azure, setting credentials from env")
+            self.cloud_storage_azure_storage_account = storage_account
+            self.cloud_storage_azure_shared_key = shared_key
+
+            self.endpoint_url = None
+            self.cloud_storage_disable_tls = False
+        else:
+            logger.debug("Running in Dockerised env against Azurite. "
+                         "Using Azurite defualt credentials.")
+
+    def _load_s3_context(self, logger, test_context):
         """
         Update based on the test context, to e.g. consume AWS access keys in
         the globals dictionary.
@@ -320,13 +376,33 @@ class SISettings:
             logger.debug(
                 'No AWS credentials supplied, assuming minio defaults')
 
+    @property
+    def cloud_storage_bucket(self):
+        if self.cloud_storage_type == CloudStorageType.S3:
+            return self._cloud_storage_bucket
+        elif self.cloud_storage_type == CloudStorageType.ABS:
+            return self._cloud_storage_azure_container
+
+    @cloud_storage_bucket.setter
+    def cloud_storage_bucket(self, bucket: str):
+        self._cloud_storage_bucket = bucket
+
     # Call this to update the extra_rp_conf
     def update_rp_conf(self, conf) -> dict[str, Any]:
+        if self.cloud_storage_type == CloudStorageType.S3:
+            conf["cloud_storage_access_key"] = self.cloud_storage_access_key
+            conf["cloud_storage_secret_key"] = self.cloud_storage_secret_key
+            conf["cloud_storage_region"] = self.cloud_storage_region
+            conf["cloud_storage_bucket"] = self._cloud_storage_bucket
+        elif self.cloud_storage_type == CloudStorageType.ABS:
+            conf[
+                'cloud_storage_azure_storage_account'] = self.cloud_storage_azure_storage_account
+            conf[
+                'cloud_storage_azure_container'] = self._cloud_storage_azure_container
+            conf[
+                'cloud_storage_azure_shared_key'] = self.cloud_storage_azure_shared_key
+
         conf["log_segment_size"] = self.log_segment_size
-        conf["cloud_storage_access_key"] = self.cloud_storage_access_key
-        conf["cloud_storage_secret_key"] = self.cloud_storage_secret_key
-        conf["cloud_storage_region"] = self.cloud_storage_region
-        conf["cloud_storage_bucket"] = self.cloud_storage_bucket
         conf["cloud_storage_enabled"] = True
         conf["cloud_storage_cache_size"] = self.cloud_storage_cache_size
         conf[
@@ -1345,21 +1421,37 @@ class RedpandaService(Service):
         self.start_service(node, start_wasm_service)
 
     def start_si(self):
-        self.cloud_storage_client = S3Client(
-            region=self._si_settings.cloud_storage_region,
-            access_key=self._si_settings.cloud_storage_access_key,
-            secret_key=self._si_settings.cloud_storage_secret_key,
-            endpoint=self._si_settings.endpoint_url,
-            logger=self.logger,
-        )
+        if self._si_settings.cloud_storage_type == CloudStorageType.S3:
+            self.cloud_storage_client = S3Client(
+                region=self._si_settings.cloud_storage_region,
+                access_key=self._si_settings.cloud_storage_access_key,
+                secret_key=self._si_settings.cloud_storage_secret_key,
+                endpoint=self._si_settings.endpoint_url,
+                logger=self.logger,
+            )
 
-        self.logger.debug(
-            f"Creating S3 bucket: {self._si_settings.cloud_storage_bucket}")
+            self.logger.debug(
+                f"Creating S3 bucket: {self._si_settings.cloud_storage_bucket}"
+            )
+        elif self._si_settings.cloud_storage_type == CloudStorageType.ABS:
+            self.cloud_storage_client = ABSClient(
+                logger=self.logger,
+                storage_account=self._si_settings.
+                cloud_storage_azure_storage_account,
+                shared_key=self._si_settings.cloud_storage_azure_shared_key,
+                endpoint=self._si_settings.endpoint_url)
+            self.logger.debug(
+                f"Creating ABS container: {self._si_settings.cloud_storage_bucket}"
+            )
+
         if not self._si_settings.bypass_bucket_creation:
             self.cloud_storage_client.create_bucket(
                 self._si_settings.cloud_storage_bucket)
 
     def delete_bucket_from_si(self):
+        self.logger.debug(
+            f"Deleting bucket/container: {self._si_settings.cloud_storage_bucket}"
+        )
         assert self.cloud_storage_client is not None
 
         failed_deletions = self.cloud_storage_client.empty_bucket(

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1359,10 +1359,6 @@ class RedpandaService(Service):
             self.s3_client.create_bucket(
                 self._si_settings.cloud_storage_bucket)
 
-    def list_buckets(self) -> dict[str, Union[list, dict]]:
-        assert self.s3_client is not None
-        return self.s3_client.list_buckets()
-
     def delete_bucket_from_si(self):
         assert self.s3_client is not None
 
@@ -1529,7 +1525,7 @@ class RedpandaService(Service):
         manifests_to_dump = []
         for o in self.s3_client.list_objects(
                 self._si_settings.cloud_storage_bucket):
-            key = o.Key
+            key = o.key
             if key_dump_limit > 0:
                 self.logger.info(f"  {key}")
                 key_dump_limit -= 1

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -198,7 +198,7 @@ class ArchivalTest(RedpandaTest):
             # firewall is blocked. No segments or partition manifest should be present.
             topic_manifest_id = "d0000000/meta/kafka/panda-topic/topic_manifest.json"
             objects = self.s3_client.list_objects(self.s3_bucket_name)
-            keys = [x.Key for x in objects]
+            keys = [x.key for x in objects]
 
             assert len(keys) < 2, \
                 f"Bucket should be empty or contain only {topic_manifest_id}, but contains {keys}"
@@ -644,7 +644,7 @@ class ArchivalTest(RedpandaTest):
             self.logger.debug(f"ListObjects(source: manifest): {results}")
         except:
             results = [
-                loc.Key
+                loc.key
                 for loc in self.s3_client.list_objects(self.s3_bucket_name)
             ]
             self.logger.debug(f"ListObjects: {results}")
@@ -776,9 +776,9 @@ class ArchivalTest(RedpandaTest):
             self.logger.info(f"object: {o}")
 
         return {
-            normalize(it.Key): (it.ETag, it.ContentLength)
+            normalize(it.key): (it.etag, it.content_length)
             for it in self.s3_client.list_objects(self.s3_bucket_name)
-            if included(it.Key)
+            if included(it.key)
         }
 
     def _get_partial_checksum(self, hostname, normalized_path, tail_bytes):

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -177,7 +177,7 @@ class ArchivalTest(RedpandaTest):
                                         'true')
 
     def tearDown(self):
-        self.s3_client.empty_bucket(self.s3_bucket_name)
+        self.cloud_storage_client.empty_bucket(self.s3_bucket_name)
         super().tearDown()
 
     @cluster(num_nodes=3)
@@ -197,7 +197,8 @@ class ArchivalTest(RedpandaTest):
             # Topic manifest can be present in the bucket because topic is created before
             # firewall is blocked. No segments or partition manifest should be present.
             topic_manifest_id = "d0000000/meta/kafka/panda-topic/topic_manifest.json"
-            objects = self.s3_client.list_objects(self.s3_bucket_name)
+            objects = self.cloud_storage_client.list_objects(
+                self.s3_bucket_name)
             keys = [x.key for x in objects]
 
             assert len(keys) < 2, \
@@ -460,7 +461,8 @@ class ArchivalTest(RedpandaTest):
                 f"expected path {expected} is not found in the bucket, bucket content: \n{objlist}"
             )
             assert not id is None
-        manifest = self.s3_client.get_object_data(self.s3_bucket_name, id)
+        manifest = self.cloud_storage_client.get_object_data(
+            self.s3_bucket_name, id)
         self.logger.info(f"manifest found: {manifest}")
         return json.loads(manifest)
 
@@ -636,16 +638,16 @@ class ArchivalTest(RedpandaTest):
         try:
             topic_manifest_id = "d0000000/meta/kafka/panda-topic/topic_manifest.json"
             partition_manifest_id = "d0000000/meta/kafka/panda-topic/0_9/manifest.json"
-            manifest = self.s3_client.get_object_data(self.s3_bucket_name,
-                                                      partition_manifest_id)
+            manifest = self.cloud_storage_client.get_object_data(
+                self.s3_bucket_name, partition_manifest_id)
             results = [topic_manifest_id, partition_manifest_id]
             for id in manifest['segments'].keys():
                 results.append(id)
             self.logger.debug(f"ListObjects(source: manifest): {results}")
         except:
             results = [
-                loc.key
-                for loc in self.s3_client.list_objects(self.s3_bucket_name)
+                loc.key for loc in self.cloud_storage_client.list_objects(
+                    self.s3_bucket_name)
             ]
             self.logger.debug(f"ListObjects: {results}")
         return results
@@ -768,7 +770,7 @@ class ArchivalTest(RedpandaTest):
             manifest_extension = ".json"
             return not path.endswith(manifest_extension)
 
-        objects = self.s3_client.list_objects(self.s3_bucket_name)
+        objects = self.cloud_storage_client.list_objects(self.s3_bucket_name)
         self.logger.info(
             f"got {len(list(objects))} objects from bucket {self.s3_bucket_name}"
         )
@@ -777,8 +779,8 @@ class ArchivalTest(RedpandaTest):
 
         return {
             normalize(it.key): (it.etag, it.content_length)
-            for it in self.s3_client.list_objects(self.s3_bucket_name)
-            if included(it.key)
+            for it in self.cloud_storage_client.list_objects(
+                self.s3_bucket_name) if included(it.key)
         }
 
     def _get_partial_checksum(self, hostname, normalized_path, tail_bytes):

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -9,7 +9,7 @@
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import RedpandaService, SISettings
+from rptest.services.redpanda import CloudStorageType, RedpandaService, SISettings
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
@@ -21,7 +21,7 @@ from rptest.util import (
     firewall_blocked,
 )
 
-from ducktape.mark import matrix
+from ducktape.mark import matrix, parametrize
 
 from collections import namedtuple, defaultdict
 import time
@@ -182,14 +182,18 @@ class ArchivalTest(RedpandaTest):
         super().tearDown()
 
     @cluster(num_nodes=3)
-    def test_write(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_write(self, cloud_storage_type):
         """Simpe smoke test, write data to redpanda and check if the
         data hit the S3 storage bucket"""
         self.kafka_tools.produce(self.topic, 10000, 1024)
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    def test_isolate(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_isolate(self, cloud_storage_type):
         """Verify that our isolate/rejoin facilities actually work"""
         with firewall_blocked(self.redpanda.nodes, self._s3_port):
             self.kafka_tools.produce(self.topic, 10000, 1024)
@@ -210,7 +214,9 @@ class ArchivalTest(RedpandaTest):
                     f"Bucket should be empty or contain only {topic_manifest_id}, but contains {keys[0]}"
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    def test_reconnect(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_reconnect(self, cloud_storage_type):
         """Disconnect redpanda from S3, write data, connect redpanda to S3
         and check that the data is uploaded"""
         with firewall_blocked(self.redpanda.nodes, self._s3_port):
@@ -222,7 +228,9 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    def test_one_node_reconnect(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_one_node_reconnect(self, cloud_storage_type):
         """Disconnect one redpanda node from S3, write data, connect redpanda to S3
         and check that the data is uploaded"""
         self.kafka_tools.produce(self.topic, 1000, 1024)
@@ -236,7 +244,9 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    def test_connection_drop(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_connection_drop(self, cloud_storage_type):
         """Disconnect redpanda from S3 during the active upload, restore connection
         and check that everything is uploaded"""
         self.kafka_tools.produce(self.topic, 10000, 1024)
@@ -248,7 +258,9 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    def test_connection_flicker(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_connection_flicker(self, cloud_storage_type):
         """Disconnect redpanda from S3 during the active upload for short period of time
         during upload and check that everything is uploaded"""
         con_enabled = True
@@ -265,7 +277,9 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3)
-    def test_single_partition_leadership_transfer(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_single_partition_leadership_transfer(self, cloud_storage_type):
         """Start uploading data, restart leader node of the partition 0 to trigger the
         leadership transfer, continue upload, verify S3 bucket content"""
         self.kafka_tools.produce(self.topic, 5000, 1024)
@@ -280,7 +294,9 @@ class ArchivalTest(RedpandaTest):
         validate(self._cross_node_verify, self.logger, 90)
 
     @cluster(num_nodes=3)
-    def test_all_partitions_leadership_transfer(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_all_partitions_leadership_transfer(self, cloud_storage_type):
         """Start uploading data, restart leader nodes of all partitions to trigger the
         leadership transfer, continue upload, verify S3 bucket content"""
         self.kafka_tools.produce(self.topic, 5000, 1024)
@@ -296,8 +312,9 @@ class ArchivalTest(RedpandaTest):
         validate(self._cross_node_verify, self.logger, 90)
 
     @cluster(num_nodes=3)
-    @matrix(acks=[-1, 0, 1])
-    def test_timeboxed_uploads(self, acks):
+    @matrix(acks=[-1, 0, 1],
+            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    def test_timeboxed_uploads(self, acks, cloud_storage_type):
         """This test checks segment upload time limit. The feature is enabled in the
         configuration. The configuration defines maximum time interval between uploads.
         If the option is set then redpanda will start uploading a segment partially if
@@ -374,8 +391,9 @@ class ArchivalTest(RedpandaTest):
         validate(check_upload, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @matrix(acks=[1, -1])
-    def test_retention_archival_coordination(self, acks):
+    @matrix(acks=[1, -1],
+            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    def test_retention_archival_coordination(self, acks, cloud_storage_type):
         """
         Test that only archived segments can be evicted and that eviction
         restarts once the segments have been archived.

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -146,7 +146,8 @@ class ArchivalTest(RedpandaTest):
                         replication_factor=3), )
 
     def __init__(self, test_context):
-        si_settings = SISettings(cloud_storage_max_connections=5,
+        si_settings = SISettings(test_context,
+                                 cloud_storage_max_connections=5,
                                  log_segment_size=self.log_segment_size)
         self.s3_bucket_name = si_settings.cloud_storage_bucket
 

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -34,7 +34,8 @@ class CloudRetentionTest(PreallocNodesTest):
             test_context=test_context,
             node_prealloc_count=1,
             num_brokers=3,
-            si_settings=SISettings(log_segment_size=self.segment_size),
+            si_settings=SISettings(test_context,
+                                   log_segment_size=self.segment_size),
             extra_rp_conf=extra_rp_conf)
 
     @cluster(num_nodes=4)

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -103,7 +103,7 @@ class CloudRetentionTest(PreallocNodesTest):
         def check_bucket_size():
             try:
                 size = sum(obj.content_length
-                           for obj in self.s3_client.list_objects(
+                           for obj in self.cloud_storage_client.list_objects(
                                self.si_settings.cloud_storage_bucket))
                 self.logger.info(f"bucket size: {size}")
                 # check that for each partition there is more than 1

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -102,7 +102,7 @@ class CloudRetentionTest(PreallocNodesTest):
 
         def check_bucket_size():
             try:
-                size = sum(obj.ContentLength
+                size = sum(obj.content_length
                            for obj in self.s3_client.list_objects(
                                self.si_settings.cloud_storage_bucket))
                 self.logger.info(f"bucket size: {size}")

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -31,7 +31,8 @@ BOOTSTRAP_CONFIG = {
     'enable_idempotence': False,
 }
 
-SECRET_CONFIG_NAMES = frozenset(["cloud_storage_secret_key"])
+SECRET_CONFIG_NAMES = frozenset(
+    ["cloud_storage_secret_key", "cloud_storage_azure_shared_key"])
 
 
 class ClusterConfigUpgradeTest(RedpandaTest):

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -56,6 +56,7 @@ class EndToEndShadowIndexingBase(EndToEndTest):
         self.topic = self.s3_topic_name
 
         self.si_settings = SISettings(
+            test_context,
             cloud_storage_max_connections=5,
             log_segment_size=self.segment_size,  # 1MB
         )
@@ -434,7 +435,8 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
     topics = [TopicSpec()]
 
     def __init__(self, test_context: TestContext):
-        si_settings = SISettings(log_segment_size=self.segment_size,
+        si_settings = SISettings(test_context,
+                                 log_segment_size=self.segment_size,
                                  cloud_storage_cache_size=20 * 2**30,
                                  cloud_storage_enable_remote_read=False,
                                  cloud_storage_enable_remote_write=False)

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -121,13 +121,13 @@ class EndToEndTopicRecovery(RedpandaTest):
     def _s3_has_all_data(self, num_messages):
         objects = list(self.redpanda.get_objects_from_si())
         for o in objects:
-            if o.Key.endswith("/manifest.json") and self.topic in o.Key:
+            if o.key.endswith("/manifest.json") and self.topic in o.key:
                 data = self.redpanda.s3_client.get_object_data(
-                    self._bucket, o.Key)
+                    self._bucket, o.key)
                 manifest = json.loads(data)
                 last_upl_offset = manifest['last_offset']
                 self.logger.info(
-                    f"Found manifest at {o.Key}, last_offset is {last_upl_offset}"
+                    f"Found manifest at {o.key}, last_offset is {last_upl_offset}"
                 )
                 # We have one partition so this invariant holds
                 # it has to be changed when the number of partitions

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -122,7 +122,7 @@ class EndToEndTopicRecovery(RedpandaTest):
         objects = list(self.redpanda.get_objects_from_si())
         for o in objects:
             if o.key.endswith("/manifest.json") and self.topic in o.key:
-                data = self.redpanda.s3_client.get_object_data(
+                data = self.redpanda.cloud_storage_client.get_object_data(
                     self._bucket, o.key)
                 manifest = json.loads(data)
                 last_upl_offset = manifest['last_offset']

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -41,6 +41,7 @@ class EndToEndTopicRecovery(RedpandaTest):
             group_initial_rebalance_delay=300,
         )
         si_settings = SISettings(
+            test_context,
             log_segment_size=1024 * 1024,
             cloud_storage_segment_max_upload_interval_sec=5,
             cloud_storage_enable_remote_read=True,

--- a/tests/rptest/tests/license_upgrade_test.py
+++ b/tests/rptest/tests/license_upgrade_test.py
@@ -36,9 +36,10 @@ class UpgradeToLicenseChecks(RedpandaTest):
         # Setting 'si_settings' enables a licensed feature, however at v22.1.4 there
         # are no license checks present. This test verifies behavior between versions
         # of redpanda that do and do not have the licensing feature built-in.
-        super(UpgradeToLicenseChecks, self).__init__(test_context=test_context,
-                                                     num_brokers=3,
-                                                     si_settings=SISettings())
+        super(UpgradeToLicenseChecks,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             si_settings=SISettings(test_context))
         self.installer = self.redpanda._installer
         self.admin = Admin(self.redpanda)
 
@@ -118,7 +119,7 @@ class UpgradeMigratingLicenseVersion(RedpandaTest):
         super(UpgradeMigratingLicenseVersion,
               self).__init__(test_context=test_context,
                              num_brokers=3,
-                             si_settings=SISettings())
+                             si_settings=SISettings(test_context))
         self.installer = self.redpanda._installer
         self.admin = Admin(self.redpanda)
 

--- a/tests/rptest/tests/multi_restarts_with_archival_test.py
+++ b/tests/rptest/tests/multi_restarts_with_archival_test.py
@@ -37,7 +37,8 @@ class MultiRestartTest(EndToEndTest):
         # on debug builds.
         partition_count = 10 if self.debug_mode else 60
 
-        si_settings = SISettings(cloud_storage_max_connections=5,
+        si_settings = SISettings(self.test_context,
+                                 cloud_storage_max_connections=5,
                                  log_segment_size=self.log_segment_size)
         self.s3_bucket_name = si_settings.cloud_storage_bucket
 

--- a/tests/rptest/tests/multi_restarts_with_archival_test.py
+++ b/tests/rptest/tests/multi_restarts_with_archival_test.py
@@ -10,7 +10,8 @@
 import uuid
 
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings
+from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
@@ -31,7 +32,9 @@ class MultiRestartTest(EndToEndTest):
                                                extra_rp_conf=extra_rp_conf)
 
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    def test_recovery_after_multiple_restarts(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_recovery_after_multiple_restarts(self, cloud_storage_type):
         # If a debug build has to do a restart across a significant
         # number of partitions, it gets slow.  Use fewer partitions
         # on debug builds.

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -42,6 +42,7 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
                 "log_compaction_interval_ms": 1000
             },
             si_settings=SISettings(
+                test_context,
                 log_segment_size=OffsetForLeaderEpochArchivalTest.segment_size,
                 cloud_storage_cache_size=5 *
                 OffsetForLeaderEpochArchivalTest.segment_size))

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -770,6 +770,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         # Force shadow indexing to be used by most reads
         # in one test
         si_settings = SISettings(
+            ctx,
             cloud_storage_max_connections=5,
             log_segment_size=10240,  # 10KiB
             cloud_storage_enable_remote_read=True,

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -150,8 +150,8 @@ class TestReadReplicaService(EndToEndTest):
         bucket = self.si_settings.cloud_storage_bucket
         for o in s3.list_objects(bucket):
             num_objects += 1
-            total_bytes += o.ContentLength
-            keys.add(o.Key)
+            total_bytes += o.content_length
+            keys.add(o.key)
         self.redpanda.logger.info(f"bucket usage {num_objects} objects, " +
                                   f"{total_bytes} bytes for {bucket}")
         return BucketUsage(num_objects, total_bytes, keys)

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -143,9 +143,9 @@ class TestReadReplicaService(EndToEndTest):
             "because topic manifest is not in S3.")
 
     def _bucket_usage(self) -> BucketUsage:
-        assert self.redpanda and self.redpanda.s3_client
+        assert self.redpanda and self.redpanda.cloud_storage_client
         keys: set[str] = set()
-        s3 = self.redpanda.s3_client
+        s3 = self.redpanda.cloud_storage_client
         num_objects = total_bytes = 0
         bucket = self.si_settings.cloud_storage_bucket
         for o in s3.list_objects(bucket):
@@ -187,12 +187,12 @@ class TestReadReplicaService(EndToEndTest):
             second_rpk.produce(self.topic_name, "", "test payload")
 
         objects_before = set(
-            self.redpanda.s3_client.list_objects(
+            self.redpanda.cloud_storage_client.list_objects(
                 self.si_settings.cloud_storage_bucket))
         assert len(objects_before) > 0
         second_rpk.delete_topic(self.topic_name)
         objects_after = set(
-            self.redpanda.s3_client.list_objects(
+            self.redpanda.cloud_storage_client.list_objects(
                 self.si_settings.cloud_storage_bucket))
         if len(objects_after) < len(objects_before):
             deleted = objects_before - objects_after

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -41,6 +41,7 @@ class TestReadReplicaService(EndToEndTest):
         super(TestReadReplicaService, self).__init__(
             test_context=test_context,
             si_settings=SISettings(
+                test_context,
                 cloud_storage_max_connections=5,
                 log_segment_size=TestReadReplicaService.log_segment_size,
                 cloud_storage_readreplica_manifest_sync_timeout_ms=500,
@@ -50,6 +51,7 @@ class TestReadReplicaService(EndToEndTest):
         # We're adding 'none' as a bucket name without creating
         # an actual bucket with such name.
         self.rr_settings = SISettings(
+            test_context,
             bypass_bucket_creation=True,
             cloud_storage_max_connections=5,
             log_segment_size=TestReadReplicaService.log_segment_size,

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -18,7 +18,7 @@ from rptest.util import expect_exception
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import CloudStorageType, RedpandaService
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.utils.expect_rate import ExpectRate, RateTarget
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
@@ -171,8 +171,10 @@ class TestReadReplicaService(EndToEndTest):
             return None
 
     @cluster(num_nodes=7)
-    @matrix(partition_count=[10])
-    def test_writes_forbidden(self, partition_count: int) -> None:
+    @matrix(partition_count=[10],
+            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    def test_writes_forbidden(self, partition_count: int,
+                              cloud_storage_type: CloudStorageType) -> None:
         """
         Verify that the read replica cluster does not permit writes,
         and does not perform other data-modifying actions such as
@@ -206,9 +208,11 @@ class TestReadReplicaService(EndToEndTest):
             assert len(objects_after) >= len(objects_before)
 
     @cluster(num_nodes=9)
-    @matrix(partition_count=[10], min_records=[10000])
-    def test_simple_end_to_end(self, partition_count: int,
-                               min_records: int) -> None:
+    @matrix(partition_count=[10],
+            min_records=[10000],
+            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    def test_simple_end_to_end(self, partition_count: int, min_records: int,
+                               cloud_storage_type: CloudStorageType) -> None:
 
         self._setup_read_replica(num_messages=min_records,
                                  partition_count=partition_count)

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -92,8 +92,8 @@ class RedpandaTest(Test):
         return os.environ.get('CI', None) != 'false'
 
     @property
-    def s3_client(self):
-        return self.redpanda.s3_client
+    def cloud_storage_client(self):
+        return self.redpanda.cloud_storage_client
 
     def setUp(self):
         self.redpanda.start()

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -443,7 +443,8 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                             bytes_to_produce=total_bytes)
 
         def cloud_log_size() -> int:
-            s3_snapshot = S3Snapshot([topic], self.redpanda.s3_client,
+            s3_snapshot = S3Snapshot([topic],
+                                     self.redpanda.cloud_storage_client,
                                      self.s3_bucket_name, self.logger)
             cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(topic.name, 0)
             self.logger.debug(f"Current cloud log size is: {cloud_log_size}")
@@ -505,7 +506,8 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                             bytes_to_produce=total_bytes)
 
         def cloud_log_segment_count() -> int:
-            s3_snapshot = S3Snapshot([topic], self.redpanda.s3_client,
+            s3_snapshot = S3Snapshot([topic],
+                                     self.redpanda.cloud_storage_client,
                                      self.s3_bucket_name, self.logger)
             count = s3_snapshot.cloud_log_segment_count_for_ntp(topic.name, 0)
             self.logger.debug(
@@ -583,7 +585,8 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                             bytes_to_produce=total_bytes)
 
         def ntp_in_manifest() -> int:
-            s3_snapshot = S3Snapshot([topic], self.redpanda.s3_client,
+            s3_snapshot = S3Snapshot([topic],
+                                     self.redpanda.cloud_storage_client,
                                      self.s3_bucket_name, self.logger)
             return s3_snapshot.is_ntp_in_manifest(topic.name, 0)
 
@@ -605,7 +608,8 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
         wait_until(lambda: ntp_in_manifest(), timeout_sec=10)
 
         def cloud_log_size() -> int:
-            s3_snapshot = S3Snapshot([topic], self.redpanda.s3_client,
+            s3_snapshot = S3Snapshot([topic],
+                                     self.redpanda.cloud_storage_client,
                                      self.s3_bucket_name, self.logger)
             cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(topic.name, 0)
             self.logger.debug(f"Current cloud log size is: {cloud_log_size}")

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -202,7 +202,8 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
                              retention_local_target_bytes_default=self.
                              default_retention_segments * self.segment_size)
 
-        si_settings = SISettings(log_segment_size=self.segment_size)
+        si_settings = SISettings(test_context,
+                                 log_segment_size=self.segment_size)
         super(ShadowIndexingLocalRetentionTest,
               self).__init__(test_context=test_context,
                              num_brokers=1,
@@ -352,7 +353,8 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
     def __init__(self, test_context):
         extra_rp_conf = dict(log_compaction_interval_ms=1000)
 
-        si_settings = SISettings(log_segment_size=self.segment_size)
+        si_settings = SISettings(test_context,
+                                 log_segment_size=self.segment_size)
         super(ShadowIndexingCloudRetentionTest,
               self).__init__(test_context=test_context,
                              si_settings=si_settings,

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -67,7 +67,7 @@ class SIAdminApiTest(RedpandaTest):
         self.redpanda.set_cluster_config({'admin_api_require_auth': True})
 
     def tearDown(self):
-        self.s3_client.empty_bucket(self.s3_bucket_name)
+        self.cloud_storage_client.empty_bucket(self.s3_bucket_name)
         super().tearDown()
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
@@ -109,8 +109,8 @@ class SIAdminApiTest(RedpandaTest):
 
         segment_to_remove = self.find_deletion_candidate()
         self.logger.info(f"trying to remove segment {segment_to_remove}")
-        self.s3_client.delete_object(self.s3_bucket_name, segment_to_remove,
-                                     True)
+        self.cloud_storage_client.delete_object(self.s3_bucket_name,
+                                                segment_to_remove, True)
 
         self.logger.info("trying to sync remote partition")
         for node in self.redpanda.nodes:
@@ -130,7 +130,7 @@ class SIAdminApiTest(RedpandaTest):
             assert part.start_offset > 0, f"start-offset of the partition is {part.start_offset}, should be greater than 0"
 
     def find_deletion_candidate(self):
-        for obj in self.s3_client.list_objects(self.s3_bucket_name):
+        for obj in self.cloud_storage_client.list_objects(self.s3_bucket_name):
             if re.match(r'.*/0-[\d-]*-1-v1.log\.\d+$', obj.key):
                 return obj.key
         return None

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -131,6 +131,6 @@ class SIAdminApiTest(RedpandaTest):
 
     def find_deletion_candidate(self):
         for obj in self.s3_client.list_objects(self.s3_bucket_name):
-            if re.match(r'.*/0-[\d-]*-1-v1.log\.\d+$', obj.Key):
-                return obj.Key
+            if re.match(r'.*/0-[\d-]*-1-v1.log\.\d+$', obj.key):
+                return obj.key
         return None

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -9,7 +9,7 @@ import re
 
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import RedpandaService, SISettings
+from rptest.services.redpanda import CloudStorageType, RedpandaService, SISettings
 
 from rptest.services.admin import Admin
 from rptest.clients.types import TopicSpec
@@ -19,6 +19,7 @@ from rptest.util import (
     produce_until_segments,
     wait_for_segments_removal,
 )
+from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 
 # Log errors expected when connectivity between redpanda and the S3
@@ -72,7 +73,9 @@ class SIAdminApiTest(RedpandaTest):
         super().tearDown()
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    def test_bucket_validation(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_bucket_validation(self, cloud_storage_type):
         """
         The test produces to the partition and waits untils the
         data is uploaded to S3 and the oldest segments are picked

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -38,6 +38,7 @@ class SIAdminApiTest(RedpandaTest):
 
     def __init__(self, test_context):
         si_settings = SISettings(
+            test_context,
             cloud_storage_max_connections=5,
             log_segment_size=self.log_segment_size,
             cloud_storage_enable_remote_read=True,

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -91,7 +91,8 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
                                        original_snapshot=original_snapshot)
 
         def compacted_segments_uploaded():
-            manifest = S3Snapshot(self.topics, self.redpanda.s3_client,
+            manifest = S3Snapshot(self.topics,
+                                  self.redpanda.cloud_storage_client,
                                   self.si_settings.cloud_storage_bucket,
                                   self.logger).manifest_for_ntp(self.topic,
                                                                 partition=0)
@@ -103,7 +104,8 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
                    backoff_sec=2,
                    err_msg=lambda: f"Compacted segments not uploaded")
 
-        s3_snapshot = S3Snapshot(self.topics, self.redpanda.s3_client,
+        s3_snapshot = S3Snapshot(self.topics,
+                                 self.redpanda.cloud_storage_client,
                                  self.si_settings.cloud_storage_bucket,
                                  self.logger)
         s3_snapshot.assert_at_least_n_uploaded_segments_compacted(self.topic,

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -20,7 +20,8 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
     def __init__(self, test_context):
         super().__init__(test_context)
         self.num_brokers = 3
-        self.si_settings = SISettings(cloud_storage_max_connections=5)
+        self.si_settings = SISettings(test_context,
+                                      cloud_storage_max_connections=5)
         extra_rp_conf = dict(
             enable_leader_balancer=False,
             partition_autobalancing_mode="off",

--- a/tests/rptest/tests/shadow_indexing_firewall_test.py
+++ b/tests/rptest/tests/shadow_indexing_firewall_test.py
@@ -38,7 +38,8 @@ class ShadowIndexingFirewallTest(RedpandaTest):
                         replication_factor=3), )
 
     def __init__(self, test_context):
-        si_settings = SISettings(cloud_storage_max_connections=5,
+        si_settings = SISettings(test_context,
+                                 cloud_storage_max_connections=5,
                                  log_segment_size=self.log_segment_size)
 
         super(ShadowIndexingFirewallTest,

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -34,7 +34,8 @@ class ShadowIndexingTxTest(RedpandaTest):
             group_initial_rebalance_delay=300,
         )
 
-        si_settings = SISettings(cloud_storage_max_connections=5,
+        si_settings = SISettings(test_context,
+                                 cloud_storage_max_connections=5,
                                  log_segment_size=self.segment_size)
 
         super(ShadowIndexingTxTest, self).__init__(test_context=test_context,

--- a/tests/rptest/tests/test_si_cache_space_leak.py
+++ b/tests/rptest/tests/test_si_cache_space_leak.py
@@ -100,7 +100,7 @@ class ShadowIndexingCacheSpaceLeakTest(RedpandaTest):
             objects = list(self.redpanda.get_objects_from_si())
             total_size = 0
             for o in objects:
-                total_size += o.ContentLength
+                total_size += o.content_length
             return total_size > self._segment_size
 
         wait_until(s3_has_some_data, timeout_sec=300, backoff_sec=5)

--- a/tests/rptest/tests/test_si_cache_space_leak.py
+++ b/tests/rptest/tests/test_si_cache_space_leak.py
@@ -43,7 +43,7 @@ class ShadowIndexingCacheSpaceLeakTest(RedpandaTest):
         test_name = test_context.test_name
         si_params = self.test_defaults.get(
             test_name) or self.test_defaults.get('default')
-        si_settings = SISettings(**si_params)
+        si_settings = SISettings(test_context, **si_params)
         self._segment_size = si_params['log_segment_size']
         extra_rp_conf = {
             'disable_metrics': True,

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -223,6 +223,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
 
         if cloud_storage:
             si_settings = SISettings(
+                self.test_context,
                 cloud_storage_max_connections=5,
                 log_segment_size=self.log_segment_size,
 
@@ -307,10 +308,12 @@ class TestReadReplicaTimeQuery(RedpandaTest):
         super(TestReadReplicaTimeQuery, self).__init__(
             test_context=test_context,
             si_settings=SISettings(
+                test_context,
                 log_segment_size=TestReadReplicaTimeQuery.log_segment_size,
                 cloud_storage_segment_max_upload_interval_sec=5))
 
         self.rr_settings = SISettings(
+            test_context,
             bypass_bucket_creation=True,
             cloud_storage_readreplica_manifest_sync_timeout_ms=500)
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -689,8 +689,8 @@ class CreateTopicUpgradeTest(RedpandaTest):
         self.logger.debug(f"Deleting {topic_name} and checking S3 result")
 
         before_objects = set(
-            o.Key for o in self.s3_client.list_objects(self._s3_bucket)
-            if topic_name in o.Key)
+            o.key for o in self.s3_client.list_objects(self._s3_bucket)
+            if topic_name in o.key)
 
         # Test is meaningless if there were no objects to start with
         assert len(before_objects) > 0
@@ -699,7 +699,7 @@ class CreateTopicUpgradeTest(RedpandaTest):
 
         def is_empty():
             return sum(1 for o in self.s3_client.list_objects(self._s3_bucket)
-                       if topic_name in o.Key) == 0
+                       if topic_name in o.key) == 0
 
         if expect_s3_deletion:
             wait_until(is_empty, timeout_sec=10, backoff_sec=1)
@@ -710,8 +710,8 @@ class CreateTopicUpgradeTest(RedpandaTest):
             sleep(10)
 
         after_objects = set(
-            o.Key for o in self.s3_client.list_objects(self._s3_bucket)
-            if topic_name in o.Key)
+            o.key for o in self.s3_client.list_objects(self._s3_bucket)
+            if topic_name in o.key)
         deleted_objects = before_objects - after_objects
         if expect_s3_deletion:
             assert deleted_objects

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -194,6 +194,7 @@ class CreateTopicsTest(RedpandaTest):
 
     def __init__(self, test_context):
         si_settings = SISettings(
+            test_context,
             cloud_storage_max_connections=5,
             cloud_storage_segment_max_upload_interval_sec=10,
             log_segment_size=100 * 1024 * 1024)
@@ -221,9 +222,10 @@ class CreateTopicsTest(RedpandaTest):
 
 class CreateSITopicsTest(RedpandaTest):
     def __init__(self, test_context):
-        super(CreateSITopicsTest, self).__init__(test_context=test_context,
-                                                 num_brokers=1,
-                                                 si_settings=SISettings())
+        super(CreateSITopicsTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=1,
+                             si_settings=SISettings(test_context))
 
     def _to_bool(self, x: str) -> bool:
         return True if x == "true" else False
@@ -462,7 +464,8 @@ class RecreateTopicMetadataTest(RedpandaTest):
 
 class CreateTopicUpgradeTest(RedpandaTest):
     def __init__(self, test_context):
-        si_settings = SISettings(cloud_storage_enable_remote_write=False,
+        si_settings = SISettings(test_context,
+                                 cloud_storage_enable_remote_write=False,
                                  cloud_storage_enable_remote_read=False)
         self._s3_bucket = si_settings.cloud_storage_bucket
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -689,7 +689,8 @@ class CreateTopicUpgradeTest(RedpandaTest):
         self.logger.debug(f"Deleting {topic_name} and checking S3 result")
 
         before_objects = set(
-            o.key for o in self.s3_client.list_objects(self._s3_bucket)
+            o.key
+            for o in self.cloud_storage_client.list_objects(self._s3_bucket)
             if topic_name in o.key)
 
         # Test is meaningless if there were no objects to start with
@@ -698,8 +699,8 @@ class CreateTopicUpgradeTest(RedpandaTest):
         self.rpk.delete_topic(topic_name)
 
         def is_empty():
-            return sum(1 for o in self.s3_client.list_objects(self._s3_bucket)
-                       if topic_name in o.key) == 0
+            return sum(1 for o in self.cloud_storage_client.list_objects(
+                self._s3_bucket) if topic_name in o.key) == 0
 
         if expect_s3_deletion:
             wait_until(is_empty, timeout_sec=10, backoff_sec=1)
@@ -710,7 +711,8 @@ class CreateTopicUpgradeTest(RedpandaTest):
             sleep(10)
 
         after_objects = set(
-            o.key for o in self.s3_client.list_objects(self._s3_bucket)
+            o.key
+            for o in self.cloud_storage_client.list_objects(self._s3_bucket)
             if topic_name in o.key)
         deleted_objects = before_objects - after_objects
         if expect_s3_deletion:

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -240,7 +240,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         gives up.
         """
         self._populate_topic(self.topic)
-        keys_before = set(o.Key for o in self.redpanda.s3_client.list_objects(
+        keys_before = set(o.key for o in self.redpanda.s3_client.list_objects(
             self.si_settings.cloud_storage_bucket, topic=self.topic))
         assert len(keys_before) > 0
 
@@ -260,7 +260,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             time.sleep(90)
 
             # Confirm our firewall block is really working, nothing was deleted
-            keys_after = set(o.Key
+            keys_after = set(o.key
                              for o in self.redpanda.s3_client.list_objects(
                                  self.si_settings.cloud_storage_bucket))
             assert len(keys_after) >= len(keys_before)
@@ -274,7 +274,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                       partition_count=self.partition_count,
                       cleanup_policy=TopicSpec.CLEANUP_DELETE))
         self._populate_topic(next_topic)
-        after_keys = set(o.Key for o in self.redpanda.s3_client.list_objects(
+        after_keys = set(o.key for o in self.redpanda.s3_client.list_objects(
             self.si_settings.cloud_storage_bucket, topic=next_topic))
         assert len(after_keys) > 0
 
@@ -320,7 +320,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         self._populate_topic(self.topic)
 
-        keys_before = set(o.Key for o in self.redpanda.s3_client.list_objects(
+        keys_before = set(o.key for o in self.redpanda.s3_client.list_objects(
             self.si_settings.cloud_storage_bucket))
 
         # Delete topic
@@ -337,7 +337,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             # instantly, but that they also are not deleted after some
             # delay.
             time.sleep(10)
-            keys_after = set(o.Key
+            keys_after = set(o.key
                              for o in self.redpanda.s3_client.list_objects(
                                  self.si_settings.cloud_storage_bucket))
             objects_deleted = keys_before - keys_after
@@ -374,7 +374,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         self._populate_topic(self.topic)
 
-        keys_before = set(o.Key for o in self.redpanda.s3_client.list_objects(
+        keys_before = set(o.key for o in self.redpanda.s3_client.list_objects(
             self.si_settings.cloud_storage_bucket))
 
         def get_nodes(partition):
@@ -399,7 +399,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # Some additional time in case a buggy deletion path is async
         time.sleep(5)
 
-        keys_after = set(o.Key for o in self.redpanda.s3_client.list_objects(
+        keys_after = set(o.key for o in self.redpanda.s3_client.list_objects(
             self.si_settings.cloud_storage_bucket))
 
         deleted = keys_before - keys_after

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -223,7 +223,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                                             timeout_sec=30)
 
         # Confirm objects in remote storage
-        objects = self.s3_client.list_objects(
+        objects = self.cloud_storage_client.list_objects(
             self.si_settings.cloud_storage_bucket, topic=topic_name)
         assert sum(1 for _ in objects) > 0
 
@@ -240,8 +240,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         gives up.
         """
         self._populate_topic(self.topic)
-        keys_before = set(o.key for o in self.redpanda.s3_client.list_objects(
-            self.si_settings.cloud_storage_bucket, topic=self.topic))
+        keys_before = set(
+            o.key for o in self.redpanda.cloud_storage_client.list_objects(
+                self.si_settings.cloud_storage_bucket, topic=self.topic))
         assert len(keys_before) > 0
 
         with firewall_blocked(self.redpanda.nodes, self._s3_port):
@@ -260,9 +261,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             time.sleep(90)
 
             # Confirm our firewall block is really working, nothing was deleted
-            keys_after = set(o.key
-                             for o in self.redpanda.s3_client.list_objects(
-                                 self.si_settings.cloud_storage_bucket))
+            keys_after = set(
+                o.key for o in self.redpanda.cloud_storage_client.list_objects(
+                    self.si_settings.cloud_storage_bucket))
             assert len(keys_after) >= len(keys_before)
 
         # Check that after the controller backend experiences errors trying
@@ -274,8 +275,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                       partition_count=self.partition_count,
                       cleanup_policy=TopicSpec.CLEANUP_DELETE))
         self._populate_topic(next_topic)
-        after_keys = set(o.key for o in self.redpanda.s3_client.list_objects(
-            self.si_settings.cloud_storage_bucket, topic=next_topic))
+        after_keys = set(
+            o.key for o in self.redpanda.cloud_storage_client.list_objects(
+                self.si_settings.cloud_storage_bucket, topic=next_topic))
         assert len(after_keys) > 0
 
         self.kafka_tools.delete_topic(next_topic)
@@ -292,13 +294,13 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # if we ever implement a mechanism for automatically GCing objects after
         # a drop in the object storage backend.
         final_objects = set(
-            self.s3_client.list_objects(self.si_settings.cloud_storage_bucket,
-                                        topic=self.topic))
+            self.cloud_storage_client.list_objects(
+                self.si_settings.cloud_storage_bucket, topic=self.topic))
         assert len(final_objects) >= len(keys_before)
 
     def _topic_remote_deleted(self, topic_name: str):
         """Return true if all objects removed from cloud storage"""
-        after_objects = self.s3_client.list_objects(
+        after_objects = self.cloud_storage_client.list_objects(
             self.si_settings.cloud_storage_bucket, topic=topic_name)
         self.logger.debug(f"Objects after topic {topic_name} deletion:")
         empty = True
@@ -320,8 +322,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         self._populate_topic(self.topic)
 
-        keys_before = set(o.key for o in self.redpanda.s3_client.list_objects(
-            self.si_settings.cloud_storage_bucket))
+        keys_before = set(
+            o.key for o in self.redpanda.cloud_storage_client.list_objects(
+                self.si_settings.cloud_storage_bucket))
 
         # Delete topic
         self.kafka_tools.delete_topic(self.topic)
@@ -337,9 +340,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             # instantly, but that they also are not deleted after some
             # delay.
             time.sleep(10)
-            keys_after = set(o.key
-                             for o in self.redpanda.s3_client.list_objects(
-                                 self.si_settings.cloud_storage_bucket))
+            keys_after = set(
+                o.key for o in self.redpanda.cloud_storage_client.list_objects(
+                    self.si_settings.cloud_storage_bucket))
             objects_deleted = keys_before - keys_after
             self.logger.debug(
                 f"Objects deleted after topic deletion: {objects_deleted}")
@@ -374,8 +377,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         self._populate_topic(self.topic)
 
-        keys_before = set(o.key for o in self.redpanda.s3_client.list_objects(
-            self.si_settings.cloud_storage_bucket))
+        keys_before = set(
+            o.key for o in self.redpanda.cloud_storage_client.list_objects(
+                self.si_settings.cloud_storage_bucket))
 
         def get_nodes(partition):
             return list(r['node_id'] for r in partition['replicas'])
@@ -399,8 +403,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # Some additional time in case a buggy deletion path is async
         time.sleep(5)
 
-        keys_after = set(o.key for o in self.redpanda.s3_client.list_objects(
-            self.si_settings.cloud_storage_bucket))
+        keys_after = set(
+            o.key for o in self.redpanda.cloud_storage_client.list_objects(
+                self.si_settings.cloud_storage_bucket))
 
         deleted = keys_before - keys_after
         self.logger.debug(f"Objects deleted after partition move: {deleted}")

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -187,7 +187,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                         cleanup_policy=TopicSpec.CLEANUP_DELETE), )
 
     def __init__(self, test_context):
-        self.si_settings = SISettings(log_segment_size=1024 * 1024)
+        self.si_settings = SISettings(test_context,
+                                      log_segment_size=1024 * 1024)
         super().__init__(
             test_context=test_context,
             # Use all nodes as brokers: enables each test to set num_nodes

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -222,7 +222,7 @@ class BaseCase:
 
     def _list_objects(self):
         """Return list of all topics in the bucket (only names)"""
-        results = [loc.Key for loc in self._s3.list_objects(self._bucket)]
+        results = [loc.key for loc in self._s3.list_objects(self._bucket)]
         self.logger.info(f"ListObjects: {results}")
         return results
 
@@ -571,7 +571,7 @@ class MissingSegment(BaseCase):
 
     def _delete(self, key):
         self._deleted_segment_size = self._s3.get_object_meta(
-            self._bucket, key).ContentLength
+            self._bucket, key).content_length
         self.logger.info(
             f"deleting segment file {key} of size {self._deleted_segment_size}"
         )
@@ -659,9 +659,9 @@ class FastCheck(BaseCase):
             if s3_snapshot.is_segment_part_of_a_manifest(item)
         ]
         for seg in segments:
-            components = parse_s3_segment_path(seg.Key)
+            components = parse_s3_segment_path(seg.key)
             ntp = components.ntp
-            segment_data = self._s3.get_object_data(self._bucket, seg.Key)
+            segment_data = self._s3.get_object_data(self._bucket, seg.key)
             segment_size = len(segment_data)
             segment = SegmentReader(io.BytesIO(segment_data))
             # We want to skip segments where the size is lower than EMPTY_SEGMENT_SIZE,
@@ -1108,7 +1108,7 @@ class TopicRecoveryTest(RedpandaTest):
             assert self.s3_client
             lst = self.s3_client.list_objects(self.s3_bucket)
             for obj in lst:
-                self.logger.debug(f'checking S3 object: {obj.Key}')
+                self.logger.debug(f'checking S3 object: {obj.key}')
                 if path_matcher.is_partition_manifest(obj):
                     manifests.append(obj)
                 elif path_matcher.is_topic_manifest(obj):
@@ -1136,8 +1136,8 @@ class TopicRecoveryTest(RedpandaTest):
                         tmp_size += size
                 size_on_disk = max(tmp_size, size_on_disk)
 
-            size_in_cloud = sum(obj.ContentLength for obj in segments
-                                if obj.ContentLength > EMPTY_SEGMENT_SIZE)
+            size_in_cloud = sum(obj.content_length for obj in segments
+                                if obj.content_length > EMPTY_SEGMENT_SIZE)
             self.logger.debug(
                 f'segments in cloud: {pprint.pformat(segments, indent=2)}, '
                 f'size in cloud: {size_in_cloud}')

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -983,8 +983,8 @@ class TopicRecoveryTest(RedpandaTest):
                            acks=acks)
 
     def tearDown(self):
-        assert self.s3_client
-        self.s3_client.empty_bucket(self.s3_bucket)
+        assert self.cloud_storage_client
+        self.cloud_storage_client.empty_bucket(self.s3_bucket)
         super().tearDown()
 
     def _collect_file_checksums(self) -> dict[str, FileToChecksumSize]:
@@ -1105,8 +1105,8 @@ class TopicRecoveryTest(RedpandaTest):
             manifests = []
             topic_manifests = []
             segments = []
-            assert self.s3_client
-            lst = self.s3_client.list_objects(self.s3_bucket)
+            assert self.cloud_storage_client
+            lst = self.cloud_storage_client.list_objects(self.s3_bucket)
             for obj in lst:
                 self.logger.debug(f'checking S3 object: {obj.key}')
                 if path_matcher.is_partition_manifest(obj):
@@ -1269,8 +1269,8 @@ class TopicRecoveryTest(RedpandaTest):
         """If we're trying to recovery a topic which didn't have any data
         in old cluster the empty topic should be created. We should be able
         to produce to the topic."""
-        test_case = NoDataCase(self.s3_client, self.kafka_tools, self.rpk,
-                               self.s3_bucket, self.logger,
+        test_case = NoDataCase(self.cloud_storage_client, self.kafka_tools,
+                               self.rpk, self.s3_bucket, self.logger,
                                self.rpk_producer_maker)
         self.do_run(test_case)
 
@@ -1279,8 +1279,9 @@ class TopicRecoveryTest(RedpandaTest):
     def test_empty_segments(self):
         """Test case in which the segments are uploaded but they doesn't
         have any data batches but they do have configuration batches."""
-        test_case = EmptySegmentsCase(self.s3_client, self.kafka_tools,
-                                      self.rpk, self.s3_bucket, self.logger,
+        test_case = EmptySegmentsCase(self.cloud_storage_client,
+                                      self.kafka_tools, self.rpk,
+                                      self.s3_bucket, self.logger,
                                       self.rpk_producer_maker, self.redpanda)
         self.do_run(test_case)
 
@@ -1290,8 +1291,9 @@ class TopicRecoveryTest(RedpandaTest):
         """If we're trying to recovery a topic which didn't have any data
         in old cluster the empty topic should be created. We should be able
         to produce to the topic."""
-        test_case = MissingTopicManifest(self.s3_client, self.kafka_tools,
-                                         self.rpk, self.s3_bucket, self.logger,
+        test_case = MissingTopicManifest(self.cloud_storage_client,
+                                         self.kafka_tools, self.rpk,
+                                         self.s3_bucket, self.logger,
                                          self.rpk_producer_maker)
         self.do_run(test_case)
 
@@ -1304,8 +1306,9 @@ class TopicRecoveryTest(RedpandaTest):
         locations that could be used if the partition was moved between the
         nodes.
         """
-        test_case = MissingPartition(self.s3_client, self.kafka_tools,
-                                     self.rpk, self.s3_bucket, self.logger,
+        test_case = MissingPartition(self.cloud_storage_client,
+                                     self.kafka_tools, self.rpk,
+                                     self.s3_bucket, self.logger,
                                      self.rpk_producer_maker)
         self.do_run(test_case)
 
@@ -1315,8 +1318,8 @@ class TopicRecoveryTest(RedpandaTest):
         """Test the handling of the missing segment. The segment is
         missing if it's present in the manifest but deleted from the
         bucket."""
-        test_case = MissingSegment(self.s3_client, self.kafka_tools, self.rpk,
-                                   self.s3_bucket, self.logger,
+        test_case = MissingSegment(self.cloud_storage_client, self.kafka_tools,
+                                   self.rpk, self.s3_bucket, self.logger,
                                    self.rpk_producer_maker)
         self.do_run(test_case)
 
@@ -1329,8 +1332,8 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=1,
                       replication_factor=3)
         ]
-        test_case = FastCheck(self.s3_client, self.kafka_tools, self.rpk,
-                              self.s3_bucket, self.logger,
+        test_case = FastCheck(self.cloud_storage_client, self.kafka_tools,
+                              self.rpk, self.s3_bucket, self.logger,
                               self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
@@ -1346,8 +1349,8 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=3,
                       replication_factor=3),
         ]
-        test_case = FastCheck(self.s3_client, self.kafka_tools, self.rpk,
-                              self.s3_bucket, self.logger,
+        test_case = FastCheck(self.cloud_storage_client, self.kafka_tools,
+                              self.rpk, self.s3_bucket, self.logger,
                               self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
@@ -1366,8 +1369,8 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=2,
                       replication_factor=3),
         ]
-        test_case = FastCheck(self.s3_client, self.kafka_tools, self.rpk,
-                              self.s3_bucket, self.logger,
+        test_case = FastCheck(self.cloud_storage_client, self.kafka_tools,
+                              self.rpk, self.s3_bucket, self.logger,
                               self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
@@ -1381,8 +1384,9 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=1,
                       replication_factor=3)
         ]
-        test_case = SizeBasedRetention(self.s3_client, self.kafka_tools,
-                                       self.rpk, self.s3_bucket, self.logger,
+        test_case = SizeBasedRetention(self.cloud_storage_client,
+                                       self.kafka_tools, self.rpk,
+                                       self.s3_bucket, self.logger,
                                        self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
@@ -1397,8 +1401,9 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=1,
                       replication_factor=3)
         ]
-        test_case = TimeBasedRetention(self.s3_client, self.kafka_tools,
-                                       self.rpk, self.s3_bucket, self.logger,
+        test_case = TimeBasedRetention(self.cloud_storage_client,
+                                       self.kafka_tools, self.rpk,
+                                       self.s3_bucket, self.logger,
                                        self.rpk_producer_maker, topics, False)
         self.do_run(test_case)
 
@@ -1413,7 +1418,8 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=1,
                       replication_factor=3)
         ]
-        test_case = TimeBasedRetention(self.s3_client, self.kafka_tools,
-                                       self.rpk, self.s3_bucket, self.logger,
+        test_case = TimeBasedRetention(self.cloud_storage_client,
+                                       self.kafka_tools, self.rpk,
+                                       self.s3_bucket, self.logger,
                                        self.rpk_producer_maker, topics, True)
         self.do_run(test_case)

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -947,7 +947,8 @@ class TopicRecoveryTest(RedpandaTest):
                  test_context: TestContext,
                  num_brokers: Optional[int] = None,
                  extra_rp_conf=dict()):
-        si_settings = SISettings(cloud_storage_max_connections=5,
+        si_settings = SISettings(test_context,
+                                 cloud_storage_max_connections=5,
                                  cloud_storage_segment_max_upload_interval_sec=
                                  CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC,
                                  log_segment_size=default_log_segment_size)

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -587,7 +587,8 @@ class UpgradeFrom22_2_7VerifyMigratedRetentionSettings(RedpandaTest):
         produce_until_segments(self.redpanda, topic.name, 0, total_segments)
 
         def cloud_log_size() -> int:
-            s3_snapshot = S3Snapshot([topic], self.redpanda.s3_client,
+            s3_snapshot = S3Snapshot([topic],
+                                     self.redpanda.cloud_storage_client,
                                      self.s3_bucket_name, self.logger)
             cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(topic.name, 0)
             self.logger.debug(f"Current cloud log size is: {cloud_log_size}")

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -361,7 +361,7 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
         super().__init__(
             test_context=test_context,
             num_brokers=3,
-            si_settings=SISettings(),
+            si_settings=SISettings(test_context),
             extra_rp_conf={
                 # We will exercise storage/cloud_storage read paths, get the
                 # batch cache out of the way to ensure reads hit storage layer.
@@ -537,7 +537,8 @@ class UpgradeFrom22_2_7VerifyMigratedRetentionSettings(RedpandaTest):
     segment_size = 1000000  # 1MB
 
     def __init__(self, test_context):
-        si_settings = SISettings(log_segment_size=self.segment_size)
+        si_settings = SISettings(test_context,
+                                 log_segment_size=self.segment_size)
         super().__init__(
             test_context=test_context,
             num_brokers=3,

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -18,7 +18,7 @@ setup(
         'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',
         'psutil==5.9.0', 'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
-        'jump-consistent-hash==3.2.0',
+        'jump-consistent-hash==3.2.0', 'azure-storage-blob==12.14.1',
         'kafkatest@git+https://github.com/apache/kafka.git@058589b03db686803b33052d574ce887fb5cfbd1#egg=kafkatest&subdirectory=tests'
     ],
     scripts=[],


### PR DESCRIPTION
## Cover Letter

Fixes https://github.com/redpanda-data/core-internal/issues/127
Fixes https://github.com/redpanda-data/redpanda/issues/7556

### High Level Description
This set of patches adds Azure Blob Storage support to Redpanda Tiered Storage. In theory, everything that works with S3 should also be supported in ABS as all RPCs used during normal operation are implemented.

### Configuration
ABS can be configured via the three cluster level configuration properties listed below. If `cloud_storage_azure_storage_account` is set, then all of them need to be set (otherwise Redpanda will refuse to start).
Note that if you wish to disable TLS for testing via `cloud_storage_disable_tls` you need to override the port via `cloud_storage_api_endpoint_port`. I'll attach an example config file to this PR.
* `cloud_storage_azure_storage_account`: the name of your storage account
* `cloud_storage_azure_container`: the name of the container
* `cloud_storage_azure_shared_key`: Shared Key provided by Azure

### Implementation Details

This PR can be split in a few high level logical stages:
1. Preliminaries: small tidy-ups, adjusting the client probe, adding ABS error codes
2. ABS client implementation
3. Configuration options and hooking the ABS client in
4. Changes in the test tree to get ABS tests running in CI against [Azurite](https://github.com/Azure/Azurite)

The general idea is that an instance of the `cloud_storage_clients::client_configuration` variant is created at start-up
and threaded into the relevant sharded service. It eventually reaches `cloud_storage_clients::client_pool` where it drives the type of client that's created.

The ABS client itself is designed in a similar way to the S3 client. It handles most exceptions locally and returns a recommendation to the remote on how to proceed (retry, slow down, give up, etc.).

### Testing

The idea is to leverage the existing tiered storage tests and run them against ABS. This PR enables a number
of tiered storage tests to run with ABS in CI, but the list is not exhaustive. I've also been testing this locally and
it seems pretty solid thus far. 

We also need to:
* Run tests against real Azure in CDT
* Find the write throughput limit from which we start getting throttled.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Features
* Redpanda gains support for using Azure Blob Storage with Tiered Storage. In order to point Redpanda at your ABS container, set the following new cluster configs: `cloud_storage_azure_storage_account`, `cloud_storage_azure_container`, `cloud_storage_azure_shared_key`.

### Improvements
* The existing `vectorized_s3_client.*` metrics have been renamed to `vectorized_cloud_client.*` in order to match the naming on the `public_metrics` endpoint.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
