### PR TITLE
RPK io-properties quoting and format

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -581,7 +581,7 @@ func buildRedpandaFlags(
 				if err != nil {
 					return nil, err
 				}
-				sFlags.ioProperties = fmt.Sprintf("'%s'", yaml)
+				sFlags.ioProperties = yaml
 			}
 		}
 	}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -577,11 +577,11 @@ func buildRedpandaFlags(
 			if err != nil {
 				log.Warn(err)
 			} else if ioProps != nil {
-				yaml, err := iotune.ToYaml(*ioProps)
+				json, err := iotune.ToJSON(*ioProps)
 				if err != nil {
 					return nil, err
 				}
-				sFlags.ioProperties = yaml
+				sFlags.ioProperties = json
 			}
 		}
 	}

--- a/src/go/rpk/pkg/tuners/iotune/data.go
+++ b/src/go/rpk/pkg/tuners/iotune/data.go
@@ -10,19 +10,19 @@
 package iotune
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cloud/vendor"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 )
 
 type IoProperties struct {
-	MountPoint     string `yaml:"mountpoint"`
-	ReadIops       int64  `yaml:"read_iops"`
-	ReadBandwidth  int64  `yaml:"read_bandwidth"`
-	WriteIops      int64  `yaml:"write_iops"`
-	WriteBandwidth int64  `yaml:"write_bandwidth"`
+	MountPoint     string `json:"mountpoint"`
+	ReadIops       int64  `json:"read_iops"`
+	ReadBandwidth  int64  `json:"read_bandwidth"`
+	WriteIops      int64  `json:"write_iops"`
+	WriteBandwidth int64  `json:"write_bandwidth"`
 }
 
 type io = IoProperties
@@ -56,15 +56,15 @@ func DataForVendor(
 	return DataFor(mountpoint, v.Name(), vmType, "default")
 }
 
-func ToYaml(props IoProperties) (string, error) {
+func ToJSON(props IoProperties) (string, error) {
 	type ioPropertiesWrapper struct {
-		Disks []IoProperties `yaml:"disks"`
+		Disks []IoProperties `json:"disks"`
 	}
-	yaml, err := yaml.Marshal(ioPropertiesWrapper{[]io{props}})
+	json, err := json.Marshal(ioPropertiesWrapper{[]io{props}})
 	if err != nil {
 		return "", err
 	}
-	return string(yaml), nil
+	return string(json), nil
 }
 
 func precompiledData() map[string]map[string]map[string]io {


### PR DESCRIPTION
Fixes quoting issue in rpk start, changes format to json.

See changes for detailed descriptions.

Fixes #8283.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

We aren't yet sure about the backport since this depends on another fix for #8280 too.

## Release Notes

  * none