### PR TITLE
tests: mark unstable random node operations tests ok_to_fail

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -11,6 +11,7 @@ import random
 import threading
 
 from ducktape.mark import matrix
+from ducktape.mark import ok_to_fail
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
@@ -47,6 +48,7 @@ class RandomNodeOperationsTest(EndToEndTest):
 
         self.topic = random.choice(topics).name
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8142
     @skip_debug_mode
     @cluster(num_nodes=7,
              log_allow_list=CHAOS_LOG_ALLOW_LIST + PREV_VERSION_LOG_ALLOW_LIST)


### PR DESCRIPTION
Mark unstable random node operations tests ok_to_fail

Related: https://github.com/redpanda-data/redpanda/issues/8142

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

  * none

## Release Notes

  * none