### PR TITLE
Fix `ControllerEraseTest.test_erase_controller_log`

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -15,6 +15,7 @@
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
 #include "cluster/scheduling/leader_balancer.h"
+#include "model/fundamental.h"
 #include "raft/fwd.h"
 #include "rpc/fwd.h"
 #include "security/fwd.h"
@@ -147,6 +148,14 @@ public:
      * Called when the node is ready to become a leader
      */
     ss::future<> set_ready();
+
+    ss::future<model::offset> get_last_applied_offset() {
+        return _stm.invoke_on(controller_stm_shard, [](auto& stm) {
+            return stm.get_last_applied_offset();
+        });
+    }
+
+    model::offset get_commited_index() { return _raft0->committed_offset(); }
 
 private:
     friend controller_probe;

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -134,6 +134,8 @@ public:
       ss::abort_source& as,
       std::optional<model::term_id> term = std::nullopt);
 
+    model::offset get_last_applied_offset() { return last_applied_offset(); }
+
 private:
     using promise_t = expiring_promise<std::error_code>;
 

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -132,6 +132,21 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/controller_status",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get last_applied_offset and commited_index for controller log",
+                    "type": "controller_status",
+                    "nickname": "get_controller_status",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
     ],
     "models": {
@@ -180,6 +195,20 @@
                 "since_last_status": {
                     "type": "long",
                     "description": "Milliseconds since last update from peer"
+                }
+            }
+        },
+        "controller_status": {
+            "id": "controller_status",
+            "description": "Controller status",
+            "properties": {
+                "last_applied_offset": {
+                    "type": "long",
+                    "description": "Last applied offset for controller stm"
+                },
+                "commited_index": {
+                    "type": "long",
+                    "description": "Commited index for controller consensus"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3310,6 +3310,21 @@ void admin_server::register_debug_routes() {
           return ss::make_ready_future<ss::json::json_return_type>(
             _metadata_cache.local().is_node_isolated());
       });
+
+    register_route<user>(
+      seastar::httpd::debug_json::get_controller_status,
+      [this](std::unique_ptr<ss::httpd::request>)
+        -> ss::future<ss::json::json_return_type> {
+          return _controller->get_last_applied_offset().then(
+            [this](auto offset) {
+                using result_t = ss::httpd::debug_json::controller_status;
+                result_t ans;
+                ans.last_applied_offset = offset;
+                ans.commited_index = _controller->get_commited_index();
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::json_return_type(ans));
+            });
+      });
 }
 ss::future<ss::json::json_return_type>
 admin_server::get_partition_balancer_status_handler(

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -774,6 +774,10 @@ class Admin:
         return self._request("GET", f"debug/peer_status/{peer_id}",
                              node=node).json()
 
+    def get_controller_status(self, node):
+        return self._request("GET", f"debug/controller_status",
+                             node=node).json()
+
     def get_cluster_uuid(self, node):
         try:
             r = self._request("GET", "cluster/uuid", node=node)


### PR DESCRIPTION
This pr added new admin_api request, which returns last_applied_offset and commited_index for controller log. And test now delete all segment with start_offset > `last_applied_offset`

### Problem in test was:

Test delete last segment from disk and after startup node should signal that last_applied_offset does not present on the disk.
But in this test run node only replicated last controller log segment, but not applied it. So last_applied_offset was from another segment on the disk, which test did not delete.


Fixes #8217

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes
* none

## Release Notes

  * new admin_api request `/v1/debug/controller_status`