### PR TITLE
rpk: add k8s logs to debug bundle

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
 	github.com/tklauser/go-sysconf v0.3.10
+	github.com/trstringer/go-systemd-time v1.0.0
 	github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce
 	github.com/twmb/franz-go/pkg/kadm v1.3.0
 	github.com/twmb/franz-go/pkg/kmsg v1.2.0
@@ -41,6 +42,7 @@ require (
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/api v0.21.4
 	k8s.io/apimachinery v0.21.4
 	k8s.io/client-go v0.21.4
 )
@@ -100,7 +102,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 	honnef.co/go/tools v0.3.2 // indirect
-	k8s.io/api v0.21.4 // indirect
 	k8s.io/klog/v2 v2.8.0 // indirect
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -462,6 +462,8 @@ github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYa
 github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hMwiKKqXCQ=
 github.com/tklauser/numcpus v0.5.0 h1:ooe7gN0fg6myJ0EKoTAf5hebTZrH52px3New/D9iJ+A=
 github.com/tklauser/numcpus v0.5.0/go.mod h1:OGzpTxpcIMNGYQdit2BYL1pvk/dSOaJWjKoflh+RQjo=
+github.com/trstringer/go-systemd-time v1.0.0 h1:85YYNtMuiDJtbnQveqN5M2+GHVKqYpPvOxLZMOLD4BY=
+github.com/trstringer/go-systemd-time v1.0.0/go.mod h1:zmxXIRFeksWrNr4tdJeHBvxev3nmViuoEZNs+OllX20=
 github.com/twmb/franz-go v1.9.0/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce h1:aMSo6EtBEMvTg5ATviVUEq0LOwcCTDQhJ1GJcN3gi0o=
 github.com/twmb/franz-go v1.9.2-0.20221101035527-a07b8c8a01ce/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=


### PR DESCRIPTION
With the correct RBAC, rpk will be able to collect all nodes' logs when executing `rpk debug bundle` in a k8s environment.

It supports the `--logs-since` and `--logs-size-limit` flags using the same inputs as if they were for journalctl commands.

Example:
```
$ rpk debug bundle --logs-since -1h
...
$ cat /tmp/bundle/logs/redpanda-0.txt
INFO  2023-01-16 23:25:11,213 [shard 0] storage - segment.cc:655 - Creating new segment /var/lib/redpanda/data/redpanda/controller/0_0/51-35-v1.log
INFO  2023-01-16 23:25:11,363 [shard 0] cluster - members_manager.cc:214 - Applying update to members_manager
INFO  2023-01-16 23:25:11,363 [shard 0] cluster - members_table.cc:211 - marking node 0 in maintenance state
INFO  2023-01-16 23:25:11,363 [shard 0] cluster - drain_manager.cc:49 - Node draining is starting
INFO  2023-01-16 23:25:11,363 [shard 0] cluster - drain_manager.cc:143 - Node draining has started
INFO  2023-01-16 23:25:11,363 [shard 0] cluster - drain_manager.cc:256 - Node draining has completed on shard 0
INFO  2023-01-16 23:25:16,497 [shard 0] cluster - members_manager.cc:214 - Applying update to members_manager
INFO  2023-01-16 23:25:16,497 [shard 0] cluster - members_table.cc:167 - marking node 0 not in maintenance state
INFO  2023-01-16 23:25:16,497 [shard 0] cluster - drain_manager.cc:65 - Node draining is stopping
INFO  2023-01-16 23:25:16,497 [shard 0] cluster - drain_manager.cc:268 - Node drain stopped


$ rpk debug bundle --logs-size-limit 10KB
...
$ ls -l /tmp/bundle/logs                
total 40K
-rw-r--r--. 1 rvasquez rvasquez 9.8K Jul 29  2114 redpanda-0.txt
-rw-r--r--. 1 rvasquez rvasquez 9.8K Jul 29  2114 redpanda-1.txt
-rw-r--r--. 1 rvasquez rvasquez 9.8K Jul 29  2114 redpanda-2.txt
-rw-r--r--. 1 rvasquez rvasquez  115 Jul 29  2114 redpanda-post-install-wvns5.txt
```

This is how the bundle looks for a k8s cluster when executing `rpk debug bundle` **in a single node** (with the correct RBAC):
```
/tmp/bundle
├── admin
│   ├── brokers.json
│   ├── cluster_config.json
│   ├── cluster_view_10.244.1.2:9644.json
│   ├── cluster_view_10.244.2.2:9644.json
│   ├── cluster_view_10.244.3.2:9644.json
│   ├── health_overview.json
│   ├── license.json
│   ├── node_config_10.244.1.2:9644.json
│   ├── node_config_10.244.2.2:9644.json
│   ├── node_config_10.244.3.2:9644.json
│   └── reconfigurations.json
├── controller
│   ├── 0-1-v1.log
│   ├── 16-2-v1.log
│   ├── 17-3-v1.log
├── data-dir.txt
├── du.txt
├── k8s
│   ├── configmaps.json
│   ├── endpoints.json
│   ├── events.json
│   ├── limitranges.json
│   ├── persistentvolumeclaims.json
│   ├── pods.json
│   ├── replicationcontrollers.json
│   ├── resourcequotas.json
│   ├── serviceaccounts.json
│   └── services.json
├── kafka.json
├── logs
│   ├── redpanda-0.txt
│   ├── redpanda-1.txt
│   ├── redpanda-2.txt
│   └── redpanda-post-install-wvns5.txt
├── metrics
│   ├── metric_10.244.1.2:9644.txt
│   ├── metric_10.244.2.2:9644.txt
│   ├── metric_10.244.3.2:9644.txt
│   ├── public_metrics_10.244.1.2:9644.txt
│   ├── public_metrics_10.244.2.2:9644.txt
│   └── public_metrics_10.244.3.2:9644.txt
├── ntp.txt
├── proc
│   ├── cpuinfo
│   └── interrupts
├── redpanda.yaml
└── resource-usage.json

```

Fixes #8278
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix


## Release Notes
  ### Features

  * When running `rpk debug bundle` in a k8s cluster it will collect the logs of all nodes in the given namespace

