### PR TITLE
features: gssapi principal mapping rules

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -14,6 +14,7 @@
 #include "config/node_config.h"
 #include "config/validators.h"
 #include "model/metadata.h"
+#include "security/gssapi_principal_mapper.h"
 #include "security/mtls.h"
 #include "storage/chunk_cache.h"
 #include "storage/segment_appender.h"
@@ -849,6 +850,13 @@ configuration::configuration()
       "The primary of the Kerberos Service Principal Name (SPN) for Redpanda",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       "redpanda")
+  , sasl_kerberos_principal_mapping(
+      *this,
+      "sasl_kerberos_principal_mapping",
+      "Rules for mapping Kerberos Service Principal Name (SPN) to Redpanda",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      {"DEFAULT"},
+      security::validate_kerberos_mapping_rules)
   , kafka_enable_authorization(
       *this,
       "kafka_enable_authorization",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -181,6 +181,7 @@ struct configuration final : public config_store {
     property<std::vector<ss::sstring>> sasl_mechanisms;
     property<ss::sstring> sasl_kerberos_keytab;
     property<ss::sstring> sasl_kerberos_principal;
+    property<std::vector<ss::sstring>> sasl_kerberos_principal_mapping;
     property<std::optional<bool>> kafka_enable_authorization;
     property<std::optional<std::vector<ss::sstring>>>
       kafka_mtls_principal_mapping_rules;

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     acl.cc
     mtls.cc
     license.cc
+    gssapi_principal_mapper.cc
   DEPS
     v::bytes
     v::utils

--- a/src/v/security/gssapi_principal_mapper.cc
+++ b/src/v/security/gssapi_principal_mapper.cc
@@ -426,6 +426,16 @@ std::ostream& operator<<(std::ostream& os, const gssapi_principal_mapper& m) {
     fmt::print(os, "{}", m);
     return os;
 }
+
+std::optional<ss::sstring> validate_kerberos_mapping_rules(
+  const std::optional<std::vector<ss::sstring>>& r) noexcept {
+    try {
+        detail::parse_rules("", r);
+    } catch (const std::exception& e) {
+        return e.what();
+    }
+    return std::nullopt;
+}
 } // namespace security
 
 // explicit instantiations so as to avoid bringing in <fmt/ranges.h> in the

--- a/src/v/security/gssapi_principal_mapper.cc
+++ b/src/v/security/gssapi_principal_mapper.cc
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "security/gssapi_principal_mapper.h"
+
+#include "security/logger.h"
+#include "vassert.h"
+#include "vlog.h"
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include <charconv>
+
+namespace security {
+static constexpr std::string_view non_simple_pattern = R"([/@])";
+static constexpr std::string_view parameter_pattern = R"(([^$]*)(\$(\d*))?)";
+
+gssapi_rule::gssapi_rule(std::string_view default_realm)
+  : _default_realm(default_realm) {}
+
+gssapi_rule::gssapi_rule(
+  std::string_view default_realm,
+  int number_of_components,
+  std::string_view format,
+  std::string_view match,
+  std::string_view from_pattern,
+  std::string_view to_pattern,
+  repeat repeat_,
+  case_change_operation case_change)
+  : _default_realm(default_realm)
+  , _is_default(false)
+  , _number_of_components(number_of_components)
+  , _format(format)
+  , _match(match)
+  , _from_pattern(std::regex{
+      from_pattern.begin(),
+      from_pattern.length(),
+      std::regex_constants::ECMAScript | std::regex_constants::optimize})
+  , _from_pattern_str(from_pattern)
+  , _to_pattern(to_pattern)
+  , _repeat(repeat_)
+  , _case_change(case_change) {}
+
+std::optional<ss::sstring>
+gssapi_rule::apply(std::vector<std::string_view> params) const {
+    static thread_local const re2::RE2 non_simple_regex(
+      non_simple_pattern, re2::RE2::Quiet);
+    const re2::StringPiece match_piece(_match.data(), _match.size());
+    const re2::RE2 match_regex(match_piece, re2::RE2::Quiet);
+    vassert(
+      non_simple_regex.ok(),
+      "Invalid non-simple-regex: {}",
+      non_simple_regex.error());
+    // Even if _match is empty, the RE2 will be 'ok'
+    vassert(match_regex.ok(), "Invalid match regex: {}", match_regex.error());
+
+    /*
+     * How this works:
+     *
+     * Take a rule like this:
+     *
+     * RULE:[2:$1foo$2](Admin\.(.*)s/Admin\.(.*)/$1/
+     *
+     * And say the GSSAPI principal name is:
+     * Admin.site-user/example.com@REALM.com.
+     *
+     * The name breaks down to:
+     * service-name: Admin.site-user
+     * host-name: example.com
+     * realm: REALM.com
+     *
+     * First, the "2" at the beginning ensures there are two parameters in the
+     * principal name (ignoring realm, we have the service-name and host-name).
+     *
+     * If we were missing the host-name, then we would only have one parameter
+     * and this rule would be ignored.
+     *
+     * Now, the "$1foo$2".  This is the 'format'.  This formats the GSSAPI name,
+     * so it can be fed into the next match regex.
+     *
+     * $0 - Realm
+     * $1 - service-name
+     * $2 - host-name
+     *
+     * So this 'format' takes the name and turns it into
+     * "Admin.site-userfooexample.com"
+     *
+     * Next, we test if this formatted name matches the "match" regex which in
+     * this case is "(Admin\.(.*))".  Meaning anything that begins with "Admin".
+     *
+     * It does, so then we move on to the replacement regex:
+     * "s/Admin\.(.*)/$1/".
+     *
+     * The "Admin\.(.*)" is the from pattern.
+     * The "$1" is the to pattern.
+     *
+     * This rule effectively removes the "Admin." at the beginning of the
+     * formatted name:
+     * "site-userfooexample.com" is the result.
+     */
+
+    ss::sstring result;
+
+    if (_is_default && params.size() >= 2) {
+        // If rule is a default rule, check to see if the realm and default
+        // realm matches and then use the primary value
+        if (_default_realm == params.at(0)) {
+            result = ss::sstring(params.at(1));
+        }
+    } else if (
+      !params.empty()
+      && params.size() - 1 == static_cast<size_t>(_number_of_components)) {
+        auto base = replace_parameters(_format, params);
+        if (!base) {
+            return std::nullopt;
+        }
+        const re2::StringPiece base_piece(base->data(), base->size());
+        if (_match.empty() || re2::RE2::FullMatch(base_piece, match_regex)) {
+            if (!_from_pattern) {
+                result = *base;
+            } else {
+                result = replace_substitution(
+                  *base, *_from_pattern, _to_pattern, _repeat);
+            }
+        }
+    }
+
+    const re2::StringPiece result_piece(result.data(), result.size());
+    if (
+      !result.empty()
+      && re2::RE2::PartialMatch(result_piece, non_simple_regex)) {
+        vlog(
+          seclog.error,
+          "Non-simple name {} after auth_to_local rule {}",
+          result,
+          *this);
+        return std::nullopt;
+    }
+
+    if (!result.empty()) {
+        switch (_case_change) {
+        case case_change_operation::noop:
+            break;
+
+        case case_change_operation::make_lower:
+            boost::algorithm::to_lower(result, std::locale::classic());
+            break;
+
+        case case_change_operation::make_upper:
+            boost::algorithm::to_upper(result, std::locale::classic());
+            break;
+        }
+    }
+
+    if (result.empty()) {
+        return std::nullopt;
+    } else {
+        return result;
+    }
+}
+
+std::optional<ss::sstring> gssapi_rule::replace_parameters(
+  std::string_view format, std::vector<std::string_view> params) {
+    static thread_local const re2::RE2 parameter_parser(
+      parameter_pattern, re2::RE2::Quiet);
+    vassert(
+      parameter_parser.ok(),
+      "Invalid parameter pattern: {}",
+      parameter_parser.error());
+
+    ss::sstring result;
+    re2::StringPiece format_piece(format.data(), format.size());
+
+    re2::StringPiece text_replace, index_replace;
+    while (re2::RE2::Consume(
+      &format_piece,
+      parameter_parser,
+      &text_replace,
+      nullptr,
+      &index_replace)) {
+        if (!text_replace.empty()) {
+            result.append(text_replace.data(), text_replace.size());
+        }
+        if (!index_replace.empty()) {
+            std::size_t index = std::numeric_limits<std::size_t>::max();
+            auto conv_result = std::from_chars(
+              index_replace.begin(), index_replace.end(), index);
+            if (conv_result.ec != std::errc()) {
+                vlog(
+                  seclog.warn,
+                  "Bad format in username mapping in {}",
+                  std::string_view{index_replace.data(), index_replace.size()});
+                return std::nullopt;
+            } else if (index >= params.size()) {
+                vlog(
+                  seclog.warn,
+                  "Invalid index provided ({}).  Outside range of "
+                  "parameters (length {})",
+                  index,
+                  params.size());
+                return std::nullopt;
+            } else {
+                const auto& param_index = params[index];
+                result.append(param_index.data(), param_index.size());
+            }
+        }
+
+        // format_piece will be empty if we have parsed all of format_piece
+        // text_replace and index_replace will be empty if nothing was grouped
+        // into those but re2::RE2::Consume still returns true (and doesn't
+        // update format_piece)
+        if (
+          format_piece.empty()
+          || (text_replace.empty() && index_replace.empty())) {
+            break;
+        }
+    }
+
+    return result;
+}
+
+ss::sstring gssapi_rule::replace_substitution(
+  std::string_view base,
+  const std::regex& from,
+  std::string_view to,
+  repeat repeat_) {
+    ss::sstring replace_value;
+
+    std::regex_constants::match_flag_type const flags
+      = std::regex_constants::format_default
+        | (repeat_ ? std::regex_constants::match_default : std::regex_constants::format_first_only);
+
+    replace_value = std::regex_replace(base.data(), from, to.data(), flags);
+
+    return replace_value;
+}
+
+std::ostream& operator<<(std::ostream& os, const gssapi_rule& r) {
+    fmt::print(os, "{}", r);
+    return os;
+}
+} // namespace security
+
+// explicit instantiations so as to avoid bringing in <fmt/ranges.h> in the
+// header, whch breaks compilation in another part of the codebase.
+template<>
+typename fmt::basic_format_context<fmt::appender, char>::iterator
+fmt::formatter<security::gssapi_rule, char, void>::format<
+  fmt::basic_format_context<fmt::appender, char>>(
+  security::gssapi_rule const& r,
+  fmt::basic_format_context<fmt::appender, char>& ctx) const {
+    if (r._is_default) {
+        return format_to(ctx.out(), "DEFAULT");
+    }
+    format_to(ctx.out(), "RULE:[{}:{}]", r._number_of_components, r._format);
+    if (!r._match.empty()) {
+        format_to(ctx.out(), "({})", r._match);
+    }
+    if (r._from_pattern) {
+        format_to(ctx.out(), "s/{}/{}/", r._from_pattern_str, r._to_pattern);
+        if (r._repeat) {
+            format_to(ctx.out(), "g");
+        }
+    }
+    switch (r._case_change) {
+    case security::gssapi_rule::noop:
+        break;
+    case security::gssapi_rule::make_lower:
+        format_to(ctx.out(), "/L");
+        break;
+    case security::gssapi_rule::make_upper:
+        format_to(ctx.out(), "/U");
+        break;
+    }
+
+    return ctx.out();
+}

--- a/src/v/security/gssapi_principal_mapper.h
+++ b/src/v/security/gssapi_principal_mapper.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <fmt/core.h>
+#include <re2/re2.h>
+
+#include <regex>
+
+namespace security {
+
+class gssapi_rule {
+public:
+    enum case_change_operation { noop, make_lower, make_upper };
+    using repeat = ss::bool_class<struct repeat_tag>;
+
+    explicit gssapi_rule(std::string_view default_realm);
+
+    gssapi_rule(
+      std::string_view default_realm,
+      int number_of_components,
+      std::string_view format,
+      std::string_view match,
+      std::string_view from_pattern,
+      std::string_view to_pattern,
+      repeat repeat_,
+      case_change_operation case_change);
+
+    /**
+     * Applies the rule to the provided parameters
+     * @param params The first element is realm, second and later elements are
+     * the components of the name "a/b@FOO" -> {"FOO", "a", "b"}
+     * @return The short name if this rule applies or nothing
+     * @throws std::invalid_argument If there is something wrong with the rules
+     */
+    std::optional<ss::sstring>
+    apply(std::vector<std::string_view> params) const;
+
+private:
+    friend struct fmt::formatter<gssapi_rule>;
+
+    friend std::ostream& operator<<(std::ostream& os, const gssapi_rule& r);
+
+    static std::optional<ss::sstring> replace_parameters(
+      std::string_view format, std::vector<std::string_view> params);
+    static ss::sstring replace_substitution(
+      std::string_view base,
+      const std::regex& from,
+      std::string_view to,
+      repeat repeat_);
+
+    ss::sstring _default_realm;
+    bool _is_default{true};
+    int _number_of_components{0};
+    ss::sstring _format;
+    ss::sstring _match;
+    // Reason for using std::regex -
+    // This regex is used to replace the selected GSSAPI principal name
+    // components using the regex found at the end of the rule.  The regex
+    // allows for group selection and replacement using "$n" to select which
+    // group to use.  Google's RE2 uses "\n" to select a group.
+    // See:
+    // https://github.com/google/re2/blob/4be240789d5b322df9f02b7e19c8651f3ccbf205/re2/re2.h#L455
+    // So instead of having to write another regex to parse through that and
+    // replace the "$" with the "\", I opted to just use std::regex.
+    std::optional<std::regex> _from_pattern;
+    ss::sstring _from_pattern_str;
+    ss::sstring _to_pattern;
+    repeat _repeat{false};
+    case_change_operation _case_change{case_change_operation::noop};
+};
+} // namespace security
+
+template<>
+struct fmt::formatter<security::gssapi_rule> {
+    using type = security::gssapi_rule;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator
+    format(const type& r, FormatContext& ctx) const;
+};

--- a/src/v/security/gssapi_principal_mapper.h
+++ b/src/v/security/gssapi_principal_mapper.h
@@ -22,6 +22,28 @@
 
 namespace security {
 
+class gssapi_name {
+public:
+    gssapi_name(
+      std::string_view primary,
+      std::string_view host_name,
+      std::string_view realm);
+    static gssapi_name parse(std::string_view principal_name);
+
+    const ss::sstring& primary() const noexcept;
+    const ss::sstring& host_name() const noexcept;
+    const ss::sstring& realm() const noexcept;
+
+private:
+    friend struct fmt::formatter<gssapi_name>;
+
+    friend std::ostream& operator<<(std::ostream& os, const gssapi_name& n);
+
+    ss::sstring _primary;
+    ss::sstring _host_name;
+    ss::sstring _realm;
+};
+
 class gssapi_rule {
 public:
     enum case_change_operation { noop, make_lower, make_upper };
@@ -83,6 +105,17 @@ private:
     case_change_operation _case_change{case_change_operation::noop};
 };
 } // namespace security
+
+template<>
+struct fmt::formatter<security::gssapi_name> {
+    using type = security::gssapi_name;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator
+    format(const type& r, FormatContext& ctx) const;
+};
 
 template<>
 struct fmt::formatter<security::gssapi_rule> {

--- a/src/v/security/gssapi_principal_mapper.h
+++ b/src/v/security/gssapi_principal_mapper.h
@@ -125,6 +125,9 @@ private:
       _principal_to_local_rules_binding;
     std::vector<gssapi_rule> _rules;
 };
+
+std::optional<ss::sstring> validate_kerberos_mapping_rules(
+  const std::optional<std::vector<ss::sstring>>& r) noexcept;
 } // namespace security
 
 template<>

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ rp_test(
     authorizer_test.cc
     mtls_test.cc
     license_test.cc
+    gssapi_principal_mapper_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
   LABELS kafka

--- a/src/v/security/tests/gssapi_principal_mapper_test.cc
+++ b/src/v/security/tests/gssapi_principal_mapper_test.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "security/gssapi_principal_mapper.h"
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+
+namespace security {
+
+namespace bdata = boost::unit_test::data;
+
+struct gssapi_test_record {
+    gssapi_test_record(
+      std::string_view gssapi_principal_name,
+      std::string_view expected_primary,
+      std::string_view expected_host_name,
+      std::string_view expected_realm)
+      : gssapi_principal_name(gssapi_principal_name)
+      , expected_primary(expected_primary)
+      , expected_host_name(expected_host_name)
+      , expected_realm(expected_realm) {}
+    std::string_view gssapi_principal_name;
+    std::string_view expected_primary;
+    std::string_view expected_host_name;
+    std::string_view expected_realm;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const gssapi_test_record& r) {
+        fmt::print(
+          os, "gssapi_principal_name: '{}', ", r.gssapi_principal_name);
+        fmt::print(os, "expected_primary: '{}', ", r.expected_primary);
+        fmt::print(os, "expected_host_name: '{}', ", r.expected_host_name);
+        fmt::print(os, "expected_realm: '{}'", r.expected_realm);
+
+        return os;
+    }
+};
+
+static std::array<gssapi_test_record, 3> gssapi_name_test_data{
+  gssapi_test_record{
+    "App.service-name/example.com@REALM.com",
+    "App.service-name",
+    "example.com",
+    "REALM.com"},
+  {"App.service-name@REALM.com", "App.service-name", "", "REALM.com"},
+  {"user/host@REALM.com", "user", "host", "REALM.com"}};
+
+BOOST_DATA_TEST_CASE(test_gssapi_name, bdata::make(gssapi_name_test_data), c) {
+    BOOST_REQUIRE_NO_THROW(
+      auto name = gssapi_name::parse(c.gssapi_principal_name);
+      BOOST_REQUIRE_EQUAL(c.expected_primary, name.primary());
+      BOOST_REQUIRE_EQUAL(c.expected_host_name, name.host_name());
+      BOOST_REQUIRE_EQUAL(c.expected_realm, name.realm());
+      BOOST_REQUIRE_EQUAL(c.gssapi_principal_name, fmt::format("{}", name)););
+}
+} // namespace security

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -564,6 +564,13 @@ class ClusterConfigTest(RedpandaTest):
                 # arbitrary strings because the config system validates them.
                 valid_value = ['SCRAM', 'GSSAPI']
 
+            if name == 'sasl_kerberos_principal_mapping':
+                # The default value is ['DEFAULT'], but the array must contain
+                # valid Kerberos mapping rules
+                valid_value = [
+                    'RULE:[1:$1]/L', 'RULE:[2:$1](Test.*)s/ABC///L', 'DEFAULT'
+                ]
+
             if name == 'enable_coproc':
                 # Don't try enabling coproc, it has external dependencies
                 continue


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

Supports parsing and application of Kerberos rules from user config onto Kerberos principals to be used with the ACL.

Changes from force-push `55d45bc`:

* Updated headers
* Added newlines to end of files
* Replaced `const char * const` to `std::string_view`
* Replaced `service_name` with `primary`
* Added `thread_local`
* Directly using `re2` namespace when using `RE2` class calls
* Checks for param size
* Replace `return {}` with `return std::nullopt`

Changes from force-push `4bd9447`:

* Static analysis test failure fix

Changes from force-push `d0b765c`:

* Replaced `make_{upper_lower}` flags with enum

Changes from force-push `18edbc6`:

* Updated log levels/messages

Changes from force-push `0996ea5`:

* Fixed failing `ClusterConfigTest.test_valid_settings` test

Changes from force-push `8b118e5`:

* Fixed python linting error introduced in `0996ea5`

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

To set Kerberos principal mapping rules:

```
rpk cluster config set sasl_kerberos_principal_mapping '["RULE:[1:$1](App\\..*)s/App\\.(.*)/$1/g","DEFAULT"]'
```

To see the current Kerberos principal mapping rules:

```
rpk cluster config get sasl_kerberos_principal_mapping
```

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

### Features
* Supports parsing and applying Kerberos rules
