### PR TITLE
tests/offset_for_leader_epoch: allow gaps in term space

### DIFF
--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -107,8 +107,12 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
                                                            leader_epoch=1)
 
         for o in leader_epoch_offsets:
+            # check if the offset epoch matches what is expected or it is not available
+            # (may be the case if leader wasn't elected in term 1 but other term in this case the offset for term 1 will not be presetn)
             assert initial_offsets[(o.topic,
-                                    o.partition)] == o.epoch_end_offset
+                                    o.partition)] == o.epoch_end_offset or (
+                                        o.epoch_end_offset == -1
+                                        and o.leader_epoch > 1)
 
         # restart all the nodes to force leader election,
         # increase start timeout as partition count may get large
@@ -123,7 +127,9 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
 
         for o in leader_epoch_offsets:
             assert initial_offsets[(o.topic,
-                                    o.partition)] == o.epoch_end_offset
+                                    o.partition)] == o.epoch_end_offset or (
+                                        o.epoch_end_offset == -1
+                                        and o.leader_epoch > 2)
 
         last_offsets = self.list_offsets(topics=topics,
                                          total_partitions=total_partitions)


### PR DESCRIPTION
In redpanda not every term increase result in a leader being elected. The test assumed that last offset for term `1` should always be preset but it may not be the case when election in term `1` was inconclusive.

Made the assertion in test aware of the fact that there may be a gap in term space.

Fixes: #7397


<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

  * none
