### PR TITLE
ducktape/kerberos: Use FQDN for Kerberos testing

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -613,6 +613,7 @@ class RedpandaService(Service):
     # When configuring multiple listeners for testing, a secondary port to use
     # instead of the default.
     KAFKA_ALTERNATE_PORT = 9093
+    KAFKA_KERBEROS_PORT = 9094
     ADMIN_ALTERNATE_PORT = 9647
 
     CLUSTER_CONFIG_DEFAULTS = {
@@ -1962,6 +1963,15 @@ class RedpandaService(Service):
         with self.config_file_lock:
             return super(RedpandaService, self).render(path, **kwargs)
 
+    @staticmethod
+    def get_node_fqdn(node):
+        ip = socket.gethostbyname(node.account.hostname)
+        hostname = node.account.ssh_output(cmd=f"dig -x {ip} +short").decode(
+            'utf-8').split('\n')[0].removesuffix(".")
+        fqdn = node.account.ssh_output(
+            cmd=f"host {hostname}").decode('utf-8').split(' ')[0]
+        return fqdn
+
     def write_node_conf_file(self,
                              node,
                              override_cfg_params=None,
@@ -1987,6 +1997,10 @@ class RedpandaService(Service):
         # exercise code paths that deal with multiple listeners
         node_ip = socket.gethostbyname(node.account.hostname)
 
+        # Grab the node's FQDN which is needed for Kerberos name
+        # resolution
+        fqdn = self.get_node_fqdn(node)
+
         conf = self.render("redpanda.yaml",
                            node=node,
                            data_dir=RedpandaService.DATA_DIR,
@@ -1996,6 +2010,8 @@ class RedpandaService(Service):
                            seed_servers=self._seed_servers,
                            node_ip=node_ip,
                            kafka_alternate_port=self.KAFKA_ALTERNATE_PORT,
+                           kafka_kerberos_port=self.KAFKA_KERBEROS_PORT,
+                           fqdn=fqdn,
                            admin_alternate_port=self.ADMIN_ALTERNATE_PORT,
                            pandaproxy_config=self._pandaproxy_config,
                            schema_registry_config=self._schema_registry_config,
@@ -2329,12 +2345,18 @@ class RedpandaService(Service):
             for tokens in map(lambda l: l.split(), lines)
         }
 
-    def broker_address(self, node):
+    def broker_address(self, node, listener: str = "dnslistener"):
         assert node in self.nodes, f"where node is {node.name}"
         assert node in self._started
         cfg = self._node_configs[node]
         if cfg['redpanda']['kafka_api']:
-            return f"{node.account.hostname}:{one_or_many(cfg['redpanda']['kafka_api'])['port']}"
+            if isinstance(cfg['redpanda']['kafka_api'], list):
+                for entry in cfg['redpanda']['kafka_api']:
+                    if entry['name'] == listener:
+                        return f'{entry["address"]}:{entry["port"]}'
+            else:
+                entry = cfg["redpanda"]["kafka_api"]
+                return f'{entry["address"]}:{entry["port"]}'
         else:
             return None
 
@@ -2350,11 +2372,15 @@ class RedpandaService(Service):
     def admin_endpoints(self):
         return ",".join(self.admin_endpoints_list())
 
-    def brokers(self, limit=None) -> str:
-        return ",".join(self.brokers_list(limit))
+    def brokers(self, limit=None, listener: str = "dnslistener") -> str:
+        return ",".join(self.brokers_list(limit, listener))
 
-    def brokers_list(self, limit=None) -> list[str]:
-        brokers = [self.broker_address(n) for n in self._started[:limit]]
+    def brokers_list(self,
+                     limit=None,
+                     listener: str = "dnslistener") -> list[str]:
+        brokers = [
+            self.broker_address(n, listener) for n in self._started[:limit]
+        ]
         brokers = [b for b in brokers if b is not None]
         random.shuffle(brokers)
         return brokers

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -31,6 +31,9 @@ redpanda:
       {% if endpoint_authn_method %}
       authentication_method: {{ endpoint_authn_method }}
       {% endif %}
+    - name: kerberoslistener
+      address: "{{fqdn}}"
+      port: {{kafka_kerberos_port}}
   admin:
     - address: 127.0.0.1
       port: 9644

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -59,17 +59,6 @@ class RedpandaKerberosTestBase(Test):
 
         self.client = KrbClient(test_context, self.kdc, self.redpanda)
 
-    def _service_principal(self, primary: str, node):
-        ip = socket.gethostbyname(node.account.hostname)
-        out = node.account.ssh_output(cmd=f"dig -x {ip} +short")
-        hostname = out.decode('utf-8').split('\n')[0].removesuffix(".")
-        fqdn = node.account.ssh_output(
-            cmd=f"host {hostname}").decode('utf-8').split(' ')[0]
-        return f"{primary}/{fqdn}@{REALM}"
-
-    def _client_principal(self, primary):
-        return f"{primary}@{REALM}"
-
     def setUp(self):
         self.redpanda.logger.info("Starting KDC")
         self.kdc.start()


### PR DESCRIPTION
Kerberos is very sensitive to hostnames and it must use fully qualified domain names (FQDNs) to reference hosts that are registered with the KDC.  The Redpanda dnslistener uses only the hostname for its address however that is insufficient for kerberos.  This change adds in a new kerberos listener to the Redpanda configuration that uses the FQDN.

Co-authored-by: Michael Boquard <michael@redpanda.com>
Co-authored-by: Ben Pope <ben@redpanda.com>
Signed-off-by: Michael Boquard <michael@redpanda.com>

Force push `925c7e8`:

* Removed `kerberos_brokers` and added `listener` option to `brokers` method
* Removed unused code line
* Created static `get_node_fqdn` to `RedpandaService` class

Force push `4715143`

* Removed authentication method from redpanda config template for kerberoslistener as was causing mtls tests to fail

Force push `1873d18`:

* Fixed issue when `kafka_api` configuration is not a list

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

* none

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

* none
