### PR TITLE
Balanced node-wide throughput limits

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1731,6 +1731,33 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       5000ms,
       {.min = 1ms, .max = bottomless_token_bucket::max_width})
+  , kafka_quota_balancer_node_period(
+      *this,
+      "kafka_quota_balancer_node_period_ms",
+      "Intra-node throughput quota balancer invocation period, in "
+      "milliseconds. Value of 0 disables the balancer and makes all the "
+      "thoughput quotas immutable.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      750ms,
+      {.min = 0ms})
+  , kafka_quota_balancer_min_shard_thoughput_ratio(
+      *this,
+      "kafka_quota_balancer_min_shard_thoughput_ratio",
+      "The lowest value of the throughput quota a shard can get in the process "
+      "of quota balancing, expressed as a ratio of default shard quota. "
+      "0 means there is no minimum, 1 means no quota can be taken away "
+      "by the balancer.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      0.01,
+      &validate_0_to_1_ratio)
+  , kafka_quota_balancer_min_shard_thoughput_bps(
+      *this,
+      "kafka_quota_balancer_min_shard_thoughput_bps",
+      "The lowest value of the throughput quota a shard can get in the process "
+      "of quota balancing, in bytes/s. 0 means there is no minimum.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      256,
+      {.min = 0})
   , node_isolation_heartbeat_timeout(
       *this,
       "node_isolation_heartbeat_timeout",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -364,6 +364,10 @@ struct configuration final : public config_store {
     bounded_property<std::optional<uint64_t>>
       kafka_throughput_limit_node_out_bps;
     bounded_property<std::chrono::milliseconds> kafka_quota_balancer_window;
+    bounded_property<std::chrono::milliseconds>
+      kafka_quota_balancer_node_period;
+    property<double> kafka_quota_balancer_min_shard_thoughput_ratio;
+    bounded_property<int64_t> kafka_quota_balancer_min_shard_thoughput_bps;
 
     bounded_property<int64_t> node_isolation_heartbeat_timeout;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -359,9 +359,8 @@ struct configuration final : public config_store {
       controller_log_accummulation_rps_capacity_configuration_operations;
 
     // node and cluster throughput limiting
-    bounded_property<std::optional<uint64_t>>
-      kafka_throughput_limit_node_in_bps;
-    bounded_property<std::optional<uint64_t>>
+    bounded_property<std::optional<int64_t>> kafka_throughput_limit_node_in_bps;
+    bounded_property<std::optional<int64_t>>
       kafka_throughput_limit_node_out_bps;
     bounded_property<std::chrono::milliseconds> kafka_quota_balancer_window;
     bounded_property<std::chrono::milliseconds>

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -117,7 +117,13 @@ validate_sasl_mechanisms(const std::vector<ss::sstring>& mechanisms) {
             return ssx::sformat("'{}' is not a supported SASL mechanism", m);
         }
     }
+    return std::nullopt;
+}
 
+std::optional<ss::sstring> validate_0_to_1_ratio(const double d) {
+    if (d < 0 || d > 1) {
+        return fmt::format("Ratio must be in the [0,1] range, got: {}", d);
+    }
     return std::nullopt;
 }
 

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -33,4 +33,6 @@ std::optional<ss::sstring> validate_client_groups_byte_rate_quota(
 std::optional<ss::sstring>
 validate_sasl_mechanisms(const std::vector<ss::sstring>& mechanisms);
 
+std::optional<ss::sstring> validate_0_to_1_ratio(const double d);
+
 }; // namespace config

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -45,6 +45,7 @@ v_cc_library(
     server/server.cc
     server/protocol_utils.cc
     server/quota_manager.cc
+    server/snc_quota_manager.cc
     server/fetch_session_cache.cc
     server/replicated_partition.cc
     server/partition_proxy.cc

--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -20,6 +20,7 @@ class fetch_session_cache;
 class group_manager;
 class group_router;
 class quota_manager;
+class snc_quota_manager;
 class request_context;
 class rm_group_frontend;
 class rm_group_proxy_impl;

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -36,33 +36,11 @@ quota_manager::quota_manager()
       config::shard_local_cfg().kafka_client_group_byte_rate_quota.bind())
   , _target_fetch_tp_rate_per_client_group(
       config::shard_local_cfg().kafka_client_group_fetch_byte_rate_quota.bind())
-  , _kafka_throughput_limit_node_in_bps(
-      config::shard_local_cfg().kafka_throughput_limit_node_in_bps.bind())
-  , _kafka_throughput_limit_node_out_bps(
-      config::shard_local_cfg().kafka_throughput_limit_node_out_bps.bind())
-  , _kafka_quota_balancer_window(
-      config::shard_local_cfg().kafka_quota_balancer_window.bind())
-  , _shard_ingress_quota(
-      get_shard_ingress_quota_default(), _kafka_quota_balancer_window())
-  , _shard_egress_quota(
-      get_shard_egress_quota_default(), _kafka_quota_balancer_window())
   , _gc_freq(config::shard_local_cfg().quota_manager_gc_sec())
   , _max_delay(config::shard_local_cfg().max_kafka_throttle_delay_ms.bind()) {
     _gc_timer.set_callback([this] {
         auto full_window = _default_num_windows() * _default_window_width();
         gc(full_window);
-    });
-    _kafka_throughput_limit_node_in_bps.watch([this] {
-        _shard_ingress_quota.set_quota(get_shard_ingress_quota_default());
-    });
-    _kafka_throughput_limit_node_out_bps.watch([this] {
-        _shard_egress_quota.set_quota(get_shard_egress_quota_default());
-    });
-    _kafka_quota_balancer_window.watch([this] {
-        const auto v = _kafka_quota_balancer_window();
-        vlog(klog.debug, "Set shard TP token bucket window {}", v);
-        _shard_ingress_quota.set_width(v);
-        _shard_egress_quota.set_width(v);
     });
 }
 
@@ -77,10 +55,6 @@ ss::future<> quota_manager::start() {
     _gc_timer.arm_periodic(_gc_freq);
     return ss::make_ready_future<>();
 }
-
-/*
- * Per-Client and Per-Client-Group Quotas
- */
 
 quota_manager::client_quotas_t::iterator
 quota_manager::maybe_add_and_retrieve_quota(
@@ -319,92 +293,6 @@ void quota_manager::gc(clock::duration full_window) {
       [now, expire_age](const std::pair<ss::sstring, client_quota>& q) {
           return (now - q.second.last_seen) > expire_age;
       });
-}
-
-/*
- * Shard Global Quotas
- */
-
-namespace {
-
-bottomless_token_bucket::quota_t get_default_quota_from_property(
-  const config::binding<std::optional<uint64_t>>& prop) {
-    if (prop()) {
-        const uint64_t v = *prop() / ss::smp::count;
-        if (v >= static_cast<uint64_t>(bottomless_token_bucket::max_quota)) {
-            return bottomless_token_bucket::max_quota;
-        }
-        if (v < 1) {
-            return 1;
-        }
-        return static_cast<bottomless_token_bucket::quota_t>(v);
-    } else {
-        return bottomless_token_bucket::max_quota;
-    }
-}
-
-using delay_t = std::chrono::milliseconds;
-
-/// Evaluate throttling delay required based on the state of a token bucket
-delay_t eval_delay(const bottomless_token_bucket& tb) noexcept {
-    // no delay if tokens are over the bottom
-    if (tb.tokens() >= 0) {
-        return delay_t::zero();
-    }
-    // quota is in [tokens/s], so we need to scale it to `delay_t` by dividing
-    // by the `delay_t` unit scale denominator (and multiplying by the numerator
-    // but that one has to be 1)
-    static_assert(delay_t::period::num == 1);
-    return delay_t(muldiv(-tb.tokens(), delay_t::period::den, tb.quota()));
-}
-
-} // namespace
-
-quota_manager::shard_quota_t
-quota_manager::get_shard_ingress_quota_default() const {
-    const shard_quota_t v = get_default_quota_from_property(
-      _kafka_throughput_limit_node_in_bps);
-    vlog(klog.debug, "Default shard TP ingress quota: {}", v);
-    return v;
-}
-
-quota_manager::shard_quota_t
-quota_manager::get_shard_egress_quota_default() const {
-    const shard_quota_t v = get_default_quota_from_property(
-      _kafka_throughput_limit_node_out_bps);
-    vlog(klog.debug, "Default shard TP egress quota {}", v);
-    return v;
-}
-
-quota_manager::shard_delays_t quota_manager::get_shard_delays(
-  clock::time_point& connection_throttle_until,
-  const clock::time_point now) const {
-    shard_delays_t res;
-
-    // force throttle whatever the client did not do on its side
-    if (now < connection_throttle_until) {
-        res.enforce = connection_throttle_until - now;
-    }
-
-    // throttling delay the connection should be requested to throttle
-    // this time
-    res.request = std::min(
-      _max_delay(),
-      std::max(
-        eval_delay(_shard_ingress_quota), eval_delay(_shard_egress_quota)));
-    connection_throttle_until = now + res.request;
-
-    return res;
-}
-
-void quota_manager::record_request_tp(
-  const size_t request_size, const clock::time_point now) noexcept {
-    _shard_ingress_quota.use(request_size, now);
-}
-
-void quota_manager::record_response_tp(
-  const size_t request_size, const clock::time_point now) noexcept {
-    _shard_egress_quota.use(request_size, now);
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -15,7 +15,6 @@
 #include "kafka/server/token_bucket_rate_tracker.h"
 #include "resource_mgmt/rate.h"
 #include "seastarx.h"
-#include "utils/bottomless_token_bucket.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -106,28 +105,6 @@ public:
       uint32_t mutations,
       clock::time_point now = clock::now());
 
-    /// @p enforce delay to enforce in this call
-    /// @p request delay to request from the client via throttle_ms
-    struct shard_delays_t {
-        clock::duration enforce{0};
-        clock::duration request{0};
-    };
-
-    /// Determine throttling required by shard level TP quotas.
-    /// @param connection_throttle_until (in,out) until what time the client
-    /// on this conection should throttle until. If it does not, this throttling
-    /// will be enforced on the next call. In: value from the last call, out:
-    /// value saved until the next call.
-    shard_delays_t get_shard_delays(
-      clock::time_point& connection_throttle_until,
-      clock::time_point now) const;
-
-    void record_request_tp(
-      size_t request_size, clock::time_point now = clock::now()) noexcept;
-
-    void record_response_tp(
-      size_t request_size, clock::time_point now = clock::now()) noexcept;
-
 private:
     std::chrono::milliseconds do_record_partition_mutations(
       std::optional<std::string_view> client_id,
@@ -167,10 +144,6 @@ private:
     std::optional<int64_t> get_client_target_fetch_tp_rate(
       const std::optional<std::string_view>& quota_id);
 
-    using shard_quota_t = bottomless_token_bucket::quota_t;
-    shard_quota_t get_shard_ingress_quota_default() const;
-    shard_quota_t get_shard_egress_quota_default() const;
-
 private:
     config::binding<int16_t> _default_num_windows;
     config::binding<std::chrono::milliseconds> _default_window_width;
@@ -183,15 +156,7 @@ private:
     config::binding<std::unordered_map<ss::sstring, config::client_group_quota>>
       _target_fetch_tp_rate_per_client_group;
 
-    config::binding<std::optional<uint64_t>>
-      _kafka_throughput_limit_node_in_bps;
-    config::binding<std::optional<uint64_t>>
-      _kafka_throughput_limit_node_out_bps;
-    config::binding<std::chrono::milliseconds> _kafka_quota_balancer_window;
-
     client_quotas_t _client_quotas;
-    bottomless_token_bucket _shard_ingress_quota;
-    bottomless_token_bucket _shard_egress_quota;
 
     ss::timer<> _gc_timer;
     clock::duration _gc_freq;

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -78,6 +78,7 @@ server::server(
   ss::sharded<cluster::config_frontend>& cf,
   ss::sharded<features::feature_table>& ft,
   ss::sharded<quota_manager>& quota,
+  ss::sharded<snc_quota_manager>& snc_quota_mgr,
   ss::sharded<kafka::group_router>& router,
   ss::sharded<cluster::shard_table>& tbl,
   ss::sharded<cluster::partition_manager>& pm,
@@ -98,6 +99,7 @@ server::server(
   , _feature_table(ft)
   , _metadata_cache(meta)
   , _quota_mgr(quota)
+  , _snc_quota_mgr(snc_quota_mgr)
   , _group_router(router)
   , _shard_table(tbl)
   , _partition_manager(pm)

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -42,6 +42,7 @@ public:
       ss::sharded<cluster::config_frontend>&,
       ss::sharded<features::feature_table>&,
       ss::sharded<quota_manager>&,
+      ss::sharded<snc_quota_manager>&,
       ss::sharded<kafka::group_router>&,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::partition_manager>&,
@@ -100,6 +101,7 @@ public:
         return _fetch_session_cache.local();
     }
     quota_manager& quota_mgr() { return _quota_mgr.local(); }
+    snc_quota_manager& snc_quota_mgr() { return _snc_quota_mgr.local(); }
     bool is_idempotence_enabled() const { return _is_idempotence_enabled; }
     bool are_transactions_enabled() const { return _are_transactions_enabled; }
 
@@ -144,6 +146,7 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
     ss::sharded<quota_manager>& _quota_mgr;
+    ss::sharded<snc_quota_manager>& _snc_quota_mgr;
     ss::sharded<kafka::group_router>& _group_router;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::partition_manager>& _partition_manager;

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -26,6 +26,14 @@ snc_quota_manager::snc_quota_manager()
       config::shard_local_cfg().kafka_throughput_limit_node_out_bps.bind())
   , _kafka_quota_balancer_window(
       config::shard_local_cfg().kafka_quota_balancer_window.bind())
+  , _kafka_quota_balancer_node_period(
+      config::shard_local_cfg().kafka_quota_balancer_node_period.bind())
+  , _kafka_quota_balancer_min_shard_thoughput_ratio(
+      config::shard_local_cfg()
+        .kafka_quota_balancer_min_shard_thoughput_ratio.bind())
+  , _kafka_quota_balancer_min_shard_thoughput_bps(
+      config::shard_local_cfg()
+        .kafka_quota_balancer_min_shard_thoughput_bps.bind())
   , _shard_ingress_quota(
       get_shard_ingress_quota_default(), _kafka_quota_balancer_window())
   , _shard_egress_quota(

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -1,0 +1,133 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/snc_quota_manager.h"
+
+#include "config/configuration.h"
+#include "kafka/server/logger.h"
+#include "prometheus/prometheus_sanitize.h"
+
+using namespace std::chrono_literals;
+
+namespace kafka {
+
+snc_quota_manager::snc_quota_manager()
+  : _max_kafka_throttle_delay(
+    config::shard_local_cfg().max_kafka_throttle_delay_ms.bind())
+  , _kafka_throughput_limit_node_in_bps(
+      config::shard_local_cfg().kafka_throughput_limit_node_in_bps.bind())
+  , _kafka_throughput_limit_node_out_bps(
+      config::shard_local_cfg().kafka_throughput_limit_node_out_bps.bind())
+  , _kafka_quota_balancer_window(
+      config::shard_local_cfg().kafka_quota_balancer_window.bind())
+  , _shard_ingress_quota(
+      get_shard_ingress_quota_default(), _kafka_quota_balancer_window())
+  , _shard_egress_quota(
+      get_shard_egress_quota_default(), _kafka_quota_balancer_window()) {
+    _kafka_throughput_limit_node_in_bps.watch([this] {
+        _shard_ingress_quota.set_quota(get_shard_ingress_quota_default());
+    });
+    _kafka_throughput_limit_node_out_bps.watch([this] {
+        _shard_egress_quota.set_quota(get_shard_egress_quota_default());
+    });
+    _kafka_quota_balancer_window.watch([this] {
+        const auto v = _kafka_quota_balancer_window();
+        vlog(klog.debug, "Set shard TP token bucket window {}", v);
+        _shard_ingress_quota.set_width(v);
+        _shard_egress_quota.set_width(v);
+    });
+}
+
+ss::future<> snc_quota_manager::start() { return ss::make_ready_future<>(); }
+
+ss::future<> snc_quota_manager::stop() { return ss::make_ready_future<>(); }
+
+namespace {
+
+bottomless_token_bucket::quota_t get_default_quota_from_property(
+  const config::binding<std::optional<uint64_t>>& prop) {
+    if (prop()) {
+        const uint64_t v = *prop() / ss::smp::count;
+        if (v >= static_cast<uint64_t>(bottomless_token_bucket::max_quota)) {
+            return bottomless_token_bucket::max_quota;
+        }
+        if (v < 1) {
+            return 1;
+        }
+        return static_cast<bottomless_token_bucket::quota_t>(v);
+    } else {
+        return bottomless_token_bucket::max_quota;
+    }
+}
+
+using delay_t = std::chrono::milliseconds;
+
+/// Evaluate throttling delay required based on the state of a token bucket
+delay_t eval_delay(const bottomless_token_bucket& tb) noexcept {
+    // no delay if tokens are over the bottom
+    if (tb.tokens() >= 0) {
+        return delay_t::zero();
+    }
+    // quota is in [tokens/s], so we need to scale it to `delay_t` by dividing
+    // by the `delay_t` unit scale denominator (and multiplying by the numerator
+    // but that one has to be 1)
+    static_assert(delay_t::period::num == 1);
+    return delay_t(muldiv(-tb.tokens(), delay_t::period::den, tb.quota()));
+}
+
+} // namespace
+
+snc_quota_manager::quota_t
+snc_quota_manager::get_shard_ingress_quota_default() const {
+    const quota_t v = get_default_quota_from_property(
+      _kafka_throughput_limit_node_in_bps);
+    vlog(klog.debug, "Default shard TP ingress quota: {}", v);
+    return v;
+}
+
+snc_quota_manager::quota_t
+snc_quota_manager::get_shard_egress_quota_default() const {
+    const quota_t v = get_default_quota_from_property(
+      _kafka_throughput_limit_node_out_bps);
+    vlog(klog.debug, "Default shard TP egress quota {}", v);
+    return v;
+}
+
+snc_quota_manager::delays_t snc_quota_manager::get_shard_delays(
+  clock::time_point& connection_throttle_until,
+  const clock::time_point now) const {
+    delays_t res;
+
+    // force throttle whatever the client did not do on its side
+    if (now < connection_throttle_until) {
+        res.enforce = connection_throttle_until - now;
+    }
+
+    // throttling delay the connection should be requested to throttle
+    // this time
+    res.request = std::min(
+      _max_kafka_throttle_delay(),
+      std::max(
+        eval_delay(_shard_ingress_quota), eval_delay(_shard_egress_quota)));
+    connection_throttle_until = now + res.request;
+
+    return res;
+}
+
+void snc_quota_manager::record_request_tp(
+  const size_t request_size, const clock::time_point now) noexcept {
+    _shard_ingress_quota.use(request_size, now);
+}
+
+void snc_quota_manager::record_response_tp(
+  const size_t request_size, const clock::time_point now) noexcept {
+    _shard_egress_quota.use(request_size, now);
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -59,16 +59,16 @@ ss::future<> snc_quota_manager::stop() { return ss::make_ready_future<>(); }
 namespace {
 
 bottomless_token_bucket::quota_t get_default_quota_from_property(
-  const config::binding<std::optional<uint64_t>>& prop) {
+  const config::binding<std::optional<int64_t>>& prop) {
     if (prop()) {
-        const uint64_t v = *prop() / ss::smp::count;
-        if (v >= static_cast<uint64_t>(bottomless_token_bucket::max_quota)) {
+        const bottomless_token_bucket::quota_t v = *prop() / ss::smp::count;
+        if (v > bottomless_token_bucket::max_quota) {
             return bottomless_token_bucket::max_quota;
         }
         if (v < 1) {
             return 1;
         }
-        return static_cast<bottomless_token_bucket::quota_t>(v);
+        return v;
     } else {
         return bottomless_token_bucket::max_quota;
     }

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -123,6 +123,10 @@ private:
     /// Return current quota values
     ingress_egress_state<quota_t> get_quota() const noexcept;
 
+    /// If the current quota is sufficient for the shard, returns 0,
+    /// otherwise returns a positive value
+    ingress_egress_state<quota_t> get_deficiency() const noexcept;
+
     /// If the current quota is more than sufficient for the shard,
     /// returns how much it is more than sufficient as a positive value,
     /// otherwise returns 0.

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "config/property.h"
+#include "seastarx.h"
+#include "utils/bottomless_token_bucket.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sharded.hh>
+
+#include <chrono>
+#include <optional>
+
+namespace kafka {
+
+class snc_quota_manager
+  : public ss::peering_sharded_service<snc_quota_manager> {
+public:
+    using clock = ss::lowres_clock;
+
+    snc_quota_manager();
+    snc_quota_manager(const snc_quota_manager&) = delete;
+    snc_quota_manager& operator=(const snc_quota_manager&) = delete;
+    snc_quota_manager(snc_quota_manager&&) = delete;
+    snc_quota_manager& operator=(snc_quota_manager&&) = delete;
+    ~snc_quota_manager() noexcept = default;
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    /// @p enforce delay to enforce in this call
+    /// @p request delay to request from the client via throttle_ms
+    struct delays_t {
+        clock::duration enforce{0};
+        clock::duration request{0};
+    };
+
+    /// Determine throttling required by shard level TP quotas.
+    /// @param connection_throttle_until (in,out) until what time the client
+    /// on this conection should throttle until. If it does not, this throttling
+    /// will be enforced on the next call. In: value from the last call, out:
+    /// value saved until the next call.
+    delays_t get_shard_delays(
+      clock::time_point& connection_throttle_until,
+      clock::time_point now) const;
+
+    void record_request_tp(
+      size_t request_size, clock::time_point now = clock::now()) noexcept;
+
+    void record_response_tp(
+      size_t request_size, clock::time_point now = clock::now()) noexcept;
+
+private:
+    using quota_t = bottomless_token_bucket::quota_t;
+    quota_t get_shard_ingress_quota_default() const;
+    quota_t get_shard_egress_quota_default() const;
+
+private:
+    // configuration
+    config::binding<std::chrono::milliseconds> _max_kafka_throttle_delay;
+    config::binding<std::optional<uint64_t>>
+      _kafka_throughput_limit_node_in_bps;
+    config::binding<std::optional<uint64_t>>
+      _kafka_throughput_limit_node_out_bps;
+    config::binding<std::chrono::milliseconds> _kafka_quota_balancer_window;
+
+    // operational, used on each shard
+    bottomless_token_bucket _shard_ingress_quota;
+    bottomless_token_bucket _shard_egress_quota;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -73,6 +73,10 @@ private:
     config::binding<std::optional<uint64_t>>
       _kafka_throughput_limit_node_out_bps;
     config::binding<std::chrono::milliseconds> _kafka_quota_balancer_window;
+    config::binding<std::chrono::milliseconds>
+      _kafka_quota_balancer_node_period;
+    config::binding<double> _kafka_quota_balancer_min_shard_thoughput_ratio;
+    config::binding<quota_t> _kafka_quota_balancer_min_shard_thoughput_bps;
 
     // operational, used on each shard
     bottomless_token_bucket _shard_ingress_quota;

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -68,9 +68,8 @@ private:
 private:
     // configuration
     config::binding<std::chrono::milliseconds> _max_kafka_throttle_delay;
-    config::binding<std::optional<uint64_t>>
-      _kafka_throughput_limit_node_in_bps;
-    config::binding<std::optional<uint64_t>>
+    config::binding<std::optional<quota_t>> _kafka_throughput_limit_node_in_bps;
+    config::binding<std::optional<quota_t>>
       _kafka_throughput_limit_node_out_bps;
     config::binding<std::chrono::milliseconds> _kafka_quota_balancer_window;
     config::binding<std::chrono::milliseconds>

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -23,6 +23,14 @@
 
 namespace kafka {
 
+/// Represents a homogenous pair of values that correspond to
+/// ingress and egress side of the same entity
+template<class T>
+struct ingress_egress_state {
+    T in;
+    T eg;
+};
+
 class snc_quota_manager
   : public ss::peering_sharded_service<snc_quota_manager> {
 public:

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -13,6 +13,7 @@
 #include "kafka/protocol/produce.h"
 #include "kafka/protocol/request_reader.h"
 #include "kafka/server/handlers/produce.h"
+#include "kafka/server/snc_quota_manager.h"
 #include "model/fundamental.h"
 #include "random/generators.h"
 #include "redpanda/tests/fixture.h"

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -206,49 +206,86 @@ single_batch(const size_t volume) {
     return res;
 }
 
-FIXTURE_TEST(test_node_throughput_limits, prod_consume_fixture) {
-    namespace ch = std::chrono;
+namespace ch = std::chrono;
 
-    // configure
-    constexpr uint64_t pershard_rate_limit_in = 9_KiB;
-    constexpr uint64_t pershard_rate_limit_out = 7_KiB;
-    constexpr auto window_width = 200ms;
-    constexpr size_t batch_size = 256;
-    ss::smp::invoke_on_all([&] {
-        auto& config = config::shard_local_cfg();
-        config.get("kafka_throughput_limit_node_in_bps")
-          .set_value(
-            std::make_optional(pershard_rate_limit_in * ss::smp::count));
-        config.get("kafka_throughput_limit_node_out_bps")
-          .set_value(
-            std::make_optional(pershard_rate_limit_out * ss::smp::count));
-        config.get("kafka_quota_balancer_window_ms").set_value(window_width);
-        config.get("fetch_max_bytes").set_value(batch_size);
-        config.get("max_kafka_throttle_delay_ms").set_value(60'000ms);
-    }).get0();
-    wait_for_controller_leadership().get();
-    start();
+struct throughput_limits_fixure : prod_consume_fixture {
+    ch::milliseconds _window_width;
+    ch::milliseconds _balancer_period;
+    int64_t _rate_minimum;
 
-    // PRODUCE 10 KiB in smaller batches, check throttle but do not honour it,
-    // check that has to take 1 s
-    size_t kafka_in_data_len = 0;
-    {
+    void config_set(const std::string_view name, const std::any value) {
+        ss::smp::invoke_on_all([&] {
+            config::shard_local_cfg().get(name).set_value(value);
+        }).get0();
+    }
+
+    void config_set_window_width(const ch::milliseconds window_width) {
+        _window_width = window_width;
+        ss::smp::invoke_on_all([window_width] {
+            config::shard_local_cfg()
+              .get("kafka_quota_balancer_window_ms")
+              .set_value(window_width);
+        }).get0();
+    }
+
+    void config_set_balancer_period(const ch::milliseconds balancer_period) {
+        _balancer_period = balancer_period;
+        ss::smp::invoke_on_all([balancer_period] {
+            config::shard_local_cfg()
+              .get("kafka_quota_balancer_node_period_ms")
+              .set_value(balancer_period);
+        }).get0();
+    }
+
+    void config_set_rate_minimum(const int64_t rate_minimum) {
+        _rate_minimum = rate_minimum;
+        ss::smp::invoke_on_all([rate_minimum] {
+            config::shard_local_cfg()
+              .get("kafka_quota_balancer_min_shard_thoughput_bps")
+              .set_value(rate_minimum);
+        }).get0();
+    }
+
+    int warmup_cycles(const size_t rate_limit, const size_t packet_size) const {
+        // warmup is the number of iterations enough to exhaust the token bucket
+        // at least twice, and for the balancer to run at least 4 times after
+        // that.
+        const int warmup_bytes = rate_limit
+                                 * ch::duration_cast<ch::milliseconds>(
+                                     // token bucket component
+                                     2 * _window_width
+                                     // balancer component
+                                     + 4 * _balancer_period)
+                                     .count()
+                                 / 1000;
+        return warmup_bytes / packet_size + 1;
+    }
+
+    size_t test_ingress(
+      const size_t rate_limit_in,
+      const size_t batch_size,
+      const int tolerance_percent) {
+        size_t kafka_in_data_len = 0;
         constexpr size_t kafka_packet_overhead = 127;
-        const auto batches_cnt = pershard_rate_limit_in
+        // do not divide rate by smp::count because
+        // - balanced case: TP will be balanced and  the entire quota will end
+        // up in one shard
+        // - static case: rate_limit is per shard
+        const auto batches_cnt = /* 1s * */ rate_limit_in
                                  / (batch_size + kafka_packet_overhead);
         ch::steady_clock::time_point start;
         ch::milliseconds throttle_time{};
-        // warmup is the number of iterations enough to exhaust the token bucket
-        // at least twice
-        const int warmup
-          = 2 * pershard_rate_limit_in
-              * ch::duration_cast<ch::milliseconds>(window_width).count() / 1000
-              / (batch_size + kafka_packet_overhead)
-            + 1;
-        for (int k = -warmup; k != batches_cnt; ++k) {
+
+        for (int k = -warmup_cycles(
+               rate_limit_in, batch_size + kafka_packet_overhead);
+             k != batches_cnt;
+             ++k) {
             if (k == 0) {
                 start = ch::steady_clock::now();
                 throttle_time = {};
+                BOOST_TEST_WARN(
+                  false,
+                  "Ingress measurement starts. batches: " << batches_cnt);
             }
             throttle_time += produce_raw(single_batch(batch_size))
                                .then([](const kafka::produce_response& r) {
@@ -260,36 +297,48 @@ FIXTURE_TEST(test_node_throughput_limits, prod_consume_fixture) {
         const auto stop = ch::steady_clock::now();
         const auto wire_data_length = (batch_size + kafka_packet_overhead)
                                       * batches_cnt;
+        const auto rate_estimated = rate_limit_in
+                                    - _rate_minimum * (ss::smp::count - 1);
         const auto time_estimated = ch::milliseconds(
-          wire_data_length * 1000 / pershard_rate_limit_in);
+          wire_data_length * 1000 / rate_estimated);
         BOOST_TEST_CHECK(
-          abs(stop - start - time_estimated) < time_estimated / 25,
-          "stop-start[" << stop - start << "] == time_estimated["
-                        << time_estimated << "] ±4%");
+          abs(stop - start - time_estimated)
+            < time_estimated * tolerance_percent / 100,
+          "Ingress time: stop-start["
+            << stop - start << "] ≈ time_estimated[" << time_estimated << "] ±"
+            << tolerance_percent << "%, error: " << std::setprecision(3)
+            << (stop - start - time_estimated) * 100.0 / time_estimated << "%");
+        return kafka_in_data_len;
     }
 
-    // CONSUME
-    size_t kafka_out_data_len = 0;
-    {
+    size_t test_egress(
+      const size_t kafka_data_available,
+      const size_t rate_limit_out,
+      const size_t batch_size,
+      const int tolerance_percent) {
+        size_t kafka_out_data_len = 0;
         constexpr size_t kafka_packet_overhead = 62;
         ch::steady_clock::time_point start;
         size_t total_size{};
         ch::milliseconds throttle_time{};
-        const int warmup
-          = 2 * pershard_rate_limit_out
-              * ch::duration_cast<ch::milliseconds>(window_width).count() / 1000
-              / (batch_size + kafka_packet_overhead)
-            + 1;
         // consume cannot be measured by the number of fetches because the size
         // of fetch payload is up to redpanda, "fetch_max_bytes" is merely a
         // guidance. Therefore the consume test runs as long as there is data
         // to fetch. We only can consume almost as much as have been produced:
-        const auto kafka_data_cap = kafka_in_data_len - batch_size * 2;
-        for (int k = -warmup; kafka_out_data_len < kafka_data_cap; ++k) {
+        const auto kafka_data_cap = kafka_data_available - batch_size * 2;
+        for (int k = -warmup_cycles(
+               rate_limit_out, batch_size + kafka_packet_overhead);
+             kafka_out_data_len < kafka_data_cap;
+             ++k) {
             if (k == 0) {
                 start = ch::steady_clock::now();
                 total_size = {};
                 throttle_time = {};
+                BOOST_TEST_WARN(
+                  false,
+                  "Egress measurement starts. kafka_out_data_len: "
+                    << kafka_out_data_len
+                    << ", kafka_data_cap: " << kafka_data_cap);
             }
             const auto fetch_resp = fetch_next().get0();
             BOOST_REQUIRE_EQUAL(fetch_resp.data.topics.size(), 1);
@@ -305,13 +354,82 @@ FIXTURE_TEST(test_node_throughput_limits, prod_consume_fixture) {
             kafka_out_data_len += kafka_data_len;
         }
         const auto stop = ch::steady_clock::now();
+        const auto rate_estimated = rate_limit_out
+                                    - _rate_minimum * (ss::smp::count - 1);
         const auto time_estimated = ch::milliseconds(
-          total_size * 1000 / pershard_rate_limit_out);
+          total_size * 1000 / rate_estimated);
         BOOST_TEST_CHECK(
-          abs(stop - start - time_estimated) < time_estimated / 25,
-          "stop-start[" << stop - start << "] == time_estimated["
-                        << time_estimated << "] ±4%");
+          abs(stop - start - time_estimated)
+            < (time_estimated * tolerance_percent / 100),
+          "Egress time: stop-start["
+            << stop - start << "] ≈ time_estimated[" << time_estimated << "] ±"
+            << tolerance_percent << "%, error: " << std::setprecision(3)
+            << (stop - start - time_estimated) * 100.0 / time_estimated << "%");
+        return kafka_out_data_len;
     }
+};
+
+FIXTURE_TEST(test_node_throughput_limits_static, throughput_limits_fixure) {
+    // configure
+    constexpr int64_t pershard_rate_limit_in = 9_KiB;
+    constexpr int64_t pershard_rate_limit_out = 7_KiB;
+    constexpr size_t batch_size = 256;
+    config_set(
+      "kafka_throughput_limit_node_in_bps",
+      std::make_optional(pershard_rate_limit_in * ss::smp::count));
+    config_set(
+      "kafka_throughput_limit_node_out_bps",
+      std::make_optional(pershard_rate_limit_out * ss::smp::count));
+    config_set("fetch_max_bytes", batch_size);
+    config_set("max_kafka_throttle_delay_ms", 60'000ms);
+    config_set_window_width(200ms);
+    config_set_balancer_period(0ms);
+    config_set_rate_minimum(0);
+
+    wait_for_controller_leadership().get();
+    start();
+
+    // PRODUCE 10 KiB in smaller batches, check throttle but do not honour it,
+    // check that has to take 1 s
+    const size_t kafka_in_data_len = test_ingress(
+      pershard_rate_limit_in, batch_size, 3 /*%*/);
+
+    // CONSUME
+    const size_t kafka_out_data_len = test_egress(
+      kafka_in_data_len, pershard_rate_limit_out, batch_size, 3 /*%*/);
+
+    // otherwise test is not valid:
+    BOOST_REQUIRE_GT(kafka_in_data_len, kafka_out_data_len);
+}
+
+FIXTURE_TEST(test_node_throughput_limits_balanced, throughput_limits_fixure) {
+    // configure
+    constexpr int64_t rate_limit_in = 9_KiB;
+    constexpr int64_t rate_limit_out = 7_KiB;
+    constexpr size_t batch_size = 256;
+    config_set(
+      "kafka_throughput_limit_node_in_bps", std::make_optional(rate_limit_in));
+    config_set(
+      "kafka_throughput_limit_node_out_bps",
+      std::make_optional(rate_limit_out));
+    config_set("fetch_max_bytes", batch_size);
+    config_set("max_kafka_throttle_delay_ms", 60'000ms);
+    config_set("kafka_quota_balancer_min_shard_thoughput_ratio", 0.);
+    config_set_window_width(100ms);
+    config_set_balancer_period(50ms);
+    config_set_rate_minimum(250);
+
+    wait_for_controller_leadership().get();
+    start();
+
+    // PRODUCE 10 KiB in smaller batches, check throttle but do not honour it,
+    // check that has to take 1 s
+    const size_t kafka_in_data_len = test_ingress(
+      rate_limit_in, batch_size, 8 /*%*/);
+
+    // CONSUME
+    size_t kafka_out_data_len = test_egress(
+      kafka_in_data_len, rate_limit_out, batch_size, 8 /*%*/);
 
     // otherwise test is not valid:
     BOOST_REQUIRE_GT(kafka_in_data_len, kafka_out_data_len);

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -121,6 +121,7 @@ public:
     ss::sharded<kafka::fetch_session_cache> fetch_session_cache;
     ss::sharded<kafka::group_router> group_router;
     ss::sharded<kafka::quota_manager> quota_mgr;
+    ss::sharded<kafka::snc_quota_manager> snc_quota_mgr;
     ss::sharded<kafka::rm_group_frontend> rm_group_frontend;
 
     ss::sharded<raft::group_manager> raft_group_manager;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -118,6 +118,7 @@ public:
           app.controller->get_config_frontend(),
           app.controller->get_feature_table(),
           app.quota_mgr,
+          app.snc_quota_mgr,
           app.group_router,
           app.shard_table,
           app.partition_manager,


### PR DESCRIPTION
Node-wide throughput quotas introduced in #8023 are now balanced between the shards withing each node. New config properties added to control the balancer and minimum amount of quotas in each shard. All properties are updateable at runtime. Included is refactoring of #8023 that makes shard-(and-higher)-level quota manager an independent sharded service.

Fixes #7855.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

New cluster configuration properties:
| Name | Description |
| --- | --- |
| kafka_quota_balancer_node_period_ms | Intra-node throughput quota balancer invocation period, in milliseconds. Value of 0 disables the balancer and makes all the thoughput quotas immutable. |
| kafka_quota_balancer_min_shard_thoughput_ratio | The lowest value of the throughput quota a shard can get in the process of quota balancing, expressed as a ratio of default shard quota. 0 means there is no minimum, 1 means no quota can be taken away by the balancer. |
| kafka_quota_balancer_min_shard_thoughput_bps | The lowest value of the throughput quota a shard can get in the process of quota balancing, in bytes/s. 0 means there is no minimum. |


<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.
-->
  ### Features

  * Throughput limit can now be applied at node scope. Each individual node will limit the overall ingress throughput of all Kafka client connections it serves to the number specified by `kafka_throughput_limit_node_in_bps` cluster property; same can be done on the egress side using `kafka_throughput_limit_node_out_bps`.

<!--
  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
