### PR TITLE
[v22.1.x] rpk: redact secret values when importing from file (Backport 8339 and 7229)

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration.go
@@ -233,7 +233,7 @@ func (r *ClusterReconciler) retrieveClusterState(
 	if err != nil {
 		return nil, nil, nil, errorWithContext(err, "could not get centralized configuration schema")
 	}
-	clusterConfig, err := adminAPI.Config()
+	clusterConfig, err := adminAPI.Config(true)
 	if err != nil {
 		return nil, nil, nil, errorWithContext(err, "could not get current centralized configuration from cluster")
 	}

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
@@ -132,7 +132,7 @@ func (r *ClusterConfigurationDriftReconciler) Reconcile(
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get cluster schema to check drifts: %w", err)
 	}
-	clusterConfig, err := adminAPI.Config()
+	clusterConfig, err := adminAPI.Config(true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get cluster configuration to check drifts: %w", err)
 	}

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
@@ -128,7 +128,8 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
 
 			By("Marking the last applied configuration in the configmap")
-			baseConfig, err := testAdminAPI.Config()
+			baseConfig, err := testAdminAPI.Config(true)
+
 			Expect(err).To(BeNil())
 			expectedAnnotation, err := json.Marshal(baseConfig)
 			Expect(err).To(BeNil())

--- a/src/go/k8s/controllers/redpanda/suite_test.go
+++ b/src/go/k8s/controllers/redpanda/suite_test.go
@@ -172,7 +172,7 @@ func (*unavailableError) Error() string {
 	return "unavailable"
 }
 
-func (m *mockAdminAPI) Config() (admin.Config, error) {
+func (m *mockAdminAPI) Config(bool) (admin.Config, error) {
 	m.monitor.Lock()
 	defer m.monitor.Unlock()
 	if m.unavailable {

--- a/src/go/k8s/pkg/admin/admin.go
+++ b/src/go/k8s/pkg/admin/admin.go
@@ -70,7 +70,7 @@ func NewInternalAdminAPI(
 // AdminAPIClient is a sub interface of the admin API containing what we need in the operator
 // nolint:revive // usually package is called adminutils
 type AdminAPIClient interface {
-	Config() (admin.Config, error)
+	Config(includeDefaults bool) (admin.Config, error)
 	ClusterConfigStatus(sendToLeader bool) (admin.ConfigStatusResponse, error)
 	ClusterConfigSchema() (admin.ConfigSchema, error)
 	PatchClusterConfig(upsert map[string]interface{}, remove []string) (admin.ClusterConfigWriteResult, error)

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -23,9 +23,14 @@ type Config map[string]interface{}
 
 // Config returns a single admin endpoint's configuration. This errors if
 // multiple URLs are configured.
-func (a *AdminAPI) Config() (Config, error) {
+//
+// If includeDefaults is true, all properties are returned, including those
+// that are simply reporting their defaults.  Otherwise, only properties with
+// non-default values are included (i.e. those which have been set at some
+// point).
+func (a *AdminAPI) Config(includeDefaults bool) (Config, error) {
 	var rawResp []byte
-	err := a.sendAny(http.MethodGet, "/v1/config", nil, &rawResp)
+	err := a.sendAny(http.MethodGet, fmt.Sprintf("/v1/cluster_config?include_defaults=%t", includeDefaults), nil, &rawResp)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/rpk/pkg/api/admin/api_config.go
+++ b/src/go/rpk/pkg/api/admin/api_config.go
@@ -74,6 +74,7 @@ type ConfigPropertyMetadata struct {
 	Description  string              `json:"description"`           // One liner human readable string
 	Nullable     bool                `json:"nullable"`              // If true, may be null
 	NeedsRestart bool                `json:"needs_restart"`         // If true, won't take effect until restart
+	IsSecret     bool                `json:"is_secret"`             // If true, the field should be redacted.
 	Visibility   string              `json:"visibility"`            // One of 'user', 'deprecated', 'tunable'
 	Units        string              `json:"units,omitempty"`       // A unit like 'ms', or empty.
 	Example      string              `json:"example,omitempty"`     // A non-default value for use in docs or tests

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/edit.go
@@ -55,7 +55,8 @@ to edit all properties including these tunables.
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			// GET current config
-			currentConfig, err := client.Config()
+
+			currentConfig, err := client.Config(true)
 			out.MaybeDie(err, "unable to get current config: %v", err)
 
 			err = executeEdit(client, schema, currentConfig, all)
@@ -115,7 +116,7 @@ func executeEdit(
 	}
 
 	// Read back template & parse
-	err = importConfig(client, filename, currentConfig, schema, *all)
+	err = importConfig(client, filename, currentConfig, currentConfig, schema, *all)
 	if err != nil {
 		return fmt.Errorf("error updating config: %v", err)
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/export.go
@@ -157,7 +157,7 @@ to include all properties including these low level tunables.
 
 			// GET current config
 			var currentConfig admin.Config
-			currentConfig, err = client.Config()
+			currentConfig, err = client.Config(true)
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			// Generate a yaml template for editing

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/get.go
@@ -39,7 +39,7 @@ output, use the 'edit' and 'export' commands respectively.`,
 			client, err := admin.NewClient(fs, cfg)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			currentConfig, err := client.Config()
+			currentConfig, err := client.Config(true)
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			val, exists := currentConfig[key]

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
@@ -38,6 +38,7 @@ func importConfig(
 	client *admin.AdminAPI,
 	filename string,
 	oldConfig admin.Config,
+	oldConfigFull admin.Config,
 	schema admin.ConfigSchema,
 	all bool,
 ) (err error) {
@@ -63,6 +64,8 @@ func importConfig(
 	remove := make([]string, 0)
 	for k, v := range readbackConfig {
 		oldVal, haveOldVal := oldConfig[k]
+		oldValMaterialized, haveOldValMaterialized := oldConfigFull[k]
+
 		if meta, ok := schema[k]; ok {
 			// For numeric types need special handling because
 			// yaml encoding will see '1' as an integer, even
@@ -76,6 +79,9 @@ func importConfig(
 
 				if oldVal != nil {
 					oldVal = int(oldVal.(float64))
+				}
+				if oldValMaterialized != nil {
+					oldValMaterialized = int(oldValMaterialized.(float64))
 				}
 			} else if meta.Type == "number" {
 				switch x := v.(type) {
@@ -92,6 +98,9 @@ func importConfig(
 				}
 				if oldVal != nil {
 					oldVal = loadStringArray(oldVal.([]interface{}))
+				}
+				if oldValMaterialized != nil {
+					oldValMaterialized = loadStringArray(oldValMaterialized.([]interface{}))
 				}
 			}
 
@@ -119,13 +128,16 @@ func importConfig(
 				upsert[k] = v
 			}
 		} else {
-			// Present in input but not original config, insert
-			upsert[k] = v
-			propertyDeltas = append(propertyDeltas, propertyDelta{k, "", fmt.Sprintf("%v", v)})
+			// Present in input but not original config, insert if it differs
+			// from the materialized current value (which may be a default)
+			if !haveOldValMaterialized || !reflect.DeepEqual(oldValMaterialized, v) {
+				upsert[k] = v
+				propertyDeltas = append(propertyDeltas, propertyDelta{k, fmt.Sprintf("%v", oldValMaterialized), fmt.Sprintf("%v", v)})
+			}
 		}
 	}
 
-	for k := range oldConfig {
+	for k := range oldConfigFull {
 		if _, found := readbackConfig[k]; !found {
 			if k == "cluster_id" {
 				// see above
@@ -140,9 +152,11 @@ func importConfig(
 			if !all && meta.Visibility == "tunable" {
 				continue
 			}
-			oldValue := oldConfig[k]
-			propertyDeltas = append(propertyDeltas, propertyDelta{k, fmt.Sprintf("%v", oldValue), ""})
-			remove = append(remove, k)
+			oldValue, found := oldConfig[k]
+			if found {
+				propertyDeltas = append(propertyDeltas, propertyDelta{k, fmt.Sprintf("%v", oldValue), ""})
+				remove = append(remove, k)
+			}
 		}
 	}
 
@@ -235,11 +249,14 @@ from the YAML file, it is reset to its default value.  `,
 			out.MaybeDie(err, "unable to query config schema: %v", err)
 
 			// GET current config
-			currentConfig, err := client.Config()
+			currentConfig, err := client.Config(false)
+			out.MaybeDie(err, "unable to query config values: %v", err)
+
+			currentFullConfig, err := client.Config(true)
 			out.MaybeDie(err, "unable to query config values: %v", err)
 
 			// Read back template & parse
-			err = importConfig(client, filename, currentConfig, schema, *all)
+			err = importConfig(client, filename, currentConfig, currentFullConfig, schema, *all)
 			if fe := (*formattedError)(nil); errors.As(err, &fe) {
 				fmt.Fprint(os.Stderr, err)
 				out.Die("No changes were made")

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/config/config.go
@@ -45,7 +45,7 @@ func newPrintCommand(fs afero.Fs) *cobra.Command {
 			cl, err := admin.NewHostClient(fs, cfg, host)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			conf, err := cl.Config()
+			conf, err := cl.Config(true)
 			out.MaybeDie(err, "unable to request configuration: %v", err)
 
 			marshaled, err := json.MarshalIndent(conf, "", "  ")

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -621,11 +621,11 @@ class ClusterConfigTest(RedpandaTest):
         self.logger.debug(f"_import status: {last_line}")
 
         if m is None and allow_noop:
-            return None
+            return None, None
 
         assert m is not None, f"Config version not found: {last_line}"
         version = int(m.group(1))
-        return version
+        return version, import_stdout
 
     def _export_import_modify_one(self, before: str, after: str, all=False):
         return self._export_import_modify([(before, after)], all)
@@ -648,7 +648,7 @@ class ClusterConfigTest(RedpandaTest):
         self.logger.debug(f"Exported config after modification: {text}")
 
         # Edit a setting, import the resulting document
-        version = self._import(text, all)
+        version, _ = self._import(text, all)
 
         return version, text
 
@@ -709,20 +709,25 @@ class ClusterConfigTest(RedpandaTest):
 
         # Check that an import/export with no edits does nothing.
         text = self._export(all=True)
-        noop_version = self._import(text, allow_noop=True, all=True)
+        noop_version, _ = self._import(text, allow_noop=True, all=True)
         assert noop_version is None
 
         # Now try setting a secret.
         text = text.replace("cloud_storage_secret_key:",
                             "cloud_storage_secret_key: different_secret")
-        version_e = self._import(text, all)
+        version_e, import_output = self._import(text, all)
         assert version_e is not None
         assert version_e > version_d
+
+        # Check that rpk doesn't print the secret to stdout.
+        assert "different_secret" not in import_output
+        # Instead, prints a [redacted] text.
+        assert "[redacted]" in import_output
 
         # Because rpk doesn't know the contents of the secrets, it can't
         # determine whether a secret is new. The request should be de-duped on
         # the server side, and the same config version should be returned.
-        version_f = self._import(text, all)
+        version_f, _ = self._import(text, all)
         assert version_f is not None
         assert version_f == version_e
 
@@ -731,12 +736,12 @@ class ClusterConfigTest(RedpandaTest):
         # setting the secret to the redacted string.
         text = text.replace("cloud_storage_secret_key: different_secret",
                             "cloud_storage_secret_key: [secret]")
-        noop_version = self._import(text, allow_noop=True, all=True)
+        noop_version, _ = self._import(text, allow_noop=True, all=True)
         assert noop_version is None
 
         # Removing a secret should succeed with a new version.
         text = text.replace("cloud_storage_secret_key: [secret]", "")
-        version_g = self._import(text, all)
+        version_g, _ = self._import(text, all)
         assert version_g is not None
         assert version_g > version_f
 
@@ -758,7 +763,7 @@ class ClusterConfigTest(RedpandaTest):
         superusers: [alice]
         """
 
-        new_version = self._import(text, all, allow_noop=True)
+        new_version, _ = self._import(text, all, allow_noop=True)
         self._wait_for_version_sync(new_version)
 
         schema_properties = self.admin.get_cluster_config_schema(

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -741,6 +741,49 @@ class ClusterConfigTest(RedpandaTest):
         assert version_g > version_f
 
     @cluster(num_nodes=3)
+    @parametrize(all=True)
+    @parametrize(all=False)
+    def test_rpk_import_sparse(self, all):
+        """
+        Verify that a user setting just their properties they're interested in
+        gets a suitable terse output, stability across multiple calls, and
+        that the resulting config is all-default apart from the values they set.
+
+        This is a typical gitops-type use case, where they have defined their
+        subset of configuration in a file somewhere, and periodically try
+        to apply it to the cluster.
+        """
+
+        text = """
+        superusers: [alice]
+        """
+
+        new_version = self._import(text, all, allow_noop=True)
+        self._wait_for_version_sync(new_version)
+
+        schema_properties = self.admin.get_cluster_config_schema(
+        )['properties']
+
+        conf = self.admin.get_cluster_config(include_defaults=False)
+        assert conf['superusers'] == ['alice']
+        if all:
+            # We should have wiped out any non-default property except the one we set,
+            # and cluster_id which rpk doesn't touch.
+            assert len(conf) == 2
+        else:
+            # Apart from the one we set, all the other properties should be tunables
+            for key in conf.keys():
+                if key == 'superusers' or key == 'cluster_id':
+                    continue
+                else:
+                    property_schema = schema_properties[key]
+                    is_tunable = property_schema['visibility'] == 'tunable'
+                    if not is_tunable:
+                        self.logger.error(
+                            "Unexpected property {k} set in config")
+                        self.logger.error("{k} schema: {property_schema}")
+
+    @cluster(num_nodes=3)
     def test_rpk_import_validation(self):
         """
         Verify that RPK handles 400 responses on import nicely


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/8339 and https://github.com/redpanda-data/redpanda/pull/7229 (had to include this parent commit)

## Release Notes
### Improvements
* Output from `rpk cluster config import` is made more succinct if the input file leaves out properties and those properties are already set to the default.

### Bug Fixes
* rpk won't print the values of secret properties that are being imported from a file when using `rpk cluster config import/edit`