### PR TITLE
Implement operator== for license struct

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1779,6 +1779,10 @@ admin_server::put_license_handler(std::unique_ptr<ss::httpd::request> req) {
         if (loaded_license && (*loaded_license == license)) {
             /// Loaded license is idential to license in request, do
             /// nothing and return 200(OK)
+            vlog(
+              logger.info,
+              "Attempted to load identical license, doing nothing: {}",
+              license);
             co_return ss::json::json_void();
         }
         auto& fm = _controller->get_feature_manager();

--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -81,8 +81,16 @@ struct license
     /// Seconds since epoch until license expiration
     std::chrono::seconds expires() const noexcept;
 
+    auto operator<=>(const license&) const = delete;
+
 private:
     friend struct fmt::formatter<license>;
+
+    friend bool operator==(const license& a, const license& b) {
+        return a.format_version == b.format_version && a.type == b.type
+               && a.organization == b.organization && a.expiry == b.expiry
+               && a.checksum == b.checksum;
+    }
 
     friend std::ostream& operator<<(std::ostream& os, const license& lic);
 };

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -316,16 +316,23 @@ def inject_remote_script(node, script_name):
     return remote_path
 
 
-def get_cluster_license():
-    license = os.environ.get("REDPANDA_SAMPLE_LICENSE", None)
+def _get_cluster_license(env_var):
+    license = os.environ.get(env_var, None)
     if license is None:
         is_ci = os.environ.get("CI", "false")
         if is_ci == "true":
             raise RuntimeError(
-                "Expected REDPANDA_SAMPLE_LICENSE variable to be set in this environment"
-            )
+                f"Expected {env_var} variable to be set in this environment")
 
     return license
+
+
+def get_cluster_license():
+    return _get_cluster_license("REDPANDA_SAMPLE_LICENSE")
+
+
+def get_second_cluster_license():
+    return _get_cluster_license("REDPANDA_SECOND_SAMPLE_LICENSE")
 
 
 class firewall_blocked:


### PR DESCRIPTION
Fix for an issue that manifested to a customer in newer versions of redpanda, where licenses could not be re-uploaded. The cause occurres when comparing two `security::license`s via operator==, where this method was actually called on the superclass of `security::license` which is `serde::envelope`. The envelopes will always be the same in the scenario, so this comparison would always return `true`, preventing users from uploading newer licenses.

The fix is to correctly implement `operator==` for `security::license`. 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  ### Bug Fixes

  * Fixes a bug where licenses could not be re-uploaded.
