### PR TITLE
kafka: track group offset commit and expire timestamps

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2269,7 +2269,8 @@ void group::update_store_offset_builder(
   model::offset committed_offset,
   leader_epoch committed_leader_epoch,
   const ss::sstring& metadata,
-  model::timestamp commit_timestamp) {
+  model::timestamp commit_timestamp,
+  std::optional<model::timestamp> expiry_timestamp) {
     offset_metadata_key key{
       .group_id = _id, .topic = name, .partition = partition};
 
@@ -2279,6 +2280,10 @@ void group::update_store_offset_builder(
       .metadata = metadata,
       .commit_timestamp = commit_timestamp,
     };
+
+    if (expiry_timestamp.has_value()) {
+        value.expiry_timestamp = expiry_timestamp.value();
+    }
 
     auto kv = _md_serializer.to_kv(
       offset_metadata_kv{.key = std::move(key), .value = std::move(value)});
@@ -2309,7 +2314,8 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
               p.committed_offset,
               p.committed_leader_epoch,
               p.committed_metadata.value_or(""),
-              model::timestamp(p.commit_timestamp));
+              model::timestamp(p.commit_timestamp),
+              expiry_timestamp);
 
             model::topic_partition tp(t.name, p.partition_index);
             offset_metadata md{
@@ -3040,7 +3046,8 @@ group::do_commit(kafka::group_id group_id, model::producer_identity pid) {
           metadata.offset,
           metadata.committed_leader_epoch,
           metadata.metadata,
-          model::timestamp{-1});
+          metadata.commit_timestamp,
+          metadata.expiry_timestamp);
     }
 
     batches.push_back(std::move(store_offset_builder).build());

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -808,7 +808,8 @@ private:
       model::offset commited_offset,
       leader_epoch commited_leader_epoch,
       const ss::sstring& metadata,
-      model::timestamp commited_timestemp);
+      model::timestamp commited_timestemp,
+      std::optional<model::timestamp> expiry_timestamp);
 
     ss::future<cluster::abort_group_tx_reply> do_abort(
       kafka::group_id group_id,

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -155,6 +155,8 @@ public:
         model::offset offset;
         ss::sstring metadata;
         kafka::leader_epoch committed_leader_epoch;
+        model::timestamp commit_timestamp;
+        std::optional<model::timestamp> expiry_timestamp;
 
         friend std::ostream& operator<<(std::ostream&, const offset_metadata&);
     };

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -454,9 +454,9 @@ ss::future<> group_manager::do_recover_group(
             group->try_upsert_offset(
               tp,
               group::offset_metadata{
-                meta.log_offset,
-                meta.metadata.offset,
-                meta.metadata.metadata,
+                .log_offset = meta.log_offset,
+                .offset = meta.metadata.offset,
+                .metadata = meta.metadata.metadata,
               });
         }
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -451,12 +451,18 @@ ss::future<> group_manager::do_recover_group(
         }
 
         for (auto& [tp, meta] : group_stm.offsets()) {
+            const auto expiry_timestamp
+              = meta.metadata.expiry_timestamp == model::timestamp(-1)
+                  ? std::optional<model::timestamp>(std::nullopt)
+                  : meta.metadata.expiry_timestamp;
             group->try_upsert_offset(
               tp,
               group::offset_metadata{
                 .log_offset = meta.log_offset,
                 .offset = meta.metadata.offset,
                 .metadata = meta.metadata.metadata,
+                .commit_timestamp = meta.metadata.commit_timestamp,
+                .expiry_timestamp = expiry_timestamp,
               });
         }
 

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -45,12 +45,15 @@ void group_stm::update_prepared(
         prepared_it->second.offsets.clear();
     }
 
+    const auto now = model::timestamp::now();
     for (const auto& tx_offset : val.offsets) {
         group::offset_metadata md{
           .log_offset = offset,
           .offset = tx_offset.offset,
           .metadata = tx_offset.metadata.value_or(""),
           .committed_leader_epoch = kafka::leader_epoch(tx_offset.leader_epoch),
+          .commit_timestamp = now,
+          .expiry_timestamp = std::nullopt,
         };
         prepared_it->second.offsets[tx_offset.tp] = md;
     }

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -80,7 +80,11 @@ void group_stm::commit(model::producer_identity pid) {
           .leader_epoch
           = kafka::invalid_leader_epoch, // we never use leader_epoch down the
                                          // stack
-          .metadata = md.metadata};
+          .metadata = md.metadata,
+          .commit_timestamp = md.commit_timestamp,
+          .expiry_timestamp = md.expiry_timestamp.value_or(
+            model::timestamp(-1)),
+        };
 
         _offsets[tp] = logged_metadata{
           .log_offset = md.log_offset, .metadata = std::move(val)};


### PR DESCRIPTION
Kafka group offset metadata contains commit timestamp and expire timestamp whose source is Kafka client requests commit offset and txn commit offset. Up until now we effectively ignored these values, by not representing them in our in-memory representation of offset metadata, because they had no use.

However, group offset retention feature will use both of these timestamps when evaluating the expiration policy and selecting to keep or delete stale offsets.

This PR is structured in two parts. The first part stores these timestamps in our in-memory representation as they arrive from the client, and as we recovery group state from disk. The second part of the PR arranges for the in-memory state to be added to the state stored in the consumer group internal topic.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->

  * none
