### PR TITLE
Controller snapshots part 1

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -100,6 +100,7 @@ v_cc_library(
     controller_backend.cc
     controller_probe.cc
     controller_log_limiter.cc
+    controller_stm.cc
     controller.cc
     partition.cc
     partition_probe.cc

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -208,6 +208,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
           };
           return _stm.start_single(
             std::move(limiter_conf),
+            std::ref(_feature_table),
+            config::shard_local_cfg().controller_snapshot_max_age_sec.bind(),
             std::ref(clusterlog),
             _raft0.get(),
             raft::persistent_last_applied::yes,

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/types.h"
+#include "serde/envelope.h"
+#include "serde/serde.h"
+
+namespace cluster {
+
+struct controller_snapshot
+  : public serde::checksum_envelope<
+      controller_snapshot,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    friend bool
+    operator==(const controller_snapshot&, const controller_snapshot&)
+      = default;
+
+    auto serde_fields() { return std::tie(); }
+};
+
+} // namespace cluster

--- a/src/v/cluster/controller_stm.cc
+++ b/src/v/cluster/controller_stm.cc
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/controller_stm.h"
+
+#include "bytes/iostream.h"
+#include "cluster/controller_snapshot.h"
+#include "cluster/logger.h"
+#include "cluster/members_manager.h"
+#include "vlog.h"
+
+namespace cluster {
+
+ss::future<> controller_stm::on_batch_applied() {
+    if (!_feature_table.is_active(features::feature::controller_snapshots)) {
+        co_return;
+    }
+    if (_gate.is_closed()) {
+        co_return;
+    }
+
+    if (
+      get_last_applied_offset() > _raft->last_snapshot_index()
+      && !_snapshot_debounce_timer.armed()) {
+        _snapshot_debounce_timer.arm(_snapshot_max_age());
+    };
+}
+
+ss::future<> controller_stm::stop() {
+    _snapshot_debounce_timer.cancel();
+    return base_t::stop();
+}
+
+void controller_stm::snapshot_timer_callback() {
+    ssx::background
+      = ssx::spawn_with_gate_then(_gate, [this] {
+            return maybe_write_snapshot().then([](bool written) {
+                if (!written) {
+                    vlog(clusterlog.info, "skipped writing snapshot");
+                }
+            });
+        }).handle_exception([](const std::exception_ptr& e) {
+            vlog(clusterlog.warn, "failed to write snapshot: {}", e);
+        });
+}
+
+ss::future<std::optional<iobuf>>
+controller_stm::maybe_make_snapshot(ssx::semaphore_units apply_mtx_holder) {
+    auto started_at = ss::steady_clock_type::now();
+
+    if (!_feature_table.is_active(features::feature::controller_snapshots)) {
+        vlog(clusterlog.warn, "skipping snapshotting, feature not enabled");
+        co_return std::nullopt;
+    }
+
+    controller_snapshot data;
+    // TODO: fill snapshot
+
+    vlog(
+      clusterlog.info,
+      "created snapshot at offset {} in {} ms",
+      get_last_applied_offset(),
+      (ss::steady_clock_type::now() - started_at) / 1ms);
+
+    // release apply_mtx and let the stm continue operation while we are
+    // serializing.
+    apply_mtx_holder.return_all();
+    co_await ss::yield();
+
+    iobuf snapshot_buf;
+    co_await serde::write_async(snapshot_buf, std::move(data));
+    co_return snapshot_buf;
+}
+
+ss::future<> controller_stm::apply_snapshot(
+  model::offset offset, storage::snapshot_reader& reader) {
+    const size_t size = co_await reader.get_snapshot_size();
+    vlog(
+      clusterlog.info,
+      "loading snapshot at offset: {}, size: {}, previous last_applied: {}",
+      offset,
+      size,
+      get_last_applied_offset());
+
+    auto snap_buf_parser = iobuf_parser{
+      co_await read_iobuf_exactly(reader.input(), size)};
+    co_await serde::read_async<controller_snapshot>(snap_buf_parser);
+
+    vassert(false, "not implemented");
+}
+
+} // namespace cluster

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -36,9 +36,16 @@ class controller_stm final
       bootstrap_backend> {
 public:
     template<typename... Args>
-    controller_stm(limiter_configuration limiter_conf, Args&&... stm_args)
+    controller_stm(
+      limiter_configuration limiter_conf,
+      const ss::sharded<features::feature_table>& feature_table,
+      config::binding<std::chrono::seconds>&& snapshot_max_age,
+      Args&&... stm_args)
       : mux_state_machine(std::forward<Args>(stm_args)...)
-      , _limiter(std::move(limiter_conf)) {}
+      , _limiter(std::move(limiter_conf))
+      , _feature_table(feature_table.local())
+      , _snapshot_max_age(std::move(snapshot_max_age))
+      , _snapshot_debounce_timer([this] { snapshot_timer_callback(); }) {}
 
     controller_stm(controller_stm&&) = delete;
     controller_stm(const controller_stm&) = delete;
@@ -50,18 +57,22 @@ public:
     requires ControllerCommand<Cmd>
     bool throttle() { return _limiter.throttle<Cmd>(); }
 
+    virtual ss::future<> stop() final;
+
 private:
+    ss::future<> on_batch_applied() final;
+    void snapshot_timer_callback();
+
     ss::future<std::optional<iobuf>>
-    maybe_make_snapshot(ssx::semaphore_units apply_mtx_holder) final {
-        co_return std::nullopt;
-    }
-    ss::future<>
-    apply_snapshot(model::offset, storage::snapshot_reader&) final {
-        vassert(false, "not implemented");
-    }
+    maybe_make_snapshot(ssx::semaphore_units apply_mtx_holder) final;
+    ss::future<> apply_snapshot(model::offset, storage::snapshot_reader&) final;
 
 private:
     controller_log_limiter _limiter;
+    const features::feature_table& _feature_table;
+    config::binding<std::chrono::seconds> _snapshot_max_age;
+
+    ss::timer<ss::lowres_clock> _snapshot_debounce_timer;
 };
 
 static constexpr ss::shard_id controller_stm_shard = 0;

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -51,6 +51,16 @@ public:
     bool throttle() { return _limiter.throttle<Cmd>(); }
 
 private:
+    ss::future<std::optional<iobuf>>
+    maybe_make_snapshot(ssx::semaphore_units apply_mtx_holder) final {
+        co_return std::nullopt;
+    }
+    ss::future<>
+    apply_snapshot(model::offset, storage::snapshot_reader&) final {
+        vassert(false, "not implemented");
+    }
+
+private:
     controller_log_limiter _limiter;
 };
 

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -57,6 +57,7 @@ class self_test_backend;
 class self_test_frontend;
 class topic_recovery_status_frontend;
 class node_isolation_watcher;
+struct controller_snapshot;
 
 namespace node {
 class local_monitor;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -111,7 +111,8 @@ ss::future<consensus_ptr> partition_manager::manage(
   std::vector<model::broker> initial_nodes,
   std::optional<remote_topic_properties> rtp,
   std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
-  raft::with_learner_recovery_throttle enable_learner_recovery_throttle) {
+  raft::with_learner_recovery_throttle enable_learner_recovery_throttle,
+  raft::keep_snapshotted_log keep_snapshotted_log) {
     gate_guard guard(_gate);
     auto dl_result = co_await maybe_download_log(ntp_cfg, rtp);
     auto [logs_recovered, min_kafka_offset, max_kafka_offset, manifest]
@@ -180,7 +181,11 @@ ss::future<consensus_ptr> partition_manager::manage(
 
     ss::lw_shared_ptr<raft::consensus> c
       = co_await _raft_manager.local().create_group(
-        group, std::move(initial_nodes), log, enable_learner_recovery_throttle);
+        group,
+        std::move(initial_nodes),
+        log,
+        enable_learner_recovery_throttle,
+        keep_snapshotted_log);
 
     auto p = ss::make_lw_shared<partition>(
       c,

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -89,7 +89,8 @@ public:
       std::optional<remote_topic_properties> = std::nullopt,
       std::optional<cloud_storage_clients::bucket_name> = std::nullopt,
       raft::with_learner_recovery_throttle
-      = raft::with_learner_recovery_throttle::yes);
+      = raft::with_learner_recovery_throttle::yes,
+      raft::keep_snapshotted_log = raft::keep_snapshotted_log::no);
 
     ss::future<> shutdown(const model::ntp& ntp);
 

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -60,6 +60,12 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
           labels)
           .aggregate(aggregate_labels),
         sm::make_gauge(
+          "start_offset",
+          [this] { return _partition.start_offset(); },
+          sm::description("start offset"),
+          labels)
+          .aggregate(aggregate_labels),
+        sm::make_gauge(
           "last_stable_offset",
           [this] { return _partition.last_stable_offset(); },
           sm::description("Last stable offset"),

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -37,7 +37,8 @@ static ss::future<consensus_ptr> create_raft0(
         std::move(initial_brokers),
         std::nullopt,
         std::nullopt,
-        raft::with_learner_recovery_throttle::no)
+        raft::with_learner_recovery_throttle::no,
+        raft::keep_snapshotted_log::yes)
       .then([&st](consensus_ptr p) {
           // Add raft 0 to shard table
           return st

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1831,7 +1831,14 @@ configuration::configuration()
       "considering itself to be isolated",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       3000,
-      {.min = 100, .max = 10000}) {}
+      {.min = 100, .max = 10000})
+  , controller_snapshot_max_age_sec(
+      *this,
+      "controller_snapshot_max_age_sec",
+      "Max time that will pass before we make an attempt to create a "
+      "controller snapshot, after a new controller command appears",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      60s) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -383,6 +383,8 @@ struct configuration final : public config_store {
 
     bounded_property<int64_t> node_isolation_heartbeat_timeout;
 
+    property<std::chrono::seconds> controller_snapshot_max_age_sec;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -69,6 +69,9 @@ std::string_view to_string_view(feature f) {
         return "rpc_transport_unknown_errc";
     case feature::membership_change_controller_cmds:
         return "membership_change_controller_cmds";
+    case feature::controller_snapshots:
+        return "controller_snapshots";
+
     /*
      * testing features
      */

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -55,6 +55,7 @@ enum class feature : std::uint64_t {
     group_offset_retention = 1ULL << 20U,
     rpc_transport_unknown_errc = 1ULL << 21U,
     membership_change_controller_cmds = 1ULL << 22U,
+    controller_snapshots = 1ULL << 23U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 62U,
@@ -245,6 +246,12 @@ constexpr static std::array feature_schema{
     "membership_change_controller_cmds",
     feature::membership_change_controller_cmds,
     feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{10},
+    "controller_snapshots",
+    feature::controller_snapshots,
+    feature_spec::available_policy::explicit_only,
     feature_spec::prepare_policy::always},
 
   // For testing, a feature that does not auto-activate

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2006,8 +2006,13 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
           _last_snapshot_term = metadata.last_included_term;
 
           // TODO: add applying snapshot content to state machine
+          auto prev_commit_index = _commit_index;
           _commit_index = std::max(_last_snapshot_index, _commit_index);
           maybe_update_last_visible_index(_commit_index);
+          if (prev_commit_index != _commit_index) {
+              _commit_index_updated.broadcast();
+              _event_manager.notify_commit_index();
+          }
 
           update_follower_stats(metadata.latest_configuration);
           return _configuration_manager

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -99,7 +99,8 @@ public:
       std::optional<std::reference_wrapper<recovery_throttle>>,
       recovery_memory_quota&,
       features::feature_table&,
-      std::optional<voter_priority> = std::nullopt);
+      std::optional<voter_priority> = std::nullopt,
+      keep_snapshotted_log = keep_snapshotted_log::no);
 
     /// Initial call. Allow for internal state recovery
     ss::future<> start();
@@ -715,6 +716,7 @@ private:
     model::offset _visibility_upper_bound_index;
     voter_priority _target_priority = voter_priority::max();
     std::optional<voter_priority> _node_priority_override;
+    keep_snapshotted_log _keep_snapshotted_log;
 
     // used to track currently installed snapshot
     model::offset _received_snapshot_index;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -410,7 +410,7 @@ private:
     ss::future<append_entries_reply>
     do_append_entries(append_entries_request&&);
     ss::future<install_snapshot_reply>
-    do_install_snapshot(install_snapshot_request&& r);
+    do_install_snapshot(install_snapshot_request r);
     ss::future<> do_start();
 
     ss::future<result<replicate_result>> dispatch_replicate(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -700,6 +700,10 @@ private:
     voter_priority _target_priority = voter_priority::max();
     std::optional<voter_priority> _node_priority_override;
 
+    // used to track currently installed snapshot
+    model::offset _received_snapshot_index;
+    size_t _received_snapshot_bytes = 0;
+
     /**
      * We keep an idex of the most recent entry replicated with quorum
      * consistency level to make sure that all requests replicated with quorum

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -81,7 +81,8 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
   raft::group_id id,
   std::vector<model::broker> nodes,
   storage::log log,
-  with_learner_recovery_throttle enable_learner_recovery_throttle) {
+  with_learner_recovery_throttle enable_learner_recovery_throttle,
+  keep_snapshotted_log keep_snapshotted_log) {
     auto revision = log.config().get_revision();
     auto raft_cfg = create_initial_configuration(std::move(nodes), revision);
 
@@ -105,7 +106,8 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
         : std::nullopt,
       _recovery_mem_quota,
       _feature_table,
-      _is_ready ? std::nullopt : std::make_optional(min_voter_priority));
+      _is_ready ? std::nullopt : std::make_optional(min_voter_priority),
+      keep_snapshotted_log);
 
     return ss::with_gate(_gate, [this, raft] {
         return _heartbeats.register_group(raft).then([this, raft] {

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -63,7 +63,8 @@ public:
       raft::group_id id,
       std::vector<model::broker> nodes,
       storage::log log,
-      with_learner_recovery_throttle enable_learner_recovery_throttle);
+      with_learner_recovery_throttle enable_learner_recovery_throttle,
+      keep_snapshotted_log = keep_snapshotted_log::no);
 
     ss::future<> shutdown(ss::lw_shared_ptr<raft::consensus>);
 

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -122,11 +122,10 @@ private:
     public:
         explicit batch_applicator(state_machine*);
         ss::future<ss::stop_iteration> operator()(model::record_batch);
-        model::offset end_of_stream() const { return _last_applied; }
+        void end_of_stream() const {}
 
     private:
         state_machine* _machine;
-        model::offset _last_applied;
     };
 
     friend batch_applicator;

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -802,6 +802,9 @@ std::ostream& operator<<(std::ostream& o, const append_entries_reply::status&);
 
 using with_learner_recovery_throttle
   = ss::bool_class<struct with_recovery_throttle_tag>;
+
+using keep_snapshotted_log = ss::bool_class<struct keep_snapshotted_log_tag>;
+
 } // namespace raft
 
 namespace reflection {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -612,7 +612,7 @@ struct install_snapshot_reply
     //  as the value for byte_offset in the next request (most importantly,
     //  when a follower reboots, it returns 0 here and the leader starts at
     //  offset 0 in the next request).
-    uint64_t bytes_stored;
+    uint64_t bytes_stored = 0;
     // indicates if the request was successfull
     bool success = false;
 

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -105,6 +105,12 @@ class Partition:
         # until they're sealed)
         return n_recovered >= len(self.segments) - 1
 
+    def get_mtime(self, filename):
+        path = os.path.join(self.path, filename)
+        out = self.node.account.ssh_capture(f"stat --format=%Y {path}")
+        mtime = ''.join(out).strip()
+        return int(mtime)
+
     def __repr__(self):
         return "part-{}-{}-{}".format(self.node.name, self.num, self.segments)
 

--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -167,10 +167,7 @@ class CompactionRecoveryUpgradeTest(RedpandaTest):
             for sname, seg in partition.segments.items():
                 if seg.base_index:
                     path = os.path.join(partition.path, seg.data_file)
-                    out = partition.node.account.ssh_capture(
-                        f"stat --format=%Y {path}")
-                    mtime = ''.join(out).strip()
-                    seg2mtime[path] = int(mtime)
+                    seg2mtime[path] = partition.get_mtime(seg.data_file)
 
             for k, v in sorted(seg2mtime.items()):
                 self.logger.debug(f"mtime for closed segment {k}: {v}")

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -1,0 +1,83 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
+from rptest.clients.rpk import RpkTool
+from rptest.util import wait_until_result
+
+from ducktape.utils.util import wait_until
+
+
+class ControllerSnapshotTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         num_brokers=3,
+                         extra_rp_conf={'controller_snapshot_max_age_sec': 5},
+                         **kwargs)
+
+    def setUp(self):
+        # start the nodes manually
+        pass
+
+    def _controller_start_offset(self, node):
+        metrics = list(self.redpanda.metrics(node))
+        for family in metrics:
+            if family.name == 'vectorized_cluster_partition_start_offset':
+                for s in family.samples:
+                    if s.labels['namespace'] == 'redpanda' and s.labels[
+                            'topic'] == 'controller':
+                        return int(s.value)
+        return 0
+
+    def _wait_for_controller_snapshot(self,
+                                      node,
+                                      prev_mtime=0,
+                                      prev_start_offset=0):
+        def check():
+            storage = self.redpanda.node_storage(node)
+            controller = storage.partitions('redpanda', 'controller')
+            assert len(controller) == 1
+            controller = controller[0]
+
+            mtime = 0
+            if 'snapshot' in controller.files:
+                mtime = controller.get_mtime('snapshot')
+
+            so = self._controller_start_offset(node)
+            self.logger.info(
+                f"node {node.account.hostname}: "
+                f"controller start offset: {so}, snapshot mtime: {mtime}")
+
+            return (mtime > prev_mtime and so > prev_start_offset, (mtime, so))
+
+        return wait_until_result(check, timeout_sec=30, backoff_sec=1)
+
+    @cluster(num_nodes=3)
+    def test_snapshotting_policy(self):
+        """
+        Test that Redpanda creates a controller snapshot some time after controller commands appear.
+        """
+        self.redpanda.start()
+        node = self.redpanda.nodes[0]
+        assert self._controller_start_offset(node) == 0
+
+        admin = Admin(self.redpanda)
+        admin.put_feature("controller_snapshots", {"state": "active"})
+
+        # first snapshot will be triggered by the feature_update command
+        (mtime1, start_offset1) = self._wait_for_controller_snapshot(node)
+
+        # second snapshot will be triggered by the topic creation
+        RpkTool(self.redpanda).create_topic('test')
+        self._wait_for_controller_snapshot(node,
+                                           prev_mtime=mtime1,
+                                           prev_start_offset=start_offset1)


### PR DESCRIPTION
This is part 1 of the implementation of the controller snapshots feature. It contains just snapshot writing/loading code, actual code that saves/restores STM state will go into separate PRs.

RFC with the detailed design description is [here](https://docs.google.com/document/d/1n6GN-WGFR015R1Een63Ligmak_uoP1sLzPO4P-NAkLE/edit?usp=sharing).

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
### Features
* Implemented controller log snapshots. This should improve startup times of nodes in long-running Redpanda clusters. To enable, activate the `controller_snapshots` feature.