### PR TITLE
c/metrics_reporter: Report status of kafka_gssapi

### DIFF
--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -69,6 +69,7 @@ public:
         uint32_t partition_count;
 
         std::vector<node_metrics> nodes;
+        bool has_kafka_gssapi;
     };
     static constexpr ss::shard_id shard = 0;
 

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -80,10 +80,13 @@ class MetricsReporterTest(RedpandaTest):
         # cluster uuid and create timestamp should stay the same across requests
         assert_fields_are_the_same(metadata, 'cluster_uuid')
         assert_fields_are_the_same(metadata, 'cluster_created_ts')
+        # Configuration should be the same across requests
+        assert_fields_are_the_same(metadata, 'has_kafka_gssapi')
         # get the last report
         last = metadata.pop()
         assert last['topic_count'] == total_topics
         assert last['partition_count'] == total_partitions
+        assert last['has_kafka_gssapi'] is False
         nodes_meta = last['nodes']
 
         assert len(last['nodes']) == len(self.redpanda.nodes)


### PR DESCRIPTION
Add a new field to the report: `has_kafka_gssapi`

E.g.:
```json
{
  "cluster_uuid": "3d53d84c-69d3-4c5e-9098-9c3e4af079e6",
  "cluster_created_ts": 1673994399728,
  "topic_count": 5,
  "partition_count": 24,
  "nodes": [
    {
      "node_id": 1,
      "cpu_count": 2,
      "version": "no_version - 000-dev",
      "uptime_ms": 10223,
      "is_alive": true,
      "disks": [
        {
          "free": 153149313024,
          "total": 930158792704
        }
      ]
    }
  ],
  "has_kafka_gssapi": true
}
```

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
