### PR TITLE
cluster: fix `has_overrides` ignoring disabled local target retention

### DIFF
--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -258,16 +258,16 @@ get_retention_policy(const storage::ntp_config::default_overrides& prop) {
         //
         // This differs from ordinary storage GC, in that we are applying
         // space _or_ time bounds: not both together.
-        if (prop.retention_local_target_bytes.has_value()) {
+        if (prop.retention_local_target_bytes.has_optional_value()) {
             auto v = prop.retention_local_target_bytes.value();
 
-            if (prop.retention_bytes.has_value()) {
+            if (prop.retention_bytes.has_optional_value()) {
                 v = std::min(prop.retention_bytes.value(), v);
             }
             return size_bound_deletion_parameters{v};
-        } else if (prop.retention_local_target_ms.has_value()) {
+        } else if (prop.retention_local_target_ms.has_optional_value()) {
             auto v = prop.retention_local_target_ms.value();
-            if (prop.retention_time.has_value()) {
+            if (prop.retention_time.has_optional_value()) {
                 v = std::min(prop.retention_time.value(), v);
             }
             return time_bound_deletion_parameters{v};

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -187,10 +187,10 @@ SEASTAR_THREAD_TEST_CASE(min_config_update_all_fields_correct) {
     BOOST_REQUIRE(!topic_config.properties.segment_size);
     BOOST_REQUIRE(
       !topic_config.properties.retention_bytes.is_disabled()
-      && !topic_config.properties.retention_bytes.has_value());
+      && !topic_config.properties.retention_bytes.has_optional_value());
     BOOST_REQUIRE(
       !topic_config.properties.retention_duration.is_disabled()
-      && !topic_config.properties.retention_duration.has_value());
+      && !topic_config.properties.retention_duration.has_optional_value());
 }
 
 SEASTAR_THREAD_TEST_CASE(full_config_update_all_fields_correct) {

--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -403,7 +403,8 @@ FIXTURE_TEST(recovery_with_retention_ms_override, fixture) {
     auto topic = app.controller->get_topics_state().local().get_topic_cfg(
       tp_ns);
     BOOST_REQUIRE(topic.has_value());
-    BOOST_REQUIRE(topic->properties.retention_local_target_ms.has_value());
+    BOOST_REQUIRE(
+      topic->properties.retention_local_target_ms.has_optional_value());
     BOOST_REQUIRE_EQUAL(
       topic->properties.retention_local_target_ms.value().count(), 10000);
 }
@@ -429,7 +430,8 @@ FIXTURE_TEST(recovery_with_retention_bytes_override, fixture) {
     auto topic = app.controller->get_topics_state().local().get_topic_cfg(
       tp_ns);
     BOOST_REQUIRE(topic.has_value());
-    BOOST_REQUIRE(topic->properties.retention_local_target_bytes.has_value());
+    BOOST_REQUIRE(
+      topic->properties.retention_local_target_bytes.has_optional_value());
     BOOST_REQUIRE_EQUAL(
       topic->properties.retention_local_target_bytes.value(), 10000);
 }

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -388,7 +388,7 @@ void topic_manifest::serialize(std::ostream& out) const {
     // - key is not null - tristate is enabled and set
     if (!_topic_config->properties.retention_bytes.is_disabled()) {
         w.Key("retention_bytes");
-        if (_topic_config->properties.retention_bytes.has_value()) {
+        if (_topic_config->properties.retention_bytes.has_optional_value()) {
             w.Int64(_topic_config->properties.retention_bytes.value());
         } else {
             w.Null();
@@ -396,7 +396,7 @@ void topic_manifest::serialize(std::ostream& out) const {
     }
     if (!_topic_config->properties.retention_duration.is_disabled()) {
         w.Key("retention_duration");
-        if (_topic_config->properties.retention_duration.has_value()) {
+        if (_topic_config->properties.retention_duration.has_optional_value()) {
             w.Int64(
               _topic_config->properties.retention_duration.value().count());
         } else {

--- a/src/v/cluster/remote_topic_configuration_source.cc
+++ b/src/v/cluster/remote_topic_configuration_source.cc
@@ -93,10 +93,10 @@ static void apply_retention_defaults(
     if (!target.cleanup_policy_bitflags) {
         target.cleanup_policy_bitflags = source.cleanup_policy_bitflags;
     }
-    if (!target.retention_bytes.has_value()) {
+    if (!target.retention_bytes.has_optional_value()) {
         target.retention_bytes = source.retention_bytes;
     }
-    if (!target.retention_duration.has_value()) {
+    if (!target.retention_duration.has_optional_value()) {
         target.retention_duration = source.retention_duration;
     }
 }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -130,16 +130,13 @@ bool topic_properties::is_compacted() const {
 
 bool topic_properties::has_overrides() const {
     return cleanup_policy_bitflags || compaction_strategy || segment_size
-             || retention_bytes.has_optional_value()
-             || retention_bytes.is_disabled()
-             || retention_duration.has_optional_value()
-             || retention_duration.is_disabled() || recovery.has_value()
-             || shadow_indexing.has_value() || read_replica.has_value()
-             || batch_max_bytes.has_value()
-             || retention_local_target_bytes.has_optional_value()
-             || retention_local_target_ms.has_optional_value()
-             || remote_delete != storage::ntp_config::default_remote_delete
-             || segment_ms.has_optional_value() || segment_ms.is_disabled();
+           || retention_bytes.is_engaged() || retention_duration.is_engaged()
+           || recovery.has_value() || shadow_indexing.has_value()
+           || read_replica.has_value() || batch_max_bytes.has_value()
+           || retention_local_target_bytes.is_engaged()
+           || retention_local_target_ms.is_engaged()
+           || remote_delete != storage::ntp_config::default_remote_delete
+           || segment_ms.is_engaged();
 }
 
 storage::ntp_config::default_overrides

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -130,14 +130,16 @@ bool topic_properties::is_compacted() const {
 
 bool topic_properties::has_overrides() const {
     return cleanup_policy_bitflags || compaction_strategy || segment_size
-           || retention_bytes.has_value() || retention_bytes.is_disabled()
-           || retention_duration.has_value() || retention_duration.is_disabled()
-           || recovery.has_value() || shadow_indexing.has_value()
-           || read_replica.has_value() || batch_max_bytes.has_value()
-           || retention_local_target_bytes.has_value()
-           || retention_local_target_ms.has_value()
-           || remote_delete != storage::ntp_config::default_remote_delete
-           || segment_ms.has_value() || segment_ms.is_disabled();
+             || retention_bytes.has_optional_value()
+             || retention_bytes.is_disabled()
+             || retention_duration.has_optional_value()
+             || retention_duration.is_disabled() || recovery.has_value()
+             || shadow_indexing.has_value() || read_replica.has_value()
+             || batch_max_bytes.has_value()
+             || retention_local_target_bytes.has_optional_value()
+             || retention_local_target_ms.has_optional_value()
+             || remote_delete != storage::ntp_config::default_remote_delete
+             || segment_ms.has_optional_value() || segment_ms.is_disabled();
 }
 
 storage::ntp_config::default_overrides

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -727,7 +727,7 @@ void rjson_serialize(
     w.Key("status");
     if (t.is_disabled()) {
         w.Int(uint8_t(tristate_status::disabled));
-    } else if (!t.has_value()) {
+    } else if (!t.has_optional_value()) {
         w.Int(uint8_t(tristate_status::not_set));
     } else {
         w.Int(uint8_t(tristate_status::set));

--- a/src/v/compat/model_json.h
+++ b/src/v/compat/model_json.h
@@ -225,7 +225,7 @@ void rjson_serialize_exceptional_type(
     w.Key("status");
     if (t.is_disabled()) {
         w.Int(uint8_t(tristate_status::disabled));
-    } else if (!t.has_value()) {
+    } else if (!t.has_optional_value()) {
         w.Int(uint8_t(tristate_status::not_set));
     } else {
         w.Int(uint8_t(tristate_status::set));

--- a/src/v/features/migrators/cloud_storage_config.cc
+++ b/src/v/features/migrators/cloud_storage_config.cc
@@ -51,8 +51,8 @@ ss::future<> cloud_storage_config::do_mutate() {
             || config::shard_local_cfg().cloud_storage_enable_remote_write();
 
         if (
-          props.retention_local_target_bytes.has_value()
-          || props.retention_local_target_ms.has_value()) {
+          props.retention_local_target_bytes.has_optional_value()
+          || props.retention_local_target_ms.has_optional_value()) {
             // This may be a retry, if we got partway through an upgrade and
             // were interrupted: do not keep emitting configuration update
             // events for all topics

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -312,7 +312,7 @@ static void add_topic_config_if_requested(
 
 template<typename T>
 static ss::sstring maybe_print_tristate(const tristate<T>& tri) {
-    if (tri.is_disabled() || !tri.has_value()) {
+    if (tri.is_disabled() || !tri.has_optional_value()) {
         return "-1";
     }
     return ssx::sformat("{}", tri.value());
@@ -330,7 +330,7 @@ static void add_topic_config(
     // Wrap overrides in an optional because add_topic_config expects
     // optional<S> where S = tristate<T>
     std::optional<tristate<T>> override_value;
-    if (overrides.is_disabled() || overrides.has_value()) {
+    if (overrides.is_disabled() || overrides.has_optional_value()) {
         override_value = std::make_optional(overrides);
     }
 
@@ -548,7 +548,7 @@ int64_t describe_retention_duration(
     if (overrides.is_disabled()) {
         return -1;
     }
-    if (overrides.has_value()) {
+    if (overrides.has_optional_value()) {
         return overrides.value().count();
     }
 
@@ -559,7 +559,7 @@ int64_t describe_retention_bytes(
     if (overrides.is_disabled()) {
         return -1;
     }
-    if (overrides.has_value()) {
+    if (overrides.has_optional_value()) {
         return overrides.value();
     }
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -244,11 +244,11 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
         config_entries[topic_property_segment_size] = from_config_type(
           *properties.segment_size);
     }
-    if (properties.retention_bytes.has_value()) {
+    if (properties.retention_bytes.has_optional_value()) {
         config_entries[topic_property_retention_bytes] = from_config_type(
           properties.retention_bytes.value());
     }
-    if (properties.retention_duration.has_value()) {
+    if (properties.retention_duration.has_optional_value()) {
         config_entries[topic_property_retention_duration] = from_config_type(
           *properties.retention_duration);
     }
@@ -284,12 +284,12 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
           *properties.read_replica_bucket);
     }
 
-    if (properties.retention_local_target_bytes.has_value()) {
+    if (properties.retention_local_target_bytes.has_optional_value()) {
         config_entries[topic_property_retention_local_target_bytes]
           = from_config_type(*properties.retention_local_target_bytes);
     }
 
-    if (properties.retention_local_target_ms.has_value()) {
+    if (properties.retention_local_target_ms.has_optional_value()) {
         config_entries[topic_property_retention_local_target_ms]
           = from_config_type(*properties.retention_local_target_ms);
     }
@@ -297,7 +297,7 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
     config_entries[topic_property_remote_delete] = from_config_type(
       properties.remote_delete);
 
-    if (properties.segment_ms.has_value()) {
+    if (properties.segment_ms.has_optional_value()) {
         config_entries[topic_property_segment_ms] = from_config_type(
           properties.segment_ms.value());
     }

--- a/src/v/model/adl_serde.h
+++ b/src/v/model/adl_serde.h
@@ -156,7 +156,7 @@ struct adl<tristate<T>> {
             adl<int8_t>{}.to(out, -1);
             return;
         }
-        if (!t.has_value()) {
+        if (!t.has_optional_value()) {
             adl<int8_t>{}.to(out, 0);
             return;
         }

--- a/src/v/model/tests/model_serialization_test.cc
+++ b/src/v/model/tests/model_serialization_test.cc
@@ -66,6 +66,6 @@ SEASTAR_THREAD_TEST_CASE(tristate_rt_test) {
 
     BOOST_REQUIRE_EQUAL(r_disabled.is_disabled(), true);
     BOOST_REQUIRE_EQUAL(r_empty.is_disabled(), false);
-    BOOST_REQUIRE_EQUAL(r_empty.has_value(), false);
+    BOOST_REQUIRE_EQUAL(r_empty.has_optional_value(), false);
     BOOST_REQUIRE_EQUAL(r_present.value(), 1024);
 }

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -84,45 +84,51 @@ public:
       : _fmt(fmt) {}
 
     bool Null() {
-        if (auto res = maybe_json(&json_writer::Null); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::Null);
+            res.has_optional_value()) {
             return res.value();
         }
         return false;
     }
     bool Bool(bool b) {
-        if (auto res = maybe_json(&json_writer::Bool, b); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::Bool, b);
+            res.has_optional_value()) {
             return res.value();
         }
         return false;
     }
     bool Int64(int64_t v) {
-        if (auto res = maybe_json(&json_writer::Int64, v); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::Int64, v);
+            res.has_optional_value()) {
             return res.value();
         }
         return false;
     }
     bool Uint64(uint64_t v) {
-        if (auto res = maybe_json(&json_writer::Uint64, v); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::Uint64, v);
+            res.has_optional_value()) {
             return res.value();
         }
         return false;
     }
     bool Double(double v) {
-        if (auto res = maybe_json(&json_writer::Double, v); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::Double, v);
+            res.has_optional_value()) {
             return res.value();
         }
         return false;
     }
     bool RawNumber(const Ch* str, ::json::SizeType len, bool b) {
         if (auto res = maybe_json(&json_writer::RawNumber, str, len, b);
-            res.has_value()) {
+            res.has_optional_value()) {
             return res.value();
         }
         return false;
     }
 
     bool Int(int i) {
-        if (auto res = maybe_json(&json_writer::Int, i); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::Int, i);
+            res.has_optional_value()) {
             return res.value();
         }
         if (state == state::partition) {
@@ -134,7 +140,8 @@ public:
     }
 
     bool Uint(unsigned u) {
-        if (auto res = maybe_json(&json_writer::Uint, u); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::Uint, u);
+            res.has_optional_value()) {
             return res.value();
         }
         if (state == state::partition) {
@@ -149,7 +156,7 @@ public:
         if (auto res = maybe_json<bool (json_writer::*)(
               const Ch*, ::json::SizeType, bool)>(
               &json_writer::String, str, len, b);
-            res.has_value()) {
+            res.has_optional_value()) {
             return res.value();
         }
         if (state == state::key) {
@@ -176,7 +183,7 @@ public:
         if (auto res = maybe_json<bool (json_writer::*)(
               const Ch*, ::json::SizeType, bool)>(
               &json_writer::Key, str, len, b);
-            res.has_value()) {
+            res.has_optional_value()) {
             return res.value();
         }
         auto key = std::string_view(str, len);
@@ -206,7 +213,8 @@ public:
     }
 
     bool StartObject() {
-        if (auto res = maybe_json(&json_writer::StartObject); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::StartObject);
+            res.has_optional_value()) {
             return res.value();
         }
         if (state == state::empty) {
@@ -222,7 +230,7 @@ public:
 
     bool EndObject(::json::SizeType s) {
         if (auto res = maybe_json(&json_writer::EndObject, s);
-            res.has_value()) {
+            res.has_optional_value()) {
             return res.value();
         }
         if (state == state::record) {
@@ -237,14 +245,16 @@ public:
     }
 
     bool StartArray() {
-        if (auto res = maybe_json(&json_writer::StartArray); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::StartArray);
+            res.has_optional_value()) {
             return res.value();
         }
         return state == state::records;
     }
 
     bool EndArray(::json::SizeType s) {
-        if (auto res = maybe_json(&json_writer::EndArray, s); res.has_value()) {
+        if (auto res = maybe_json(&json_writer::EndArray, s);
+            res.has_optional_value()) {
             return res.value();
         }
         return state == state::records;

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -421,7 +421,7 @@ template<typename T>
 void write(iobuf& out, tristate<T> t) {
     if (t.is_disabled()) {
         write<int8_t>(out, -1);
-    } else if (!t.has_value()) {
+    } else if (!t.has_optional_value()) {
         write<int8_t>(out, 0);
     } else {
         write<int8_t>(out, 1);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -643,17 +643,19 @@ disk_log_impl::override_retention_config(compaction_config cfg) const {
     // defaults.
     if (
       !local_retention_bytes.is_disabled()
-      && !local_retention_bytes.has_value()) {
+      && !local_retention_bytes.has_optional_value()) {
         local_retention_bytes = tristate<size_t>{
           config::shard_local_cfg().retention_local_target_bytes_default()};
     }
 
-    if (!local_retention_ms.is_disabled() && !local_retention_ms.has_value()) {
+    if (
+      !local_retention_ms.is_disabled()
+      && !local_retention_ms.has_optional_value()) {
         local_retention_ms = tristate<std::chrono::milliseconds>{
           config::shard_local_cfg().retention_local_target_ms_default()};
     }
 
-    if (local_retention_bytes.has_value()) {
+    if (local_retention_bytes.has_optional_value()) {
         if (cfg.max_bytes) {
             cfg.max_bytes = std::min(
               local_retention_bytes.value(), cfg.max_bytes.value());
@@ -662,7 +664,7 @@ disk_log_impl::override_retention_config(compaction_config cfg) const {
         }
     }
 
-    if (local_retention_ms.has_value()) {
+    if (local_retention_ms.has_optional_value()) {
         cfg.eviction_time = std::max(
           model::timestamp(
             model::timestamp::now().value()
@@ -699,7 +701,7 @@ disk_log_impl::apply_overrides(compaction_config defaults) const {
     if (retention_bytes.is_disabled()) {
         ret.max_bytes = std::nullopt;
     }
-    if (retention_bytes.has_value()) {
+    if (retention_bytes.has_optional_value()) {
         ret.max_bytes = retention_bytes.value();
     }
 
@@ -710,7 +712,7 @@ disk_log_impl::apply_overrides(compaction_config defaults) const {
     if (retention_time.is_disabled()) {
         ret.eviction_time = model::timestamp::min();
     }
-    if (retention_time.has_value()) {
+    if (retention_time.has_optional_value()) {
         ret.eviction_time = model::timestamp(
           model::timestamp::now().value() - retention_time.value().count());
     }

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -164,7 +164,7 @@ public:
             if (_overrides->retention_bytes.is_disabled()) {
                 return std::nullopt;
             }
-            if (_overrides->retention_bytes.has_value()) {
+            if (_overrides->retention_bytes.has_optional_value()) {
                 return _overrides->retention_bytes.value();
             }
             // If no value set, fall through and use the cluster-wide default.
@@ -178,7 +178,7 @@ public:
             if (_overrides->retention_time.is_disabled()) {
                 return std::nullopt;
             }
-            if (_overrides->retention_time.has_value()) {
+            if (_overrides->retention_time.has_optional_value()) {
                 return _overrides->retention_time.value();
             }
             // If no value set, fall through and use the cluster-wide default.
@@ -227,7 +227,7 @@ public:
             if (_overrides->segment_ms.is_disabled()) {
                 return std::nullopt;
             }
-            if (_overrides->segment_ms.has_value()) {
+            if (_overrides->segment_ms.has_optional_value()) {
                 return _overrides->segment_ms.value();
             }
             // fall through to server config

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3251,14 +3251,14 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
         }
 
         if (
-          tc.topic_cloud_bytes.has_value()
+          tc.topic_cloud_bytes.has_optional_value()
           || tc.topic_cloud_bytes.is_disabled()) {
             have_overrides = true;
             overrides.retention_bytes = tc.topic_cloud_bytes;
         }
 
         if (
-          tc.topic_cloud_bytes.has_value()
+          tc.topic_cloud_bytes.has_optional_value()
           || tc.topic_cloud_bytes.is_disabled()) {
             have_overrides = true;
             overrides.retention_local_target_bytes = tc.topic_cloud_bytes;

--- a/src/v/tristate.h
+++ b/src/v/tristate.h
@@ -42,7 +42,12 @@ public:
         return std::holds_alternative<std::monostate>(_value);
     }
 
-    constexpr bool has_value() const {
+    /// \brief Checks if the tristate is in the "Set" state. That means
+    /// it is not disabled and it holds a value.
+    ///
+    /// \return true if the tristate is in the "Set" state
+    ///         false otherwise
+    constexpr bool has_optional_value() const {
         return !is_disabled() && get_optional().has_value();
     }
 
@@ -88,7 +93,7 @@ public:
             fmt::print(o, "{{disabled}}");
             return o;
         }
-        if (t.has_value()) {
+        if (t.has_optional_value()) {
             fmt::print(o, "{{{}}}", t.value());
             return o;
         }

--- a/src/v/tristate.h
+++ b/src/v/tristate.h
@@ -51,6 +51,16 @@ public:
         return !is_disabled() && get_optional().has_value();
     }
 
+    /// \brief Checks if the tristate is in the "Disabled or "Set" states.
+    /// We often use "Not set" as the default state of a tristate, and
+    /// it's useful to check if any explicit changes were made.
+    ///
+    /// \return true if the tristate is in the "Disabled" or "Set" state
+    ///         false otherwise
+    constexpr bool is_engaged() const {
+        return is_disabled() || get_optional().has_value();
+    }
+
     constexpr const T& operator*() const& { return *get_optional(); }
     constexpr T& operator*() & { return *get_optional(); }
     constexpr T&& operator*() && { return *get_optional(); }

--- a/src/v/utils/tests/tristate_test.cc
+++ b/src/v/utils/tests/tristate_test.cc
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(tristate_having_value) {
     // with_value
     tristate<int> has_value(10);
     BOOST_REQUIRE_EQUAL(has_value.is_disabled(), false);
-    BOOST_REQUIRE_EQUAL(has_value.has_value(), true);
+    BOOST_REQUIRE_EQUAL(has_value.has_optional_value(), true);
     BOOST_REQUIRE_EQUAL(*has_value, 10);
     BOOST_REQUIRE_EQUAL(has_value.value(), 10);
 }
@@ -24,12 +24,12 @@ BOOST_AUTO_TEST_CASE(disabled_tristate) {
     // disabled
     tristate<int> disabled;
     BOOST_REQUIRE_EQUAL(disabled.is_disabled(), true);
-    BOOST_REQUIRE_EQUAL(disabled.has_value(), false);
+    BOOST_REQUIRE_EQUAL(disabled.has_optional_value(), false);
 }
 
 BOOST_AUTO_TEST_CASE(tristate_with_empty_value) {
     // empty
     tristate<int> empty(std::nullopt);
     BOOST_REQUIRE_EQUAL(empty.is_disabled(), false);
-    BOOST_REQUIRE_EQUAL(empty.has_value(), false);
+    BOOST_REQUIRE_EQUAL(empty.has_optional_value(), false);
 }


### PR DESCRIPTION
This PR fixes a latent bug where 'retention_local_target_ms' and/or
'retention_local_target_bytes' being disabled was ignored by
'topic_properties::has_overrides'. The bug never manifested as we
override 'cleanup_policy_bitflags' for all Kafka topics (see code [here](https://github.com/redpanda-data/redpanda/blob/dev/src/v/kafka/server/handlers/create_topics.cc#L247-L258)).

It also attempts to make the `tristate` interface a bit more obvious by folding
in suggestions from @andrwng.

Fixes #8344

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none
