### PR TITLE
features: fix populating original_version on upgrades

### DIFF
--- a/src/v/cluster/feature_backend.cc
+++ b/src/v/cluster/feature_backend.cc
@@ -24,6 +24,24 @@ feature_backend::apply_update(model::record_batch b) {
     auto cmd = co_await cluster::deserialize(std::move(b), accepted_commands);
 
     if (base_offset <= _feature_table.local().get_applied_offset()) {
+        // Special case for systems pre-dating the original_version field: they
+        // may have loaded a snapshot that doesn't contain an original version,
+        // so must populate it from updates.
+        if (
+          _feature_table.local().get_original_version()
+          == cluster::invalid_version) {
+            co_await ss::visit(
+              cmd,
+              [this](feature_update_cmd update) {
+                  return _feature_table.invoke_on_all(
+                    [v = update.key.logical_version](
+                      features::feature_table& ft) {
+                        ft.set_original_version(v);
+                    });
+              },
+              [](feature_update_license_update_cmd) { return ss::now(); });
+        }
+
         co_return errc::success;
     }
 

--- a/src/v/features/feature_table_snapshot.h
+++ b/src/v/features/feature_table_snapshot.h
@@ -53,7 +53,7 @@ struct feature_table_snapshot
     cluster::cluster_version version{cluster::invalid_version};
     std::optional<security::license> license;
     std::vector<feature_state_snapshot> states;
-    cluster::cluster_version original_version;
+    cluster::cluster_version original_version{cluster::invalid_version};
 
     auto serde_fields() {
         return std::tie(


### PR DESCRIPTION
This was found in https://github.com/redpanda-data/redpanda/pull/7836

When the upgraded-from version has feature table snapshots (e.g. upgrading from 22.3.x), the snapshot prevents the features backend from replaying early messages that would populate original version.

On top of that, there was an uninitialized variable that led to feature table having garbage in its original_version field when deserializing a v22.3.x struct.

Fortunately this change wasn't released yet, so we don't have to worry about systems in the wild in a bad state.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none