### PR TITLE
config: change default segment size to 128MiB

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -35,7 +35,7 @@ configuration::configuration()
     {.needs_restart = needs_restart::no,
      .example = "2147483648",
      .visibility = visibility::tunable},
-    1_GiB,
+    128_MiB,
     {.min = 1_MiB})
   , log_segment_size_min(
       *this,

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -138,7 +138,7 @@ class DescribeTopicsTest(RedpandaTest):
             "segment.bytes":
             ConfigProperty(
                 config_type="LONG",
-                value="1073741824",
+                value="134217728",
                 doc_string=
                 "Default log segment size in bytes for topics which do not set segment.bytes"
             )


### PR DESCRIPTION
This size is a more suitable default, to have
finer granularity of disk usage, and finer
granularity of tiered storage read cache when
tiered storage is in use.

For systems that write high bandwidths to a single partition, this will increase the number of segment rolls, but should not outright break anything unless the system was already very close to limits of e.g. file handles or memory.

Fixes https://github.com/redpanda-data/redpanda/issues/8170

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  ### Improvements

  * The default log segment size is now 128MiB, decreased from the previous 1GiB.
