### PR TITLE
kafka: alter partitions followups & tests

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -327,4 +327,8 @@ const topic_table::updates_t& metadata_cache::updates_in_progress() const {
     return _topics_state.local().updates_in_progress();
 }
 
+bool metadata_cache::is_update_in_progress(const model::ntp& ntp) const {
+    return _topics_state.local().is_update_in_progress(ntp);
+}
+
 } // namespace cluster

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -188,6 +188,7 @@ public:
     std::optional<std::vector<model::broker_shard>>
     get_previous_replica_set(const model::ntp& ntp) const;
     const topic_table::updates_t& updates_in_progress() const;
+    bool is_update_in_progress(const model::ntp& ntp) const;
 
 private:
     ss::sharded<topic_table>& _topics_state;

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -47,6 +47,8 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
         return error_code::invalid_request;
     case cluster::errc::throttling_quota_exceeded:
         return error_code::throttling_quota_exceeded;
+    case cluster::errc::no_update_in_progress:
+        return error_code::no_reassignment_in_progress;
     case cluster::errc::replication_error:
     case cluster::errc::shutting_down:
     case cluster::errc::join_request_dispatch_error:
@@ -78,7 +80,6 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::error_collecting_health_report:
     case cluster::errc::leadership_changed:
     case cluster::errc::feature_disabled:
-    case cluster::errc::no_update_in_progress:
     case cluster::errc::unknown_update_interruption_error:
     case cluster::errc::cluster_already_exists:
     case cluster::errc::no_partition_assignments:

--- a/src/v/kafka/server/handlers/alter_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/alter_partition_reassignments.cc
@@ -246,7 +246,10 @@ ss::future<response_ptr> alter_partition_reassignments_handler::handle(
             }
         }
 
-        resp.data.responses.push_back(topic_response);
+        // Insert into the response if there were valid partitions
+        if (std::distance(topic.partitions.begin(), valid_partitions_end) > 0) {
+            resp.data.responses.emplace_back(std::move(topic_response));
+        }
     }
 
     co_return co_await ctx.respond(std::move(resp));

--- a/src/v/kafka/server/handlers/alter_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/alter_partition_reassignments.cc
@@ -236,13 +236,7 @@ ss::future<response_ptr> alter_partition_reassignments_handler::handle(
                       "Failed to cancel pending request: ntp {}, ec {}",
                       ntp,
                       clerr);
-                    // Explicitly check for no_update_in_progress here. We could
-                    // change the mapping in map_topic_error_code but that may
-                    // cause a regression since several places call this
-                    // function
-                    auto kerr = clerr == cluster::errc::no_update_in_progress
-                                  ? error_code::no_reassignment_in_progress
-                                  : map_topic_error_code(clerr);
+                    auto kerr = map_topic_error_code(clerr);
                     topic_response.partitions.push_back(
                       reassignable_partition_response{
                         .partition_index = partition.partition_index,

--- a/src/v/kafka/server/handlers/alter_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/alter_partition_reassignments.cc
@@ -96,8 +96,8 @@ partitions_request_iterator validate_partitions(
     std::vector<reassignable_partition_response> invalid_partitions;
 
     valid_partitions_end = validate_replicas(
+      begin,
       valid_partitions_end,
-      end,
       std::back_inserter(invalid_partitions),
       error_code::invalid_replica_assignment,
       "Empty replica list specified in partition reassignment.",
@@ -106,8 +106,8 @@ partitions_request_iterator validate_partitions(
       });
 
     valid_partitions_end = validate_replicas(
+      begin,
       valid_partitions_end,
-      end,
       std::back_inserter(invalid_partitions),
       error_code::invalid_replica_assignment,
       "Duplicate replica ids in partition reassignment replica list",
@@ -123,8 +123,8 @@ partitions_request_iterator validate_partitions(
       });
 
     valid_partitions_end = validate_replicas(
+      begin,
       valid_partitions_end,
-      end,
       std::back_inserter(invalid_partitions),
       error_code::invalid_replica_assignment,
       "Invalid broker id in replica list",
@@ -137,8 +137,8 @@ partitions_request_iterator validate_partitions(
       });
 
     valid_partitions_end = validate_replicas(
+      begin,
       valid_partitions_end,
-      end,
       std::back_inserter(invalid_partitions),
       error_code::invalid_replica_assignment,
       "Replica assignment has brokers that are not alive",

--- a/src/v/kafka/server/handlers/alter_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/alter_partition_reassignments.cc
@@ -275,7 +275,11 @@ ss::future<response_ptr> alter_partition_reassignments_handler::handle(
                                 ntp,
                                 model::timeout_clock::now()
                                   + request.data.timeout_ms);
-                if (errc) {
+                if (!errc) {
+                    topic_response.partitions.push_back(
+                      reassignable_partition_response{
+                        .partition_index = partition.partition_index});
+                } else {
                     auto clerr = static_cast<cluster::errc>(errc.value());
                     vlog(
                       klog.debug,

--- a/src/v/kafka/server/handlers/list_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/list_partition_reassignments.cc
@@ -69,8 +69,9 @@ ongoing_partition_reassignment list_partition_reassignments(
 }
 
 // Returns all reassignments currently in progress
-std::vector<ongoing_topic_reassignment> all_active_partition_reassignments(
-  const cluster::topic_table::updates_t& in_progress) {
+std::vector<ongoing_topic_reassignment> all_in_progress_partition_reassignments(
+  const cluster::metadata_cache& md_cache) {
+    const auto& in_progress = md_cache.updates_in_progress();
     // The in progress reassignments are in a map: ntp -> list of brokers which
     // is not suitable to use with the ListPartitionReassignments response. So
     // we restructure them here.
@@ -78,17 +79,15 @@ std::vector<ongoing_topic_reassignment> all_active_partition_reassignments(
       reassignments_by_topic;
 
     for (const auto& [ntp, status] : in_progress) {
-        // Convert list of broker shards to node ids
-        std::vector<model::node_id> replicas;
-        std::for_each(
-          status.get_previous_replicas().begin(),
-          status.get_previous_replicas().end(),
-          [&replicas](const model::broker_shard& bshard) {
-              replicas.push_back(bshard.node_id);
-          });
+        auto current_assignment = md_cache.get_partition_assignment(ntp);
+        if (!current_assignment.has_value()) {
+            vlog(klog.debug, "No replica set: ntp {}", ntp);
+            continue;
+        }
 
-        ongoing_partition_reassignment partition_reassignment{
-          .partition_index = ntp.tp.partition, .replicas = replicas};
+        auto partition_reassignment = list_partition_reassignments(
+          *current_assignment, status.get_previous_replicas());
+        partition_reassignment.partition_index = ntp.tp.partition;
         if (reassignments_by_topic.contains(ntp.tp.topic)) {
             reassignments_by_topic[ntp.tp.topic].partitions.push_back(
               std::move(partition_reassignment));
@@ -98,13 +97,13 @@ std::vector<ongoing_topic_reassignment> all_active_partition_reassignments(
         }
     }
 
-    std::vector<ongoing_topic_reassignment> all_active_reassignments;
-    all_active_reassignments.reserve(reassignments_by_topic.size());
+    std::vector<ongoing_topic_reassignment> all_in_progress_reassignments;
+    all_in_progress_reassignments.reserve(reassignments_by_topic.size());
     for (auto& [_, reassignments] : reassignments_by_topic) {
-        all_active_reassignments.push_back(std::move(reassignments));
+        all_in_progress_reassignments.push_back(std::move(reassignments));
     }
 
-    return all_active_reassignments;
+    return all_in_progress_reassignments;
 }
 
 template<>
@@ -127,14 +126,15 @@ ss::future<response_ptr> list_partition_reassignments_handler::handle(
         co_return co_await ctx.respond(std::move(resp));
     }
 
-    // If topics is undefined, get all active reassignments
+    // If topics is undefined, get all in progress reassignments
     if (!request.data.topics.has_value()) {
-        auto all_active_reassignments = all_active_partition_reassignments(
-          ctx.metadata_cache().updates_in_progress());
-        resp.data.topics.reserve(all_active_reassignments.size());
+        vlog(klog.debug, "Request to list all in progress reassignments");
+        auto all_in_progress_reassignments
+          = all_in_progress_partition_reassignments(ctx.metadata_cache());
+        resp.data.topics.reserve(all_in_progress_reassignments.size());
         std::for_each(
-          all_active_reassignments.begin(),
-          all_active_reassignments.end(),
+          all_in_progress_reassignments.begin(),
+          all_in_progress_reassignments.end(),
           [&resp](const ongoing_topic_reassignment& topic_reassignment) {
               resp.data.topics.push_back(topic_reassignment);
           });

--- a/src/v/kafka/server/handlers/list_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/list_partition_reassignments.cc
@@ -171,7 +171,10 @@ ss::future<response_ptr> list_partition_reassignments_handler::handle(
                 vlog(klog.debug, "No updates in progress: ntp {}", ntp);
             }
         }
-        resp.data.topics.push_back(topic_reassignment);
+
+        if (!topic_reassignment.partitions.empty()) {
+            resp.data.topics.push_back(topic_reassignment);
+        }
     }
 
     co_return co_await ctx.respond(std::move(resp));

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -31,7 +31,8 @@ set(srcs
   fetch_session_test.cc
   alter_config_test.cc
   produce_consume_test.cc
-  group_metadata_serialization_test.cc)
+  group_metadata_serialization_test.cc
+  partition_reassignments_test.cc)
 
 rp_test(
   FIXTURE_TEST

--- a/src/v/kafka/server/tests/partition_reassignments_test.cc
+++ b/src/v/kafka/server/tests/partition_reassignments_test.cc
@@ -1,0 +1,262 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/configuration.h"
+#include "kafka/protocol/alter_partition_reassignments.h"
+#include "kafka/protocol/list_partition_reassignments.h"
+#include "kafka/protocol/metadata.h"
+#include "kafka/protocol/schemata/alter_partition_reassignments_request.h"
+#include "kafka/protocol/schemata/list_partition_reassignments_request.h"
+#include "kafka/server/handlers/topics/types.h"
+#include "kafka/types.h"
+#include "model/namespace.h"
+#include "redpanda/tests/fixture.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/defer.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+#include <optional>
+
+using namespace std::chrono_literals; // NOLINT
+
+inline ss::logger test_log("test"); // NOLINT
+
+class partition_reassignments_test_fixture : public redpanda_thread_fixture {
+public:
+    void create_topic(model::topic name, int partitions) {
+        model::topic_namespace tp_ns(model::kafka_namespace, std::move(name));
+
+        add_topic(tp_ns, partitions).get();
+
+        ss::parallel_for_each(
+          boost::irange(0, partitions),
+          [this, tp_ns](int i) {
+              return wait_for_partition_offset(
+                model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id(i)),
+                model::offset(0));
+          })
+          .get();
+    }
+
+    kafka::alter_partition_reassignments_response alter_partition_reassignments(
+      kafka::client::transport& client,
+      std::optional<model::topic> topic_name,
+      std::vector<kafka::reassignable_partition> reassignable_partitions) {
+        kafka::alter_partition_reassignments_request req;
+
+        if (topic_name.has_value()) {
+            req.data.topics = std::vector<kafka::reassignable_topic>{
+              kafka::reassignable_topic{
+                .name = *topic_name,
+                .partitions = std::move(reassignable_partitions)}};
+        }
+        return client.dispatch(std::move(req), kafka::api_version(0)).get();
+    }
+
+    kafka::list_partition_reassignments_response list_partition_reassignments(
+      kafka::client::transport& client,
+      std::optional<std::vector<kafka::list_partition_reassignments_topics>>
+        topics
+      = std::nullopt) {
+        kafka::list_partition_reassignments_request req;
+        req.data.topics = topics;
+        return client.dispatch(std::move(req), kafka::api_version(0)).get();
+    }
+};
+
+FIXTURE_TEST(
+  test_alter_partition_reassignments, partition_reassignments_test_fixture) {
+    wait_for_controller_leadership().get();
+    model::topic test_tp{"topic-1"};
+    create_topic(test_tp, 6);
+
+    auto client = make_kafka_client().get0();
+    client.connect().get();
+    model::partition_id pid0{0};
+
+    {
+        test_log.info("Empty topics");
+        auto resp = alter_partition_reassignments(
+          client, std::nullopt, std::vector<kafka::reassignable_partition>{});
+        BOOST_CHECK_EQUAL(resp.data.responses.size(), 0);
+    }
+
+    {
+        test_log.info("Empty partitions");
+        auto resp = alter_partition_reassignments(
+          client, test_tp, std::vector<kafka::reassignable_partition>{});
+        BOOST_CHECK_EQUAL(resp.data.responses.size(), 0);
+    }
+
+    {
+        test_log.info("Empty replicas (!= undefined replicas)");
+        kafka::reassignable_partition new_partition{
+          .partition_index = pid0, .replicas = std::vector<model::node_id>{}};
+        auto resp = alter_partition_reassignments(
+          client,
+          test_tp,
+          std::vector<kafka::reassignable_partition>{new_partition});
+        BOOST_CHECK_EQUAL(resp.data.responses.size(), 1);
+        for (auto& tp_resp : resp.data.responses) {
+            BOOST_CHECK(tp_resp.name() == test_tp());
+            BOOST_CHECK_EQUAL(tp_resp.partitions.size(), 1);
+            for (auto& p_resp : tp_resp.partitions) {
+                BOOST_CHECK_EQUAL(p_resp.partition_index(), pid0());
+                BOOST_CHECK_EQUAL(
+                  p_resp.error_code,
+                  kafka::error_code::invalid_replica_assignment);
+                BOOST_CHECK(
+                  *p_resp.error_message
+                  == ss::sstring{
+                    "Empty replica list specified in partition reassignment."});
+            }
+        }
+    }
+
+    {
+        test_log.info("Duplicate node ids");
+        std::vector<model::node_id> new_replicas = {
+          model::node_id{0}, model::node_id{0}};
+        kafka::reassignable_partition new_partition{
+          .partition_index = pid0, .replicas = std::move(new_replicas)};
+        auto resp = alter_partition_reassignments(
+          client,
+          test_tp,
+          std::vector<kafka::reassignable_partition>{new_partition});
+        BOOST_CHECK_EQUAL(resp.data.responses.size(), 1);
+        for (auto& tp_resp : resp.data.responses) {
+            BOOST_CHECK(tp_resp.name() == test_tp());
+            BOOST_CHECK_EQUAL(tp_resp.partitions.size(), 1);
+            for (auto& p_resp : tp_resp.partitions) {
+                BOOST_CHECK_EQUAL(p_resp.partition_index(), pid0());
+                BOOST_CHECK_EQUAL(
+                  p_resp.error_code,
+                  kafka::error_code::invalid_replica_assignment);
+                BOOST_CHECK(
+                  *p_resp.error_message
+                  == ss::sstring{"Duplicate replica ids in partition "
+                                 "reassignment replica list"});
+            }
+        }
+    }
+
+    {
+        test_log.info("Negative node ids");
+        std::vector<model::node_id> new_replicas = {model::node_id{-1}};
+        kafka::reassignable_partition new_partition{
+          .partition_index = pid0, .replicas = std::move(new_replicas)};
+        auto resp = alter_partition_reassignments(
+          client,
+          test_tp,
+          std::vector<kafka::reassignable_partition>{new_partition});
+        BOOST_CHECK_EQUAL(resp.data.responses.size(), 1);
+        for (auto& tp_resp : resp.data.responses) {
+            BOOST_CHECK(tp_resp.name() == test_tp());
+            BOOST_CHECK_EQUAL(tp_resp.partitions.size(), 1);
+            for (auto& p_resp : tp_resp.partitions) {
+                BOOST_CHECK_EQUAL(p_resp.partition_index(), pid0());
+                BOOST_CHECK_EQUAL(
+                  p_resp.error_code,
+                  kafka::error_code::invalid_replica_assignment);
+                BOOST_CHECK(
+                  *p_resp.error_message
+                  == ss::sstring{"Invalid broker id in replica list"});
+            }
+        }
+    }
+
+    {
+        test_log.info("Unknown node id");
+        std::vector<model::node_id> new_replicas = {model::node_id{4}};
+        kafka::reassignable_partition new_partition{
+          .partition_index = pid0, .replicas = std::move(new_replicas)};
+        auto resp = alter_partition_reassignments(
+          client,
+          test_tp,
+          std::vector<kafka::reassignable_partition>{new_partition});
+        BOOST_CHECK_EQUAL(resp.data.responses.size(), 1);
+        for (auto& tp_resp : resp.data.responses) {
+            BOOST_CHECK(tp_resp.name() == test_tp());
+            BOOST_CHECK_EQUAL(tp_resp.partitions.size(), 1);
+            for (auto& p_resp : tp_resp.partitions) {
+                BOOST_CHECK_EQUAL(p_resp.partition_index(), pid0());
+                BOOST_CHECK_EQUAL(
+                  p_resp.error_code,
+                  kafka::error_code::invalid_replica_assignment);
+                BOOST_CHECK(
+                  *p_resp.error_message
+                  == ss::sstring{
+                    "Replica assignment has brokers that are not alive"});
+            }
+        }
+    }
+
+    {
+        test_log.info("Cancel request expect fail");
+        auto resp = alter_partition_reassignments(
+          client,
+          test_tp,
+          std::vector<kafka::reassignable_partition>{
+            kafka::reassignable_partition{
+              .partition_index = model::partition_id{0}}});
+        BOOST_CHECK_EQUAL(resp.data.responses.size(), 1);
+        for (auto& tp_resp : resp.data.responses) {
+            BOOST_CHECK(tp_resp.name() == test_tp());
+            BOOST_CHECK_EQUAL(tp_resp.partitions.size(), 1);
+            for (auto& p_resp : tp_resp.partitions) {
+                BOOST_CHECK_EQUAL(p_resp.partition_index(), pid0());
+                BOOST_CHECK_EQUAL(
+                  p_resp.error_code,
+                  kafka::error_code::no_reassignment_in_progress);
+                BOOST_CHECK(
+                  *p_resp.error_message
+                  == ss::sstring{"no_reassignment_in_progress"});
+            }
+        }
+    }
+
+    client.stop().then([&client] { client.shutdown(); }).get();
+}
+
+FIXTURE_TEST(
+  test_list_partition_reassignments, partition_reassignments_test_fixture) {
+    wait_for_controller_leadership().get();
+    model::topic test_tp{"topic-1"};
+    int num_partitions = 6;
+    create_topic(test_tp, num_partitions);
+
+    auto client = make_kafka_client().get0();
+    client.connect().get();
+
+    {
+        test_log.info(
+          "List partition assignments {} expect an empty response", test_tp);
+        std::vector<model::partition_id> pids;
+        for (int pid = 0; pid < num_partitions; ++pid) {
+            pids.emplace_back(pid);
+        }
+        auto resp = list_partition_reassignments(
+          client,
+          std::vector<kafka::list_partition_reassignments_topics>{
+            kafka::list_partition_reassignments_topics{
+              .name = test_tp, .partition_indexes = pids}});
+        BOOST_CHECK_EQUAL(resp.data.topics.size(), 0);
+    }
+
+    {
+        test_log.info("List all ongoing reassignments expect an empty reponse");
+        auto resp = list_partition_reassignments(client);
+        BOOST_CHECK_EQUAL(resp.data.topics.size(), 0);
+    }
+
+    client.stop().then([&client] { client.shutdown(); }).get();
+}

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -267,6 +267,10 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             args.append("--execute")
         elif operation == "verify":
             args.append("--verify")
+            args.append("--preserve-throttles")
+        elif operation == "cancel":
+            args.append("--cancel")
+            args.append("--preserve-throttles")
         else:
             raise NotImplementedError(f"Unknown operation: {operation}")
 
@@ -277,7 +281,7 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
                                           operation="execute")
         return output.splitlines()
 
-    def verify_reassign_partitions(self, reassignments: dict):
+    def verify_reassign_partitions(self, reassignments: dict, timeout_s: int):
         output = None
 
         def do_reassign_partitions():
@@ -290,7 +294,16 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             # Retry the script if there is reassignment still in progress
             return "is still in progress." not in output
 
-        wait_until(do_reassign_partitions, timeout_sec=20, backoff_sec=1)
+        wait_until(do_reassign_partitions,
+                   timeout_sec=timeout_s,
+                   backoff_sec=1)
+
+        return output.splitlines()
+
+    def cancel_reassign_partitions(self, reassignments: dict):
+        output = self.reassign_partitions(reassignments=reassignments,
+                                          operation="cancel",
+                                          write_reassignments_to_disk=False)
 
         return output.splitlines()
 
@@ -420,8 +433,6 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
                 raise AuthenticationError(e.output)
             if "ClusterAuthorizationException: Cluster authorization failed" in e.output:
                 raise ClusterAuthorizationError(e.output)
-            if e.output.startswith("Status of partition reassignment:"):
-                return e.output
             raise
 
     def _script(self, script):

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -13,6 +13,7 @@ import re
 import subprocess
 import time
 import itertools
+from typing import Optional
 
 KclPartitionOffset = namedtuple(
     'KclPartitionOffset',
@@ -31,6 +32,10 @@ KclCreatePartitionsRequestTopic = namedtuple('KclCreatePartitionsRequestTopic',
 
 KclOffsetDeleteResponse = namedtuple(
     'KclOffsetDeleteResponse', ['topic', 'partition', 'status', 'error_msg'])
+
+KclListPartitionReassignmentsResponse = namedtuple(
+    'KclListPartitionReassignmentsResponse',
+    ['topic', 'partition', 'replicas', 'adding_replicas', 'removing_replicas'])
 
 
 class KCL:
@@ -222,6 +227,136 @@ class KCL:
             KclOffsetDeleteResponse(x['topic'], int(x['partition']),
                                     x['status'], x['error']) for x in matched
         ]
+
+    def get_user_credentials_cmd(self,
+                                 user_cred: Optional[dict[str, str]] = None):
+        if user_cred is not None:
+            assert "user" in user_cred
+            assert "passwd" in user_cred
+            assert "method" in user_cred
+            return [
+                "-X", f'sasl_user={user_cred["user"]}', "-X",
+                f'sasl_pass={user_cred["passwd"]}', "-X",
+                f'sasl_method={user_cred["method"]}'
+            ]
+
+        return []
+
+    def alter_partition_reassignments(self,
+                                      topics: dict[str, dict[int, list[int]]],
+                                      user_cred: Optional[dict[str,
+                                                               str]] = None):
+        """
+        :param topics: the key is a topic and the value is a dict that maps partition IDs
+                       to new replica assignments
+        :return: list of KclAlterPartitionReassignmentsResponse
+        """
+        cmd = self.get_user_credentials_cmd(user_cred) + [
+            "admin", "partas", "alter"
+        ]
+
+        for topic in topics:
+            assert len(topics[topic]) > 0
+            reassignment_str = f"{topic}:"
+            partitions = []
+            for pid in topics[topic]:
+                if len(topics[topic][pid]) == 0:
+                    raise NotImplementedError(
+                        'Canceling a reassignment is unsupported')
+
+                part_str = f"{pid}->{topics[topic][pid]}"
+                # Remove empty and [] characters
+                part_str = part_str.replace('[', '').replace(']', '')
+                part_str = part_str.replace(' ', '')
+                partitions.append(part_str)
+            join_partitions = ";".join(partitions)
+            reassignment_str += join_partitions
+            cmd.append(reassignment_str)
+
+        lines = self._cmd(cmd).splitlines()
+        self._redpanda.logger.debug(lines)
+        ok_re = re.compile(
+            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +OK$")
+        no_broker_re = re.compile(
+            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +BROKER_NOT_AVAILABLE.*$"
+        )
+        bad_rep_factor_re = re.compile(
+            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +INVALID_REPLICATION_FACTOR.*$"
+        )
+        for l in lines:
+            l = l.strip()
+            self._redpanda.logger.debug(l)
+
+            m = no_broker_re.match(l)
+            # No broker available means the partition did not find any eligible allocation nodes.
+            # See the map from cluster errors to kafka errors in kafka::map_topic_error_code()
+            if m is not None:
+                raise RuntimeError('No eligible allocation nodes')
+
+            m = bad_rep_factor_re.match(l)
+            # Invalid replication factor means the number of replicas for one (or more) partitions
+            # in a request does not match the replication factor for the topic.
+            if m is not None:
+                raise RuntimeError(
+                    'Number of replicas != topic replication factor')
+
+            m = ok_re.match(l)
+            assert m is not None
+
+        return lines
+
+    def list_partition_reassignments(self,
+                                     topics: Optional[dict[str,
+                                                           list[int]]] = None,
+                                     user_cred: Optional[dict[str,
+                                                              str]] = None):
+        """
+        :param topics: dict where topic name is the key and the value is the list
+                       of partition IDs
+        :return: list of KclListPartitionReassignmentsResponse
+        """
+        cmd = self.get_user_credentials_cmd(user_cred) + [
+            "admin", "partas", "list"
+        ]
+
+        lines = None
+        if topics is None:
+            lines = self._cmd(cmd).splitlines()
+        else:
+            for topic in topics:
+                topic_str = f"{topic}:{topics[topic]}"
+                # Remove empty and [] characters
+                topic_str = topic_str.replace('[', '').replace(']', '')
+                topic_str = topic_str.replace(' ', '')
+                cmd.append(topic_str)
+
+            lines = self._cmd(cmd, attempts=1).splitlines()
+        self._redpanda.logger.debug(lines)
+
+        def replicas_as_int(replicas: list[str]):
+            return [int(node_id) for node_id in replicas]
+
+        res_re = re.compile(
+            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +\[(?P<replicas>[0-9 ]+?)\] +\[(?P<adding>[0-9 ]*?)\] +\[(?P<removing>[0-9 ]*?)\]$"
+        )
+        ret = []
+        for l in lines:
+            l = l.strip()
+            self._redpanda.logger.debug(l)
+            m = res_re.match(l)
+            if m is not None:
+                replicas = replicas_as_int(list(m["replicas"].replace(' ',
+                                                                      '')))
+                adding_replicas = replicas_as_int(
+                    list(m["adding"].replace(' ', '')))
+                removing_replicas = replicas_as_int(
+                    list(m["removing"].replace(' ', '')))
+                ret.append(
+                    KclListPartitionReassignmentsResponse(
+                        m['topic'], int(m['partition']), replicas,
+                        adding_replicas, removing_replicas))
+
+        return ret
 
     def _cmd(self, cmd, input=None, attempts=5):
         """


### PR DESCRIPTION
## Cover lettter

https://github.com/redpanda-data/redpanda/pull/7685 Introduced the AlterPartitionReassignments and ListPartitionReassignments APIs following [KIP-455](https://cwiki.apache.org/confluence/display/KAFKA/KIP-455%3A+Create+an+Administrative+API+for+Replica+Reassignment). However, there are several follow ups to do listed in #8325

This PR adds testing and addresses those followups

Fixes #8325 

Changes from force-push `50b42f5`:
- Edit error mapping 
- Add unit test for duplicate partition id
- Add DT test for even number replication factor

Changes from force-push `ba668a3`:
- Use `const auto&` where applicable
- Split up commits to make the commit history more clear
- When listing all inprogress reassignments, we must compare the current replica set with the previous
- Shorten some if statements with the ternary operator
- In the unit tests, pass the `kafka::client::transport` into function calls instead of creating a new client for every request
- Keep comments that explain that a null replicas vector is OK

Changes from force-push `b697481`:
- Add test for canceling an AlterPartitionReassignments request

Changes from force-push `d42c393`, `73543ff`, `0148fe4`:
- Resolve conflicts so CI will run
- Remove duplicate partition Id unit test

Changes from force-push `e0a0594`:
- Added ACLs test to DT
- Added even replication factor test to DT
- Added a check for topic replication factor in the AlterPartition handler
- Styling fixes

Changes from force-push `3ee5b1e`:
- Added DT test for canceling an AlterPartition request
- Added bug fix for canceling an AlterPartition request
- Styling fixes to ducktape

Changes from force-push `00e0715`:
- Added DT test for executing an AlterPartition req with a downed node
- Styling fixes
- Rebased dev to resolve conflicts

Changes from force-push `938b29f`:
- Check for in-progress updates before executing ListPartitions
- Style fixes
- Refactor test code
- Wait for a new topic leader when we stop a RP broker

Changes from force-push `2fd1d7b`:
- List partitions should not put the topic name in the response unless the `ntp` has in-progress updates
- Fix unit tests
- Change recovery rate for some DT tests

Changes from force-push `ec84001`:
- Removed `test_reassignments_on_stopped_nodes` DT test because we have other tests in the tree that accomplish the same thing
- Increased some timeouts to address timeout failures
- In AlterPartitions, validation should check the list of **alive nodes**. Previously, we were checking the list of **all nodes in the cluster**

Changes from force-push `a2105ec` and `5dd33b5`:
- Set a lower throttle in `test_reassignments_cancel` so that all reassignments are still in-progress for the call to `cancel` to work
- Increased timeouts
- Fix typos

Changes from force-push `57982f4`:
- Switch from RpkProducer to VerifiableProducer. RpkProducer was yielding some strange DT failures during partition move
- Account for no_reassignment_in_progress on attempts to cancel an in-progress reassignment

Changes from force-push `20f8cdf`:
- Rebase dev to resolve merge conflicts

Changes from force-push `48e613b`:
- In ListPartitions: Make sure topic field is filled in for every response
- In ListParitions: Return an empty response when all ntps do **not** have in-progress reassignments

Changes from force-push `c6ad694`:
- Comment style change
- Use the `std::back_insert_iterator` type

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
