### PR TITLE
tests: fix wait_for_local_storage_truncate

### DIFF
--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -20,6 +20,8 @@ class Segment:
         self.data_file = None
         self.base_index = None
         self.compaction_index = None
+
+        # Size of data_file, if caller chooses to populate it via set_size
         self.size = None
 
     def add_file(self, fn, ext):
@@ -75,8 +77,12 @@ class Partition:
             seg.add_file(fn, ext)
 
     def set_segment_size(self, segment_name: str, size: int):
-        seg, _ = os.path.splitext(segment_name)
-        if not re.match(r"^\d+\-\d+\-v\d+$", seg):
+        """Set the data size of a segment: this is not the physical size of
+           all the segment's files, but just the size of the data part, excluding
+           space used by any indices.  This is usually what you care about, because
+           it's how Redpanda itself reasons about size for retention."""
+        seg, ext = os.path.splitext(segment_name)
+        if not (re.match(r"^\d+\-\d+\-v\d+$", seg) and ext == ".log"):
             return
         self.segments[seg].set_size(size)
 

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -222,11 +222,17 @@ def wait_for_local_storage_truncate(redpanda,
         storage = redpanda.storage(sizes=True)
         sizes = []
         for node_partition in storage.partitions("kafka", topic):
+            if node_partition.num != partition_idx:
+                continue
             total_size = sum(s.size if s.size else 0
                              for s in node_partition.segments.values())
             redpanda.logger.debug(
                 f"  {topic}/{partition_idx} node {node_partition.node.name} local size {total_size} ({len(node_partition.segments)} segments)"
             )
+            for s in node_partition.segments.values():
+                redpanda.logger.debug(
+                    f"    {topic}/{partition_idx} node {node_partition.node.name} {s.name} {s.size}"
+                )
             sizes.append(total_size)
 
         return all(s <= target_bytes for s in sizes)


### PR DESCRIPTION

This was causing some tests to proceed sooner than they should, because the size on disk was being underestimated.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
