### PR TITLE
cluster: fast-forward feature table before joining cluster

### DIFF
--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -165,7 +165,7 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd) {
               });
         } else if (
           _feature_table.local().get_original_version()
-          == cluster::invalid_version) {
+          < cmd.value.founding_version) {
             // Special case for systems pre-dating the original_version field:
             // they may have loaded a snapshot that doesn't contain an original
             // version, so must populate it from updates.

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -147,6 +147,7 @@ ss::future<bool> cluster_discovery::dispatch_node_uuid_registration_to_seeds(
               s.addr,
               config::node().rpc_server_tls(),
               _join_timeout,
+              rpc::transport_version::v2,
               [&self, this](controller_client_protocol c) {
                   return c
                     .join_node(
@@ -217,6 +218,7 @@ cluster_discovery::request_cluster_bootstrap_info_single(
               addr,
               config::node().rpc_server_tls(),
               2s,
+              rpc::transport_version::v2,
               [](cluster_bootstrap_client_protocol c) {
                   return c
                     .cluster_bootstrap_info(

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -152,6 +152,7 @@ ss::future<bool> cluster_discovery::dispatch_node_uuid_registration_to_seeds(
                     .join_node(
                       join_node_request(
                         features::feature_table::get_latest_logical_version(),
+                        features::feature_table::get_earliest_logical_version(),
                         _node_uuid().to_vector(),
                         self),
                       rpc::client_opts(rpc::clock_type::now() + _join_timeout))

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -488,6 +488,8 @@ void members_manager::join_raft0() {
                             std::move(join_node_request{
                               features::feature_table::
                                 get_latest_logical_version(),
+                              features::feature_table::
+                                get_earliest_logical_version(),
                               _storage.local().node_uuid()().to_vector(),
                               _self}))
                      .then([this](result<join_node_reply> r) {
@@ -734,10 +736,11 @@ members_manager::handle_join_request(join_node_request const req) {
     }
     vlog(
       clusterlog.info,
-      "Processing node '{} ({})' join request (version {})",
+      "Processing node '{} ({})' join request (version {}-{})",
       req.node.id(),
       node_uuid_str,
-      req.logical_version);
+      req.earliest_logical_version,
+      req.latest_logical_version);
 
     if (!_raft0->is_elected_leader()) {
         vlog(clusterlog.debug, "Not the leader; dispatching to leader node");

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -472,6 +472,7 @@ ss::future<result<join_node_reply>> members_manager::dispatch_join_to_remote(
       target.addr,
       _rpc_tls_config,
       _join_timeout,
+      rpc::transport_version::v2,
       [req = std::move(req), timeout = rpc::clock_type::now() + _join_timeout](
         controller_client_protocol c) mutable {
           return c.join_node(std::move(req), rpc::client_opts(timeout))

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -53,7 +53,8 @@ metadata_dissemination_service::metadata_dissemination_service(
   ss::sharded<members_table>& members,
   ss::sharded<topic_table>& topics,
   ss::sharded<rpc::connection_cache>& clients,
-  ss::sharded<health_monitor_frontend>& health_monitor)
+  ss::sharded<health_monitor_frontend>& health_monitor,
+  ss::sharded<features::feature_table>& feature_table)
   : _raft_manager(raft_manager)
   , _partition_manager(partition_manager)
   , _leaders(leaders)
@@ -61,6 +62,7 @@ metadata_dissemination_service::metadata_dissemination_service(
   , _topics(topics)
   , _clients(clients)
   , _health_monitor(health_monitor)
+  , _feature_table(feature_table)
   , _self(make_self_broker(config::node()))
   , _dissemination_interval(
       config::shard_local_cfg().metadata_dissemination_interval_ms)

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -271,6 +271,9 @@ metadata_dissemination_service::dispatch_get_metadata_update(
       address,
       _rpc_tls_config,
       _dissemination_interval,
+      _feature_table.local().is_active(features::feature::rpc_v2_by_default)
+        ? rpc::transport_version::v2
+        : rpc::transport_version::v1,
       [this](metadata_dissemination_rpc_client_protocol c) {
           return c
             .get_leadership(

--- a/src/v/cluster/metadata_dissemination_service.h
+++ b/src/v/cluster/metadata_dissemination_service.h
@@ -15,6 +15,7 @@
 #include "cluster/health_monitor_types.h"
 #include "cluster/metadata_dissemination_types.h"
 #include "config/tls_config.h"
+#include "features/fwd.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
@@ -79,7 +80,8 @@ public:
       ss::sharded<members_table>&,
       ss::sharded<topic_table>&,
       ss::sharded<rpc::connection_cache>&,
-      ss::sharded<health_monitor_frontend>&);
+      ss::sharded<health_monitor_frontend>&,
+      ss::sharded<features::feature_table>&);
 
     void disseminate_leadership(
       model::ntp,
@@ -147,6 +149,7 @@ private:
     ss::sharded<topic_table>& _topics;
     ss::sharded<rpc::connection_cache>& _clients;
     ss::sharded<health_monitor_frontend>& _health_monitor;
+    ss::sharded<features::feature_table>& _feature_table;
     model::broker _self;
     std::chrono::milliseconds _dissemination_interval;
     config::tls_config _rpc_tls_config;

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1371,16 +1371,17 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         }
         cluster::join_node_request data{
           tests::random_named_int<cluster::cluster_version>(),
+          tests::random_named_int<cluster::cluster_version>(),
           node_uuid,
           model::random_broker()};
-        roundtrip_test(data);
+        serde_roundtrip_test(data);
     }
     {
         cluster::join_node_reply data{
           tests::random_bool(),
           tests::random_named_int<model::node_id>(),
         };
-        roundtrip_test(data);
+        serde_roundtrip_test(data);
     }
     {
         std::vector<model::broker_shard> new_replica_set;

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1083,7 +1083,7 @@ cluster::join_request adl<cluster::join_request>::from(iobuf_parser& in) {
 void adl<cluster::join_node_request>::to(
   iobuf& out, cluster::join_node_request&& r) {
     adl<uint8_t>().to(out, r.current_version);
-    adl<cluster::cluster_version>().to(out, r.logical_version);
+    adl<cluster::cluster_version>().to(out, r.latest_logical_version);
     adl<std::vector<uint8_t>>().to(out, r.node_uuid);
     adl<model::broker>().to(out, std::move(r.node));
 }
@@ -1100,7 +1100,8 @@ adl<cluster::join_node_request>::from(iobuf_parser& in) {
     auto node_uuid = adl<std::vector<uint8_t>>().from(in);
     auto node = adl<model::broker>().from(in);
 
-    return cluster::join_node_request{logical_version, node_uuid, node};
+    return cluster::join_node_request{
+      logical_version, cluster::invalid_version, node_uuid, node};
 }
 
 void adl<cluster::configuration_update_request>::to(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1023,27 +1023,39 @@ struct join_reply
 ///   in future.
 struct join_node_request
   : serde::
-      envelope<join_node_request, serde::version<0>, serde::compat_version<0>> {
+      envelope<join_node_request, serde::version<1>, serde::compat_version<0>> {
     join_node_request() noexcept = default;
 
     explicit join_node_request(
-      cluster_version lv, std::vector<uint8_t> nuuid, model::broker b)
-      : logical_version(lv)
+      cluster_version lv,
+      cluster_version ev,
+      std::vector<uint8_t> nuuid,
+      model::broker b)
+      : latest_logical_version(lv)
       , node_uuid(nuuid)
-      , node(std::move(b)) {}
+      , node(std::move(b))
+      , earliest_logical_version(ev) {}
 
-    explicit join_node_request(cluster_version lv, model::broker b)
-      : logical_version(lv)
-      , node(std::move(b)) {}
+    explicit join_node_request(
+      cluster_version lv, cluster_version ev, model::broker b)
+      : latest_logical_version(lv)
+      , node(std::move(b))
+      , earliest_logical_version(ev) {}
 
     static constexpr int8_t current_version = 1;
-    cluster_version logical_version;
+
+    // The highest version that the joining node supports
+    cluster_version latest_logical_version{cluster::invalid_version};
 
     // node_uuid may be empty: this is for future use implementing auto
     // selection of node_id.  Convert to a more convenient type later:
     // the vector is just to reserve the on-disk layout.
     std::vector<uint8_t> node_uuid;
     model::broker node;
+
+    // The lowest version that the joining node supports, it will already
+    // have its feature table initialized to this version.
+    cluster_version earliest_logical_version{cluster::invalid_version};
 
     friend bool operator==(const join_node_request&, const join_node_request&)
       = default;
@@ -1052,14 +1064,18 @@ struct join_node_request
     operator<<(std::ostream& o, const join_node_request& r) {
         fmt::print(
           o,
-          "logical_version {} node_uuid {} node {}",
-          r.logical_version,
+          "logical_version {}-{} node_uuid {} node {}",
+          r.earliest_logical_version,
+          r.latest_logical_version,
           r.node_uuid,
           r.node);
         return o;
     }
 
-    auto serde_fields() { return std::tie(logical_version, node_uuid, node); }
+    auto serde_fields() {
+        return std::tie(
+          latest_logical_version, node_uuid, node, earliest_logical_version);
+    }
 };
 
 struct join_node_reply

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -142,20 +142,22 @@ GEN_COMPAT_CHECK(
 GEN_COMPAT_CHECK(
   cluster::join_reply, { json_write(success); }, { json_read(success); });
 
-GEN_COMPAT_CHECK(
+GEN_COMPAT_CHECK_SERDE_ONLY(
   cluster::join_node_request,
   {
-      json_write(logical_version);
+      json_write(latest_logical_version);
+      json_write(earliest_logical_version);
       json_write(node_uuid);
       json_write(node);
   },
   {
-      json_read(logical_version);
+      json_read(latest_logical_version);
+      json_read(earliest_logical_version);
       json_read(node_uuid);
       json_read(node);
   });
 
-GEN_COMPAT_CHECK(
+GEN_COMPAT_CHECK_SERDE_ONLY(
   cluster::join_node_reply,
   {
       json_write(success);

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -308,6 +308,7 @@ struct instance_generator<cluster::join_node_request> {
     static cluster::join_node_request random() {
         return cluster::join_node_request{
           tests::random_named_int<cluster::cluster_version>(),
+          tests::random_named_int<cluster::cluster_version>(),
           tests::random_vector(
             [] { return random_generators::get_int<uint8_t>(); }),
           model::random_broker()};

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -333,6 +333,8 @@ public:
 
     static cluster::cluster_version get_latest_logical_version();
 
+    static cluster::cluster_version get_earliest_logical_version();
+
     feature_table();
 
     feature_state& get_state(feature f_id);

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -116,11 +116,19 @@
             "properties": {
                 "cluster_version": {
                     "type": "long",
-                    "description": "Logical version of cluster"
+                    "description": "Logical version of cluster: this should equal latest_node_version if the cluster is not currently being upgraded."
                 },
                 "original_cluster_version": {
                     "type": "long",
-                    "description": "Logical version at time of cluster creation"
+                    "description": "Logical version at time of cluster creation.  This should equal latest_node_version on a newly created cluster."
+                },
+                "node_earliest_version": {
+                    "type": "long",
+                    "description": "Earliest logical version supported by the node answering this request"
+                },
+                "node_latest_version": {
+                    "type": "long",
+                    "description": "Latest logical version supported by the node answering this request"
                 },
                 "features": {
                     "type": "array",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1872,6 +1872,8 @@ void admin_server::register_features_routes() {
 
           res.cluster_version = version;
           res.original_cluster_version = ft.get_original_version();
+          res.node_earliest_version = ft.get_earliest_logical_version();
+          res.node_latest_version = ft.get_latest_logical_version();
           for (const auto& fs : ft.get_feature_state()) {
               ss::httpd::features_json::feature_state item;
               vlog(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1166,7 +1166,8 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(controller->get_members_table()),
       std::ref(controller->get_topics_state()),
       std::ref(_connection_cache),
-      std::ref(controller->get_health_monitor()))
+      std::ref(controller->get_health_monitor()),
+      std::ref(feature_table))
       .get();
 
     if (archival_storage_enabled()) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1649,7 +1649,8 @@ void application::start_bootstrap_services() {
         feature_table
           .invoke_on_all([](features::feature_table& ft) {
               ft.bootstrap_active_version(
-                features::feature_table::get_earliest_logical_version());
+                features::feature_table::get_earliest_logical_version(),
+                features::feature_table::version_durability::ephemeral);
 
               // We do _not_ write a snapshot here: the persistent record of
               // feature table state is only set for the first time in

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -139,7 +139,7 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         self.redpanda.set_environment({
             '__REDPANDA_TEST_FEATURES':
             "ON",
-            '__REDPANDA_LOGICAL_VERSION':
+            '__REDPANDA_LATEST_LOGICAL_VERSION':
             f'{feature_alpha_version}'
         })
         self.redpanda.restart_nodes(self.redpanda.nodes)

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -681,7 +681,10 @@ class UpgradeTransactionTest(RedpandaTest):
                 "enable_leader_balancer": False,
                 "enable_auto_rebalance_on_node_add": False,
             },
-            environment={"__REDPANDA_LATEST_LOGICAL_VERSION": 5})
+            environment={
+                "__REDPANDA_LATEST_LOGICAL_VERSION": 5,
+                "__REDPANDA_EARLIEST_LOGICAL_VERSION": 5
+            })
 
         self.redpanda.start()
 
@@ -710,7 +713,10 @@ class UpgradeTransactionTest(RedpandaTest):
 
         self.check_consume(topic_name, max_tx)
 
-        self.redpanda.set_environment({"__REDPANDA_LATEST_LOGICAL_VERSION": 6})
+        self.redpanda.set_environment({
+            "__REDPANDA_LATEST_LOGICAL_VERSION": 6,
+            "__REDPANDA_EARLIEST_LOGICAL_VERSION": 5
+        })
         for n in self.redpanda.nodes:
             self.redpanda.restart_nodes(n, stop_timeout=60)
 

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -681,7 +681,7 @@ class UpgradeTransactionTest(RedpandaTest):
                 "enable_leader_balancer": False,
                 "enable_auto_rebalance_on_node_add": False,
             },
-            environment={"__REDPANDA_LOGICAL_VERSION": 5})
+            environment={"__REDPANDA_LATEST_LOGICAL_VERSION": 5})
 
         self.redpanda.start()
 
@@ -710,7 +710,7 @@ class UpgradeTransactionTest(RedpandaTest):
 
         self.check_consume(topic_name, max_tx)
 
-        self.redpanda.set_environment({"__REDPANDA_LOGICAL_VERSION": 6})
+        self.redpanda.set_environment({"__REDPANDA_LATEST_LOGICAL_VERSION": 6})
         for n in self.redpanda.nodes:
             self.redpanda.restart_nodes(n, stop_timeout=60)
 


### PR DESCRIPTION
This follows https://github.com/redpanda-data/redpanda/pull/8225

- Introduce the concept of an "earliest version" in the feature table.  This is the earliest version that the node will interact with, and it's the version that it will fast-forward its feature table to on an initial startup.  For former property makes the latter safe: if our earliest version is 8 and we fast forward to 8, then there's no risk of that being "too far" because we should never be allowed to join a cluster whose active version is any older than that.
- Expose earliest+latest versions in admin API: this makes it easy for an external program like a test to reason about whether the node is fully updated or not.
- Extend validation on node_join_request RPCs, where the incoming RPC will specify its earliest-latest version range, and the RPC shall be rejected if the active version of the cluster is not within that range (inclusive)
- Fix locations where RPC clients were being constructed with always transport version 1, this included the clients used to generate node join requests.   Transports for join requests are now always constructed at rpc version 2, which is safe because a 23.1 cluster should never be trying to join a <= 21.11 cluster.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Improvements

- Additional safety checks on the version compatibility of nodes joining a cluster.  Please ensure that when adding nodes to a cluster, the new nodes are from the same feature series, or at most one feature series newer (e.g. adding a 23.1.1 node to a cluster of 22.3.x nodes).  Nodes from an older feature version will not be permitted to join a cluster that has previously been upgraded fully to a newer feature version.