### PR TITLE
admin: correct moving_to.node_id calculation

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2035,7 +2035,7 @@ admin_server::get_decommission_progress_handler(
         status.topic = p.ntp.tp.topic;
         status.partition = p.ntp.tp.partition;
         auto added_replicas = cluster::subtract_replica_sets(
-          p.previous_assignment, p.current_assignment);
+          p.current_assignment, p.previous_assignment);
         // we are only interested in reconfigurations where one replica was
         // added to the node
         if (added_replicas.size() != 1) {


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

The new endpoint `GET /v1/brokers/<id>/decommission`, introduced via https://github.com/redpanda-data/redpanda/pull/8167, returns `moving_to.node_id` as the source (decommissioning) node id. 
See the example in https://github.com/redpanda-data/redpanda/issues/8268 where all of `moving_to.node_id` is `3` whereas I was decommissioning `3`. This commit corrects the calculation by just changing the order of `p.previous_assignment` and `p.current_assignment` in admin_server.cc.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

no change
<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Show the correct node id in `moving_to.node_id` when decommissionoing



-->
