### PR TITLE
cluster: set feature_table version during bootstrap

### DIFF
--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -16,6 +16,7 @@
 #include "cluster/logger.h"
 #include "cluster/members_manager.h"
 #include "cluster/types.h"
+#include "features/feature_table.h"
 #include "security/credential_store.h"
 
 namespace cluster {
@@ -35,10 +36,12 @@ namespace cluster {
 bootstrap_backend::bootstrap_backend(
   ss::sharded<security::credential_store>& credentials,
   ss::sharded<storage::api>& storage,
-  ss::sharded<members_manager>& members_manager)
+  ss::sharded<members_manager>& members_manager,
+  ss::sharded<features::feature_table>& feature_table)
   : _credentials(credentials)
   , _storage(storage)
-  , _members_manager(members_manager) {}
+  , _members_manager(members_manager)
+  , _feature_table(feature_table) {}
 
 namespace {
 

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -13,6 +13,7 @@
 
 #include "cluster/commands.h"
 #include "cluster/fwd.h"
+#include "features/fwd.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
@@ -41,7 +42,8 @@ public:
     bootstrap_backend(
       ss::sharded<security::credential_store>&,
       ss::sharded<storage::api>&,
-      ss::sharded<members_manager>&);
+      ss::sharded<members_manager>&,
+      ss::sharded<features::feature_table>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -56,6 +58,7 @@ private:
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<storage::api>& _storage;
     ss::sharded<members_manager>& _members_manager;
+    ss::sharded<features::feature_table>& _feature_table;
     std::optional<model::cluster_uuid> _cluster_uuid_applied;
 };
 

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -43,7 +43,8 @@ public:
       ss::sharded<security::credential_store>&,
       ss::sharded<storage::api>&,
       ss::sharded<members_manager>&,
-      ss::sharded<features::feature_table>&);
+      ss::sharded<features::feature_table>&,
+      ss::sharded<feature_backend>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -59,6 +60,7 @@ private:
     ss::sharded<storage::api>& _storage;
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<features::feature_table>& _feature_table;
+    ss::sharded<feature_backend>& _feature_backend;
     std::optional<model::cluster_uuid> _cluster_uuid_applied;
 };
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -160,7 +160,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
           return _bootstrap_backend.start_single(
             std::ref(_credentials),
             std::ref(_storage),
-            std::ref(_members_manager));
+            std::ref(_members_manager),
+            std::ref(_feature_table));
       })
       .then([this] {
           return _config_frontend.start(
@@ -623,7 +624,8 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
         cmd_data.bootstrap_user_cred
           = security_frontend::get_bootstrap_user_creds_from_env();
         cmd_data.node_ids_by_uuid = std::move(discovery.get_node_ids_by_uuid());
-        cmd_data.founding_version = features::feature_table::get_latest_logical_version();
+        cmd_data.founding_version
+          = features::feature_table::get_latest_logical_version();
         co_return co_await create_cluster(std::move(cmd_data));
     }
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -623,6 +623,7 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
         cmd_data.bootstrap_user_cred
           = security_frontend::get_bootstrap_user_creds_from_env();
         cmd_data.node_ids_by_uuid = std::move(discovery.get_node_ids_by_uuid());
+        cmd_data.founding_version = features::feature_table::get_latest_logical_version();
         co_return co_await create_cluster(std::move(cmd_data));
     }
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -161,7 +161,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_credentials),
             std::ref(_storage),
             std::ref(_members_manager),
-            std::ref(_feature_table));
+            std::ref(_feature_table),
+            std::ref(_feature_backend));
       })
       .then([this] {
           return _config_frontend.start(

--- a/src/v/cluster/feature_backend.cc
+++ b/src/v/cluster/feature_backend.cc
@@ -11,6 +11,7 @@
 
 #include "feature_backend.h"
 
+#include "cluster/logger.h"
 #include "features/feature_table.h"
 #include "features/feature_table_snapshot.h"
 #include "seastar/core/coroutine.hh"
@@ -87,10 +88,24 @@ feature_backend::apply_feature_update_command(feature_update_cmd update) {
     }
 }
 
+bool feature_backend::has_snapshot() {
+    return _storage.local()
+      .kvs()
+      .get(
+        storage::kvstore::key_space::controller,
+        features::feature_table_snapshot::kvstore_key())
+      .has_value();
+}
+
 ss::future<> feature_backend::save_snapshot() {
     // kvstore is shard-local: must be on a consistent shard every
     // time for snapshot storage to work.
     vassert(ss::this_shard_id() == ss::shard_id{0}, "wrong shard");
+
+    vlog(
+      clusterlog.info,
+      "Saving feature_table_snapshot at version {}...",
+      _feature_table.local().get_active_version());
 
     auto snapshot = features::feature_table_snapshot::from(
       _feature_table.local());

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -39,6 +39,7 @@ public:
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
+    bool has_snapshot();
     ss::future<> save_snapshot();
 
     bool is_batch_applicable(const model::record_batch& b) {

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -45,6 +45,7 @@ class health_monitor_frontend;
 class health_monitor_backend;
 class metrics_reporter;
 class feature_frontend;
+class feature_backend;
 class feature_manager;
 class drain_manager;
 class partition_balancer_backend;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2306,7 +2306,7 @@ struct user_and_credential
 struct bootstrap_cluster_cmd_data
   : serde::envelope<
       bootstrap_cluster_cmd_data,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
@@ -2315,12 +2315,18 @@ struct bootstrap_cluster_cmd_data
       = default;
 
     auto serde_fields() {
-        return std::tie(uuid, bootstrap_user_cred, node_ids_by_uuid);
+        return std::tie(
+          uuid, bootstrap_user_cred, node_ids_by_uuid, founding_version);
     }
 
     model::cluster_uuid uuid;
     std::optional<user_and_credential> bootstrap_user_cred;
     absl::flat_hash_map<model::node_uuid, model::node_id> node_ids_by_uuid;
+
+    // If this is set, fast-forward the feature_table to enable features
+    // from this version. Indicates the version of Redpanda of
+    // the node that generated the bootstrap record.
+    cluster_version founding_version{invalid_version};
 };
 
 enum class reconciliation_status : int8_t {

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -59,6 +59,8 @@ std::string_view to_string_view(feature f) {
         return "kafka_gssapi";
     case feature::test_alpha:
         return "__test_alpha";
+    case feature::test_bravo:
+        return "__test_alpha";
     }
     __builtin_unreachable();
 }
@@ -190,6 +192,40 @@ void feature_table::set_active_version(cluster_version v) {
 
     for (auto& fs : _feature_state) {
         fs.notify_version(v);
+    }
+
+    on_update();
+}
+
+/**
+ * The "normal" set_active_version method increments the version but does
+ * not activate features (though it may make them available).  This is
+ * because activating features on upgrade is optional, and that optionality
+ * is respected at time of writing to the controller log, not replaying it.
+ *
+ * The reason for making auto-activation optional is to enable cautious
+ * upgrades, but during cluster bootstrap this motivation goes away, so
+ * we will unconditionally switch on all the available features when we
+ * see the bootstrap message's cluster version in the controller log.  That
+ * is what this function does, as well as calling through to set_active_version.
+ */
+void feature_table::bootstrap_active_version(cluster_version v) {
+    if (ss::this_shard_id() == ss::shard_id{0}) {
+        vlog(
+          featureslog.info, "Activating features from bootstrap version {}", v);
+    }
+    set_active_version(v);
+
+    for (auto& fs : _feature_state) {
+        if (
+          fs.get_state() == feature_state::state::available
+          && fs.spec.available_rule == feature_spec::available_policy::always
+          && _active_version >= fs.spec.require_version) {
+            // Intentionally do not pass through the 'preparing' state, as
+            // that is for upgrade handling, and we are replaying the bootstrap
+            // of a cluster that started at this version.
+            fs.transition_active();
+        }
     }
 
     on_update();

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -319,11 +319,14 @@ public:
 
     model::offset get_applied_offset() const { return _applied_offset; }
 
-private:
-    // Only for use by our friends feature backend & manager, and during
-    // bootstrap by bootstrap_backend.
-    void set_active_version(cluster::cluster_version);
+    // application and bootstrap_backend may use this to fast-forward a
+    // feature table to the desired version synchronously, early in the
+    // lifetime of a node.
     void bootstrap_active_version(cluster::cluster_version);
+
+private:
+    // Only for use by our friends feature backend & manager
+    void set_active_version(cluster::cluster_version);
     void apply_action(const cluster::feature_update_action& fua);
 
     // The controller log offset of last batch applied to this state machine
@@ -365,10 +368,6 @@ private:
     // feature_backend is a friend for routine updates when
     // applying raft0 log events.
     friend class cluster::feature_backend;
-
-    // bootstrap_backend is a friend for using set_active_version during
-    // bootstrap, thereby fast-forwarding past the usual version negotiation.
-    friend class cluster::bootstrap_backend;
 
     // Unit testing hook.
     friend class feature_table_fixture;

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -50,7 +50,8 @@ enum class feature : std::uint64_t {
     kafka_gssapi = 1ULL << 17U,
 
     // Dummy features for testing only
-    test_alpha = 1ULL << 63U,
+    test_alpha = 1ULL << 62U,
+    test_bravo = 1ULL << 63U,
 };
 
 /**
@@ -208,12 +209,23 @@ constexpr static std::array feature_schema{
     feature::kafka_gssapi,
     feature_spec::available_policy::explicit_only,
     feature_spec::prepare_policy::always},
+
+  // For testing, a feature that does not auto-activate
   feature_spec{
     cluster::cluster_version{2001},
     "__test_alpha",
     feature::test_alpha,
     feature_spec::available_policy::explicit_only,
-    feature_spec::prepare_policy::always}};
+    feature_spec::prepare_policy::always},
+
+  // For testing, a feature that auto-activates
+  feature_spec{
+    cluster::cluster_version{2001},
+    "__test_bravo",
+    feature::test_bravo,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+};
 
 std::string_view to_string_view(feature);
 std::string_view to_string_view(feature_state::state);
@@ -309,6 +321,7 @@ public:
 private:
     // Only for use by our friends feature backend & manager
     void set_active_version(cluster::cluster_version);
+    void bootstrap_active_version(cluster::cluster_version);
     void apply_action(const cluster::feature_update_action& fua);
 
     // The controller log offset of last batch applied to this state machine

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -23,6 +23,7 @@
 namespace cluster {
 class feature_backend;
 class feature_manager;
+class bootstrap_backend;
 } // namespace cluster
 
 namespace features {
@@ -319,7 +320,8 @@ public:
     model::offset get_applied_offset() const { return _applied_offset; }
 
 private:
-    // Only for use by our friends feature backend & manager
+    // Only for use by our friends feature backend & manager, and during
+    // bootstrap by bootstrap_backend.
     void set_active_version(cluster::cluster_version);
     void bootstrap_active_version(cluster::cluster_version);
     void apply_action(const cluster::feature_update_action& fua);
@@ -363,6 +365,10 @@ private:
     // feature_backend is a friend for routine updates when
     // applying raft0 log events.
     friend class cluster::feature_backend;
+
+    // bootstrap_backend is a friend for using set_active_version during
+    // bootstrap, thereby fast-forwarding past the usual version negotiation.
+    friend class cluster::bootstrap_backend;
 
     // Unit testing hook.
     friend class feature_table_fixture;


### PR DESCRIPTION
    cluster: set feature_table version during bootstrap
    
    In some circumstances, a cluster can have two nodes up+bootstrapped,
    with an active controller raft group, but a third founding node
    trying to join the cluster by requesting an ID (because this node
    reported in earlier, but had trouble following through with the
    bootstrap process).
    
    Because handing out node IDs is behind a feature gate, this
    would fail, and the cluster logical version would not advance
    because there was a node in the members_table who had not
    reported its logical version.
    
    Avoid this class of issues by including logical version in
    the controller bootstrap event, so that as soon as there is
    a bootstrap message in the log, we are certain to have activated
    all the features that a node might need to proceed.

    
Fixes https://github.com/redpanda-data/redpanda/issues/8203


## Backports Required


- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  ### Bug Fixes

  * An issue is fixed that could prevent clusters forming successfully when network disruptions happened during initial startup of the founding nodes.

