### PR TITLE
[v22.3.x] k8s: broker_tls is enabled only if internal listener has tls

### DIFF
--- a/src/go/k8s/pkg/resources/certmanager/type_helpers.go
+++ b/src/go/k8s/pkg/resources/certmanager/type_helpers.go
@@ -138,6 +138,7 @@ type apiCertificates struct {
 	clientCertificates []resources.Resource
 	rootResources      []resources.Resource
 	tlsEnabled         bool
+	internalTlsEnabled bool
 	// true if api is using our own generated self-signed issuer
 	selfSignedNodeCertificate bool
 
@@ -251,6 +252,9 @@ func (cc *ClusterCertificates) prepareAPI(
 		return tlsDisabledAPICertificates(), nil
 	}
 	result := tlsEnabledAPICertificates(cc.pandaCluster.Namespace)
+	if internalTLSListener != nil {
+		result.internalTlsEnabled = true
+	}
 
 	// TODO(#3550): Do not create rootIssuer if nodeSecretRef is passed and mTLS is disabled
 	toApplyRoot, rootIssuerRef := prepareRoot(rootCertSuffix, cc.client, cc.pandaCluster, cc.scheme, cc.logger)
@@ -669,7 +673,7 @@ func (cc *ClusterCertificates) GetTLSConfig(
 
 // KafkaClientBrokerTLS returns configuration to connect to kafka api with tls
 func (cc *ClusterCertificates) KafkaClientBrokerTLS(mountPoints *resourcetypes.TLSMountPoints) *config.ServerTLS {
-	if !cc.kafkaAPI.tlsEnabled {
+	if !cc.kafkaAPI.internalTlsEnabled {
 		return nil
 	}
 	result := config.ServerTLS{

--- a/src/go/k8s/pkg/resources/certmanager/type_helpers.go
+++ b/src/go/k8s/pkg/resources/certmanager/type_helpers.go
@@ -138,7 +138,7 @@ type apiCertificates struct {
 	clientCertificates []resources.Resource
 	rootResources      []resources.Resource
 	tlsEnabled         bool
-	internalTlsEnabled bool
+	internalTLSEnabled bool
 	// true if api is using our own generated self-signed issuer
 	selfSignedNodeCertificate bool
 
@@ -253,7 +253,7 @@ func (cc *ClusterCertificates) prepareAPI(
 	}
 	result := tlsEnabledAPICertificates(cc.pandaCluster.Namespace)
 	if internalTLSListener != nil {
-		result.internalTlsEnabled = true
+		result.internalTLSEnabled = true
 	}
 
 	// TODO(#3550): Do not create rootIssuer if nodeSecretRef is passed and mTLS is disabled
@@ -673,7 +673,7 @@ func (cc *ClusterCertificates) GetTLSConfig(
 
 // KafkaClientBrokerTLS returns configuration to connect to kafka api with tls
 func (cc *ClusterCertificates) KafkaClientBrokerTLS(mountPoints *resourcetypes.TLSMountPoints) *config.ServerTLS {
-	if !cc.kafkaAPI.internalTlsEnabled {
+	if !cc.kafkaAPI.internalTLSEnabled {
 		return nil
 	}
 	result := config.ServerTLS{

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -194,7 +194,7 @@ func (r *StatefulSetResource) Ensure(ctx context.Context) error {
 	return r.handleScaling(ctx)
 }
 
-// GetCentralizedConfigurationHashFromCluster retrieves the current centralized configuratino hash from the statefulset
+// GetCentralizedConfigurationHashFromCluster retrieves the current centralized configuration hash from the statefulset
 func (r *StatefulSetResource) GetCentralizedConfigurationHashFromCluster(
 	ctx context.Context,
 ) (string, error) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8057
