### PR TITLE
rpk: redact secret values when importing from file

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -75,6 +75,7 @@ type ConfigPropertyMetadata struct {
 	Description  string              `json:"description"`           // One liner human readable string
 	Nullable     bool                `json:"nullable"`              // If true, may be null
 	NeedsRestart bool                `json:"needs_restart"`         // If true, won't take effect until restart
+	IsSecret     bool                `json:"is_secret"`             // If true, the field should be redacted.
 	Visibility   string              `json:"visibility"`            // One of 'user', 'deprecated', 'tunable'
 	Units        string              `json:"units,omitempty"`       // A unit like 'ms', or empty.
 	Example      string              `json:"example,omitempty"`     // A non-default value for use in docs or tests

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -663,11 +663,11 @@ class ClusterConfigTest(RedpandaTest):
         self.logger.debug(f"_import status: {import_stdout}")
 
         if m is None and allow_noop:
-            return None
+            return None, None
 
         assert m is not None, f"Config version not found: {import_stdout}"
         version = int(m.group(1))
-        return version
+        return version, import_stdout
 
     def _export_import_modify_one(self, before: str, after: str, all=False):
         return self._export_import_modify([(before, after)], all)
@@ -690,7 +690,7 @@ class ClusterConfigTest(RedpandaTest):
         self.logger.debug(f"Exported config after modification: {text}")
 
         # Edit a setting, import the resulting document
-        version = self._import(text, all)
+        version, _ = self._import(text, all)
 
         return version, text
 
@@ -766,20 +766,25 @@ class ClusterConfigTest(RedpandaTest):
 
         # Check that an import/export with no edits does nothing.
         text = self._export(all=True)
-        noop_version = self._import(text, allow_noop=True, all=True)
+        noop_version, _ = self._import(text, allow_noop=True, all=True)
         assert noop_version is None
 
         # Now try setting a secret.
         text = text.replace("cloud_storage_secret_key:",
                             "cloud_storage_secret_key: different_secret")
-        version_e = self._import(text, all)
+        version_e, import_output = self._import(text, all)
         assert version_e is not None
         assert version_e > version_d
+
+        # Check that rpk doesn't print the secret to stdout.
+        assert "different_secret" not in import_output
+        # Instead, prints a [redacted] text.
+        assert "[redacted]" in import_output
 
         # Because rpk doesn't know the contents of the secrets, it can't
         # determine whether a secret is new. The request should be de-duped on
         # the server side, and the same config version should be returned.
-        version_f = self._import(text, all)
+        version_f, _ = self._import(text, all)
         assert version_f is not None
         assert version_f == version_e
 
@@ -788,12 +793,12 @@ class ClusterConfigTest(RedpandaTest):
         # setting the secret to the redacted string.
         text = text.replace("cloud_storage_secret_key: different_secret",
                             "cloud_storage_secret_key: [secret]")
-        noop_version = self._import(text, allow_noop=True, all=True)
+        noop_version, _ = self._import(text, allow_noop=True, all=True)
         assert noop_version is None
 
         # Removing a secret should succeed with a new version.
         text = text.replace("cloud_storage_secret_key: [secret]", "")
-        version_g = self._import(text, all)
+        version_g, _ = self._import(text, all)
         assert version_g is not None
         assert version_g > version_f
 
@@ -815,7 +820,7 @@ class ClusterConfigTest(RedpandaTest):
         superusers: [alice]
         """
 
-        new_version = self._import(text, all, allow_noop=True)
+        new_version, _ = self._import(text, all, allow_noop=True)
         self._wait_for_version_sync(new_version)
 
         schema_properties = self.admin.get_cluster_config_schema(


### PR DESCRIPTION
Now if a value is a secret we will use [redacted] instead of printing the raw value.

```yaml
# Running import when the file have a secret field:
$ rpk cluster config import -f /tmp/config.yaml    
PROPERTY                  PRIOR     NEW
cloud_storage_secret_key  [secret]  [redacted]

Successfully updated configuration. New configuration version is 54.

Cluster needs to be restarted. See more details with 'rpk cluster config status'.

# No edits in rpk cluster config edit:
$ rpk cluster config edit
No changes were made.

# Edit in rpk cluster config edit
$ rpk cluster config edit
PROPERTY                  PRIOR     NEW
cloud_storage_secret_key  [secret]  [redacted]

Successfully updated configuration. New configuration version is 54.

Cluster needs to be restarted. See more details with 'rpk cluster config status'.
```
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x


## Release Notes

  ### Bug Fixes

  * rpk won't print the values of secret properties that are being imported from a file when using `rpk cluster config import/edit`

