### PR TITLE
cloud_roles: handle connection timeout

### DIFF
--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -14,9 +14,7 @@
 #include "cloud_roles/aws_sts_refresh_impl.h"
 #include "cloud_roles/gcp_refresh_impl.h"
 #include "cloud_roles/logger.h"
-#include "cloud_roles/request_response_helpers.h"
 #include "config/configuration.h"
-#include "config/node_config.h"
 #include "model/metadata.h"
 #include "net/tls.h"
 
@@ -36,7 +34,8 @@ struct override_api_endpoint_env_vars {
 /// Multiplier to derive sleep duration from expiry time. Leaves 0.1 * expiry
 /// seconds as buffer to make API calls. For default expiry of 1 hour, this
 /// results in a fetch after 54 minutes.
-static constexpr float sleep_from_expiry_multiplier = 0.9;
+constexpr float sleep_from_expiry_multiplier = 0.9;
+constexpr std::chrono::milliseconds max_retry_interval_ms{300000};
 
 refresh_credentials::refresh_credentials(
   std::unique_ptr<impl> impl,
@@ -208,7 +207,19 @@ std::chrono::milliseconds refresh_credentials::impl::calculate_sleep_duration(
 void refresh_credentials::impl::increment_retries() {
     _retries += 1;
     auto sleep_ms = _retry_params.backoff_ms * (2 * _retries);
-    vlog(clrl_log.info, "retry after {} ms", sleep_ms);
+    vlog(
+      clrl_log.debug,
+      "Failed to refresh credentials, will retry after {}",
+      sleep_ms);
+    if (sleep_ms > max_retry_interval_ms) {
+        sleep_ms = max_retry_interval_ms;
+        vlog(
+          clrl_log.warn,
+          "Retry interval capped to {} after {} failed attempts to refresh "
+          "credentials",
+          sleep_ms,
+          _retries);
+    }
     _sleep_duration = sleep_ms;
 }
 

--- a/src/v/cloud_roles/request_response_helpers.cc
+++ b/src/v/cloud_roles/request_response_helpers.cc
@@ -12,6 +12,7 @@
 
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iostream.h"
+#include "config/configuration.h"
 #include "json/istreamwrapper.h"
 #include "logger.h"
 
@@ -79,8 +80,10 @@ ss::future<api_response> static do_request(
 static ss::future<api_response> make_get_request(
   http::client& client,
   http::client::request_header req,
-  std::chrono::milliseconds timeout) {
-    auto response_stream = co_await client.request(std::move(req), timeout);
+  std::optional<std::chrono::milliseconds> timeout) {
+    auto tout = timeout.value_or(
+      config::shard_local_cfg().cloud_storage_roles_operation_timeout_ms);
+    auto response_stream = co_await client.request(std::move(req), tout);
     auto status = co_await get_status(response_stream);
     if (is_retryable(status)) {
         co_return make_retryable_error(
@@ -97,11 +100,13 @@ static ss::future<api_response> make_get_request(
 ss::future<api_response> make_request(
   http::client client,
   http::client::request_header req,
-  std::chrono::milliseconds timeout) {
+  std::optional<std::chrono::milliseconds> timeout) {
+    auto tout = timeout.value_or(
+      config::shard_local_cfg().cloud_storage_roles_operation_timeout_ms);
     return http::with_client(
-      std::move(client), [req = std::move(req), timeout](auto& client) mutable {
-          return do_request(req, [&client, timeout](auto& req) mutable {
-              return make_get_request(client, req, timeout);
+      std::move(client), [req = std::move(req), tout](auto& client) mutable {
+          return do_request(req, [&client, tout](auto& req) mutable {
+              return make_get_request(client, req, tout);
           });
       });
 }
@@ -119,13 +124,15 @@ static ss::future<api_response> make_post_request(
   http::client& client,
   http::client::request_header& req,
   iobuf content,
-  std::chrono::milliseconds timeout) {
+  std::optional<std::chrono::milliseconds> timeout) {
     req.set(
       boost::beast::http::field::content_length,
       boost::beast::to_static_string(content.size_bytes()));
 
     auto stream = make_iobuf_input_stream(std::move(content));
-    auto response = co_await client.request(std::move(req), stream, timeout);
+    auto tout = timeout.value_or(
+      config::shard_local_cfg().cloud_storage_roles_operation_timeout_ms);
+    auto response = co_await client.request(std::move(req), stream, tout);
     auto status = co_await get_status(response);
     if (is_retryable(status)) {
         co_return make_retryable_error(
@@ -145,17 +152,18 @@ ss::future<api_response> post_request(
   http::client client,
   http::client::request_header req,
   iobuf content,
-  std::chrono::milliseconds timeout) {
+  std::optional<std::chrono::milliseconds> timeout) {
+    auto tout = timeout.value_or(
+      config::shard_local_cfg().cloud_storage_roles_operation_timeout_ms);
+
     return http::with_client(
       std::move(client),
-      [req = std::move(req), content = std::move(content), timeout](
+      [req = std::move(req), content = std::move(content), tout](
         auto& client) mutable -> ss::future<api_response> {
           return do_request(
             req,
-            [&client, content = std::move(content), timeout](
-              auto& req) mutable {
-                return make_post_request(
-                  client, req, std::move(content), timeout);
+            [&client, content = std::move(content), tout](auto& req) mutable {
+                return make_post_request(client, req, std::move(content), tout);
             });
       });
 }
@@ -164,11 +172,12 @@ ss::future<api_response> post_request(
   http::client client,
   http::client::request_header req,
   seastar::sstring content,
-  std::chrono::milliseconds timeout) {
+  std::optional<std::chrono::milliseconds> timeout) {
     iobuf b;
     b.append(content.data(), content.size());
-    return post_request(
-      std::move(client), std::move(req), std::move(b), timeout);
+    auto tout = timeout.value_or(
+      config::shard_local_cfg().cloud_storage_roles_operation_timeout_ms);
+    return post_request(std::move(client), std::move(req), std::move(b), tout);
 }
 
 std::chrono::system_clock::time_point parse_timestamp(std::string_view sv) {

--- a/src/v/cloud_roles/request_response_helpers.h
+++ b/src/v/cloud_roles/request_response_helpers.h
@@ -16,24 +16,22 @@
 
 namespace cloud_roles {
 
-inline constexpr std::chrono::milliseconds default_request_timeout{5000};
-
 ss::future<api_response> make_request(
   http::client client,
   http::client::request_header req,
-  std::chrono::milliseconds timeout = default_request_timeout);
+  std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
 ss::future<api_response> post_request(
   http::client client,
   http::client::request_header req,
   iobuf content,
-  std::chrono::milliseconds timeout = default_request_timeout);
+  std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
 ss::future<api_response> post_request(
   http::client client,
   http::client::request_header req,
   ss::sstring content,
-  std::chrono::milliseconds timeout = default_request_timeout);
+  std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
 ss::future<boost::beast::http::status>
 get_status(http::client::response_stream_ref& resp);

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -9,9 +9,12 @@
  */
 
 #include "bytes/iobuf.h"
+#include "cloud_roles/logger.h"
 #include "cloud_roles/refresh_credentials.h"
 #include "cloud_roles/tests/test_definitions.h"
+#include "config/configuration.h"
 #include "http/tests/http_imposter.h"
+#include "test_utils/async.h"
 #include "test_utils/fixture.h"
 
 #include <seastar/core/file.hh>
@@ -352,4 +355,38 @@ FIXTURE_TEST(test_client_closed_on_error, http_imposter_fixture) {
     gate.close().get();
 
     BOOST_REQUIRE(has_call(cloud_role_tests::aws_role_query_url));
+}
+
+FIXTURE_TEST(test_handle_temporary_timeout, http_imposter_fixture) {
+    // This test asserts that if the remote endpoint is not reachable, the
+    // refresh operation will attempt to retry. In order not to expose the retry
+    // counter or make similar changes to the class just for testing, this test
+    // scans the log for the message emitted when a ss::timed_out_error is seen.
+    std::stringstream ss;
+    cloud_roles::clrl_log.set_ostream(ss);
+    ss::abort_source as;
+    ss::gate gate;
+    std::optional<cloud_roles::credentials> c;
+
+    one_shot_fetch s(c, as);
+
+    auto refresh = cloud_roles::make_refresh_credentials(
+      model::cloud_credentials_source::aws_instance_metadata,
+      gate,
+      as,
+      s,
+      cloud_roles::aws_region_name{""},
+      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+
+    config::shard_local_cfg()
+      .cloud_storage_roles_operation_timeout_ms.set_value(
+        std::chrono::milliseconds{100ms});
+    refresh.start();
+
+    tests::cooperative_spin_wait_with_timeout(5s, [&ss] {
+        return ss.str().find("api request failed (retrying after cool-off "
+                             "period): timedout")
+               != std::string::npos;
+    }).get();
+    gate.close().get();
 }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1143,6 +1143,12 @@ configuration::configuration()
        model::cloud_credentials_source::aws_instance_metadata,
        model::cloud_credentials_source::sts,
        model::cloud_credentials_source::gcp_instance_metadata})
+  , cloud_storage_roles_operation_timeout_ms(
+      *this,
+      "cloud_storage_roles_operation_timeout_ms",
+      "Timeout for IAM role related operations (ms)",
+      {.visibility = visibility::tunable},
+      30s)
   , cloud_storage_reconciliation_ms(
       *this, "cloud_storage_reconciliation_interval_ms")
   , cloud_storage_upload_loop_initial_backoff_ms(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -231,6 +231,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_api_endpoint;
     enum_property<model::cloud_credentials_source>
       cloud_storage_credentials_source;
+    property<std::chrono::milliseconds>
+      cloud_storage_roles_operation_timeout_ms;
     deprecated_property cloud_storage_reconciliation_ms;
     property<std::chrono::milliseconds>
       cloud_storage_upload_loop_initial_backoff_ms;


### PR DESCRIPTION
In case of a timeout while connecting to the cloud storage backend, the task which refreshes the IAM roles token may exit on an unhandled exception, causing subsequent requests to the storage API to fail.

These kind of connection errors are transient and should be retried after a period of time. This change ensures that connection failures are retried after a cool-off period, similar to how transient errors in the API response are treated.

Additionally the timeout is increased from 5 seconds to 30 seconds and is made tunable by a new property: `cloud_storage_roles_operation_timeout_ms`.

Fixes: #8386 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## Release Notes

  * none
