### PR TITLE
[v22.3.x] Backport #8225 (cluster: set feature_table version during bootstrap)

### DIFF
--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -16,6 +16,7 @@
 #include "cluster/logger.h"
 #include "cluster/members_manager.h"
 #include "cluster/types.h"
+#include "features/feature_table.h"
 #include "security/credential_store.h"
 
 namespace cluster {
@@ -35,10 +36,12 @@ namespace cluster {
 bootstrap_backend::bootstrap_backend(
   ss::sharded<security::credential_store>& credentials,
   ss::sharded<storage::api>& storage,
-  ss::sharded<members_manager>& members_manager)
+  ss::sharded<members_manager>& members_manager,
+  ss::sharded<features::feature_table>& feature_table)
   : _credentials(credentials)
   , _storage(storage)
-  , _members_manager(members_manager) {}
+  , _members_manager(members_manager)
+  , _feature_table(feature_table) {}
 
 namespace {
 

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -13,6 +13,7 @@
 
 #include "cluster/commands.h"
 #include "cluster/fwd.h"
+#include "features/fwd.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
@@ -41,7 +42,8 @@ public:
     bootstrap_backend(
       ss::sharded<security::credential_store>&,
       ss::sharded<storage::api>&,
-      ss::sharded<members_manager>&);
+      ss::sharded<members_manager>&,
+      ss::sharded<features::feature_table>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -56,6 +58,7 @@ private:
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<storage::api>& _storage;
     ss::sharded<members_manager>& _members_manager;
+    ss::sharded<features::feature_table>& _feature_table;
     std::optional<model::cluster_uuid> _cluster_uuid_applied;
 };
 

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -43,7 +43,8 @@ public:
       ss::sharded<security::credential_store>&,
       ss::sharded<storage::api>&,
       ss::sharded<members_manager>&,
-      ss::sharded<features::feature_table>&);
+      ss::sharded<features::feature_table>&,
+      ss::sharded<feature_backend>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -59,6 +60,7 @@ private:
     ss::sharded<storage::api>& _storage;
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<features::feature_table>& _feature_table;
+    ss::sharded<feature_backend>& _feature_backend;
     std::optional<model::cluster_uuid> _cluster_uuid_applied;
 };
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -160,7 +160,8 @@ ss::future<> controller::start(cluster_discovery& discovery) {
           return _bootstrap_backend.start_single(
             std::ref(_credentials),
             std::ref(_storage),
-            std::ref(_members_manager));
+            std::ref(_members_manager),
+            std::ref(_feature_table));
       })
       .then([this] {
           return _config_frontend.start(
@@ -581,7 +582,8 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
         cmd_data.bootstrap_user_cred
           = security_frontend::get_bootstrap_user_creds_from_env();
         cmd_data.node_ids_by_uuid = std::move(discovery.get_node_ids_by_uuid());
-        cmd_data.founding_version = features::feature_table::get_latest_logical_version();
+        cmd_data.founding_version
+          = features::feature_table::get_latest_logical_version();
         co_return co_await create_cluster(std::move(cmd_data));
     }
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -581,6 +581,7 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
         cmd_data.bootstrap_user_cred
           = security_frontend::get_bootstrap_user_creds_from_env();
         cmd_data.node_ids_by_uuid = std::move(discovery.get_node_ids_by_uuid());
+        cmd_data.founding_version = features::feature_table::get_latest_logical_version();
         co_return co_await create_cluster(std::move(cmd_data));
     }
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -161,7 +161,8 @@ ss::future<> controller::start(cluster_discovery& discovery) {
             std::ref(_credentials),
             std::ref(_storage),
             std::ref(_members_manager),
-            std::ref(_feature_table));
+            std::ref(_feature_table),
+            std::ref(_feature_backend));
       })
       .then([this] {
           return _config_frontend.start(

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -39,6 +39,7 @@ public:
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
+    bool has_snapshot();
     ss::future<> save_snapshot();
 
     bool is_batch_applicable(const model::record_batch& b) {

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -46,6 +46,7 @@ class health_monitor_frontend;
 class health_monitor_backend;
 class metrics_reporter;
 class feature_frontend;
+class feature_backend;
 class feature_manager;
 class drain_manager;
 class partition_balancer_backend;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2161,7 +2161,10 @@ struct user_and_credential
 };
 
 struct bootstrap_cluster_cmd_data
-  : serde::envelope<bootstrap_cluster_cmd_data, serde::version<0>> {
+  : serde::envelope<
+      bootstrap_cluster_cmd_data,
+      serde::version<1>,
+      serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     friend bool operator==(
@@ -2169,12 +2172,18 @@ struct bootstrap_cluster_cmd_data
       = default;
 
     auto serde_fields() {
-        return std::tie(uuid, bootstrap_user_cred, node_ids_by_uuid);
+        return std::tie(
+          uuid, bootstrap_user_cred, node_ids_by_uuid, founding_version);
     }
 
     model::cluster_uuid uuid;
     std::optional<user_and_credential> bootstrap_user_cred;
     absl::flat_hash_map<model::node_uuid, model::node_id> node_ids_by_uuid;
+
+    // If this is set, fast-forward the feature_table to enable features
+    // from this version. Indicates the version of Redpanda of
+    // the node that generated the bootstrap record.
+    cluster_version founding_version{invalid_version};
 };
 
 enum class reconciliation_status : int8_t {

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -49,7 +49,8 @@ enum class feature : std::uint64_t {
     tm_stm_cache = 1ULL << 16U,
 
     // Dummy features for testing only
-    test_alpha = 1ULL << 63U,
+    test_alpha = 1ULL << 62U,
+    test_bravo = 1ULL << 63U,
 };
 
 /**
@@ -201,12 +202,23 @@ constexpr static std::array feature_schema{
     feature::tm_stm_cache,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
+
+  // For testing, a feature that does not auto-activate
   feature_spec{
     cluster::cluster_version{2001},
     "__test_alpha",
     feature::test_alpha,
     feature_spec::available_policy::explicit_only,
-    feature_spec::prepare_policy::always}};
+    feature_spec::prepare_policy::always},
+
+  // For testing, a feature that auto-activates
+  feature_spec{
+    cluster::cluster_version{2001},
+    "__test_bravo",
+    feature::test_bravo,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+};
 
 std::string_view to_string_view(feature);
 std::string_view to_string_view(feature_state::state);
@@ -298,6 +310,7 @@ public:
 private:
     // Only for use by our friends feature backend & manager
     void set_active_version(cluster::cluster_version);
+    void bootstrap_active_version(cluster::cluster_version);
     void apply_action(const cluster::feature_update_action& fua);
 
     // The controller log offset of last batch applied to this state machine

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -308,11 +308,14 @@ public:
 
     model::offset get_applied_offset() const { return _applied_offset; }
 
-private:
-    // Only for use by our friends feature backend & manager, and during
-    // bootstrap by bootstrap_backend.
-    void set_active_version(cluster::cluster_version);
+    // application and bootstrap_backend may use this to fast-forward a
+    // feature table to the desired version synchronously, early in the
+    // lifetime of a node.
     void bootstrap_active_version(cluster::cluster_version);
+
+private:
+    // Only for use by our friends feature backend & manager
+    void set_active_version(cluster::cluster_version);
     void apply_action(const cluster::feature_update_action& fua);
 
     // The controller log offset of last batch applied to this state machine
@@ -346,10 +349,6 @@ private:
     // feature_backend is a friend for routine updates when
     // applying raft0 log events.
     friend class cluster::feature_backend;
-
-    // bootstrap_backend is a friend for using set_active_version during
-    // bootstrap, thereby fast-forwarding past the usual version negotiation.
-    friend class cluster::bootstrap_backend;
 
     // Unit testing hook.
     friend class feature_table_fixture;

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -23,6 +23,7 @@
 namespace cluster {
 class feature_backend;
 class feature_manager;
+class bootstrap_backend;
 } // namespace cluster
 
 namespace features {
@@ -308,7 +309,8 @@ public:
     model::offset get_applied_offset() const { return _applied_offset; }
 
 private:
-    // Only for use by our friends feature backend & manager
+    // Only for use by our friends feature backend & manager, and during
+    // bootstrap by bootstrap_backend.
     void set_active_version(cluster::cluster_version);
     void bootstrap_active_version(cluster::cluster_version);
     void apply_action(const cluster::feature_update_action& fua);
@@ -344,6 +346,10 @@ private:
     // feature_backend is a friend for routine updates when
     // applying raft0 log events.
     friend class cluster::feature_backend;
+
+    // bootstrap_backend is a friend for using set_active_version during
+    // bootstrap, thereby fast-forwarding past the usual version negotiation.
+    friend class cluster::bootstrap_backend;
 
     // Unit testing hook.
     friend class feature_table_fixture;

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -38,6 +38,9 @@ public:
     feature_table ft;
     ss::abort_source as;
     void set_active_version(cluster_version v) { ft.set_active_version(v); }
+    void bootstrap_active_version(cluster_version v) {
+        ft.bootstrap_active_version(v);
+    }
     void apply_action(const feature_update_action& fua) {
         ft.apply_action(fua);
     }
@@ -237,4 +240,37 @@ FIXTURE_TEST(feature_uniqueness, feature_table_fixture) {
               || other.bits == current_feature);
         }
     }
+}
+
+/**
+ * Validate that the bootstrap method not only updates the cluster version,
+ * but also activates elegible features.
+ */
+FIXTURE_TEST(feature_table_bootstrap, feature_table_fixture) {
+    bootstrap_active_version(cluster_version{2001});
+
+    // A non-auto-activating feature should remain in available state:
+    // explicit_only features always require explicit activation, even
+    // if the cluster was bootstrapped in a version where the feature
+    // is available.
+    BOOST_REQUIRE(
+      ft.get_state(feature::test_alpha).get_state()
+      == feature_state::state::available);
+    BOOST_REQUIRE(!ft.is_active(feature::test_alpha));
+
+    // An auto-activating feature fast-forwards to the active state
+    BOOST_REQUIRE(
+      ft.get_state(feature::test_bravo).get_state()
+      == feature_state::state::active);
+    BOOST_REQUIRE(ft.is_active(feature::test_bravo));
+
+    // A feature that has a preparing state skips it when bootstrapping
+    // straight into the version where the feature is available.
+    BOOST_REQUIRE(
+      ft.get_state(feature::cloud_retention).spec.prepare_rule
+      == feature_spec::prepare_policy::requires_migration);
+    BOOST_REQUIRE(
+      ft.get_state(feature::cloud_retention).get_state()
+      == feature_state::state::active);
+    BOOST_REQUIRE(ft.is_active(feature::cloud_retention));
 }


### PR DESCRIPTION

Backport of PR #8225


## Backports Required


- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  ### Bug Fixes

  * An issue is fixed that could prevent clusters forming successfully when network disruptions happened during initial startup of the founding nodes.

