### PR TITLE
gha: add label to merge-queue PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,6 +5,15 @@ on:
 - pull_request_target
 
 jobs:
+  merge-queue-pr-labeler:
+    if: ${{ startsWith(github.event.pull_request.title, 'merge-queue') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: add label to merge-queue PR
+        env:
+          PR_NUM: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr -R "$GITHUB_REPOSITORY_OWNER/redpanda" edit "$PR_NUM" --add-label=ci-repeat-5
   triage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Github action to add label [ci-repeat-5](https://github.com/redpanda-data/redpanda/labels?q=ci-repeat-5) to PRs with title starting with `merge-queue`. This will help check for flakiness of tests before the PR in the merge queue is merged to `dev` branch.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none