### PR TITLE
github: fix typo in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -71,7 +71,7 @@ point of the change, e.g.
   * Short description of how this PR improves existing behavior.
 
 If the changes in this PR do not need to be mentioned in the release
-notes, then don't add a sub-sction and simply list `none`, e.g.
+notes, then don't add a sub-section and simply list `none`, e.g.
 
   * none
 


### PR DESCRIPTION
fix typo in pr template

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none