### PR TITLE
Made partition move cancellations more robust

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -92,6 +92,7 @@ static constexpr int8_t create_partition_cmd_type = 5;
 static constexpr int8_t create_non_replicable_topic_cmd_type = 6;
 static constexpr int8_t cancel_moving_partition_replicas_cmd_type = 7;
 static constexpr int8_t move_topic_replicas_cmd_type = 8;
+static constexpr int8_t revert_cancel_partition_move_cmd_type = 9;
 
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
@@ -182,6 +183,13 @@ using cancel_moving_partition_replicas_cmd = controller_command<
   cancel_moving_partition_replicas_cmd_type,
   model::record_batch_type::topic_management_cmd,
   serde_opts::adl_and_serde>;
+
+using revert_cancel_partition_move_cmd = controller_command<
+  int8_t, // unused
+  revert_cancel_partition_move_cmd_data,
+  revert_cancel_partition_move_cmd_type,
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::serde_only>;
 
 using create_user_cmd = controller_command<
   security::credential_user,

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -289,6 +289,7 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_partition_leaders),
             std::ref(_tp_frontend),
             std::ref(_storage),
+            std::ref(_feature_table),
             std::ref(_as));
       })
       .then(

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -72,6 +72,11 @@
             "output_type": "finish_reallocation_reply"
         },
         {
+            "name": "revert_cancel_partition_move",
+            "input_type": "revert_cancel_partition_move_request",
+            "output_type": "revert_cancel_partition_move_reply"
+        },
+        {
             "name": "set_maintenance_mode",
             "input_type": "set_maintenance_mode_request",
             "output_type": "set_maintenance_mode_reply"

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -24,6 +24,7 @@
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/node_config.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "outcome.h"
@@ -258,6 +259,7 @@ controller_backend::controller_backend(
   ss::sharded<partition_leaders_table>& leaders,
   ss::sharded<topics_frontend>& frontend,
   ss::sharded<storage::api>& storage,
+  ss::sharded<features::feature_table>& features,
   ss::sharded<ss::abort_source>& as)
   : _topics(tp_state)
   , _shard_table(st)
@@ -266,6 +268,7 @@ controller_backend::controller_backend(
   , _partition_leaders_table(leaders)
   , _topics_frontend(frontend)
   , _storage(storage)
+  , _features(features)
   , _self(*config::node().node_id())
   , _data_directory(config::node().data_directory().as_sstring())
   , _housekeeping_timer_interval(
@@ -582,6 +585,26 @@ ss::future<std::error_code> revert_configuration_update(
       replicas);
     co_return co_await p->update_replica_set(std::move(brokers), rev);
 }
+
+bool is_finishing_operation(
+  const topic_table::delta& operation, const topic_table::delta& candidate) {
+    if (candidate.type != topic_table_delta::op_type::update_finished) {
+        return false;
+    }
+
+    if (operation.new_assignment == candidate.new_assignment) {
+        return true;
+    }
+    if (
+      operation.type == topic_table_delta::op_type::cancel_update
+      || operation.type == topic_table_delta::op_type::force_abort_update) {
+        return operation.previous_replica_set
+               == candidate.new_assignment.replicas;
+    }
+
+    return false;
+}
+
 } // namespace
 
 ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
@@ -635,11 +658,7 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
                      */
                     auto fit = std::find_if(
                       it, deltas.end(), [&it](const delta_metadata& m) {
-                          return m.delta.type
-                                   == topic_table::delta::op_type::
-                                     update_finished
-                                 && m.delta.new_assignment.replicas
-                                      == it->delta.new_assignment.replicas;
+                          return is_finishing_operation(it->delta, m.delta);
                       });
 
                     /**
@@ -943,7 +962,12 @@ controller_backend::process_partition_reconfiguration(
          *
          */
         co_return co_await execute_reconfiguration(
-          type, ntp, target_assignment.replicas, replica_revisions, rev);
+          type,
+          ntp,
+          target_assignment.replicas,
+          replica_revisions,
+          previous_replicas,
+          rev);
     }
     const auto cross_core_move = contains_node(_self, previous_replicas)
                                  && !has_local_replicas(
@@ -967,7 +991,12 @@ controller_backend::process_partition_reconfiguration(
         // try executing reconfiguration, this method will return success if
         // partition configuration is up to date with requested assignment
         auto ec = co_await execute_reconfiguration(
-          type, ntp, target_assignment.replicas, replica_revisions, rev);
+          type,
+          ntp,
+          target_assignment.replicas,
+          replica_revisions,
+          previous_replicas,
+          rev);
         if (!ec) {
             /**
              *  After one of the replicas find the configuration to be
@@ -1161,6 +1190,7 @@ ss::future<std::error_code> controller_backend::execute_reconfiguration(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replica_set,
   const topic_table_delta::revision_map_t& replica_revisions,
+  const std::vector<model::broker_shard>& previous_replica_set,
   model::revision_id revision) {
     switch (type) {
     case topic_table_delta::op_type::update:
@@ -1168,10 +1198,10 @@ ss::future<std::error_code> controller_backend::execute_reconfiguration(
           ntp, replica_set, replica_revisions, revision);
     case topic_table_delta::op_type::cancel_update:
         co_return co_await cancel_replica_set_update(
-          ntp, replica_set, replica_revisions, revision);
+          ntp, replica_set, replica_revisions, previous_replica_set, revision);
     case topic_table_delta::op_type::force_abort_update:
         co_return co_await force_abort_replica_set_update(
-          ntp, replica_set, replica_revisions, revision);
+          ntp, replica_set, replica_revisions, previous_replica_set, revision);
     default:
         vassert(
           false, "delta of type {} is not partition reconfiguration", type);
@@ -1215,7 +1245,12 @@ ss::future<> controller_backend::process_partition_properties_update(
  */
 ss::future<std::error_code> controller_backend::dispatch_update_finished(
   model::ntp ntp, partition_assignment assignment) {
-    vlog(clusterlog.trace, "[{}] dispatching update finished event for", ntp);
+    vlog(
+      clusterlog.trace,
+      "[{}] dispatching update finished event with replicas: {}",
+      ntp,
+      assignment.replicas);
+
     return ss::with_gate(
       _gate,
       [this,
@@ -1294,6 +1329,7 @@ ss::future<std::error_code> controller_backend::cancel_replica_set_update(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replicas,
   const topic_table_delta::revision_map_t& replica_revisions,
+  const std::vector<model::broker_shard>& previous_replicas,
   model::revision_id rev) {
     /**
      * Following scenarios can happen in here:
@@ -1307,7 +1343,7 @@ ss::future<std::error_code> controller_backend::cancel_replica_set_update(
       ntp,
       replicas,
       rev,
-      [this, &ntp, rev, replicas, &replica_revisions](
+      [this, &ntp, rev, replicas, &previous_replicas, &replica_revisions](
         ss::lw_shared_ptr<partition> p) {
           const auto current_cfg = p->group_configuration();
           // we do not have to request update/cancellation twice
@@ -1316,18 +1352,54 @@ ss::future<std::error_code> controller_backend::cancel_replica_set_update(
                 errc::waiting_for_recovery);
           }
 
-          const auto raft_cfg_update_finished
+          const auto raft_not_reconfiguring
             = current_cfg.get_state() == raft::configuration_state::simple;
+          // TODO: emit revert command when we have learners in an old
+          // configuration of raft group as they are about to be removed.
 
+          const auto not_yet_moved = are_configuration_replicas_up_to_date(
+            current_cfg, replicas);
+          const auto already_moved = are_configuration_replicas_up_to_date(
+            current_cfg, previous_replicas);
           // raft already finished its part, we need to move replica back
-          if (raft_cfg_update_finished) {
-              return revert_configuration_update(
-                ntp,
-                replicas,
-                replica_revisions,
-                rev,
-                std::move(p),
-                _members_table.local());
+          if (raft_not_reconfiguring) {
+              // move hasn't yet requested
+              if (not_yet_moved) {
+                  // just update configuration revision
+                  auto it = _topics.local().all_topics_metadata().find(
+                    model::topic_namespace_view(ntp));
+                  // no longer in progress
+                  if (it == _topics.local().all_topics_metadata().end()) {
+                      return ss::make_ready_future<std::error_code>(
+                        errc::success);
+                  }
+
+                  auto brokers = create_brokers_set(
+                    replicas, replica_revisions, _members_table.local());
+                  vlog(
+                    clusterlog.debug,
+                    "[{}] updating replica set with {}",
+                    ntp,
+                    replicas);
+
+                  return p->update_replica_set(std::move(brokers), rev);
+              } else if (already_moved) {
+                  if (likely(_features.local().is_active(
+                        features::feature::partition_move_revert_cancel))) {
+                      return dispatch_revert_cancel_move(ntp);
+                  }
+
+                  return revert_configuration_update(
+                    ntp,
+                    replicas,
+                    replica_revisions,
+                    rev,
+                    std::move(p),
+                    _members_table.local());
+              }
+              return ss::make_ready_future<std::error_code>(
+                errc::waiting_for_recovery);
+
           } else {
               vlog(clusterlog.debug, "[{}] cancelling reconfiguration", ntp);
               return p->cancel_replica_set_update(rev);
@@ -1335,10 +1407,22 @@ ss::future<std::error_code> controller_backend::cancel_replica_set_update(
       });
 }
 
+ss::future<std::error_code>
+controller_backend::dispatch_revert_cancel_move(model::ntp ntp) {
+    vlog(clusterlog.trace, "[{}] dispatching revert cancel move command", ntp);
+    auto holder = _gate.hold();
+
+    co_return co_await _topics_frontend.local().revert_cancel_partition_move(
+      std::move(ntp),
+      model::timeout_clock::now()
+        + config::shard_local_cfg().replicate_append_timeout_ms());
+}
+
 ss::future<std::error_code> controller_backend::force_abort_replica_set_update(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replicas,
   const topic_table_delta::revision_map_t& replica_revisions,
+  const std::vector<model::broker_shard>& previous_replicas,
   model::revision_id rev) {
     /**
      * Force abort configuration change for each of the partition replicas.
@@ -1363,25 +1447,43 @@ ss::future<std::error_code> controller_backend::force_abort_replica_set_update(
         co_return errc::waiting_for_recovery;
     }
 
-    const auto raft_cfg_update_finished = current_cfg.get_state()
-                                          == raft::configuration_state::simple;
+    const auto raft_not_reconfiguring = current_cfg.get_state()
+                                        == raft::configuration_state::simple;
+    const auto not_yet_moved = are_configuration_replicas_up_to_date(
+      current_cfg, replicas);
+    const auto already_moved = are_configuration_replicas_up_to_date(
+      current_cfg, previous_replicas);
 
-    if (raft_cfg_update_finished) {
-        co_return co_await apply_configuration_change_on_leader(
-          ntp,
-          replicas,
-          rev,
-          [this, rev, &replicas, &ntp, &replica_revisions](
-            ss::lw_shared_ptr<cluster::partition> p) {
-              return revert_configuration_update(
-                ntp,
-                replicas,
-                replica_revisions,
-                rev,
-                std::move(p),
-                _members_table.local());
-          });
+    // raft already finished its part, we need to move replica back
+    if (raft_not_reconfiguring) {
+        // move hasn't yet requested
+        if (not_yet_moved) {
+            // just update configuration revision
 
+            co_return co_await update_partition_replica_set(
+              ntp, replicas, replica_revisions, rev);
+        } else if (already_moved) {
+            if (likely(_features.local().is_active(
+                  features::feature::partition_move_revert_cancel))) {
+                co_return co_await dispatch_revert_cancel_move(ntp);
+            }
+
+            co_return co_await apply_configuration_change_on_leader(
+              ntp,
+              replicas,
+              rev,
+              [this, rev, &replicas, &ntp, &replica_revisions](
+                ss::lw_shared_ptr<cluster::partition> p) {
+                  return revert_configuration_update(
+                    ntp,
+                    replicas,
+                    replica_revisions,
+                    rev,
+                    std::move(p),
+                    _members_table.local());
+              });
+        }
+        co_return errc::waiting_for_recovery;
     } else {
         auto ec = co_await partition->force_abort_replica_set_update(rev);
 

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -356,6 +356,7 @@ private:
       model::ntp, ss::shard_id, partition_assignment);
 
     bool can_finish_update(
+      std::optional<model::node_id> current_leader,
       uint64_t current_retry,
       topic_table_delta::op_type operation_type,
       const std::vector<model::broker_shard>& requested_replicas);

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "outcome.h"
@@ -237,6 +238,7 @@ public:
       ss::sharded<cluster::partition_leaders_table>&,
       ss::sharded<topics_frontend>&,
       ss::sharded<storage::api>&,
+      ss::sharded<features::feature_table>&,
       ss::sharded<seastar::abort_source>&);
 
     ss::future<> stop();
@@ -288,6 +290,7 @@ private:
       const model::ntp&,
       const std::vector<model::broker_shard>&,
       const topic_table_delta::revision_map_t&,
+      const std::vector<model::broker_shard>&,
       model::revision_id);
 
     ss::future<> finish_partition_update(
@@ -322,16 +325,20 @@ private:
       const model::ntp&,
       const std::vector<model::broker_shard>&,
       const topic_table_delta::revision_map_t&,
+      const std::vector<model::broker_shard>&,
       model::revision_id);
 
     ss::future<std::error_code> force_abort_replica_set_update(
       const model::ntp&,
       const std::vector<model::broker_shard>&,
       const topic_table_delta::revision_map_t&,
+      const std::vector<model::broker_shard>&,
       model::revision_id);
 
     ss::future<std::error_code>
       dispatch_update_finished(model::ntp, partition_assignment);
+
+    ss::future<std::error_code> dispatch_revert_cancel_move(model::ntp);
 
     ss::future<> do_bootstrap();
     ss::future<> bootstrap_ntp(const model::ntp&, deltas_t&);
@@ -362,6 +369,7 @@ private:
     ss::sharded<partition_leaders_table>& _partition_leaders_table;
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<storage::api>& _storage;
+    ss::sharded<features::feature_table>& _features;
     model::node_id _self;
     ss::sstring _data_directory;
     std::chrono::milliseconds _housekeeping_timer_interval;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -58,6 +58,9 @@ public:
     ss::future<finish_partition_update_reply> finish_partition_update(
       finish_partition_update_request&&, rpc::streaming_context&) final;
 
+    ss::future<revert_cancel_partition_move_reply> revert_cancel_partition_move(
+      revert_cancel_partition_move_request&&, rpc::streaming_context&) final;
+
     ss::future<update_topic_properties_reply> update_topic_properties(
       update_topic_properties_request&&, rpc::streaming_context&) final;
     ss::future<reconciliation_state_reply> get_reconciliation_state(
@@ -125,6 +128,9 @@ private:
 
     ss::future<finish_reallocation_reply>
       do_finish_reallocation(finish_reallocation_request);
+
+    ss::future<revert_cancel_partition_move_reply>
+      do_revert_cancel_partition_move(revert_cancel_partition_move_request);
 
     ss::future<get_node_health_reply>
       do_collect_node_health_report(get_node_health_request);

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -96,6 +96,9 @@ public:
         const std::vector<model::broker_shard>& get_previous_replicas() const {
             return _previous_replicas;
         }
+        const std::vector<model::broker_shard>& get_target_replicas() const {
+            return _target_replicas;
+        }
 
         const replicas_revision_map& get_replicas_revisions() const {
             return _replicas_revisions;
@@ -339,6 +342,13 @@ public:
      */
     std::optional<std::vector<model::broker_shard>>
     get_previous_replica_set(const model::ntp&) const;
+    /**
+     * returns target replica set of partition if partition is currently being
+     * reconfigured. For reconfiguration from [1,2,3] to [2,3,4] this method
+     * will return [2,3,4].
+     */
+    std::optional<std::vector<model::broker_shard>>
+    get_target_replica_set(const model::ntp&) const;
 
     const absl::node_hash_map<model::ntp, in_progress_update>&
     in_progress_updates() const {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -51,27 +51,27 @@ public:
     public:
         explicit in_progress_update(
           std::vector<model::broker_shard> previous_replicas,
-          std::vector<model::broker_shard> result_replicas,
+          std::vector<model::broker_shard> target_replicas,
           reconfiguration_state state,
           model::revision_id update_revision,
           replicas_revision_map replicas_revisions,
           topic_table_probe& probe)
           : _previous_replicas(std::move(previous_replicas))
-          , _result_replicas(std::move(result_replicas))
+          , _target_replicas(std::move(target_replicas))
           , _state(state)
           , _update_revision(update_revision)
           , _replicas_revisions(std::move(replicas_revisions))
           , _probe(probe) {
-            _probe.handle_update(_previous_replicas, _result_replicas);
+            _probe.handle_update(_previous_replicas, _target_replicas);
         }
 
         ~in_progress_update() {
-            _probe.handle_update_finish(_previous_replicas, _result_replicas);
+            _probe.handle_update_finish(_previous_replicas, _target_replicas);
             if (
               _state == reconfiguration_state::cancelled
               || _state == reconfiguration_state::force_cancelled) {
                 _probe.handle_update_cancel_finish(
-                  _previous_replicas, _result_replicas);
+                  _previous_replicas, _target_replicas);
                 ;
             }
         }
@@ -88,7 +88,7 @@ public:
               _state == reconfiguration_state::in_progress
               && (state == reconfiguration_state::cancelled || state == reconfiguration_state::force_cancelled)) {
                 _probe.handle_update_cancel(
-                  _previous_replicas, _result_replicas);
+                  _previous_replicas, _target_replicas);
             }
             _state = state;
         }
@@ -107,7 +107,7 @@ public:
 
     private:
         std::vector<model::broker_shard> _previous_replicas;
-        std::vector<model::broker_shard> _result_replicas;
+        std::vector<model::broker_shard> _target_replicas;
         reconfiguration_state _state;
         model::revision_id _update_revision;
         replicas_revision_map _replicas_revisions;

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -173,10 +173,6 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
                         "currently being updated",
                         ntp);
 
-                      auto to_delete = subtract_replica_sets(
-                        current_assignment->replicas, *new_target_replicas);
-                      _partition_allocator.local().remove_allocations(
-                        to_delete, get_allocation_domain(ntp));
                       _partition_balancer_state.local().handle_ntp_update(
                         ntp.ns,
                         ntp.tp.topic,
@@ -187,13 +183,36 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
                   });
             },
             [this, base_offset](finish_moving_partition_replicas_cmd cmd) {
+                // initial replica set of the move command (not changed when
+                // operation is cancelled)
                 auto previous_replicas
                   = _topic_table.local().get_previous_replica_set(cmd.key);
+                // requested/target replica set of original move command(not
+                // changed when move is cancelled)
+                auto target_replicas
+                  = _topic_table.local().get_target_replica_set(cmd.key);
+                /**
+                 * Finish moving command may be related either with cancellation
+                 * or with finish of an original move
+                 *
+                 * For original move the direction of data transfer is:
+                 *
+                 *  previous_replica -> target_replicas
+                 *
+                 * for cancelled move it is:
+                 *
+                 *  target_replicas -> previous_replicas
+                 *
+                 * Finish command contains the final replica set it will be
+                 * target_replicas for finished move and previous_replicas for
+                 * finished cancellation
+                 */
                 return dispatch_updates_to_cores(cmd, base_offset)
                   .then([this,
                          ntp = std::move(cmd.key),
-                         previous_replicas = previous_replicas,
-                         current_replicas = std::move(cmd.value)](
+                         previous_replicas = std::move(previous_replicas),
+                         target_replicas = std::move(target_replicas),
+                         command_replicas = std::move(cmd.value)](
                           std::error_code ec) {
                       if (ec) {
                           return ec;
@@ -204,11 +223,33 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
                         "update can only be applied to partition that is "
                         "currently being updated",
                         ntp);
-
-                      auto to_delete = subtract_replica_sets(
-                        *previous_replicas, current_replicas);
+                      vassert(
+                        target_replicas.has_value(),
+                        "Target replicas for NTP {} must exists as finish "
+                        "update can only be applied to partition that is "
+                        "currently being updated",
+                        ntp);
+                      std::vector<model::broker_shard> to_delete;
+                      // move was successful, not cancelled
+                      if (target_replicas == command_replicas) {
+                          to_delete = subtract_replica_sets(
+                            *previous_replicas, command_replicas);
+                      } else {
+                          vassert(
+                            previous_replicas == command_replicas,
+                            "When finishing cancelled move of partition {} the "
+                            "finish command replica set {} must be equal to "
+                            "previous_replicas {} from topic table in progress "
+                            "update tracker",
+                            ntp,
+                            command_replicas,
+                            previous_replicas);
+                          to_delete = subtract_replica_sets(
+                            *target_replicas, command_replicas);
+                      }
                       _partition_allocator.local().remove_allocations(
                         to_delete, get_allocation_domain(ntp));
+
                       return ec;
                   });
             },

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -68,7 +68,8 @@ public:
       create_partition_cmd,
       create_non_replicable_topic_cmd,
       cancel_moving_partition_replicas_cmd,
-      move_topic_replicas_cmd>();
+      move_topic_replicas_cmd,
+      revert_cancel_partition_move_cmd>();
 
     bool is_batch_applicable(const model::record_batch& batch) const {
         return batch.header().type

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -83,6 +83,9 @@ public:
       std::vector<model::broker_shard>,
       model::timeout_clock::time_point);
 
+    ss::future<std::error_code> revert_cancel_partition_move(
+      model::ntp, model::timeout_clock::time_point);
+
     /**
      * Cancelling partition replicas move will use graceful path i.e. will never
      * allow data loss but it may require to be able to contact majority nodes

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2951,6 +2951,20 @@ struct cancel_partition_movements_reply
     std::vector<move_cancellation_result> partition_results;
 };
 
+struct revert_cancel_partition_move_cmd_data
+  : serde::envelope<
+      revert_cancel_partition_move_cmd_data,
+      serde::version<0>,
+      serde::version<0>> {
+    model::ntp ntp;
+
+    auto serde_fields() { return std::tie(ntp); }
+
+    friend bool operator==(
+      const revert_cancel_partition_move_cmd_data&,
+      const revert_cancel_partition_move_cmd_data&)
+      = default;
+};
 /**
  * Broker state transitions are coordinated centrally as opposite to
  * configuration which change is requested by the described node itself. Broker

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2965,6 +2965,39 @@ struct revert_cancel_partition_move_cmd_data
       const revert_cancel_partition_move_cmd_data&)
       = default;
 };
+
+struct revert_cancel_partition_move_request
+  : serde::envelope<
+      revert_cancel_partition_move_request,
+      serde::version<0>,
+      serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    model::ntp ntp;
+
+    auto serde_fields() { return std::tie(ntp); }
+
+    friend bool operator==(
+      const revert_cancel_partition_move_request&,
+      const revert_cancel_partition_move_request&)
+      = default;
+};
+
+struct revert_cancel_partition_move_reply
+  : serde::envelope<
+      revert_cancel_partition_move_reply,
+      serde::version<0>,
+      serde::version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    errc result;
+
+    auto serde_fields() { return std::tie(result); }
+
+    friend bool operator==(
+      const revert_cancel_partition_move_reply&,
+      const revert_cancel_partition_move_reply&)
+      = default;
+};
+
 /**
  * Broker state transitions are coordinated centrally as opposite to
  * configuration which change is requested by the described node itself. Broker

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -57,6 +57,8 @@ std::string_view to_string_view(feature f) {
         return "tm_stm_cache";
     case feature::kafka_gssapi:
         return "kafka_gssapi";
+    case feature::partition_move_revert_cancel:
+        return "partition_move_cancel_revert";
     case feature::test_alpha:
         return "__test_alpha";
     case feature::test_bravo:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -49,6 +49,7 @@ enum class feature : std::uint64_t {
     seeds_driven_bootstrap_capable = 1ULL << 15U,
     tm_stm_cache = 1ULL << 16U,
     kafka_gssapi = 1ULL << 17U,
+    partition_move_revert_cancel = 1ULL << 18U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 62U,
@@ -209,6 +210,12 @@ constexpr static std::array feature_schema{
     "kafka_gssapi",
     feature::kafka_gssapi,
     feature_spec::available_policy::explicit_only,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{9},
+    "partition_move_revert_cancel",
+    feature::partition_move_revert_cancel,
+    feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 
   // For testing, a feature that does not auto-activate


### PR DESCRIPTION
# Problem statement
Since reverting partition configuration involves a genuine Raft group reconfiguration it is vulnerable to all the same issues that may prevent raft reconfiguration from finishing. 

Since the replica set of partition was already updated in the topic table the controller backend reconciliation loop would wait for the reconfiguration to finish and as the movement was already cancelled it can not be cancelled again.


## Example
Consider a situation where in a 4-nodes cluster containing nodes `(0,1,2,3) `a partition is being moved from replica set `(0,1,2)` to `(1,2,3)`. In this case a node 3 is added to the replica set while node 0 is removed. When configuration change is requested Raft configuration is going through the set of changes as described in [1] if cancel is requested after raft reconfiguration to `(1,2,3)` finished but before the finish_moving_replicas command was replicated controller backend will instruct raft to revert configuration back to `(0,1,2)`. The first step involving change from `(1,2,3)` to `(0,1,2)` is adding node 0 as a learner to the current configuration i.e. there will be one learner - 0. If node 0 is unavailable the raft reconfiguration will never finish as node 0 will never be promoted to the voter. 

# Solution 

Added handling for `revert_cancel_partition_move` command to the topic table. The command is going to be emitted by controller_backend when partition underlying raft group reconfiguration that is requested to be canceled is already finished. The command finishes move and updates the topic partition with replica set aligned with the target of original
move command.

## Partition movement state transitions:
 When partition is being moved from replica set A to replica set B it may
 either be finished or cancelled. The cancellation on the other hand may be
 reverted. The partition movement state transitions are explained in the
 following diagram:


```

 A - replica set A
 B - replica set B

 ┌──────────┐   move           ┌──────────┐       finish         ┌──────────┐
 │  static  │                  │  moving  │                      │  static  │
 │          ├─────────────────►│          ├─────────────────────►│          │
 │    A     │                  │  A -> B  │                      │    B     │
 └──────────┘                  └────┬─────┘                      └──────────┘
      ▲                             │                                  ▲
      │                             │                                  │
      │                             │ cancel/force_cancel              │
      │                             │                                  │
      │                             │                                  │
      │                             ▼                                  │
      │                        ┌──────────┐                            │
      │        finish          │  moving  │     revert_cancel          │
      └────────────────────────┤          ├────────────────────────────┘
                               │  B -> A  │
                               └──────────┴─────┐
                                    ▲           │
                                    │           │
                                    │           │
                                    │           │
                                    └───────────┘
                                        force_cancel
```

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
  ### Improvements
- more robust partition movements related with decommissioning/recommissioning nodes that are unavailable 