### PR TITLE
ducktape/kerberos: Improvements to Kerberos tests

### DIFF
--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -100,10 +100,6 @@ EOF
 """
         node.account.ssh(cmd, allow_fail=False)
 
-    def start_cmd(self):
-        cmd = f"krb5kdc -P {KRB5KDC_PID_PATH};kadmind -P {KADMIND_PID_PATH}"
-        return cmd
-
     def pids(self, node):
         def pid(path: str):
             try:
@@ -126,11 +122,8 @@ EOF
 
     def start_node(self, node):
         self._render_cfg(node)
+        # Also runs krb5kdc and kadmind
         self._init_realm(node)
-        # Run kdc
-        cmd = self.start_cmd()
-        self.logger.debug("kdc command: %s", cmd)
-        node.account.ssh(cmd, allow_fail=False)
         wait_until(lambda: self.alive(node),
                    timeout_sec=30,
                    backoff_sec=.5,

--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -111,7 +111,7 @@ EOF
                     return [p]
 
             except (RemoteCommandError, ValueError):
-                self.logger.warn("pidfile not found: {path}")
+                self.logger.warn(f"pidfile not found: {path}")
 
             return []
 

--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -18,8 +18,12 @@ KDC_CONF_TMPL = """
 		max_renewable_life = 7d 0h 0m 0s
 		supported_enctypes = {supported_encryption_types}
 		default_principal_flags = +preauth
-	}}
+}}
+[logging]
+    kdc = FILE = /var/log/kdc.log
+    admin_server = FILE:/var/log/kadmin.log
 """
+
 KDC_CONF_PATH = "/etc/krb5kdc/kdc.conf"
 
 KRB5_CONF_TMPL = """
@@ -42,6 +46,16 @@ KDC_DB_PATH = "/var/lib/krb5kdc/principal"
 
 
 class KrbKdc(Service):
+    logs = {
+        "kdc_log": {
+            "path": "/var/log/kdc.log",
+            "collect_default": True
+        },
+        "kadmin_log": {
+            "path": "/var/log/kadmin.log",
+            "collect_default": True
+        }
+    }
     """
     A Kerberos KDC implementation backed by krb5-kdc (MIT).
     """


### PR DESCRIPTION
* [Collect kdc and kadmind logs](https://github.com/redpanda-data/redpanda/commit/3e4aabf65e080285312e251e30c28c3db070e6fe) for easier debugging
* [newrealm starts krb5kdc && kadmind](https://github.com/redpanda-data/redpanda/commit/3a985d20f57b0ba354baebb070c124b2b98e3eb5) - don't leave behind extra processes on cleanup
* [Fix format string for missing pidfile](https://github.com/redpanda-data/redpanda/commit/55a648e9ade6bc0e917e8e641cce048843b214f7) 
* [Ensure the service principal has fqdn](https://github.com/redpanda-data/redpanda/commit/da0b2cc8454e0f90293dad0ff590e99dcd4bb999) -  should allow running on CDT

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none