### PR TITLE
Fix 8186: Update scramful_eos_test to retry on auth ec

### DIFF
--- a/tests/rptest/tests/scramful_eos_test.py
+++ b/tests/rptest/tests/scramful_eos_test.py
@@ -18,6 +18,7 @@ from time import sleep
 from confluent_kafka import (Producer, KafkaException)
 
 TOPIC_AUTHORIZATION_FAILED = 29
+CLUSTER_AUTHORIZATION_FAILED = 31
 TRANSACTIONAL_ID_AUTHORIZATION_FAILED = 53
 
 
@@ -44,7 +45,7 @@ class ScramfulEosTest(RedpandaTest):
                                               security=security,
                                               extra_rp_conf=extra_rp_conf)
 
-    def retry(self, func, retries, accepted_error_code):
+    def retry(self, func, retries, accepted_ec):
         while True:
             retries -= 1
             try:
@@ -54,7 +55,7 @@ class ScramfulEosTest(RedpandaTest):
                 if retries == 0:
                     raise e
                 assert e.args[0].code(
-                ) == accepted_error_code, f"only {accepted_error_code} error code is expected"
+                ) in accepted_ec, f"only {accepted_ec} error codes are expected"
                 sleep(1)
 
     def write_by_bob(self, algorithm):
@@ -99,7 +100,7 @@ class ScramfulEosTest(RedpandaTest):
                                  "topic", "topic1", username, password,
                                  algorithm)
         self.retry(lambda: self.write_by_bob(algorithm), 5,
-                   TOPIC_AUTHORIZATION_FAILED)
+                   [TOPIC_AUTHORIZATION_FAILED, CLUSTER_AUTHORIZATION_FAILED])
 
     @cluster(num_nodes=3)
     def test_idempotent_write_passes_2(self):
@@ -110,7 +111,7 @@ class ScramfulEosTest(RedpandaTest):
         rpk.sasl_allow_principal("User:bob", ["write", "read", "describe"],
                                  "topic", "*", username, password, algorithm)
         self.retry(lambda: self.write_by_bob(algorithm), 5,
-                   TOPIC_AUTHORIZATION_FAILED)
+                   [TOPIC_AUTHORIZATION_FAILED, CLUSTER_AUTHORIZATION_FAILED])
 
     def init_by_bob(self, tx_id, algorithm):
         producer = Producer({
@@ -158,7 +159,7 @@ class ScramfulEosTest(RedpandaTest):
                                  password, algorithm)
 
         self.retry(lambda: self.init_by_bob("tx-id-1", algorithm), 5,
-                   TRANSACTIONAL_ID_AUTHORIZATION_FAILED)
+                   [TRANSACTIONAL_ID_AUTHORIZATION_FAILED])
 
     @cluster(num_nodes=3)
     def test_tx_init_passes_2(self):
@@ -174,4 +175,4 @@ class ScramfulEosTest(RedpandaTest):
                                  algorithm)
 
         self.retry(lambda: self.init_by_bob("tx-id-2", algorithm), 5,
-                   TRANSACTIONAL_ID_AUTHORIZATION_FAILED)
+                   [TRANSACTIONAL_ID_AUTHORIZATION_FAILED])


### PR DESCRIPTION
It takes time to propagate auth info, add retries on expected error codes to account for the delay.

Fixes https://github.com/redpanda-data/redpanda/issues/8186

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

  * none

## Release Notes

  * none