### PR TITLE
Basic node decommission progress API

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -370,6 +370,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_tp_state),
             std::ref(_shard_table),
             std::ref(_connections),
+            std::ref(_hm_frontend),
+            std::ref(_members_table),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -10,10 +10,13 @@
  */
 #include "cluster/controller_api.h"
 
+#include "cluster/cluster_utils.h"
 #include "cluster/controller_backend.h"
 #include "cluster/controller_service.h"
 #include "cluster/errc.h"
+#include "cluster/health_monitor_frontend.h"
 #include "cluster/logger.h"
+#include "cluster/members_table.h"
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
 #include "cluster/topic_table.h"
@@ -24,6 +27,8 @@
 #include "rpc/connection_cache.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/sleep.hh>
 
 #include <absl/container/node_hash_map.h>
@@ -36,12 +41,16 @@ controller_api::controller_api(
   ss::sharded<topic_table>& topics,
   ss::sharded<shard_table>& shard_table,
   ss::sharded<rpc::connection_cache>& cache,
+  ss::sharded<health_monitor_frontend>& health_monitor,
+  ss::sharded<members_table>& members,
   ss::sharded<ss::abort_source>& as)
   : _self(self)
   , _backend(backend)
   , _topics(topics)
   , _shard_table(shard_table)
   , _connections(cache)
+  , _health_monitor(health_monitor)
+  , _members(members)
   , _as(as) {}
 
 ss::future<std::vector<ntp_reconciliation_state>>
@@ -307,4 +316,126 @@ ss::future<result<bool>> controller_api::are_ntps_ready(
         return !is_ready_result.has_error() && is_ready_result.value();
     });
 }
+
+ss::future<result<std::vector<partition_reconfiguration_state>>>
+controller_api::get_partitions_reconfiguration_state(
+  std::vector<model::ntp> partitions,
+  model::timeout_clock::time_point timeout) {
+    auto& updates_in_progress = _topics.local().in_progress_updates();
+
+    partitions_filter partitions_filter;
+    absl::node_hash_map<model::ntp, partition_reconfiguration_state> states;
+    for (auto& ntp : partitions) {
+        auto progress_it = updates_in_progress.find(ntp);
+        if (progress_it == updates_in_progress.end()) {
+            continue;
+        }
+        auto p_as = _topics.local().get_partition_assignment(ntp);
+        if (!p_as) {
+            continue;
+        }
+        partition_reconfiguration_state state;
+        state.ntp = ntp;
+
+        state.current_assignment = std::move(p_as->replicas);
+        state.previous_assignment = progress_it->second.get_previous_replicas();
+        state.state = progress_it->second.get_state();
+        states.emplace(ntp, std::move(state));
+
+        auto [tp_it, _] = partitions_filter.namespaces.try_emplace(
+          ntp.ns, partitions_filter::topic_map_t{});
+
+        auto [p_it, inserted] = tp_it->second.try_emplace(
+          ntp.tp.topic, partitions_filter::partitions_set_t{});
+
+        p_it->second.emplace(ntp.tp.partition);
+    }
+
+    auto result = co_await _health_monitor.local().get_cluster_health(
+      cluster_report_filter{
+        .node_report_filter
+        = node_report_filter{.ntp_filters = std::move(partitions_filter)}},
+      force_refresh::no,
+      timeout);
+
+    if (!result) {
+        co_return result.error();
+    }
+
+    auto& report = result.value();
+
+    for (auto& node_report : report.node_reports) {
+        for (auto& tp : node_report.topics) {
+            for (auto& p : tp.partitions) {
+                model::ntp ntp(tp.tp_ns.ns, tp.tp_ns.tp, p.id);
+                auto it = states.find(ntp);
+                if (it == states.end()) {
+                    continue;
+                }
+
+                if (p.leader_id == node_report.id) {
+                    it->second.current_partition_size = p.size_bytes;
+                }
+                const auto moving_to = moving_to_node(
+                  node_report.id,
+                  it->second.previous_assignment,
+                  it->second.current_assignment);
+
+                // node was added to replica set
+                if (moving_to) {
+                    it->second.already_transferred_bytes.emplace_back(
+                      replica_bytes{
+                        .node = node_report.id, .bytes = p.size_bytes});
+                }
+
+                co_await ss::maybe_yield();
+            }
+        }
+    }
+    std::vector<partition_reconfiguration_state> ret;
+    ret.reserve(states.size());
+    for (auto& [_, state] : states) {
+        ret.push_back(std::move(state));
+    }
+    co_return ret;
+}
+
+ss::future<result<node_decommission_progress>>
+controller_api::get_node_decommission_progress(
+  model::node_id id, model::timeout_clock::time_point timeout) {
+    node_decommission_progress ret{};
+    auto node = _members.local().get_node_metadata_ref(id);
+
+    if (!node) {
+        auto removed_node = _members.local().get_removed_node_metadata_ref(id);
+        // node was removed, decommissioning is done
+        if (removed_node) {
+            ret.finished = true;
+            co_return ret;
+        }
+        co_return errc::node_does_not_exists;
+    }
+
+    if (
+      node.value().get().state.get_membership_state()
+      != model::membership_state::draining) {
+        co_return errc::invalid_node_operation;
+    }
+
+    ret.replicas_left = _topics.local().get_node_partition_count(id);
+    auto moving_from_node = _topics.local().ntps_moving_from_node(id);
+
+    // replicas that are moving from decommissioned node are still present on a
+    // node but their metadata is update, add them explicitly
+    ret.replicas_left += moving_from_node.size();
+    auto states = co_await get_partitions_reconfiguration_state(
+      std::move(moving_from_node), timeout);
+
+    if (states) {
+        ret.current_reconfigurations = std::move(states.value());
+    }
+
+    co_return ret;
+}
+
 } // namespace cluster

--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -37,6 +37,8 @@ public:
       ss::sharded<topic_table>&,
       ss::sharded<shard_table>&,
       ss::sharded<rpc::connection_cache>&,
+      ss::sharded<health_monitor_frontend>&,
+      ss::sharded<members_table>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<result<std::vector<ntp_reconciliation_state>>>
@@ -65,6 +67,14 @@ public:
     ss::future<std::error_code> wait_for_topic(
       model::topic_namespace_view, model::timeout_clock::time_point);
 
+    ss::future<result<std::vector<partition_reconfiguration_state>>>
+      get_partitions_reconfiguration_state(
+        std::vector<model::ntp>, model::timeout_clock::time_point);
+
+    ss::future<result<node_decommission_progress>>
+      get_node_decommission_progress(
+        model::node_id, model::timeout_clock::time_point);
+
 private:
     ss::future<result<bool>> are_ntps_ready(
       absl::node_hash_map<model::node_id, std::vector<model::ntp>>,
@@ -78,6 +88,8 @@ private:
     ss::sharded<topic_table>& _topics;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<rpc::connection_cache>& _connections;
+    ss::sharded<health_monitor_frontend>& _health_monitor;
+    ss::sharded<members_table>& _members;
     ss::sharded<ss::abort_source>& _as;
 };
 } // namespace cluster

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -651,9 +651,7 @@ void partition_balancer_planner::get_full_node_reassignments(
 void partition_balancer_planner::get_unavailable_node_movement_cancellations(
   plan_data& result, const reallocation_request_state& rrs) {
     for (const auto& update : _state.topics().updates_in_progress()) {
-        if (
-          update.second.get_state()
-          != topic_table::in_progress_state::update_requested) {
+        if (update.second.get_state() != reconfiguration_state::in_progress) {
             continue;
         }
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1012,4 +1012,19 @@ void topic_table::change_partition_replicas(
       revisions_it->second);
 }
 
+size_t topic_table::get_node_partition_count(model::node_id id) const {
+    size_t cnt = 0;
+    // NOTE: if this loop will cause reactor stalls with large partition counts
+    // we may consider making this method asynchronous
+    for (const auto& [_, tp_md] : _topics) {
+        cnt += std::count_if(
+          tp_md.get_assignments().begin(),
+          tp_md.get_assignments().end(),
+          [id](const partition_assignment& p_as) {
+              return contains_node(p_as.replicas, id);
+          });
+    }
+    return cnt;
+}
+
 } // namespace cluster

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -309,23 +309,23 @@ topic_table::apply(cancel_moving_partition_replicas_cmd cmd, model::offset o) {
         co_return errc::no_update_in_progress;
     }
     switch (in_progress_it->second.get_state()) {
-    case in_progress_state::update_requested:
+    case reconfiguration_state::in_progress:
         break;
-    case in_progress_state::cancel_requested:
+    case reconfiguration_state::cancelled:
         // partition reconfiguration already cancelled, only allow force
         // cancelling it
         if (cmd.value.force == force_abort_update::no) {
             co_return errc::no_update_in_progress;
         }
         break;
-    case in_progress_state::force_cancel_requested:
+    case reconfiguration_state::force_cancelled:
         // partition reconfiguration already cancelled forcibly
         co_return errc::no_update_in_progress;
     }
 
     in_progress_it->second.set_state(
-      cmd.value.force ? in_progress_state::force_cancel_requested
-                      : in_progress_state::cancel_requested);
+      cmd.value.force ? reconfiguration_state::force_cancelled
+                      : reconfiguration_state::cancelled);
 
     auto replicas = current_assignment_it->replicas;
     // replace replica set with set from in progress operation
@@ -936,7 +936,7 @@ void topic_table::change_partition_replicas(
       in_progress_update(
         current_assignment.replicas,
         new_assignment,
-        in_progress_state::update_requested,
+        reconfiguration_state::in_progress,
         model::revision_id(o),
         // snapshot replicas revisions
         revisions_it->second,
@@ -972,7 +972,7 @@ void topic_table::change_partition_replicas(
               in_progress_update(
                 current_assignment.replicas,
                 new_assignment,
-                in_progress_state::update_requested,
+                reconfiguration_state::in_progress,
                 model::revision_id(o),
                 // empty replicas revisions
                 {},
@@ -1010,19 +1010,6 @@ void topic_table::change_partition_replicas(
       delta::op_type::update,
       std::move(previous_assignment),
       revisions_it->second);
-}
-
-std::ostream&
-operator<<(std::ostream& o, topic_table::in_progress_state update) {
-    switch (update) {
-    case topic_table::in_progress_state::update_requested:
-        return o << "update_requested";
-    case topic_table::in_progress_state::cancel_requested:
-        return o << "cancel_requested";
-    case topic_table::in_progress_state::force_cancel_requested:
-        return o << "force_cancel_requested";
-    }
-    __builtin_unreachable();
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -368,6 +368,11 @@ public:
 
     size_t partition_count() const { return _partition_count; }
 
+    /**
+     * Returns number of partitions allocated on given node
+     */
+    size_t get_node_partition_count(model::node_id) const;
+
 private:
     friend topic_table_probe;
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -969,6 +969,17 @@ std::ostream& operator<<(std::ostream& o, const node_metadata& nm) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, reconfiguration_state update) {
+    switch (update) {
+    case reconfiguration_state::in_progress:
+        return o << "in_progress";
+    case reconfiguration_state::cancelled:
+        return o << "cancelled";
+    case reconfiguration_state::force_cancelled:
+        return o << "force_cancelled";
+    }
+    __builtin_unreachable();
+}
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2994,7 +2994,13 @@ struct node_metadata {
       = default;
     friend std::ostream& operator<<(std::ostream&, const node_metadata&);
 };
+/**
+ * Reconfiguration state indicates if ongoing reconfiguration is a result of
+ * partition movement, cancellation or forced cancellation
+ */
+enum class reconfiguration_state { in_progress, cancelled, force_cancelled };
 
+std::ostream& operator<<(std::ostream&, reconfiguration_state);
 /*
  * Partition Allocation Domains is the way to make certain partition replicas
  * distributed evenly across the nodes of the cluster. When partition allocation

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3001,6 +3001,34 @@ struct node_metadata {
 enum class reconfiguration_state { in_progress, cancelled, force_cancelled };
 
 std::ostream& operator<<(std::ostream&, reconfiguration_state);
+
+struct replica_bytes {
+    model::node_id node;
+    size_t bytes{0};
+};
+
+struct partition_reconfiguration_state {
+    model::ntp ntp;
+    // assignments
+    std::vector<model::broker_shard> previous_assignment;
+    std::vector<model::broker_shard> current_assignment;
+    // state indicating if reconfiguration was cancelled or requested
+    reconfiguration_state state;
+    // amount of bytes already transferred to new replicas
+    std::vector<replica_bytes> already_transferred_bytes;
+    // current size of partition
+    size_t current_partition_size{0};
+};
+
+struct node_decommission_progress {
+    // indicate if node decommissioning finished
+    bool finished = false;
+    // number of replicas left on decommissioned node
+    size_t replicas_left{0};
+    // list of currently ongoing partition reconfigurations
+    std::vector<partition_reconfiguration_state> current_reconfigurations;
+};
+
 /*
  * Partition Allocation Domains is the way to make certain partition replicas
  * distributed evenly across the nodes of the cluster. When partition allocation

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -66,6 +66,23 @@
             "path": "/v1/brokers/{id}/decommission",
             "operations": [
                 {
+                    "method": "GET",
+                    "summary": "get broker decommission progress",
+                    "type": "void",
+                    "nickname": "get_decommission",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "long"
+                        }
+                    ]
+                },
+                {
                     "method": "PUT",
                     "summary": "decommission broker",
                     "type": "void",
@@ -308,6 +325,75 @@
                 "failed": {
                     "type": "long",
                     "description": "failed transfer partition count"
+                }
+            }
+        },
+        "decommission_status": {
+            "id": "decommission_status",
+            "description": "Node decommissioning status",
+            "properties": {
+                "finished": {
+                    "type": "boolean",
+                    "description": "indicate if decommissioning is finished"
+                },
+                "replicas_left": {
+                    "type": "long",
+                    "description": "number of replicas left on a node"
+                },
+                "partitions": {
+                    "type": "array",
+                    "items": {
+                        "type": "partition_reconfiguration_status"
+                    },
+                    "description": "Array of partition reconfiguration statues"
+                }
+            }
+        },
+        "partition_reconfiguration_status": {
+            "id": "partition_reconfiguration_status",
+            "description": "Partition reconfiguration status",
+            "properties": {
+                "ns": {
+                    "type": "string",
+                    "description": "namespace"
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "topic"
+                },
+                "partition": {
+                    "type": "int",
+                    "description": "partition"
+                },
+                "moving_to": {
+                    "type": "broker_shard",
+                    "description": "information where the partition is being moved"
+                },
+                "bytes_left_to_move": {
+                    "type": "long",
+                    "description": "bytes left to move to new replica"
+                },
+                "bytes_moved": {
+                    "type": "long",
+                    "description": "bytes moved to target broker"
+                },
+                "partition_size": {
+                    "type": "long",
+                    "description": "current size of partition"
+                }
+            }
+        },
+        "broker_shard": {
+            "id": "broker_shard",
+            "description": "Replica placement",
+            "properties": {
+                "node_id": {
+                    "type": "int",
+                    "description": "id of a node"
+                },
+                "core": {
+                    "type": "int",
+                    "description": "id of a core on a given node"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1947,6 +1947,73 @@ ss::future<ss::json::json_return_type> admin_server::decomission_broker_handler(
     co_return ss::json::json_void();
 }
 
+ss::future<ss::json::json_return_type>
+admin_server::get_decommission_progress_handler(
+  std::unique_ptr<ss::httpd::request> req) {
+    model::node_id id = parse_broker_id(*req);
+    auto res
+      = co_await _controller->get_api().local().get_node_decommission_progress(
+        id, 5s + model::timeout_clock::now());
+    if (!res) {
+        if (res.error() == cluster::errc::node_does_not_exists) {
+            throw ss::httpd::base_exception(
+              fmt::format("Node {} does not exists", id),
+              ss::httpd::reply::status_type::not_found);
+        } else if (res.error() == cluster::errc::invalid_node_operation) {
+            throw ss::httpd::base_exception(
+              fmt::format("Node {} is not decommissioning", id),
+              ss::httpd::reply::status_type::bad_request);
+        }
+
+        throw ss::httpd::base_exception(
+          fmt::format(
+            "Unable to get decommission status for {} - {}",
+            id,
+            res.error().message()),
+          ss::httpd::reply::status_type::internal_server_error);
+    }
+    ss::httpd::broker_json::decommission_status ret;
+    auto& decommission_progress = res.value();
+
+    ret.replicas_left = decommission_progress.replicas_left;
+    ret.finished = decommission_progress.finished;
+
+    for (auto& p : decommission_progress.current_reconfigurations) {
+        ss::httpd::broker_json::partition_reconfiguration_status status;
+        status.ns = p.ntp.ns;
+        status.topic = p.ntp.tp.topic;
+        status.partition = p.ntp.tp.partition;
+        auto added_replicas = cluster::subtract_replica_sets(
+          p.previous_assignment, p.current_assignment);
+        // we are only interested in reconfigurations where one replica was
+        // added to the node
+        if (added_replicas.size() != 1) {
+            continue;
+        }
+        ss::httpd::broker_json::broker_shard moving_to{};
+        moving_to.node_id = added_replicas.front().node_id();
+        moving_to.core = added_replicas.front().shard;
+        status.moving_to = moving_to;
+        size_t left_to_move = 0;
+        size_t already_moved = 0;
+        for (auto replica_status : p.already_transferred_bytes) {
+            left_to_move += (p.current_partition_size - replica_status.bytes);
+            already_moved += replica_status.bytes;
+        }
+        status.bytes_left_to_move = left_to_move;
+        status.bytes_moved = already_moved;
+        status.partition_size = p.current_partition_size;
+        // if no information from partitions is present yet, we may indicate
+        // that everything have to be moved
+        if (already_moved == 0 && left_to_move == 0) {
+            status.bytes_left_to_move = p.current_partition_size;
+        }
+        ret.partitions.push(status);
+    }
+
+    co_return ret;
+}
+
 ss::future<ss::json::json_return_type> admin_server::recomission_broker_handler(
   std::unique_ptr<ss::httpd::request> req) {
     model::node_id id = parse_broker_id(*req);
@@ -2028,6 +2095,12 @@ void admin_server::register_broker_routes() {
       ss::httpd::broker_json::get_broker,
       [this](std::unique_ptr<ss::httpd::request> req) {
           return get_broker_handler(std::move(req));
+      });
+
+    register_route<user>(
+      ss::httpd::broker_json::get_decommission,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return get_decommission_progress_handler(std::move(req));
       });
 
     register_route<superuser>(

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -270,6 +270,9 @@ private:
     ss::future<ss::json::json_return_type>
       decomission_broker_handler(std::unique_ptr<ss::httpd::request>);
     ss::future<ss::json::json_return_type>
+      get_decommission_progress_handler(std::unique_ptr<ss::httpd::request>);
+
+    ss::future<ss::json::json_return_type>
       recomission_broker_handler(std::unique_ptr<ss::httpd::request>);
     ss::future<ss::json::json_return_type>
       start_broker_maintenance_handler(std::unique_ptr<ss::httpd::request>);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -468,6 +468,13 @@ class Admin:
         self.redpanda.logger.debug(f"decommissioning {path}")
         return self._request('put', path, node=node)
 
+    def get_decommission_status(self, id, node=None):
+        """
+        Get broker decommission status
+        """
+        path = f"brokers/{id}/decommission"
+        return self._request('get', path, node=node).json()
+
     def recommission_broker(self, id, node=None):
         """
         Recommission broker i.e. abort ongoing decommissioning


### PR DESCRIPTION
Added REST endpoint allowing caller to query node decommissioning status. 
```
GET /v1/brokers/<id>/decommission
```
When node is being decommission Redpanda automatically move all the replicas from
the decommissioned node to other nodes. This process
may take a long time as it involves data transfer between nodes. Added
REST API will allow user to observe progress of decommissioning process.

Fixes: #7874
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
### Improvements
-  new admin API `GET /v1/brokers/<id>/decommission`