### PR TITLE
cdt: enable '/cdt' slash command

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -3,6 +3,7 @@ on:
     types: 
       - ci-repeat-command
       - test-codecov-command
+      - cdt-command
 
 jobs:
   run-build:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -16,6 +16,7 @@ jobs:
             backport
             ci-repeat
             test-codecov
+            cdt
           static-args: |
             org=redpanda-data
             repo=redpanda


### PR DESCRIPTION
Enable `/cdt` slash command for triggering `cdt` tests in PRs

ref https://github.com/redpanda-data/devprod/issues/500

## Backports Required

TBD

## Release Notes

* none
