### PR TITLE
Add SAX parser for list-v2 results

### DIFF
--- a/src/v/cloud_storage/recovery_utils.cc
+++ b/src/v/cloud_storage/recovery_utils.cc
@@ -84,8 +84,8 @@ ss::future<std::vector<recovery_result>> gather_recovery_results(
     std::regex result_expr{fmt::format(
       "{}/(.*?)/(.*?)/(\\d+)_(.*?).(true|false)", recovery_result_prefix)};
 
-    results.reserve(result.value().size());
-    for (const auto& item : result.value()) {
+    results.reserve(result.value().contents.size());
+    for (const auto& item : result.value().contents) {
         std::cmatch matches;
         if (std::regex_match(
               item.key.begin(), item.key.end(), matches, result_expr)) {

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -699,7 +699,8 @@ ss::future<upload_result> remote::delete_objects(
 ss::future<remote::list_result> remote::list_objects(
   const cloud_storage_clients::bucket_name& bucket,
   retry_chain_node& parent,
-  std::optional<cloud_storage_clients::object_key> prefix) {
+  std::optional<cloud_storage_clients::object_key> prefix,
+  std::optional<cloud_storage_clients::client::item_filter> item_filter) {
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(cst_log, fib);
@@ -722,7 +723,8 @@ ss::future<remote::list_result> remote::list_objects(
           std::nullopt,
           std::nullopt,
           continuation_token,
-          fib.get_timeout());
+          fib.get_timeout(),
+          item_filter);
 
         if (res) {
             auto list_result = res.value();

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -700,6 +700,7 @@ ss::future<remote::list_result> remote::list_objects(
   const cloud_storage_clients::bucket_name& bucket,
   retry_chain_node& parent,
   std::optional<cloud_storage_clients::object_key> prefix,
+  std::optional<char> delimiter,
   std::optional<cloud_storage_clients::client::item_filter> item_filter) {
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
@@ -724,6 +725,7 @@ ss::future<remote::list_result> remote::list_objects(
           std::nullopt,
           continuation_token,
           fib.get_timeout(),
+          delimiter,
           item_filter);
 
         if (res) {

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -274,11 +274,15 @@ public:
     /// \param name The bucket to delete from
     /// \param parent The retry chain node to manage timeouts
     /// \param prefix Optional prefix to restrict listing of objects
-    /// \param item_filter Optional filter to apply to items before collecting
+    /// \param delimiter A character to use as a delimiter when grouping list
+    /// results
+    /// \param item_filter Optional filter to apply to items before
+    /// collecting
     ss::future<list_result> list_objects(
       const cloud_storage_clients::bucket_name& name,
       retry_chain_node& parent,
       std::optional<cloud_storage_clients::object_key> prefix = std::nullopt,
+      std::optional<char> delimiter = std::nullopt,
       std::optional<cloud_storage_clients::client::item_filter> item_filter
       = std::nullopt);
 

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -264,10 +264,9 @@ public:
       std::vector<cloud_storage_clients::object_key> keys,
       retry_chain_node& parent);
 
-    using list_bucket_items
-      = std::vector<cloud_storage_clients::client::list_bucket_item>;
-    using list_result
-      = result<list_bucket_items, cloud_storage_clients::error_outcome>;
+    using list_result = result<
+      cloud_storage_clients::client::list_bucket_result,
+      cloud_storage_clients::error_outcome>;
 
     /// \brief Lists objects in a bucket
     ///

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -274,10 +274,13 @@ public:
     /// \param name The bucket to delete from
     /// \param parent The retry chain node to manage timeouts
     /// \param prefix Optional prefix to restrict listing of objects
+    /// \param item_filter Optional filter to apply to items before collecting
     ss::future<list_result> list_objects(
       const cloud_storage_clients::bucket_name& name,
       retry_chain_node& parent,
-      std::optional<cloud_storage_clients::object_key> prefix = std::nullopt);
+      std::optional<cloud_storage_clients::object_key> prefix = std::nullopt,
+      std::optional<cloud_storage_clients::client::item_filter> item_filter
+      = std::nullopt);
 
     /// \brief Upload small objects to bucket. Suitable for uploading simple
     /// strings, does not check for leadership before upload like the segment

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -441,7 +441,7 @@ FIXTURE_TEST(test_list_bucket, s3_imposter_fixture) {
     BOOST_REQUIRE(result.has_value());
 
     auto items = result.value();
-    BOOST_REQUIRE_EQUAL(items.size(), 2);
+    BOOST_REQUIRE_EQUAL(items.contents.size(), 2);
 }
 
 FIXTURE_TEST(test_list_bucket_with_prefix, s3_imposter_fixture) {
@@ -458,7 +458,7 @@ FIXTURE_TEST(test_list_bucket_with_prefix, s3_imposter_fixture) {
                      bucket, fib, cloud_storage_clients::object_key{"x"})
                     .get0();
     BOOST_REQUIRE(result.has_value());
-    auto items = result.value();
+    auto items = result.value().contents;
     BOOST_REQUIRE_EQUAL(items.size(), 2);
     BOOST_REQUIRE_EQUAL(items[0].key, "a");
     BOOST_REQUIRE_EQUAL(items[1].key, "b");
@@ -483,10 +483,11 @@ FIXTURE_TEST(test_list_bucket_with_filter, s3_imposter_fixture) {
                      bucket,
                      fib,
                      std::nullopt,
+                     std::nullopt,
                      [](const auto& item) { return item.key == "b"; })
                     .get0();
     BOOST_REQUIRE(result.has_value());
-    auto items = result.value();
+    auto items = result.value().contents;
     BOOST_REQUIRE_EQUAL(items.size(), 1);
     BOOST_REQUIRE_EQUAL(items[0].key, "b");
 }

--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -35,13 +35,15 @@ const ss::sstring no_manifests = R"XML(
     </ListBucketResult>
     )XML";
 
-const ss::sstring a_manifest = R"XML(
+const ss::sstring top_level_result = R"XML(
     <ListBucketResult>
       <IsTruncated>false</IsTruncated>
       <Contents>
-          <Key>head/meta/kafka/foobar/topic_manifest.json</Key>
       </Contents>
       <NextContinuationToken>n</NextContinuationToken>
+      <CommonPrefixes>
+        <Prefix>b0000000/</Prefix>
+      </CommonPrefixes>
     </ListBucketResult>
     )XML";
 
@@ -75,6 +77,27 @@ const ss::sstring topic_manifest_json = R"JSON({
     })JSON";
 
 const model::topic_namespace tp_ns{model::ns{"kafka"}, model::topic{"test"}};
+
+const s3_imposter_fixture::expectation root_level{
+  .url = "/?list-type=2&delimiter=/",
+  .body = top_level_result,
+};
+
+const s3_imposter_fixture::expectation meta_level{
+  .url = "/?list-type=2&prefix=b0000000/",
+  .body = valid_manifest_list,
+};
+
+const s3_imposter_fixture::expectation manifest{
+  .url = "/b0000000/meta/kafka/test/topic_manifest.json",
+  .body = topic_manifest_json,
+};
+
+const s3_imposter_fixture::expectation recovery_state{
+  .url = "/?list-type=2&prefix=recovery_state",
+  .body = recovery_results,
+};
+
 } // namespace
 
 class fixture
@@ -140,7 +163,7 @@ FIXTURE_TEST(start_with_good_request, fixture) {
 
 FIXTURE_TEST(recovery_with_no_topics_exits_early, fixture) {
     set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = no_manifests}});
+      {{.url = root_level.url, .body = no_manifests}});
 
     auto& service = app.topic_recovery_service;
     auto result = service.local().start_recovery({});
@@ -155,9 +178,9 @@ FIXTURE_TEST(recovery_with_no_topics_exits_early, fixture) {
     wait_for_n_requests(1, equals::yes);
 
     const auto& list_topics_req = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req._url, "/?list-type=2");
+    BOOST_REQUIRE_EQUAL(list_topics_req._url, root_level.url);
 
-    // Wait until recovery exists after finding no topics to create
+    // Wait until recovery exits after finding no topics to create
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
         return service.local().is_active() == false;
     }).get();
@@ -176,37 +199,39 @@ void do_test(fixture& f) {
 
     BOOST_REQUIRE_EQUAL(result, expected);
 
-    // Wait until two requests are received:
-    // 1. to list bucket for manifest files
-    // 2. to download manifest
-    f.wait_for_n_requests(2, fixture::equals::yes);
+    // Wait until three requests are received:
+    // 1. to list bucket for topic meta prefixes
+    // 2. to list the topic meta prefix itself
+    // 3. to download manifest
+    f.wait_for_n_requests(3, fixture::equals::yes);
 
     const auto& list_topics_req = f.get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req._url, "/?list-type=2");
+    BOOST_REQUIRE_EQUAL(list_topics_req._url, root_level.url);
 
-    const auto& get_manifest_req = f.get_requests()[1];
-    BOOST_REQUIRE_EQUAL(
-      get_manifest_req._url, "/head/meta/kafka/foobar/topic_manifest.json");
+    const auto& list_prefix_req = f.get_requests()[1];
+    BOOST_REQUIRE_EQUAL(list_prefix_req._url, meta_level.url);
 
-    // Wait until recovery exists after finding no topics to create
+    const auto& get_manifest_req = f.get_requests()[2];
+    BOOST_REQUIRE_EQUAL(get_manifest_req._url, manifest.url);
+
+    // Wait until recovery exits after finding no topics to create
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
         return service.local().is_active() == false;
     }).get();
 
-    BOOST_REQUIRE_EQUAL(f.get_requests().size(), 2);
+    BOOST_REQUIRE_EQUAL(f.get_requests().size(), 3);
 }
 
 FIXTURE_TEST(recovery_with_unparseable_topic_manifest, fixture) {
     set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = a_manifest},
-       {.url = "/head/meta/kafka/foobar/topic_manifest.json",
-        .body = "bad json"}});
+      {root_level, meta_level, {.url = manifest.url, .body = "bad json"}});
     do_test(*this);
 }
 
 FIXTURE_TEST(recovery_with_missing_topic_manifest, fixture) {
     set_expectations_and_listen({
-      {.url = "/?list-type=2", .body = a_manifest},
+      root_level,
+      meta_level,
     });
     do_test(*this);
 }
@@ -221,9 +246,7 @@ FIXTURE_TEST(recovery_with_existing_topic, fixture) {
                                  .create_topics(topic_cfg, model::no_timeout)
                                  .get();
     wait_for_topics(std::move(topic_create_result)).get();
-    set_expectations_and_listen({
-      {.url = "/?list-type=2", .body = valid_manifest_list},
-    });
+    set_expectations_and_listen({root_level, meta_level});
 
     auto& service = app.topic_recovery_service;
     auto result = service.local().start_recovery({});
@@ -233,25 +256,24 @@ FIXTURE_TEST(recovery_with_existing_topic, fixture) {
       .message = "recovery started"};
 
     BOOST_REQUIRE_EQUAL(result, expected);
-    wait_for_n_requests(1, equals::yes);
+    wait_for_n_requests(2, equals::yes);
 
     const auto& list_topics_req = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req._url, "/?list-type=2");
+    BOOST_REQUIRE_EQUAL(list_topics_req._url, root_level.url);
+
+    const auto& prefix_req = get_requests()[1];
+    BOOST_REQUIRE_EQUAL(prefix_req._url, meta_level.url);
 
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
         return service.local().is_active() == false;
     }).get();
 
-    BOOST_REQUIRE_EQUAL(get_requests().size(), 1);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 }
 
 FIXTURE_TEST(recovery_where_topic_is_created, fixture) {
     set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = valid_manifest_list},
-       {.url = "/b0000000/meta/kafka/test/topic_manifest.json",
-        .body = topic_manifest_json},
-       {.url = "/?list-type=2&prefix=recovery_state",
-        .body = recovery_results}});
+      {root_level, meta_level, manifest, recovery_state});
 
     auto& service = app.topic_recovery_service;
     auto result = service.local().start_recovery({});
@@ -261,14 +283,16 @@ FIXTURE_TEST(recovery_where_topic_is_created, fixture) {
       .message = "recovery started"};
 
     BOOST_REQUIRE_EQUAL(result, expected);
-    wait_for_n_requests(2);
+    wait_for_n_requests(3);
 
     const auto& list_topics_req = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req._url, "/?list-type=2");
+    BOOST_REQUIRE_EQUAL(list_topics_req._url, root_level.url);
 
-    const auto& get_manifest = get_requests()[1];
-    BOOST_REQUIRE_EQUAL(
-      get_manifest._url, "/b0000000/meta/kafka/test/topic_manifest.json");
+    const auto& prefix_req = get_requests()[1];
+    BOOST_REQUIRE_EQUAL(prefix_req._url, meta_level.url);
+
+    const auto& get_manifest = get_requests()[2];
+    BOOST_REQUIRE_EQUAL(get_manifest._url, manifest.url);
 
     // Wait for the topic to appear
     wait_for_topic(tp_ns);
@@ -293,40 +317,33 @@ FIXTURE_TEST(recovery_where_topic_is_created, fixture) {
         .cloud_storage_recovery_temporary_retention_bytes_default.value());
     // We will have at least three requests, there could be more depending on
     // partition recovery manager:
-    // 1. list results
-    // 2. download manifest
-    // 3. try to clear recovery results from previous runs
-    BOOST_REQUIRE_GE(get_requests().size(), 3);
+    // 1. list prefixes
+    // 2. list prefix content
+    // 3. download manifest
+    // 4. try to clear recovery results from previous runs
+    BOOST_REQUIRE_GE(get_requests().size(), 4);
 }
 
 FIXTURE_TEST(recovery_result_clear_before_start, fixture) {
     set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = valid_manifest_list},
-       {.url = "/b0000000/meta/kafka/test/topic_manifest.json",
-        .body = topic_manifest_json},
-       {.url = "/?list-type=2&prefix=recovery_state",
-        .body = recovery_results}});
+      {root_level, meta_level, manifest, recovery_state});
 
     auto& service = app.topic_recovery_service;
     service.local().start_recovery({});
-    wait_for_n_requests(4);
+    wait_for_n_requests(5);
 
-    const auto& delete_request = get_requests()[3];
+    const auto& delete_request = get_requests()[4];
     BOOST_REQUIRE_EQUAL(delete_request._url, "/?delete");
     BOOST_REQUIRE_EQUAL(delete_request._method, "POST");
 }
 
 FIXTURE_TEST(recovery_download_tracking, fixture) {
     set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = valid_manifest_list},
-       {.url = "/b0000000/meta/kafka/test/topic_manifest.json",
-        .body = topic_manifest_json},
-       {.url = "/?list-type=2&prefix=recovery_state",
-        .body = recovery_results}});
+      {root_level, meta_level, manifest, recovery_state});
 
     auto& service = app.topic_recovery_service;
     service.local().start_recovery({});
-    wait_for_n_requests(2);
+    wait_for_n_requests(3);
     wait_for_topic(tp_ns);
 
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
@@ -342,10 +359,10 @@ FIXTURE_TEST(recovery_download_tracking, fixture) {
 }
 
 FIXTURE_TEST(recovery_with_topic_name_pattern_without_match, fixture) {
-    set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = valid_manifest_list},
-       {.url = "/b0000000/meta/kafka/test/topic_manifest.json",
-        .body = topic_manifest_json}});
+    set_expectations_and_listen({
+      root_level,
+      meta_level,
+    });
 
     ss::httpd::request r;
     r._headers = {{"Content-Type", "application/json"}};
@@ -354,22 +371,18 @@ FIXTURE_TEST(recovery_with_topic_name_pattern_without_match, fixture) {
     auto& service = app.topic_recovery_service;
     service.local().start_recovery(r);
 
-    wait_for_n_requests(1, equals::yes);
+    wait_for_n_requests(2, equals::yes);
 
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
         return !service.local().is_active();
     }).get();
 
-    BOOST_REQUIRE_EQUAL(get_requests().size(), 1);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
 }
 
 FIXTURE_TEST(recovery_with_topic_name_pattern_with_match, fixture) {
     set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = valid_manifest_list},
-       {.url = "/b0000000/meta/kafka/test/topic_manifest.json",
-        .body = topic_manifest_json},
-       {.url = "/?list-type=2&prefix=recovery_state",
-        .body = recovery_results}});
+      {root_level, meta_level, manifest, recovery_state});
 
     ss::httpd::request r;
     r._headers = {{"Content-Type", "application/json"}};
@@ -378,17 +391,13 @@ FIXTURE_TEST(recovery_with_topic_name_pattern_with_match, fixture) {
     auto& service = app.topic_recovery_service;
     service.local().start_recovery(r);
 
-    wait_for_n_requests(4);
+    wait_for_n_requests(5);
     wait_for_topic(tp_ns);
 }
 
 FIXTURE_TEST(recovery_with_retention_ms_override, fixture) {
     set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = valid_manifest_list},
-       {.url = "/b0000000/meta/kafka/test/topic_manifest.json",
-        .body = topic_manifest_json},
-       {.url = "/?list-type=2&prefix=recovery_state",
-        .body = recovery_results}});
+      {root_level, meta_level, manifest, recovery_state});
 
     ss::httpd::request r;
     r._headers = {{"Content-Type", "application/json"}};
@@ -398,7 +407,7 @@ FIXTURE_TEST(recovery_with_retention_ms_override, fixture) {
     auto& service = app.topic_recovery_service;
     service.local().start_recovery(r);
 
-    wait_for_n_requests(4);
+    wait_for_n_requests(5);
     wait_for_topic(tp_ns);
     auto topic = app.controller->get_topics_state().local().get_topic_cfg(
       tp_ns);
@@ -410,11 +419,7 @@ FIXTURE_TEST(recovery_with_retention_ms_override, fixture) {
 
 FIXTURE_TEST(recovery_with_retention_bytes_override, fixture) {
     set_expectations_and_listen(
-      {{.url = "/?list-type=2", .body = valid_manifest_list},
-       {.url = "/b0000000/meta/kafka/test/topic_manifest.json",
-        .body = topic_manifest_json},
-       {.url = "/?list-type=2&prefix=recovery_state",
-        .body = recovery_results}});
+      {root_level, meta_level, manifest, recovery_state});
 
     ss::httpd::request r;
     r._headers = {{"Content-Type", "application/json"}};
@@ -424,7 +429,7 @@ FIXTURE_TEST(recovery_with_retention_bytes_override, fixture) {
     auto& service = app.topic_recovery_service;
     service.local().start_recovery(r);
 
-    wait_for_n_requests(4);
+    wait_for_n_requests(5);
     wait_for_topic(tp_ns);
     auto topic = app.controller->get_topics_state().local().get_topic_cfg(
       tp_ns);

--- a/src/v/cloud_storage/topic_recovery_service.h
+++ b/src/v/cloud_storage/topic_recovery_service.h
@@ -116,7 +116,7 @@ private:
     /// process.
     ss::future<std::vector<cloud_storage::topic_manifest>>
     filter_existing_topics(
-      const remote::list_bucket_items& items,
+      std::vector<remote_segment_path> items,
       const recovery_request& request,
       std::optional<model::ns> filter_ns);
 

--- a/src/v/cloud_storage_clients/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+find_package(LibXml2 REQUIRED)
+
 v_cc_library(
   NAME cloud_storage_clients
   SRCS
@@ -10,11 +12,13 @@ v_cc_library(
     s3_client.cc
     s3_error.cc
     util.cc
+    xml_sax_parser.cc
   DEPS
     Seastar::seastar
     v::bytes
     v::cloud_roles
     v::net
+    LibXml2::LibXml2
   DEFINES
     -DBOOST_ASIO_HAS_STD_INVOKE_RESULT
 )

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -591,7 +591,8 @@ abs_client::list_objects(
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
   std::optional<ss::sstring> continuation_token,
-  ss::lowres_clock::duration timeout) {
+  ss::lowres_clock::duration timeout,
+  std::optional<item_filter> collect_item_if) {
     return send_request(
       do_list_objects(
         name,
@@ -599,7 +600,8 @@ abs_client::list_objects(
         std::move(start_after),
         max_keys,
         std::move(continuation_token),
-        timeout),
+        timeout,
+        std::move(collect_item_if)),
       name,
       object_key{""});
 }
@@ -610,7 +612,8 @@ ss::future<abs_client::list_bucket_result> abs_client::do_list_objects(
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
   [[maybe_unused]] std::optional<ss::sstring> continuation_token,
-  ss::lowres_clock::duration timeout) {
+  ss::lowres_clock::duration timeout,
+  std::optional<item_filter>) {
     auto header = _requestor.make_list_blobs_request(
       name, std::move(prefix), std::move(start_after), max_keys);
     if (!header) {

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -71,12 +71,14 @@ public:
     /// \param prefix prefix of returned blob's names
     /// \param start_after is always ignored
     /// \param max_keys is the max number of returned objects
+    /// \param delimiter used to group common prefixes
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_list_blobs_request(
       const bucket_name& name,
       std::optional<object_key> prefix,
       std::optional<object_key> start_after,
-      std::optional<size_t> max_keys);
+      std::optional<size_t> max_keys,
+      std::optional<char> delimiter = std::nullopt);
 
 private:
     access_point_uri _ap;
@@ -159,6 +161,7 @@ public:
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
       ss::lowres_clock::duration timeout = http::default_connect_timeout,
+      std::optional<char> delimiter = std::nullopt,
       std::optional<item_filter> collect_item_if = std::nullopt) override;
 
     /// Send Delete Blob request
@@ -217,6 +220,7 @@ private:
       std::optional<size_t> max_keys,
       std::optional<ss::sstring> continuation_token,
       ss::lowres_clock::duration timeout,
+      std::optional<char> delimiter = std::nullopt,
       std::optional<item_filter> collect_item_if = std::nullopt);
 
     abs_request_creator _requestor;

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -158,8 +158,8 @@ public:
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
-      ss::lowres_clock::duration timeout
-      = http::default_connect_timeout) override;
+      ss::lowres_clock::duration timeout = http::default_connect_timeout,
+      std::optional<item_filter> collect_item_if = std::nullopt) override;
 
     /// Send Delete Blob request
     /// \param name is a container name
@@ -216,7 +216,8 @@ private:
       std::optional<object_key> start_after,
       std::optional<size_t> max_keys,
       std::optional<ss::sstring> continuation_token,
-      ss::lowres_clock::duration timeout);
+      ss::lowres_clock::duration timeout,
+      std::optional<item_filter> collect_item_if = std::nullopt);
 
     abs_request_creator _requestor;
     http::client _client;

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -144,7 +144,10 @@ public:
     /// \param prefix optional prefix of objects to list
     /// \param start_after optional object key to start listing after
     /// \param max_keys optional upper bound on the number of returned keys
-    /// \param body is an input_stream that can be used to read body
+    /// \param continuation_token token returned by a previous call
+    /// \param timeout operation timeout
+    /// \param collect_item_if if present, only items passing this predicate are
+    /// collected.
     /// \return future that becomes ready when the request is completed
     virtual ss::future<result<list_bucket_result, error_outcome>> list_objects(
       const bucket_name& name,
@@ -152,7 +155,8 @@ public:
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
-      ss::lowres_clock::duration timeout = http::default_connect_timeout)
+      ss::lowres_clock::duration timeout = http::default_connect_timeout,
+      std::optional<item_filter> collect_item_if = std::nullopt)
       = 0;
 
     /// Delete object from cloud storage

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -133,6 +133,11 @@ public:
         std::vector<list_bucket_item> contents;
     };
 
+    /// A predicate to allow list_objects to collect items selectively, saving
+    /// memory. This cannot be ss::noncopyable_function because remote needs to
+    /// copy this object for calls in a loop.
+    using item_filter = std::function<bool(const list_bucket_item&)>;
+
     /// List the objects in a bucket
     ///
     /// \param name is a bucket name

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -131,6 +131,7 @@ public:
         ss::sstring prefix;
         ss::sstring next_continuation_token;
         std::vector<list_bucket_item> contents;
+        std::vector<ss::sstring> common_prefixes;
     };
 
     /// A predicate to allow list_objects to collect items selectively, saving
@@ -146,6 +147,7 @@ public:
     /// \param max_keys optional upper bound on the number of returned keys
     /// \param continuation_token token returned by a previous call
     /// \param timeout operation timeout
+    /// \param delimiter character used to group prefixes when listing
     /// \param collect_item_if if present, only items passing this predicate are
     /// collected.
     /// \return future that becomes ready when the request is completed
@@ -156,6 +158,7 @@ public:
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
       ss::lowres_clock::duration timeout = http::default_connect_timeout,
+      std::optional<char> delimiter = std::nullopt,
       std::optional<item_filter> collect_item_if = std::nullopt)
       = 0;
 

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -170,7 +170,10 @@ request_creator::make_list_objects_v2_request(
     auto host = fmt::format("{}.{}", name(), _ap());
     auto target = fmt::format("/?list-type=2");
     if (prefix.has_value()) {
-        target = fmt::format("/?list-type=2&prefix={}", (*prefix)().string());
+        target = fmt::format("{}&prefix={}", target, (*prefix)().string());
+    }
+    if (delimiter.has_value()) {
+        target = fmt::format("{}&delimiter={}", target, *delimiter);
     }
     header.method(boost::beast::http::verb::get);
     header.target(target);

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -720,8 +720,9 @@ ss::future<s3_client::list_bucket_result> s3_client::do_list_objects_v2(
                   resp->as_input_stream(),
                   xml_sax_parser{},
                   [pred = std::move(gather_item_if)](
-                    ss::input_stream<char>& stream, xml_sax_parser& p) {
-                      p.start_parse(std::move(pred));
+                    ss::input_stream<char>& stream, xml_sax_parser& p) mutable {
+                      p.start_parse(
+                        std::make_unique<aws_parse_impl>(std::move(pred)));
                       return ss::do_until(
                                [&stream] { return stream.eof(); },
                                [&stream, &p] {

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -13,6 +13,7 @@
 #include "cloud_storage_clients/logger.h"
 #include "cloud_storage_clients/s3_error.h"
 #include "cloud_storage_clients/util.h"
+#include "cloud_storage_clients/xml_sax_parser.h"
 #include "hashing/secure.h"
 #include "http/client.h"
 #include "net/types.h"
@@ -319,49 +320,6 @@ request_creator::make_delete_objects_request(
 }
 
 // client //
-
-static s3_client::list_bucket_result iobuf_to_list_bucket_result(iobuf&& buf) {
-    try {
-        for (auto& frag : buf) {
-            vlog(
-              s3_log.trace,
-              "iobuf_to_list_bucket_result part {}",
-              ss::sstring{frag.get(), frag.size()});
-        }
-        s3_client::list_bucket_result result;
-        auto root = util::iobuf_to_ptree(std::move(buf), s3_log);
-        for (const auto& [tag, value] : root.get_child("ListBucketResult")) {
-            if (tag == "Contents") {
-                s3_client::list_bucket_item item;
-                for (const auto& [item_tag, item_value] : value) {
-                    if (item_tag == "Key") {
-                        item.key = item_value.get_value<ss::sstring>();
-                    } else if (item_tag == "Size") {
-                        item.size_bytes = item_value.get_value<size_t>();
-                    } else if (item_tag == "LastModified") {
-                        item.last_modified = util::parse_timestamp(
-                          item_value.get_value<ss::sstring>());
-                    } else if (item_tag == "ETag") {
-                        item.etag = item_value.get_value<ss::sstring>();
-                    }
-                }
-                result.contents.push_back(std::move(item));
-            } else if (tag == "IsTruncated") {
-                // read value as bool
-                result.is_truncated = value.get_value<bool>();
-            } else if (tag == "Prefix") {
-                result.prefix = value.get_value<ss::sstring>("");
-            } else if (tag == "NextContinuationToken") {
-                result.next_continuation_token = value.get_value<ss::sstring>(
-                  "");
-            }
-        }
-        return result;
-    } catch (...) {
-        vlog(s3_log.error, "!!error parse result {}", std::current_exception());
-        throw;
-    }
-}
 
 template<class ResultT = void>
 ss::future<ResultT>
@@ -691,11 +649,18 @@ s3_client::list_objects(
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
   std::optional<ss::sstring> continuation_token,
-  ss::lowres_clock::duration timeout) {
+  ss::lowres_clock::duration timeout,
+  std::optional<item_filter> collect_item_if) {
     const object_key dummy{""};
     co_return co_await send_request(
       do_list_objects_v2(
-        name, prefix, start_after, max_keys, continuation_token, timeout),
+        name,
+        prefix,
+        start_after,
+        max_keys,
+        continuation_token,
+        timeout,
+        std::move(collect_item_if)),
       name,
       dummy);
 }
@@ -706,34 +671,57 @@ ss::future<s3_client::list_bucket_result> s3_client::do_list_objects_v2(
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
   std::optional<ss::sstring> continuation_token,
-  ss::lowres_clock::duration timeout) {
+  ss::lowres_clock::duration timeout,
+  std::optional<item_filter> collect_item_if) {
     auto header = _requestor.make_list_objects_v2_request(
       name,
       std::move(prefix),
       std::move(start_after),
       max_keys,
-      continuation_token);
+      std::move(continuation_token));
     if (!header) {
         return ss::make_exception_future<list_bucket_result>(
           std::system_error(header.error()));
     }
     vlog(s3_log.trace, "send https request:\n{}", header.value());
     return _client.request(std::move(header.value()), timeout)
-      .then([](const http::client::response_stream_ref& resp) mutable {
-          return util::drain_chunked_response_stream(resp).then(
-            [resp](iobuf outbuf) {
+      .then([pred = std::move(collect_item_if)](
+              const http::client::response_stream_ref& resp) mutable {
+          return resp->prefetch_headers().then(
+            [resp, gather_item_if = std::move(pred)]() mutable {
                 const auto& header = resp->get_headers();
                 if (header.result() != boost::beast::http::status::ok) {
-                    // We received error response so the outbuf contains
-                    // error digest instead of the result of the query
                     vlog(s3_log.warn, "S3 replied with error: {:l}", header);
-                    return parse_rest_error_response<
-                      s3_client::list_bucket_result>(
-                      header.result(), std::move(outbuf));
+
+                    // In the error path we drain the response stream fully, the
+                    // error response should not be very large.
+                    return util::drain_chunked_response_stream(resp).then(
+                      [result = header.result()](iobuf buf) {
+                          return parse_rest_error_response<list_bucket_result>(
+                            result, std::move(buf));
+                      });
                 }
-                auto res = iobuf_to_list_bucket_result(std::move(outbuf));
-                return ss::make_ready_future<list_bucket_result>(
-                  std::move(res));
+
+                return ss::do_with(
+                  resp->as_input_stream(),
+                  xml_sax_parser{},
+                  [pred = std::move(gather_item_if)](
+                    ss::input_stream<char>& stream, xml_sax_parser& p) {
+                      p.start_parse(std::move(pred));
+                      return ss::do_until(
+                               [&stream] { return stream.eof(); },
+                               [&stream, &p] {
+                                   return stream.read().then(
+                                     [&p](ss::temporary_buffer<char>&& chunk) {
+                                         p.parse_chunk(std::move(chunk));
+                                     });
+                               })
+                        .then([&stream] { return stream.close(); })
+                        .then([&p] {
+                            p.end_parse();
+                            return p.result();
+                        });
+                  });
             });
       });
 }

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -170,8 +170,8 @@ public:
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
-      ss::lowres_clock::duration timeout
-      = http::default_connect_timeout) override;
+      ss::lowres_clock::duration timeout = http::default_connect_timeout,
+      std::optional<item_filter> collect_item_if = std::nullopt) override;
 
     ss::future<result<no_response, error_outcome>> delete_object(
       const bucket_name& bucket,
@@ -209,7 +209,8 @@ private:
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
-      ss::lowres_clock::duration timeout = http::default_connect_timeout);
+      ss::lowres_clock::duration timeout = http::default_connect_timeout,
+      std::optional<item_filter> collect_item_if = std::nullopt);
 
     ss::future<> do_delete_object(
       const bucket_name& bucket,

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -93,13 +93,16 @@ public:
     /// \param region to connect
     /// \param max_keys is a max number of returned objects
     /// \param offset is an offset of the first returned object
+    /// \param continuation_token used to paginate list results
+    /// \param delimiter used to group results with common prefixes
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_list_objects_v2_request(
       const bucket_name& name,
       std::optional<object_key> prefix,
       std::optional<object_key> start_after,
       std::optional<size_t> max_keys,
-      std::optional<ss::sstring> continuation_token);
+      std::optional<ss::sstring> continuation_token,
+      std::optional<char> delimiter = std::nullopt);
 
 private:
     access_point_uri _ap;
@@ -171,6 +174,7 @@ public:
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
       ss::lowres_clock::duration timeout = http::default_connect_timeout,
+      std::optional<char> delimiter = std::nullopt,
       std::optional<item_filter> collect_item_if = std::nullopt) override;
 
     ss::future<result<no_response, error_outcome>> delete_object(
@@ -210,6 +214,7 @@ private:
       std::optional<size_t> max_keys = std::nullopt,
       std::optional<ss::sstring> continuation_token = std::nullopt,
       ss::lowres_clock::duration timeout = http::default_connect_timeout,
+      std::optional<char> delimiter = std::nullopt,
       std::optional<item_filter> collect_item_if = std::nullopt);
 
     ss::future<> do_delete_object(

--- a/src/v/cloud_storage_clients/tests/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ rp_test(
   BINARY_NAME s3_single_thread
   SOURCES
     s3_client_test.cc
+    xml_sax_parser_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::http v::cloud_storage_clients v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -567,6 +567,12 @@ SEASTAR_TEST_CASE(test_list_objects_success) {
 
         BOOST_REQUIRE(!result.value().is_truncated);
         BOOST_REQUIRE_EQUAL(result.value().next_continuation_token, "next");
+        std::vector<ss::sstring> common_prefixes{"test-prefix"};
+        BOOST_REQUIRE_EQUAL_COLLECTIONS(
+          common_prefixes.begin(),
+          common_prefixes.end(),
+          result.value().common_prefixes.begin(),
+          result.value().common_prefixes.end());
         server->stop().get();
     });
 }
@@ -586,6 +592,7 @@ SEASTAR_TEST_CASE(test_list_objects_with_filter) {
                 std::nullopt,
                 std::nullopt,
                 http::default_connect_timeout,
+                std::nullopt,
                 [](const auto& item) { return item.key == "test-key2"; })
               .get0();
 

--- a/src/v/cloud_storage_clients/tests/xml_sax_parser_test.cc
+++ b/src/v/cloud_storage_clients/tests/xml_sax_parser_test.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/util.h"
+#include "cloud_storage_clients/xml_sax_parser.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+static constexpr std::string_view payload = R"XML(
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>test-bucket</Name>
+  <Prefix>test-prefix</Prefix>
+  <KeyCount>2</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <Delimiter>/</Delimiter>
+  <IsTruncated>false</IsTruncated>
+  <NextContinuationToken>next</NextContinuationToken>
+  <Contents>
+    <Key>test-key1</Key>
+    <LastModified>2021-01-10T01:00:00.000Z</LastModified>
+    <ETag>test-etag-1</ETag>
+    <Size>111</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+  <Contents>
+    <Key>test-key2</Key>
+    <LastModified>2021-01-10T02:00:00.000Z</LastModified>
+    <ETag>test-etag-2</ETag>
+    <Size>222</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+  <CommonPrefixes>
+    <Prefix>test-prefix</Prefix>
+  </CommonPrefixes>
+</ListBucketResult>
+)XML";
+
+inline ss::logger test_log("test");
+
+BOOST_AUTO_TEST_CASE(test_parse_payload) {
+    cloud_storage_clients::xml_sax_parser p{};
+    ss::temporary_buffer<char> buffer(payload.data(), payload.size());
+    p.start_parse();
+    p.parse_chunk(std::move(buffer));
+    p.end_parse();
+    auto result = p.result();
+    BOOST_REQUIRE_EQUAL(result.contents.size(), 2);
+    BOOST_REQUIRE_EQUAL(result.contents[0].key, "test-key1");
+    BOOST_REQUIRE_EQUAL(result.contents[0].size_bytes, 111);
+    BOOST_REQUIRE_EQUAL(result.contents[0].etag, "test-etag-1");
+    BOOST_REQUIRE(
+      result.contents[0].last_modified
+      == cloud_storage_clients::util::parse_timestamp(
+        "2021-01-10T01:00:00.000Z"));
+    BOOST_REQUIRE_EQUAL(result.contents[1].key, "test-key2");
+    BOOST_REQUIRE_EQUAL(result.contents[1].etag, "test-etag-2");
+    BOOST_REQUIRE(
+      result.contents[1].last_modified
+      == cloud_storage_clients::util::parse_timestamp(
+        "2021-01-10T02:00:00.000Z"));
+    BOOST_REQUIRE_EQUAL(result.contents[1].size_bytes, 222);
+    BOOST_REQUIRE_EQUAL(result.is_truncated, false);
+    BOOST_REQUIRE_EQUAL(result.next_continuation_token, "next");
+    BOOST_REQUIRE_EQUAL(result.prefix, "test-prefix");
+}
+
+BOOST_AUTO_TEST_CASE(test_invalid_xml) {
+    cloud_storage_clients::xml_sax_parser p{};
+    std::string_view bad_payload = "not xml!";
+    ss::temporary_buffer<char> buffer(bad_payload.data(), bad_payload.size());
+    p.start_parse();
+
+    // BOOST_REQUIRE_THROWS breaks static analysis because of a use-after-move
+    // inference
+    try {
+        p.parse_chunk(std::move(buffer));
+        BOOST_FAIL("unexpected successful parse");
+    } catch (const cloud_storage_clients::xml_parse_exception&) {
+    } catch (...) {
+        BOOST_FAIL("unexpected exception");
+    }
+}

--- a/src/v/cloud_storage_clients/xml_sax_parser.cc
+++ b/src/v/cloud_storage_clients/xml_sax_parser.cc
@@ -1,0 +1,207 @@
+
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/xml_sax_parser.h"
+
+#include "cloud_storage_clients/logger.h"
+#include "cloud_storage_clients/util.h"
+
+namespace {
+constexpr std::string_view list_bucket_results{"ListBucketResult"};
+constexpr std::string_view contents{"Contents"};
+constexpr std::string_view key{"Key"};
+constexpr std::string_view size{"Size"};
+constexpr std::string_view last_modified{"LastModified"};
+constexpr std::string_view etag{"ETag"};
+constexpr std::string_view is_truncated{"IsTruncated"};
+constexpr std::string_view prefix{"Prefix"};
+constexpr std::string_view next_continuation_token{"NextContinuationToken"};
+} // namespace
+
+namespace cloud_storage_clients {
+
+static parser_state* load_state(void* user_data) {
+    return reinterpret_cast<parser_state*>(user_data);
+}
+
+static bool is_top_level(const std::vector<ss::sstring>& tags) {
+    return tags.size() == 1 && tags[0] == list_bucket_results;
+}
+
+static bool is_in_contents(const std::vector<ss::sstring>& tags) {
+    return tags.size() == 2 && tags[0] == list_bucket_results
+           && tags[1] == contents;
+}
+
+parser_state::parser_state(std::optional<client::item_filter> gather_item_if)
+  : _current_tag(xml_tag::unset)
+  , _item_filter(std::move(gather_item_if)) {}
+
+void parser_state::handle_start_element(std::string_view element_name) {
+    if (element_name == contents && is_top_level(_tags)) {
+        // Reinitialize the item in preparation for next values
+        _current_item.emplace();
+    } else if (element_name == key && is_in_contents(_tags)) {
+        _current_tag = xml_tag::key;
+    } else if (element_name == size && is_in_contents(_tags)) {
+        _current_tag = xml_tag::size;
+    } else if (element_name == last_modified && is_in_contents(_tags)) {
+        _current_tag = xml_tag::last_modified;
+    } else if (element_name == etag && is_in_contents(_tags)) {
+        _current_tag = xml_tag::etag;
+    } else if (element_name == is_truncated && is_top_level(_tags)) {
+        _current_tag = xml_tag::is_truncated;
+    } else if (element_name == prefix && is_top_level(_tags)) {
+        _current_tag = xml_tag::prefix;
+    } else if (element_name == next_continuation_token && is_top_level(_tags)) {
+        _current_tag = xml_tag::next_continuation_token;
+    }
+    _tags.emplace_back(element_name.data(), element_name.size());
+}
+
+void parser_state::handle_end_element(std::string_view element_name) {
+    _tags.pop_back();
+    if (element_name == contents && _current_item) {
+        if (!_item_filter || _item_filter.value()(_current_item.value())) {
+            _items.contents.push_back(std::move(_current_item.value()));
+        }
+        _current_item.reset();
+    }
+
+    _current_tag = xml_tag::unset;
+}
+
+void parser_state::handle_characters(std::string_view characters) {
+    switch (_current_tag) {
+    case xml_tag::key:
+        if (_current_item) {
+            _current_item->key = {characters.data(), characters.size()};
+        } else {
+            throw xml_parse_exception{
+              "Invalid state: parsing Key when not in Contents tag"};
+        }
+        break;
+    case xml_tag::size:
+        if (_current_item) {
+            _current_item->size_bytes = std::stoll(
+              {characters.data(), characters.size()});
+        } else {
+            throw xml_parse_exception{
+              "Invalid state: parsing Size when not in Contents tag"};
+        }
+        break;
+    case xml_tag::last_modified:
+        if (_current_item) {
+            _current_item->last_modified = util::parse_timestamp(characters);
+        } else {
+            throw xml_parse_exception{
+              "Invalid state: parsing LastModified when not in Contents tag"};
+        }
+        break;
+    case xml_tag::etag:
+        if (_current_item) {
+            _current_item->etag = {characters.data(), characters.size()};
+        } else {
+            throw xml_parse_exception{
+              "Invalid state: parsing ETag when not in Contents tag"};
+        }
+        break;
+    case xml_tag::is_truncated:
+        _items.is_truncated = characters == "true";
+        break;
+    case xml_tag::prefix:
+        _items.prefix = {characters.data(), characters.size()};
+        break;
+    case xml_tag::next_continuation_token:
+        _items.next_continuation_token = {characters.data(), characters.size()};
+        break;
+    case xml_tag::unset:
+        return;
+    }
+}
+
+client::list_bucket_result parser_state::parsed_items() const { return _items; }
+
+xml_sax_parser::xml_sax_parser(xml_sax_parser&& other) noexcept {
+    vassert(!other._ctx, "parser moved after starting parse operation");
+}
+
+xml_sax_parser::~xml_sax_parser() {
+    if (_ctx) {
+        xmlFreeParserCtxt(_ctx);
+    }
+}
+
+void xml_sax_parser::parse_chunk(ss::temporary_buffer<char> buffer) {
+    vassert(_ctx, "parser is not initialized");
+    auto res = xmlParseChunk(_ctx, buffer.get(), buffer.size(), 0);
+    if (res != 0) {
+        auto last_error = xmlGetLastError();
+        vlog(
+          s3_log.error,
+          "Failed to parse response from S3: {} [{}]",
+          last_error->message,
+          res);
+        throw xml_parse_exception{last_error->message};
+    }
+}
+
+void xml_sax_parser::start_parse(
+  std::optional<client::item_filter> gather_item_if) {
+    _handler = std::make_unique<xmlSAXHandler>();
+    _handler->startElement = start_element;
+    _handler->endElement = end_element;
+    _handler->characters = characters;
+
+    _state = std::make_unique<parser_state>(std::move(gather_item_if));
+    _ctx = xmlCreatePushParserCtxt(
+      _handler.get(), _state.get(), nullptr, 0, nullptr);
+}
+
+void xml_sax_parser::end_parse() {
+    vassert(_ctx, "parser is not initialized");
+    auto res = xmlParseChunk(_ctx, nullptr, 0, 1);
+    if (res != 0) {
+        auto last_error = xmlGetLastError();
+        vlog(
+          s3_log.error,
+          "Failed to end parse: {} [{}]",
+          last_error->message,
+          res);
+        throw xml_parse_exception{last_error->message};
+    }
+}
+
+client::list_bucket_result xml_sax_parser::result() const {
+    return _state->parsed_items();
+}
+
+void xml_sax_parser::start_element(
+  void* user_data, const xmlChar* name, const xmlChar**) {
+    auto* state = load_state(user_data);
+    std::string_view element_name{reinterpret_cast<const char*>(name)};
+    state->handle_start_element(element_name);
+}
+
+void xml_sax_parser::end_element(void* user_data, const xmlChar* name) {
+    auto* state = load_state(user_data);
+    std::string_view element_name{reinterpret_cast<const char*>(name)};
+    state->handle_end_element(element_name);
+}
+
+void xml_sax_parser::characters(
+  void* user_data, const xmlChar* data, int size) {
+    auto* state = load_state(user_data);
+    state->handle_characters(
+      {reinterpret_cast<const char*>(data), static_cast<size_t>(size)});
+}
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/xml_sax_parser.h
+++ b/src/v/cloud_storage_clients/xml_sax_parser.h
@@ -1,0 +1,105 @@
+
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage_clients/client.h"
+#include "libxml/parser.h"
+
+#include <stack>
+
+namespace cloud_storage_clients {
+
+class xml_parse_exception : public std::exception {
+public:
+    explicit xml_parse_exception(std::string_view error_message)
+      : _error_message{error_message.data(), error_message.size()} {}
+
+    const char* what() const noexcept override { return _error_message.data(); }
+
+private:
+    ss::sstring _error_message;
+};
+
+/// \brief The current tag the parser is processing, used to collect tag
+/// contents
+enum class xml_tag {
+    key,
+    size,
+    last_modified,
+    etag,
+    is_truncated,
+    prefix,
+    next_continuation_token,
+    unset,
+};
+
+struct parser_state {
+    explicit parser_state(std::optional<client::item_filter>);
+
+    /// \brief callbacks for registering with libxml
+    void handle_start_element(std::string_view element_name);
+    void handle_end_element(std::string_view element_name);
+    void handle_characters(std::string_view characters);
+
+    client::list_bucket_result parsed_items() const;
+
+private:
+    client::list_bucket_result _items;
+    std::optional<client::list_bucket_item> _current_item;
+
+    xml_tag _current_tag;
+    std::vector<ss::sstring> _tags;
+    std::optional<client::item_filter> _item_filter;
+};
+
+class xml_sax_parser {
+public:
+    xml_sax_parser(const xml_sax_parser&) = delete;
+    xml_sax_parser& operator=(const xml_sax_parser&) = delete;
+    xml_sax_parser& operator=(xml_sax_parser&&) = delete;
+
+    xml_sax_parser() = default;
+    /// \brief Placeholder to assert that parser is not moved mid-parse.
+    xml_sax_parser(xml_sax_parser&& other) noexcept;
+
+    void parse_chunk(ss::temporary_buffer<char> buffer);
+
+    /// \brief Initializes the pointers in parser. This is decoupled from the
+    /// constructor to allow for the parser to be initialized after move, for
+    /// example when used in a `ss::do_with` construct, so that moving of
+    /// internal state is avoided.
+    void start_parse(
+      std::optional<client::item_filter> gather_item_if = std::nullopt);
+
+    /// \brief This function is expected to be called at the end of a parse
+    /// after all the XML content has been processed through parse_chunk, to
+    /// make sure that libxml2 parsing is finished.
+    void end_parse();
+
+    client::list_bucket_result result() const;
+
+    /// \brief frees up the parser context pointer
+    ~xml_sax_parser();
+
+private:
+    static void
+    start_element(void* user_data, const xmlChar* name, const xmlChar**);
+    static void end_element(void* user_data, const xmlChar* name);
+    static void characters(void* user_data, const xmlChar* data, int size);
+
+private:
+    std::unique_ptr<parser_state> _state;
+    std::unique_ptr<xmlSAXHandler> _handler;
+    xmlParserCtxtPtr _ctx{nullptr};
+};
+
+} // namespace cloud_storage_clients


### PR DESCRIPTION
Fixes #8329 

Changes the list-v2 API to use a sax parser, and allows caller to provide a predicate so that the entire xml document is not loaded in memory at once.

The topic recovery service uses this to only collect topic manifest files.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none