### PR TITLE
kafka: fix bugprone-branch-clone clang-tidy warning

### DIFF
--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -312,13 +312,10 @@ static void add_topic_config_if_requested(
 
 template<typename T>
 static ss::sstring maybe_print_tristate(const tristate<T>& tri) {
-    if (tri.is_disabled()) {
-        return "-1";
-    } else if (tri.has_value()) {
-        return ssx::sformat("{}", tri.value());
-    } else {
+    if (tri.is_disabled() || !tri.has_value()) {
         return "-1";
     }
+    return ssx::sformat("{}", tri.value());
 }
 
 template<typename T>

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -106,42 +106,41 @@ constexpr bool is_long = std::is_integral_v<T>&& num_bits<T> > 32
 // https://github.com/apache/kafka/blob/be032735b39360df1a6de1a7feea8b4336e5bcc0/core/src/main/scala/kafka/server/ConfigHelper.scala
 template<typename T>
 consteval describe_configs_type property_config_type() {
-    if constexpr (reflection::is_std_optional<T>) {
+    // clang-format off
+    constexpr auto is_string_type = std::is_same_v<T, ss::sstring> ||
+        std::is_same_v<T, model::compression> ||
+        std::is_same_v<T, model::cleanup_policy_bitflags> ||
+        std::is_same_v<T, model::timestamp_type> ||
+        std::is_same_v<T, config::data_directory_path> ||
+        std::is_same_v<T, v8_engine::data_policy>;
+
+    constexpr auto is_long_type = is_long<T> ||
+        // Long type since seconds is atleast a 35-bit signed integral
+        // https://en.cppreference.com/w/cpp/chrono/duration
+        std::is_same_v<T, std::chrono::seconds> ||
+        // Long type since milliseconds is atleast a 45-bit signed integral
+        // https://en.cppreference.com/w/cpp/chrono/duration
+        std::is_same_v<T, std::chrono::milliseconds>;
+    // clang-format on
+
+    if constexpr (
+      reflection::is_std_optional<T> || reflection::is_tristate<T>) {
         return property_config_type<typename T::value_type>();
-    } else if constexpr (reflection::is_tristate<T>) {
         return property_config_type<typename T::value_type>();
     } else if constexpr (std::is_same_v<T, bool>) {
         return describe_configs_type::boolean;
-    } else if constexpr (std::is_same_v<T, ss::sstring>) {
+    } else if constexpr (is_string_type) {
         return describe_configs_type::string;
     } else if constexpr (is_short<T>) {
         return describe_configs_type::short_type;
     } else if constexpr (is_int<T>) {
         return describe_configs_type::int_type;
-    } else if constexpr (is_long<T>) {
+    } else if constexpr (is_long_type) {
         return describe_configs_type::long_type;
     } else if constexpr (std::is_floating_point_v<T>) {
         return describe_configs_type::double_type;
     } else if constexpr (reflection::is_std_vector<T>) {
         return describe_configs_type::list;
-    } else if constexpr (std::is_same_v<T, model::compression>) {
-        return describe_configs_type::string;
-    } else if constexpr (std::is_same_v<T, model::cleanup_policy_bitflags>) {
-        return describe_configs_type::string;
-    } else if constexpr (std::is_same_v<T, std::chrono::seconds>) {
-        // Long type since seconds is atleast a 35-bit signed integral
-        // https://en.cppreference.com/w/cpp/chrono/duration
-        return describe_configs_type::long_type;
-    } else if constexpr (std::is_same_v<T, std::chrono::milliseconds>) {
-        // Long type since milliseconds is atleast a 45-bit signed integral
-        // https://en.cppreference.com/w/cpp/chrono/duration
-        return describe_configs_type::long_type;
-    } else if constexpr (std::is_same_v<T, model::timestamp_type>) {
-        return describe_configs_type::string;
-    } else if constexpr (std::is_same_v<T, config::data_directory_path>) {
-        return describe_configs_type::string;
-    } else if constexpr (std::is_same_v<T, v8_engine::data_policy>) {
-        return describe_configs_type::string;
     } else {
         static_assert(
           config::detail::dependent_false<T>::value,


### PR DESCRIPTION
Fix bugprone-branch-clone clang tidy warning.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->
  * none

