### PR TITLE
Revert "Disable admin operation validation for alter_topic_configuration"

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -461,13 +461,6 @@ class AdminOperationsFuzzer():
             self.append_to_history(op)
 
             def validate_result():
-                # TODO: enable alter configuration validation back after issues 8102 & 8083 are fixed
-                #
-                # issues:
-                # https://github.com/redpanda-data/redpanda/issues/8083
-                # https://github.com/redpanda-data/redpanda/issues/8102
-
-                return True
                 try:
                     return op.validate(self.operation_ctx)
                 except Exception as e:


### PR DESCRIPTION
Reverts redpanda-data/redpanda#8137


## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

  * none

## Release Notes

  * none