### PR TITLE
Small cleanup/improvements in partition replicas scheduling

### DIFF
--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -69,7 +69,7 @@ public:
         }
         return _max_capacity;
     }
-    // Overall partition space of the node, less reseved partitions
+    // Overall partition space of the node, less reserved partitions
     allocation_capacity max_capacity() const { return _max_capacity; }
 
     void decommission() {

--- a/src/v/cluster/scheduling/allocation_strategy.cc
+++ b/src/v/cluster/scheduling/allocation_strategy.cc
@@ -87,24 +87,30 @@ model::node_id find_best_fit(
         if (it == nodes.end()) {
             continue;
         }
+        /**
+         * Score is normalized so that it is always in range [0, max_score_size]
+         */
+        uint32_t score
+          = std::accumulate(
+              constraints.begin(),
+              constraints.end(),
+              uint32_t{0},
+              [&node = it->second](
+                uint32_t score,
+                const allocation_constraints::soft_constraint_ev_ptr& ev) {
+                  const auto current_score = ev->score(*node);
+                  vlog(
+                    clusterlog.trace,
+                    "constraint: {}, node: {}, score: {}",
+                    *ev,
+                    node->id(),
+                    current_score);
+                  return score + current_score;
+              })
+            / constraints.size();
 
-        uint32_t score = std::accumulate(
-          constraints.begin(),
-          constraints.end(),
-          0,
-          [&node = it->second](
-            uint32_t score,
-            const allocation_constraints::soft_constraint_ev_ptr& ev) {
-              const auto current_score = ev->score(*node);
-              vlog(
-                clusterlog.trace,
-                "constraint: {}, node: {}, score: {}",
-                *ev,
-                node->id(),
-                current_score);
-              return score + current_score;
-          });
-
+        vlog(
+          clusterlog.trace, "node: {}, total normalized score: {}", id, score);
         if (score >= best_score) {
             if (score > best_score) {
                 // untied, winner clear out existing winners

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -73,7 +73,13 @@ soft_constraint_evaluator least_disk_filled(
   const absl::flat_hash_map<model::node_id, node_disk_space>&
     node_disk_reports);
 
-soft_constraint_evaluator
+hard_constraint_evaluator
 distinct_rack(const std::vector<model::broker_shard>&, const allocation_state&);
+
+inline soft_constraint_evaluator distinct_rack_preferred(
+  const std::vector<model::broker_shard>& replicas,
+  const allocation_state& state) {
+    return make_soft_constraint(distinct_rack(replicas, state));
+}
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -49,8 +49,8 @@ hard_constraint_evaluator disk_not_overflowed_by_partition(
 soft_constraint_evaluator least_allocated();
 
 /*
- * scores nodes based on allocation capacity used by priorty partitions
- * returning `0` for nodes fully allocated for priority partitons
+ * scores nodes based on allocation capacity used by priority partitions
+ * returning `0` for nodes fully allocated for priority partitions
  * and `max_capacity` for nodes without any priority partitions
  * non-priority partition allocations are ignored
  */

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -19,6 +19,12 @@
 namespace cluster {
 
 class allocation_state;
+/**
+ * make_soft_constraint adapts hard constraint to soft one by returning
+ * max score for nodes that matches the soft constraint and 0 for
+ * the ones that not
+ */
+soft_constraint_evaluator make_soft_constraint(hard_constraint_evaluator);
 
 hard_constraint_evaluator not_fully_allocated();
 hard_constraint_evaluator is_active();

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -88,8 +88,8 @@ partition_allocator::allocate_partition(
       *_state, p_constraints.replication_factor, domain);
 
     for (auto r = 0; r < p_constraints.replication_factor; ++r) {
-        auto effective_constraits = default_constraints(domain);
-        effective_constraits.hard_constraints.push_back(
+        auto effective_constraints = default_constraints(domain);
+        effective_constraints.hard_constraints.push_back(
           ss::make_lw_shared<hard_constraint_evaluator>(
             distinct_from(replicas.get())));
 
@@ -101,14 +101,14 @@ partition_allocator::allocate_partition(
               current_replicas.end(),
               not_changed_replicas.begin(),
               not_changed_replicas.end());
-            effective_constraits.soft_constraints.push_back(
+            effective_constraints.soft_constraints.push_back(
               ss::make_lw_shared<soft_constraint_evaluator>(
                 distinct_rack(current_replicas, *_state)));
         }
 
-        effective_constraits.add(p_constraints.constraints);
+        effective_constraints.add(p_constraints.constraints);
         auto replica = _allocation_strategy.allocate_replica(
-          effective_constraits, *_state, domain);
+          effective_constraints, *_state, domain);
 
         if (!replica) {
             return replica.error();

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -103,7 +103,7 @@ partition_allocator::allocate_partition(
               not_changed_replicas.end());
             effective_constraints.soft_constraints.push_back(
               ss::make_lw_shared<soft_constraint_evaluator>(
-                distinct_rack(current_replicas, *_state)));
+                distinct_rack_preferred(current_replicas, *_state)));
         }
 
         effective_constraints.add(p_constraints.constraints);

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -23,7 +23,7 @@ class allocation_node;
 class allocation_state;
 
 /**
- * Constraints evaluators loosely inspired by Fenzo Constrainst Solver.
+ * Constraints evaluators loosely inspired by Fenzo Constraints Solver.
  *
  * https://github.com/Netflix/Fenzo/blob/master/fenzo-core/src/main/java/com/netflix/fenzo/ConstraintEvaluator.java
  * https://github.com/Netflix/Fenzo/blob/master/fenzo-core/src/main/java/com/netflix/fenzo/VMTaskFitnessCalculator.java
@@ -109,7 +109,7 @@ private:
 
 /**
  * Configuration used to request partition allocation, if current allocations
- * are not empty then allocation strategy will allocate as many replis as
+ * are not empty then allocation strategy will allocate as many replicas as
  * required to achieve requested replication factor.
  */
 struct allocation_constraints {
@@ -125,7 +125,7 @@ struct allocation_constraints {
     operator<<(std::ostream&, const allocation_constraints&);
 };
 /**
- * RAII based helper holding allocated partititions, allocation is reverted
+ * RAII based helper holding allocated partitions, allocation is reverted
  * after this object goes out of scope.
  *
  * WARNING: this object contains an embedded reference to the partition
@@ -178,7 +178,7 @@ private:
 /**
  * Configuration used to request manual allocation configuration for topic.
  * Custom allocation only designate nodes where partition should be placed but
- * not the shards on each node, allocation strategy will assing shards to each
+ * not the shards on each node, allocation strategy will assign shards to each
  * replica
  */
 struct partition_constraints {


### PR DESCRIPTION
Small improvements in `partition_allocator` and constraints evaluation logic. 
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
  * none
