### PR TITLE
storage_e2e_test: silence botched remove() in test

### DIFF
--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -29,6 +29,7 @@
 #include "storage/types.h"
 #include "test_utils/async.h"
 #include "units.h"
+#include "utils/directory_walker.h"
 #include "utils/to_string.h"
 #include "vassert.h"
 
@@ -2624,8 +2625,23 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
     // Ensure we've cleaned up all our staging segments such that a removal of
     // the log results in nothing leftover.
     auto dir_path = log.config().work_directory();
-    mgr.remove(ntp).get();
-    BOOST_REQUIRE_EQUAL(false, ss::file_exists(dir_path).get());
+    try {
+        mgr.remove(ntp).get();
+    } catch (...) {
+        directory_walker walker;
+        walker
+          .walk(
+            dir_path,
+            [](const ss::directory_entry& de) {
+                info("Leftover file: {}", de.name);
+                return ss::make_ready_future<>();
+            })
+          .get();
+        // TODO: re-enable. See:
+        // https://github.com/redpanda-data/redpanda/issues/8153
+        // throw;
+    }
+    // BOOST_REQUIRE_EQUAL(false, ss::file_exists(dir_path).get());
 };
 
 FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {


### PR DESCRIPTION
Disabling the test failure until the issue is fixed to avoid disturbing CI.

See https://github.com/redpanda-data/redpanda/issues/8153

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
