### PR TITLE
ducktape/kerberos: Improve the tests

### DIFF
--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -22,8 +22,8 @@ KDC_CONF_TMPL = """
 		default_principal_flags = +preauth
 }}
 [logging]
-    kdc = FILE = /var/log/kdc.log
-    admin_server = FILE:/var/log/kadmin.log
+    kdc = FILE=/var/log/kdc.log
+    admin_server = FILE=/var/log/kadmin.log
 """
 
 KDC_CONF_PATH = "/etc/krb5kdc/kdc.conf"


### PR DESCRIPTION
* Improve logging
* Improve precess control for kadmind and krb5kdc 

The tests now run on CDT. Fixes #8287 

## Backports Required


- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none