### PR TITLE
test/docker: moved ducktape dependencies to standalone script

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -17,13 +17,11 @@ FROM public.ecr.aws/docker/library/ubuntu:kinetic-20220830
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive
 
+COPY --chown=0:0 tests/docker/ducktape-deps.sh /opt/ducktape-deps.sh
+RUN chmod +x /opt/ducktape-deps.sh
+
 # Install dependencies of Java client builds.
-RUN apt update && \
-    apt install -y \
-      build-essential \
-      default-jdk \
-      git \
-      maven && \
+RUN /opt/ducktape-deps.sh install_java_client_deps && \
     rm -rf /var/lib/apt/lists/*
 
 # Install kafka streams examples.  This is a very slow step (tens of minutes), doing
@@ -44,30 +42,7 @@ RUN mvn clean package --batch-mode --file /opt/redpanda-tests/java/e2e-verifiers
 # - install distro-packaged depedencies
 # - allow user env variables in ssh sessions
 # - install dependencies of 'rpk debug' system scan
-RUN apt-get update && \
-    apt-get install -qq \
-      bind9-utils \
-      bind9-dnsutils \
-      bsdmainutils \
-      curl \
-      dmidecode \
-      cmake \
-      iproute2 \
-      iptables \
-      libatomic1 \
-      libyajl-dev \
-      libsasl2-dev \
-      libssl-dev \
-      net-tools \
-      lsof \
-      pciutils \
-      nodejs \
-      npm \
-      openssh-server \
-      netcat-openbsd \
-      sudo \
-      llvm \
-      python3-pip && \
+RUN /opt/ducktape-deps.sh install_system_deps && \
     rm -rf /var/lib/apt/lists/* && \
     echo 'PermitUserEnvironment yes' >> /etc/ssh/sshd_config && \
     echo 'UsePAM yes' >> /etc/ssh/sshd_config && \
@@ -76,79 +51,41 @@ RUN apt-get update && \
 
 
 # Install the OMB tool
-RUN git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git && \
-    cd /opt/openmessaging-benchmark && git reset --hard 6eba1030cb7c199e03f76676b6c2df9dcc3b219d && mvn clean package -DskipTests
+RUN /opt/ducktape-deps.sh install_omb
 
 # install kafka binary dependencies, librdkafka dev, kcat and kaf tools
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
-RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.3.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.3.1" && \
-    mkdir -p "/opt/kafka-2.4.1" && chmod a+rw /opt/kafka-2.4.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.4.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.4.1" && \
-    mkdir -p "/opt/kafka-2.5.0" && chmod a+rw /opt/kafka-2.5.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.5.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.5.0" && \
-    mkdir -p "/opt/kafka-2.7.0" && chmod a+rw /opt/kafka-2.7.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.7.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.7.0" && \
-    mkdir -p "/opt/kafka-3.0.0" && chmod a+rw /opt/kafka-3.0.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.0.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.0.0" && \
-    ln -s /opt/kafka-3.0.0 /opt/kafka-dev && \
-    mkdir /opt/librdkafka && \
-    curl -SL "https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka && \
-    cd /opt/librdkafka && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install && \
-    cd /opt/librdkafka/tests && \
-    make build -j$(nproc) && \
-    mkdir /tmp/kcat && \
-    curl -SL "https://github.com/edenhill/kcat/archive/1.7.0.tar.gz" | tar -xz --strip-components=1 -C /tmp/kcat && \
-    cd /tmp/kcat && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig
+RUN /opt/ducktape-deps.sh install_kafka_tools && \
+    /opt/ducktape-deps.sh install_librdkafka && \
+    /opt/ducktape-deps.sh install_kcat
 
 # install go
-RUN mkdir -p /usr/local/go/ && \
-    bash -c 'if [[ $(uname -m) = "aarch64" ]]; then ARCHID="arm64"; else export ARCHID="amd64"; fi && \
-    curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 https://golang.org/dl/go1.19.2.linux-${ARCHID}.tar.gz | tar -xz -C /usr/local/go/ --strip 1'
+RUN /opt/ducktape-deps.sh install_golang
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 # Install `kaf`
-RUN go install github.com/birdayz/kaf/cmd/kaf@v0.2.3 && \
-    mv /root/go/bin/kaf /usr/local/bin/
+RUN /opt/ducktape-deps.sh install_kaf
 
 ENV PATH="${PATH}:/usr/local/go/bin"
 # Compile and install rust-based workload generator.
 # Install & remove compiler in the same step, to avoid bulking
 # out the resulting container image.
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    export PATH="/root/.cargo/bin:${PATH}" && \
-    git clone https://github.com/redpanda-data/client-swarm.git && \
-    cd client-swarm && \
-    git reset --hard a03a8ae && \
-    cargo build --release && \
-    cp target/release/client-swarm /usr/local/bin && \
-    cd .. && rm -rf client-swarm && rm -rf /root/.cargo
+RUN /opt/ducktape-deps.sh install_client_swarm /root
 
 # Install golang dependencies for kafka clients such as sarama
-RUN git -C /opt clone -b v1.32.0 --single-branch https://github.com/Shopify/sarama.git && \
-    cd /opt/sarama/examples/interceptors && go mod tidy && go build && \
-    cd /opt/sarama/examples/http_server && go mod tidy && go build && \
-    cd /opt/sarama/examples/consumergroup && go mod tidy && go build && \
-    cd /opt/sarama/examples/sasl_scram_client && go mod tidy && go build
+RUN /opt/ducktape-deps.sh install_sarama_examples
 
 # Install our in-tree go tests
 COPY --chown=0:0 tests/go /opt/redpanda-tests/go
 RUN cd /opt/redpanda-tests/go/sarama/produce_test && go mod tidy && go build
 
 # Install franz-go
-RUN git -C /opt clone -b v1.5.0 --single-branch https://github.com/twmb/franz-go.git && \
-    cd /opt/franz-go && \
-    cd /opt/franz-go/examples/bench && go mod tidy && go build
+RUN /opt/ducktape-deps.sh install_franz_bench
 
-RUN go install github.com/twmb/kcl@v0.8.0 && \
-    mv /root/go/bin/kcl /usr/local/bin/
+RUN /opt/ducktape-deps.sh install_kcl
 
 # Install the kgo-verifier tool
-RUN git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git && \
-    cd /opt/kgo-verifier && git reset --hard a2b3ae780b0dc0bc1b4cf2aa33a9d43d10578b0b && \
-    go mod tidy && make
+RUN /opt/ducktape-deps.sh install_kgo_verifier
 
 # Expose port 8080 for any http examples within clients
 EXPOSE 8080
@@ -175,10 +112,7 @@ RUN mkdir /root/external_test_suites && \
     cd /root/external_test_suites/arroyo && \
     python3 -m pip install --force --no-cache-dir -e /root/external_test_suites/arroyo
 
-RUN mkdir -p /opt/scripts && \
-    curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/addr2line.py -o /opt/scripts/addr2line.py && \
-    curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/seastar-addr2line -o /opt/scripts/seastar-addr2line && \
-    chmod +x /opt/scripts/seastar-addr2line
+RUN /opt/ducktape-deps.sh install_addr2line
 
 RUN mkdir -p /opt/scripts/offline_log_viewer
 COPY --chown=0:0 tools/offline_log_viewer /opt/scripts/offline_log_viewer

--- a/tests/docker/Dockerfile.dockerignore
+++ b/tests/docker/Dockerfile.dockerignore
@@ -6,3 +6,4 @@
 !tests/go
 !tools/offline_log_viewer
 !tools/consumer_offsets_recovery
+!tests/docker/ducktape-deps.sh

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -e
+
+function install_java_client_deps() {
+  apt update
+  apt install -y \
+    build-essential \
+    default-jdk \
+    git \
+    maven
+}
+
+function install_system_deps() {
+  apt-get update
+  apt-get install -qq \
+    bind9-utils \
+    bind9-dnsutils \
+    bsdmainutils \
+    curl \
+    dmidecode \
+    cmake \
+    iproute2 \
+    iptables \
+    libatomic1 \
+    libyajl-dev \
+    libsasl2-dev \
+    libssl-dev \
+    net-tools \
+    lsof \
+    pciutils \
+    nodejs \
+    npm \
+    openssh-server \
+    netcat-openbsd \
+    sudo \
+    llvm \
+    python3-pip
+}
+
+function install_omb() {
+  git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git
+  cd /opt/openmessaging-benchmark
+  git reset --hard 6eba1030cb7c199e03f76676b6c2df9dcc3b219d
+  mvn clean package -DskipTests
+}
+
+function install_kafka_tools() {
+  for ver in "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0"; do
+    mkdir -p "/opt/kafka-${ver}" && chmod a+rw "/opt/kafka-${ver}" && curl -s "$KAFKA_MIRROR/kafka_2.12-${ver}.tgz" | tar xz --strip-components=1 -C "/opt/kafka-${ver}"
+  done
+  ln -s /opt/kafka-3.0.0/ /opt/kafka-dev
+}
+
+function install_librdkafka() {
+  mkdir /opt/librdkafka
+  curl -SL "https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
+  cd /opt/librdkafka
+  ./configure
+  make -j$(nproc)
+  make install
+  cd /opt/librdkafka/tests
+  make build -j$(nproc)
+}
+
+function install_kcat() {
+  mkdir /tmp/kcat
+  curl -SL "https://github.com/edenhill/kcat/archive/1.7.0.tar.gz" | tar -xz --strip-components=1 -C /tmp/kcat
+  cd /tmp/kcat
+  ./configure
+  make -j$(nproc)
+  make install
+  ldconfig
+}
+
+function install_golang() {
+  mkdir -p /usr/local/go/
+  if [ $(uname -m) = "aarch64" ]; then
+    export ARCHID="arm64"
+  else
+    export ARCHID="amd64"
+  fi
+  curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 "https://golang.org/dl/go1.19.2.linux-${ARCHID}.tar.gz" | tar -xz -C /usr/local/go/ --strip 1
+}
+
+function install_kaf() {
+  go install github.com/birdayz/kaf/cmd/kaf@v0.2.3
+  mv /root/go/bin/kaf /usr/local/bin/
+}
+
+function install_client_swarm() {
+  dir="$1"
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  export PATH="$dir/.cargo/bin:${PATH}"
+  pushd /tmp
+  git clone https://github.com/redpanda-data/client-swarm.git
+  pushd client-swarm
+  git reset --hard a03a8ae &&
+    cargo build --release &&
+    cp target/release/client-swarm /usr/local/bin &&
+    popd
+  rm -rf client-swarm
+  popd
+  rm -rf $dir/.cargo
+}
+
+function install_sarama_examples() {
+  git -C /opt clone -b v1.32.0 --single-branch https://github.com/Shopify/sarama.git
+  cd /opt/sarama/examples/interceptors && go mod tidy && go build
+  cd /opt/sarama/examples/http_server && go mod tidy && go build
+  cd /opt/sarama/examples/consumergroup && go mod tidy && go build
+  cd /opt/sarama/examples/sasl_scram_client && go mod tidy && go build
+}
+
+function install_franz_bench() {
+  git -C /opt clone -b v1.5.0 --single-branch https://github.com/twmb/franz-go.git
+  cd /opt/franz-go
+  cd /opt/franz-go/examples/bench && go mod tidy && go build
+}
+
+function install_kcl() {
+  go install github.com/twmb/kcl@v0.8.0
+  mv /root/go/bin/kcl /usr/local/bin/
+}
+
+function install_kgo_verifier() {
+  git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git &&
+    cd /opt/kgo-verifier && git reset --hard a2b3ae780b0dc0bc1b4cf2aa33a9d43d10578b0b &&
+    go mod tidy && make
+}
+
+function install_addr2line() {
+  mkdir -p /opt/scripts &&
+    curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/addr2line.py -o /opt/scripts/addr2line.py &&
+    curl https://raw.githubusercontent.com/redpanda-data/seastar/2a9504b3238cba4150be59353bf8d0b3a01fe39c/scripts/seastar-addr2line -o /opt/scripts/seastar-addr2line &&
+    chmod +x /opt/scripts/seastar-addr2line
+}
+
+$@


### PR DESCRIPTION
motivation: there are common dependencies
between the tests/docker/Dockerfile and
cdt install-deps. This commit, groups
those common dependencies to a single script
that will be used by both tests/docker/Dockerfile
and cdt's install-deps.
For the dependencies that there were different
versions, I chose to keep the ones in the
tests/docker/Dockerfile

ref https://github.com/redpanda-data/devprod/issues/514

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
