### PR TITLE
kafka: convert process_one_request to use coroutines

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -64,11 +64,12 @@ ss::future<> connection_context::process_one_request() {
                 && sasl()->state()
                      == security::sasl_server::sasl_state::authenticate
                 && sasl()->handshake_v0())) {
-              co_return co_await handle_auth_v0(*sz).handle_exception(
-                [this](std::exception_ptr e) {
-                    vlog(klog.info, "Detected error processing request: {}", e);
+              try {
+              co_return co_await handle_auth_v0(*sz);
+              } catch (...) {
+                    vlog(klog.info, "Detected error processing request: {}", std::current_exception());
                     conn->shutdown_input();
-                });
+              }
           }
           auto s = sz.value();
           auto h = co_await parse_header(conn->input());

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -42,66 +42,65 @@ namespace kafka {
 
 ss::future<> connection_context::process_one_request() {
     auto sz = co_await parse_size(conn->input());
-          if (!sz) {
-              co_return co_await ss::make_ready_future<>();
-          }
-          if (sz > _max_request_size()) {
-              co_return co_await ss::make_exception_future<>(
-                net::invalid_request_error(fmt::format(
-                  "request size {} is larger than the configured max {}",
-                  sz,
-                  _max_request_size())));
-          }
-          /*
-           * Intercept the wire protocol when:
-           *
-           * 1. sasl is enabled (implied by 2)
-           * 2. during auth phase
-           * 3. handshake was v0
-           */
-          if (unlikely(
-                sasl()
-                && sasl()->state()
-                     == security::sasl_server::sasl_state::authenticate
-                && sasl()->handshake_v0())) {
-              try {
-              co_return co_await handle_auth_v0(*sz);
-              } catch (...) {
-                    vlog(klog.info, "Detected error processing request: {}", std::current_exception());
-                    conn->shutdown_input();
-              }
-          }
-          auto s = sz.value();
-          auto h = co_await parse_header(conn->input());
-                _server.probe().add_bytes_received(s);
-                if (!h) {
-                    vlog(
-                      klog.debug,
-                      "could not parse header from client: {}",
-                      conn->addr);
-                    _server.probe().header_corrupted();
-                    co_return co_await ss::make_ready_future<>();
-                }
-                try {
-                co_return co_await dispatch_method_once(std::move(h.value()), s);
-                } catch (const kafka_api_version_not_supported_exception& e) {
-                        vlog(
-                          klog.warn,
-                          "Error while processing request from {} - {}",
-                          conn->addr,
-                          e.what());
-                        conn->shutdown_input();
-                } catch (const std::bad_alloc&) {
-                      // In general, dispatch_method_once does not throw,
-                      // but bad_allocs are an exception.  Log it cleanly
-                      // to avoid this bubbling up as an unhandled
-                      // exceptional future.
-                      vlog(
-                        klog.error,
-                        "Request from {} failed on memory exhaustion "
-                        "(std::bad_alloc)",
-                        conn->addr);
-                }
+    if (!sz) {
+        co_return co_await ss::make_ready_future<>();
+    }
+    if (sz > _max_request_size()) {
+        co_return co_await ss::make_exception_future<>(
+          net::invalid_request_error(fmt::format(
+            "request size {} is larger than the configured max {}",
+            sz,
+            _max_request_size())));
+    }
+    /*
+     * Intercept the wire protocol when:
+     *
+     * 1. sasl is enabled (implied by 2)
+     * 2. during auth phase
+     * 3. handshake was v0
+     */
+    if (unlikely(
+          sasl()
+          && sasl()->state() == security::sasl_server::sasl_state::authenticate
+          && sasl()->handshake_v0())) {
+        try {
+            co_return co_await handle_auth_v0(*sz);
+        } catch (...) {
+            vlog(
+              klog.info,
+              "Detected error processing request: {}",
+              std::current_exception());
+            conn->shutdown_input();
+        }
+    }
+    auto s = sz.value();
+    auto h = co_await parse_header(conn->input());
+    _server.probe().add_bytes_received(s);
+    if (!h) {
+        vlog(klog.debug, "could not parse header from client: {}", conn->addr);
+        _server.probe().header_corrupted();
+        co_return co_await ss::make_ready_future<>();
+    }
+    try {
+        co_return co_await dispatch_method_once(std::move(h.value()), s);
+    } catch (const kafka_api_version_not_supported_exception& e) {
+        vlog(
+          klog.warn,
+          "Error while processing request from {} - {}",
+          conn->addr,
+          e.what());
+        conn->shutdown_input();
+    } catch (const std::bad_alloc&) {
+        // In general, dispatch_method_once does not throw,
+        // but bad_allocs are an exception.  Log it cleanly
+        // to avoid this bubbling up as an unhandled
+        // exceptional future.
+        vlog(
+          klog.error,
+          "Request from {} failed on memory exhaustion "
+          "(std::bad_alloc)",
+          conn->addr);
+    }
 }
 
 /*


### PR DESCRIPTION
kafka: convert process_one_request to use coroutines

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

-->
  * none

