### PR TITLE
Remove node from config_manager status when it is removed from the cluster

### DIFF
--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -12,7 +12,9 @@
 #pragma once
 
 #include "cluster/commands.h"
+#include "cluster/fwd.h"
 #include "features/feature_table.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "rpc/fwd.h"
 
@@ -51,6 +53,7 @@ public:
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
       ss::sharded<features::feature_table>&,
+      ss::sharded<cluster::members_table>&,
       ss::sharded<ss::abort_source>&);
 
     static ss::future<preload_result> preload(YAML::Node const&);
@@ -107,6 +110,7 @@ private:
     static std::filesystem::path bootstrap_path();
     static std::filesystem::path cache_path();
     ss::future<> wait_for_bootstrap();
+    void handle_cluster_members_update(const std::vector<model::node_id>&);
 
     config_status my_latest_status;
     status_map status;
@@ -119,6 +123,8 @@ private:
     ss::sharded<rpc::connection_cache>& _connection_cache;
     ss::sharded<partition_leaders_table>& _leaders;
     ss::sharded<features::feature_table>& _feature_table;
+    ss::sharded<cluster::members_table>& _members;
+    notification_id_type _member_removed_notification;
 
     ss::condition_variable _reconcile_wait;
     ss::sharded<ss::abort_source>& _as;

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -177,6 +177,7 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_connections),
             std::ref(_partition_leaders),
             std::ref(_feature_table),
+            std::ref(_members_table),
             std::ref(_as));
       })
       .then([this] {


### PR DESCRIPTION
When node is removed from the cluster we should remove its configuration
status as it is not longer needed and may confuse users listing
configuration status.

Fixes: #6846

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

### Bug Fixes

  * Made list of nodes returned by `/brokers` and `/config_status` endpoints consistent
