### PR TITLE
rpk: fix not passing the IO parameters when a well-known host type is detected

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -344,6 +344,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 				sFlags,
 				cmd.Flags(),
 				!prestartCfg.checkEnabled,
+				resolveWellKnownIo,
 			)
 			if err != nil {
 				return err
@@ -551,6 +552,7 @@ func buildRedpandaFlags(
 	sFlags seastarFlags,
 	flags *pflag.FlagSet,
 	skipChecks bool,
+	ioResolver func(*config.Config, bool) (*iotune.IoProperties, error),
 ) (*rp.RedpandaArgs, error) {
 	wellKnownIOSet := conf.Rpk.WellKnownIo != ""
 	ioPropsSet := flags.Changed(ioPropertiesFileFlag) || flags.Changed(ioPropertiesFlag)
@@ -562,18 +564,23 @@ func buildRedpandaFlags(
 		)
 	}
 
+	// We want to preserve the IOProps flags in case we find them either by
+	// finding the file in the default location or by resolving to a well known
+	// IO.
+	preserve := make(map[string]bool, 2)
 	if !ioPropsSet {
 		// If --io-properties-file and --io-properties weren't set, try
 		// finding an IO props file in the default location.
-		sFlags.ioPropertiesFile = rp.GetIOConfigPath(
-			filepath.Dir(conf.FileLocation()),
-		)
+		sFlags.ioPropertiesFile = rp.GetIOConfigPath(filepath.Dir(conf.FileLocation()))
+		preserve[ioPropertiesFileFlag] = true
+
 		if exists, _ := afero.Exists(fs, sFlags.ioPropertiesFile); !exists {
 			sFlags.ioPropertiesFile = ""
-		}
-		// Otherwise, try to deduce the IO props.
-		if sFlags.ioPropertiesFile == "" {
-			ioProps, err := resolveWellKnownIo(conf, skipChecks)
+			preserve[ioPropertiesFileFlag] = false
+
+			// If the file is not located in the default location either, we try
+			// to deduce the IO props.
+			ioProps, err := ioResolver(conf, skipChecks)
 			if err != nil {
 				log.Warn(err)
 			} else if ioProps != nil {
@@ -582,12 +589,13 @@ func buildRedpandaFlags(
 					return nil, err
 				}
 				sFlags.ioProperties = json
+				preserve[ioPropertiesFlag] = true
 			}
 		}
 	}
 	flagsMap := flagsMap(sFlags)
 	for flag := range flagsMap {
-		if !flags.Changed(flag) {
+		if !flags.Changed(flag) && !preserve[flag] {
 			delete(flagsMap, flag)
 		}
 	}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -1074,6 +1074,7 @@ environments:
         * topic_partitions_per_shard: 1000
         * fetch_reads_debounce_timeout: 10
         * group_initial_rebalance_delay: 0
+        * log_segment_size_min: 1
 
 After redpanda starts you can modify the cluster properties using:
     rpk config set <key> <value>`

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -599,12 +599,12 @@ func buildRedpandaFlags(
 	for n, v := range flagsMap {
 		if _, alreadyPresent := finalFlags[n]; alreadyPresent {
 			return nil, fmt.Errorf(
-				"Configuration conflict. Flag '--%s'"+
+				"configuration conflict. Flag '--%s'"+
 					" is also present in"+
 					" 'rpk.additional_start_flags' in"+
 					" configuration file '%s'. Please"+
 					" remove it and pass '--%s' directly"+
-					" to `rpk start`.",
+					" to `rpk start`",
 				n,
 				conf.FileLocation(),
 				n,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -1365,7 +1365,7 @@ func TestStartCommand(t *testing.T) {
 			conf.Rpk.AdditionalStartFlags = []string{"--overprovisioned"}
 			return conf.Write(fs)
 		},
-		expectedErrMsg: "Configuration conflict. Flag '--overprovisioned' is also present in 'rpk.additional_start_flags' in configuration file '/etc/redpanda/redpanda.yaml'. Please remove it and pass '--overprovisioned' directly to `rpk start`.",
+		expectedErrMsg: "configuration conflict. Flag '--overprovisioned' is also present in 'rpk.additional_start_flags' in configuration file '/etc/redpanda/redpanda.yaml'. Please remove it and pass '--overprovisioned' directly to `rpk start`",
 	}, {
 		name: "it should fail if --smp is set in the config file too",
 		args: []string{
@@ -1376,7 +1376,7 @@ func TestStartCommand(t *testing.T) {
 			conf.Rpk.AdditionalStartFlags = []string{"--smp=1"}
 			return conf.Write(fs)
 		},
-		expectedErrMsg: "Configuration conflict. Flag '--smp' is also present in 'rpk.additional_start_flags' in configuration file '/etc/redpanda/redpanda.yaml'. Please remove it and pass '--smp' directly to `rpk start`.",
+		expectedErrMsg: "configuration conflict. Flag '--smp' is also present in 'rpk.additional_start_flags' in configuration file '/etc/redpanda/redpanda.yaml'. Please remove it and pass '--smp' directly to `rpk start`",
 	}, {
 		name: "it should fail if --memory is set in the config file too",
 		args: []string{
@@ -1387,7 +1387,7 @@ func TestStartCommand(t *testing.T) {
 			conf.Rpk.AdditionalStartFlags = []string{"--memory=1G"}
 			return conf.Write(fs)
 		},
-		expectedErrMsg: "Configuration conflict. Flag '--memory' is also present in 'rpk.additional_start_flags' in configuration file '/etc/redpanda/redpanda.yaml'. Please remove it and pass '--memory' directly to `rpk start`.",
+		expectedErrMsg: "configuration conflict. Flag '--memory' is also present in 'rpk.additional_start_flags' in configuration file '/etc/redpanda/redpanda.yaml'. Please remove it and pass '--memory' directly to `rpk start`",
 	}, {
 		name: "it should pass the last instance of a duplicate flag set in rpk.additional_start_flags",
 		args: []string{

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/iotune"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
@@ -1679,4 +1680,138 @@ func TestExtraFlags(t *testing.T) {
 			require.Exactly(st, tt.expected, result)
 		})
 	}
+}
+
+func Test_buildRedpandaFlags(t *testing.T) {
+	type args struct {
+		conf       *config.Config
+		args       []string
+		sFlags     seastarFlags
+		flags      map[string]string
+		ioResolver func(*config.Config, bool) (*iotune.IoProperties, error)
+	}
+	tests := []struct {
+		name       string
+		args       args
+		writeIoCfg bool
+		exp        map[string]string
+		expErr     bool
+	}{
+		{
+			name: "err when ioPropertiesFlag and wellKnownIo are set",
+			args: args{
+				conf:  &config.Config{Rpk: config.RpkConfig{WellKnownIo: "some io"}},
+				flags: map[string]string{ioPropertiesFlag: "{some:value}"},
+			},
+			expErr: true,
+		}, {
+			name: "err when ioPropertiesFileFlag and wellKnownIo are set",
+			args: args{
+				conf:  &config.Config{Rpk: config.RpkConfig{WellKnownIo: "some io"}},
+				flags: map[string]string{ioPropertiesFileFlag: ""},
+			},
+			expErr: true,
+		}, {
+			name: "setting the properties from the config file ",
+			args: args{
+				conf: &config.Config{Rpk: config.RpkConfig{
+					Overprovisioned:      true,
+					EnableMemoryLocking:  false,
+					SMP:                  intPtr(2),
+					AdditionalStartFlags: []string{"--abort-on-seastar-bad-alloc=true"},
+				}},
+			},
+			exp: map[string]string{
+				"overprovisioned":            "true",
+				"lock-memory":                "false",
+				"smp":                        "2",
+				"abort-on-seastar-bad-alloc": "true",
+			},
+		}, {
+			name: "err if flag and additional_start_flags are present",
+			args: args{
+				flags: map[string]string{maxIoRequestsFlag: "2"},
+				conf: &config.Config{Rpk: config.RpkConfig{
+					AdditionalStartFlags: []string{"--max-io-requests=3"},
+				}},
+			},
+			expErr: true,
+		}, {
+			name: "get the io property file from the default location",
+			args: args{
+				conf: &config.Config{},
+			},
+			writeIoCfg: true,
+			exp: map[string]string{
+				"io-properties-file": "io-config.yaml",
+				// These 2 are false because of the empty config
+				"overprovisioned": "false",
+				"lock-memory":     "false",
+			},
+		}, {
+			name: "get the io property from the  ioResolver",
+			args: args{
+				conf: &config.Config{},
+				ioResolver: func(_ *config.Config, _ bool) (*iotune.IoProperties, error) {
+					return &iotune.IoProperties{
+						MountPoint:     "/mnt/",
+						ReadIops:       2,
+						ReadBandwidth:  3,
+						WriteIops:      4,
+						WriteBandwidth: 5,
+					}, nil
+				},
+			},
+			exp: map[string]string{
+				"io-properties": `{"disks":[{"mountpoint":"/mnt/","read_iops":2,"read_bandwidth":3,"write_iops":4,"write_bandwidth":5}]}`,
+				// These 2 are false because of the empty config
+				"overprovisioned": "false",
+				"lock-memory":     "false",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+
+			if tt.writeIoCfg {
+				err := afero.WriteFile(fs, "io-config.yaml", []byte{}, 0o655)
+				require.NoError(t, err)
+			}
+
+			cmdFlag := NewStartCommand(fs, &noopLauncher{}).Flags()
+			if len(tt.args.flags) > 0 {
+				for k, v := range tt.args.flags {
+					err := cmdFlag.Set(k, v)
+					require.NoError(t, err)
+				}
+			}
+
+			ioResolver := func(*config.Config, bool) (*iotune.IoProperties, error) {
+				return nil, nil
+			}
+			if tt.args.ioResolver != nil {
+				ioResolver = tt.args.ioResolver
+			}
+
+			// We can safely pass 'skipCheck:true' to buildRedpandaFlags since
+			// this is only used for the ioResolver function, and we are mocking
+			// it.
+			rpArgs, err := buildRedpandaFlags(fs, tt.args.conf, tt.args.args, tt.args.sFlags, cmdFlag, true, ioResolver)
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// We will just test the output of the built flags, since the other
+			// field of the struct is the config file location which we are
+			// writing in a MemMap FS in the test
+			require.Equal(t, tt.exp, rpArgs.SeastarFlags)
+		})
+	}
+}
+
+func intPtr(i int) *int {
+	return &i
 }


### PR DESCRIPTION
>If no io-properties file is specified or found on disk, rpk will try to detect the AWS or GCP host type and then use a hardcoded set of io parameters passed to --io-properties if the machine type is known.

But due to a bug in rpk we were stripping the flag, this PR solves that in addition to 2 small nits that I found during the development (first 2 commits)

Fixes #8280

In draft, until we merge https://github.com/redpanda-data/redpanda/pull/8298 and I adjust this PR.

## Backports Required
We should backport this along with https://github.com/redpanda-data/redpanda/pull/8298

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.
