### PR TITLE
k/topic_utils: do not return an error when waiting for leaders failed

### DIFF
--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -79,7 +79,11 @@ ss::future<> wait_for_topics(
                    })
             .then([&md_cache, &results, timeout]() {
                 return wait_for_leaders(md_cache, results, timeout)
-                  .discard_result();
+                  .discard_result()
+                  .handle_exception_type([](const ss::timed_out_error&) {
+                      // discard timed out exception, even tho waiting failed
+                      // the topic is created
+                  });
             });
       });
 }


### PR DESCRIPTION
Recently introduced change (waiting for leaders before returning from create topics) change the behavior of `CreateTopicsRequest` handler. Previously handler was waiting for topic partitions to be created but even if that timed out it returned success to the client. Waiting for leaders threw an exception when timeout was trigger which caused client connection to be dropped.

Fixed an error by going back to previous behavior i.e. ignoring waiting timeouts. The timeout does not indicate that topic creation failed actually when waiting for creation, topic already exists.

Fixes: #7942


<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

  * none
