### PR TITLE
Enable memory diagnostics in ducktape

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1025,6 +1025,7 @@ class RedpandaService(Service):
             f" --redpanda-cfg {RedpandaService.NODE_CONFIG_FILE}"
             f" {self._log_config.to_args()} "
             " --abort-on-seastar-bad-alloc "
+            " --dump-memory-diagnostics-on-alloc-failure-kind=all "
             f" {res_args} "
             f" >> {RedpandaService.STDOUT_STDERR_CAPTURE} 2>&1 &")
 
@@ -1231,8 +1232,8 @@ class RedpandaService(Service):
 
     def start_node_with_rpk(self, node, additional_args="", clean_node=True):
         """
-        Start a single instance of redpanda using rpk. similar to start_node, 
-        this function will not return until redpanda appears to have started 
+        Start a single instance of redpanda using rpk. similar to start_node,
+        this function will not return until redpanda appears to have started
         successfully.
         """
         if clean_node:


### PR DESCRIPTION
In princple, memory diagnostics should already be output but due to various test configs, the logging config needed to do this isn't always propagated.

This change emits diagnostics unconditionally when we die from OOM.

Issue #5800.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

 * none