### PR TITLE
kafka: fix bugprone-clone-branch clang tidy warning

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -143,7 +143,7 @@ static error_code map_produce_error_code(std::error_code ec) {
         // map shutting down error code to timeout since replication result may
         // be not determined, it may succeed or be aborted earlier and abandoned
         case raft::errc::shutting_down:
-            return error_code::request_timed_out;
+            [[fallthrough]];
         default:
             return error_code::request_timed_out;
         }

--- a/src/v/outcome_tests.cc
+++ b/src/v/outcome_tests.cc
@@ -57,7 +57,7 @@ public:
     default_error_condition(int c) const noexcept override final {
         switch (static_cast<conversion_errc>(c)) {
         case conversion_errc::empty_string:
-            return make_error_condition(std::errc::invalid_argument);
+            [[fallthrough]];
         case conversion_errc::illegal_char:
             return make_error_condition(std::errc::invalid_argument);
         case conversion_errc::too_long:


### PR DESCRIPTION
kafka: fix bugprone-clone-branch clang tidy warning

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->
  * none

