### PR TITLE
tests: extend log allow list in test_read_from_replica

### DIFF
--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -165,7 +165,8 @@ class CloudStorageCompactionTest(EndToEndTest):
     # TODO: remove this low allow-list when that issue is resolved.
     @cluster(num_nodes=9,
              log_allow_list=[
-                 "Cannot validate Kafka record batch. Missmatching CRC"
+                 "Cannot validate Kafka record batch. Missmatching CRC",
+                 "batch has invalid CRC"
              ])
     def test_read_from_replica(self):
         self.start_workload()


### PR DESCRIPTION
This test was meant to ignore CRC errors, while #6631 is investigated.  Turns out we log two different messages for these.

Fixes: https://github.com/redpanda-data/redpanda/issues/8101

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
