### PR TITLE
cloud_storage: Add list and delete apis to remote

### DIFF
--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -258,6 +258,45 @@ public:
       const cloud_storage_clients::object_key& path,
       retry_chain_node& parent);
 
+    /// \brief Delete multiple objects from S3
+    ///
+    /// Deletes multiple objects from S3, utilizing the S3 client delete_objects
+    /// API.
+    /// \param bucket The bucket to delete from
+    /// \param keys A vector of keys which will be deleted
+    ss::future<upload_result> delete_objects(
+      const cloud_storage_clients::bucket_name& bucket,
+      std::vector<cloud_storage_clients::object_key> keys,
+      retry_chain_node& parent);
+
+    using list_bucket_items
+      = std::vector<cloud_storage_clients::client::list_bucket_item>;
+    using list_result
+      = result<list_bucket_items, cloud_storage_clients::error_outcome>;
+
+    /// \brief Lists objects in a bucket
+    ///
+    /// \param name The bucket to delete from
+    /// \param parent The retry chain node to manage timeouts
+    /// \param prefix Optional prefix to restrict listing of objects
+    ss::future<list_result> list_objects(
+      const cloud_storage_clients::bucket_name& name,
+      retry_chain_node& parent,
+      std::optional<cloud_storage_clients::object_key> prefix = std::nullopt);
+
+    /// \brief Upload small objects to bucket. Suitable for uploading simple
+    /// strings, does not check for leadership before upload like the segment
+    /// upload function.
+    ///
+    /// \param bucket The bucket to upload to
+    /// \param object_path The path to upload to
+    /// \param payload The data to place in the bucket
+    ss::future<upload_result> upload_object(
+      const cloud_storage_clients::bucket_name& bucket,
+      const cloud_storage_clients::object_key& object_path,
+      ss::sstring payload,
+      retry_chain_node& parent);
+
     ss::future<download_result> do_download_manifest(
       const cloud_storage_clients::bucket_name& bucket,
       const remote_manifest_path& key,

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -151,6 +151,11 @@ void s3_imposter_fixture::set_routes(
                   "S3 imposter response: {}",
                   repl.response_line());
                 return "";
+            } else if (
+              request._method == "POST"
+              && request.query_parameters.contains("delete")) {
+                // Delete objects
+                return R"xml(<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>)xml";
             }
             BOOST_FAIL("Unexpected request");
             return "";

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -129,6 +129,7 @@ public:
     struct list_bucket_result {
         bool is_truncated;
         ss::sstring prefix;
+        ss::sstring next_continuation_token;
         std::vector<list_bucket_item> contents;
     };
 
@@ -145,6 +146,7 @@ public:
       std::optional<object_key> prefix = std::nullopt,
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
+      std::optional<ss::sstring> continuation_token = std::nullopt,
       const ss::lowres_clock::duration& timeout = http::default_connect_timeout)
       = 0;
 

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -98,7 +98,8 @@ public:
       const bucket_name& name,
       std::optional<object_key> prefix,
       std::optional<object_key> start_after,
-      std::optional<size_t> max_keys);
+      std::optional<size_t> max_keys,
+      std::optional<ss::sstring> continuation_token);
 
 private:
     access_point_uri _ap;
@@ -168,6 +169,7 @@ public:
       std::optional<object_key> prefix = std::nullopt,
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
+      std::optional<ss::sstring> continuation_token = std::nullopt,
       const ss::lowres_clock::duration& timeout
       = http::default_connect_timeout) override;
 
@@ -206,6 +208,7 @@ private:
       std::optional<object_key> prefix = std::nullopt,
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
+      std::optional<ss::sstring> continuation_token = std::nullopt,
       const ss::lowres_clock::duration& timeout
       = http::default_connect_timeout);
 


### PR DESCRIPTION
Add support for list and delete-objects (multiple) APIs to remote. These APIs were already present in the cloud storage client, they are wired through remote here.

The list-v2 API exposed via remote collects all objects in the bucket, potentially making multiple calls using the continuation token returned by previous calls.

The APIs are required to support automated topic recovery.

## Backports Required


- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

  * none

## Release Notes

  * none
