### PR TITLE
Support for self-test via rpk

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_debug.go
+++ b/src/go/rpk/pkg/api/admin/api_debug.go
@@ -1,0 +1,131 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	debugEndpoint          = "/v1/debug/self_test"
+	DiskcheckTagIdentifier = "disk"
+	NetcheckTagIdentifier  = "network"
+)
+
+// A SelfTestNodeResult describes the results of a particular self-test run.
+// Currently there are only two types of tests, disk & network. The struct
+// contains latency and throughput metrics as well as any errors or warnings
+// that may have arisen during the tests execution.
+type SelfTestNodeResult struct {
+	P50            *uint   `json:"p50,omitempty"`
+	P90            *uint   `json:"p90,omitempty"`
+	P99            *uint   `json:"p99,omitempty"`
+	P999           *uint   `json:"p999,omitempty"`
+	MaxLatency     *uint   `json:"max_latency,omitempty"`
+	RequestsPerSec *uint   `json:"rps,omitempty"`
+	BytesPerSec    *uint   `json:"bps,omitempty"`
+	Timeouts       uint    `json:"timeouts"`
+	TestID         string  `json:"test_id"`
+	TestName       string  `json:"name"`
+	TestInfo       string  `json:"info"`
+	TestType       string  `json:"test_type"`
+	Duration       uint    `json:"duration"`
+	Warning        *string `json:"warning,omitempty"`
+	Error          *string `json:"error,omitempty"`
+}
+
+// SelfTestNodeReport describes the result returned from one member of the cluster.
+// A query for results will return an array of these structs, one from each member.
+type SelfTestNodeReport struct {
+	NodeID int `json:"node_id"`
+	// One of { "idle", "running", "unreachable" }
+	//
+	// If a status of idle is returned, the following `Results` variable will not
+	// be nil. In all other cases it will be nil.
+	Status string `json:"status"`
+	// If value of `Status` is "idle", then this field will contain one result for
+	// each peer involved in the test. It represents the results of the last
+	// successful test run.
+	Results []SelfTestNodeResult `json:"results,omitempty"`
+}
+
+// DiskcheckParameters describes what parameters redpanda will use when starting the diskcheck benchmark.
+type DiskcheckParameters struct {
+	/// Descriptive name given to test run
+	Name string `json:"name"`
+	// Open the file with O_DSYNC flag option
+	DSync bool `json:"dsync"`
+	// Set to true to disable the write portion of the benchmark
+	SkipWrite bool `json:"skip_write"`
+	// Set to true to disable the read portion of the benchmark
+	SkipRead bool `json:"skip_read"`
+	// Total size of all benchmark files to exist on disk
+	DataSize uint `json:"data_size"`
+	// Size of individual read and/or write requests
+	RequestSize uint `json:"request_size"`
+	// Total duration of the benchmark
+	DurationMs uint `json:"duration_ms"`
+	// Amount of fibers to run per shard
+	Parallelism uint `json:"parallelism"`
+	// Filled in automatically by the \ref StartSelfTest method
+	Type string `json:"type"`
+}
+
+// NetcheckParameters describes what parameters redpanda will use when starting the netcheck benchmark.
+type NetcheckParameters struct {
+	/// Descriptive name given to test run
+	Name string `json:"name"`
+	// Size of individual request
+	RequestSize uint `json:"request_size"`
+	// Total duration of an individual benchmark
+	DurationMs uint `json:"duration_ms"`
+	// Number of fibers per shard used to make network requests
+	Parallelism uint `json:"parallelism"`
+	// Filled in automatically by the \ref StartSelfTest method
+	Type string `json:"type"`
+}
+
+// SelfTestRequest represents the body of a self-test start POST request.
+type SelfTestRequest struct {
+	Tests []any `json:"tests,omitempty"`
+	Nodes []int `json:"nodes,omitempty"`
+}
+
+func (a *AdminAPI) StartSelfTest(ctx context.Context, nodeIds []int, params []any) (string, error) {
+	var testID string
+	body := SelfTestRequest{
+		Tests: params,
+		Nodes: nodeIds,
+	}
+	err := a.sendToLeader(ctx,
+		http.MethodPost,
+		fmt.Sprintf("%s/start", debugEndpoint),
+		body,
+		&testID)
+	return testID, err
+}
+
+func (a *AdminAPI) StopSelfTest(ctx context.Context) error {
+	return a.sendToLeader(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("%s/stop", debugEndpoint),
+		nil,
+		nil,
+	)
+}
+
+func (a *AdminAPI) SelfTestStatus(ctx context.Context) ([]SelfTestNodeReport, error) {
+	var response []SelfTestNodeReport
+	err := a.sendAny(ctx, http.MethodGet, fmt.Sprintf("%s/status", debugEndpoint), nil, &response)
+	return response, err
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/cluster.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/license"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/maintenance"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/partitions"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/selftest"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/group"
 	"github.com/spf13/afero"
@@ -63,6 +64,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		license.NewLicenseCommand(fs),
 		maintenance.NewMaintenanceCommand(fs),
 		partitions.NewPartitionsCommand(fs),
+		selftest.NewSelfTestCommand(fs),
 		offsets,
 	)
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/selftest.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/selftest.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package selftest contains commands to talk to the Redpanda's admin self_test
+// endpoints.
+package selftest
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewSelfTestCommand(fs afero.Fs) *cobra.Command {
+	var (
+		adminURL       string
+		adminEnableTLS bool
+		adminCertFile  string
+		adminKeyFile   string
+		adminCAFile    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "self-test",
+		Short: "Start, stop and query redpanda self-test runs through the admin listener",
+		Args:  cobra.ExactArgs(0),
+	}
+
+	common.AddAdminAPITLSFlags(cmd,
+		&adminEnableTLS,
+		&adminCertFile,
+		&adminKeyFile,
+		&adminCAFile,
+	)
+
+	cmd.AddCommand(
+		NewStartCommand(fs),
+		NewStopCommand(fs),
+		NewStatusCommand(fs),
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&adminURL,
+		config.FlagAdminHosts2,
+		"",
+		"Comma-separated list of admin API addresses (<IP>:<port>)")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/selftest_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/selftest_test.go
@@ -1,0 +1,240 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package selftest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterStatus(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		serverResponse  string
+		runningNodes    []int
+		isUninitialized bool
+	}{
+		{
+			name: "runningNodes all running case",
+			serverResponse: `[
+               {
+                 "node_id": 1,
+                 "status": "running"
+               },
+               {
+                 "node_id": 0,
+                 "status": "running"
+               },
+               {
+                 "node_id": 2,
+                 "status": "running"
+               }
+            ]`,
+			runningNodes:    []int{0, 1, 2},
+			isUninitialized: false,
+		},
+		{
+			name: "runningNodes some running case",
+			serverResponse: `[
+               {
+                 "node_id": 1,
+                 "status": "running"
+               },
+               {
+                 "node_id": 0,
+                 "status": "idle"
+               },
+               {
+                 "node_id": 2,
+                 "status": "idle"
+               }
+            ]`,
+			runningNodes:    []int{1},
+			isUninitialized: false,
+		},
+		{
+			name: "runningNodes method negative case",
+			serverResponse: `[
+               {
+                 "node_id": 1,
+                 "status": "idle"
+               },
+               {
+                 "node_id": 0,
+                 "status": "idle"
+               },
+               {
+                 "node_id": 2,
+                 "status": "idle"
+               }
+            ]`,
+			runningNodes:    []int{},
+			isUninitialized: true,
+		},
+		{
+			name: "isUninitialized some init'ed condition",
+			serverResponse: `[
+               {
+                 "node_id": 1,
+                 "status": "idle",
+                 "results": [{}]
+               },
+               {
+                 "node_id": 0,
+                 "status": "idle"
+               },
+               {
+                 "node_id": 2,
+                 "status": "idle"
+               }
+            ]`,
+			runningNodes:    []int{},
+			isUninitialized: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var reports []admin.SelfTestNodeReport
+			json.Unmarshal([]byte(test.serverResponse), &reports)
+			running := runningNodes(reports)
+			uninited := isUninitialized(reports)
+			require.Equal(t, test.runningNodes, running)
+			require.Equal(t, test.isUninitialized, uninited)
+		})
+	}
+}
+
+func TestSelfTestResults(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		serverResponse   string
+		expectedHeadings []string
+		expectedRows     map[int][][]string
+	}{
+		{
+			name: "makeReportTable() method w/ mixed report types",
+			serverResponse: `[
+               {
+                 "node_id": 1,
+                 "status": "idle",
+                 "results": [
+                   {
+                     "p50": 123,
+                     "p90": 456,
+                     "p99": 789,
+                     "p999": 999,
+                     "max_latency": 1200,
+                     "rps": 2222,
+                     "bps": 929283,
+                     "timeouts": 1,
+                     "test_id": "8272-3843-38c8-381f",
+                     "name": "unittesting",
+                     "info": "golang unit tests",
+                     "test_type": "disk",
+                     "duration": 50000,
+                     "warning": "Mild transient issue detected"
+                   }
+                 ]
+               },
+               {
+                 "node_id": 0,
+                 "status": "idle",
+                 "results": [
+                   {
+                     "timeouts": 55,
+                     "test_id": "8272-3843-38c8-381f",
+                     "name": "unittesting",
+                     "info": "golang unit tests",
+                     "test_type": "disk",
+                     "duration": 50000,
+                     "error": "Unexpected exception detected"
+                   }
+                 ]
+               },
+               {
+                 "node_id": 2,
+                 "status": "idle",
+                 "results": [
+                   {
+                     "timeouts": 78,
+                     "test_id": "8272-3843-38c8-381f",
+                     "name": "unittesting",
+                     "info": "golang unit tests",
+                     "test_type": "disk",
+                     "duration": 50000,
+                     "error": "Unexpected exception detected"
+                   }
+                 ]
+               }
+            ]`,
+			expectedHeadings: []string{
+				"NODE ID: 0 | STATUS: idle",
+				"NODE ID: 1 | STATUS: idle",
+				"NODE ID: 2 | STATUS: idle",
+			},
+			expectedRows: map[int][][]string{
+				1: {
+					{"NAME", "unittesting"},
+					{"INFO", "golang unit tests"},
+					{"TYPE", "disk"},
+					{"TEST ID", "8272-3843-38c8-381f"},
+					{"TIMEOUTS", "1"},
+					{"DURATION", "50000ms"},
+					{"IOPS", "2222 req/sec"},
+					{"THROUGHPUT", "907.5KiB/sec"},
+					{"WARNING", "Mild transient issue detected"},
+					{"LATENCY", "P50", "P90", "P99", "P999", "MAX"},
+					{"", "123us", "456us", "789us", "999us", "1200us"},
+					{""},
+				},
+				0: {
+					[]string{"NAME", "unittesting"},
+					[]string{"INFO", "golang unit tests"},
+					[]string{"TYPE", "disk"},
+					[]string{"TEST ID", "8272-3843-38c8-381f"},
+					[]string{"TIMEOUTS", "55"},
+					[]string{"DURATION", "50000ms"},
+					[]string{"ERROR", "Unexpected exception detected"},
+					[]string{""},
+				},
+				2: {
+					[]string{"NAME", "unittesting"},
+					[]string{"INFO", "golang unit tests"},
+					[]string{"TYPE", "disk"},
+					[]string{"TEST ID", "8272-3843-38c8-381f"},
+					[]string{"TIMEOUTS", "78"},
+					[]string{"DURATION", "50000ms"},
+					[]string{"ERROR", "Unexpected exception detected"},
+					[]string{""},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var reports []admin.SelfTestNodeReport
+			json.Unmarshal([]byte(test.serverResponse), &reports)
+			require.Equal(t, len(reports), len(test.expectedHeadings))
+			for _, report := range reports {
+				header := makeReportHeader(report)
+				require.Contains(t, test.expectedHeadings, header)
+				tableResults := makeReportTable(report)
+				expReport := test.expectedRows[report.NodeID]
+				totalRows := 0
+				for _, row := range tableResults {
+					require.Contains(t, expReport, row)
+					totalRows += 1
+				}
+				require.Equal(t, len(expReport), totalRows)
+			}
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
@@ -1,0 +1,150 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package selftest
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+
+	"github.com/docker/go-units"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewStartCommand(fs afero.Fs) *cobra.Command {
+	var (
+		noConfirm      bool
+		diskDurationMs uint
+		netDurationMs  uint
+		onNodes        []int
+		onlyDisk       bool
+		onlyNetwork    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Starts a new self test run",
+		Long: `Starts one or more pre-canned tests on a selection or all nodes
+of the cluster. Current tests that will run are:
+
+* Disk tests:
+  * Throughput test: 512k r/w sequential
+    * Higher request sizes and deeper io queue depth will sacrifice IOPS /
+      latency numbers in order to write / read more bytes in a shorter amount
+      of time.
+  * Latency test: 4k r/w sequential
+    * Smaller request sizes and lower levels of parallelism to achieve higher
+      IOPS and lower latency results.
+
+* Network tests:
+  * 8192b throughput test
+    * Unique pairs of redpanda nodes will act as either a client or server.
+    * Benchmark attempts to push as much data over the wire within the test
+      parameters.
+
+This command will immediately return once invoked with success. It is up to the
+user to periodically check back for the result set using the 'self-test status'
+command.`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			// Load config settings
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			// Warn user before continuing, proceed only via explicit signal
+			if !noConfirm {
+				confirmed, err := out.Confirm("Invoking the redpanda self tests may put excessive pressure on your system. It attempts to benchmark disk and network hardware to find their max throughputs. Its advised to not start the test if there are already large workloads running on the system.")
+				out.MaybeDie(err, "unable to confirm user confirmation: %v", err)
+				if !confirmed {
+					out.Exit("self-test start was cancelled")
+				}
+			}
+
+			// Create new HTTP client for communication w/ admin server
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			// Using cmd line args, assemble self_test_start_request body
+			tests := assembleTests(onlyDisk, onlyNetwork, diskDurationMs, netDurationMs)
+
+			// Make HTTP POST request to leader that starts the actual test
+			tid, err := cl.StartSelfTest(cmd.Context(), onNodes, tests)
+			out.MaybeDie(err, "unable to start self test: %v", err)
+			fmt.Printf("Redpanda self-test has started, test identifier: %v, To check the status run:\n    rpk redpanda admin self-test status", tid)
+		},
+	}
+
+	// Collect arguments via command line
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Acknowledge warning prompt skipping read from stdin")
+	cmd.Flags().UintVar(&diskDurationMs, "disk-duration-ms", 5000,
+		"The duration in milliseconds of individual disk test runs")
+	cmd.Flags().UintVar(&netDurationMs, "network-duration-ms", 5000,
+		"The duration in milliseconds of individual disk test runs")
+	cmd.Flags().IntSliceVar(&onNodes, "participant-node-ids", nil,
+		"ids of nodes that the tests will run on. Omitting this implies all nodes.")
+	cmd.Flags().BoolVar(&onlyDisk, "only-disk-test", false, "Runs only the disk benchmarks")
+	cmd.Flags().BoolVar(&onlyNetwork, "only-network-test", false, "Runs only network benchmarks")
+	cmd.MarkFlagsMutuallyExclusive("only-disk-test", "only-network-test")
+	return cmd
+}
+
+// assembleTests creates types of pre-canned tests depending on user input
+// 1. onlyDisk - Only runs the throughput/latency disk benchmarks
+// 2. onlyNetwork - Only runs the network benchmark
+// 3. All false - Runs the default which is the combination of option 1 & 2.
+func assembleTests(onlyDisk bool, onlyNetwork bool, durationDisk uint, durationNet uint) []any {
+	diskcheck := []any{
+		// One test weighted for better throughput results
+		admin.DiskcheckParameters{
+			Name:        "512K sequential r/w throughput disk test",
+			DSync:       true,
+			SkipWrite:   false,
+			SkipRead:    false,
+			DataSize:    1 * units.GiB,
+			RequestSize: 512 * units.KiB,
+			DurationMs:  durationDisk,
+			Parallelism: 4,
+			Type:        admin.DiskcheckTagIdentifier,
+		},
+		// .. and another for better latency/iops results
+		admin.DiskcheckParameters{
+			Name:        "4k sequential r/w latency/iops disk test",
+			DSync:       true,
+			SkipWrite:   false,
+			SkipRead:    false,
+			DataSize:    1 * units.GiB,
+			RequestSize: 512 * units.KiB,
+			DurationMs:  durationNet,
+			Parallelism: 2,
+			Type:        admin.DiskcheckTagIdentifier,
+		},
+	}
+	netcheck := []any{
+		admin.NetcheckParameters{
+			Name:        "8K Network Throughput Test",
+			RequestSize: 8192,
+			DurationMs:  durationNet,
+			Parallelism: 10,
+			Type:        admin.NetcheckTagIdentifier,
+		},
+	}
+	switch {
+	case onlyDisk:
+		return diskcheck
+	case onlyNetwork:
+		return netcheck
+	default:
+		return append(diskcheck, netcheck...)
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/status.go
@@ -1,0 +1,176 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package selftest
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/system"
+
+	"github.com/docker/go-units"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+const (
+	statusIdle    = "idle"
+	statusRunning = "running"
+)
+
+func NewStatusCommand(fs afero.Fs) *cobra.Command {
+	var format string
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Queries status of current self test run or returns last results",
+		Long: `Returns self-test current or previous state.
+
+Use this command after invoking 'self-test start' to determine the status of
+the jobs launched. Possible results are:
+
+* One or more jobs still running
+  * Node ids of redpanda nodes that are still running self-tests.
+
+* No jobs running:
+  * Last cached results on all nodes returned.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			// Load config settings
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			// Create new HTTP client for communication w/ admin server
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			// Make HTTP GET request to any node requesting for status
+			// Returns last runs results, or status of which nodes have jobs running
+			reports, err := cl.SelfTestStatus(cmd.Context())
+			out.MaybeDie(err, "unable to query self-test status: %v", err)
+
+			if format == "json" {
+				asJSON, err := json.MarshalIndent(reports, "", "\t")
+				out.MaybeDie(err, "unable to format response as JSON: %v", err)
+				fmt.Print(string(asJSON))
+				return
+			}
+
+			// If there is outstanding work, indicate which nodes, then exit
+			running := runningNodes(reports)
+			if len(running) > 0 {
+				fmt.Printf("Nodes %v are still running jobs\n", running)
+				return
+			}
+
+			// .. or redpanda has never run any tests, no cached data exists
+			if isUninitialized(reports) {
+				fmt.Println("All nodes are idle with no cached test results")
+				return
+			}
+
+			// In all other cases there are results, print them and exit
+			tw := out.NewTabWriter()
+			defer tw.Flush()
+			for _, report := range reports {
+				header := makeReportHeader(report)
+				tw.PrintColumn(header)
+				tw.PrintColumn(strings.Repeat("=", len(header)))
+				tableResults := makeReportTable(report)
+				for _, row := range tableResults {
+					all := rowDataAsInterface(row[1:])
+					tw.PrintColumn(row[0], all...)
+				}
+			}
+		},
+	}
+	cmd.Flags().StringVar(&format, "format", "text", "Output format (text, json)")
+	return cmd
+}
+
+func rowDataAsInterface(row []string) []interface{} {
+	var iarr []interface{}
+	for _, x := range row {
+		iarr = append(iarr, x)
+	}
+	return iarr
+}
+
+func runningNodes(reports []admin.SelfTestNodeReport) []int {
+	running := []int{}
+	for _, report := range reports {
+		if report.Status == statusRunning {
+			running = append(running, report.NodeID)
+		}
+	}
+	sort.Ints(running)
+	return running
+}
+
+func isUninitialized(reports []admin.SelfTestNodeReport) bool {
+	noResults := 0
+	for _, report := range reports {
+		if report.Status == statusIdle && len(report.Results) == 0 {
+			noResults += 1
+		}
+	}
+	return noResults == len(reports)
+}
+
+func makeReportHeader(report admin.SelfTestNodeReport) string {
+	return fmt.Sprintf("NODE ID: %d | STATUS: %s", report.NodeID, report.Status)
+}
+
+func makeReportTable(report admin.SelfTestNodeReport) [][]string {
+	var table [][]string
+	for _, sr := range report.Results {
+		table = append(table, []string{"NAME", sr.TestName})
+		if sr.TestInfo != "" {
+			table = append(table, []string{"INFO", sr.TestInfo})
+		}
+		table = append(table, []string{"TYPE", sr.TestType})
+		table = append(table, []string{"TEST ID", sr.TestID})
+		table = append(table, []string{"TIMEOUTS", fmt.Sprintf("%d", sr.Timeouts)})
+		table = append(table, []string{"DURATION", fmt.Sprintf("%dms", sr.Duration)})
+		if sr.Warning != nil {
+			table = append(table, []string{"WARNING", *sr.Warning})
+		}
+		if sr.Error != nil {
+			table = append(table, []string{"ERROR", *sr.Error})
+			table = append(table, []string{""})
+			continue
+		}
+		table = append(table, []string{"IOPS", fmt.Sprintf("%d req/sec", *sr.RequestsPerSec)})
+		throughput := ""
+		if sr.TestType == admin.NetcheckTagIdentifier {
+			throughput = system.BitsToHuman(float64(*sr.BytesPerSec))
+		} else {
+			throughput = units.BytesSize(float64(*sr.BytesPerSec))
+		}
+		table = append(table, []string{"THROUGHPUT", fmt.Sprintf("%s/sec", throughput)})
+		table = append(table, []string{"LATENCY", "P50", "P90", "P99", "P999", "MAX"})
+		table = append(table, []string{
+			"",
+			fmt.Sprintf("%dus", *sr.P50),
+			fmt.Sprintf("%dus", *sr.P90),
+			fmt.Sprintf("%dus", *sr.P99),
+			fmt.Sprintf("%dus", *sr.P999),
+			fmt.Sprintf("%dus", *sr.MaxLatency),
+		})
+		table = append(table, []string{""})
+	}
+	return table
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/stop.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package selftest
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewStopCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stops the currently executing self test",
+		Long: `Stops all self tests.
+
+For use with the redpanda self-test framework, this command will stop all currently
+executing self-tests cluster wide. The command is synchronous and will return
+when either:
+
+* all jobs have been stopped - success reported
+* broker timeouts have expired - errors reported
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			// Load config settings
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			// Create new HTTP client for communication w/ admin server
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			// Make HTTP POST request to leader that stops all self tests on all nodes
+			err = cl.StopSelfTest(cmd.Context())
+			out.MaybeDie(err, "unable to stop self test: %v", err)
+
+			fmt.Print("All self-test jobs have been stopped\n")
+		},
+	}
+}

--- a/src/go/rpk/pkg/system/utils.go
+++ b/src/go/rpk/pkg/system/utils.go
@@ -10,6 +10,7 @@
 package system
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
@@ -33,6 +34,25 @@ func UnameAndDistro(timeout time.Duration) (string, error) {
 		res += " " + ls[0]
 	}
 	return res, nil
+}
+
+// Returns a string representation of the input in terms of Gib/Mib/Kib or bits
+// depending on how large the input is.
+func BitsToHuman(bytes float64) string {
+	bits := bytes * 8
+	asGib := bits / (1 << 30)
+	asMib := bits / (1 << 20)
+	asKib := bits / (1 << 10)
+	if asGib > 1.0 {
+		return fmt.Sprintf("%.2fGib", asGib)
+	}
+	if asMib > 1.0 {
+		return fmt.Sprintf("%.2fMib", asMib)
+	}
+	if asKib > 1.0 {
+		return fmt.Sprintf("%.2fKib", asKib)
+	}
+	return fmt.Sprintf("%v", bytes)
 }
 
 func int8ToString(ints [65]int8) string {

--- a/src/v/cluster/self_test/diskcheck.cc
+++ b/src/v/cluster/self_test/diskcheck.cc
@@ -157,6 +157,7 @@ diskcheck::run_configured_benchmarks(ss::file& file) {
     auto result = write_metrics.to_st_result();
     result.name = _opts.name;
     result.info = "write run";
+    result.test_type = "disk";
     if (_cancelled) {
         result.warning = "Run was manually cancelled";
     }
@@ -167,6 +168,7 @@ diskcheck::run_configured_benchmarks(ss::file& file) {
         auto result = read_metrics.to_st_result();
         result.name = _opts.name;
         result.info = "read run";
+        result.test_type = "disk";
         if (_cancelled) {
             result.warning = "Run was manually cancelled";
         }

--- a/src/v/cluster/self_test/netcheck.cc
+++ b/src/v/cluster/self_test/netcheck.cc
@@ -119,6 +119,7 @@ netcheck::run_individual_benchmark(model::node_id peer) {
     }
     result.name = _opts.name;
     result.info = fmt::format("Test performed against node: {}", peer);
+    result.test_type = "network";
     co_return result;
 }
 

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -60,13 +60,14 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
             } else {
                 results.push_back(self_test_result{
                   .name = dto.name,
+                  .test_type = "disk",
                   .warning = "Disk self test prevented from starting due to "
                              "cancel signal"});
             }
         } catch (const std::exception& ex) {
             vlog(clusterlog.warn, "Disk self test finished with error");
-            results.push_back(
-              self_test_result{.name = dto.name, .error = ex.what()});
+            results.push_back(self_test_result{
+              .name = dto.name, .test_type = "disk", .error = ex.what()});
         }
     }
     for (auto& nto : ntos) {
@@ -81,6 +82,7 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
                 } else {
                     results.push_back(self_test_result{
                       .name = nto.name,
+                      .test_type = "network",
                       .warning
                       = "Network self test prevented from starting due to "
                         "cancel signal"});
@@ -88,12 +90,13 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
             } else {
                 results.push_back(self_test_result{
                   .name = nto.name,
+                  .test_type = "network",
                   .warning = "No peers to start network test against"});
             }
         } catch (const std::exception& ex) {
             vlog(clusterlog.warn, "Network self test finished with error");
-            results.push_back(
-              self_test_result{.name = nto.name, .error = ex.what()});
+            results.push_back(self_test_result{
+              .name = nto.name, .test_type = "network", .error = ex.what()});
         }
     }
     co_return results;

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -65,7 +65,11 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
                              "cancel signal"});
             }
         } catch (const std::exception& ex) {
-            vlog(clusterlog.warn, "Disk self test finished with error");
+            vlog(
+              clusterlog.warn,
+              "Disk self test finished with error: {} - options: {}",
+              ex.what(),
+              dto);
             results.push_back(self_test_result{
               .name = dto.name, .test_type = "disk", .error = ex.what()});
         }
@@ -94,7 +98,11 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
                   .warning = "No peers to start network test against"});
             }
         } catch (const std::exception& ex) {
-            vlog(clusterlog.warn, "Network self test finished with error");
+            vlog(
+              clusterlog.warn,
+              "Network self test finished with error: {} - options: {}",
+              ex.what(),
+              nto);
             results.push_back(self_test_result{
               .name = nto.name, .test_type = "network", .error = ex.what()});
         }

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -185,19 +185,19 @@ struct netcheck_opts
 struct self_test_result
   : serde::
       envelope<self_test_result, serde::version<0>, serde::compat_version<0>> {
-    double p50;
-    double p90;
-    double p99;
-    double p999;
-    double max;
-    uint64_t rps;
-    uint64_t bps;
-    uint32_t timeouts;
+    double p50{0};
+    double p90{0};
+    double p99{0};
+    double p999{0};
+    double max{0};
+    uint64_t rps{0};
+    uint64_t bps{0};
+    uint32_t timeouts{0};
     uuid_t test_id;
     ss::sstring name;
     ss::sstring info;
     ss::sstring test_type;
-    ss::lowres_clock::duration duration;
+    ss::lowres_clock::duration duration{};
     std::optional<ss::sstring> warning;
     std::optional<ss::sstring> error;
 

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -196,6 +196,7 @@ struct self_test_result
     uuid_t test_id;
     ss::sstring name;
     ss::sstring info;
+    ss::sstring test_type;
     ss::lowres_clock::duration duration;
     std::optional<ss::sstring> warning;
     std::optional<ss::sstring> error;
@@ -205,8 +206,8 @@ struct self_test_result
         fmt::print(
           o,
           "{{p50: {} p90: {} p99: {} p999: {} max: {} rps: {} bps: {} "
-          "timeouts: {} test_id: {} name: {} info: {} duration: {}ms warning: "
-          "{} error: {}}}",
+          "timeouts: {} test_id: {} name: {} info: {} type: {} duration: {}ms "
+          "warning: {} error: {}}}",
           r.p50,
           r.p90,
           r.p99,
@@ -218,6 +219,7 @@ struct self_test_result
           r.test_id,
           r.name,
           r.info,
+          r.test_type,
           std::chrono::duration_cast<std::chrono::milliseconds>(r.duration)
             .count(),
           r.warning ? *r.warning : "<no_value>",

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -231,6 +231,10 @@
                     "type": "string",
                     "description": "Additional test labels, metadata and/or information"
                 },
+                "test_type": {
+                    "type": "string",
+                    "description": "Type of self test, one of either disk/network"
+                },
                 "duration": {
                     "type": "long",
                     "description": "Length of time the test took to complete"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3176,12 +3176,20 @@ admin_server::self_test_stop_handler(std::unique_ptr<ss::httpd::request> req) {
 static ss::httpd::debug_json::self_test_result
 self_test_result_to_json(const cluster::self_test_result& str) {
     ss::httpd::debug_json::self_test_result r;
+    r.test_id = ss::sstring(str.test_id);
+    r.name = str.name;
+    r.info = str.info;
+    r.test_type = str.test_type;
+    r.duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                   str.duration)
+                   .count();
+    r.timeouts = str.timeouts;
+    if (str.warning) {
+        r.warning = *str.warning;
+    }
     if (str.error) {
         r.error = *str.error;
         return r;
-    }
-    if (str.warning) {
-        r.warning = *str.warning;
     }
     r.p50 = str.p50;
     r.p90 = str.p90;
@@ -3190,14 +3198,6 @@ self_test_result_to_json(const cluster::self_test_result& str) {
     r.max_latency = str.max;
     r.rps = str.rps;
     r.bps = str.bps;
-    r.timeouts = str.timeouts;
-    r.test_id = ss::sstring(str.test_id);
-    r.name = str.name;
-    r.info = str.info;
-    r.test_type = str.test_type;
-    r.duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-                   str.duration)
-                   .count();
     return r;
 }
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3194,6 +3194,7 @@ self_test_result_to_json(const cluster::self_test_result& str) {
     r.test_id = ss::sstring(str.test_id);
     r.name = str.name;
     r.info = str.info;
+    r.test_type = str.test_type;
     r.duration = std::chrono::duration_cast<std::chrono::milliseconds>(
                    str.duration)
                    .count();

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import json
 import subprocess
 import re
 import typing
@@ -642,6 +643,48 @@ class RpkTool:
             self._rpk_binary(), 'wasm', 'generate', '--skip-version', directory
         ]
         return self._execute(cmd)
+
+    def self_test_start(self,
+                        disk_duration_ms=None,
+                        network_duration_ms=None,
+                        only_disk=False,
+                        only_network=False,
+                        only_connectivity=False,
+                        node_ids=None):
+        cmd = [
+            self._rpk_binary(), '--api-urls',
+            self._admin_host(), 'cluster', 'self-test', 'start', '--no-confirm'
+        ]
+        if disk_duration_ms is not None:
+            cmd += ['--disk-duration-ms', str(disk_duration_ms)]
+        if network_duration_ms is not None:
+            cmd += ['--network-duration-ms', str(network_duration_ms)]
+        if only_disk is True:
+            cmd += ['--only-disk-test']
+        if only_network is True:
+            cmd += ['--only-network-test']
+        if only_connectivity is True:
+            cmd += ['--only-connectivity-test']
+        if node_ids is not None:
+            ids = ",".join([str(x) for x in node_ids])
+            cmd += ['--participants-node-ids', ids]
+        return self._execute(cmd)
+
+    def self_test_stop(self):
+        cmd = [
+            self._rpk_binary(), '--api-urls',
+            self._admin_host(), 'cluster', 'self-test', 'stop'
+        ]
+        return self._execute(cmd)
+
+    def self_test_status(self, output_format='json'):
+        cmd = [
+            self._rpk_binary(), '--api-urls',
+            self._admin_host(), 'cluster', 'self-test', 'status', '--format',
+            output_format
+        ]
+        output = self._execute(cmd)
+        return json.loads(output) if output_format == 'json' else output
 
     def _run_topic(self, cmd, stdin=None, timeout=None):
         cmd = [self._rpk_binary(), "topic"] + self._kafka_conn_settings() + cmd

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -10,16 +10,18 @@
 import time
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from ducktape.utils.util import wait_until
+from rptest.util import wait_until_result
 
 
 class SelfTestTest(RedpandaTest):
     """Tests for the redpanda self test feature."""
     def __init__(self, ctx):
         super(SelfTestTest, self).__init__(test_context=ctx)
-        self._admin = Admin(self.redpanda)
+        self._rpk = RpkTool(self.redpanda)
 
     def wait_for_self_test_completion(self):
         """
@@ -27,80 +29,33 @@ class SelfTestTest(RedpandaTest):
         status in the self_test_status() API
         """
         def all_idle():
-            node_reports = self._admin.self_test_status()
-            return not any([x['status'] == 'running' for x in node_reports])
+            node_reports = self._rpk.self_test_status()
+            return not any([x['status'] == 'running'
+                            for x in node_reports]), node_reports
 
-        wait_until(all_idle, timeout_sec=30, backoff_sec=1)
-
-    def _disk_test_parameters(self, name, duration_ms):
-        return {
-            'type': 'disk',
-            'name': name,
-            'duration_ms': duration_ms,
-            'skip_read': False,
-            'skip_write': False,
-            'dsync': False,
-            'data_size': 10 << 20,  # 10 MiB
-            'request_size': 2 << 11,  # 4 KiB
-            'parallelism': 4
-        }
-
-    def _network_test_parameters(self, name, duration_ms):
-        return {
-            'type': 'network',
-            'name': name,
-            'request_size': 2 << 11,  # 4KiB
-            'duration_ms': duration_ms,
-            'parallelism': 4
-        }
-
-    def _self_test_options(self,
-                           disk_test_name_and_duration,
-                           network_test_name_and_duration,
-                           nodes=None):
-        (dt_name, dt_duration) = disk_test_name_and_duration
-        (nt_name, nt_duration) = network_test_name_and_duration
-        test_options = {
-            'tests': [
-                self._disk_test_parameters(dt_name, dt_duration),
-                self._network_test_parameters(nt_name, nt_duration)
-            ]
-        }
-        if nodes is not None:
-            test_options['nodes'] = nodes
-        return test_options
+        return wait_until_result(all_idle, timeout_sec=30, backoff_sec=1)
 
     @cluster(num_nodes=3)
     def test_self_test(self):
         """Assert the self test starts/completes with success."""
-        test_options = self._self_test_options(('ducktape dsk', 1000),
-                                               ('ducktape net', 1000))
-
-        # Launch the self test with the options above
-        assert self._admin.self_test_start(test_options).status_code == 200
+        self._rpk.self_test_start(1000, 1000)
 
         # Wait for completion
-        self.wait_for_self_test_completion()
+        node_reports = self.wait_for_self_test_completion()
 
         # Verify returned results
-        node_reports = self._admin.self_test_status()
         for node in node_reports:
             assert node['status'] == 'idle'
             assert node.get('results') is not None
             for report in node['results']:
                 assert 'error' not in report
                 assert 'warning' not in report
-                assert 'duration' in report
-                assert report['duration'] > 0
+                assert report['duration'] > 0, report['duration']
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_self_test_node_crash(self):
         """Assert the self test starts/completes with success."""
-        test_options = self._self_test_options(('ducktape dsk', 3000),
-                                               ('ducktape net', 3000))
-
-        # Launch the self test with the options above
-        assert self._admin.self_test_start(test_options).status_code == 200
+        self._rpk.self_test_start(3000, 3000)
 
         # Allow for some work be done
         time.sleep(1)
@@ -111,12 +66,11 @@ class SelfTestTest(RedpandaTest):
         self.redpanda.stop_node(self.redpanda.get_node(stopped_nid))
 
         # Wait for completion
-        self.wait_for_self_test_completion()
+        node_reports = self.wait_for_self_test_completion()
 
         # Verify returned results
-        all_status = self._admin.self_test_status()
         good_node_reports = [
-            x for x in all_status if x['node_id'] != stopped_nid
+            x for x in node_reports if x['node_id'] != stopped_nid
         ]
         for node in good_node_reports:
             assert node['status'] == 'idle'
@@ -128,10 +82,9 @@ class SelfTestTest(RedpandaTest):
                         'error'] == f'Failed to reach peer with node_id: {stopped_nid}'
                 else:
                     assert 'warning' not in report
-                    assert 'duration' in report
-                    assert report['duration'] > 0
+                    assert report['duration'] > 0, report['duration']
         crashed_nodes_report = [
-            x for x in all_status if x['node_id'] == stopped_nid
+            x for x in node_reports if x['node_id'] == stopped_nid
         ][0]
         assert crashed_nodes_report['status'] == 'unreachable'
         assert crashed_nodes_report.get('results') is None
@@ -141,19 +94,16 @@ class SelfTestTest(RedpandaTest):
         """Assert the self test can cancel an action on command."""
         disk_test_time = 5000  # ms
         network_test_time = 5000  # ms
-        test_options = self._self_test_options(
-            ('ducktape dsk', disk_test_time),
-            ('ducktape net', network_test_time))
 
         # Launch the self test with the options above
+        self._rpk.self_test_start(disk_test_time, network_test_time)
         start = time.time()
-        assert self._admin.self_test_start(test_options).status_code == 200
 
         # Wait a second, then send a stop() request
         time.sleep(1)
 
         # Stop is synchronous and will return when all jobs have stopped
-        assert self._admin.self_test_stop().status_code == 200
+        self._rpk.self_test_stop()
 
         # Assert that at least a second of total recorded test time has
         # passed between start & stop calls
@@ -162,14 +112,15 @@ class SelfTestTest(RedpandaTest):
         assert total_time_sec < (disk_test_time + network_test_time)
 
         # Ensure system is in an idle state and contains expected report
-        node_reports = self._admin.self_test_status()
+        node_reports = self._rpk.self_test_status()
         for node in node_reports:
             assert node['status'] == 'idle'
             assert node.get('results') is not None
             for report in node['results']:
                 assert 'error' not in report, report['error']
+                # Match for string 'cancel' in warning
                 assert 'warning' in report
-                assert 'duration' in report
+                assert report['warning'].find('cancel') != -1
                 # If test was running it was cancelled otherwise it was
                 # cancelled before it even had a chance to start, resulting in
                 # a 0 value for duration


### PR DESCRIPTION
This patchset adds introduction for the end user to start/stop/view self test runs and results, all via the `rpk` command:

```
➜ rpk cluster self-test --help

Start, stop and query redpanda self-test runs through the admin listener

Usage:
  rpk cluster self-test [command]

Available Commands:
  start       Starts a new self test run
  status      Queries status of current self test run or returns last results
  stop        Stops the currently executing self test

Flags:
  -h, --help   Help for self-test
```

## Usage

### Start

The customer can start a test at any time using the `start` command.

```
➜ rpk cluster self-test start --help
Starts a new self test run

Usage:
  rpk cluster self-test start [flags]

Flags:
      --disk-duration-ms int        The duration in milliseconds of individual disk test runs (default 5000)
  -h, --help                        Help for start
      --network-duration-ms int     The duration in milliseconds of individual disk test runs (default 5000)
      --only-disk-test              Runs only the disk benchmarks
      --only-network-test           Runs only network benchmarks
      --participant-node-ids ints   ids of nodes that the tests will run on. Omitting this implies all nodes.
      --no-confirm                         Acknowledge warning prompt skipping read from stdin
```
There are high level options to modify test duration, to run a subset of tests and/or to run the tests only on a particular set of nodes. If tests are already running, they will be stopped automatically behind the scenes and this new start command will prevail. On success it prints the `test_uuid` to the console.

### Status

Once results are available they will be printed in table format (unless `format=json` was specified), looking something like this:
```
➜ rpk cluster self-test status
Nodes [0 1 2] are still running jobs                        
➜ rpk cluster self-test status
NodeID: 0 | Status: idle                                    
=========================                                   
NAME        4k sequential r/w latency/iops disk test        
INFO        write run                                       
TYPE        disk                                            
TEST ID:    345a68b8-98e7-4146-8dfa-7ab39e2bcbba            
TIMEOUTS:   0                                               
DURATION    5019ms                                                                                                      
IOPS        99 requests/sec                                 
THROUGHPUT  399.20KiB/sec                                                                                               
LATENCY     P50      P90      P99      P999     Max         
            20479us  24575us  31743us  34815us  34815us                                                                 
...
```
If there are still nodes running jobs a list of node ids and their respective status' will be returned.

### Stop

At any given time the tests may be stopped. Stop is a synchronous command that returns when all jobs have been confirmed to stop. Subsequent queries will show result sets that indicate that jobs were cancelled.

```
➜ rpk cluster self-test stop
All self-test jobs have been stopped

➜ rpk cluster self-test status

NAME        8K Network Throughput Test
INFO        
TYPE        network
TEST ID:    d851f307-81d1-4aec-a2d7-f5d7632b0924
DURATION    0ms
WARNING     Network self test prevented from starting due to cancel signal
IOPS        0 requests/sec
THROUGHPUT  0/sec
LATENCY     P50   P90   P99   P999  Max
            0us   0us   0us   0us   0us
...            
```

## Backports Required

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

Support for integration with redpanda self tests via the rpk command. New commands are:
- rpk cluster self-test start
- rpk cluster self-test stop
- rpk cluster self-test status

## Release Notes

  ### Features

  * Self test rpk integration
