### PR TITLE
Fix finishing move when all added nodes are down

### DIFF
--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -140,7 +140,7 @@ controller_api::get_reconciliation_state(model::topic_namespace_view tp_ns) {
     co_return co_await get_reconciliation_state(std::move(ntps));
 }
 
-ss::future<std::vector<topic_table_delta>>
+ss::future<std::vector<controller_backend::delta_metadata>>
 controller_api::get_remote_core_deltas(model::ntp ntp, ss::shard_id shard) {
     return _backend.invoke_on(
       shard, [ntp = std::move(ntp)](controller_backend& backend) {
@@ -171,11 +171,11 @@ controller_api::get_reconciliation_state(model::ntp ntp) {
           local_deltas.begin(),
           local_deltas.end(),
           std::back_inserter(ops),
-          [shard](topic_table_delta& delta) {
+          [shard](controller_backend::delta_metadata& m) {
               return backend_operation{
                 .source_shard = shard,
-                .p_as = std::move(delta.new_assignment),
-                .type = delta.type,
+                .p_as = std::move(m.delta.new_assignment),
+                .type = m.delta.type,
               };
           });
     }

--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "cluster/controller_backend.h"
 #include "cluster/fwd.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
@@ -80,7 +81,7 @@ private:
       absl::node_hash_map<model::node_id, std::vector<model::ntp>>,
       model::timeout_clock::time_point);
 
-    ss::future<std::vector<topic_table_delta>>
+    ss::future<std::vector<controller_backend::delta_metadata>>
       get_remote_core_deltas(model::ntp, ss::shard_id);
 
     model::node_id _self;

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -963,7 +963,8 @@ controller_backend::process_partition_reconfiguration(
                 co_return co_await dispatch_update_finished(
                   std::move(ntp), target_assignment);
             }
-            co_return ec;
+            // Wait fo the operation to be finished on one of the nodes
+            co_return errc::waiting_for_reconfiguration_finish;
         }
 
         /**

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -273,14 +273,15 @@ private:
     ss::future<> reconcile_topics();
     ss::future<> reconcile_ntp(deltas_t&);
 
-    ss::future<std::error_code> execute_partition_op(const topic_table::delta&);
+    ss::future<std::error_code> execute_partition_op(const delta_metadata&);
     ss::future<std::error_code> process_partition_reconfiguration(
-      topic_table_delta::op_type,
-      model::ntp,
-      const partition_assignment&,
-      const std::vector<model::broker_shard>&,
-      const topic_table_delta::revision_map_t&,
-      model::revision_id);
+      uint64_t current_retry,
+      topic_table_delta::op_type operation_type,
+      model::ntp ntp,
+      const partition_assignment& requested_assignment,
+      const std::vector<model::broker_shard>& previous_replica_set,
+      const topic_table_delta::revision_map_t& revisions_map,
+      model::revision_id rev);
 
     ss::future<std::error_code> execute_reconfiguration(
       topic_table_delta::op_type,
@@ -348,9 +349,9 @@ private:
       model::ntp, ss::shard_id, partition_assignment);
 
     bool can_finish_update(
-      topic_table_delta::op_type,
-      const std::vector<model::broker_shard>&,
-      const std::vector<model::broker_shard>&);
+      uint64_t current_retry,
+      topic_table_delta::op_type operation_type,
+      const std::vector<model::broker_shard>& requested_replicas);
 
     void housekeeping();
     void setup_metrics();

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -35,6 +35,7 @@ enum class errc : int16_t {
     not_leader,
     partition_already_exists,
     waiting_for_recovery,
+    waiting_for_reconfiguration_finish,
     update_in_progress,
     user_exists,
     user_does_not_exist,
@@ -116,6 +117,8 @@ struct errc_category final : public std::error_category {
             return "Requested partition already exists";
         case errc::waiting_for_recovery:
             return "Waiting for partition to recover";
+        case errc::waiting_for_reconfiguration_finish:
+            return "Waiting for partition recovery to be finished";
         case errc::update_in_progress:
             return "Partition configuration update in progress";
         case errc::user_exists:

--- a/src/v/cluster/tests/controller_backend_test.cc
+++ b/src/v/cluster/tests/controller_backend_test.cc
@@ -30,53 +30,54 @@ make_assignment(std::vector<model::broker_shard> replicas) {
 
 using op_t = cluster::topic_table::delta::op_type;
 using delta_t = cluster::topic_table::delta;
-using deltas_t = std::vector<cluster::topic_table::delta>;
+using meta_t = cluster::controller_backend::delta_metadata;
+using deltas_t = std::vector<meta_t>;
 
-cluster::topic_table::delta make_delta(
+meta_t make_delta(
   std::vector<model::broker_shard> replicas,
   int64_t o,
   cluster::topic_table::delta::op_type type) {
-    return cluster::topic_table::delta(
-      test_ntp, make_assignment(std::move(replicas)), model::offset(o), type);
+    return meta_t(cluster::topic_table::delta(
+      test_ntp, make_assignment(std::move(replicas)), model::offset(o), type));
 };
 
-delta_t add_current = make_delta(
+meta_t add_current = make_delta(
   {make_bs(0, 0), make_bs(2, 1), make_bs(1, 0)}, 1, op_t::add);
 
-delta_t add_different = make_delta(
+meta_t add_different = make_delta(
   {make_bs(3, 0), make_bs(2, 1), make_bs(1, 0)}, 2, op_t::add);
 
-delta_t delete_current = make_delta(
+meta_t delete_current = make_delta(
   {make_bs(0, 0), make_bs(2, 1), make_bs(1, 0)}, 3, op_t::del);
 
-delta_t recreate_different = make_delta({make_bs(3, 0)}, 4, op_t::add);
+meta_t recreate_different = make_delta({make_bs(3, 0)}, 4, op_t::add);
 
-delta_t recreate_current = make_delta({make_bs(0, 0)}, 5, op_t::add);
+meta_t recreate_current = make_delta({make_bs(0, 0)}, 5, op_t::add);
 
-delta_t update_with_current = make_delta(
+meta_t update_with_current = make_delta(
   {make_bs(0, 0), make_bs(10, 0)}, 6, op_t::update);
 
-delta_t finish_update_with_current = make_delta(
+meta_t finish_update_with_current = make_delta(
   {make_bs(0, 0), make_bs(10, 0)}, 7, op_t::update_finished);
 
-delta_t update_without_current = make_delta(
+meta_t update_without_current = make_delta(
   {make_bs(1, 0), make_bs(10, 0)}, 8, op_t::update);
 
-delta_t finish_update_without_current = make_delta(
+meta_t finish_update_without_current = make_delta(
   {make_bs(1, 0), make_bs(10, 0)}, 9, op_t::update_finished);
 
-delta_t update_without_current_2 = make_delta(
+meta_t update_without_current_2 = make_delta(
   {make_bs(10, 0)}, 10, op_t::update);
 
-delta_t finish_update_without_current_2 = make_delta(
+meta_t finish_update_without_current_2 = make_delta(
   {make_bs(10, 0)}, 11, op_t::update_finished);
 
-delta_t update_with_current_2 = make_delta({make_bs(0, 0)}, 12, op_t::update);
+meta_t update_with_current_2 = make_delta({make_bs(0, 0)}, 12, op_t::update);
 
-delta_t finish_update_with_current_2 = make_delta(
+meta_t finish_update_with_current_2 = make_delta(
   {make_bs(0, 0)}, 13, op_t::update_finished);
 
-delta_t final_delete = make_delta(
+meta_t final_delete = make_delta(
   {make_bs(0, 0), make_bs(2, 1), make_bs(1, 0)}, 100, op_t::del);
 
 SEASTAR_THREAD_TEST_CASE(test_simple_bootstrap) {
@@ -86,7 +87,7 @@ SEASTAR_THREAD_TEST_CASE(test_simple_bootstrap) {
       current_node, std::move(d_1));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas.back().offset, add_current.offset);
+    BOOST_REQUIRE_EQUAL(deltas.back().delta.offset, add_current.delta.offset);
 
     // add topic on different node, should include this as this is noop on the
     // current node
@@ -94,28 +95,31 @@ SEASTAR_THREAD_TEST_CASE(test_simple_bootstrap) {
     deltas = cluster::calculate_bootstrap_deltas(current_node, std::move(d_2));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas.back().offset, add_different.offset);
+    BOOST_REQUIRE_EQUAL(deltas.back().delta.offset, add_different.delta.offset);
 
     // add & delete topic
     deltas_t d_3{add_current, delete_current};
     deltas = cluster::calculate_bootstrap_deltas(current_node, std::move(d_3));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas.back().offset, delete_current.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas.back().delta.offset, delete_current.delta.offset);
 
     // recreate topic on current node
     deltas_t d_4{add_current, delete_current, recreate_current};
     deltas = cluster::calculate_bootstrap_deltas(current_node, std::move(d_4));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas.back().offset, recreate_current.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas.back().delta.offset, recreate_current.delta.offset);
 
     // recreate topic on different node
     deltas_t d_5{add_current, delete_current, recreate_different};
     deltas = cluster::calculate_bootstrap_deltas(current_node, std::move(d_5));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas.back().offset, recreate_different.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas.back().delta.offset, recreate_different.delta.offset);
 }
 
 SEASTAR_THREAD_TEST_CASE(update_including_current_node) {
@@ -132,9 +136,11 @@ SEASTAR_THREAD_TEST_CASE(update_including_current_node) {
       current_node, std::move(d_1));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 3);
-    BOOST_REQUIRE_EQUAL(deltas[0].offset, recreate_current.offset);
-    BOOST_REQUIRE_EQUAL(deltas[1].offset, update_with_current.offset);
-    BOOST_REQUIRE_EQUAL(deltas[2].offset, finish_update_with_current.offset);
+    BOOST_REQUIRE_EQUAL(deltas[0].delta.offset, recreate_current.delta.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas[1].delta.offset, update_with_current.delta.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas[2].delta.offset, finish_update_with_current.delta.offset);
 }
 
 SEASTAR_THREAD_TEST_CASE(update_excluding_current_node) {
@@ -147,7 +153,8 @@ SEASTAR_THREAD_TEST_CASE(update_excluding_current_node) {
       current_node, std::move(all));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas[0].offset, finish_update_without_current.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas[0].delta.offset, finish_update_without_current.delta.offset);
 }
 
 SEASTAR_THREAD_TEST_CASE(final_delete_on_current_node) {
@@ -165,7 +172,7 @@ SEASTAR_THREAD_TEST_CASE(final_delete_on_current_node) {
       current_node, std::move(d_1));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas[0].offset, final_delete.offset);
+    BOOST_REQUIRE_EQUAL(deltas[0].delta.offset, final_delete.delta.offset);
 }
 
 SEASTAR_THREAD_TEST_CASE(move_back_to_current_node) {
@@ -185,8 +192,10 @@ SEASTAR_THREAD_TEST_CASE(move_back_to_current_node) {
       current_node, std::move(all));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 2);
-    BOOST_REQUIRE_EQUAL(deltas[0].offset, update_with_current_2.offset);
-    BOOST_REQUIRE_EQUAL(deltas[1].offset, finish_update_with_current_2.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas[0].delta.offset, update_with_current_2.delta.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas[1].delta.offset, finish_update_with_current_2.delta.offset);
 }
 
 SEASTAR_THREAD_TEST_CASE(move_back_to_current_node_not_finished) {
@@ -205,5 +214,6 @@ SEASTAR_THREAD_TEST_CASE(move_back_to_current_node_not_finished) {
       current_node, std::move(all));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas[0].offset, update_with_current_2.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas[0].delta.offset, update_with_current_2.delta.offset);
 }

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -56,6 +56,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::partition_not_exists:
     case cluster::errc::partition_already_exists:
     case cluster::errc::waiting_for_recovery:
+    case cluster::errc::waiting_for_reconfiguration_finish:
     case cluster::errc::update_in_progress:
     case cluster::errc::user_exists:
     case cluster::errc::user_does_not_exist:

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -144,8 +144,10 @@ class NodesDecommissioningTest(EndToEndTest):
 
     def _wait_for_node_removed(self, decommissioned_id):
 
-        waiter = NodeDecommissionWaiter(self.redpanda, decommissioned_id,
-                                        self.logger)
+        waiter = NodeDecommissionWaiter(self.redpanda,
+                                        decommissioned_id,
+                                        self.logger,
+                                        progress_timeout=60)
         waiter.wait_for_removal()
 
         self._check_state_consistent(decommissioned_id)


### PR DESCRIPTION
Using delta operation retry counter to chose a replica that is going to
dispatch finish update command. Dispatching the command multiple times
does not cause any harm as it is idempotent.

Previously only nodes that were added to the replica set were allowed to
dispatch finish update command. This approach is to restrictive as any
of the replicas from current assignment can do it safely.

This approach fixes situation in which partition move cancel would never
finish in situation when node added to replica set as a result of
cancel operation is offline.


<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

  ### Improvements

  * More robust stop condition for finishing partition movement.
