### PR TITLE
cluster/persisted_stm: fix initialization of insync_offset

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -359,6 +359,7 @@ ss::future<> persisted_stm::start() {
         auto next_offset = model::next_offset(snapshot.header.offset);
         if (next_offset >= _c->start_offset()) {
             co_await apply_snapshot(snapshot.header, std::move(snapshot.data));
+            set_next(next_offset);
         } else {
             // This can happen on an out-of-date replica that re-joins the group
             // after other replicas have already evicted logs to some offset
@@ -369,13 +370,15 @@ ss::future<> persisted_stm::start() {
               clusterlog.warn,
               "Skipping snapshot {} since it's out of sync with the log",
               _snapshot_mgr.snapshot_path());
+            _insync_offset = model::prev_offset(next_offset);
+            set_next(next_offset);
         }
-        set_next(next_offset);
 
         _resolved_when_snapshot_hydrated.set_value();
     } else {
         auto offset = _c->start_offset();
         if (offset >= model::offset(0)) {
+            _insync_offset = model::prev_offset(offset);
             set_next(offset);
         }
         _resolved_when_snapshot_hydrated.set_value();

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -90,6 +90,7 @@ public:
     model::offset max_collectible_offset() override;
     ss::future<std::vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
+    const ss::sstring& name() override { return _snapshot_mgr.name(); }
 
     virtual ss::future<> remove_persistent_state();
 

--- a/src/v/storage/snapshot.h
+++ b/src/v/storage/snapshot.h
@@ -277,6 +277,8 @@ public:
         return _snapshot.remove_snapshot(_filename);
     }
 
+    const ss::sstring& name() { return _filename; }
+
 private:
     ss::sstring _filename;
     snapshot_manager _snapshot;

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -10,14 +10,26 @@
 #include "storage/types.h"
 
 #include "storage/compacted_index.h"
+#include "storage/logger.h"
 #include "storage/ntp_config.h"
 #include "utils/human.h"
 #include "utils/to_string.h"
+#include "vlog.h"
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 
 namespace storage {
+
+model::offset stm_manager::max_collectible_offset() {
+    model::offset result = model::offset::max();
+    for (const auto& stm : _stms) {
+        auto mco = stm->max_collectible_offset();
+        result = std::min(result, mco);
+        vlog(stlog.trace, "max_collectible_offset[{}] = {}", stm->name(), mco);
+    }
+    return result;
+}
 
 std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
     switch (d) {

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -73,6 +73,8 @@ public:
     // log eviction attempts to offsets not greater than this.
     virtual model::offset max_collectible_offset() = 0;
 
+    virtual const ss::sstring& name() = 0;
+
     // Only valid for state machines maintaining transactional state.
     // Returns aborted transactions in range [from, to] offsets.
     virtual ss::future<std::vector<model::tx_range>>
@@ -135,13 +137,7 @@ public:
         }
     }
 
-    model::offset max_collectible_offset() {
-        model::offset result = model::offset::max();
-        for (const auto& stm : _stms) {
-            result = std::min(result, stm->max_collectible_offset());
-        }
-        return result;
-    }
+    model::offset max_collectible_offset();
 
     ss::future<std::vector<model::tx_range>>
     aborted_tx_ranges(model::offset to, model::offset from) {


### PR DESCRIPTION
In situations where the log had been written to, but no snapshot
was found, this was being left at min() while the _next pointer
was being advanced.

In f54ad33, set_next was extended
to allow _waiters to proceed up to the offset before _next.  An
assertion in ensure_snapshot_exists required that insync_offset
be >= the offset that _waiters had proceeded past: this could fail.

Fixes https://github.com/redpanda-data/redpanda/issues/8293

## Backports Required

**Needs backporting along with https://github.com/redpanda-data/redpanda/pull/8271 -- cherry pick this into the backport PRs that already exist for #8271**

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes


  * none


