### PR TITLE
k/group: bump error log messages to info

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1035,14 +1035,14 @@ error_code group_manager::validate_group_status(
   const model::ntp& ntp, const group_id& group, api_key api) {
     if (!valid_group_id(group, api)) {
         vlog(
-          klog.trace, "Group name {} is invalid for operation {}", group, api);
+          klog.debug, "Group name {} is invalid for operation {}", group, api);
         return error_code::invalid_group_id;
     }
 
     if (const auto it = _partitions.find(ntp); it != _partitions.end()) {
         if (!it->second->partition->is_leader()) {
             vlog(
-              klog.trace,
+              klog.debug,
               "Group {} operation {} sent to non-leader coordinator {}",
               group,
               api,
@@ -1052,7 +1052,7 @@ error_code group_manager::validate_group_status(
 
         if (it->second->loading) {
             vlog(
-              klog.trace,
+              klog.debug,
               "Group {} operation {} sent to loading coordinator {}",
               group,
               api,
@@ -1077,7 +1077,7 @@ error_code group_manager::validate_group_status(
     }
 
     vlog(
-      klog.trace,
+      klog.debug,
       "Group {} operation {} misdirected to non-coordinator {}",
       group,
       api,


### PR DESCRIPTION
Currently to be able to see context behind congroup related errors, kafka logger needs to be set to trace level, which is really polluted with lines like
```
kafka - fetch.cc:348 - fetch_ntps_in_parallel: for 1 partitions returning 0 total bytes
```
The idea behind this change is that we don't need to do any tuning to be able to see anomalies in the log.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

* none

## Release Notes

### Improvements

* Consumer group related errors are now logged at a higher level (info)

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
