### PR TITLE
features: Make kafka_gssapi cluster_version{9}

### DIFF
--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -203,7 +203,7 @@ constexpr static std::array feature_schema{
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
-    cluster::cluster_version{8},
+    cluster::cluster_version{9},
     "kafka_gssapi",
     feature::kafka_gssapi,
     feature_spec::available_policy::explicit_only,


### PR DESCRIPTION
New features should be at version 9, which was the `latest_version` at the time `kafka_gssapi` was merged.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none