### PR TITLE
security: Initial gssapi support

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -30,6 +30,8 @@ deb_deps=(
   curl
   git
   golang-go
+  libkrb5-dev
+  libgssapi-krb5-2
   libsnappy-dev
   libxxhash-dev
   libzstd-dev
@@ -50,6 +52,8 @@ fedora_deps=(
   curl
   git
   golang
+  krb5-libs
+  krb5-devel
   libzstd-devel
   libzstd-static
   llvm

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -23,6 +23,7 @@ please keep this up to date with every new library use.
 | gnutls          | LGPL v2.1                          |
 | HdrHistogram    | BSD 2                              |
 | hwloc           | BSD                                |
+| krb5            | MIT                                |
 | libcxx          | Apache License 2                   |
 | libcxxabi       | Apache License 2                   |
 | libnumactl      | LGPL v2.1                          |

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -832,7 +832,7 @@ configuration::configuration()
   , sasl_mechanisms(
       *this,
       "sasl_mechanisms",
-      "A list of supported SASL mechanisms. `SCRAM` is allowed.",
+      "A list of supported SASL mechanisms. `SCRAM` and `GSSAPI` are allowed.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {"SCRAM"},
       validate_sasl_mechanisms)

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -829,6 +829,25 @@ configuration::configuration()
       "required. see also `kafka_enable_authorization`",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , sasl_mechanisms(
+      *this,
+      "sasl_mechanisms",
+      "A list of supported SASL mechanisms. `SCRAM` is allowed.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      {"SCRAM"},
+      validate_sasl_mechanisms)
+  , sasl_kerberos_keytab(
+      *this,
+      "sasl_kerberos_keytab",
+      "The location of the Kerberos keytab file for Redpanda",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      "/var/lib/redpanda/redpanda.keytab")
+  , sasl_kerberos_principal(
+      *this,
+      "sasl_kerberos_principal",
+      "The primary of the Kerberos Service Principal Name (SPN) for Redpanda",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      "redpanda")
   , kafka_enable_authorization(
       *this,
       "kafka_enable_authorization",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -178,6 +178,9 @@ struct configuration final : public config_store {
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
+    property<std::vector<ss::sstring>> sasl_mechanisms;
+    property<ss::sstring> sasl_kerberos_keytab;
+    property<ss::sstring> sasl_kerberos_principal;
     property<std::optional<bool>> kafka_enable_authorization;
     property<std::optional<std::vector<ss::sstring>>>
       kafka_mtls_principal_mapping_rules;

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -108,7 +108,8 @@ std::optional<ss::sstring> validate_client_groups_byte_rate_quota(
 
 std::optional<ss::sstring>
 validate_sasl_mechanisms(const std::vector<ss::sstring>& mechanisms) {
-    static const absl::flat_hash_set<std::string_view> supported{"SCRAM"};
+    static const absl::flat_hash_set<std::string_view> supported{
+      "GSSAPI", "SCRAM"};
 
     // Validate results
     for (const auto& m : mechanisms) {

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -13,7 +13,9 @@
 
 #include "config/client_group_byte_rate_quota.h"
 #include "net/inet_address_wrapper.h"
+#include "ssx/sformat.h"
 
+#include <absl/container/flat_hash_set.h>
 #include <absl/container/node_hash_set.h>
 #include <fmt/format.h>
 
@@ -98,6 +100,20 @@ std::optional<ss::sstring> validate_client_groups_byte_rate_quota(
                   gal.second.clients_prefix,
                   another_group.second.clients_prefix);
             }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<ss::sstring>
+validate_sasl_mechanisms(const std::vector<ss::sstring>& mechanisms) {
+    static const absl::flat_hash_set<std::string_view> supported{"SCRAM"};
+
+    // Validate results
+    for (const auto& m : mechanisms) {
+        if (!supported.contains(m)) {
+            return ssx::sformat("'{}' is not a supported SASL mechanism", m);
         }
     }
 

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -17,6 +17,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <optional>
+#include <vector>
 
 namespace config {
 
@@ -28,5 +29,8 @@ validate_connection_rate(const std::vector<ss::sstring>& ips_with_limit);
 
 std::optional<ss::sstring> validate_client_groups_byte_rate_quota(
   const std::unordered_map<ss::sstring, config::client_group_quota>&);
+
+std::optional<ss::sstring>
+validate_sasl_mechanisms(const std::vector<ss::sstring>& mechanisms);
 
 }; // namespace config

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -55,6 +55,8 @@ std::string_view to_string_view(feature f) {
         return "seeds_driven_bootstrap_capable";
     case feature::tm_stm_cache:
         return "tm_stm_cache";
+    case feature::kafka_gssapi:
+        return "kafka_gssapi";
     case feature::test_alpha:
         return "__test_alpha";
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -47,6 +47,7 @@ enum class feature : std::uint64_t {
     ephemeral_secrets = 1ULL << 14U,
     seeds_driven_bootstrap_capable = 1ULL << 15U,
     tm_stm_cache = 1ULL << 16U,
+    kafka_gssapi = 1ULL << 17U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 63U,
@@ -200,6 +201,12 @@ constexpr static std::array feature_schema{
     "tm_stm_cache",
     feature::tm_stm_cache,
     feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{8},
+    "kafka_gssapi",
+    feature::kafka_gssapi,
+    feature_spec::available_policy::explicit_only,
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{2001},

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -46,6 +46,7 @@
 #include "security/scram_algorithm.h"
 #include "security/scram_authenticator.h"
 #include "ssx/future-util.h"
+#include "ssx/thread_worker.h"
 #include "utils/utf8.h"
 #include "vlog.h"
 
@@ -88,7 +89,8 @@ server::server(
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
   ss::sharded<coproc::partition_manager>& coproc_partition_manager,
-  std::optional<qdc_monitor::config> qdc_config) noexcept
+  std::optional<qdc_monitor::config> qdc_config,
+  ssx::thread_worker& tw) noexcept
   : net::server(cfg, klog)
   , _smp_group(smp)
   , _topics_frontend(tf)
@@ -112,7 +114,8 @@ server::server(
   , _tx_gateway_frontend(tx_gateway_frontend)
   , _coproc_partition_manager(coproc_partition_manager)
   , _mtls_principal_mapper(
-      config::shard_local_cfg().kafka_mtls_principal_mapping_rules.bind()) {
+      config::shard_local_cfg().kafka_mtls_principal_mapping_rules.bind())
+  , _thread_worker(tw) {
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);
     }

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -23,6 +23,7 @@
 #include "security/authorizer.h"
 #include "security/credential_store.h"
 #include "security/mtls.h"
+#include "ssx/fwd.h"
 #include "utils/ema.h"
 
 #include <seastar/core/future.hh>
@@ -52,7 +53,8 @@ public:
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
       ss::sharded<coproc::partition_manager>&,
-      std::optional<qdc_monitor::config>) noexcept;
+      std::optional<qdc_monitor::config>,
+      ssx::thread_worker&) noexcept;
 
     ~server() noexcept override = default;
     server(const server&) = delete;
@@ -133,6 +135,8 @@ public:
 
     latency_probe& latency_probe() { return _probe; }
 
+    ssx::thread_worker& thread_worker() { return _thread_worker; }
+
 private:
     ss::smp_service_group _smp_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
@@ -158,6 +162,7 @@ private:
     security::tls::principal_mapper _mtls_principal_mapper;
 
     class latency_probe _probe;
+    ssx::thread_worker& _thread_worker;
 };
 
 } // namespace kafka

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -43,6 +43,7 @@
 #include "rpc/fwd.h"
 #include "rpc/rpc_server.h"
 #include "seastarx.h"
+#include "ssx/fwd.h"
 #include "ssx/metrics.h"
 #include "storage/api.h"
 #include "storage/fwd.h"
@@ -125,6 +126,8 @@ public:
 
     std::unique_ptr<cluster::controller> controller;
     std::unique_ptr<coproc::api> coprocessing;
+
+    std::unique_ptr<ssx::thread_worker> thread_worker;
 
 private:
     using deferred_actions

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -129,7 +129,8 @@ public:
           app.controller->get_api(),
           app.tx_gateway_frontend,
           app.cp_partition_manager,
-          std::nullopt);
+          std::nullopt,
+          *app.thread_worker);
 
         configs.stop().get();
     }

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   SRCS
     scram_algorithm.cc
     scram_authenticator.cc
+    gssapi_authenticator.cc
     credential.cc
     acl.cc
     mtls.cc

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -14,6 +14,8 @@ v_cc_library(
     absl::flat_hash_set
     cryptopp
     re2
+    gssapi_krb5
+    krb5
  )
 
 add_subdirectory(tests)

--- a/src/v/security/errc.h
+++ b/src/v/security/errc.h
@@ -18,6 +18,7 @@ enum class errc {
     success = 0,
     invalid_credentials,
     invalid_scram_state,
+    invalid_gssapi_state,
 };
 
 struct errc_category final : public std::error_category {
@@ -31,9 +32,10 @@ struct errc_category final : public std::error_category {
             return "security: Invalid credentials";
         case errc::invalid_scram_state:
             return "security: Invalid SCRAM state";
-        default:
-            return "security: Unknown error";
+        case errc::invalid_gssapi_state:
+            return "security: Invalid GSSAPI state";
         }
+        return "security: Unknown error";
     }
 };
 

--- a/src/v/security/gssapi.h
+++ b/src/v/security/gssapi.h
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "bytes/bytes.h"
+
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_ext.h>
+
+#include <string_view>
+
+namespace security::gss {
+
+class buffer_view {
+public:
+    explicit buffer_view(::gss_buffer_desc bd)
+      : _impl{bd} {}
+    explicit buffer_view(std::string_view sv)
+      : _impl{sv.size(), const_cast<char*>(sv.data())} {}
+    explicit buffer_view(bytes_view bv)
+      : _impl{bv.size(), const_cast<unsigned char*>(bv.data())} {}
+
+    explicit operator std::string_view() const {
+        return {static_cast<char*>(_impl.value), _impl.length};
+    };
+    explicit operator bytes_view() const {
+        return {static_cast<unsigned char*>(_impl.value), _impl.length};
+    };
+
+    const void* value() const { return _impl.value; }
+    size_t size() const { return _impl.length; }
+    const gss_buffer_desc* operator&() const { return &_impl; };
+    // TODO BP: Should I wrap every call that only uses this as an input param?
+    gss_buffer_desc* operator&() { return &_impl; };
+
+private:
+    ::gss_buffer_desc _impl;
+};
+
+class buffer : public buffer_view {
+public:
+    using buffer_view::buffer_view;
+    explicit buffer()
+      : buffer_view{::gss_buffer_desc{0, nullptr}} {}
+    buffer(buffer&& other) noexcept
+      : buffer_view{other} {
+        buffer_view& other_view = other;
+        other_view = buffer_view{::gss_buffer_desc{0, nullptr}};
+    }
+    buffer(const buffer&) = delete;
+    buffer operator=(buffer&&) = delete;
+    buffer operator=(buffer const&) = delete;
+
+    ~buffer() {
+        if (value() != nullptr) {
+            OM_uint32 minor{};
+            gss_release_buffer(&minor, &(*this));
+        }
+    }
+};
+
+class buffer_set {
+public:
+    buffer_set() = default;
+    buffer_set(buffer_set&&) = delete;
+    buffer_set(const buffer_set&) = delete;
+    buffer_set operator=(buffer_set&&) = delete;
+    buffer_set operator=(buffer_set const&) = delete;
+
+    ~buffer_set() {
+        if (_impl != nullptr) {
+            OM_uint32 minor{};
+            ::gss_release_buffer_set(&minor, &_impl);
+        }
+    }
+
+    auto size() const { return _impl->count; }
+    buffer_view operator[](int i) const {
+        return buffer_view{_impl->elements[i]};
+    }
+
+    operator gss_buffer_set_t() { return _impl; };
+    gss_buffer_set_t* operator&() { return &_impl; };
+
+private:
+    gss_buffer_set_t _impl{nullptr};
+};
+
+class name {
+public:
+    name() = default;
+    name(name&&) = delete;
+    name(const name&) = delete;
+    name operator=(name&&) = delete;
+    name operator=(name const&) = delete;
+
+    ~name() {
+        if (_impl != nullptr) {
+            OM_uint32 minor{};
+            gss_release_name(&minor, &_impl);
+        }
+    }
+
+    operator gss_name_t() { return _impl; };
+    gss_name_t* operator&() { return &_impl; };
+
+    gss::buffer display_name_buffer() const {
+        OM_uint32 minor_status{};
+        gss_OID* oid{};
+        gss::buffer display_name;
+        auto major_status = ::gss_display_name(
+          &minor_status, _impl, &display_name, oid);
+        if (major_status != GSS_S_COMPLETE) {
+            return gss::buffer{};
+        }
+        return display_name;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, name const& name) {
+        fmt::print(os, "{}", std::string_view(name.display_name_buffer()));
+        return os;
+    }
+
+private:
+    gss_name_t _impl{nullptr};
+};
+
+class cred_id {
+public:
+    cred_id() = default;
+    cred_id(cred_id&&) = delete;
+    cred_id(const cred_id&) = delete;
+    cred_id operator=(cred_id&&) = delete;
+    cred_id operator=(cred_id const&) = delete;
+    ~cred_id() { reset(); }
+
+    void reset() {
+        if (_impl != nullptr) {
+            OM_uint32 minor{};
+            gss_release_cred(&minor, &_impl);
+        }
+    }
+
+    operator gss_cred_id_t() { return _impl; };
+    gss_cred_id_t* operator&() { return &_impl; };
+
+private:
+    gss_cred_id_t _impl{nullptr};
+};
+
+class ctx_id {
+public:
+    ctx_id() = default;
+    ctx_id(ctx_id&&) = delete;
+    ctx_id(const ctx_id&) = delete;
+    ctx_id operator=(ctx_id&&) = delete;
+    ctx_id operator=(ctx_id const&) = delete;
+    ~ctx_id() { reset(); }
+
+    void reset() {
+        if (_impl != nullptr) {
+            OM_uint32 minor{};
+            gss_delete_sec_context(&minor, &_impl, GSS_C_NO_BUFFER);
+        }
+    }
+
+    operator gss_ctx_id_t() { return _impl; };
+    gss_ctx_id_t* operator&() { return &_impl; };
+
+private:
+    gss_ctx_id_t _impl{nullptr};
+};
+
+} // namespace security::gss
+
+namespace fmt {
+template<>
+struct fmt::formatter<::gss_OID_desc_struct> final
+  : fmt::formatter<string_view> {
+    template<typename FormatContext>
+    auto format(::gss_OID_desc_struct& v, FormatContext& ctx) const {
+        OM_uint32 minor_status{};
+        security::gss::buffer oid_name;
+        auto major_status = ::gss_oid_to_str(&minor_status, &v, &oid_name);
+        if (major_status != GSS_S_COMPLETE) {
+            return format_to(
+              ctx.out(), "error {}:{}", major_status, minor_status);
+        } else {
+            return format_to(ctx.out(), "{}", std::string_view(oid_name));
+        }
+    }
+};
+
+} // namespace fmt

--- a/src/v/security/gssapi_authenticator.cc
+++ b/src/v/security/gssapi_authenticator.cc
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "security/gssapi_authenticator.h"
+
+#include "bytes/bytes.h"
+#include "config/configuration.h"
+#include "kafka/protocol/request_reader.h"
+#include "security/acl.h"
+#include "security/errc.h"
+#include "security/gssapi.h"
+#include "security/logger.h"
+#include "vlog.h"
+
+#include <boost/outcome/basic_outcome.hpp>
+#include <boost/outcome/success_failure.hpp>
+#include <fmt/ranges.h>
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_ext.h>
+
+#include <array>
+#include <sstream>
+#include <string_view>
+
+namespace security {
+
+std::ostream&
+operator<<(std::ostream& os, gssapi_authenticator::state const s) {
+    using state = gssapi_authenticator::state;
+    switch (s) {
+    case state::init:
+        return os << "init";
+    case state::more:
+        return os << "more";
+    case state::ssfcap:
+        return os << "ssfcap";
+    case state::ssfreq:
+        return os << "ssfreq";
+    case state::complete:
+        return os << "complete";
+    case state::failed:
+        return os << "failed";
+    }
+}
+
+static void display_status_1(std::string_view m, OM_uint32 code, int type) {
+    while (true) {
+        OM_uint32 msg_ctx{};
+        OM_uint32 min_stat{};
+        gss::buffer msg;
+        auto maj_stat = gss_display_status(
+          &min_stat, code, type, GSS_C_NO_OID, &msg_ctx, &msg);
+        if (maj_stat != GSS_S_COMPLETE) {
+            vlog(seclog.info, "gss status from {}", m);
+            break;
+        } else {
+            vlog(seclog.info, "GSS_API error {}: {}", m, msg);
+        }
+
+        if (!msg_ctx) {
+            break;
+        }
+    }
+}
+
+std::string display_ctx_flags(OM_uint32 flags) {
+    std::stringstream ss;
+
+    if (flags & GSS_C_DELEG_FLAG) ss << "GSS_C_DELEG_FLAG, ";
+    if (flags & GSS_C_MUTUAL_FLAG) ss << "GSS_C_MUTUAL_FLAG, ";
+    if (flags & GSS_C_REPLAY_FLAG) ss << "GSS_C_REPLAY_FLAG, ";
+    if (flags & GSS_C_SEQUENCE_FLAG) ss << "GSS_C_SEQUENCE_FLAG, ";
+    if (flags & GSS_C_CONF_FLAG) ss << "GSS_C_CONF_FLAG, ";
+    if (flags & GSS_C_INTEG_FLAG) ss << "GSS_C_INTEG_FLAG, ";
+    auto str = ss.str();
+    if (str.length() > 2) {
+        str.resize(str.length() - 2);
+    }
+    return str;
+}
+
+/*
+ * Function: display_status
+ *
+ * Purpose: displays GSS-API messages
+ *
+ * Arguments:
+ *
+ *      msg             a string to be displayed with the message
+ *      maj_stat        the GSS-API major status code
+ *      min_stat        the GSS-API minor status code
+ *
+ * Effects:
+ *
+ * The GSS-API messages associated with maj_stat and min_stat are
+ * displayed on stderr, each preceeded by "GSS-API error <msg>:
+" and
+ * followed by a newline.
+ */
+void display_status(
+  std::string_view msg, OM_uint32 maj_stat, OM_uint32 min_stat) {
+    display_status_1(msg, maj_stat, GSS_C_GSS_CODE);
+    display_status_1(msg, min_stat, GSS_C_MECH_CODE);
+}
+
+ss::future<result<bytes>> gssapi_authenticator::authenticate(bytes auth_bytes) {
+    vlog(
+      seclog.trace,
+      "gss {} authenticate received {} bytes",
+      _state,
+      auth_bytes.size());
+
+    switch (_state) {
+    case state::init: {
+        auto principal = config::shard_local_cfg().sasl_kerberos_principal();
+        auto keytab = config::shard_local_cfg().sasl_kerberos_keytab();
+
+        auto res = co_await _worker.submit(
+          [this,
+           principal{std::move(principal)},
+           keytab{std::move(keytab)}]() mutable {
+              return init(std::move(principal), std::move(keytab));
+          });
+        if (res.has_error()) {
+            co_return res.assume_error();
+        }
+    }
+        [[fallthrough]];
+    case state::more: {
+        co_return co_await _worker.submit(
+          [this, auth_bytes]() { return more(auth_bytes); });
+    }
+    case state::ssfcap: {
+        co_return co_await _worker.submit(
+          [this, auth_bytes]() { return ssfcap(auth_bytes); });
+    }
+    case state::ssfreq: {
+        co_return co_await _worker.submit(
+          [this, auth_bytes]() { return ssfreq(auth_bytes); });
+    }
+    case state::complete:
+    case state::failed:
+        break;
+    }
+
+    fail(0, 0, "gss {} authenticate failed", _state);
+    co_return errc::invalid_gssapi_state;
+}
+
+result<void>
+gssapi_authenticator::init(ss::sstring principal, ss::sstring keytab) {
+    OM_uint32 minor_status{};
+    gss::buffer_view service_name{principal};
+    gss::name server_name{};
+
+    auto major_status = ::gss_import_name(
+      &minor_status, &service_name, GSS_C_NT_HOSTBASED_SERVICE, &server_name);
+
+    if (major_status != GSS_S_COMPLETE) {
+        fail(
+          major_status,
+          minor_status,
+          "gss {} failed to import service principal {}",
+          _state,
+          principal);
+        return errc::invalid_credentials;
+    }
+
+    gss_key_value_element_desc elem{.key = "keytab", .value = keytab.c_str()};
+    gss_key_value_set_desc store{.count = 1, .elements = &elem};
+
+    major_status = ::gss_acquire_cred_from(
+      &minor_status,
+      server_name,
+      0,
+      GSS_C_NO_OID_SET,
+      GSS_C_ACCEPT,
+      &store,
+      &_server_creds,
+      NULL,
+      NULL);
+
+    if (major_status != GSS_S_COMPLETE) {
+        fail(
+          major_status,
+          minor_status,
+          "gss {} failed to acquire credentials for principal {} in keytab {}",
+          _state,
+          principal,
+          keytab);
+        return errc::invalid_credentials;
+    }
+
+    _state = state::more;
+    return outcome::success();
+}
+
+result<bytes> gssapi_authenticator::more(bytes_view auth_bytes) {
+    gss::buffer_view recv_tok{auth_bytes};
+    gss::buffer send_tok;
+    OM_uint32 minor_status{};
+    OM_uint32 ret_flags{};
+    gss_OID oid;
+    gss::name client_name;
+
+    auto major_status = ::gss_accept_sec_context(
+      &minor_status,
+      &_context,
+      _server_creds,
+      &recv_tok,
+      GSS_C_NO_CHANNEL_BINDINGS,
+      &client_name,
+      &oid,
+      &send_tok,
+      &ret_flags,
+      nullptr,  /* ignore time_rec */
+      nullptr); /* ignore del_cred_handle */
+
+    if (
+      major_status != GSS_S_COMPLETE && major_status != GSS_S_CONTINUE_NEEDED) {
+        fail(
+          major_status,
+          minor_status,
+          "gss {} failed to accept security context",
+          _state);
+        return errc::invalid_credentials;
+    }
+
+    bytes ret{bytes_view{send_tok}};
+    vlog(seclog.trace, "gss {} sending {} bytes", _state, ret.size());
+
+    if (major_status == GSS_S_COMPLETE) {
+        _state = state::ssfcap;
+    } else if (major_status == GSS_S_CONTINUE_NEEDED) {
+        _state = state::more;
+    }
+
+    return ret;
+}
+
+result<bytes> gssapi_authenticator::ssfcap(bytes_view auth_bytes) {
+    if (!auth_bytes.empty()) {
+        fail(
+          0,
+          0,
+          "gss {} expected empty response but got {} bytes",
+          _state,
+          auth_bytes.size());
+        return errc::invalid_credentials;
+    }
+
+    OM_uint32 minor_status{};
+    gss::buffer_set bufset;
+    auto major_status = gss_inquire_sec_context_by_oid(
+      &minor_status, _context, GSS_C_SEC_CONTEXT_SASL_SSF, &bufset);
+    if (major_status != GSS_S_COMPLETE) {
+        fail(
+          major_status, minor_status, "gss {} failed to inquire ssf", _state);
+        return errc::invalid_credentials;
+    }
+    if ((bufset.size() != 1) || (bufset[0].size() != 4)) {
+        fail(0, 0, "gss {} unexpected data in ssf", _state);
+        return errc::invalid_credentials;
+    }
+
+    uint32_t ssf{};
+    memcpy(&ssf, bufset[0].value(), sizeof(ssf));
+    auto mech_ssf = ntohl(ssf);
+    vlog(seclog.trace, "gss {} mech_ssf: {}", _state, mech_ssf);
+
+    bytes sasl_data{0x1, 0x0, 0x0, 0xff};
+    gss::buffer_view input{sasl_data};
+    gss::buffer output_token;
+    major_status = ::gss_wrap(
+      &minor_status,
+      _context,
+      1,
+      GSS_C_QOP_DEFAULT,
+      &input,
+      nullptr,
+      &output_token);
+    if (major_status != GSS_S_COMPLETE) {
+        fail(
+          major_status,
+          minor_status,
+          "gss {} failed to wrap ssf",
+          major_status,
+          minor_status);
+        return errc::invalid_credentials;
+    }
+
+    vlog(seclog.trace, "gss {} sending {} bytes", _state, output_token.size());
+    _state = state::ssfreq;
+    return bytes{bytes_view{output_token}};
+}
+
+result<bytes> gssapi_authenticator::ssfreq(bytes_view auth_bytes) {
+    gss::buffer_view input_token{auth_bytes};
+    gss::buffer output_token{};
+    OM_uint32 minor_status{};
+    auto major_status = gss_unwrap(
+      &minor_status, _context, &input_token, &output_token, nullptr, nullptr);
+    if (major_status != GSS_S_COMPLETE) {
+        fail(
+          major_status,
+          minor_status,
+          "gss {} failed to unwrap ssf of {} bytes",
+          _state,
+          auth_bytes.size());
+        return errc::invalid_credentials;
+    }
+
+    if (output_token.size() < 4) {
+        fail(
+          0,
+          0,
+          "gss {} unexpected data in unwrapped result of {} bytes",
+          _state,
+          output_token.size());
+    }
+
+    if (auto res = check(); res.has_error()) {
+        return res.assume_error();
+    }
+
+    bytes ret{};
+    vlog(seclog.trace, "gss {} sending {} bytes", _state, ret.size());
+    finish();
+    return ret;
+}
+
+result<void> gssapi_authenticator::check() {
+    OM_uint32 major_status{};
+    OM_uint32 minor_status{};
+    OM_uint32 lifetime_rec{};
+    gss::name source;
+    gss::name target;
+    gss_OID mech{};
+    OM_uint32 ctx_flags{};
+    int open{};
+
+    major_status = ::gss_inquire_context(
+      &minor_status,
+      _context,
+      &source,
+      &target,
+      &lifetime_rec,
+      &mech,
+      &ctx_flags,
+      nullptr,
+      &open);
+    if (major_status != GSS_S_COMPLETE) {
+        fail(
+          major_status,
+          minor_status,
+          "gss {} failed to inquire context",
+          _state);
+        return errc::invalid_scram_state;
+    }
+
+    auto target_buf = target.display_name_buffer();
+    std::string_view target_name{target_buf};
+    if (target_name.empty()) {
+        fail(0, 0, "gss {} failed to get service principal", _state);
+        return errc::invalid_scram_state;
+    }
+
+    auto source_buf = source.display_name_buffer();
+    std::string_view source_name{source_buf};
+    if (source_name.empty()) {
+        fail(0, 0, "gss {} failed to get client principal", _state);
+        return errc::invalid_scram_state;
+    }
+
+    vlog(
+      seclog.debug,
+      "gss_inquire_context: source: {}, target: {}, lifetime_rec: {}, "
+      "ctx_flags: {}, open: {}",
+      source_name,
+      target_name,
+      lifetime_rec,
+      display_ctx_flags(ctx_flags),
+      open);
+
+    // None of this is needed - left here temporarily for posterity
+    // if ((ctx_flags & GSS_C_INTEG_FLAG) == 0) {
+    //     // No integrity
+    //     _state = state::failed;
+    //     return errc::invalid_credentials;
+    // } else if ((ctx_flags & GSS_C_CONF_FLAG) == 0) {
+    //     // No confidentiality
+    //     _state = state::failed;
+    //     return errc::invalid_credentials;
+    // }
+
+    _principal = acl_principal{principal_type::user, ss::sstring{source_name}};
+    return outcome::success();
+}
+
+void gssapi_authenticator::finish() {
+    _context.reset();
+    _server_creds.reset();
+    _state = state::complete;
+}
+
+void gssapi_authenticator::fail_impl(
+  OM_uint32 maj_stat, OM_uint32 min_stat, std::string_view msg) {
+    if (maj_stat != 0 || min_stat != 0) {
+        display_status(msg, maj_stat, min_stat);
+    } else {
+        vlog(seclog.info, "{}", msg);
+    }
+    _state = state::failed;
+}
+
+} // namespace security

--- a/src/v/security/gssapi_authenticator.h
+++ b/src/v/security/gssapi_authenticator.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+#include "security/acl.h"
+#include "security/credential_store.h"
+#include "security/gssapi.h"
+#include "security/logger.h"
+#include "security/sasl_authentication.h"
+#include "security/scram_algorithm.h"
+#include "security/types.h"
+#include "ssx/thread_worker.h"
+#include "utils/mutex.h"
+
+namespace security {
+
+class gssapi_authenticator final : public sasl_mechanism {
+    enum class state { init = 0, more, ssfcap, ssfreq, complete, failed };
+    friend std::ostream&
+    operator<<(std::ostream& os, gssapi_authenticator::state const s);
+
+public:
+    static constexpr const char* name = "GSSAPI";
+
+    explicit gssapi_authenticator(ssx::thread_worker& thread_worker)
+      : _worker{thread_worker} {}
+
+    ss::future<result<bytes>> authenticate(bytes) override;
+
+    bool complete() const override { return _state == state::complete; }
+    bool failed() const override { return _state == state::failed; }
+
+    const security::acl_principal& principal() const override {
+        return _principal;
+    }
+
+private:
+    result<void> init(ss::sstring principal, ss::sstring keytab);
+    result<bytes> more(bytes_view);
+    result<bytes> ssfcap(bytes_view);
+    result<bytes> ssfreq(bytes_view);
+    result<void> check();
+    void finish();
+    void
+    fail_impl(OM_uint32 maj_stat, OM_uint32 min_stat, std::string_view msg);
+    template<typename... Args>
+    void fail(
+      OM_uint32 maj_stat,
+      OM_uint32 min_stat,
+      fmt::format_string<Args...> format_str,
+      Args&&... args) {
+        auto msg = ssx::sformat(format_str, std::forward<Args>(args)...);
+        fail_impl(maj_stat, min_stat, msg);
+    }
+
+    ssx::thread_worker& _worker;
+    security::acl_principal _principal;
+    state _state{state::init};
+    gss::cred_id _server_creds;
+    gss::ctx_id _context;
+};
+
+} // namespace security

--- a/src/v/security/sasl_authentication.h
+++ b/src/v/security/sasl_authentication.h
@@ -26,7 +26,7 @@ public:
     virtual bool complete() const = 0;
     virtual bool failed() const = 0;
     virtual const acl_principal& principal() const = 0;
-    virtual result<bytes> authenticate(bytes_view) = 0;
+    virtual ss::future<result<bytes>> authenticate(bytes) = 0;
 };
 
 /*
@@ -53,8 +53,8 @@ public:
     bool has_mechanism() const { return bool(_mechanism); }
     sasl_mechanism& mechanism() { return *_mechanism; }
 
-    result<bytes> authenticate(bytes data) {
-        return _mechanism->authenticate(data);
+    ss::future<result<bytes>> authenticate(bytes data) {
+        return _mechanism->authenticate(std::move(data));
     }
 
     void set_mechanism(std::unique_ptr<sasl_mechanism> m) {

--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -119,13 +119,14 @@ result<bytes> scram_authenticator<T>::handle_next(bytes_view auth_bytes) {
 }
 
 template<typename T>
-result<bytes> scram_authenticator<T>::authenticate(bytes_view auth_bytes) {
+ss::future<result<bytes>>
+scram_authenticator<T>::authenticate(bytes auth_bytes) {
     auto ret = handle_next(auth_bytes);
     if (!ret) {
         _state = state::failed;
         clear_credentials();
     }
-    return ret;
+    co_return ret;
 }
 
 template class scram_authenticator<scram_sha256>;

--- a/src/v/security/scram_authenticator.h
+++ b/src/v/security/scram_authenticator.h
@@ -27,7 +27,7 @@ public:
       : _state{state::client_first_message}
       , _credentials(credentials) {}
 
-    result<bytes> authenticate(bytes_view auth_bytes) override;
+    ss::future<result<bytes>> authenticate(bytes auth_bytes) override;
 
     bool complete() const override { return _state == state::complete; }
     bool failed() const override { return _state == state::failed; }

--- a/src/v/ssx/fwd.h
+++ b/src/v/ssx/fwd.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace ssx {
+
+class thread_worker;
+
+} // namespace ssx

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ rp_test(
     async_transforms.cc
     sformat.cc
     future_util.cc
+    thread_worker.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::ssx
   LABELS ssx
@@ -13,7 +14,9 @@ rp_test(
 rp_test(
   BENCHMARK_TEST
   BINARY_NAME ssx_bench
-  SOURCES sformat_bench.cc
+  SOURCES
+    sformat_bench.cc
+    thread_worker_bench.cc
   LIBRARIES Seastar::seastar_perf_testing v::ssx
   LABELS ssx
 )

--- a/src/v/ssx/tests/thread_worker.cc
+++ b/src/v/ssx/tests/thread_worker.cc
@@ -1,0 +1,78 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/thread_worker.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/later.hh>
+
+#include <absl/algorithm/container.h>
+#include <boost/test/unit_test_log.hpp>
+
+template<size_t tries, size_t stop_at>
+auto thread_worker_test() {
+    BOOST_REQUIRE_GT(ss::smp::count, 1);
+
+    auto w = ssx::thread_worker{};
+    w.start().get();
+
+    std::vector<std::vector<ss::future<size_t>>> all_results(ss::smp::count);
+
+    ss::smp::invoke_on_all([&w, &all_results]() {
+        auto& results = all_results[ss::this_shard_id()];
+        results.reserve(tries);
+        for (size_t i = 0; i < tries; ++i) {
+            results.push_back(w.submit([i]() { return i; }));
+        }
+    }).get();
+
+    BOOST_REQUIRE(absl::c_all_of(
+      all_results, [](const auto& c) { return c.size() == tries; }));
+
+    ss::smp::invoke_on_all([&w, &all_results]() {
+        return [](auto& w, auto& all_results) -> ss::future<> {
+            bool is_worker_shard = w.shard_id == ss::this_shard_id();
+            auto& results = all_results[ss::this_shard_id()];
+            for (size_t i = 0; i < tries; ++i) {
+                if (i == stop_at && is_worker_shard) {
+                    co_await w.stop();
+                }
+                auto result = co_await std::move(results[i])
+                                .handle_exception_type(
+                                  [i](const seastar::gate_closed_exception&) {
+                                      return i;
+                                  });
+                BOOST_REQUIRE_EQUAL(result, i);
+            }
+        }(w, all_results);
+    }).get();
+
+    if (stop_at >= tries) {
+        w.stop().get();
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(thread_worker_single_cancel_after) {
+    // cancel thread worker at the after all of the gets
+    thread_worker_test<1, 1>();
+}
+
+SEASTAR_THREAD_TEST_CASE(thread_worker_many_cancel_after) {
+    // cancel thread worker at the after all of the gets
+    thread_worker_test<128, 128>();
+}
+
+SEASTAR_THREAD_TEST_CASE(thread_worker_many_cancel_middle) {
+    // cancel thread worker half way through the gets
+    thread_worker_test<128, 64>();
+}

--- a/src/v/ssx/tests/thread_worker_bench.cc
+++ b/src/v/ssx/tests/thread_worker_bench.cc
@@ -1,0 +1,40 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "seastarx.h"
+#include "ssx/thread_worker.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+ss::future<> run_test(size_t data_size) {
+    auto w = ssx::thread_worker{};
+    co_await w.start();
+
+    std::vector<ss::future<size_t>> vec;
+    vec.reserve(data_size);
+
+    perf_tests::start_measuring_time();
+    for (size_t i = 0; i < data_size; ++i) {
+        vec.push_back(w.submit([i]() { return i; }));
+    }
+
+    for (size_t i = 0; i < data_size; ++i) {
+        auto val = co_await std::move(vec[i]);
+        vassert(val == i, "Failed");
+        perf_tests::do_not_optimize(val);
+    }
+    perf_tests::stop_measuring_time();
+    co_await w.stop();
+}
+
+struct thread_worker_test {};
+PERF_TEST_C(thread_worker_test, 1) { co_return co_await run_test(1); }
+PERF_TEST_C(thread_worker_test, 10) { co_return co_await run_test(10); }
+PERF_TEST_C(thread_worker_test, 100) { co_return co_await run_test(100); }
+PERF_TEST_C(thread_worker_test, 1000) { co_return co_await run_test(1000); }

--- a/src/v/ssx/thread_worker.h
+++ b/src/v/ssx/thread_worker.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "utils/mutex.h"
+#include "vassert.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/alien.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/internal/pollable_fd.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/std-coroutine.hh>
+
+#include <sys/eventfd.h>
+
+#include <exception>
+#include <memory>
+#include <thread>
+
+namespace ssx {
+
+namespace impl {
+
+class task_base {
+public:
+    task_base() = default;
+    task_base(task_base&&) = delete;
+    task_base(task_base const&) = delete;
+    task_base& operator=(task_base&&) = delete;
+    task_base& operator=(task_base const&) = delete;
+
+    virtual void process(ss::alien::instance&, ss::shard_id) = 0;
+    virtual void
+    set_exception(ss::alien::instance&, ss::shard_id, std::exception_ptr)
+      = 0;
+    virtual ~task_base() = default;
+};
+
+template<typename Func>
+class worker_task final : public task_base {
+    using futurator = ss::futurize<std::invoke_result_t<Func>>;
+
+public:
+    explicit worker_task(Func func)
+      : _func{std::move(func)} {}
+
+    typename futurator::type get_future() noexcept {
+        return _promise.get_future();
+    }
+
+    void process(ss::alien::instance& alien, ss::shard_id shard) final {
+        auto f = futurator::invoke(_func);
+        ss::alien::run_on(alien, shard, [this, f{std::move(f)}]() mutable {
+            f.forward_to(std::move(_promise));
+        });
+    }
+
+    void set_exception(
+      ss::alien::instance& alien,
+      ss::shard_id shard,
+      std::exception_ptr p) final {
+        ss::alien::run_on(
+          alien, shard, [this, p]() mutable { _promise.set_exception(p); });
+    }
+
+private:
+    Func _func;
+    typename futurator::promise_type _promise;
+};
+
+class thread_worker {
+    static constexpr eventfd_t RUNNABLE_INIT = 0;
+    static constexpr eventfd_t RUNNABLE_READY = 1;
+    static constexpr eventfd_t RUNNABLE_STOP = 2;
+
+public:
+    thread_worker()
+      : _alien{ss::engine().alien()}
+      , _shard_id(ss::this_shard_id()) {}
+
+    void start() {
+        _worker = std::thread([this]() { return run(); });
+    }
+
+    ss::future<> stop() {
+        co_await _gate.close();
+        _ready.signal(RUNNABLE_STOP);
+        if (_worker.joinable()) {
+            _worker.join();
+        }
+    }
+
+    template<typename Func>
+    auto submit(Func func) {
+        auto gh = _gate.hold();
+        return _mutex.get_units().then(
+          [this, func{std::move(func)}, gh{std::move(gh)}](auto units) mutable {
+              vassert(_task == nullptr, "Only one task supported at a time");
+              auto task = std::make_unique<impl::worker_task<Func>>(
+                std::move(func));
+              auto f = task->get_future().finally(
+                [this, gh{std::move(gh)}, units{std::move(units)}] {
+                    _task.reset();
+                });
+              _task = std::move(task);
+              _ready.signal(RUNNABLE_READY);
+              return f;
+          });
+    }
+
+private:
+    void configure_thread() {
+        ::pthread_setname_np(::pthread_self(), "ssx::thread_worker");
+        // Ignore all signals - let seastar handle them
+        sigset_t mask;
+        ::sigfillset(&mask);
+        ss::throw_pthread_error(::pthread_sigmask(SIG_BLOCK, &mask, nullptr));
+    }
+    size_t run() {
+        configure_thread();
+        while (true) {
+            eventfd_t result = 0;
+            auto r = ::eventfd_read(_ready.get_read_fd(), &result);
+            if (r < 0 || result != RUNNABLE_READY) {
+                if (_task) {
+                    _task->set_exception(
+                      _alien,
+                      _shard_id,
+                      std::make_exception_ptr(ss::abort_requested_exception{}));
+                }
+            }
+            if (r < 0) {
+                return r;
+            } else if (result == RUNNABLE_STOP) {
+                return 0;
+            }
+            _task->process(_alien, _shard_id);
+        }
+    }
+
+    ss::alien::instance& _alien;
+    ss::shard_id _shard_id;
+    std::thread _worker;
+    ss::gate _gate;
+    mutex _mutex;
+    seastar::writeable_eventfd _ready{RUNNABLE_INIT};
+    std::unique_ptr<impl::task_base> _task{nullptr};
+};
+
+} // namespace impl
+
+/**
+ * thread_worker runs tasks in a std::thread
+ *
+ * By running in a std::thread, it's possible to make blocking calls such as
+ * file I/O and posix thread primitives.
+ *
+ * The thread worker will drain all operations before joining the thread in
+ * stop()
+ */
+class thread_worker {
+public:
+    static constexpr ss::shard_id shard_id = 0;
+    thread_worker() = default;
+
+    /**
+     * start the background thread
+     */
+    ss::future<> start() {
+        vassert(
+          ss::this_shard_id() == shard_id,
+          "thread_worker must be started on shard ",
+          shard_id);
+        co_await _gate.start();
+        _impl.start();
+    }
+
+    /**
+     * stop and join the background thread
+     */
+    ss::future<> stop() {
+        vassert(
+          ss::this_shard_id() == shard_id,
+          "thread_worker must be stopped on shard ",
+          shard_id);
+
+        co_await _gate.invoke_on_all(&ss::gate::close);
+        co_await _impl.stop();
+        co_await _gate.stop();
+    }
+
+    /**
+     * submit a task to the background thread
+     */
+    template<typename Func>
+    auto submit(Func func) ->
+      typename ss::futurize<std::invoke_result_t<Func>>::type {
+        return ss::with_gate(
+          _gate.local(), [this, func{std::move(func)}]() mutable {
+              return ss::smp::submit_to(
+                shard_id, [this, func{std::move(func)}]() mutable {
+                    return _impl.submit(std::move(func));
+                });
+          });
+    }
+
+private:
+    ss::sharded<ss::gate> _gate;
+    impl::thread_worker _impl;
+};
+
+} // namespace ssx

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -20,11 +20,15 @@ function install_system_deps() {
     curl \
     dmidecode \
     cmake \
+    krb5-admin-server \
+    krb5-kdc \
+    krb5-user \
     iproute2 \
     iptables \
     libatomic1 \
     libyajl-dev \
     libsasl2-dev \
+    libsasl2-modules-gssapi-mit \
     libssl-dev \
     net-tools \
     lsof \

--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -68,6 +68,11 @@ class KafkaCat:
                     f"sasl.username={cfg['sasl_plain_username']}", "-X",
                     f"sasl.password={cfg['sasl_plain_password']}"
                 ]
+                if cfg['sasl_mechanism'] == "GSSAPI":
+                    cmd += [
+                        "-X", "sasl.kerberos.service.name=redpanda",
+                        '-Xsasl.kerberos.kinit.cmd=kinit client -t /var/lib/redpanda/client.keytab'
+                    ]
             try:
                 res = subprocess.check_output(
                     ["kcat", "-b", self._redpanda.brokers()] + cmd,

--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -1,0 +1,222 @@
+import json
+import os
+
+from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.services.service import Service
+from ducktape.utils.util import wait_until
+
+KADM5_ACL_TMPL = """
+{kadmin_principal}@{realm} *
+noPermissions@{realm} X
+"""
+KADM5_ACL_PATH = "/etc/krb5kdc/kadm5.acl"
+
+KDC_CONF_TMPL = """
+[realms]
+	{realm} = {{
+		acl_file = {kadm5_acl_path}
+		max_renewable_life = 7d 0h 0m 0s
+		supported_enctypes = {supported_encryption_types}
+		default_principal_flags = +preauth
+	}}
+"""
+KDC_CONF_PATH = "/etc/krb5kdc/kdc.conf"
+
+KRB5_CONF_TMPL = """
+[libdefaults]
+	default_realm = {realm}
+
+[realms]
+	{realm} = {{
+		kdc_ports = 88,750
+		kadmind_port = 749
+		kdc = {node.account.hostname}
+		admin_server = {node.account.hostname}
+	}}
+"""
+KRB5_CONF_PATH = "/etc/krb5.conf"
+
+KRB5KDC_PID_PATH = "/var/run/krb5kdc.pid"
+KADMIND_PID_PATH = "/var/run/kadmind.pid"
+KDC_DB_PATH = "/var/lib/krb5kdc/principal"
+
+
+class KrbKdc(Service):
+    """
+    A Kerberos KDC implementation backed by krb5-kdc (MIT).
+    """
+    def __init__(self, context, realm="example.com", log_level="DEBUG"):
+        super(KrbKdc, self).__init__(context, num_nodes=1)
+        self.realm = realm
+        self.supported_encryption_types = "aes256-cts-hmac-sha1-96:normal"
+        self.kadmin_principal = "kadmin/admin"
+        self.kadmin_password = "adminpassword"
+        self.kadm5_acl_path = KADM5_ACL_PATH
+        self.kdc_conf_path = KDC_CONF_PATH
+        self.krb5_conf_path = KRB5_CONF_PATH
+        self.log_level = log_level
+
+    def _render_cfg(self, node):
+        tmpl = KRB5_CONF_TMPL.format(node=node, realm=self.realm)
+        self.logger.info(f"{self.krb5_conf_path}: {tmpl}")
+        node.account.create_file(self.krb5_conf_path, tmpl)
+
+        tmpl = KDC_CONF_TMPL.format(
+            realm=self.realm,
+            kadm5_acl_path=self.kadm5_acl_path,
+            supported_encryption_types=self.supported_encryption_types)
+        self.logger.info(f"{self.kdc_conf_path}: {tmpl}")
+        node.account.create_file(self.kdc_conf_path, tmpl)
+
+        tmpl = KADM5_ACL_TMPL.format(realm=self.realm,
+                                     kadmin_principal=self.kadmin_principal)
+        self.logger.info(f"{self.kadm5_acl_path}: {tmpl}")
+        node.account.create_file(self.kadm5_acl_path, tmpl)
+
+    def _hard_delete_principals(self, node):
+        node.account.ssh(f"rm -fr {KDC_DB_PATH}*", allow_fail=True)
+
+    def _init_realm(self, node):
+        self._hard_delete_principals(node)
+        master_password = "1NSMkA4W7TBYapV9lC2MMeUcAEJDGK"
+        cmd = f"""krb5_newrealm<<EOF
+{master_password}
+{master_password}
+EOF
+"""
+        node.account.ssh(cmd, allow_fail=False)
+
+    def start_cmd(self):
+        cmd = f"krb5kdc -P {KRB5KDC_PID_PATH};kadmind -P {KADMIND_PID_PATH}"
+        return cmd
+
+    def pids(self, node):
+        def pid(path: str):
+            try:
+                it = node.account.ssh_capture(f"cat {path}",
+                                              allow_fail=False,
+                                              callback=int)
+                p = next(it)
+                if node.account.alive(p):
+                    return [p]
+
+            except (RemoteCommandError, ValueError):
+                self.logger.warn("pidfile not found: {path}")
+
+            return []
+
+        return pid(KRB5KDC_PID_PATH) + pid(KADMIND_PID_PATH)
+
+    def alive(self, node):
+        return len(self.pids(node)) == 2
+
+    def start_node(self, node):
+        self._render_cfg(node)
+        self._init_realm(node)
+        # Run kdc
+        cmd = self.start_cmd()
+        self.logger.debug("kdc command: %s", cmd)
+        node.account.ssh(cmd, allow_fail=False)
+        wait_until(lambda: self.alive(node),
+                   timeout_sec=30,
+                   backoff_sec=.5,
+                   err_msg="kdc took too long to start.")
+        self.logger.debug("kdc is alive")
+        self.add_principal(f"{self.kadmin_principal}@{self.realm}",
+                           self.kadmin_password)
+        self.add_principal(f"noPermissions@{self.realm}", self.kadmin_password)
+
+    def stop_node(self, node, clean_shutdown=True):
+        s = "TERM" if clean_shutdown else "KILL"
+        self.logger.warn(f"Stopping node {node.name}")
+        for p in self.pids(node):
+            node.account.ssh(f"kill -s {s} {p}", allow_fail=not clean_shutdown)
+
+        wait_until(lambda: not self.alive(node),
+                   timeout_sec=30,
+                   backoff_sec=.5,
+                   err_msg="kdc took too long to stop.")
+
+    def clean_node(self, node):
+        self.logger.warn(f"Cleaning node {node.name}")
+        if self.alive(node):
+            self.logger.warn(
+                "kdc was still alive at cleanup time. Killing forcefully...")
+            self.stop_node(node, False)
+        self._hard_delete_principals(node)
+
+    def add_principal(self, principal: str, password: str):
+        self.nodes[0].account.ssh(
+            f'kadmin.local -q "add_principal -pw {password} {principal}"',
+            allow_fail=False)
+
+    def add_principal_randkey(self, principal: str):
+        self.nodes[0].account.ssh(
+            f'kadmin.local -q "add_principal -randkey {principal}"',
+            allow_fail=False)
+
+    def delete_principal(self, principal: str):
+        self.nodes[0].account.ssh(
+            f'kadmin.local -q "delete_principal -force {principal}"',
+            allow_fail=False)
+
+    def ktadd(self, principal: str, dst: str, nodes):
+        src = "/temporary.keytab"
+        self.nodes[0].account.ssh(f"rm {src}", allow_fail=True)
+        for node in nodes:
+            # hostname = next(node.account.ssh_capture("hostname -f")).strip()
+            self.nodes[0].account.ssh(
+                f'kadmin.local -q "ktadd -k {src} {principal}"')
+            self.logger.info(
+                f"Copying: {self.nodes[0].name}:{src} -> {node.name}:{dst}")
+            node.account.ssh(f"mkdir -p {os.path.dirname(dst)}")
+            self.nodes[0].account.copy_between(src, dst, node)
+            self.nodes[0].account.copy_between(src, "/node.keytab", node)
+            node.account.ssh(f"kinit {principal} -t {dst}")
+            kl = node.account.ssh_capture(f"klist -k {dst}")
+            self.logger.info(f"klist: {list(kl)}")
+
+    def list_principals(self):
+        princs = self.nodes[0].account.ssh_capture(
+            'kadmin.local -q "list_principals"',
+            allow_fail=False,
+            callback=lambda l: l.strip())
+        # Drop the first line, which is login details
+        return list(princs)[1:]
+
+
+class KrbClient(Service):
+    """
+    A Kerberos KDC implementation backed by krb5-kdc (MIT).
+    """
+    def __init__(self, context, kdc, redpanda, principal: str):
+        super(KrbClient, self).__init__(context, num_nodes=1)
+        self.kdc = kdc
+        self.redpanda = redpanda
+        self.principal = principal
+        self.krb5_conf_path = KRB5_CONF_PATH
+
+    def _render_cfg(self, node):
+        tmpl = KRB5_CONF_TMPL.format(node=self.kdc.nodes[0],
+                                     realm=self.kdc.realm)
+        self.logger.info(f"{self.krb5_conf_path}: {tmpl}")
+        node.account.create_file(self.krb5_conf_path, tmpl)
+
+    def start_node(self, node):
+        self._render_cfg(node)
+
+    def stop_node(self, node, clean_shutdown=True):
+        self.logger.warn(f"Stopping node {node.name}")
+
+    def clean_node(self, node):
+        self.logger.warn(f"Cleaning node {node.name}")
+
+    def metadata(self):
+        self.logger.info("Metadata request")
+        res = self.nodes[0].account.ssh_output(
+            cmd=
+            f"KRB5_TRACE=/dev/stderr kcat -L -J -b {self.redpanda.brokers()} -X security.protocol=sasl_plaintext -X sasl.mechanisms=GSSAPI '-Xsasl.kerberos.kinit.cmd=kinit {self.principal} -t {self.redpanda.PERSISTENT_ROOT}/client.keytab' -X sasl.kerberos.service.name=redpanda",
+            allow_fail=False,
+            combine_stderr=False)
+        self.logger.debug(f"Metadata request: {res}")
+        return json.loads(res)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -393,6 +393,7 @@ class SecurityConfig:
     def __init__(self):
         self.enable_sasl = False
         self.kafka_enable_authorization: Optional[bool] = None
+        self.sasl_mechanisms: Optional[list[str]] = None
         self.endpoint_authn_method: Optional[str] = None
         self.tls_provider: Optional[TLSProvider] = None
         self.require_client_auth: bool = True
@@ -1949,6 +1950,11 @@ class RedpandaService(Service):
             conf.update(
                 dict(kafka_enable_authorization=self._security.
                      kafka_enable_authorization))
+        if self._security.sasl_mechanisms is not None:
+            self.logger.debug(
+                f"Setting sasl_mechanisms: {self._security.sasl_mechanisms} in cluster configuration"
+            )
+            conf.update(dict(sasl_mechanisms=self._security.sasl_mechanisms))
 
         conf_yaml = yaml.dump(conf)
         for node in self.nodes:

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -559,6 +559,11 @@ class ClusterConfigTest(RedpandaTest):
             else:
                 raise NotImplementedError(p['type'])
 
+            if name == 'sasl_mechanisms':
+                # The default value is ['SCRAM'], but the array cannot contain
+                # arbitrary strings because the config system validates them.
+                valid_value = ['SCRAM', 'GSSAPI']
+
             if name == 'enable_coproc':
                 # Don't try enabling coproc, it has external dependencies
                 continue

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -1,0 +1,93 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+
+from ducktape.tests.test import Test
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.kerberos import KrbKdc, KrbClient
+from rptest.services.redpanda import LoggingConfig, RedpandaService, SecurityConfig
+
+LOG_CONFIG = LoggingConfig('info',
+                           logger_levels={
+                               'security': 'debug',
+                               'kafka': 'trace',
+                               'admin_api_server': 'trace',
+                           })
+
+REALM = "EXAMPLE.COM"
+
+
+class RedpandaKerberosTest(Test):
+    """
+    Base class for tests that use the Redpanda service with Kerberos
+    """
+    def __init__(self, test_context, num_nodes=5, **kwargs):
+        super(RedpandaKerberosTest, self).__init__(test_context, **kwargs)
+
+        self.kdc = KrbKdc(test_context, realm=REALM)
+
+        security = SecurityConfig()
+        security.enable_sasl = True
+        security.sasl_mechanisms = ["SCRAM", "GSSAPI"]
+        self.redpanda = RedpandaService(
+            test_context,
+            # environment={"KRB5_TRACE": "/dev/stdout"},
+            num_brokers=num_nodes - 2,
+            log_config=LOG_CONFIG,
+            security=security,
+            **kwargs)
+
+        self.client = KrbClient(test_context, self.kdc, self.redpanda,
+                                f"client@{REALM}")
+
+    def setUp(self):
+        self.redpanda.logger.info("Starting KDC")
+        self.kdc.start()
+        self.redpanda.logger.info("Starting Redpanda")
+        self.redpanda.start()
+        self.redpanda.logger.info("Starting Client")
+        self.client.start()
+
+        self.redpanda.logger.info("Setting up krb5.conf on Redpanda nodes")
+        for node in self.redpanda.nodes:
+            self.client.start_node(node)
+
+        for node in self.redpanda.nodes:
+            redpanda_principal = f"redpanda/{node.name}.redpanda-test@{REALM}"
+            self.redpanda.logger.info(
+                f"Configuring Redpanda {redpanda_principal}")
+            self.kdc.add_principal_randkey(redpanda_principal)
+            self.kdc.ktadd(redpanda_principal,
+                           f"{self.redpanda.PERSISTENT_ROOT}/redpanda.keytab",
+                           [node])
+
+        client_principal = f"client@{REALM}"
+        self.kdc.add_principal_randkey(client_principal)
+        self.kdc.ktadd(client_principal,
+                       f"{self.redpanda.PERSISTENT_ROOT}/client.keytab",
+                       self.client.nodes)
+
+    @cluster(num_nodes=5)
+    def test_init(self):
+        feature_name = "kafka_gssapi"
+        self.redpanda.logger.info(f"Principals: {self.kdc.list_principals()}")
+        admin = Admin(self.redpanda)
+        admin.put_feature(feature_name, {"state": "active"})
+        self.redpanda.await_feature_active(feature_name, timeout_sec=30)
+
+        kcat = KafkaCat(self.redpanda)
+        metadata = kcat.metadata()
+        self.redpanda.logger.info(f"Metadata (SCRAM): {metadata}")
+        assert (len(metadata['brokers']) == 3)
+        metadata = self.client.metadata()
+        self.redpanda.logger.info(f"Metadata (GSSAPI): {metadata}")
+        assert (len(metadata['brokers']) == 3)


### PR DESCRIPTION
Initial end-to-end test and feature for GSSAPI support.

This contains lots of debug code, and is underdocumented, but essentially it works:

TODO:
* [x] Play more nicely with seastar - krb5 now runs in the `worker_thread`
* [ ] Configuration for `krb5.conf` - I think this can wait.
* [ ] More wrappers for gssapi types - some failures still result in leaks
* [x] Logging cleanup (some trace logging results in binary written to the log)
* [ ] Much more testing

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

GSSAPI is now a supported SASL mechanism on the Kafka API.

To enable the feature:
```sh
curl -sv -X PUT http://127.0.0.1:9644/v1/features/kafka_gssapi -d '{"state":"active"}'
```
To disable the feature:
```sh
curl -sv -X PUT http://127.0.0.1:9644/v1/features/kafka_gssapi -d '{"state":"disabled"}'
```
To enable GSSAPI as a support SASL mechanism:
```sh
rpk cluster config set sasl_mechanisms '["SCRAM","GSSAPI"]' --api-urls 127.0.0.1:9644
```

## Release Notes

### Features

* Support GSSAPI as a SASL mechanism on the Kafka API.
