### PR TITLE
operator: ensure each cluster is deleted before starting the next test

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -48,6 +49,11 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		centralizedConfigurationHashKey = "redpanda.vectorized.io/centralized-configuration-hash"
 		lastAppliedConfiguraitonHashKey = "redpanda.vectorized.io/last-applied-configuration"
 	)
+
+	deletePolicy := metav1.DeletePropagationForeground
+	foregroundDeleteOptions := &client.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	}
 
 	Context("When managing a RedpandaCluster with centralized config", func() {
 		It("Can initialize a cluster with centralized configuration", func() {
@@ -82,7 +88,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &sts, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should interact with the admin API when doing changes", func() {
@@ -140,7 +146,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should remove properties from the admin API when needed", func() {
@@ -229,7 +235,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should restart the cluster only when strictly required", func() {
@@ -330,7 +336,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(testAdminAPI.NumPatchesGetter(), timeoutShort, intervalShort).Should(Equal(numberOfPatches))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should defer updating the centralized configuration when admin API is unavailable", func() {
@@ -368,7 +374,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(testAdminAPI.PropertyGetter("prop")()).To(Equal(propValue))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 
@@ -415,7 +421,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey)()).To(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 
@@ -463,7 +469,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(testAdminAPI.NumPatchesGetter(), timeoutShort, intervalShort).Should(Equal(0))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should be able to upgrade and change a cluster even if the admin API is unavailable", func() {
@@ -539,7 +545,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(testAdminAPI.PropertyGetter("prop")()).To(Equal(propValue))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 
@@ -621,7 +627,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey)()).To(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should report direct validation errors in the condition", func() {
@@ -666,7 +672,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey)()).To(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should report configuration errors present in the .bootstrap.yaml file", func() {
@@ -706,7 +712,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey)()).To(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 
@@ -765,7 +771,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(testAdminAPI.PropertyGetter(unmanagedProp)()).To(Equal(externalChangeUnmanagedPropValue))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Occasionally a cluster that's deleted in the background may not be completely reconciled when the test moves on to the next test. This can cause the previous test to cause activity on the mockAdminAPI which shows up as a failure when that API is not expected to have any changes.

This change causes the delete to wait until the resource is fully removed, ensuring the operator will no longer be reconciling it before starting the next test.

Fixes https://github.com/redpanda-data/redpanda/issues/7395

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
