### PR TITLE
rpk: check in default path for ballast file

### DIFF
--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -170,12 +170,16 @@ func NewIOConfigFileExistanceChecker(fs afero.Fs, filePath string) Checker {
 }
 
 func NewBallastFileChecker(fs afero.Fs, conf *config.Config) Checker {
+	path := config.DefaultBallastFilePath
+	if conf.Rpk.BallastFilePath != "" {
+		path = conf.Rpk.BallastFilePath
+	}
 	return NewFileExistanceChecker(
 		fs,
 		IoConfigFileChecker,
 		"Ballast file present",
 		Warning,
-		conf.Rpk.BallastFilePath,
+		path,
 	)
 }
 


### PR DESCRIPTION
Ballast file checker will check if the ballast
file is in the default location or in the
redpanda.yaml's `rpk.ballast_file_path`

Fixes #8223

## Backports Required


- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  ### Bug Fixes

  * rpk now will check if the ballast file is present in the default location when running `rpk redpanda check`