### PR TITLE
security: Default operator== for license

### DIFF
--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -86,11 +86,7 @@ struct license
 private:
     friend struct fmt::formatter<license>;
 
-    friend bool operator==(const license& a, const license& b) {
-        return a.format_version == b.format_version && a.type == b.type
-               && a.organization == b.organization && a.expiry == b.expiry
-               && a.checksum == b.checksum;
-    }
+    friend bool operator==(const license& a, const license& b) = default;
 
     friend std::ostream& operator<<(std::ostream& os, const license& lic);
 };


### PR DESCRIPTION
- Future proofs against potential issues with inequality if member variables are added later on.

## Release Notes
  * none