### PR TITLE
Enhancements to self-test infra

### DIFF
--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -23,6 +23,9 @@
 
 namespace cluster {
 
+self_test_backend::self_test_backend(ss::scheduling_group sg)
+  : _st_sg(sg) {}
+
 ss::future<> self_test_backend::start() { return ss::now(); }
 
 ss::future<> self_test_backend::stop() {
@@ -39,6 +42,7 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
     for (auto& dto : dtos) {
         try {
             vlog(clusterlog.info, "Starting disk self test...");
+            dto.sg = _st_sg;
             auto dtr = co_await _disk_test.run(dto).then([](auto result) {
                 vlog(clusterlog.info, "Disk self test finished with success");
                 return result;
@@ -53,6 +57,7 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
     for (auto& nto : ntos) {
         try {
             vlog(clusterlog.info, "Starting network self test...");
+            nto.sg = _st_sg;
             auto ntr = co_await _network_test.run(nto).then([](auto results) {
                 vlog(
                   clusterlog.info, "Network self test finished with success");

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -33,14 +33,13 @@ ss::future<> self_test_backend::stop() {
 }
 
 ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
-  std::optional<diskcheck_opts> dto, std::optional<netcheck_opts> nto) {
+  std::vector<diskcheck_opts> dtos, std::vector<netcheck_opts> ntos) {
     auto gate_holder = _gate.hold();
     std::vector<self_test_result> results;
-    if (dto) {
-        /// Disk
+    for (auto& dto : dtos) {
         try {
             vlog(clusterlog.info, "Starting disk self test...");
-            auto dtr = co_await _disk_test.run(*dto).then([](auto result) {
+            auto dtr = co_await _disk_test.run(dto).then([](auto result) {
                 vlog(clusterlog.info, "Disk self test finished with success");
                 return result;
             });
@@ -48,14 +47,13 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
         } catch (const std::exception& ex) {
             vlog(clusterlog.warn, "Disk self test finished with error");
             results.push_back(
-              self_test_result{.name = dto->name, .error = ex.what()});
+              self_test_result{.name = dto.name, .error = ex.what()});
         }
     }
-    if (nto) {
-        /// Network
+    for (auto& nto : ntos) {
         try {
             vlog(clusterlog.info, "Starting network self test...");
-            auto ntr = co_await _network_test.run(*nto).then([](auto results) {
+            auto ntr = co_await _network_test.run(nto).then([](auto results) {
                 vlog(
                   clusterlog.info, "Network self test finished with success");
                 return results;
@@ -64,7 +62,7 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
         } catch (const std::exception& ex) {
             vlog(clusterlog.warn, "Network self test finished with error");
             results.push_back(
-              self_test_result{.name = nto->name, .error = ex.what()});
+              self_test_result{.name = nto.name, .error = ex.what()});
         }
     }
     co_return results;
@@ -77,7 +75,7 @@ get_status_response self_test_backend::start_test(start_test_request req) {
         _id = req.id;
         vlog(
           clusterlog.info, "Starting redpanda self-tests with id: {}", req.id);
-        (void)do_start_test(req.dto, req.nto)
+        (void)do_start_test(req.dtos, req.ntos)
           .then([this, id = req.id](auto results) {
               _prev_run = get_status_response{
                 .id = id,

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -40,11 +40,11 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
         /// Disk
         try {
             vlog(clusterlog.info, "Starting disk self test...");
-            results.push_back(
-              co_await _disk_test.run(*dto).then([](auto result) {
-                  vlog(clusterlog.info, "Disk self test finished with success");
-                  return result;
-              }));
+            auto dtr = co_await _disk_test.run(*dto).then([](auto result) {
+                vlog(clusterlog.info, "Disk self test finished with success");
+                return result;
+            });
+            std::copy(dtr.begin(), dtr.end(), std::back_inserter(results));
         } catch (const std::exception& ex) {
             vlog(clusterlog.warn, "Disk self test finished with error");
             results.push_back(

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -47,7 +47,8 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
               }));
         } catch (const std::exception& ex) {
             vlog(clusterlog.warn, "Disk self test finished with error");
-            results.push_back(self_test_result{.error = ex.what()});
+            results.push_back(
+              self_test_result{.name = dto->name, .error = ex.what()});
         }
     }
     if (nto) {
@@ -62,7 +63,8 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
             std::copy(ntr.begin(), ntr.end(), std::back_inserter(results));
         } catch (const std::exception& ex) {
             vlog(clusterlog.warn, "Network self test finished with error");
-            results.push_back(self_test_result{.error = ex.what()});
+            results.push_back(
+              self_test_result{.name = nto->name, .error = ex.what()});
         }
     }
     co_return results;

--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -15,6 +15,7 @@
 #include "utils/mutex.h"
 #include "utils/uuid.h"
 
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/smp.hh>
 
 namespace cluster {
@@ -29,6 +30,8 @@ namespace cluster {
 class self_test_backend {
 public:
     static constexpr ss::shard_id shard = 0;
+
+    explicit self_test_backend(ss::scheduling_group sg);
 
     ss::future<> start();
     ss::future<> stop();
@@ -59,10 +62,11 @@ private:
 
 private:
     // cached values
-    uuid_t _id;
+    uuid_t _id{};
     get_status_response _prev_run{.status = self_test_status::idle};
 
     ss::gate _gate;
+    ss::scheduling_group _st_sg;
     mutex _lock;
     diskcheck _disk_test;
     networkcheck _network_test;

--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -55,7 +55,7 @@ public:
 
 private:
     ss::future<std::vector<self_test_result>> do_start_test(
-      std::optional<diskcheck_opts> dto, std::optional<netcheck_opts> nto);
+      std::vector<diskcheck_opts> dtos, std::vector<netcheck_opts> ntos);
 
 private:
     // cached values

--- a/src/v/cluster/self_test_benchmarks.h
+++ b/src/v/cluster/self_test_benchmarks.h
@@ -77,8 +77,7 @@ public:
         auto start = ss::lowres_clock::now();
         auto was_cancelled = co_await gated_sleep(opts.duration);
         auto result = self_test_result{
-          .name = "Stub disk test",
-          .duration = ss::lowres_clock::now() - start};
+          .name = opts.name, .duration = ss::lowres_clock::now() - start};
         if (was_cancelled) {
             result.warning = "Test aborted during run";
         }
@@ -92,8 +91,7 @@ public:
         auto start = ss::lowres_clock::now();
         auto was_cancelled = co_await gated_sleep(opts.duration);
         auto result = self_test_result{
-          .name = "Stub network test",
-          .duration = ss::lowres_clock::now() - start};
+          .name = opts.name, .duration = ss::lowres_clock::now() - start};
         if (was_cancelled) {
             result.warning = "Test aborted during run";
         }

--- a/src/v/cluster/self_test_benchmarks.h
+++ b/src/v/cluster/self_test_benchmarks.h
@@ -74,28 +74,38 @@ private:
 class diskcheck final : public self_test_stub {
 public:
     ss::future<std::vector<self_test_result>> run(diskcheck_opts opts) {
-        auto start = ss::lowres_clock::now();
-        auto was_cancelled = co_await gated_sleep(opts.duration);
-        auto result = self_test_result{
-          .name = opts.name, .duration = ss::lowres_clock::now() - start};
-        if (was_cancelled) {
-            result.warning = "Test aborted during run";
-        }
-        co_return std::vector<self_test_result>{result};
+        return ss::with_scheduling_group(opts.sg, [this, opts]() {
+            auto start = ss::lowres_clock::now();
+            return gated_sleep(opts.duration)
+              .then([opts, start](bool was_cancelled) {
+                  auto result = self_test_result{
+                    .name = opts.name,
+                    .duration = ss::lowres_clock::now() - start};
+                  if (was_cancelled) {
+                      result.warning = "Test aborted during run";
+                  }
+                  return std::vector<self_test_result>{result};
+              });
+        });
     }
 };
 
 class networkcheck final : public self_test_stub {
 public:
     ss::future<std::vector<self_test_result>> run(netcheck_opts opts) {
-        auto start = ss::lowres_clock::now();
-        auto was_cancelled = co_await gated_sleep(opts.duration);
-        auto result = self_test_result{
-          .name = opts.name, .duration = ss::lowres_clock::now() - start};
-        if (was_cancelled) {
-            result.warning = "Test aborted during run";
-        }
-        co_return std::vector<self_test_result>{result};
+        return ss::with_scheduling_group(opts.sg, [this, opts]() {
+            auto start = ss::lowres_clock::now();
+            return gated_sleep(opts.duration)
+              .then([opts, start](bool was_cancelled) {
+                  auto result = self_test_result{
+                    .name = opts.name,
+                    .duration = ss::lowres_clock::now() - start};
+                  if (was_cancelled) {
+                      result.warning = "Test aborted during run";
+                  }
+                  return std::vector<self_test_result>{result};
+              });
+        });
     }
 };
 

--- a/src/v/cluster/self_test_benchmarks.h
+++ b/src/v/cluster/self_test_benchmarks.h
@@ -73,7 +73,7 @@ private:
 
 class diskcheck final : public self_test_stub {
 public:
-    ss::future<self_test_result> run(diskcheck_opts opts) {
+    ss::future<std::vector<self_test_result>> run(diskcheck_opts opts) {
         auto start = ss::lowres_clock::now();
         auto was_cancelled = co_await gated_sleep(opts.duration);
         auto result = self_test_result{
@@ -81,7 +81,7 @@ public:
         if (was_cancelled) {
             result.warning = "Test aborted during run";
         }
-        co_return result;
+        co_return std::vector<self_test_result>{result};
     }
 };
 

--- a/src/v/cluster/self_test_frontend.cc
+++ b/src/v/cluster/self_test_frontend.cc
@@ -125,10 +125,9 @@ ss::future<> self_test_frontend::start() { return ss::now(); }
 
 ss::future<> self_test_frontend::stop() { co_await _gate.close(); }
 
-ss::future<uuid_t> self_test_frontend::start_test(
-  std::optional<diskcheck_opts> dto, std::optional<netcheck_opts> nto) {
+ss::future<uuid_t> self_test_frontend::start_test(start_test_request req) {
     auto gate_holder = _gate.hold();
-    if (!dto && !nto) {
+    if (req.dtos.empty() && req.ntos.empty()) {
         throw self_test_exception("No tests specified to run");
     }
     const auto stopped_results = co_await stop_test();
@@ -141,7 +140,6 @@ ss::future<uuid_t> self_test_frontend::start_test(
 
     /// Invoke command to start test on all nodes, using the same test id
     const auto id = uuid_t::create();
-    start_test_request req{.id = id, .dto = dto, .nto = nto};
     auto state = co_await invoke_on_all_nodes(
       [req](auto& handle) { return handle->start_test(req); });
     co_return id;

--- a/src/v/cluster/self_test_frontend.h
+++ b/src/v/cluster/self_test_frontend.h
@@ -71,8 +71,7 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    ss::future<uuid_t>
-      start_test(std::optional<diskcheck_opts>, std::optional<netcheck_opts>);
+    ss::future<uuid_t> start_test(start_test_request);
     ss::future<global_test_state> stop_test();
     ss::future<global_test_state> status();
 

--- a/src/v/cluster/self_test_frontend.h
+++ b/src/v/cluster/self_test_frontend.h
@@ -71,7 +71,12 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    ss::future<uuid_t> start_test(start_test_request);
+    /// Plan + test parameters
+    ///
+    /// Launches the indicated self_tests on the specified nodes
+    ss::future<uuid_t>
+    start_test(start_test_request req, std::vector<model::node_id> ids);
+
     ss::future<global_test_state> stop_test();
     ss::future<global_test_state> status();
 

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -48,13 +48,13 @@ struct diskcheck_opts
 
     ss::lowres_clock::duration duration;
 
-    static diskcheck_opts from_json(const json::Document& doc) {
+    static diskcheck_opts from_json(const json::Value& obj) {
         static const auto default_duration = 5;
         return cluster::diskcheck_opts{
-          .name = doc.HasMember("name") ? doc["name"].GetString() : "",
+          .name = obj.HasMember("name") ? obj["name"].GetString() : "",
           .duration = std::chrono::seconds(
-            doc.HasMember("disk_test_execution_time")
-              ? doc["disk_test_execution_time"].GetInt()
+            obj.HasMember("disk_test_execution_time")
+              ? obj["disk_test_execution_time"].GetInt()
               : default_duration)};
     }
 
@@ -75,13 +75,13 @@ struct netcheck_opts
 
     ss::lowres_clock::duration duration;
 
-    static netcheck_opts from_json(const json::Document& doc) {
+    static netcheck_opts from_json(const json::Value& obj) {
         static const auto default_duration = 5;
         return cluster::netcheck_opts{
-          .name = doc.HasMember("name") ? doc["name"].GetString() : "",
+          .name = obj.HasMember("name") ? obj["name"].GetString() : "",
           .duration = std::chrono::seconds(
-            doc.HasMember("network_test_execution_time")
-              ? doc["network_test_execution_time"].GetInt()
+            obj.HasMember("network_test_execution_time")
+              ? obj["network_test_execution_time"].GetInt()
               : default_duration)};
     }
 
@@ -151,21 +151,17 @@ struct start_test_request
     using rpc_adl_exempt = std::true_type;
 
     uuid_t id;
-    std::optional<diskcheck_opts> dto;
-    std::optional<netcheck_opts> nto;
+    std::vector<diskcheck_opts> dtos;
+    std::vector<netcheck_opts> ntos;
 
     friend std::ostream&
     operator<<(std::ostream& o, const start_test_request& r) {
         std::stringstream ss;
-        if (r.dto) {
-            fmt::print(ss, "diskcheck_opts: {}", *r.dto);
-        } else {
-            fmt::print(ss, "diskcheck_opts: <no_value>");
+        for (auto& v : r.dtos) {
+            fmt::print(ss, "diskcheck_opts: {}", v);
         }
-        if (r.nto) {
-            fmt::print(ss, "netcheck_opts: {}", *r.nto);
-        } else {
-            fmt::print(ss, "netcheck_opts: <no_value>");
+        for (auto& v : r.ntos) {
+            fmt::print(ss, "netcheck_opts: {}", v);
         }
         fmt::print(o, "{{id: {} {}}}", r.id, ss.str());
         return o;

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -43,11 +43,15 @@ inline std::ostream& operator<<(std::ostream& o, self_test_status sts) {
 struct diskcheck_opts
   : serde::
       envelope<diskcheck_opts, serde::version<0>, serde::compat_version<0>> {
+    /// Descriptive name given to test run
+    ss::sstring name;
+
     ss::lowres_clock::duration duration;
 
     static diskcheck_opts from_json(const json::Document& doc) {
         static const auto default_duration = 5;
         return cluster::diskcheck_opts{
+          .name = doc.HasMember("name") ? doc["name"].GetString() : "",
           .duration = std::chrono::seconds(
             doc.HasMember("disk_test_execution_time")
               ? doc["disk_test_execution_time"].GetInt()
@@ -56,7 +60,8 @@ struct diskcheck_opts
 
     friend std::ostream&
     operator<<(std::ostream& o, const diskcheck_opts& opts) {
-        fmt::print(o, "{{duration: {}}}", opts.duration.count());
+        fmt::print(
+          o, "{{name: {} duration: {}}}", opts.name, opts.duration.count());
         return o;
     }
 };
@@ -65,11 +70,15 @@ struct diskcheck_opts
 struct netcheck_opts
   : serde::
       envelope<netcheck_opts, serde::version<0>, serde::compat_version<0>> {
+    /// Descriptive name given to test run
+    ss::sstring name;
+
     ss::lowres_clock::duration duration;
 
     static netcheck_opts from_json(const json::Document& doc) {
         static const auto default_duration = 5;
         return cluster::netcheck_opts{
+          .name = doc.HasMember("name") ? doc["name"].GetString() : "",
           .duration = std::chrono::seconds(
             doc.HasMember("network_test_execution_time")
               ? doc["network_test_execution_time"].GetInt()
@@ -78,7 +87,11 @@ struct netcheck_opts
 
     friend std::ostream&
     operator<<(std::ostream& o, const netcheck_opts& opts) {
-        fmt::print(o, "{{test_duration: {}}}", opts.duration.count());
+        fmt::print(
+          o,
+          "{{name: {} test_duration: {}}}",
+          opts.name,
+          opts.duration.count());
         return o;
     }
 };

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -45,8 +45,12 @@ struct diskcheck_opts
       envelope<diskcheck_opts, serde::version<0>, serde::compat_version<0>> {
     /// Descriptive name given to test run
     ss::sstring name;
+    /// Scheduling group that the benchmark will operate under
+    ss::scheduling_group sg;
 
     ss::lowres_clock::duration duration;
+
+    auto serde_fields() { return std::tie(name, duration); }
 
     static diskcheck_opts from_json(const json::Value& obj) {
         static const auto default_duration = 5;
@@ -72,8 +76,12 @@ struct netcheck_opts
       envelope<netcheck_opts, serde::version<0>, serde::compat_version<0>> {
     /// Descriptive name given to test run
     ss::sstring name;
+    /// Scheduling group that the benchmark will operate under
+    ss::scheduling_group sg;
 
     ss::lowres_clock::duration duration;
+
+    auto serde_fields() { return std::tie(name, duration); }
 
     static netcheck_opts from_json(const json::Value& obj) {
         static const auto default_duration = 5;

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -208,6 +208,10 @@
                     "type": "string",
                     "description": "Name of the test run"
                 },
+                "info": {
+                    "type": "string",
+                    "description": "Additional test labels, metadata and/or information"
+                },
                 "duration": {
                     "type": "long",
                     "description": "Length of time the test took to complete"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3010,6 +3010,7 @@ self_test_result_to_json(const cluster::self_test_result& str) {
     r.bps = str.bps;
     r.test_id = ss::sstring(str.test_id);
     r.name = str.name;
+    r.info = str.info;
     r.duration = std::chrono::duration_cast<std::chrono::milliseconds>(
                    str.duration)
                    .count();

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2935,32 +2935,69 @@ void admin_server::register_transaction_routes() {
       });
 }
 
+static json::validator make_self_test_start_validator() {
+    const std::string schema = R"(
+{
+    "type": "object",
+    "properties": {
+        "tests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "required": ["type"]
+            }
+        }
+    },
+    "required": [],
+    "additionalProperties": false
+}
+)";
+    return json::validator(schema);
+}
+
 ss::future<ss::json::json_return_type>
 admin_server::self_test_start_handler(std::unique_ptr<ss::httpd::request> req) {
+    static thread_local json::validator self_test_start_validator(
+      make_self_test_start_validator());
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         vlog(logger.debug, "Need to redirect self_test_start request");
         throw co_await redirect_to_leader(*req, model::controller_ntp);
     }
     auto doc = parse_json_body(*req);
-    std::optional<cluster::diskcheck_opts> dto;
-    std::optional<cluster::netcheck_opts> nto;
-    if (!doc.HasMember("tests")) {
-        dto = cluster::diskcheck_opts::from_json(doc);
-        nto = cluster::netcheck_opts::from_json(doc);
-    } else {
-        for (const auto& name : doc["tests"].GetArray()) {
-            if (name == "disk") {
-                dto = cluster::diskcheck_opts::from_json(doc);
-            } else if (name == "network") {
-                nto = cluster::netcheck_opts::from_json(doc);
+    apply_validator(self_test_start_validator, doc);
+    cluster::start_test_request r;
+    if (!doc.IsNull()) {
+        if (doc.HasMember("tests")) {
+            const auto& params = doc["tests"].GetArray();
+            for (const auto& element : params) {
+                const auto& obj = element.GetObject();
+                const ss::sstring test_type(obj["type"].GetString());
+                if (test_type == "disk") {
+                    r.dtos.push_back(cluster::diskcheck_opts::from_json(obj));
+                } else if (test_type == "network") {
+                    r.ntos.push_back(cluster::netcheck_opts::from_json(obj));
+                } else {
+                    throw ss::httpd::bad_param_exception(
+                      "Unknown self_test 'type', valid options are 'disk' or "
+                      "'network'");
+                }
             }
+        } else {
+            /// Default test run is to start 1 disk and 1 network test with
+            /// default arguments
+            r.dtos.push_back(cluster::diskcheck_opts{});
+            r.ntos.push_back(cluster::netcheck_opts{});
         }
     }
     try {
         auto tid = co_await _self_test_frontend.invoke_on(
-          cluster::self_test_frontend::shard,
-          [dto, nto](auto& self_test_frontend) {
-              return self_test_frontend.start_test(dto, nto);
+          cluster::self_test_frontend::shard, [r](auto& self_test_frontend) {
+              return self_test_frontend.start_test(r);
           });
         vlog(logger.info, "Request to start self test succeeded: {}", tid);
         co_return ss::json::json_return_type(tid);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -932,7 +932,9 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(cloud_storage_api));
     controller->wire_up().get0();
 
-    construct_single_service_sharded(self_test_backend).get();
+    construct_single_service_sharded(
+      self_test_backend, _scheduling_groups.self_test_sg())
+      .get();
 
     construct_single_service_sharded(
       self_test_frontend,

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -37,6 +37,7 @@ public:
         _archival_upload = co_await ss::create_scheduling_group(
           "archival_upload", 100);
         _node_status = co_await ss::create_scheduling_group("node_status", 50);
+        _self_test = co_await ss::create_scheduling_group("self_test", 100);
     }
 
     ss::future<> destroy_groups() {
@@ -50,6 +51,7 @@ public:
         co_await destroy_scheduling_group(_raft_learner_recovery);
         co_await destroy_scheduling_group(_archival_upload);
         co_await destroy_scheduling_group(_node_status);
+        co_await destroy_scheduling_group(_self_test);
         co_return;
     }
 
@@ -67,6 +69,7 @@ public:
     }
     ss::scheduling_group archival_upload() { return _archival_upload; }
     ss::scheduling_group node_status() { return _node_status; }
+    ss::scheduling_group self_test_sg() { return _self_test; }
 
     std::vector<std::reference_wrapper<const ss::scheduling_group>>
     all_scheduling_groups() const {
@@ -82,7 +85,7 @@ public:
           std::cref(_raft_learner_recovery),
           std::cref(_archival_upload),
           std::cref(_node_status),
-        };
+          std::cref(_self_test)};
     }
 
 private:
@@ -98,4 +101,5 @@ private:
     ss::scheduling_group _raft_learner_recovery;
     ss::scheduling_group _archival_upload;
     ss::scheduling_group _node_status;
+    ss::scheduling_group _self_test;
 };

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -36,8 +36,13 @@ class SelfTestTest(RedpandaTest):
     def test_self_test(self):
         """Assert the self test starts/completes with success."""
         test_options = {
-            'disk_test_execution_time': 1,
-            'network_test_execution_time': 1
+            'tests': [{
+                'type': 'disk',
+                'disk_test_execution_time': 1
+            }, {
+                'type': 'network',
+                'network_test_execution_time': 1
+            }]
         }
 
         # Launch the self test with the options above
@@ -55,14 +60,20 @@ class SelfTestTest(RedpandaTest):
                 assert 'error' not in report
                 assert 'warning' not in report
                 assert 'duration' in report
-                assert report['duration'] >= 1000, report['duration']
+                assert report['duration'] >= 1000 and report[
+                    'duration'] <= 2000, report['duration']
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_self_test_node_crash(self):
         """Assert the self test starts/completes with success."""
         test_options = {
-            'disk_test_execution_time': 3,
-            'network_test_execution_time': 3
+            'tests': [{
+                'type': 'disk',
+                'disk_test_execution_time': 3
+            }, {
+                'type': 'network',
+                'network_test_execution_time': 3
+            }]
         }
 
         # Launch the self test with the options above
@@ -101,9 +112,16 @@ class SelfTestTest(RedpandaTest):
     @cluster(num_nodes=3)
     def test_self_test_cancellable(self):
         """Assert the self test can cancel an action on command."""
+        disk_test_time = 5
+        network_test_time = 5
         test_options = {
-            'disk_test_execution_time': 5,
-            'network_test_execution_time': 5
+            'tests': [{
+                'type': 'disk',
+                'disk_test_execution_time': disk_test_time
+            }, {
+                'type': 'network',
+                'network_test_execution_time': network_test_time
+            }]
         }
 
         # Launch the self test with the options above
@@ -120,8 +138,7 @@ class SelfTestTest(RedpandaTest):
         # passed between start & stop calls
         stop = time.time()
         total_time_sec = stop - start
-        assert total_time_sec < (test_options['disk_test_execution_time'] +
-                                 test_options['network_test_execution_time'])
+        assert total_time_sec < (disk_test_time + network_test_time)
 
         # Ensure system is in an idle state and contains expected report
         node_reports = self._admin.self_test_status()


### PR DESCRIPTION
This patchset adds a number of changes to the self-test framework to add new functionality such as:
1. Allow multiple test runs to start with one `start` call.
2. Execute the self-tests on a particular node in the cluster
3. Have all self-tests operate within a new scheduling group specific to self-test

## Release Notes
  * none

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/2cc6d8d9e3c5a5b015d2a19081549fe94a1fba41..d7d9450fac4b8cbf93ce3d8080f5693bb447ac49)
- Removed commits dealing with hdr_hist
- Addressed Noah's comments about error checking input

Changes in [force-push](https://github.com/redpanda-data/redpanda/compare/60b0218b3c5c5a059529018dbd92148886cf3144..b7b7acae2b58ecf4419a6a1e11b55683853ecc9e)
- Addressed Andrew's comments about using `json::validator` to validate the input