### PR TITLE
tests: fix cloud storage deletion issues #8046, #8084

### DIFF
--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -308,7 +308,6 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         return empty
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8046
     @cluster(num_nodes=3)
     @parametrize(disable_delete=False)
     @parametrize(disable_delete=True)


### PR DESCRIPTION
I'm pulling these commits out of https://github.com/redpanda-data/redpanda/pull/8090 because the #8071 fixes were thornier than expected.

Fixes #8046 
Fixes #8084 

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes


  * none

