### PR TITLE
cloud_storage: metric for memory consumed by manifest segments metadata

### DIFF
--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -82,7 +82,8 @@ public:
       raft::consensus*,
       cloud_storage::remote& remote,
       features::feature_table&,
-      ss::logger& logger);
+      ss::logger& logger,
+      ss::shared_ptr<util::mem_tracker> partition_mem_tracker = nullptr);
 
     /// Add segments to the raft log, replicate them and
     /// wait until it is applied to the STM.

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -41,6 +41,8 @@ partition::partition(
   config::binding<uint64_t> max_concurrent_producer_ids,
   std::optional<cloud_storage_clients::bucket_name> read_replica_bucket)
   : _raft(r)
+  , _partition_mem_tracker(
+      ss::make_shared<util::mem_tracker>(_raft->ntp().path()))
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _tx_gateway_frontend(tx_gateway_frontend)
   , _feature_table(feature_table)
@@ -99,7 +101,8 @@ partition::partition(
                 _raft.get(),
                 _cloud_storage_api.local(),
                 _feature_table.local(),
-                clusterlog);
+                clusterlog,
+                _partition_mem_tracker);
             stm_manager->add_stm(_archival_meta_stm);
 
             if (cloud_storage_cache.local_is_initialized()) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -314,6 +314,7 @@ public:
 
 private:
     consensus_ptr _raft;
+    ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;
     ss::lw_shared_ptr<raft::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -133,6 +133,19 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
           sm::description("Total number of bytes fetched"),
           labels)
           .aggregate(aggregate_labels),
+        sm::make_total_bytes(
+          "cloud_storage_segments_metadata_bytes",
+          [this] {
+              return _partition.archival_meta_stm()
+                       ? _partition.archival_meta_stm()
+                           ->manifest()
+                           .segments_metadata_bytes()
+                       : 0;
+          },
+          sm::description("Current number of bytes consumed by remote segments "
+                          "managed for this partition"),
+          labels)
+          .aggregate(aggregate_labels),
       });
 }
 


### PR DESCRIPTION
This commit plumbs a `util::mem_tracker` into the `partition_manifest`
so it may allocate its `segment_map` with a `tracking_allocator`. This
will be useful to expose a metric for memory consumed by segments.

This adds some unit tests to exemplify how different manifest APIs
affect tracked memory. While the results are strongly coupled with the
underlying implementation, they're still worth having around to better
understand how our memory footprint respond to different events, until
otherwise changed.

This will also be useful as a metric with which to gauge further improvements to the manifest's in-memory format (see https://github.com/redpanda-data/redpanda/pull/7898)

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Improvements

* A new partition metric `redpanda_cloud_storage_segments_metadata_bytes` is added that tracks the amount of memory consumed by segment metadata managed by the remote partition.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
