### PR TITLE
Ducktape test to execute workloads through multi-release upgrades

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -14,7 +14,7 @@ import typing
 import time
 import itertools
 from collections import namedtuple
-from typing import Optional
+from typing import Iterator, Optional
 from ducktape.cluster.cluster import ClusterNode
 from rptest.util import wait_until_result
 from rptest.services import tls
@@ -382,7 +382,9 @@ class RpkTool:
         assert m, f"Reported offset not found in: {out}"
         return int(m.group(1))
 
-    def describe_topic(self, topic: str, tolerant: bool = False):
+    def describe_topic(self,
+                       topic: str,
+                       tolerant: bool = False) -> Iterator[RpkPartition]:
         """
         By default this will omit any partitions which do not have full
         metadata in the response: this means that if we are unlucky and a

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3485,7 +3485,9 @@ class RedpandaService(RedpandaServiceBase):
 
         return False
 
-    def search_log_any(self, pattern: str, nodes: list[ClusterNode] = None):
+    def search_log_any(self,
+                       pattern: str,
+                       nodes: Optional[list[ClusterNode]] = None):
         """
         Test helper for grepping the redpanda log.
         The design follows python's built-in any() function.
@@ -3505,7 +3507,9 @@ class RedpandaService(RedpandaServiceBase):
         # Fall through, no matches
         return False
 
-    def search_log_all(self, pattern: str, nodes: list[ClusterNode] = None):
+    def search_log_all(self,
+                       pattern: str,
+                       nodes: Optional[list[ClusterNode]] = None):
         # Test helper for grepping the redpanda log
         # The design follows python's  built-in all() function.
         # https://docs.python.org/3/library/functions.html#all

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import errno
+from functools import lru_cache
 import json
 import os
 import re
@@ -445,6 +446,7 @@ class RedpandaInstaller:
             latest_unsupported_line = (latest_unsupported_line[0] - 1, 3)
         return latest_unsupported_line
 
+    @lru_cache
     def highest_from_prior_feature_version(
             self, version: RedpandaVersion) -> RedpandaVersionTriple:
         """

--- a/tests/rptest/services/workload_protocol.py
+++ b/tests/rptest/services/workload_protocol.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from abc import abstractmethod
+from typing import Protocol, Optional, ClassVar, Any
+
+from rptest.services.redpanda_installer import RedpandaInstaller, RedpandaVersion, RedpandaVersionLine, RedpandaVersionTriple
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class PWorkload(Protocol):
+    DONE: ClassVar[int] = -1
+    NOT_DONE: ClassVar[int] = 1
+    """
+    member variable to access RedpandaTest facilities
+    """
+    ctx: RedpandaTest
+
+    def get_workload_name(self) -> str:
+        return self.__class__.__name__
+
+    def get_earliest_applicable_release(
+            self) -> Optional[RedpandaVersionLine | RedpandaVersionTriple]:
+        """
+        returns the earliest release that this Workload can operate on.
+        None -> use the oldest available release
+        (X, Y) -> use the latest minor version in line vX.Y
+        (X, Y, Z) -> use the release vX.Y.Z
+        """
+        return None
+
+    def get_latest_applicable_release(self) -> RedpandaVersion:
+        """
+        returns the latest release that this Workload can operate on.
+        RedpandaInstaller.HEAD -> use head version (compiled from source
+        (X, Y) -> use the latest minor version in line vX.Y
+        (X, Y, Z) -> use the release vX.Y.Z
+        """
+        return RedpandaInstaller.HEAD
+
+    def begin(self) -> None:
+        """
+        This method is called before starting the workload. the active redpanda version is self->get_earliest_applicable_relase().
+        use this method to set up the topic this workload will operate on, with a unique and descriptive name.
+        Additionally, this method should setup an external service that will produce and consume data from the topic.
+        """
+        return
+
+    def on_partial_cluster_upgrade(
+            self, versions: dict[Any, RedpandaVersionTriple]) -> int:
+        """
+        This method is called while upgrading a cluster, in a mixed state where some of the nodes will have the new version and some the old one.
+        versions is a dictionary of redpanda node->version 
+        """
+        return PWorkload.DONE
+
+    @abstractmethod
+    def on_cluster_upgraded(self, version: RedpandaVersionTriple) -> int:
+        """
+        This method is called to ensure that Workload is progressing on the active redpanda version
+        use this method to check the external services and the Workload invariants on the active redpanda version.
+        return self.DONE to signal that no further check is needed for this redpanda version
+        return self.NOT_DONE to signal that self.progress should be called again on this redpanda version
+        """
+        raise NotImplementedError
+
+    def end(self) -> None:
+        """
+        This method is called after the last call of progress, the repdanda active version is self.get_latest_applicable_release().
+        use this method to tear down external services and perform cleanup.
+        """
+        return

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -16,7 +16,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.default import DefaultClient
 from rptest.util import Scale
 from rptest.clients.types import TopicSpec
-from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.services.redpanda_installer import RedpandaInstaller, RedpandaVersion, RedpandaVersionTriple
 from rptest.clients.rpk import RpkTool
 
 
@@ -122,7 +122,7 @@ class RedpandaTest(Test):
             self.logger.debug(f"Creating initial topic {spec}")
             client.create_topic(spec)
 
-    def load_version_range(self, initial_version):
+    def load_version_range(self, initial_version: RedpandaVersion):
         """
         For tests that do upgrades: find all the latest versions from feature branches
         between the initial version and the head version.  Result is a list, inclusive of both initial
@@ -156,7 +156,7 @@ class RedpandaTest(Test):
             self.redpanda._installer.install(self.redpanda.nodes, v)
             return v
 
-        def logical_version_stable(old_logical_version):
+        def logical_version_stable(old_logical_version: int):
             """Assuming all nodes have been updated to a particular version,
             check that the cluster's active version has advanced to match the
             logical version of the node we are talking to.

--- a/tests/rptest/tests/workload_dummy.py
+++ b/tests/rptest/tests/workload_dummy.py
@@ -1,0 +1,71 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import uuid
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.workload_protocol import PWorkload
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class DummyWorkload(PWorkload):
+    def __init__(self, ctx) -> None:
+        self.ctx = ctx
+
+    def get_earliest_applicable_release(self):
+        self.ctx.logger.info(f"returning None")
+        return super().get_earliest_applicable_release()
+
+    def get_latest_applicable_release(self):
+        self.ctx.logger.info(f"returning HEAD")
+        return super().get_latest_applicable_release()
+
+    def begin(self):
+        self.ctx.logger.info("begin: No-op")
+        return
+
+    def end(self):
+        self.ctx.logger.info("end: no-op")
+
+    def on_partial_cluster_upgrade(self, versions) -> int:
+        self.ctx.logger.info(
+            f"partial_progress called with versions={ {n.account.hostname: v for n, v in versions.items()} }"
+        )
+        return super().on_partial_cluster_upgrade(versions)
+
+    def get_workload_name(self):
+        return "DummyWorkload"
+
+    def on_cluster_upgraded(self, version: tuple[int, int, int]) -> int:
+        versions = [
+            self.ctx.redpanda.get_version(n) for n in self.ctx.redpanda.nodes
+        ]
+        self.ctx.logger.info(f"got {version=}, running on {versions=}")
+        return PWorkload.DONE
+
+
+class MinimalWorkload(PWorkload):
+    def __init__(self, ctx: RedpandaTest) -> None:
+        self.ctx = ctx
+        self.topic = TopicSpec(
+            name=f"topic-{self.__class__.__name__}-{str(uuid.uuid4())}",
+            replication_factor=3)
+
+    def begin(self):
+        self.ctx.client().create_topic(self.topic)
+
+    def end(self):
+        self.ctx.client().delete_topic(self.topic.name)
+
+    def on_cluster_upgraded(self, version: tuple[int, int, int]) -> int:
+        offset = RpkTool(self.ctx.redpanda).produce(topic=self.topic.name,
+                                                    key=f"{version}",
+                                                    msg=str(uuid.uuid4()))
+        self.ctx.logger.info(f"produced to {self.topic.name} at {offset=}")
+        return PWorkload.DONE

--- a/tests/rptest/tests/workload_license.py
+++ b/tests/rptest/tests/workload_license.py
@@ -1,0 +1,131 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+from requests.exceptions import HTTPError
+from rptest.services.admin import Admin
+from rptest.services.workload_protocol import PWorkload
+from rptest.utils.rpenv import sample_license
+from typing import Optional
+
+
+class LicenseWorkload(PWorkload):
+    """
+    Test that ensures the licensing work does not incorrectly print license
+    enforcement errors during upgrade when a guarded feature is already
+    enabled. Also tests that the license can only be uploaded once the cluster
+    has completed upgrade to the latest version.
+    """
+    LICENSE_CHECK_INTERVAL_SEC = 1
+
+    def __init__(self, ctx) -> None:
+        self.ctx = ctx
+        self.first_license_check: Optional[float] = None
+        self.license_installed = False
+        self.license: Optional[str] = None
+        self.installed_license_timeout: Optional[float] = None
+        self.assert_admin_done = False
+
+    def get_earliest_applicable_release(self):
+        return (22, 1)  # last version without the license feature
+
+    def begin(self):
+        self.license = sample_license()
+        if self.license is None:
+            self.ctx.logger.info(
+                "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
+            return
+
+        self.ctx.redpanda.set_environment({
+            '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
+            f'{LicenseWorkload.LICENSE_CHECK_INTERVAL_SEC}'
+        })
+
+    def on_partial_cluster_upgrade(self, versions) -> int:
+        if self.license is None:
+            return PWorkload.DONE
+
+        if len([v for _, v in versions.items() if v[0:2] <= (22, 1)]) > 0:
+            self.first_license_check = self.first_license_check or (
+                time.time() + LicenseWorkload.LICENSE_CHECK_INTERVAL_SEC * 2)
+            # Ensure a valid license cannot be uploaded in this cluster state
+            try:
+                Admin(self.ctx.redpanda).put_license(self.license)
+                assert False
+            except HTTPError as e:
+                assert e.response.status_code == 400
+
+            # Ensure the log is not written, if the fiber was enabled a log should
+            # appear within one interval of the license check fiber
+            if self.first_license_check > time.time():
+                return PWorkload.NOT_DONE
+
+            assert self.ctx.redpanda.search_log_any(
+                "Enterprise feature(s).*") is False
+            return PWorkload.DONE
+
+        return PWorkload.DONE
+
+    def on_cluster_upgraded(self, version: tuple[int, int, int]) -> int:
+        # skip test
+        if self.license is None:
+            return PWorkload.DONE
+
+        # just check that no log nag is present
+        if version[0:2] <= (22, 1):
+            # These logs can't exist in v22.1 but double check anyway...
+            assert self.ctx.redpanda.search_log_any(
+                "Enterprise feature(s).*") is False
+            return PWorkload.DONE
+
+        # license is installable
+        admin = Admin(self.ctx.redpanda)
+
+        if not self.assert_admin_done:
+            assert admin.supports_feature("license")
+            self.assert_admin_done = True
+
+        # first license installation
+        if not self.license_installed:
+            self.first_license_check = self.first_license_check or (
+                time.time() + LicenseWorkload.LICENSE_CHECK_INTERVAL_SEC * 2)
+            # ensure that enought time passed for log nag to appear
+            if self.first_license_check > time.time():
+                return PWorkload.NOT_DONE
+
+            # check for License nag in the log
+            found_nag = self.ctx.redpanda.search_log_any(
+                "Enterprise feature(s).*")
+            if not found_nag:
+                if self.first_license_check > time.time():
+                    return PWorkload.NOT_DONE
+                else:
+                    assert False, "License nag log not found"
+
+            # Install license
+            assert admin.put_license(self.license).status_code == 200
+            self.license_installed = True
+            return PWorkload.DONE
+
+        # license was installed and this is a new version of redpanda
+        self.installed_license_timeout = self.installed_license_timeout or (
+            time.time() + 30)
+
+        assert self.installed_license_timeout >= time.time(
+        ), "Timeout of installed license check"
+
+        # Attempt to read license written by older version
+        cluster_license = admin.get_license()
+
+        if cluster_license is not None and cluster_license['loaded'] is True:
+            self.installed_license_timeout = None  # check complete for this version
+            return PWorkload.DONE
+        else:
+            # check needs more time
+            return PWorkload.NOT_DONE

--- a/tests/rptest/tests/workload_producer_consumer.py
+++ b/tests/rptest/tests/workload_producer_consumer.py
@@ -1,0 +1,127 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import uuid
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
+from rptest.services.workload_protocol import PWorkload
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.utils.si_utils import BucketView, quiesce_uploads
+
+
+class ProducerConsumerWorkload(PWorkload):
+    """
+    This workload will setup a KGoProducer/Consumer to verify operations across an upgrade
+    """
+    def __init__(self, ctx: PreallocNodesTest) -> None:
+        self.ctx = ctx
+        self.rpk = RpkTool(self.ctx.redpanda)
+        self.last_uploaded_kafka_offset = 0
+
+        is_debug = self.ctx.debug_mode
+
+        # setup a produce workload that should span the whole test run, and then add a buffer to it
+        produce_byte_rate = 256 * 1024  # a quarter of Mb per second
+        target_runtime_secs = 20 * 60
+        self.MSG_SIZE = 256
+        self.PRODUCE_COUNT = (produce_byte_rate *
+                              target_runtime_secs) // self.MSG_SIZE
+        # the topic is requires less resources in debug mode for the sake of the test
+        self.topic = TopicSpec(
+            name=f"topic-{self.__class__.__name__}-{str(uuid.uuid4())}",
+            partition_count=1 if is_debug else 3,
+            replication_factor=1 if is_debug else 3,
+            redpanda_remote_write=True,
+            redpanda_remote_read=True,
+            segment_bytes=1024 * 1024,
+            retention_bytes=
+            1024,  # this low value will indirectly speed up the upload of segments
+        )
+
+        self._producer = KgoVerifierProducer(
+            self.ctx.test_context,
+            self.ctx.redpanda,
+            self.topic,
+            msg_size=self.MSG_SIZE,
+            msg_count=self.PRODUCE_COUNT,
+            rate_limit_bps=produce_byte_rate,
+            custom_node=self.ctx.preallocated_nodes)
+        self._seq_consumer = KgoVerifierSeqConsumer(
+            self.ctx.test_context,
+            self.ctx.redpanda,
+            self.topic,
+            self.MSG_SIZE,
+            nodes=self.ctx.preallocated_nodes)
+
+    def begin(self):
+        self.rpk.cluster_config_set("cloud_storage_enabled", "true")
+        # ensure cloud storage is enabled
+        assert self.rpk.cluster_config_get("cloud_storage_enabled") == "true"
+
+        self.ctx.client().create_topic(self.topic)
+        # double check the topic is configured correctly
+        topic_cfg = self.ctx.client().describe_topic_configs(self.topic.name)
+        assert topic_cfg["redpanda.remote.read"].value == "true" and topic_cfg[
+            "redpanda.remote.write"].value == "true"
+
+        self._producer.start(clean=False)
+        self._producer.wait_for_offset_map()
+        self._seq_consumer.start(clean=False)
+
+    def end(self):
+        self._producer.stop()
+        self._producer.wait()
+        self._seq_consumer.wait()
+        wrote_at_least = self._producer.produce_status.acked
+        assert self._seq_consumer.consumer_status.validator.valid_reads >= wrote_at_least
+
+        self.ctx.client().delete_topic(self.topic.name)
+
+    def get_earliest_applicable_release(self):
+        return (22, 3)
+
+    def on_cluster_upgraded(self, version: tuple[int, int, int]) -> int:
+        """
+        query remote storage and compute uploaded_kafka_offset, to check that progress is made
+        """
+        major_version = version[0:2]
+        quiesce_uploads(self.ctx.redpanda, [self.topic.name], 120)
+
+        # get the manifest for a topic and do some checking
+        topic_description = self.rpk.describe_topic(self.topic.name)
+        partition_zero = next(topic_description)
+
+        bucket = BucketView(self.ctx.redpanda)
+        manifest = bucket.manifest_for_ntp(self.topic.name, partition_zero.id)
+
+        if major_version < (23, 2):
+            assert manifest[
+                'version'] <= 1, f"Manifest version {manifest['version']} is not <= 1"
+        else:
+            # 23.2 starts to use the new manifest. wait until it gets uploaded
+            if manifest['version'] < 2:
+                return PWorkload.NOT_DONE
+
+        if not ("segments" in manifest and len(manifest['segments']) > 0):
+            # no segments uploaded yet
+            return PWorkload.NOT_DONE
+
+        # retrieve highest committed kafka offset and check that progress is made
+        top_segment = max(manifest['segments'].values(),
+                          key=lambda seg: seg['base_offset'])
+        uploaded_raft_offset = top_segment['committed_offset']
+        uploaded_kafka_offset = uploaded_raft_offset - top_segment[
+            'delta_offset_end']
+
+        if uploaded_kafka_offset > self.last_uploaded_kafka_offset:
+            self.last_uploaded_kafka_offset = uploaded_kafka_offset
+            return PWorkload.DONE
+
+        return PWorkload.NOT_DONE

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -21,6 +21,7 @@ from rptest.tests.workload_producer_consumer import ProducerConsumerWorkload
 from rptest.tests.workload_dummy import DummyWorkload, MinimalWorkload
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.workload_license import LicenseWorkload
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 def expand_version(
@@ -245,6 +246,7 @@ class RedpandaUpgradeTest(PreallocNodesTest):
     def cluster_version(self) -> int:
         return Admin(self.redpanda).get_features()['cluster_version']
 
+    @skip_debug_mode
     @cluster(num_nodes=4)
     def test_workloads_through_releases(self):
         # this callback will be called between each upgrade, in a mixed version state

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -1,0 +1,323 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import traceback
+from typing import Any, Optional
+from rptest.clients.offline_log_viewer import OfflineLogViewer
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
+from rptest.services.redpanda import SISettings
+from rptest.services.redpanda_installer import RedpandaInstaller, RedpandaVersion, RedpandaVersionTriple
+from rptest.services.workload_protocol import PWorkload
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.tests.workload_producer_consumer import ProducerConsumerWorkload
+from rptest.tests.workload_dummy import DummyWorkload, MinimalWorkload
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.workload_license import LicenseWorkload
+
+
+def expand_version(
+        installer: RedpandaInstaller,
+        version: Optional[RedpandaVersion]) -> RedpandaVersionTriple:
+    if version is None:
+        # return latest unsupported version
+        return installer.latest_for_line(
+            installer.latest_unsupported_line())[0]
+
+    if version == RedpandaInstaller.HEAD:
+        return installer.head_version()
+
+    if len(version) == 3:
+        return version
+
+    # version is a release line, get latest minor for it
+    return installer.latest_for_line(version)[0]
+
+
+class WorkloadAdapter(PWorkload):
+    """
+    WorkloadAdapter is a wrapper around a PWorkload that keeps track of the state and save the error if one occurs.
+    """
+    NOT_STARTED = "not_started"
+    STARTED = "started"
+    STOPPED = "stopped"
+    STOPPED_WITH_ERROR = "stopped_with_error"
+
+    def __init__(self, workload: PWorkload, ctx: RedpandaTest,
+                 installer: RedpandaInstaller) -> None:
+        self.workload = workload
+        self.ctx = ctx
+        self.installer = installer
+        self.state = WorkloadAdapter.NOT_STARTED
+        self.error: Optional[Exception] = None
+        self.earliest_v: Optional[tuple[int, int, int]] = None
+        self.latest_v: Optional[tuple[int, int, int]] = None
+        self.last_method_execution: dict[str, float] = {}
+
+    def get_earliest_applicable_release(self) -> tuple[int, int, int]:
+        if self.earliest_v is None:
+            self.earliest_v = expand_version(
+                self.installer,
+                self.workload.get_earliest_applicable_release())
+
+        return self.earliest_v
+
+    def get_latest_applicable_release(self) -> tuple[int, int, int]:
+        if self.latest_v is None:
+            self.latest_v = expand_version(
+                self.installer, self.workload.get_latest_applicable_release())
+        return self.latest_v
+
+    def _exec_workload_method(self, final_state: str, method_name: str, *args):
+        """
+        Executes a workload method and updates the state accordingly.
+        Exceptions are saved and will prevent future execution of any method
+        Execution is throttled to once per second
+        """
+        if self.state == WorkloadAdapter.STOPPED_WITH_ERROR:
+            return None
+
+        if method_name in self.last_method_execution and (
+                self.last_method_execution[method_name] + 1) > time.time():
+            # throttle execution: do not execute more than once per second
+            return PWorkload.NOT_DONE
+
+        try:
+            result = getattr(self.workload, method_name)(*args)
+            self.state = final_state
+            if result == PWorkload.DONE and method_name in self.last_method_execution:
+                # reset execution time for next round
+                self.last_method_execution.pop(method_name)
+            else:
+                # keep track of execution time
+                self.last_method_execution[method_name] = time.time()
+            return result
+        except Exception as e:
+            self.ctx.logger.error(
+                f"{self.workload.get_workload_name()} Exception in {method_name}(): {traceback.format_exception(e)}"
+            )
+            # the stacktrace is captured and saved in the trace variable
+            # so that it can be used in the error message
+            # along with time of failure
+            self.time_of_failure = time.time()
+            self.error = e
+            self.state = WorkloadAdapter.STOPPED_WITH_ERROR
+            try:
+                # attempt at cleanup anyway
+                self.workload.end()
+            except:
+                pass
+            return None
+
+    def begin(self):
+        self._exec_workload_method(WorkloadAdapter.STARTED,
+                                   PWorkload.begin.__name__)
+
+    def end(self):
+        self._exec_workload_method(WorkloadAdapter.STOPPED,
+                                   PWorkload.end.__name__)
+
+    def on_partial_cluster_upgrade(self,
+                                   versions: dict[Any, RedpandaVersionTriple]):
+        res = self._exec_workload_method(
+            self.state, PWorkload.on_partial_cluster_upgrade.__name__,
+            versions)
+        return res if res is not None else PWorkload.DONE
+
+    def get_workload_name(self):
+        return self.workload.get_workload_name()
+
+    def on_cluster_upgraded(self, version: RedpandaVersionTriple):
+        res = self._exec_workload_method(
+            self.state, PWorkload.on_cluster_upgraded.__name__, version)
+        return res if res is not None else PWorkload.DONE
+
+
+class RedpandaUpgradeTest(PreallocNodesTest):
+    def __init__(self, test_context):
+        # si_settings are needed for LicenseWorkload
+        super().__init__(test_context=test_context,
+                         num_brokers=3,
+                         si_settings=SISettings(test_context),
+                         node_prealloc_count=1,
+                         node_ready_timeout_s=60)
+        # it is expected that older versions of redpanda will generate this kind of errors, at least while we keep testing from v23.x
+        self.redpanda.si_settings.set_expected_damage({
+            'ntr_no_topic_manifest',
+            'ntpr_no_manifest',
+            'unknown_keys',
+            'missing_segments',
+        })
+
+        self.installer = self.redpanda._installer
+
+        # workloads that will be executed during this test
+        workloads: list[PWorkload] = [
+            DummyWorkload(self),
+            MinimalWorkload(self),
+            LicenseWorkload(self),
+            ProducerConsumerWorkload(self),
+        ]
+
+        # setup self as context for the workloads
+        self.adapted_workloads: list[WorkloadAdapter] = [
+            WorkloadAdapter(workload=w, ctx=self, installer=self.installer)
+            for w in workloads
+        ]
+
+        self.upgrade_steps: list[RedpandaVersionTriple] = []
+
+    def setUp(self):
+        # at the end of setUp, self.upgrade_steps will look like this:
+        # [(22, 1, 11), (22, 1, 10), (22, 1, 11),
+        #  (22, 2, 11), (22, 2, 10), (22, 2, 11),
+        #  (22, 3, 16), (22, 3, 15), (22, 3, 16),
+        #  (23, 1, 7), (23, 1, 6), (23, 1, 7),
+        #  (23, 2, 0)]
+
+        # compute the upgrade steps, merging the upgrade steps of each workload
+        workloads_steps = [
+            self.load_version_range(w.get_earliest_applicable_release())
+            for w in self.adapted_workloads
+        ]
+
+        latest_unsupported_line = self.installer.latest_unsupported_line()
+        # keeping only releases older than latest EOL.
+        forward_upgrade_steps = [
+            v for v in sorted(set(sum(workloads_steps, start=[])))
+            if v >= latest_unsupported_line
+        ]
+
+        # for each version, include a downgrade step to previous patch, then go to latest patch
+        self.upgrade_steps: list[RedpandaVersionTriple] = []
+        prev = forward_upgrade_steps[0]
+        for v in forward_upgrade_steps:
+            if v[0:2] != prev[0:2] and prev[2] > 1:
+                # if the line has changed, add previous patch and again latest for line
+                previous_patch = (prev[0], prev[1], prev[2] - 1)
+                self.upgrade_steps.extend([previous_patch, prev])
+            self.upgrade_steps.append(v)
+            # update the latest_current_line
+            prev = v
+
+        self.logger.info(f"going through these versions: {self.upgrade_steps}")
+
+    def _check_workload_list(self,
+                             to_check_list: list[WorkloadAdapter],
+                             version_param: RedpandaVersionTriple
+                             | dict[Any, RedpandaVersionTriple],
+                             partial_update: bool = False):
+        # run checks on all the workloads in the to_check_list
+        # each check could take multiple runs, so loop on a list of it until exhaustion
+
+        str_update_kind = "progress check done" if not partial_update else "partial progress check done"
+        progress_lambda = lambda w, v_param: w.on_cluster_upgraded(v_param) if not partial_update \
+                                                            else w.on_partial_cluster_upgrade(v_param)
+
+        while len(to_check_list) > 0:
+            start_time = time.time()
+            self.logger.info(
+                f"checking { str_update_kind }progress for {[w.get_workload_name() for w in to_check_list]}"
+            )
+            # check progress of each workload in the to_check_list
+            # and if a workload is done, remove it from the list
+            status_progress = {
+                w: progress_lambda(w, version_param)
+                for w in to_check_list
+            }
+            for w, state in status_progress.items():
+                if state == PWorkload.DONE:
+                    self.logger.info(
+                        f"{w.get_workload_name()} {str_update_kind}")
+                    to_check_list.remove(w)
+
+            if delay := 1 - (time.time() - start_time) > 0:
+                # ensure that checks are not performed too fast, by requesting a delay of 1 second
+                time.sleep(delay)
+
+    def cluster_version(self) -> int:
+        return Admin(self.redpanda).get_features()['cluster_version']
+
+    @cluster(num_nodes=4)
+    def test_workloads_through_releases(self):
+        # this callback will be called between each upgrade, in a mixed version state
+        def mid_upgrade_check(raw_versions: dict[Any, RedpandaVersion]):
+            rp_versions = {
+                k: expand_version(self.installer, v)
+                for k, v in raw_versions.items()
+            }
+            next_version = max(rp_versions.values())
+            # check only workload that are active and that can operate with next_version
+            to_check_workloads = [
+                w for w in self.adapted_workloads
+                if w.state == WorkloadAdapter.STARTED
+                and next_version <= w.get_latest_applicable_release()
+            ]
+            self._check_workload_list(to_check_list=to_check_workloads,
+                                      version_param=rp_versions,
+                                      partial_update=True)
+
+        # upgrade loop: for each version
+        for current_version in self.upgrade_through_versions(
+                self.upgrade_steps,
+                already_running=False,
+                mid_upgrade_check=mid_upgrade_check):
+            current_version = expand_version(self.installer, current_version)
+            # setup workload that could start at current_version
+            for w in self.adapted_workloads:
+                if w.state == WorkloadAdapter.NOT_STARTED and current_version >= w.get_earliest_applicable_release(
+                ):
+                    self.logger.info(f"setup {w.get_workload_name()}")
+                    w.begin()  # this will set in a STARTED state
+
+            # run checks on all the started workload.
+            # each check could take multiple runs, so loop on a list of it until exhaustion
+            self._check_workload_list(to_check_list= \
+                                      [w for w in self.adapted_workloads if w.state == WorkloadAdapter.STARTED],
+                                      version_param=current_version)
+
+            # stop workload that can't operate with next_version
+            for w in self.adapted_workloads:
+                if w.state == WorkloadAdapter.STARTED and current_version == w.get_latest_applicable_release(
+                ):
+                    self.logger.info(f"teardown of {w.get_workload_name()}")
+                    w.end()
+
+            # quick exit: terminate loop if no workload is active
+            if len([
+                    w for w in self.adapted_workloads
+                    if w.state == WorkloadAdapter.STARTED
+                    or w.state == WorkloadAdapter.NOT_STARTED
+            ]) == 0:
+                self.logger.info(
+                    f"terminating upgrade loop at version {current_version}, no workload is active"
+                )
+                break
+
+        # check workloads stopped with error, and format the exceptions into concat_error
+        concat_error: list[str] = []
+        for w in self.adapted_workloads:
+            if w.state == WorkloadAdapter.STOPPED_WITH_ERROR:
+                concat_error.append(
+                    f"{w.get_workload_name()} failed at {w.time_of_failure} - {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(w.time_of_failure))}"
+                )
+                concat_error.extend(traceback.format_exception(w.error))
+        # if concat_error is not empty, raise it as an exception
+        if len(concat_error) > 0:
+            raise Exception("\n".join(concat_error))
+
+        # Validate that the data structures written by a mixture of historical
+        # versions remain readable by our current debug tools
+        log_viewer = OfflineLogViewer(self.redpanda)
+        for node in self.redpanda.nodes:
+            controller_records = log_viewer.read_controller(node=node)
+            self.logger.info(
+                f"Read {len(controller_records)} controller records from node {node.name} successfully"
+            )


### PR DESCRIPTION
A framework to execute tests on a sequence of redpanda versions, composed of 2 components:
- PWorkload, an interface to implement
- RedpandaUpgradeTest, a test that runs a collection of PWorkloads through a cluster while upgrading it

A Workload can implement PWorkload, spin up an external producer/consumer, and check progress on the external service in a stable and upgrading cluster.
Workloads run in parallel, so care should be taken not to disrupt other workloads, like changing cluster properties or removing nodes. 

Various tests implementing a upgrading+testing pattern can be moved to this test to reduce the number of tests and total ci execution time while doing a more rigorous test.


Fixes https://github.com/redpanda-data/redpanda/issues/7310

<!--
-
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
 * none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
