### PR TITLE
dockerfile: use base images from ECR registries

### DIFF
--- a/src/go/k8s/Dockerfile
+++ b/src/go/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.2 as builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.19.2 as builder
 
 ARG TARGETARCH
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:kinetic-20220830
+FROM public.ecr.aws/docker/library/ubuntu:kinetic-20220830
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
To avoid hitting dockerhub limits in CI. AWS has friendlier limits

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## Release Notes

  * none