### PR TITLE
raft: fix handle_eviction in snapshots

### DIFF
--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -34,7 +34,10 @@ ss::future<> state_machine::start() {
     return ss::now();
 }
 
-void state_machine::set_next(model::offset offset) { _next = offset; }
+void state_machine::set_next(model::offset offset) {
+    _next = offset;
+    _waiters.notify(model::prev_offset(offset));
+}
 
 ss::future<> state_machine::handle_eviction() {
     vlog(


### PR DESCRIPTION
On an idle partition, we might never see any later batches with which to update _waiters during apply.  This can cause an ensure_snapshot_exists call to hang, which can stop tiered storage from evicting segments, and can stop partition::stop from completing.

By augmenting set_next with an update to _waiters, we guarantee that handle_eviction methods that update the _next pointer will also release any pending waiters.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

None

## Release Notes


  ### Bug Fixes

  * An issue is fixed where shutdown or internal housekeeping operations could fail to progress on a node that had been out of contact with peers for some time, when partitions are also not being written to.