### PR TITLE
security/kerberos: Refactored the krb5 wrappers

### DIFF
--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     acl.cc
     mtls.cc
     license.cc
+    krb5.cc
     gssapi_principal_mapper.cc
   DEPS
     v::bytes

--- a/src/v/security/gssapi_authenticator.cc
+++ b/src/v/security/gssapi_authenticator.cc
@@ -423,29 +423,29 @@ void gssapi_authenticator::fail_impl(
 
 acl_principal
 gssapi_authenticator::get_principal_from_name(std::string_view source_name) {
-    krb5::krb5_context krb5_ctx;
-    int krb5_rv = ::krb5_init_context(&krb5_ctx);
-    if (krb5_rv != 0) {
+    auto krb5_ctx = krb5::context::create();
+    if (!krb5_ctx) {
         vlog(
           seclog.error,
-          "Failed to initialize KRB5 instance for source_name mapping: {}",
-          krb5_rv);
+          "Failed to initialize krb5 context for obtaining default realm: {}",
+          krb5_ctx.assume_error());
         return {};
     }
 
-    const krb5::krb5_context_view krb5_ctx_view(&krb5_ctx);
+    auto default_realm = krb5_ctx.assume_value().get_default_realm();
 
-    krb5::krb5_default_realm default_realm(krb5_ctx_view);
-
-    krb5_rv = ::krb5_get_default_realm(
-      ::krb5_context{krb5_ctx}, &default_realm);
-
-    if (krb5_rv != 0) {
-        vlog(seclog.error, "Failed to obtain default realm: {}", krb5_rv);
+    if (!default_realm) {
+        vlog(
+          seclog.error,
+          "Failed to obtain default realm: {}",
+          default_realm.assume_error());
         return {};
     }
 
-    vlog(seclog.debug, "Default realm: '{}'", std::string_view{default_realm});
+    vlog(
+      seclog.debug,
+      "Default realm: '{}'",
+      std::string_view{default_realm.assume_value()});
 
     auto parsed_name = gssapi_name::parse(source_name);
 
@@ -457,7 +457,7 @@ gssapi_authenticator::get_principal_from_name(std::string_view source_name) {
     }
 
     auto mapped_name = _gssapi_principal_mapper.apply(
-      std::string_view{default_realm}, *parsed_name);
+      std::string_view{default_realm.assume_value()}, *parsed_name);
 
     if (!mapped_name) {
         vlog(seclog.warn, "Failed to apply rules to {}", parsed_name);

--- a/src/v/security/krb5.cc
+++ b/src/v/security/krb5.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "security/krb5.h"
+
+namespace security::krb5 {
+
+namespace impl {
+class error_message {
+    struct deleter {
+        ::krb5_context ctx;
+        void operator()(const char* realm) const {
+            ::krb5_free_error_message(ctx, realm);
+        }
+    };
+
+public:
+    explicit error_message(const char* msg, ::krb5_context ctx)
+      : _msg(msg, deleter{ctx}) {}
+
+    explicit operator std::string_view() { return _msg.get(); }
+
+private:
+    std::unique_ptr<const char, deleter> _msg;
+};
+} // namespace impl
+
+struct realm_deleter {
+    ::krb5_context ctx;
+    void operator()(char* realm) const {
+        ::krb5_free_default_realm(ctx, realm);
+    }
+};
+
+result<context> context::create() noexcept {
+    ::krb5_context krb5_ctx{nullptr};
+    int const krb5_rv = ::krb5_init_context(&krb5_ctx);
+    if (krb5_rv != 0) {
+        impl::error_message msg{
+          ::krb5_get_error_message(nullptr, krb5_rv), nullptr};
+        auto err = impl::error_impl{
+          krb5_rv, ss::sstring{std::string_view{msg}}};
+        return err;
+    }
+
+    return context{krb5_ctx};
+}
+
+result<ss::sstring> context::get_default_realm() const noexcept {
+    char* default_realm_ptr = nullptr;
+    int const krb5_rv = ::krb5_get_default_realm(
+      _ctx.get(), &default_realm_ptr);
+    if (krb5_rv != 0) {
+        impl::error_message msg{
+          ::krb5_get_error_message(_ctx.get(), krb5_rv), _ctx.get()};
+        auto err = impl::error_impl{
+          krb5_rv, ss::sstring{std::string_view{msg}}};
+        return err;
+    }
+
+    std::unique_ptr<char, realm_deleter> const default_realm(
+      default_realm_ptr, realm_deleter{_ctx.get()});
+    return ss::sstring{std::string_view{default_realm.get()}};
+}
+} // namespace security::krb5

--- a/src/v/security/krb5.h
+++ b/src/v/security/krb5.h
@@ -10,82 +10,43 @@
 
 #pragma once
 
-#include <krb5/krb5.h>
+#include "outcome.h"
+#include "seastarx.h"
 
-#include <string_view>
+#include <seastar/core/sstring.hh>
+
+#include <krb5/krb5.h>
 
 namespace security::krb5 {
 
-class krb5_context_view {
-public:
-    explicit krb5_context_view(const ::krb5_context* ctx)
-      : _ctx(ctx) {}
+namespace impl {
 
-    ::krb5_context operator*() const { return *_ctx; }
-    explicit operator const ::krb5_context*() { return _ctx; }
+struct error_impl {
+    ::krb5_error_code ec{0};
+    ss::sstring msg;
 
-private:
-    const ::krb5_context* _ctx;
+    friend std::ostream& operator<<(std::ostream& os, const error_impl& impl) {
+        os << impl.msg << " (ec: " << impl.ec << ")";
+        return os;
+    }
 };
 
-class krb5_context {
+} // namespace impl
+
+template<typename R>
+using result = result<R, impl::error_impl>;
+
+class context {
 public:
-    krb5_context() = default;
-    krb5_context(krb5_context&&) = delete;
-    krb5_context(const krb5_context&) = delete;
-    krb5_context operator=(krb5_context&&) = delete;
-    krb5_context operator=(const krb5_context&) = delete;
+    static result<context> create() noexcept;
 
-    ~krb5_context() noexcept { reset(); }
-
-    void reset() noexcept {
-        if (_ctx != nullptr) {
-            ::krb5_free_context(_ctx);
-            _ctx = nullptr;
-        }
-    }
-
-    explicit operator krb5_context_view() const {
-        return krb5_context_view{&_ctx};
-    }
-    explicit operator ::krb5_context() const { return _ctx; }
-    ::krb5_context* operator&() { return &_ctx; }
+    result<ss::sstring> get_default_realm() const noexcept;
 
 private:
-    ::krb5_context _ctx{nullptr};
-};
+    explicit context(::krb5_context ctx)
+      : _ctx(ctx, &::krb5_free_context) {}
 
-class krb5_default_realm {
-public:
-    explicit krb5_default_realm(krb5_context_view ctx)
-      : _ctx(std::move(ctx)) {}
-
-    krb5_default_realm(krb5_default_realm&&) = delete;
-    krb5_default_realm(const krb5_default_realm&) = delete;
-    krb5_default_realm& operator=(krb5_default_realm&&) = delete;
-    krb5_default_realm& operator=(const krb5_default_realm&) = delete;
-
-    ~krb5_default_realm() { reset(); }
-
-    void reset() {
-        if (_realm) {
-            ::krb5_free_default_realm(*_ctx, _realm);
-        }
-    }
-
-    explicit operator std::string_view() {
-        if (_realm) {
-            return {_realm, ::strlen(_realm)};
-        } else {
-            return {};
-        }
-    }
-
-    char** operator&() { return &_realm; }
-
-private:
-    krb5_context_view _ctx;
-    char* _realm{nullptr};
+    std::unique_ptr<::_krb5_context, void (*)(::krb5_context)> _ctx;
 };
 
 } // namespace security::krb5


### PR DESCRIPTION
Refactored the krb5 C++ wrappers to be safer:

* Removed `krb5_` prefix to not overload krb5 lib names
* Creation of `context` and `default_realm` now done via a static method that will call appropriate krb5 lib functions rather than having to expose an `operator&` method.

Fixes: #8367 

Force push `94bccf6`:

* Updated commit message

Force push `b435b0f`:

* Replaced implementation within `context` and `default_realm` with a `std::unique_ptr`
* Removed unused/unsafe operators
* Utilized a `result` to pass error messages up the stack

Force push `8c31808`:

* Fixed linter error

Force push `18c28d5`:

* Moved `krb5` library accessors to within `context` class

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

* none

## Release Notes
 
* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
