### PR TITLE
Fix clang-tidy use-after-move warnings

### DIFF
--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -2163,6 +2163,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         // append_entries_request -> iobuf
         iobuf serde_out;
+        const auto node_id = data.node_id;
+        const auto target_node_id = data.target_node_id;
+        const auto meta = data.meta;
+        const auto flush = data.flush;
         serde::write_async(serde_out, std::move(data)).get();
 
         // iobuf -> append_entries_request
@@ -2170,10 +2174,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         auto from_serde
           = serde::read_async<raft::append_entries_request>(serde_in).get0();
 
-        BOOST_REQUIRE(from_serde.node_id == data.node_id);
-        BOOST_REQUIRE(from_serde.target_node_id == data.target_node_id);
-        BOOST_REQUIRE(from_serde.meta == data.meta);
-        BOOST_REQUIRE(from_serde.flush == data.flush);
+        BOOST_REQUIRE(from_serde.node_id == node_id);
+        BOOST_REQUIRE(from_serde.target_node_id == target_node_id);
+        BOOST_REQUIRE(from_serde.meta == meta);
+        BOOST_REQUIRE(from_serde.flush == flush);
 
         auto batches_from_serde = model::consume_reader_to_memory(
                                     std::move(from_serde.batches()),

--- a/src/v/kafka/protocol/tests/batch_reader_test.cc
+++ b/src/v/kafka/protocol/tests/batch_reader_test.cc
@@ -164,6 +164,7 @@ SEASTAR_THREAD_TEST_CASE(batch_reader_record_batch_reader_impl_fail_short_hdr) {
       std::move(ctx.record_set));
 
     BOOST_REQUIRE_EXCEPTION(
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       model::consume_reader_to_memory(std::move(rdr), model::no_timeout).get(),
       kafka::exception,
       [](const kafka::exception& e) {
@@ -180,6 +181,7 @@ SEASTAR_THREAD_TEST_CASE(batch_reader_record_batch_reader_impl_fail_crc) {
       std::move(ctx.record_set));
 
     BOOST_REQUIRE_EXCEPTION(
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       model::consume_reader_to_memory(std::move(rdr), model::no_timeout).get(),
       kafka::exception,
       [](const kafka::exception& e) {
@@ -197,6 +199,7 @@ SEASTAR_THREAD_TEST_CASE(batch_reader_record_batch_reader_impl_fail_lod) {
       std::move(ctx.record_set));
 
     BOOST_REQUIRE_EXCEPTION(
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       model::consume_reader_to_memory(std::move(rdr), model::no_timeout).get(),
       kafka::exception,
       [](const kafka::exception& e) {
@@ -213,6 +216,7 @@ SEASTAR_THREAD_TEST_CASE(batch_reader_record_batch_reader_impl_fail_magic) {
       std::move(ctx.record_set));
 
     BOOST_REQUIRE_EXCEPTION(
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       model::consume_reader_to_memory(std::move(rdr), model::no_timeout).get(),
       kafka::exception,
       [](const kafka::exception& e) {

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -379,6 +379,7 @@ ss::future<collected_schema> collect_schema(
               std::move(ss.schema));
         }
     }
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     collected.insert(std::move(name), std::move(schema).def());
     co_return std::move(collected);
 }

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -238,6 +238,7 @@ validate_protobuf_schema(sharded_store& store, canonical_schema schema) {
 
 ss::future<canonical_schema>
 make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema) {
+    // NOLINTBEGIN(bugprone-use-after-move)
     canonical_schema temp{
       std::move(schema).sub(),
       {canonical_schema_definition::raw_string{schema.def().raw()()},
@@ -247,6 +248,7 @@ make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema) {
     auto validated = co_await validate_protobuf_schema(store, temp);
     co_return canonical_schema{
       std::move(temp).sub(), std::move(validated), std::move(temp).refs()};
+    // NOLINTEND(bugprone-use-after-move)
 }
 
 namespace {

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -51,11 +51,13 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
       payload.data(), pps::post_subject_versions_request_handler{sub})};
 
     // canonicalisation now requires a sharded_store, for now, minify.
+    // NOLINTBEGIN(bugprone-use-after-move)
     result = {
       std::move(result).sub(),
       pps::unparsed_schema_definition{
         ppj::minify(result.def().raw()()), pps::schema_type::avro},
       std::move(result).refs()};
+    // NOLINTEND(bugprone-use-after-move)
 
     BOOST_REQUIRE_EQUAL(expected, result);
 }

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -171,10 +171,13 @@ ss::future<bool> sharded_store::upsert(
   schema_id id,
   schema_version version,
   is_deleted deleted) {
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     co_await upsert_schema(id, std::move(schema).def());
     co_return co_await upsert_subject(
       marker,
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       std::move(schema).sub(),
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       std::move(schema).refs(),
       version,
       id,

--- a/src/v/rpc/test/netbuf_tests.cc
+++ b/src/v/rpc/test/netbuf_tests.cc
@@ -36,7 +36,7 @@ SEASTAR_THREAD_TEST_CASE(netbuf_pod) {
     src.z = 88;
     n.set_correlation_id(42);
     n.set_service_method_id(66);
-    reflection::async_adl<pod>{}.to(n.buffer(), std::move(src)).get();
+    reflection::async_adl<pod>{}.to(n.buffer(), src).get();
     // forces the computation of the header
     auto bufs = std::move(n).as_scattered().get().release().release();
     auto in = make_iobuf_input_stream(iobuf(std::move(bufs)));

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -520,6 +520,7 @@ SEASTAR_THREAD_TEST_CASE(compat_test_half_field_1) {
     };
 
     auto b = serde::to_iobuf(half_field_1{.a = 1, .b = 2, .c = 3});
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     BOOST_CHECK_THROW(serde::from_iobuf<small>(std::move(b)), std::exception);
 }
 
@@ -539,6 +540,7 @@ SEASTAR_THREAD_TEST_CASE(compat_test_half_field_2) {
 
     auto b1 = serde::to_iobuf(
       half_field_2{.a = 1, .b = 2, .c = 3, .d = 0x1234});
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     BOOST_CHECK_THROW(serde::from_iobuf<big>(std::move(b1)), std::exception);
 }
 
@@ -741,11 +743,16 @@ SEASTAR_THREAD_TEST_CASE(serde_tristate_test) {
 
     BOOST_CHECK_EQUAL(
       disabled,
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       serde::from_iobuf<tristate<ss::sstring>>(std::move(disabled_buf)));
     BOOST_CHECK_EQUAL(
-      empty, serde::from_iobuf<tristate<ss::sstring>>(std::move(empty_buf)));
+      empty,
+      // NOLINTNEXTLINE(bugprone-use-after-move)
+      serde::from_iobuf<tristate<ss::sstring>>(std::move(empty_buf)));
     BOOST_CHECK_EQUAL(
-      set, serde::from_iobuf<tristate<ss::sstring>>(std::move(set_buf)));
+      set,
+      // NOLINTNEXTLINE(bugprone-use-after-move)
+      serde::from_iobuf<tristate<ss::sstring>>(std::move(set_buf)));
 }
 
 SEASTAR_THREAD_TEST_CASE(seastar_inet_address_test) {
@@ -754,9 +761,13 @@ SEASTAR_THREAD_TEST_CASE(seastar_inet_address_test) {
     iobuf ipv4_buf = serde::to_iobuf(ipv4);
     iobuf ipv6_buf = serde::to_iobuf(ipv6);
     BOOST_CHECK_EQUAL(
-      ipv4, serde::from_iobuf<ss::net::inet_address>(std::move(ipv4_buf)));
+      ipv4,
+      // NOLINTNEXTLINE(bugprone-use-after-move)
+      serde::from_iobuf<ss::net::inet_address>(std::move(ipv4_buf)));
     BOOST_CHECK_EQUAL(
-      ipv6, serde::from_iobuf<ss::net::inet_address>(std::move(ipv6_buf)));
+      ipv6,
+      // NOLINTNEXTLINE(bugprone-use-after-move)
+      serde::from_iobuf<ss::net::inet_address>(std::move(ipv6_buf)));
 }
 
 template<template<class...> class T>


### PR DESCRIPTION
Fix use-after-move warnings.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->
  * none

