### PR TITLE
tests: do checks on all redpanda clusters in @cluster

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -9,6 +9,7 @@
 
 import functools
 
+from rptest.services.redpanda import RedpandaService
 from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.mark._mark import Mark
 
@@ -22,6 +23,19 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
     because they may raise errors that we would like to expose
     as test failures.
     """
+    def all_redpandas(test):
+        """
+        Most tests have a single RedpandaService at self.redpanda, but
+        it is legal to create multiple instances, e.g. for read replica tests.
+        
+        We find all replicas by traversing ducktape's internal service registry.
+        """
+        yield test.redpanda
+
+        for svc in test.test_context.services:
+            if isinstance(svc, RedpandaService) and svc is not test.redpanda:
+                yield svc
+
     def cluster_use_metadata_adder(f):
         Mark.mark(f, ClusterUseMetadata(**kwargs))
 
@@ -38,16 +52,18 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                     # We failed so early there isn't even a RedpandaService instantiated
                     raise
 
-                self.redpanda.logger.exception(
-                    "Test failed, doing failure checks...")
+                for redpanda in all_redpandas(self):
+                    redpanda.logger.exception(
+                        f"Test failed, doing failure checks on {redpanda.who_am_i()}..."
+                    )
 
-                # Disabled to avoid addr2line hangs
-                # (https://github.com/redpanda-data/redpanda/issues/5004)
-                # self.redpanda.decode_backtraces()
+                    # Disabled to avoid addr2line hangs
+                    # (https://github.com/redpanda-data/redpanda/issues/5004)
+                    # self.redpanda.decode_backtraces()
 
-                self.redpanda.cloud_storage_diagnostics()
+                    redpanda.cloud_storage_diagnostics()
 
-                self.redpanda.raise_on_crash()
+                    redpanda.raise_on_crash()
 
                 raise
             else:
@@ -56,22 +72,26 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                     # in a skipped test
                     return r
 
-                self.redpanda.logger.info("Test passed, doing log checks...")
-                if check_allowed_error_logs:
-                    # Only do log inspections on tests that are otherwise
-                    # successful.  This executes *before* the end-of-test
-                    # shutdown, thereby avoiding having to add the various
-                    # gate_closed etc errors to our allow list.
-                    # TODO: extend this to cover shutdown logging too, and
-                    # clean up redpanda to not log so many errors on shutdown.
-                    try:
-                        self.redpanda.raise_on_bad_logs(
-                            allow_list=log_allow_list)
-                    except:
-                        self.redpanda.cloud_storage_diagnostics()
-                        raise
+                for redpanda in all_redpandas(self):
+                    redpanda.logger.info(
+                        f"Test passed, doing log checks on {redpanda.who_am_i()}..."
+                    )
+                    if check_allowed_error_logs:
+                        # Only do log inspections on tests that are otherwise
+                        # successful.  This executes *before* the end-of-test
+                        # shutdown, thereby avoiding having to add the various
+                        # gate_closed etc errors to our allow list.
+                        # TODO: extend this to cover shutdown logging too, and
+                        # clean up redpanda to not log so many errors on shutdown.
+                        try:
+                            redpanda.raise_on_bad_logs(
+                                allow_list=log_allow_list)
+                        except:
+                            redpanda.cloud_storage_diagnostics()
+                            raise
 
-                self.redpanda.trim_logs()
+                    redpanda.trim_logs()
+
                 return r
 
         # Propagate ducktape markers (e.g. parameterize) to our function

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -255,8 +255,6 @@ class TestReadReplicaService(EndToEndTest):
 
         # Let replica consumer run to completion, assert no s3 writes
         self.run_consumer_validation()
-        # Check read-replica logs
-        self.second_cluster.raise_on_bad_logs()
 
         post_usage = self._bucket_usage()
         self.logger.info(f"post_usage {post_usage}")


### PR DESCRIPTION
...rather than just the one stored in self.redpanda.

This fixes error log detection in read-replica tests where there is a second redpanda cluster in addition to self.redpanda.

## Backports Required

**Note**: don't merge the backport of this until the read replica read fix is backported https://github.com/redpanda-data/redpanda/pull/8051

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
