### PR TITLE
tests: mark test_restore_with_aborted_tx ok_to_fail

### DIFF
--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import ok_to_fail
 from rptest.services.cluster import cluster
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.clients.types import TopicSpec
@@ -37,6 +38,7 @@ class CloudRetentionTest(PreallocNodesTest):
             si_settings=SISettings(log_segment_size=self.segment_size),
             extra_rp_conf=extra_rp_conf)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8251
     @cluster(num_nodes=4)
     def test_cloud_retention(self):
         """

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -17,6 +17,7 @@ from rptest.clients.rpk import RpkTool
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
 from rptest.utils.mode_checks import skip_debug_mode
+from ducktape.mark import ok_to_fail
 from ducktape.utils.util import wait_until
 import time
 import json
@@ -227,6 +228,7 @@ class EndToEndTopicRecovery(RedpandaTest):
         assert produce_acked >= num_messages
         assert consume_valid >= produce_acked, f"produced {produce_acked}, consumed {consume_valid}"
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/7955
     @cluster(num_nodes=5, log_allow_list=ALLOWED_ERROR_LOG_LINES)
     @matrix(recovery_overrides=[{}, {
         'retention.local.target.bytes': 1024,


### PR DESCRIPTION
Pending resolving the bug for 23.1

Related: https://github.com/redpanda-data/redpanda/issues/7955

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes


  * none
