### PR TITLE
p_balancer_state: don't move ntp before logging

### DIFF
--- a/src/v/cluster/partition_balancer_state.cc
+++ b/src/v/cluster/partition_balancer_state.cc
@@ -51,7 +51,7 @@ void partition_balancer_state::handle_ntp_update(
 
         model::ntp ntp(ns, tp, p_id);
         if (is_rack_constraint_violated) {
-            auto res = _ntps_with_broken_rack_constraint.insert(std::move(ntp));
+            auto res = _ntps_with_broken_rack_constraint.insert(ntp);
             if (res.second) {
                 vlog(
                   clusterlog.debug,


### PR DESCRIPTION
Moving before logging resulted in empty ntp name in logs

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

  * none

## Release Notes

  * none