### PR TITLE
Return not leader for partition when shard is not found

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -249,7 +249,7 @@ static partition_produce_stages produce_topic_partition(
     if (!shard) {
         return make_ready_stage(produce_response::partition{
           .partition_index = ntp.tp.partition,
-          .error_code = error_code::unknown_topic_or_partition});
+          .error_code = error_code::not_leader_for_partition});
     }
 
     // steal the batch from the adapter
@@ -307,7 +307,7 @@ static partition_produce_stages produce_topic_partition(
                 auto partition = mgr.get(ntp);
                 if (!partition) {
                     return finalize_request_with_error_code(
-                      error_code::unknown_topic_or_partition,
+                      error_code::not_leader_for_partition,
                       std::move(dispatch),
                       ntp,
                       source_shard);


### PR DESCRIPTION
When moving partition the metadata may not reflect the actual replica placement as the actual data movement may take time. If partition metadata is correct but the partition not yet exists on a node we must return retryable error to the client. There is a possibility that during handling next client request partition will already be available on the node.

Changed error returned when partition shard wasn't found from `UNKNOWN_TOPIC_OR_PARTITION` which is not retryable to `NOT_LEADER_FOR_PARTITION` which forces producer to retry.

Fixes: #8290


<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

### Bug Fixes
- fixed stopping producer when moving partitions 
