### PR TITLE
[v22.2.x] rpk: redact secret values when importing from file (Backport 8339 and 7229)

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration.go
@@ -235,7 +235,7 @@ func (r *ClusterReconciler) retrieveClusterState(
 	if err != nil {
 		return nil, nil, nil, errorWithContext(err, "could not get centralized configuration schema")
 	}
-	clusterConfig, err := adminAPI.Config(ctx)
+	clusterConfig, err := adminAPI.Config(ctx, true)
 	if err != nil {
 		return nil, nil, nil, errorWithContext(err, "could not get current centralized configuration from cluster")
 	}

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
@@ -132,7 +132,7 @@ func (r *ClusterConfigurationDriftReconciler) Reconcile(
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get cluster schema to check drifts: %w", err)
 	}
-	clusterConfig, err := adminAPI.Config(ctx)
+	clusterConfig, err := adminAPI.Config(ctx, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get cluster configuration to check drifts: %w", err)
 	}

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
@@ -127,7 +127,8 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Marking the last applied configuration in the configmap")
-			baseConfig, err := testAdminAPI.Config(context.Background())
+			baseConfig, err := testAdminAPI.Config(context.Background(), true)
+
 			Expect(err).To(BeNil())
 			expectedAnnotation, err := json.Marshal(baseConfig)
 			Expect(err).To(BeNil())

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -187,7 +187,7 @@ func (*unavailableError) Error() string {
 	return "unavailable"
 }
 
-func (m *mockAdminAPI) Config(_ context.Context) (admin.Config, error) {
+func (m *mockAdminAPI) Config(context.Context, bool) (admin.Config, error) {
 	m.monitor.Lock()
 	defer m.monitor.Unlock()
 	if m.unavailable {

--- a/src/go/k8s/pkg/admin/admin.go
+++ b/src/go/k8s/pkg/admin/admin.go
@@ -77,7 +77,7 @@ func NewInternalAdminAPI(
 // AdminAPIClient is a sub interface of the admin API containing what we need in the operator
 // nolint:revive // usually package is called adminutils
 type AdminAPIClient interface {
-	Config(ctx context.Context) (admin.Config, error)
+	Config(ctx context.Context, includeDefaults bool) (admin.Config, error)
 	ClusterConfigStatus(ctx context.Context, sendToLeader bool) (admin.ConfigStatusResponse, error)
 	ClusterConfigSchema(ctx context.Context) (admin.ConfigSchema, error)
 	PatchClusterConfig(ctx context.Context, upsert map[string]interface{}, remove []string) (admin.ClusterConfigWriteResult, error)

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -75,6 +75,7 @@ type ConfigPropertyMetadata struct {
 	Description  string              `json:"description"`           // One liner human readable string
 	Nullable     bool                `json:"nullable"`              // If true, may be null
 	NeedsRestart bool                `json:"needs_restart"`         // If true, won't take effect until restart
+	IsSecret     bool                `json:"is_secret"`             // If true, the field should be redacted.
 	Visibility   string              `json:"visibility"`            // One of 'user', 'deprecated', 'tunable'
 	Units        string              `json:"units,omitempty"`       // A unit like 'ms', or empty.
 	Example      string              `json:"example,omitempty"`     // A non-default value for use in docs or tests

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -24,9 +24,14 @@ type Config map[string]interface{}
 
 // Config returns a single admin endpoint's configuration. This errors if
 // multiple URLs are configured.
-func (a *AdminAPI) Config(ctx context.Context) (Config, error) {
+//
+// If includeDefaults is true, all properties are returned, including those
+// that are simply reporting their defaults.  Otherwise, only properties with
+// non-default values are included (i.e. those which have been set at some
+// point).
+func (a *AdminAPI) Config(ctx context.Context, includeDefaults bool) (Config, error) {
 	var rawResp []byte
-	err := a.sendAny(ctx, http.MethodGet, "/v1/config", nil, &rawResp)
+	err := a.sendAny(ctx, http.MethodGet, fmt.Sprintf("/v1/cluster_config?include_defaults=%t", includeDefaults), nil, &rawResp)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
@@ -55,7 +55,8 @@ to edit all properties including these tunables.
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			// GET current config
-			currentConfig, err := client.Config(cmd.Context())
+
+			currentConfig, err := client.Config(cmd.Context(), true)
 			out.MaybeDie(err, "unable to get current config: %v", err)
 
 			err = executeEdit(cmd.Context(), client, schema, currentConfig, all)
@@ -116,7 +117,7 @@ func executeEdit(
 	}
 
 	// Read back template & parse
-	err = importConfig(ctx, client, filename, currentConfig, schema, *all)
+	err = importConfig(ctx, client, filename, currentConfig, currentConfig, schema, *all)
 	if err != nil {
 		return fmt.Errorf("error updating config: %v", err)
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -158,7 +158,7 @@ to include all properties including these low level tunables.
 
 			// GET current config
 			var currentConfig admin.Config
-			currentConfig, err = client.Config(cmd.Context())
+			currentConfig, err = client.Config(cmd.Context(), true)
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			// Generate a yaml template for editing

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/get.go
@@ -39,7 +39,7 @@ output, use the 'edit' and 'export' commands respectively.`,
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			currentConfig, err := client.Config(cmd.Context())
+			currentConfig, err := client.Config(cmd.Context(), true)
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			val, exists := currentConfig[key]

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
@@ -45,7 +45,7 @@ func newPrintCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewHostClient(fs, cfg, host)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			conf, err := cl.Config(cmd.Context())
+			conf, err := cl.Config(cmd.Context(), true)
 			out.MaybeDie(err, "unable to request configuration: %v", err)
 
 			marshaled, err := json.MarshalIndent(conf, "", "  ")

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -615,11 +615,11 @@ class ClusterConfigTest(RedpandaTest):
         self.logger.debug(f"_import status: {last_line}")
 
         if m is None and allow_noop:
-            return None
+            return None, None
 
         assert m is not None, f"Config version not found: {last_line}"
         version = int(m.group(1))
-        return version
+        return version, import_stdout
 
     def _export_import_modify_one(self, before: str, after: str, all=False):
         return self._export_import_modify([(before, after)], all)
@@ -642,7 +642,7 @@ class ClusterConfigTest(RedpandaTest):
         self.logger.debug(f"Exported config after modification: {text}")
 
         # Edit a setting, import the resulting document
-        version = self._import(text, all)
+        version, _ = self._import(text, all)
 
         return version, text
 
@@ -718,20 +718,25 @@ class ClusterConfigTest(RedpandaTest):
 
         # Check that an import/export with no edits does nothing.
         text = self._export(all=True)
-        noop_version = self._import(text, allow_noop=True, all=True)
+        noop_version, _ = self._import(text, allow_noop=True, all=True)
         assert noop_version is None
 
         # Now try setting a secret.
         text = text.replace("cloud_storage_secret_key:",
                             "cloud_storage_secret_key: different_secret")
-        version_e = self._import(text, all)
+        version_e, import_output = self._import(text, all)
         assert version_e is not None
         assert version_e > version_d
+
+        # Check that rpk doesn't print the secret to stdout.
+        assert "different_secret" not in import_output
+        # Instead, prints a [redacted] text.
+        assert "[redacted]" in import_output
 
         # Because rpk doesn't know the contents of the secrets, it can't
         # determine whether a secret is new. The request should be de-duped on
         # the server side, and the same config version should be returned.
-        version_f = self._import(text, all)
+        version_f, _ = self._import(text, all)
         assert version_f is not None
         assert version_f == version_e
 
@@ -740,12 +745,12 @@ class ClusterConfigTest(RedpandaTest):
         # setting the secret to the redacted string.
         text = text.replace("cloud_storage_secret_key: different_secret",
                             "cloud_storage_secret_key: [secret]")
-        noop_version = self._import(text, allow_noop=True, all=True)
+        noop_version, _ = self._import(text, allow_noop=True, all=True)
         assert noop_version is None
 
         # Removing a secret should succeed with a new version.
         text = text.replace("cloud_storage_secret_key: [secret]", "")
-        version_g = self._import(text, all)
+        version_g, _ = self._import(text, all)
         assert version_g is not None
         assert version_g > version_f
 
@@ -767,7 +772,7 @@ class ClusterConfigTest(RedpandaTest):
         superusers: [alice]
         """
 
-        new_version = self._import(text, all, allow_noop=True)
+        new_version, _ = self._import(text, all, allow_noop=True)
         self._wait_for_version_sync(new_version)
 
         schema_properties = self.admin.get_cluster_config_schema(

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -750,6 +750,49 @@ class ClusterConfigTest(RedpandaTest):
         assert version_g > version_f
 
     @cluster(num_nodes=3)
+    @parametrize(all=True)
+    @parametrize(all=False)
+    def test_rpk_import_sparse(self, all):
+        """
+        Verify that a user setting just their properties they're interested in
+        gets a suitable terse output, stability across multiple calls, and
+        that the resulting config is all-default apart from the values they set.
+
+        This is a typical gitops-type use case, where they have defined their
+        subset of configuration in a file somewhere, and periodically try
+        to apply it to the cluster.
+        """
+
+        text = """
+        superusers: [alice]
+        """
+
+        new_version = self._import(text, all, allow_noop=True)
+        self._wait_for_version_sync(new_version)
+
+        schema_properties = self.admin.get_cluster_config_schema(
+        )['properties']
+
+        conf = self.admin.get_cluster_config(include_defaults=False)
+        assert conf['superusers'] == ['alice']
+        if all:
+            # We should have wiped out any non-default property except the one we set,
+            # and cluster_id which rpk doesn't touch.
+            assert len(conf) == 2
+        else:
+            # Apart from the one we set, all the other properties should be tunables
+            for key in conf.keys():
+                if key == 'superusers' or key == 'cluster_id':
+                    continue
+                else:
+                    property_schema = schema_properties[key]
+                    is_tunable = property_schema['visibility'] == 'tunable'
+                    if not is_tunable:
+                        self.logger.error(
+                            "Unexpected property {k} set in config")
+                        self.logger.error("{k} schema: {property_schema}")
+
+    @cluster(num_nodes=3)
     def test_rpk_import_validation(self):
         """
         Verify that RPK handles 400 responses on import nicely


### PR DESCRIPTION
Backport of #8339 and  #7229 (had to include this parent commit)

## Release Notes
### Improvements
* Output from `rpk cluster config import` is made more succinct if the input file leaves out properties and those properties are already set to the default.

### Bug Fixes
* rpk won't print the values of secret properties that are being imported from a file when using `rpk cluster config import/edit`