### PR TITLE
tools/dev_cluster: better defaults for CPU and memory options

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -16,7 +16,7 @@
 #   [jerry@winterland]$ dev_cluster.py -e vbuild/debug/clang/bin/redpanda
 #
 import asyncio
-import multiprocessing
+import psutil
 import pathlib
 import yaml
 import dataclasses
@@ -53,10 +53,14 @@ class RedpandaConfig:
 @dataclasses.dataclass
 class NodeConfig:
     redpanda: RedpandaConfig
+    config_path: str
+
+    # This is _not_ the node_id, just the index into our array of nodes
+    index: int
 
 
 class Redpanda:
-    def __init__(self, binary, cores, config, extra_args):
+    def __init__(self, binary, cores: int, config: NodeConfig, extra_args):
         self.binary = binary
         self.cores = cores
         self.config = config
@@ -68,18 +72,23 @@ class Redpanda:
         self.process.send_signal(signal.SIGINT)
 
     async def run(self):
-        log_path = pathlib.Path(os.path.dirname(self.config)) / "redpanda.log"
+        log_path = pathlib.Path(os.path.dirname(
+            self.config.config_path)) / "redpanda.log"
 
         # If user did not override cores with extra args, apply it from our internal cores setting
         if not {"-c", "--smp"} & set(self.extra_args):
-            cores_args = f"-c {self.cores}" if self.cores else ""
+            # Caller is required to pass a finite core count
+            assert self.cores > 0
+            base_core = self.cores * self.config.index
+
+            cores_args = f"--cpuset {base_core}-{base_core + self.cores - 1}"
         else:
             cores_args = ""
 
         extra_args = ' '.join(f"\"{a}\"" for a in self.extra_args)
 
         self.process = await asyncio.create_subprocess_shell(
-            f"{self.binary} --redpanda-cfg {self.config} {cores_args} {extra_args} 2>&1 | tee -i {log_path}",
+            f"{self.binary} --redpanda-cfg {self.config.config_path} {cores_args} {extra_args} 2>&1 | tee -i {log_path}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT)
 
@@ -139,7 +148,7 @@ async def main():
         for i in range(args.nodes)
     ]
 
-    def make_node_config(i, data_dir):
+    def make_node_config(i, data_dir, config_path):
         make_address = lambda p: NetworkAddress(args.listen_address, p + i)
         rpc_address = seed_servers[i]
         redpanda = RedpandaConfig(data_directory=data_dir,
@@ -149,7 +158,7 @@ async def main():
                                   admin=make_address(args.base_admin_port),
                                   seed_servers=seed_servers,
                                   empty_seed_starts_cluster=False)
-        return NodeConfig(redpanda=redpanda)
+        return NodeConfig(redpanda=redpanda, index=i, config_path=config_path)
 
     def pathlib_path_representer(dumper, path):
         return dumper.represent_scalar("!Path", str(path))
@@ -167,7 +176,7 @@ async def main():
         node_dir.mkdir(parents=True, exist_ok=True)
         data_dir.mkdir(parents=True, exist_ok=True)
 
-        config = make_node_config(i, data_dir)
+        config = make_node_config(i, data_dir, conf_file)
         with open(conf_file, "w") as f:
             yaml.dump(dataclasses.asdict(config),
                       f,
@@ -179,16 +188,17 @@ async def main():
         if os.path.exists(BOOTSTRAP_YAML):
             shutil.copyfile(BOOTSTRAP_YAML, node_dir / BOOTSTRAP_YAML)
 
-        return config, conf_file
+        return config
 
     configs = [prepare_node(i) for i in range(args.nodes)]
 
     cores = args.cores
     if cores is None:
-        cores = max(multiprocessing.cpu_count() // args.nodes, 1)
-    nodes = [
-        Redpanda(args.executable, cores, c[1], extra_args) for c in configs
-    ]
+        # Use 75% of cores for redpanda.  e.g. 3 node cluster on a 16 node system
+        # gives each node 4 cores.
+        cores = max((3 * (psutil.cpu_count(logical=False) // 4)) // args.nodes,
+                    1)
+    nodes = [Redpanda(args.executable, cores, c, extra_args) for c in configs]
 
     coros = [r.run() for r in nodes]
 


### PR DESCRIPTION
Clusters run with `dev_cluster`  had kinda quirky performance, while simultaneously dominating the system's resources.

- Previously we would default to using 1/Nth of cpu cores each per node, but not being specific about which cores should be used for which node.  Fix this with `--cpuset` arguments, and using only 75% of total cores, so leave some slack on the system for other processes (IDEs, compilations etc)
- Previously we would default to Redpanda trying to allocate all the node's memory from each process.  Fix this by giving 1/Nth of 75% of the host's total memory to each node.

The net result is that a 3 node cluster on my 16 core+ 64GB machine runs neatly with 4 cores and 16GB of memory for each node, and the same amount left over for other processes to use.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none