### PR TITLE
Fixed removing in flight write operations when processing stable offset updates

### DIFF
--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -84,30 +84,28 @@ static ss::future<result<iobuf>> verify_read_iobuf(
   size_t expected,
   ss::sstring msg,
   bool recover = false) {
-    return read_iobuf_exactly(in, expected)
-      .then([msg = std::move(msg), expected, recover](iobuf b) {
-          if (likely(b.size_bytes() == expected)) {
-              return ss::make_ready_future<result<iobuf>>(std::move(b));
-          }
-          if (!recover) {
-              stlog.error(
-                "cannot continue parsing. recived size:{} bytes, expected:{} "
-                "bytes. context:{}",
-                b.size_bytes(),
-                expected,
-                msg);
-          } else {
-              stlog.debug(
-                "recovery ended with short read. recived size:{} bytes, "
-                "expected:{} "
-                "bytes. context:{}",
-                b.size_bytes(),
-                expected,
-                msg);
-          }
-          return ss::make_ready_future<result<iobuf>>(
-            parser_errc::input_stream_not_enough_bytes);
-      });
+    auto b = co_await read_iobuf_exactly(in, expected);
+
+    if (likely(b.size_bytes() == expected)) {
+        co_return b;
+    }
+    if (!recover) {
+        stlog.error(
+          "cannot continue parsing. recived size:{} bytes, expected:{} "
+          "bytes. context:{}",
+          b.size_bytes(),
+          expected,
+          msg);
+    } else {
+        stlog.debug(
+          "recovery ended with short read. recived size:{} bytes, "
+          "expected:{} "
+          "bytes. context:{}",
+          b.size_bytes(),
+          expected,
+          msg);
+    }
+    co_return parser_errc::input_stream_not_enough_bytes;
 }
 
 ss::future<result<stop_parser>> continuous_batch_parser::consume_header() {

--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -78,11 +78,12 @@ static model::record_batch_header header_from_iobuf(iobuf b) {
     hdr.ctx.owner_shard = ss::this_shard_id();
     return hdr;
 }
-
+// make sure that `msg` parameter is a static string or it is not removed before
+// this function finishes
 static ss::future<result<iobuf>> verify_read_iobuf(
   ss::input_stream<char>& in,
   size_t expected,
-  ss::sstring msg,
+  const char* msg,
   bool recover = false) {
     auto b = co_await read_iobuf_exactly(in, expected);
 

--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -91,19 +91,20 @@ static ss::future<result<iobuf>> verify_read_iobuf(
         co_return b;
     }
     if (!recover) {
-        stlog.error(
-          "cannot continue parsing. recived size:{} bytes, expected:{} "
-          "bytes. context:{}",
-          b.size_bytes(),
+        vlog(
+          stlog.error,
+          "Stopping parser, short read. Expected to read {} bytes, but read {} "
+          "bytes. context: {}",
           expected,
+          b.size_bytes(),
           msg);
     } else {
-        stlog.debug(
-          "recovery ended with short read. recived size:{} bytes, "
-          "expected:{} "
-          "bytes. context:{}",
-          b.size_bytes(),
+        vlog(
+          stlog.debug,
+          "Recovery ended with short read. Expected to read {} bytes, but read "
+          "{} bytes. context: {}",
           expected,
+          b.size_bytes(),
           msg);
     }
     co_return parser_errc::input_stream_not_enough_bytes;

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -93,6 +93,8 @@ public:
     void remove_partition_bytes(size_t remove) { _partition_bytes -= remove; }
     void set_compaction_ratio(double r) { _compaction_ratio = r; }
 
+    int64_t get_batch_parse_errors() const { return _batch_parse_errors; }
+
 private:
     uint64_t _partition_bytes = 0;
     uint64_t _bytes_written = 0;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -539,7 +539,7 @@ void segment::advance_stable_offset(size_t offset) {
 
     _reader.set_file_size(it->first);
     _tracker.stable_offset = it->second;
-    _inflight.erase(_inflight.begin(), it);
+    _inflight.erase(_inflight.begin(), std::next(it));
 }
 
 std::ostream& operator<<(std::ostream& o, const segment::offset_tracker& t) {


### PR DESCRIPTION
The `absl::btree_map::erase` function erases all elements in range
[start, end) (end is exclusive). In current implementation the iterator
used to update the stable offset wasn't removed as only all the elements
preceding it were removed.

Fixed the problem by removing the iterator related with currently
processed in-flight update.

Fixes: #8091 

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
### Bug Fixes
- fixed spurious batch parse error messages emitted while reading 
