### PR TITLE
config_manager: subscribe to raft0 leadership change notifications

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -552,7 +552,8 @@ ss::future<> config_manager::reconcile_status() {
             co_await _reconcile_wait.wait(status_retry);
         } else {
             // We are clean: sleep until signalled.
-            co_await _reconcile_wait.wait();
+            co_await _reconcile_wait.wait(
+              [this]() { return should_send_status(); });
         }
     } catch (ss::condition_variable_timed_out&) {
         // Wait complete - proceed around next loop of do_until

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -223,6 +223,13 @@ ss::future<> config_manager::start() {
             handle_cluster_members_update(std::move(current_members));
         });
 
+    _raft0_leader_changed_notification
+      = _leaders.local().register_leadership_change_notification(
+        model::controller_ntp,
+        [this](model::ntp, model::term_id, std::optional<model::node_id>) {
+            _reconcile_wait.signal();
+        });
+
     return ss::now();
 }
 void config_manager::handle_cluster_members_update(
@@ -240,6 +247,8 @@ ss::future<> config_manager::stop() {
     _reconcile_wait.broken();
     _members.local().unregister_members_updated_notification(
       _member_removed_notification);
+    _leaders.local().unregister_leadership_change_notification(
+      _raft0_leader_changed_notification);
     co_await _gate.close();
 }
 
@@ -540,13 +549,7 @@ ss::future<> config_manager::reconcile_status() {
 
     try {
         if (failed || should_send_status()) {
-            // * we were dirty & failed to send our update, sleep until retry
-            // OR
-            // * our status updated while we were sending, wait a short time
-            //   before sending our next update to avoid spamming the leader
-            //   with too many set_status RPCs if we are behind on seeing
-            //   updates to the controller log.
-            co_await ss::sleep_abortable(status_retry, _as.local());
+            co_await _reconcile_wait.wait(status_retry);
         } else {
             // We are clean: sleep until signalled.
             co_await _reconcile_wait.wait();
@@ -555,8 +558,6 @@ ss::future<> config_manager::reconcile_status() {
         // Wait complete - proceed around next loop of do_until
     } catch (ss::broken_condition_variable&) {
         // Shutting down - nextiteration will drop out
-    } catch (ss::sleep_aborted&) {
-        // Shutting down - next iteration will drop out
     }
 }
 

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -125,6 +125,7 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<cluster::members_table>& _members;
     notification_id_type _member_removed_notification;
+    notification_id_type _raft0_leader_changed_notification;
 
     ss::condition_variable _reconcile_wait;
     ss::sharded<ss::abort_source>& _as;


### PR DESCRIPTION
Instead of a timed wait, use a condition variable that is signaled on a raft0 leadership change.

Fixes #8328


<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
