### PR TITLE
mergify: add initial config file for merge queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,18 @@
+pull_request_rules:
+  - name: enqueue on label
+    conditions:
+      - base=dev
+      - label=merge-queue
+    actions:
+      queue:
+        name: dev
+        merge_bot_account: vbotbuildovich
+        update_bot_account: vbotbuildovich
+queue_rules:
+  - name: dev
+    speculative_checks: 2
+    batch_size: 4
+    draft_bot_account: vbotbuildovich
+    conditions:
+      - base=dev
+      - label=merge-queue

--- a/.github/workflows/render-pr-body-release-notes.yml
+++ b/.github/workflows/render-pr-body-release-notes.yml
@@ -13,6 +13,7 @@ on:
     types: [opened, edited]
 jobs:
   render:
+    if: ${{ ! startsWith(github.event.pull_request.title, 'merge-queue') }}
     runs-on: ubuntu-latest
     steps:
       - name: Curl rpchangelog


### PR DESCRIPTION
This PR adds an initial [mergify configuration file](https://docs.mergify.com/getting-started/#configuration) for setting up a merge queue. The [vbotbuildovich ](https://github.com/vbotbuildovich) bot account will be used by [mergify](https://github.com/apps/mergify) to manage the queue.

To add a PR to the merge queue, first add the label [merge-queue](https://github.com/redpanda-data/redpanda/labels?q=merge-queue). And when the PR satisfies the branch protection rules, it will be added to the queue.

The merge queue will be processed in a FIFO order by batching up PRs (if more than one in the queue), testing the code on top of the latest tip of `dev` branch in a separate draft PR, and if everything passes, then merging the original PRs into `dev` branch.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none