### PR TITLE
bootstrap: Enforce crash-loop-retry limit

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -135,6 +135,13 @@ node_config::node_config() noexcept
       {.visibility = visibility::user},
       std::nullopt)
   , enable_central_config(*this, "enable_central_config")
+  , crash_loop_limit(
+      *this,
+      "crash_loop_limit",
+      "Maximum consecutive crashes (unclean shutdowns) allowed after which "
+      "operator intervention is needed to startup the broker.",
+      {.visibility = visibility::user},
+      std::nullopt)
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -60,6 +60,8 @@ public:
 
     deprecated_property enable_central_config;
 
+    property<std::optional<uint32_t>> crash_loop_limit;
+
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {
         return data_directory().path / "pid.lock";

--- a/src/v/model/timestamp.h
+++ b/src/v/model/timestamp.h
@@ -80,6 +80,11 @@ private:
 
 using timestamp_clock = std::chrono::system_clock;
 
+inline timestamp_clock::duration duration_since_epoch(timestamp ts) {
+    return std::chrono::duration_cast<timestamp_clock::duration>(
+      std::chrono::milliseconds{ts.value()});
+}
+
 inline timestamp to_timestamp(timestamp_clock::time_point ts) {
     return timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
                        ts.time_since_epoch())

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -100,6 +100,12 @@
 #include <exception>
 #include <vector>
 
+// This file in the data directory tracks the metadata
+// needed to detect crash loops.
+static constexpr std::string_view crash_loop_tracker_file = "startup_log";
+// Crash tracking resets every 1h.
+static constexpr model::timestamp_clock::duration crash_reset_duration{1h};
+
 static void set_local_kafka_client_config(
   std::optional<kafka::client::configuration>& client_config,
   const config::node_config& config) {
@@ -325,8 +331,14 @@ int application::run(int ac, char** av) {
                 hydrate_config(cfg);
                 initialize();
                 check_environment();
+                check_for_crash_loop();
                 setup_metrics();
                 wire_up_and_start(app_signal);
+                // We schedule the deletion _after_ the application fully
+                // starts up. This ensures that any errors like
+                // misconfigurations are also treated as unclean shutdowns
+                // thus avoiding crashloops.
+                schedule_crash_tracker_file_cleanup();
                 app_signal.wait().get();
                 vlog(_log.info, "Stopping...");
             } catch (const ss::abort_requested_exception&) {
@@ -618,6 +630,110 @@ void application::check_environment() {
               strict_data_dir_file));
         }
     }
+}
+
+/// Here we check for too many consecutive unclean shutdowns/crashes
+/// and abort the startup sequence if the limit exceeds
+/// crash_loop_limit until the operator intervenes. Crash tracking
+/// is reset if the node configuration changes or its been 1h since
+/// the broker last failed to start. This metadata is tracked in the
+/// tracker file. This is to prevent on disk state from piling up in
+/// each unclean run and creating more state to recover for the next run.
+void application::check_for_crash_loop() {
+    auto file_path = config::node().data_directory().path
+                     / crash_loop_tracker_file;
+    std::optional<crash_tracker_metadata> maybe_crash_md;
+    if (ss::file_exists(file_path.string()).get()) {
+        // Ok to read the entire file, it contains a serialized uint32_t.
+        auto buf = read_fully(file_path).get();
+        try {
+            maybe_crash_md = serde::from_iobuf<crash_tracker_metadata>(
+              std::move(buf));
+        } catch (const serde::serde_exception&) {
+            // A malformed log file, ignore and reset it later.
+            // We truncate it below.
+            vlog(_log.warn, "Ignorning malformed tracker file {}", file_path);
+        }
+    }
+
+    // Compute the checksum of the current node configuration.
+    auto current_config
+      = read_fully_to_string(config::node().get_cfg_file_path()).get0();
+    auto checksum = xxhash_64(current_config.c_str(), current_config.length());
+
+    if (maybe_crash_md) {
+        auto& crash_md = maybe_crash_md.value();
+        auto& limit = config::node().crash_loop_limit.value();
+
+        // Check if it has been atleast 1h since last unsuccessful restart.
+        // Tracking resets every 1h.
+        auto time_since_last_start
+          = model::duration_since_epoch(model::timestamp::now())
+            - model::duration_since_epoch(crash_md._last_start_ts);
+
+        auto crash_limit_ok = !limit || crash_md._crash_count <= limit.value();
+        auto node_config_changed = crash_md._config_checksum != checksum;
+        auto tracking_reset = time_since_last_start > crash_reset_duration;
+
+        auto ok_to_proceed = crash_limit_ok || node_config_changed
+                             || tracking_reset;
+
+        if (!ok_to_proceed) {
+            vlog(
+              _log.error,
+              "Crash loop detected. Too many consecutive crashes {}, exceeded "
+              "{} configured value {}. To recover Redpanda from this state, "
+              "manually remove file at path {}. Crash loop automatically "
+              "resets 1h after last crash or with node configuration changes.",
+              crash_md._crash_count,
+              config::node().crash_loop_limit.name(),
+              limit.value(),
+              file_path);
+            throw std::runtime_error("Crash loop detected, aborting startup.");
+        }
+
+        vlog(
+          _log.debug,
+          "Consecutive crashes detected: {} node config changed: {} "
+          "time based tracking reset: {}",
+          crash_md._crash_count,
+          node_config_changed,
+          tracking_reset);
+
+        if (node_config_changed || tracking_reset) {
+            crash_md._crash_count = 0;
+        }
+    }
+
+    // Truncate and bump the crash count. We consider a run to be unclean by
+    // default unless the scheduled cleanup (that runs very late in shutdown)
+    // resets the file. See schedule_crash_tracker_file_cleanup().
+    auto new_crash_count = maybe_crash_md
+                             ? maybe_crash_md.value()._crash_count + 1
+                             : 1;
+    crash_tracker_metadata updated{
+      ._crash_count = new_crash_count,
+      ._config_checksum = checksum,
+      ._last_start_ts = model::timestamp::now()};
+    write_fully(file_path, serde::to_iobuf(updated)).get();
+    ss::sync_directory(config::node().data_directory.value().as_sstring())
+      .get();
+}
+
+void application::schedule_crash_tracker_file_cleanup() {
+    // Schedule a deletion of the tracker file. On a clean shutdown,
+    // the tracker file should be deleted thus reseting the crash count on the
+    // next run. In case of an unclean shutdown, we already bumped
+    // the crash count and that should be taken into account in the
+    // next run.
+    // We emplace it in the front to make it the last task to run.
+    _deferred.emplace_front([&] {
+        auto file = config::node().data_directory().path
+                    / crash_loop_tracker_file;
+        ss::remove_file(file.string()).get();
+        ss::sync_directory(config::node().data_directory().as_sstring()).get();
+        vlog(_log.debug, "Deleted crash loop tracker file: {}", file);
+    });
 }
 
 static admin_server_cfg

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -76,6 +76,9 @@ public:
     void check_environment();
     void wire_up_and_start(::stop_signal&, bool test_mode = false);
 
+    void check_for_crash_loop();
+    void schedule_crash_tracker_file_cleanup();
+
     explicit application(ss::sstring = "main");
     ~application();
 
@@ -129,6 +132,16 @@ public:
 private:
     using deferred_actions
       = std::deque<ss::deferred_action<std::function<void()>>>;
+
+    struct crash_tracker_metadata
+      : serde::envelope<
+          crash_tracker_metadata,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        uint32_t _crash_count{0};
+        uint64_t _config_checksum{0};
+        model::timestamp _last_start_ts;
+    };
 
     // Constructs services across shards required to get bootstrap metadata.
     void wire_up_bootstrap_services();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -128,7 +128,7 @@ public:
 
 private:
     using deferred_actions
-      = std::vector<ss::deferred_action<std::function<void()>>>;
+      = std::deque<ss::deferred_action<std::function<void()>>>;
 
     // Constructs services across shards required to get bootstrap metadata.
     void wire_up_bootstrap_services();

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -1,0 +1,91 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RedpandaService
+
+
+class CrashLoopChecksTest(RedpandaTest):
+    "Checks crash loop detection works as expected."
+
+    CRASH_LOOP_LIMIT = 3
+
+    CRASH_LOOP_LOG = [
+        "Crash loop detected. Too many consecutive crashes.*",
+        ".*Failure during startup: std::runtime_error \(Crash loop detected, aborting startup.\).*"
+    ]
+
+    # main - application.cc:348 - Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found)
+    HOSTNAME_ERROR = [
+        ".*Failure during startup: std::__1::system_error \(error C-Ares:4, unreachable_host.com: Not found\)"
+    ]
+
+    CRASH_LOOP_TRACKER_FILE = f"{RedpandaService.DATA_DIR}/startup_log"
+
+    def __init__(self, test_context):
+        super(CrashLoopChecksTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=1,
+                             extra_node_conf={
+                                 "crash_loop_limit":
+                                 CrashLoopChecksTest.CRASH_LOOP_LIMIT
+                             })
+
+    def remove_crash_loop_tracker_file(self, broker):
+        broker.account.ssh(
+            f"rm -f {CrashLoopChecksTest.CRASH_LOOP_TRACKER_FILE}")
+
+    def get_broker_to_crash_loop_state(self, broker):
+        for _ in range(CrashLoopChecksTest.CRASH_LOOP_LIMIT):
+            self.redpanda.signal_redpanda(node=broker)
+            self.redpanda.start_node(broker)
+        self.redpanda.signal_redpanda(node=broker)
+        self.redpanda.start_node(node=broker, expect_fail=True)
+
+    @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG)
+    def test_crash_loop_checks_with_tracker_file(self):
+        broker = self.redpanda.nodes[0]
+        self.get_broker_to_crash_loop_state(broker)
+        # Remove the crash loop log and restart, should start up.
+        self.remove_crash_loop_tracker_file(broker)
+        self.redpanda.start_node(broker)
+
+    @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG)
+    def test_crash_loop_checks_with_node_config(self):
+        broker = self.redpanda.nodes[0]
+        self.get_broker_to_crash_loop_state(broker)
+        # Update node configuration file to reset checksum
+        update = dict(kafka_api=dict(address="127.0.0.1", port=9099))
+        self.redpanda.start_node(broker, override_cfg_params=update)
+
+    @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG + HOSTNAME_ERROR)
+    def test_crash_loop_with_misconfiguration(self):
+        broker = self.redpanda.nodes[0]
+        self.redpanda.signal_redpanda(broker)
+
+        invalid_conf = dict(
+            kafka_api=dict(address="unreachable_host.com", port=9092))
+        for _ in range(CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1):
+            self.redpanda.start_node(broker,
+                                     override_cfg_params=invalid_conf,
+                                     expect_fail=True)
+        # None of the attempts so far should be considered a crash loop.
+        assert not self.redpanda.search_log_node(
+            broker, "Too many consecutive crashes")
+
+        # Start again, crash loop should be detected.
+        self.redpanda.start_node(broker,
+                                 override_cfg_params=invalid_conf,
+                                 expect_fail=True)
+        assert self.redpanda.search_log_node(broker,
+                                             "Too many consecutive crashes")
+
+        # Fix the config and start, crash loop should be reset.
+        self.redpanda.start_node(node=broker)


### PR DESCRIPTION
Introduces --crash_loop_limit that controls the number of unclean
shutdowns a broker can tolerate before refusing to startup without
an operator intervention.

Crash loop detection is reset in the following cases

* Crash loop tracking file is deleted
* Node configuration is updated (redpanda.yaml)
* 1h after last crash.

Fixes #6569

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Features

* Avoids infinite crash loop by detecting unclean shutdowns of the process and enforcing a limit on such shutdowns, enforced via node configuration --crash_loop_limit. Once the limit is reached, operator should remove the tracker file manually to make startup progress. The tracking automatically resets if node configuration changed or if 1 hour elapsed since the last crash.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
