### PR TITLE
Clear topics orphan files

### DIFF
--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -268,6 +268,8 @@ private:
 
     // Topics
     ss::future<> bootstrap_controller_backend();
+    ss::future<>
+    clear_orphan_topic_files(model::revision_id bootstrap_revision);
     void start_topics_reconciliation_loop();
 
     ss::future<> fetch_deltas();

--- a/src/v/storage/fs_utils.h
+++ b/src/v/storage/fs_utils.h
@@ -67,6 +67,26 @@ class segment_full_path;
 
 class partition_path {
 public:
+    struct metadata {
+        model::partition_id partition_id;
+        model::revision_id revision_id;
+    };
+
+    /// Parse ntp directory name
+    static std::optional<metadata>
+    parse_partition_directory(const ss::sstring& name) {
+        const std::regex re(R"(^(\d+)_(\d+)$)");
+        std::cmatch match;
+        if (!std::regex_match(name.c_str(), match, re)) {
+            return std::nullopt;
+        }
+        return metadata{
+          .partition_id = model::partition_id(
+            boost::lexical_cast<uint64_t>(match[1].str())),
+          .revision_id = model::revision_id(
+            boost::lexical_cast<uint64_t>(match[2].str()))};
+    }
+
     partition_path(const ntp_config& ntpc);
 
     operator std::filesystem::path() const { return make_path(); }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -9,9 +9,12 @@
 
 #include "storage/log_manager.h"
 
+#include "cluster/cluster_utils.h"
+#include "cluster/topic_table.h"
 #include "config/configuration.h"
 #include "likely.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/timestamp.h"
 #include "resource_mgmt/io_priority.h"
 #include "ssx/async-clear.h"
@@ -46,6 +49,7 @@
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/util/file.hh>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <fmt/format.h>
@@ -434,6 +438,85 @@ ss::future<> log_manager::remove(model::ntp ntp) {
     // We always dispatch topic directory deletion to core 0 as requests may
     // come from different cores
     co_await dispatch_topic_dir_deletion(topic_dir);
+}
+
+ss::future<> remove_orphan_partition_files(
+  ss::sstring topic_directory_path,
+  model::topic_namespace nt,
+  ss::noncopyable_function<bool(model::ntp, partition_path::metadata)>&
+    orphan_filter) {
+    return directory_walker::walk(
+      topic_directory_path,
+      [topic_directory_path, nt, &orphan_filter](
+        ss::directory_entry entry) -> ss::future<> {
+          auto ntp_directory_data = partition_path::parse_partition_directory(
+            entry.name);
+          if (!ntp_directory_data) {
+              return ss::now();
+          }
+
+          auto ntp = model::ntp(nt.ns, nt.tp, ntp_directory_data->partition_id);
+          if (orphan_filter(ntp, *ntp_directory_data)) {
+              auto ntp_directory = std::filesystem::path(topic_directory_path)
+                                   / std::filesystem::path(entry.name);
+              vlog(stlog.info, "Cleaning up ntp directory {} ", ntp_directory);
+              return ss::recursive_remove_directory(ntp_directory)
+                .handle_exception_type([ntp_directory](
+                                         std::filesystem::
+                                           filesystem_error const& err) {
+                    vlog(
+                      stlog.error,
+                      "Exception while cleaning oprhan files for {} Error: {}",
+                      ntp_directory,
+                      err);
+                });
+          }
+          return ss::now();
+      });
+}
+
+ss::future<> log_manager::remove_orphan_files(
+  ss::sstring data_directory_path,
+  absl::flat_hash_set<model::ns> namespaces,
+  ss::noncopyable_function<bool(model::ntp, partition_path::metadata)>
+    orphan_filter) {
+    auto data_directory_exist = co_await ss::file_exists(data_directory_path);
+    if (!data_directory_exist) {
+        co_return;
+    }
+
+    for (const auto& ns : namespaces) {
+        auto namespace_directory = std::filesystem::path(data_directory_path)
+                                   / std::filesystem::path(ss::sstring(ns));
+        auto namespace_directory_exist = co_await ss::file_exists(
+          namespace_directory.string());
+        if (!namespace_directory_exist) {
+            continue;
+        }
+        co_await directory_walker::walk(
+          namespace_directory.string(),
+          [this, &namespace_directory, &ns, &orphan_filter](
+            ss::directory_entry entry) -> ss::future<> {
+              if (entry.type != ss::directory_entry_type::directory) {
+                  return ss::now();
+              }
+              auto topic_directory = namespace_directory
+                                     / std::filesystem::path(entry.name);
+              return remove_orphan_partition_files(
+                       topic_directory.string(),
+                       model::topic_namespace(ns, model::topic(entry.name)),
+                       orphan_filter)
+                .then([this, topic_directory]() {
+                    vlog(
+                      stlog.info,
+                      "Trying to clean up topic directory {} ",
+                      topic_directory);
+                    return dispatch_topic_dir_deletion(
+                      topic_directory.string());
+                });
+          });
+    }
+    co_return;
 }
 
 ss::future<> log_manager::dispatch_topic_dir_deletion(ss::sstring dir) {

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -11,9 +11,11 @@
 
 #pragma once
 
+#include "cluster/topic_table.h"
 #include "config/property.h"
 #include "features/feature_table.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "random/simple_time_jitter.h"
 #include "seastarx.h"
 #include "storage/batch_cache.h"
@@ -174,6 +176,11 @@ public:
      * rebalancing partitions across the cluster, etc...
      */
     ss::future<> remove(model::ntp);
+    ss::future<> remove_orphan_files(
+      ss::sstring data_directory_path,
+      absl::flat_hash_set<model::ns> namespaces,
+      ss::noncopyable_function<bool(model::ntp, partition_path::metadata)>
+        orphan_filter);
 
     ss::future<> stop();
 

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -25,6 +25,7 @@ from rptest.services.metrics_check import MetricCheck
 from rptest.services.redpanda import CloudStorageType, SISettings
 from rptest.util import wait_for_local_storage_truncate, firewall_blocked
 from rptest.services.admin import Admin
+from rptest.tests.partition_movement import PartitionMovementMixin
 
 
 def get_kvstore_topic_key_counts(redpanda):
@@ -243,6 +244,112 @@ class TopicDeleteTest(RedpandaTest):
         except:
             self.dump_storage_listing()
             raise
+
+
+class TopicDeleteAfterMovementTest(RedpandaTest):
+    """
+    Verify that topic deleted after partition movement.
+    """
+    partition_count = 3
+    topics = (TopicSpec(partition_count=partition_count), )
+
+    def __init__(self, test_context):
+        super(TopicDeleteAfterMovementTest,
+              self).__init__(test_context=test_context, num_brokers=4)
+
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+
+    def movement_done(self, partition, assignments):
+        results = []
+        for n in self.redpanda._started:
+            info = self.admin.get_partitions(self.topic, partition, node=n)
+            self.logger.info(
+                f"current assignments for {self.topic}-{partition}: {info}")
+            converged = PartitionMovementMixin._equal_assignments(
+                info["replicas"], assignments)
+            results.append(converged and info["status"] == "done")
+        return all(results)
+
+    def move_topic(self, assignments):
+        for partition in range(3):
+
+            def get_nodes(partition):
+                return list(r['node_id'] for r in partition['replicas'])
+
+            nodes_before = set(
+                get_nodes(self.admin.get_partitions(self.topic, partition)))
+            nodes_after = {r['node_id'] for r in assignments}
+            if nodes_before == nodes_after:
+                continue
+            self.admin.set_partition_replicas(self.topic, partition,
+                                              assignments)
+
+            wait_until(lambda: self.movement_done(partition, assignments),
+                       timeout_sec=60,
+                       backoff_sec=2)
+
+    @cluster(num_nodes=4, log_allow_list=[r'filesystem error: remove failed'])
+    def topic_delete_orphan_files_after_move_test(self):
+
+        # Write out 10MB per partition
+        self.kafka_tools.produce(self.topic,
+                                 record_size=4096,
+                                 num_records=2560 * self.partition_count)
+
+        self.admin = Admin(self.redpanda)
+
+        # Move every partition to nodes 1,2,3
+        assignments = [dict(node_id=n, core=0) for n in [1, 2, 3]]
+        self.move_topic(assignments)
+
+        down_node = self.redpanda.nodes[0]
+        try:
+            # Make topic directory immutable to prevent deleting
+            down_node.account.ssh(
+                f"chattr +i {self.redpanda.DATA_DIR}/kafka/{self.topic}")
+
+            # Move every partition from node 1 to node 4
+            new_assignments = [dict(node_id=n, core=0) for n in [2, 3, 4]]
+            self.move_topic(new_assignments)
+
+            def topic_exist_on_every_node(redpanda, topic_name):
+                storage = redpanda.storage()
+                exist_on_every = all(
+                    map(lambda n: topic_name in n.ns["kafka"].topics,
+                        storage.nodes))
+                return exist_on_every
+
+            wait_until(
+                lambda: topic_exist_on_every_node(self.redpanda, self.topic),
+                timeout_sec=30,
+                backoff_sec=2,
+                err_msg="Topic doesn't exist on some node")
+
+            self.redpanda.stop_node(down_node)
+        finally:
+            down_node.account.ssh(
+                f"chattr -i {self.redpanda.DATA_DIR}/kafka/{self.topic}")
+
+        self.redpanda.start_node(down_node)
+
+        def topic_deleted_on_down_node_and_exist_on_others(
+                redpanda, down_node, topic_name):
+            storage = redpanda.storage()
+            log_removed_on_down = topic_name not in next(
+                filter(lambda x: x.name == down_node.name,
+                       storage.nodes)).ns["kafka"].topics
+            logs_not_removed_on_others = all(
+                map(lambda n: topic_name in n.ns["kafka"].topics,
+                    filter(lambda x: x.name != down_node.name, storage.nodes)))
+            return log_removed_on_down and logs_not_removed_on_others
+
+        wait_until(
+            lambda: topic_deleted_on_down_node_and_exist_on_others(
+                self.redpanda, down_node, self.topic),
+            timeout_sec=30,
+            backoff_sec=2,
+            err_msg=
+            "Topic storage was not removed on down node or removed on other")
 
 
 class TopicDeleteCloudStorageTest(RedpandaTest):


### PR DESCRIPTION
When node is restarted while it was executing partition delete operation, this operation may be not finished and we will have orphan files for that partition left on device.
On node restart we don't have that partition data in memory so we couldn't retry partition delete operation and won't clean up partition files on reconciliation.
This pr bring garbage collector mechanism that will force delete partition files after node bootstrap.
We gather all existing ntps and then go through all data directories and check if topic directory responsible for any exisitng ntp if it don't we delete it.

Fixes #7895

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

- Mechanism for cleaning partition orphan files

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
  ### Bug Fixes
- Mechanism for cleaning partition orphan files

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

