### PR TITLE
[v22.3.x] operator: ensure each cluster is deleted before starting the next test

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -48,6 +49,11 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 		centralizedConfigurationHashKey = "redpanda.vectorized.io/centralized-configuration-hash"
 		lastAppliedConfiguraitonHashKey = "redpanda.vectorized.io/last-applied-configuration"
 	)
+
+	deletePolicy := metav1.DeletePropagationForeground
+	foregroundDeleteOptions := &client.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	}
 
 	Context("When managing a RedpandaCluster with centralized config", func() {
 		It("Can initialize a cluster with centralized configuration", func() {
@@ -82,7 +88,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &sts, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should interact with the admin API when doing changes", func() {
@@ -140,7 +146,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should remove properties from the admin API when needed", func() {
@@ -229,7 +235,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should restart the cluster only when strictly required", func() {
@@ -330,7 +336,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(testAdminAPI.NumPatchesGetter(), timeoutShort, intervalShort).Should(Equal(numberOfPatches))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should defer updating the centralized configuration when admin API is unavailable", func() {
@@ -368,7 +374,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(testAdminAPI.PropertyGetter("prop")()).To(Equal(propValue))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 
@@ -415,7 +421,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey)()).To(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 
@@ -463,7 +469,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(testAdminAPI.NumPatchesGetter(), timeoutShort, intervalShort).Should(Equal(0))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should be able to upgrade and change a cluster even if the admin API is unavailable", func() {
@@ -539,7 +545,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(testAdminAPI.PropertyGetter("prop")()).To(Equal(propValue))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 
@@ -621,7 +627,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey)()).To(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should report direct validation errors in the condition", func() {
@@ -666,7 +672,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey)()).To(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 
 		It("Should report configuration errors present in the .bootstrap.yaml file", func() {
@@ -706,7 +712,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey)()).To(BeEmpty())
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 
@@ -765,7 +771,7 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Expect(testAdminAPI.PropertyGetter(unmanagedProp)()).To(Equal(externalChangeUnmanagedPropValue))
 
 			By("Deleting the cluster")
-			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), redpandaCluster, foregroundDeleteOptions)).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8230
Fixes https://github.com/redpanda-data/redpanda/issues/8239,