### PR TITLE
tests: reduce use of segment counting

### DIFF
--- a/tests/rptest/tests/e2e_iam_role_test.py
+++ b/tests/rptest/tests/e2e_iam_role_test.py
@@ -4,7 +4,7 @@ from rptest.clients.types import TopicSpec
 from rptest.services.mock_iam_roles_server import MockIamRolesServer
 from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST
 from rptest.tests.e2e_shadow_indexing_test import EndToEndShadowIndexingBase
-from rptest.util import produce_until_segments, wait_for_segments_removal
+from rptest.util import produce_until_segments, wait_for_local_storage_truncate
 
 
 class AWSRoleFetchTests(EndToEndShadowIndexingBase):
@@ -43,17 +43,17 @@ class AWSRoleFetchTests(EndToEndShadowIndexingBase):
             count=10,
         )
 
+        local_retention = 5 * self.segment_size
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
                 TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
-                5 * self.segment_size,
+                local_retention,
             },
         )
-        wait_for_segments_removal(redpanda=self.redpanda,
-                                  topic=self.topic,
-                                  partition_idx=0,
-                                  count=6)
+        wait_for_local_storage_truncate(redpanda=self.redpanda,
+                                        topic=self.topic,
+                                        target_bytes=local_retention)
         self.start_consumer()
         self.run_validation()
 
@@ -117,17 +117,14 @@ class STSRoleFetchTests(EndToEndShadowIndexingBase):
             count=10,
         )
 
+        local_retention = 5 * self.segment_size
         self.kafka_tools.alter_topic_config(
             self.topic,
-            {
-                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
-                5 * self.segment_size,
-            },
+            {TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES: local_retention},
         )
-        wait_for_segments_removal(redpanda=self.redpanda,
-                                  topic=self.topic,
-                                  partition_idx=0,
-                                  count=6)
+        wait_for_local_storage_truncate(self.redpanda,
+                                        self.topic,
+                                        target_bytes=local_retention)
         self.start_consumer()
         self.run_validation()
 
@@ -188,17 +185,14 @@ class ShortLivedCredentialsTests(EndToEndShadowIndexingBase):
             count=10,
         )
 
+        local_retention = 5 * self.segment_size
         self.kafka_tools.alter_topic_config(
             self.topic,
-            {
-                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
-                5 * self.segment_size,
-            },
+            {TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES: local_retention},
         )
-        wait_for_segments_removal(redpanda=self.redpanda,
-                                  topic=self.topic,
-                                  partition_idx=0,
-                                  count=6)
+        wait_for_local_storage_truncate(self.redpanda,
+                                        self.topic,
+                                        target_bytes=local_retention)
         self.start_consumer()
         self.run_validation()
 

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -333,8 +333,8 @@ class EndToEndTopicRecovery(RedpandaTest):
                                "1024")
         wait_for_local_storage_truncate(self.redpanda,
                                         self.topic,
-                                        0,
-                                        int(msg_size * msg_count * 0.5),
+                                        target_bytes=int(msg_size * msg_count *
+                                                         0.5),
                                         timeout_sec=30)
         validate()
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -23,7 +23,7 @@ from rptest.services.redpanda import ResourceSettings, SISettings
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.services.rpk_producer import RpkProducer
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.util import wait_for_segments_removal, expect_exception
+from rptest.util import wait_for_local_storage_truncate, expect_exception
 from rptest.utils.mode_checks import skip_azure_blob_storage
 from rptest.clients.kcl import KCL
 
@@ -494,10 +494,18 @@ class CreateTopicUpgradeTest(RedpandaTest):
         )
         self.redpanda.start()
 
-    def _populate_tiered_storage_topic(self, topic_name):
-        for n in range(0, 8):
-            self.rpk.produce(topic_name, "key", "b" * 512 * 1024)
-        wait_for_segments_removal(self.redpanda, topic_name, 0, 1)
+    def _populate_tiered_storage_topic(self, topic_name, local_retention):
+        # Write 3x the local retention, then wait for local storage to be
+        # trimmed back accordingly.
+        bytes = local_retention * 3
+        msg_size = 131072
+        msg_count = bytes // msg_size
+        for n in range(0, msg_count):
+            self.rpk.produce(topic_name, "key", "b" * msg_size)
+
+        wait_for_local_storage_truncate(self.redpanda,
+                                        topic=topic_name,
+                                        target_bytes=local_retention)
 
     @cluster(num_nodes=3)
     @skip_azure_blob_storage
@@ -573,10 +581,11 @@ class CreateTopicUpgradeTest(RedpandaTest):
         self.rpk.create_topic("test-topic-with-retention",
                               config={"retention.bytes": 10000})
 
+        local_retention = 10000
         self.rpk.create_topic(
             "test-si-topic-with-retention",
             config={
-                "retention.bytes": 10000,
+                "retention.bytes": str(local_retention),
                 "redpanda.remote.write": "true",
                 "redpanda.remote.read": "true",
                 # Small segment.bytes so that we can readily
@@ -586,7 +595,8 @@ class CreateTopicUpgradeTest(RedpandaTest):
 
         # Write a few megabytes of data, enough to spill to S3.  This will be used
         # later for checking that deletion behavior is correct on legacy topics.
-        self._populate_tiered_storage_topic("test-si-topic-with-retention")
+        self._populate_tiered_storage_topic("test-si-topic-with-retention",
+                                            local_retention)
 
         # This topic is like "test-si-topic-with-retention", but instead
         # of settings its properties at creation time, set them via
@@ -664,10 +674,14 @@ class CreateTopicUpgradeTest(RedpandaTest):
         for (new_topic_name,
              enable_si) in [("test-topic-post-upgrade-nosi", False),
                             ("test-topic-post-upgrade-si", True)]:
+
+            segment_bytes = 1000000
+            local_retention = segment_bytes * 2
+            retention_bytes = segment_bytes * 10
             create_config = {
-                "retention.bytes": 10000,
-                "retention.local.target.bytes": 5000,
-                "segment.bytes": 1000000
+                "retention.bytes": retention_bytes,
+                "retention.local.target.bytes": local_retention,
+                "segment.bytes": segment_bytes
             }
             if enable_si:
                 create_config['redpanda.remote.write'] = 'true'
@@ -676,13 +690,13 @@ class CreateTopicUpgradeTest(RedpandaTest):
             self.rpk.create_topic(new_topic_name, config=create_config)
             new_config = self.rpk.describe_topic_configs(new_topic_name)
             assert new_config["redpanda.remote.delete"][0] == "true"
-            assert new_config["retention.bytes"] == ("10000",
+            assert new_config["retention.bytes"] == (str(retention_bytes),
                                                      "DYNAMIC_TOPIC_CONFIG")
             assert new_config["retention.ms"][1] == "DEFAULT_CONFIG"
             assert new_config["retention.local.target.ms"][
                 1] == "DEFAULT_CONFIG"
             assert new_config["retention.local.target.bytes"] == (
-                "5000", "DYNAMIC_TOPIC_CONFIG")
+                str(local_retention), "DYNAMIC_TOPIC_CONFIG")
             if enable_si:
                 assert new_config['redpanda.remote.write'][0] == "true"
                 assert new_config['redpanda.remote.read'][0] == "true"
@@ -692,7 +706,8 @@ class CreateTopicUpgradeTest(RedpandaTest):
             assert new_config['redpanda.remote.delete'][0] == "true"
 
             if enable_si:
-                self._populate_tiered_storage_topic(new_topic_name)
+                self._populate_tiered_storage_topic(new_topic_name,
+                                                    local_retention)
 
         # A newly created tiered storage topic should have its data deleted
         # in S3 when the topic is deleted

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -221,8 +221,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         for i in range(0, self.partition_count):
             wait_for_local_storage_truncate(self.redpanda,
                                             topic_name,
-                                            i,
-                                            local_retention,
+                                            partition_idx=i,
+                                            target_bytes=local_retention,
                                             timeout_sec=30,
                                             nodes=nodes)
 

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -459,13 +459,11 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
             produce(p, n_records)
 
         # Wait for archiver to upload to S3
-        for p in range(0, n_partitions):
-            wait_for_local_storage_truncate(self.redpanda,
-                                            topic,
-                                            p,
-                                            local_retention_bytes +
-                                            segment_bytes,
-                                            timeout_sec=30)
+        wait_for_local_storage_truncate(self.redpanda,
+                                        topic,
+                                        target_bytes=local_retention_bytes +
+                                        segment_bytes,
+                                        timeout_sec=30)
 
         # Restart 2/3 nodes, leave last node on old version
         self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
@@ -502,12 +500,12 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
         else:
             # In the general case, S3 PUTs are permitted during upgrade, so we should
             # see local storage getting truncated
-            wait_for_local_storage_truncate(self.redpanda,
-                                            topic,
-                                            newdata_p,
-                                            local_retention_bytes +
-                                            segment_bytes,
-                                            timeout_sec=30)
+            wait_for_local_storage_truncate(
+                self.redpanda,
+                topic,
+                partition_idx=newdata_p,
+                target_bytes=local_retention_bytes + segment_bytes,
+                timeout_sec=30)
 
         # Move leadership to the old version node and check the partition is readable
         # from there.
@@ -535,8 +533,9 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
 
         wait_for_local_storage_truncate(self.redpanda,
                                         topic,
-                                        newdata_p,
-                                        local_retention_bytes + segment_bytes,
+                                        partition_idx=newdata_p,
+                                        target_bytes=local_retention_bytes +
+                                        segment_bytes,
                                         timeout_sec=30)
 
 

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -213,7 +213,7 @@ def wait_for_removal_of_n_segments(redpanda, topic: str, partition_idx: int,
 
 def wait_for_local_storage_truncate(redpanda,
                                     topic: str,
-                                    partition_idx: int,
+                                    partition_idx: Optional[int],
                                     target_bytes: int,
                                     timeout_sec: Optional[int] = None,
                                     nodes: Optional[list] = None):
@@ -225,8 +225,9 @@ def wait_for_local_storage_truncate(redpanda,
         storage = redpanda.storage(sizes=True)
         sizes = []
         for node_partition in storage.partitions("kafka", topic):
-            if node_partition.num != partition_idx:
+            if partition_idx is not None and node_partition.num != partition_idx:
                 continue
+
             if nodes is not None and node_partition.node not in nodes:
                 continue
 


### PR DESCRIPTION
The wait_for_segments_removal function was only used correctly
in one place (when retention_test uses small time-based retention).
All the other usage sites should have been checking the size in bytes
rather than the segment count.

Using a byte size rather than a segment count is much more robust,
in case of refactoring or runtime situations that
result in segment rolls.

## Backports Required


- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes


  * none

