### PR TITLE
Pass timeout to the correct arg in ProducerSwarm.

### DIFF
--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -82,9 +82,12 @@ class ManyClientsTest(RedpandaTest):
                                  group="testgroup",
                                  save_msgs=False)
 
-        producer = ProducerSwarm(self.test_context, self.redpanda, TOPIC_NAME,
-                                 PRODUCER_COUNT, RECORDS_PER_PRODUCER,
-                                 PRODUCER_TIMEOUT_MS)
+        producer = ProducerSwarm(self.test_context,
+                                 self.redpanda,
+                                 TOPIC_NAME,
+                                 PRODUCER_COUNT,
+                                 RECORDS_PER_PRODUCER,
+                                 timeout_ms=PRODUCER_TIMEOUT_MS)
         producer.start()
         consumer_a.start()
         consumer_b.start()


### PR DESCRIPTION
Currently we are passing timeout to the the `log_level` argument. This PR changes it to be passed to the  `timeout_ms` argument.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
* none