### PR TITLE
Bundle k8s resources

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle.go
@@ -39,6 +39,7 @@ type bundleParams struct {
 	logsSince               string
 	logsUntil               string
 	path                    string
+	namespace               string
 	logsLimitBytes          int
 	controllerLogLimitBytes int
 	timeout                 time.Duration
@@ -69,6 +70,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		logsSizeLimit string
 
 		controllerLogsSizeLimit string
+		namespace               string
 
 		timeout time.Duration
 	)
@@ -110,6 +112,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 				logsSince:               logsSince,
 				logsUntil:               logsUntil,
 				path:                    path,
+				namespace:               namespace,
 				logsLimitBytes:          int(logsLimit),
 				controllerLogLimitBytes: int(controllerLogsLimit),
 				timeout:                 timeout,
@@ -173,6 +176,8 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		"20MB",
 		"Sets the limit of the controller log size that can be stored in the bundle. Multipliers are also supported, e.g. 3MB, 1GiB",
 	)
+
+	command.Flags().StringVarP(&namespace, "namespace", "n", "redpanda", "The namespace to use to collect the resources from (k8s only)")
 
 	common.AddKafkaFlags(
 		command,

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
@@ -22,7 +22,8 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -62,6 +63,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveNTPDrift(ps),
 		saveDiskUsage(ctx, ps, bp.cfg),
 		saveControllerLogDir(ps, bp.cfg, bp.controllerLogLimitBytes),
+		saveK8SResources(ctx, ps, bp.namespace),
 	}
 
 	adminAddresses, err := adminAddressesFromK8S(ctx, bp.namespace)
@@ -91,24 +93,34 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 	return nil
 }
 
-// adminAddressesFromK8S returns the admin API host:port list by querying the
-// K8S Api.
-func adminAddressesFromK8S(ctx context.Context, namespace string) ([]string, error) {
-	// This is intended to run only in a k8s cluster:
+// k8sPodList will create a clientset using the config object which uses the
+// service account kubernetes gives to pods (InClusterConfig) and the list of
+// pods in the given namespace.
+func k8sPodList(ctx context.Context, namespace string) (*kubernetes.Clientset, *v1.PodList, error) {
 	k8sCfg, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get kubernetes cluster configuration: %v", err)
+		return nil, nil, fmt.Errorf("unable to get kubernetes cluster configuration: %v", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(k8sCfg)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create kubernetes client: %v", err)
+		return nil, nil, fmt.Errorf("unable to create kubernetes client: %v", err)
 	}
 
-	// Get pods in the namespace.
-	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{})
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get kubernetes pods: %v", err)
+		return nil, nil, fmt.Errorf("unable to get pods in the %q namespace: %v", namespace, err)
+	}
+	return clientset, pods, nil
+}
+
+// adminAddressesFromK8S returns the admin API host:port list by querying the
+// K8S Api.
+func adminAddressesFromK8S(ctx context.Context, namespace string) ([]string, error) {
+	// This is intended to run only in a k8s cluster:
+	_, pods, err := k8sPodList(ctx, namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	// Get the admin addresses from ContainerPort.
@@ -222,6 +234,50 @@ func saveSingleAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, c
 			rerrs = multierror.Append(rerrs, errs)
 		}
 		return rerrs.ErrorOrNil()
+	}
+}
+
+// saveK8SResources will issue a GET request to the K8S API to a set of fixed
+// resources that we want to include in the bundle.
+func saveK8SResources(ctx context.Context, ps *stepParams, namespace string) step {
+	return func() error {
+		clientset, pods, err := k8sPodList(ctx, namespace)
+		if err != nil {
+			return err
+		}
+		// This is a safeguard, so we don't end up saving empty request for
+		// namespace who don't have any pods.
+		if len(pods.Items) == 0 {
+			return fmt.Errorf("skipping resource collection, no pods found in the %q namespace", namespace)
+		}
+
+		// We use the restInterface because it's the most straightforward
+		// approach to get namespaced resources already parsed as json.
+		restInterface := clientset.CoreV1().RESTClient()
+
+		var grp multierror.Group
+		for _, r := range []string{
+			"configmaps",
+			"endpoints",
+			"events",
+			"limitranges",
+			"persistentvolumeclaims",
+			"pods",
+			"replicationcontrollers",
+			"resourcequotas",
+			"serviceaccounts",
+			"services",
+		} {
+			r := r
+			cb := func(ctx context.Context) ([]byte, error) {
+				request := restInterface.Get().Namespace(namespace)
+				return request.Name(r).Do(ctx).Raw()
+			}
+			grp.Go(func() error { return requestAndSave(ctx, ps, fmt.Sprintf("k8s/%v.json", r), cb) })
+		}
+
+		errs := grp.Wait()
+		return errs.ErrorOrNil()
 	}
 }
 

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
@@ -78,7 +78,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 	}
 
 	stepErrs := grp.Wait()
-	if stepErrs != nil {
+	if stepErrs != nil || errs != nil {
 		errs = multierror.Append(errs, stepErrs.ErrorOrNil())
 		err := writeFileToZip(ps, "errors.txt", []byte(errs.Error()))
 		if err != nil {


### PR DESCRIPTION
This PR introduces the collection of namespaced resources in the k8s version of `rpk debug bundle`. You can modify which namespace to query via the `--namespace` flag.

Currently, we collect a fixed set of resources but depending on how we implement the RBAC in https://github.com/redpanda-data/helm-charts/issues/270 we can use the Discovery client to get all the namespaced-resources and try to list them all (similar to `kubectl api-resources --namespaced`)

This is what's in the bundle:
![image](https://user-images.githubusercontent.com/59714880/212412749-dd1d4105-f78d-429c-b947-b652353638fc.png)

Fixes #7929

## Backports Required

- [ ] none - not a bug fix


## Release Notes
  ### Features

  * rpk now collects namespaced resources in `rpk debug bundle` when used in k8s environments.
