### PR TITLE
cloud_storage: topic deletion fixes

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -627,11 +627,7 @@ ntp_archiver::upload_segment(upload_candidate candidate) {
     vlog(ctxlog.debug, "Uploading segment {} to {}", candidate, path);
 
     auto lazy_abort_source = cloud_storage::lazy_abort_source{
-      "lost leadership or term changed during upload, "
-      "current leadership status: {}, "
-      "current term: {}, "
-      "original term: {}",
-      [this](auto& s) { return archiver_lost_leadership(s); },
+      [this]() { return upload_should_abort(); },
     };
 
     auto reset_func =
@@ -655,20 +651,22 @@ ntp_archiver::upload_segment(upload_candidate candidate) {
       _segment_tags);
 }
 
-bool ntp_archiver::archiver_lost_leadership(
-  cloud_storage::lazy_abort_source& las) {
+std::optional<ss::sstring> ntp_archiver::upload_should_abort() {
     auto original_term = _parent.term();
     auto lost_leadership = !_parent.is_elected_leader()
                            || _parent.term() != original_term;
     if (unlikely(lost_leadership)) {
-        std::string reason{las.abort_reason()};
-        las.abort_reason(fmt::format(
-          fmt::runtime(reason),
+        return fmt::format(
+          "lost leadership or term changed during upload, "
+          "current leadership status: {}, "
+          "current term: {}, "
+          "original term: {}",
           _parent.is_elected_leader(),
           _parent.term(),
-          original_term));
+          original_term);
+    } else {
+        return std::nullopt;
     }
-    return lost_leadership;
 }
 
 ss::future<cloud_storage::upload_result>

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1104,7 +1104,7 @@ uint64_t ntp_archiver::estimate_backlog_size() {
 
 ss::future<std::optional<cloud_storage::partition_manifest>>
 ntp_archiver::maybe_truncate_manifest() {
-    retry_chain_node rtc;
+    retry_chain_node rtc(_as);
     ss::gate::holder gh(_gate);
     retry_chain_logger ctxlog(archival_log, rtc, _ntp.path());
     vlog(ctxlog.info, "archival metadata cleanup started");

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -301,7 +301,7 @@ private:
     segment_path_for_candidate(const upload_candidate& candidate);
 
     /// Method to use with lazy_abort_source
-    bool archiver_lost_leadership(cloud_storage::lazy_abort_source& las);
+    std::optional<ss::sstring> upload_should_abort();
 
     const cloud_storage_clients::bucket_name& get_bucket_name() const;
 

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -35,6 +35,8 @@ using namespace archival;
 
 inline ss::logger test_log("test"); // NOLINT
 
+static ss::abort_source never_abort;
+
 static const auto manifest_namespace = model::ns("kafka");      // NOLINT
 static const auto manifest_topic = model::topic("test-topic");  // NOLINT
 static const auto manifest_partition = model::partition_id(42); // NOLINT
@@ -118,7 +120,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     archival::ntp_archiver archiver(get_ntp_conf(), arch_conf, remote, *part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
-    retry_chain_node fib;
+    retry_chain_node fib(never_abort);
     auto res = upload_next_with_retries(archiver).get0();
 
     auto non_compacted_result = res.non_compacted_upload_result;
@@ -235,7 +237,7 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
     archival::ntp_archiver archiver(get_ntp_conf(), arch_conf, remote, *part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
-    retry_chain_node fib;
+    retry_chain_node fib(never_abort);
     auto res = upload_next_with_retries(archiver).get0();
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_succeeded, 4);
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
@@ -714,7 +716,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     archival::ntp_archiver archiver(get_ntp_conf(), arch_conf, remote, *part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
-    retry_chain_node fib;
+    retry_chain_node fib(never_abort);
 
     auto res = upload_next_with_retries(archiver).get0();
 
@@ -926,7 +928,7 @@ static void test_partial_upload_impl(
     archival::ntp_archiver archiver(get_ntp_conf(), aconf, remote, *part);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
-    retry_chain_node fib;
+    retry_chain_node fib(never_abort);
     part->stop_archiver().get();
     test.listen();
     auto res = upload_next_with_retries(archiver, lso).get0();

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -66,7 +66,8 @@ private:
 partition_recovery_manager::partition_recovery_manager(
   cloud_storage_clients::bucket_name bucket, ss::sharded<remote>& remote)
   : _bucket(std::move(bucket))
-  , _remote(remote) {}
+  , _remote(remote)
+  , _root(_as) {}
 
 partition_recovery_manager::~partition_recovery_manager() {
     vassert(_gate.is_closed(), "S3 downloader is not stopped properly");

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -364,7 +364,9 @@ ss::future<upload_result> remote::upload_segment(
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 permit.delay));
             _probe.upload_backoff();
-            co_await ss::sleep_abortable(permit.delay, _as);
+            if (!lazy_abort_source.abort_requested()) {
+                co_await ss::sleep_abortable(permit.delay, _as);
+            }
             permit = fib.retry();
             break;
         case cloud_storage_clients::error_outcome::key_not_found:

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -167,7 +167,8 @@ ss::future<download_result> remote::do_download_manifest(
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 retry_permit.delay));
             _probe.manifest_download_backoff();
-            co_await ss::sleep_abortable(retry_permit.delay, _as);
+            co_await ss::sleep_abortable(
+              retry_permit.delay, fib.root_abort_source());
             retry_permit = fib.retry();
             break;
         case cloud_storage_clients::error_outcome::bucket_not_found:
@@ -258,7 +259,7 @@ ss::future<upload_result> remote::upload_manifest(
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 permit.delay));
             _probe.manifest_upload_backoff();
-            co_await ss::sleep_abortable(permit.delay, _as);
+            co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
         case cloud_storage_clients::error_outcome::key_not_found:
@@ -379,7 +380,8 @@ ss::future<upload_result> remote::upload_segment(
                 permit.delay));
             _probe.upload_backoff();
             if (!lazy_abort_source.abort_requested()) {
-                co_await ss::sleep_abortable(permit.delay, _as);
+                co_await ss::sleep_abortable(
+                  permit.delay, fib.root_abort_source());
             }
             permit = fib.retry();
             break;
@@ -473,7 +475,7 @@ ss::future<download_result> remote::download_segment(
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 permit.delay));
             _probe.download_backoff();
-            co_await ss::sleep_abortable(permit.delay, _as);
+            co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
         case cloud_storage_clients::error_outcome::bucket_not_found:
@@ -546,7 +548,7 @@ ss::future<download_result> remote::segment_exists(
               bucket,
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 permit.delay));
-            co_await ss::sleep_abortable(permit.delay, _as);
+            co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
         case cloud_storage_clients::error_outcome::bucket_not_found:
@@ -617,7 +619,7 @@ ss::future<upload_result> remote::delete_object(
               bucket,
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 permit.delay));
-            co_await ss::sleep_abortable(permit.delay, _as);
+            co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
         case cloud_storage_clients::error_outcome::bucket_not_found:

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -40,21 +40,17 @@ class materialized_segments;
 struct lazy_abort_source {
     /// Predicate to be evaluated before an operation. Evaluates to true when
     /// the operation should be aborted, false otherwise.
-    using predicate_t = ss::noncopyable_function<bool(lazy_abort_source&)>;
+    using predicate_t = ss::noncopyable_function<std::optional<ss::sstring>()>;
 
-    lazy_abort_source(ss::sstring abort_reason, predicate_t predicate)
-      : _abort_reason{std::move(abort_reason)}
-      , _predicate{std::move(predicate)} {}
+    lazy_abort_source(predicate_t predicate)
+      : _predicate{std::move(predicate)} {}
 
     bool abort_requested();
 
     ss::sstring abort_reason() const;
 
-    void abort_reason(ss::sstring reason);
-
 private:
     ss::sstring _abort_reason;
-
     predicate_t _predicate;
 };
 

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -46,7 +46,6 @@ struct lazy_abort_source {
       : _predicate{std::move(predicate)} {}
 
     bool abort_requested();
-
     ss::sstring abort_reason() const;
 
 private:

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -178,6 +178,7 @@ private:
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
     ss::gate _gate;
+    ss::abort_source _as;
     remote& _api;
     cache& _cache;
     const partition_manifest& _manifest;

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -117,7 +117,7 @@ public:
       retry_chain_node& parent);
 
     /// Remove objects from S3
-    ss::future<> erase();
+    ss::future<> erase(ss::abort_source&);
 
     /// Hook for materialized_segment to notify us when a segment is evicted
     void offload_segment(model::offset);

--- a/src/v/cloud_storage/tests/offset_translation_layer_test.cc
+++ b/src/v/cloud_storage/tests/offset_translation_layer_test.cc
@@ -77,7 +77,8 @@ inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_name_translation) {
-    retry_chain_node fib;
+    ss::abort_source never_abort;
+    retry_chain_node fib(never_abort);
     partition_manifest m;
     m.update(make_manifest_stream(serialized_manifest)).get0();
     BOOST_REQUIRE_EQUAL(m.size(), 3);

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -64,7 +64,7 @@ using namespace cloud_storage;
 inline ss::logger test_log("test"); // NOLINT
 
 static cloud_storage::lazy_abort_source always_continue{
-  "no-op", [](auto&) { return false; }};
+  []() { return std::nullopt; }};
 
 static constexpr model::cloud_credentials_source config_file{
   model::cloud_credentials_source::config_file};

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -55,6 +55,8 @@ using namespace cloud_storage;
 
 inline ss::logger test_log("test"); // NOLINT
 
+static ss::abort_source never_abort;
+
 static cloud_storage::lazy_abort_source always_continue([]() {
     return std::nullopt;
 });
@@ -88,7 +90,7 @@ FIXTURE_TEST(
     uint64_t clen = segment_bytes.size_bytes();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream = make_reset_fn(segment_bytes);
-    retry_chain_node fib(1000ms, 200ms);
+    retry_chain_node fib(never_abort, 1000ms, 200ms);
     partition_manifest::segment_meta meta{
       .is_compacted = false,
       .size_bytes = segment_bytes.size_bytes(),
@@ -140,7 +142,7 @@ FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
         .delta_offset = model::offset_delta(0),
         .ntp_revision = manifest_revision});
 
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     remote_segment segment(
       remote, cache.local(), bucket, m, key.base_offset, fib);
     BOOST_REQUIRE_THROW(
@@ -172,7 +174,7 @@ FIXTURE_TEST(
     uint64_t clen = segment_bytes.size_bytes();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream = make_reset_fn(segment_bytes);
-    retry_chain_node fib(1000ms, 200ms);
+    retry_chain_node fib(never_abort, 1000ms, 200ms);
     auto upl_res = remote
                      .upload_segment(
                        bucket, path, clen, reset_stream, fib, always_continue)
@@ -258,7 +260,7 @@ void test_remote_segment_batch_reader(
       .ntp_revision = manifest_revision};
     auto path = m.generate_segment_path(meta);
     auto reset_stream = make_reset_fn(segment_bytes);
-    retry_chain_node fib(1000ms, 200ms);
+    retry_chain_node fib(never_abort, 1000ms, 200ms);
     auto upl_res = remote
                      .upload_segment(
                        bucket, path, clen, reset_stream, fib, always_continue)
@@ -370,7 +372,7 @@ FIXTURE_TEST(
       .ntp_revision = manifest_revision};
     auto path = m.generate_segment_path(meta);
     auto reset_stream = make_reset_fn(segment_bytes);
-    retry_chain_node fib(1000ms, 200ms);
+    retry_chain_node fib(never_abort, 1000ms, 200ms);
     auto upl_res = remote
                      .upload_segment(
                        bucket, path, clen, reset_stream, fib, always_continue)

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -55,8 +55,8 @@ using namespace cloud_storage;
 
 inline ss::logger test_log("test"); // NOLINT
 
-static cloud_storage::lazy_abort_source always_continue("no-op", [](auto&) {
-    return false;
+static cloud_storage::lazy_abort_source always_continue([]() {
+    return std::nullopt;
 });
 
 /**

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -76,7 +76,7 @@ static constexpr std::string_view list_response = R"XML(
 )XML";
 
 static cloud_storage::lazy_abort_source always_continue{
-  "no-op", [](auto&) { return false; }};
+  []() { return std::nullopt; }};
 
 static constexpr model::cloud_credentials_source config_file{
   model::cloud_credentials_source::config_file};
@@ -177,7 +177,7 @@ FIXTURE_TEST(
     };
     retry_chain_node fib(100ms, 20ms);
     auto lost_leadership = lazy_abort_source{
-      "lost leadership", [](auto&) { return true; }};
+      []() { return "lost leadership"; }};
     auto res = remote
                  .upload_segment(
                    cloud_storage_clients::bucket_name("bucket"),

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -45,6 +45,8 @@ using namespace cloud_storage;
 
 inline ss::logger test_log("test"); // NOLINT
 
+static ss::abort_source never_abort;
+
 static constexpr std::string_view manifest_payload = R"json({
     "version": 1,
     "namespace": "test-ns",
@@ -97,7 +99,7 @@ FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
     remote remote(connection_limit(10), conf, config_file);
     partition_manifest actual(manifest_ntp, manifest_revision);
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto res = remote
                  .download_manifest(
                    cloud_storage_clients::bucket_name("bucket"),
@@ -115,7 +117,7 @@ FIXTURE_TEST(test_download_manifest_timeout, s3_imposter_fixture) { // NOLINT
     remote remote(connection_limit(10), conf, config_file);
     partition_manifest actual(manifest_ntp, manifest_revision);
     auto action = ss::defer([&remote] { remote.stop().get(); });
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto res = remote
                  .download_manifest(
                    cloud_storage_clients::bucket_name("bucket"),
@@ -142,7 +144,7 @@ FIXTURE_TEST(test_upload_segment, s3_imposter_fixture) { // NOLINT
         co_return std::make_unique<storage::segment_reader_handle>(
           make_iobuf_input_stream(std::move(out)));
     };
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto res = remote
                  .upload_segment(
                    cloud_storage_clients::bucket_name("bucket"),
@@ -175,7 +177,8 @@ FIXTURE_TEST(
         co_return std::make_unique<storage::segment_reader_handle>(
           make_iobuf_input_stream(std::move(out)));
     };
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
+    static ss::abort_source never_abort;
     auto lost_leadership = lazy_abort_source{
       []() { return "lost leadership"; }};
     auto res = remote
@@ -206,7 +209,7 @@ FIXTURE_TEST(test_upload_segment_timeout, s3_imposter_fixture) { // NOLINT
         co_return std::make_unique<storage::segment_reader_handle>(
           make_iobuf_input_stream(std::move(out)));
     };
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto res = remote
                  .upload_segment(
                    cloud_storage_clients::bucket_name("bucket"),
@@ -236,7 +239,7 @@ FIXTURE_TEST(test_download_segment, s3_imposter_fixture) { // NOLINT
         co_return std::make_unique<storage::segment_reader_handle>(
           make_iobuf_input_stream(std::move(out)));
     };
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto upl_res = remote
                      .upload_segment(
                        bucket, path, clen, reset_stream, fib, always_continue)
@@ -274,7 +277,7 @@ FIXTURE_TEST(test_download_segment_timeout, s3_imposter_fixture) { // NOLINT
         return ss::make_ready_future<uint64_t>(0);
     };
 
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto dnl_res
       = remote.download_segment(bucket, path, try_consume, fib).get();
     BOOST_REQUIRE(dnl_res == download_result::timedout);
@@ -298,7 +301,7 @@ FIXTURE_TEST(test_segment_exists, s3_imposter_fixture) { // NOLINT
           make_iobuf_input_stream(std::move(out)));
     };
 
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
 
     auto expected_notfound = remote.segment_exists(bucket, path, fib).get();
     BOOST_REQUIRE(expected_notfound == download_result::notfound);
@@ -321,7 +324,7 @@ FIXTURE_TEST(test_segment_exists_timeout, s3_imposter_fixture) { // NOLINT
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});
 
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto expect_timeout = remote.segment_exists(bucket, path, fib).get();
     BOOST_REQUIRE(expect_timeout == download_result::timedout);
 }
@@ -335,7 +338,7 @@ FIXTURE_TEST(test_segment_delete, s3_imposter_fixture) { // NOLINT
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{1});
 
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     uint64_t clen = manifest_payload.size();
     auto action = ss::defer([&remote] { remote.stop().get(); });
     auto reset_stream =
@@ -409,7 +412,7 @@ FIXTURE_TEST(test_concat_segment_upload, s3_imposter_fixture) {
             ss::default_priority_class()));
     };
 
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto upload_size = b.get_disk_log_impl().size_bytes() - 40;
 
     remote remote(connection_limit(10), conf, config_file);
@@ -433,7 +436,7 @@ FIXTURE_TEST(test_list_bucket, s3_imposter_fixture) {
     auto action = ss::defer([&r] { r.stop().get(); });
 
     cloud_storage_clients::bucket_name bucket{"test"};
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto result = r.list_objects(bucket, fib).get0();
     BOOST_REQUIRE(result.has_value());
 
@@ -450,7 +453,7 @@ FIXTURE_TEST(test_list_bucket_with_prefix, s3_imposter_fixture) {
     auto action = ss::defer([&r] { r.stop().get(); });
 
     cloud_storage_clients::bucket_name bucket{"test"};
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
     auto result = r.list_objects(
                      bucket, fib, cloud_storage_clients::object_key{"x"})
                     .get0();
@@ -473,7 +476,7 @@ FIXTURE_TEST(test_put_string, s3_imposter_fixture) {
     auto action = ss::defer([&r] { r.stop().get(); });
 
     cloud_storage_clients::bucket_name bucket{"test"};
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
 
     cloud_storage_clients::object_key path{"p"};
     auto result = r.upload_object(bucket, path, "p", fib).get0();
@@ -491,7 +494,7 @@ FIXTURE_TEST(test_delete_objects, s3_imposter_fixture) {
     auto action = ss::defer([&r] { r.stop().get(); });
 
     cloud_storage_clients::bucket_name bucket{"test"};
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(never_abort, 100ms, 20ms);
 
     cloud_storage_clients::object_key path{"p"};
     std::vector<cloud_storage_clients::object_key> to_delete{

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -511,7 +511,7 @@ ss::future<> partition::remove_persistent_state() {
     }
 }
 
-ss::future<> partition::remove_remote_persistent_state() {
+ss::future<> partition::remove_remote_persistent_state(ss::abort_source& as) {
     // Backward compatibility: even if remote.delete is true, only do
     // deletion if the partition is in full tiered storage mode (this
     // excludes read replica clusters from deleting data in S3)
@@ -527,7 +527,7 @@ ss::future<> partition::remove_remote_persistent_state() {
           get_ntp_config(),
           get_ntp_config().is_archival_enabled(),
           get_ntp_config().is_read_replica_mode_enabled());
-        co_await _cloud_storage_partition->erase();
+        co_await _cloud_storage_partition->erase(as);
     } else {
         vlog(
           clusterlog.info, "Leaving S3 objects behind for partition {}", ntp());

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -322,22 +322,6 @@ ss::future<> partition::stop() {
 
     auto f = ss::now();
 
-    if (_id_allocator_stm) {
-        return _id_allocator_stm->stop();
-    }
-
-    if (_log_eviction_stm) {
-        f = _log_eviction_stm->stop();
-    }
-
-    if (_rm_stm) {
-        f = f.then([this] { return _rm_stm->stop(); });
-    }
-
-    if (_tm_stm) {
-        f = f.then([this] { return _tm_stm->stop(); });
-    }
-
     if (_archiver) {
         f = f.then([this] { return _archiver->stop(); });
     }
@@ -348,6 +332,22 @@ ss::future<> partition::stop() {
 
     if (_cloud_storage_partition) {
         f = f.then([this] { return _cloud_storage_partition->stop(); });
+    }
+
+    if (_id_allocator_stm) {
+        f = f.then([this] { return _id_allocator_stm->stop(); });
+    }
+
+    if (_log_eviction_stm) {
+        f = f.then([this] { return _log_eviction_stm->stop(); });
+    }
+
+    if (_rm_stm) {
+        f = f.then([this] { return _rm_stm->stop(); });
+    }
+
+    if (_tm_stm) {
+        f = f.then([this] { return _tm_stm->stop(); });
     }
 
     // no state machine

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -259,7 +259,7 @@ public:
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
     ss::future<> remove_persistent_state();
-    ss::future<> remove_remote_persistent_state();
+    ss::future<> remove_remote_persistent_state(ss::abort_source& as);
 
     std::optional<model::offset> get_term_last_offset(model::term_id) const;
 

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -208,6 +208,12 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<cluster::tm_stm_cache>& _tm_stm_cache;
     ss::gate _gate;
+
+    // In general, all our background work is in partition objects which
+    // have their own abort source.  This abort source is only for work that
+    // happens after partition stop, during deletion.
+    ss::abort_source _as;
+
     bool _block_new_leadership{false};
 
     config::binding<uint64_t> _max_concurrent_producer_ids;

--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -39,23 +39,6 @@ retry_chain_node::retry_chain_node()
   , _deadline{ss::lowres_clock::time_point::min()}
   , _parent() {}
 
-retry_chain_node::retry_chain_node(
-  ss::lowres_clock::time_point deadline,
-  ss::lowres_clock::duration backoff)
-  : _id(fiber_count++) // generate new head id
-  , _backoff{std::chrono::duration_cast<std::chrono::milliseconds>(backoff)}
-  , _deadline{deadline}
-  , _parent() {
-    vassert(
-      backoff <= milliseconds_uint16_t::max(),
-      "Initial backoff {} is too large",
-      backoff);
-}
-
-retry_chain_node::retry_chain_node(
-  ss::lowres_clock::duration timeout, ss::lowres_clock::duration backoff)
-  : retry_chain_node(ss::lowres_clock::now() + timeout, backoff) {}
-
 retry_chain_node::retry_chain_node(ss::abort_source& as)
   : _id(fiber_count++) // generate new head id
   , _backoff{0}
@@ -183,7 +166,7 @@ ss::sstring retry_chain_node::operator()() const {
 }
 
 retry_permit retry_chain_node::retry(retry_strategy st) {
-    auto &as = root_abort_source();
+    auto& as = root_abort_source();
     as.check();
 
     auto now = ss::lowres_clock::now();

--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -33,12 +33,6 @@ static constexpr size_t max_retry_chain_depth = 8;
 static constexpr uint16_t max_retry_count = std::numeric_limits<uint16_t>::max()
                                             - 1;
 
-retry_chain_node::retry_chain_node()
-  : _id(fiber_count++) // generate new head id
-  , _backoff{0}
-  , _deadline{ss::lowres_clock::time_point::min()}
-  , _parent() {}
-
 retry_chain_node::retry_chain_node(ss::abort_source& as)
   : _id(fiber_count++) // generate new head id
   , _backoff{0}

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -202,14 +202,6 @@ public:
 
     /// Create a head of the chain without backoff
     retry_chain_node();
-    /// Creates a head with the provided deadline and
-    /// backoff granularity.
-    retry_chain_node(
-      ss::lowres_clock::time_point deadline,
-      ss::lowres_clock::duration initial_backoff);
-    retry_chain_node(
-      ss::lowres_clock::duration timeout,
-      ss::lowres_clock::duration initial_backoff);
     /// Create a head of the chain without backoff but with abort_source
     explicit retry_chain_node(ss::abort_source& as);
     /// Creates a head with the provided abort_source, deadline, and
@@ -269,7 +261,6 @@ public:
         bii = ']';
         return ss::sstring(mbuf.data(), mbuf.size());
     }
-
 
     /// Find abort source in the root of the tree
     /// Always traverses the tree back to the root and returns the abort

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -270,6 +270,12 @@ public:
         return ss::sstring(mbuf.data(), mbuf.size());
     }
 
+
+    /// Find abort source in the root of the tree
+    /// Always traverses the tree back to the root and returns the abort
+    /// source if it was set in the root c-tor.
+    ss::abort_source& root_abort_source();
+
     /// \brief Request retry
     ///
     /// The retry can be allowed or disallowed. The caller can call this
@@ -323,11 +329,6 @@ private:
     /// Method returns nullptr if not root
     ss::abort_source* get_abort_source();
     const ss::abort_source* get_abort_source() const;
-
-    /// Find abort source in the root of the tree
-    /// Always traverses the tree back to the root and returns the abort
-    /// source if it was set in the root c-tor.
-    ss::abort_source* find_abort_source();
 
     /// This node's id
     uint16_t _id;

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -335,7 +335,7 @@ private:
     /// Deadline for retry attempts
     ss::lowres_clock::time_point _deadline;
     /// optional parent node or (if root) abort source for all fibers
-    std::variant<std::monostate, retry_chain_node*, ss::abort_source*> _parent;
+    std::variant<retry_chain_node*, ss::abort_source*> _parent;
 };
 
 /// Logger that adds context from retry_chain_node to the output

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -200,8 +200,9 @@ public:
     using milliseconds_uint16_t
       = std::chrono::duration<uint16_t, std::chrono::milliseconds::period>;
 
-    /// Create a head of the chain without backoff
-    retry_chain_node();
+    // No default constructor: we always need an abort source.
+    retry_chain_node() = delete;
+
     /// Create a head of the chain without backoff but with abort_source
     explicit retry_chain_node(ss::abort_source& as);
     /// Creates a head with the provided abort_source, deadline, and

--- a/src/v/utils/tests/retry_chain_node_test.cc
+++ b/src/v/utils/tests/retry_chain_node_test.cc
@@ -24,8 +24,10 @@
 
 using namespace std::chrono_literals;
 
+static ss::abort_source never_abort;
+
 SEASTAR_THREAD_TEST_CASE(check_fmt) {
-    retry_chain_node n1(ss::lowres_clock::now() + 100ms, 50ms);
+    retry_chain_node n1(never_abort, ss::lowres_clock::now() + 100ms, 50ms);
     BOOST_REQUIRE_EQUAL(n1(), "[fiber0|0|100ms]");
     {
         retry_chain_node n2(&n1);
@@ -49,13 +51,13 @@ SEASTAR_THREAD_TEST_CASE(check_fmt) {
         retry_chain_node n7(&n1);
         BOOST_REQUIRE_EQUAL(n7(), "[fiber0~1|0|100ms]");
     }
-    retry_chain_node n8(ss::lowres_clock::now() + 100ms, 50ms);
+    retry_chain_node n8(never_abort, ss::lowres_clock::now() + 100ms, 50ms);
     BOOST_REQUIRE_EQUAL(n8(), "[fiber1|0|100ms]");
     BOOST_REQUIRE_EQUAL(n8("{} + {}", 1, 2), "[fiber1|0|100ms 1 + 2]");
 }
 
 SEASTAR_THREAD_TEST_CASE(check_retry1) {
-    retry_chain_node n1;
+    retry_chain_node n1(never_abort);
     std::array<
       std::pair<ss::lowres_clock::duration, ss::lowres_clock::duration>,
       4>
@@ -72,7 +74,7 @@ SEASTAR_THREAD_TEST_CASE(check_retry1) {
     for (int i = 0; i < 4; i++) {
         permit = n2.retry();
         BOOST_REQUIRE(permit.is_allowed);
-        BOOST_REQUIRE(permit.abort_source == nullptr);
+        BOOST_REQUIRE(permit.abort_source == &never_abort);
         BOOST_REQUIRE(permit.delay >= intervals.at(i).first);
         BOOST_REQUIRE(permit.delay < intervals.at(i).second);
     }
@@ -81,7 +83,8 @@ SEASTAR_THREAD_TEST_CASE(check_retry1) {
 }
 
 SEASTAR_THREAD_TEST_CASE(check_retry2) {
-    retry_chain_node n1(ss::lowres_clock::now() + 1600ms, 100ms);
+    ss::abort_source never_abort;
+    retry_chain_node n1(never_abort, ss::lowres_clock::now() + 1600ms, 100ms);
     std::array<
       std::pair<ss::lowres_clock::duration, ss::lowres_clock::duration>,
       4>
@@ -95,7 +98,7 @@ SEASTAR_THREAD_TEST_CASE(check_retry2) {
     for (int i = 0; i < 4; i++) {
         permit = n1.retry();
         BOOST_REQUIRE(permit.is_allowed);
-        BOOST_REQUIRE(permit.abort_source == nullptr);
+        BOOST_REQUIRE(permit.abort_source == &never_abort);
         BOOST_REQUIRE(permit.delay >= intervals.at(i).first);
         BOOST_REQUIRE(permit.delay < intervals.at(i).second);
     }
@@ -107,7 +110,7 @@ SEASTAR_THREAD_TEST_CASE(check_retry2) {
     for (int i = 0; i < 4; i++) {
         permit = n2.retry();
         BOOST_REQUIRE(permit.is_allowed);
-        BOOST_REQUIRE(permit.abort_source == nullptr);
+        BOOST_REQUIRE(permit.abort_source == &never_abort);
         BOOST_REQUIRE(permit.delay >= intervals.at(i).first);
         BOOST_REQUIRE(permit.delay < intervals.at(i).second);
     }
@@ -145,28 +148,22 @@ SEASTAR_THREAD_TEST_CASE(check_abort_requested) {
     BOOST_REQUIRE_THROW(n2.check_abort(), ss::abort_requested_exception);
 }
 
-SEASTAR_THREAD_TEST_CASE(check_abort_requested_fail) {
-    retry_chain_node n1(ss::lowres_clock::now() + 1000ms, 100ms);
-    retry_chain_node n2(&n1);
-    BOOST_REQUIRE_THROW(n2.request_abort(), std::logic_error);
-}
-
 SEASTAR_THREAD_TEST_CASE(check_deadline_propogation_1) {
-    retry_chain_node n1;
+    retry_chain_node n1(never_abort);
     retry_chain_node n2(1000ms, 100ms, &n1);
     BOOST_REQUIRE(n1.get_timeout() == 0ms);
     BOOST_REQUIRE(n2.get_timeout() == 1000ms);
 }
 
 SEASTAR_THREAD_TEST_CASE(check_deadline_propogation_2) {
-    retry_chain_node n1(1000ms, 100ms);
+    retry_chain_node n1(never_abort, 1000ms, 100ms);
     retry_chain_node n2(500ms, 100ms, &n1);
     BOOST_REQUIRE(n1.get_timeout() == 1000ms);
     BOOST_REQUIRE(n2.get_timeout() == 500ms);
 }
 
 SEASTAR_THREAD_TEST_CASE(check_deadline_propogation_3) {
-    retry_chain_node n1(500ms, 100ms);
+    retry_chain_node n1(never_abort, 500ms, 100ms);
     retry_chain_node n2(1000ms, 100ms, &n1);
     BOOST_REQUIRE(n1.get_timeout() == 500ms);
     BOOST_REQUIRE(n2.get_timeout() == 500ms);

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -9,6 +9,7 @@
 
 import time
 import json
+from typing import Optional
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import parametrize, ok_to_fail
@@ -199,7 +200,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         self.kafka_tools = KafkaCliTools(self.redpanda)
 
-    def _populate_topic(self, topic_name):
+    def _populate_topic(self, topic_name, nodes: Optional[list] = None):
         """
         Get system into state where there is data in both local
         and remote storage for the topic.
@@ -220,12 +221,53 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                                             topic_name,
                                             i,
                                             local_retention,
-                                            timeout_sec=30)
+                                            timeout_sec=30,
+                                            nodes=nodes)
 
         # Confirm objects in remote storage
         objects = self.s3_client.list_objects(
             self.si_settings.cloud_storage_bucket, topic=topic_name)
         assert sum(1 for _ in objects) > 0
+
+    @cluster(num_nodes=3)
+    def topic_delete_installed_snapshots_test(self):
+        """
+        Test the case where a partition had remote snapshots installed prior
+        to deletion: this aims to expose bugs in the snapshot code vs the
+        shutdown code.
+        """
+        victim_node = self.redpanda.nodes[-1]
+        other_nodes = self.redpanda.nodes[0:2]
+
+        self.logger.info(f"Stopping victim node {victim_node.name}")
+        self.redpanda.stop_node(victim_node)
+
+        # Before populating the topic + waiting for eviction from local
+        # disk, stop one node.  This node will later get a snapshot installed
+        # when it comes back online
+        self.logger.info(
+            f"Populating topic and waiting for nodes {[n.name for n in other_nodes]}"
+        )
+        self._populate_topic(self.topic, nodes=other_nodes)
+
+        self.logger.info(f"Starting victim node {victim_node.name}")
+        self.redpanda.start_node(victim_node)
+
+        # TODO wait for victim_node to see hwm catch up
+        time.sleep(10)
+
+        # Write more: this should prompt the victim node to do some prefix truncations
+        # after having installed a snapshot
+        self._populate_topic(self.topic)
+
+        self.kafka_tools.delete_topic(self.topic)
+        wait_until(lambda: topic_storage_purged(self.redpanda, self.topic),
+                   timeout_sec=30,
+                   backoff_sec=1)
+
+        wait_until(lambda: self._topic_remote_deleted(self.topic),
+                   timeout_sec=30,
+                   backoff_sec=1)
 
     @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8071
     @cluster(

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -269,7 +269,6 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                    timeout_sec=30,
                    backoff_sec=1)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8071
     @cluster(
         num_nodes=3,
         log_allow_list=[


### PR DESCRIPTION
This PR fixes #8046 and #8071 together, in order to conveniently test them together before re-enabling the tests.

#8046 was just a bug in the test: it was using segment counts as a proxy for amounts of data removed from local storage, which does not work properly when a leadership transfer happens to overlap with the test, generating extra segments.  While debugging this I found another test issues, where under some circumstances we were mistaking a change in the manifest.json object's ETag for a failure to delete.  These are both fixed.

#8071 was a real bug in Redpanda, where partition::stop could get hung up on S3 operations in flight.  When the test used firewall to block connectivity to S3, then stuck PUT requests could exist, preventing partition shutdown.  This causes the test to fail its requirement that the deletion of local data proceeds even if remote data can't be deleted.

Fixing #8071 in a general way involved subscribing to an abort source to call `shutdown()` on http clients when a partition is stopping.  To get that abort source into the right places without too much complexity, `retry_chain_node` is improved to remove its mode with no abort source, so that its public API can conveniently expose the abort source for the `remote` object to use consistently.  The removed constructors for `retry_chain_node` were only used in unit tests, or by mistake: there is no legitimate situation where a `retry_chain_node` should exist without an abort source somewhere in its hierarchy, as the purpose of the class involves sleeps on retry.

## Backports Required

Needs backporting together with ntp_archiver refactor.

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  ### Improvements

  * Topic deletion now removes local data more reliably in situations where a tiered storage topic experiences an inabilty to connect to an object storage backend.