### PR TITLE
kafka: move processing loop into connect context

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -40,6 +40,15 @@ using namespace std::chrono_literals;
 
 namespace kafka {
 
+ss::future<> connection_context::process() {
+    while (true) {
+        if (is_finished_parsing()) {
+            break;
+        }
+        co_await process_one_request();
+    }
+}
+
 ss::future<> connection_context::process_one_request() {
     auto sz = co_await parse_size(conn->input());
     if (!sz.has_value()) {

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -187,6 +187,7 @@ public:
         return authorized;
     }
 
+    ss::future<> process();
     ss::future<> process_one_request();
     bool is_finished_parsing() const;
     ss::net::inet_address client_host() const { return _client_addr; }

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -189,11 +189,12 @@ public:
 
     ss::future<> process();
     ss::future<> process_one_request();
-    bool is_finished_parsing() const;
     ss::net::inet_address client_host() const { return _client_addr; }
     uint16_t client_port() const { return conn ? conn->addr.port() : 0; }
 
 private:
+    bool is_finished_parsing() const;
+
     // Reserve units from memory from the memory semaphore in proportion
     // to the number of bytes the request procesisng is expected to
     // take.

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -216,60 +216,60 @@ ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
     try {
         co_await ctx->process();
     } catch (...) {
-          auto eptr = std::current_exception();
-          auto disconnected = net::is_disconnect_exception(eptr);
-          if (authn_method == config::broker_authn_method::sasl) {
-              /*
-               * This block is a 2x2 matrix of:
-               * - sasl enabled or disabled
-               * - message looks like a disconnect or internal error
-               *
-               * Disconnects are logged at DEBUG level, because they are
-               * already recorded at INFO level by the outer RPC layer,
-               * so we don't want to log two INFO logs for each client
-               * disconnect.
-               */
-              if (disconnected) {
-                  vlog(
-                    klog.debug,
-                    "Disconnected {} {}:{} ({}, sasl state: {})",
-                    ctx->server().name(),
-                    ctx->client_host(),
-                    ctx->client_port(),
-                    disconnected.value(),
-                    security::sasl_state_to_str(ctx->sasl()->state()));
+        auto eptr = std::current_exception();
+        auto disconnected = net::is_disconnect_exception(eptr);
+        if (authn_method == config::broker_authn_method::sasl) {
+            /*
+             * This block is a 2x2 matrix of:
+             * - sasl enabled or disabled
+             * - message looks like a disconnect or internal error
+             *
+             * Disconnects are logged at DEBUG level, because they are
+             * already recorded at INFO level by the outer RPC layer,
+             * so we don't want to log two INFO logs for each client
+             * disconnect.
+             */
+            if (disconnected) {
+                vlog(
+                  klog.debug,
+                  "Disconnected {} {}:{} ({}, sasl state: {})",
+                  ctx->server().name(),
+                  ctx->client_host(),
+                  ctx->client_port(),
+                  disconnected.value(),
+                  security::sasl_state_to_str(ctx->sasl()->state()));
 
-              } else {
-                  vlog(
-                    klog.warn,
-                    "Error {} {}:{}: {} (sasl state: {})",
-                    ctx->server().name(),
-                    ctx->client_host(),
-                    ctx->client_port(),
-                    eptr,
-                    security::sasl_state_to_str(ctx->sasl()->state()));
-              }
-          } else {
-              if (disconnected) {
-                  vlog(
-                    klog.debug,
-                    "Disconnected {} {}:{} ({})",
-                    ctx->server().name(),
-                    ctx->client_host(),
-                    ctx->client_port(),
-                    disconnected.value());
+            } else {
+                vlog(
+                  klog.warn,
+                  "Error {} {}:{}: {} (sasl state: {})",
+                  ctx->server().name(),
+                  ctx->client_host(),
+                  ctx->client_port(),
+                  eptr,
+                  security::sasl_state_to_str(ctx->sasl()->state()));
+            }
+        } else {
+            if (disconnected) {
+                vlog(
+                  klog.debug,
+                  "Disconnected {} {}:{} ({})",
+                  ctx->server().name(),
+                  ctx->client_host(),
+                  ctx->client_port(),
+                  disconnected.value());
 
-              } else {
-                  vlog(
-                    klog.warn,
-                    "Error {} {}:{}: {}",
-                    ctx->server().name(),
-                    ctx->client_host(),
-                    ctx->client_port(),
-                    eptr);
-              }
-          }
-          std::rethrow_exception(eptr);
+            } else {
+                vlog(
+                  klog.warn,
+                  "Error {} {}:{}: {}",
+                  ctx->server().name(),
+                  ctx->client_host(),
+                  ctx->client_port(),
+                  eptr);
+            }
+        }
+        std::rethrow_exception(eptr);
     }
 }
 


### PR DESCRIPTION
The processing loop for a kafka connection was implemented at the server
level despite being part of the processing pipeline for a connection.
This commit moves that loop into the connection context itself.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->
  * none

