### PR TITLE
kafka: implement offset retention policy

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -334,6 +334,27 @@ configuration::configuration()
       "Timeout for new member joins",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       30'000ms)
+  , group_offset_retention_sec(
+      *this,
+      "group_offset_retention_sec",
+      "Consumer group offset retention seconds. Offset retention can be "
+      "disabled by setting this value to null.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      24h * 7)
+  , group_offset_retention_check_ms(
+      *this,
+      "group_offset_retention_check_ms",
+      "How often the system should check for expired group offsets.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10min)
+  , legacy_group_offset_retention_enabled(
+      *this,
+      "legacy_group_offset_retention_enabled",
+      "Group offset retention is enabled by default in versions of Redpanda >= "
+      "23.1. To enable offset retention after upgrading from an older version "
+      "set this option to true.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , metadata_dissemination_interval_ms(
       *this,
       "metadata_dissemination_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -94,6 +94,9 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> group_max_session_timeout_ms;
     property<std::chrono::milliseconds> group_initial_rebalance_delay;
     property<std::chrono::milliseconds> group_new_member_join_timeout;
+    property<std::optional<std::chrono::seconds>> group_offset_retention_sec;
+    property<std::chrono::milliseconds> group_offset_retention_check_ms;
+    property<bool> legacy_group_offset_retention_enabled;
     property<std::chrono::milliseconds> metadata_dissemination_interval_ms;
     property<std::chrono::milliseconds> metadata_dissemination_retry_delay_ms;
     property<int16_t> metadata_dissemination_retries;

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -160,7 +160,7 @@ ss::future<> consumer::join() {
           .session_timeout_ms = cfg.consumer_session_timeout(),
           .rebalance_timeout_ms = cfg.consumer_rebalance_timeout(),
           .member_id = me->_member_id,
-          .protocol_type = protocol_type{"consumer"},
+          .protocol_type = consumer_group_protocol_type,
           .protocols = make_join_group_request_protocols(me->_topics)};
         return req;
     };

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -154,4 +154,6 @@ enum class describe_configs_type : int8_t {
 
 std::ostream& operator<<(std::ostream&, describe_configs_type t);
 
+inline const kafka::protocol_type consumer_group_protocol_type("consumer");
+
 } // namespace kafka

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -88,7 +88,10 @@ group::group(
   enable_group_metrics group_metrics)
   : _id(std::move(id))
   , _state(md.members.empty() ? group_state::empty : group_state::stable)
-  , _state_timestamp(md.state_timestamp)
+  , _state_timestamp(
+      md.state_timestamp == model::timestamp(-1)
+        ? std::optional<model::timestamp>(std::nullopt)
+        : md.state_timestamp)
   , _generation(md.generation)
   , _num_members_joining(0)
   , _protocol_type(md.protocol_type)

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3302,7 +3302,7 @@ group::decode_consumer_subscriptions(iobuf data) {
 }
 
 void group::update_subscriptions() {
-    if (_protocol_type != "consumer") {
+    if (_protocol_type != consumer_group_protocol_type) {
         _subscriptions.reset();
         return;
     }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3339,4 +3339,154 @@ void group::update_subscriptions() {
     _subscriptions = std::move(subs);
 }
 
+std::vector<model::topic_partition> group::filter_expired_offsets(
+  std::chrono::seconds retention_period,
+  const std::function<bool(const model::topic&)>& subscribed,
+  const std::function<model::timestamp(const offset_metadata&)>&
+    effective_expires) {
+    /*
+     * default retention duration
+     */
+    const auto retain_for = model::timestamp(
+      std::chrono::duration_cast<std::chrono::milliseconds>(retention_period)
+        .count());
+
+    const auto now = model::timestamp::now();
+    std::vector<model::topic_partition> offsets;
+    for (const auto& offset : _offsets) {
+        /*
+         * an offset won't be removed if its topic has an active subscription or
+         * there are pending offset commits for the offset's topic.
+         */
+        if (
+          subscribed(offset.first.topic)
+          || _pending_offset_commits.contains(offset.first)) {
+            continue;
+        }
+
+        if (offset.second->metadata.expiry_timestamp.has_value()) {
+            /*
+             * the old way is explicit expiration time point per offset
+             */
+            const auto& expires
+              = offset.second->metadata.expiry_timestamp.value();
+            if (expires > now) {
+                continue;
+            }
+        } else {
+            /*
+             * the new way is a configurable global retention duration
+             */
+            const auto expires = effective_expires(offset.second->metadata);
+            if (model::timestamp(now() - expires()) < retain_for) {
+                continue;
+            }
+        }
+
+        offsets.push_back(offset.first);
+    }
+
+    return offsets;
+}
+
+std::vector<model::topic_partition>
+group::get_expired_offsets(std::chrono::seconds retention_period) {
+    const auto not_subscribed = [](const auto&) { return false; };
+
+    if (_protocol_type.has_value()) {
+        if (
+          _protocol_type.value() == consumer_group_protocol_type
+          && _subscriptions.has_value() && in_state(group_state::stable)) {
+            /*
+             * policy description from kafka source:
+             *
+             * <kafka>
+             * the group is stable and consumers exist.
+             *
+             * if an offset's topic is subscribed to and retention period has
+             * passed since the last commit timestamp, then expire the offset.
+             * offsets with pending commit are not expired.
+             * </kafka>
+             */
+            return filter_expired_offsets(
+              retention_period,
+              [this](const auto& topic) {
+                  return _subscriptions.value().contains(topic);
+              },
+              [](const offset_metadata& md) { return md.commit_timestamp; });
+
+        } else if (in_state(group_state::empty)) {
+            /*
+             * policy description from kafka source:
+             *
+             * <kafka>
+             * the group contains no consumers.
+             *
+             * if current state timestamp exists and retention period has passed
+             * since group became empty, expire all offsets with no pending
+             * offset commit.
+             *
+             * if there is no current state timestamp (old group metadata
+             * schema) and retention period has passed since the last commit
+             * timestamp, expire the offset
+             * </kafka>
+             */
+            return filter_expired_offsets(
+              retention_period,
+              not_subscribed,
+              [this](const offset_metadata& md) {
+                  if (_state_timestamp.has_value()) {
+                      return _state_timestamp.value();
+                  } else {
+                      return md.commit_timestamp;
+                  }
+              });
+        } else {
+            return {};
+        }
+    } else {
+        /*
+         * policy description from kafka source:
+         *
+         * <kafka>
+         * there is no configured protocol type, so this is a standalone/simple
+         * consumer that Kafka uses for offset storage only.
+         *
+         * expire offsets with no pending offset commits for which the retention
+         * period has passed since their last commit.
+         * </kafka>
+         */
+        return filter_expired_offsets(
+          retention_period, not_subscribed, [](const offset_metadata& md) {
+              return md.commit_timestamp;
+          });
+    }
+}
+
+std::vector<model::topic_partition>
+group::delete_expired_offsets(std::chrono::seconds retention_period) {
+    /*
+     * collect and delete expired offsets
+     */
+    auto offsets = get_expired_offsets(retention_period);
+    for (const auto& offset : offsets) {
+        vlog(_ctxlog.debug, "Expiring group offset {}", offset);
+        _offsets.erase(offset);
+    }
+
+    /*
+     * maybe mark the group as dead
+     */
+    const auto has_offsets = [this] {
+        return !_offsets.empty() || !_pending_offset_commits.empty()
+               || !_volatile_txs.empty() || !_tx_seqs.empty();
+    };
+
+    if (in_state(group_state::empty) && !has_offsets()) {
+        set_state(group_state::dead);
+    }
+
+    return offsets;
+}
+
 } // namespace kafka

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -506,6 +506,7 @@ public:
       const model::topic_partition& tp, const offset_metadata& md);
 
     void reset_tx_state(model::term_id);
+    model::term_id term() const { return _term; }
 
     ss::future<cluster::commit_group_tx_reply>
     commit_tx(cluster::commit_group_tx_request r);

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -743,7 +743,8 @@ private:
         metadata.generation = generation();
         metadata.protocol = protocol();
         metadata.leader = leader();
-        metadata.state_timestamp = _state_timestamp;
+        metadata.state_timestamp = _state_timestamp.value_or(
+          model::timestamp(-1));
 
         for (const auto& [id, member] : _members) {
             auto state = member->state().copy();
@@ -841,7 +842,7 @@ private:
 
     kafka::group_id _id;
     group_state _state;
-    model::timestamp _state_timestamp;
+    std::optional<model::timestamp> _state_timestamp;
     kafka::generation_id _generation;
     protocol_support _supported_protocols;
     member_map _members;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -646,6 +646,17 @@ public:
     void add_group_tombstone_record(
       const kafka::group_id& group, storage::record_batch_builder& builder);
 
+    /*
+     * Delete group offsets that have expired.
+     *
+     * If after expired offsets have been deleted the group is in the empty
+     * state and contains no offsets then the group will be marked as dead.
+     *
+     * The set of expired offsets that have been removed is returned.
+     */
+    std::vector<model::topic_partition>
+    delete_expired_offsets(std::chrono::seconds retention_period);
+
 private:
     using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
     using protocol_support = absl::node_hash_map<kafka::protocol_name, int>;
@@ -840,6 +851,14 @@ private:
 
     void update_subscriptions();
     std::optional<absl::node_hash_set<model::topic>> _subscriptions;
+
+    std::vector<model::topic_partition> filter_expired_offsets(
+      std::chrono::seconds retention_period,
+      const std::function<bool(const model::topic&)>&,
+      const std::function<model::timestamp(const offset_metadata&)>&);
+
+    std::vector<model::topic_partition>
+    get_expired_offsets(std::chrono::seconds retention_period);
 
     kafka::group_id _id;
     group_state _state;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -41,7 +41,6 @@ group_manager::group_manager(
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
   ss::sharded<features::feature_table>& feature_table,
   group_metadata_serializer_factory serializer_factory,
-  config::configuration& conf,
   enable_group_metrics enable_metrics)
   : _tp_ns(std::move(tp_ns))
   , _gm(gm)
@@ -50,7 +49,7 @@ group_manager::group_manager(
   , _tx_frontend(tx_frontend)
   , _feature_table(feature_table)
   , _serializer_factory(std::move(serializer_factory))
-  , _conf(conf)
+  , _conf(config::shard_local_cfg())
   , _self(cluster::make_self_broker(config::node()))
   , _enable_group_metrics(enable_metrics) {}
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -97,6 +97,32 @@ ss::future<> group_manager::start() {
             handle_topic_delta(deltas);
         });
 
+    /*
+     * periodically remove expired group offsets.
+     */
+    _timer.set_callback([this] {
+        ssx::spawn_with_gate(_gate, [this] {
+            return handle_offset_expiration().finally([this] {
+                if (!_gate.is_closed()) {
+                    _timer.arm(_offset_retention_check());
+                }
+            });
+        });
+    });
+    _timer.arm(_offset_retention_check());
+
+    /*
+     * reschedule periodic collection of expired offsets when the configured
+     * frequency changes. useful if it were accidentally configured to be much
+     * longer than desired / reasonable, and then fixed (e.g. 1 year vs 1 day).
+     */
+    _offset_retention_check.watch([this] {
+        if (_timer.armed()) {
+            _timer.cancel();
+            _timer.arm(_offset_retention_check());
+        }
+    });
+
     return ss::make_ready_future<>();
 }
 /*
@@ -174,6 +200,139 @@ std::optional<std::chrono::seconds> group_manager::offset_retention_enabled() {
     return config::shard_local_cfg().group_offset_retention_sec().value();
 }
 
+ss::future<> group_manager::handle_offset_expiration() {
+    constexpr int max_concurrent_expirations = 10;
+
+    const auto retention_period = offset_retention_enabled();
+    if (!retention_period.has_value()) {
+        co_return;
+    }
+
+    /*
+     * build a light-weight snapshot of the groups to process. the snapshot
+     * allows us to avoid concurrent modifications to _groups container.
+     */
+    fragmented_vector<group_ptr> groups;
+    for (auto& group : _groups) {
+        groups.push_back(group.second);
+    }
+
+    size_t total = 0;
+    co_await ss::max_concurrent_for_each(
+      groups,
+      max_concurrent_expirations,
+      [this, &total, retention_period = retention_period.value()](auto group) {
+          return delete_expired_offsets(group, retention_period)
+            .then([&total](auto removed) { total += removed; });
+      });
+
+    if (total) {
+        vlog(
+          klog.info, "Removed {} offsets from {} groups", total, groups.size());
+    }
+}
+
+ss::future<size_t> group_manager::delete_expired_offsets(
+  group_ptr group, std::chrono::seconds retention_period) {
+    /*
+     * delete expired offsets from the group
+     */
+    const auto offsets = group->delete_expired_offsets(retention_period);
+
+    /*
+     * build tombstones to persistent offset deletions. the group itself may
+     * also be set to dead state in which case we may be able to delete the
+     * group as well.
+     *
+     * the group may be set to dead state even if no offsets are returned from
+     * `group::delete_expired_offsets` so avoid an early return above if no
+     * offsets are returned.
+     */
+    cluster::simple_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+
+    for (auto& offset : offsets) {
+        vlog(
+          klog.trace,
+          "Preparing tombstone for expired group offset {}:{}",
+          group,
+          offset);
+        group->add_offset_tombstone_record(group->id(), offset, builder);
+    }
+
+    if (group->in_state(group_state::dead)) {
+        auto it = _groups.find(group->id());
+        if (it != _groups.end() && it->second == group) {
+            _groups.erase(it);
+            if (group->generation() > 0) {
+                vlog(
+                  klog.trace,
+                  "Preparing tombstone for dead group following offset "
+                  "expiration {}",
+                  group);
+                group->add_group_tombstone_record(group->id(), builder);
+            }
+        }
+    }
+
+    if (builder.empty()) {
+        co_return 0;
+    }
+
+    /*
+     * replicate tombstone records to the group's partition. avoid acks=all
+     * because the process is largely best-effort and the in-memory state was
+     * already cleaned up.
+     */
+    auto batch = std::move(builder).build();
+    auto reader = model::make_memory_record_batch_reader(std::move(batch));
+
+    try {
+        auto result = co_await group->partition()->raft()->replicate(
+          group->term(),
+          std::move(reader),
+          raft::replicate_options(raft::consistency_level::leader_ack));
+
+        if (result) {
+            vlog(
+              klog.debug,
+              "Wrote {} tombstone records for group {} expired offsets",
+              offsets.size(),
+              group);
+            co_return offsets.size();
+
+        } else if (result.error() == raft::errc::shutting_down) {
+            vlog(
+              klog.debug,
+              "Cannot replicate tombstone records for group {}: shutting down",
+              group);
+
+        } else if (result.error() == raft::errc::not_leader) {
+            vlog(
+              klog.debug,
+              "Cannot replicate tombstone records for group {}: not leader",
+              group);
+
+        } else {
+            vlog(
+              klog.error,
+              "Cannot replicate tombstone records for group {}: {} {}",
+              group,
+              result.error().message(),
+              result.error());
+        }
+
+    } catch (...) {
+        vlog(
+          klog.error,
+          "Exception occurred replicating tombstones for group {}: {}",
+          group,
+          std::current_exception());
+    }
+
+    co_return 0;
+}
+
 ss::future<> group_manager::stop() {
     /**
      * This is not ususal as stop() method should only be called once. For the
@@ -196,6 +355,8 @@ ss::future<> group_manager::stop() {
     for (auto& e : _partitions) {
         e.second->as.request_abort();
     }
+
+    _timer.cancel();
 
     return _gate.close().then([this]() {
         /**

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -124,7 +124,6 @@ public:
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
       ss::sharded<features::feature_table>&,
       group_metadata_serializer_factory,
-      config::configuration& conf,
       enable_group_metrics group_metrics);
 
     ss::future<> start();

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -261,6 +261,9 @@ private:
           groups, [](auto group_ptr) { return group_ptr->shutdown(); });
     }
 
+    std::optional<std::chrono::seconds> offset_retention_enabled();
+    std::optional<bool> _prev_offset_retention_enabled;
+
     ss::sharded<raft::group_manager>& _gm;
     ss::sharded<cluster::partition_manager>& _pm;
     ss::sharded<cluster::topic_table>& _topic_table;
@@ -275,6 +278,7 @@ private:
 
     model::broker _self;
     enable_group_metrics _enable_group_metrics;
+    config::binding<std::chrono::milliseconds> _offset_retention_check;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -264,6 +264,9 @@ private:
     std::optional<std::chrono::seconds> offset_retention_enabled();
     std::optional<bool> _prev_offset_retention_enabled;
 
+    ss::timer<> _timer;
+    ss::future<> handle_offset_expiration();
+    ss::future<size_t> delete_expired_offsets(group_ptr, std::chrono::seconds);
     ss::sharded<raft::group_manager>& _gm;
     ss::sharded<cluster::partition_manager>& _pm;
     ss::sharded<cluster::topic_table>& _topic_table;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1022,7 +1022,6 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(tx_gateway_frontend),
       std::ref(controller->get_feature_table()),
       &kafka::make_consumer_offsets_serializer,
-      std::ref(config::shard_local_cfg()),
       kafka::enable_group_metrics::yes)
       .get();
     syschecks::systemd_message("Creating kafka group shard mapper").get();

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -612,6 +612,9 @@ class ClusterConfigTest(RedpandaTest):
                 if isinstance(actual, bool):
                     # Lowercase because yaml and python capitalize bools differently.
                     actual = str(actual).lower()
+                    # Not all expected bools originate from example values
+                    if isinstance(expect, bool):
+                        expect = str(expect).lower()
                 else:
                     actual = str(actual)
                 if actual != str(expect):

--- a/tests/rptest/tests/offset_retention_test.py
+++ b/tests/rptest/tests/offset_retention_test.py
@@ -1,0 +1,57 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import time
+from rptest.services.cluster import cluster
+from rptest.clients.rpk import RpkTool
+from ducktape.utils.util import wait_until
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class OffsetRetentionTest(RedpandaTest):
+    topics = (TopicSpec(), )
+    period = 30
+
+    def __init__(self, test_context):
+        # retention time is set to 30 seconds and expired offset queries happen
+        # every second. these are likely unrealistic in practice, but allow us
+        # to build tests that are quick and responsive.
+        super(OffsetRetentionTest,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=dict(
+                                 group_offset_retention_sec=self.period,
+                                 group_offset_retention_check_ms=1000,
+                             ))
+
+        self.rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=3)
+    def test_offset_expiration(self):
+        group = "hey_group"
+
+        def offsets_exist():
+            desc = self.rpk.group_describe(group)
+            return len(desc.partitions) > 0
+
+        # consume from the group for twice as long as the retention period
+        # setting and verify that group offsets exist for the entire time.
+        start = time.time()
+        while time.time() - start < (self.period * 2):
+            self.rpk.produce(self.topic, "k", "v")
+            self.rpk.consume(self.topic, n=1, group=group)
+            wait_until(offsets_exist, timeout_sec=1, backoff_sec=1)
+            time.sleep(1)
+
+        # after one half life the offset should still exist
+        time.sleep(self.period / 2)
+        assert offsets_exist()
+
+        # after waiting for twice the retention period, it should be gone
+        time.sleep(self.period * 2 - self.period / 2)
+        assert not offsets_exist()


### PR DESCRIPTION
Implements Kafka group offset retention policy.

There is currently a demonstration test using ducktape that shows that expired offsets are deleted. This test effectively covers all of the high-level code paths, but doesn't cover all of the edge cases in offset expiration policies. Additional ducktape tests will be added in a follow-up PR.

Fixes: https://github.com/redpanda-data/core-internal/issues/304
Fixes: https://github.com/redpanda-data/redpanda/issues/7624

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

  ### Features

  * Adds Kafka group offset retention policy. Enabled by default in v23.1 and later. Clusters created prior to v23.1 and upgraded to v23.1 will have the feature disabled by default to retain an effective infinite retention policy.