### PR TITLE
rpk: avoid mangling timestamp in cluster config

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import.go
@@ -35,6 +35,40 @@ func (fe *formattedError) Error() string {
 	return fe.s
 }
 
+// clusterConfig represents a redpanda configuration.
+type clusterConfig map[string]any
+
+// A custom unmarshal is needed because go-yaml parse "YYYY-MM-DD" as a full
+// timestamp, writing YYYY-MM-DD HH:MM:SS +0000 UTC when encoding, so we are
+// going to treat timestamps as strings.
+// See: https://github.com/go-yaml/yaml/issues/770
+
+func replaceTimestamp(n *yaml.Node) {
+	if len(n.Content) == 0 {
+		return
+	}
+	for _, innerNode := range n.Content {
+		if innerNode.Tag == "!!map" {
+			replaceTimestamp(innerNode)
+		}
+		if innerNode.Tag == "!!timestamp" {
+			innerNode.Tag = "!!str"
+		}
+	}
+}
+
+func (c *clusterConfig) UnmarshalYAML(n *yaml.Node) error {
+	replaceTimestamp(n)
+
+	var a map[string]any
+	err := n.Decode(&a)
+	if err != nil {
+		return err
+	}
+	*c = a
+	return nil
+}
+
 func importConfig(
 	ctx context.Context,
 	client *admin.AdminAPI,
@@ -48,7 +82,7 @@ func importConfig(
 	if err != nil {
 		return fmt.Errorf("error reading file %s: %v", filename, err)
 	}
-	var readbackConfig admin.Config
+	var readbackConfig clusterConfig
 	err = yaml.Unmarshal(readbackBytes, &readbackConfig)
 	if err != nil {
 		return fmt.Errorf("error parsing edited config: %v", err)

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestClusterConfig_UnmarshalYAML(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   string
+		exp  clusterConfig
+	}{
+		{
+			name: "normal map",
+			in: `aggregate_metrics: false
+cloud_storage_access_key:
+cloud_storage_api_endpoint_port: 443
+cloud_storage_cache_size: 21474836480
+cloud_storage_credentials_source: config_file
+`,
+			exp: map[string]any{
+				"aggregate_metrics":                false,
+				"cloud_storage_access_key":         nil,
+				"cloud_storage_api_endpoint_port":  443,
+				"cloud_storage_cache_size":         21474836480,
+				"cloud_storage_credentials_source": "config_file",
+			},
+		}, {
+			name: "normal map with timestamp",
+			in: `cloud_storage_bucket: 2021-08-06
+aggregate_metrics: true
+cloud_storage_access_key:
+cloud_storage_api_endpoint_port: 443
+cloud_storage_cache_size: 21474836480
+cloud_storage_credentials_source: config_file
+`,
+			exp: map[string]any{
+				"cloud_storage_bucket":             "2021-08-06",
+				"aggregate_metrics":                true,
+				"cloud_storage_access_key":         nil,
+				"cloud_storage_api_endpoint_port":  443,
+				"cloud_storage_cache_size":         21474836480,
+				"cloud_storage_credentials_source": "config_file",
+			},
+		}, {
+			name: "map within a map",
+			in: `cloud_storage_bucket: 2021-08-06
+aggregate_metrics: true
+nested_1:
+  cloud_new_time: 2021-08-07
+  int_test: 1234
+  nested_2:
+    another_time: 2023-01-25
+    bool_test: true
+`,
+			exp: map[string]any{
+				"cloud_storage_bucket": "2021-08-06",
+				"aggregate_metrics":    true,
+				"nested_1": map[string]any{
+					"cloud_new_time": "2021-08-07",
+					"int_test":       1234,
+					"nested_2": map[string]any{
+						"another_time": "2023-01-25",
+						"bool_test":    true,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var cfg clusterConfig
+			err := yaml.Unmarshal([]byte(test.in), &cfg)
+			require.NoError(t, err)
+
+			require.Equal(t, test.exp, cfg)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/reset.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/reset.go
@@ -56,8 +56,8 @@ the setting as if it was set to the default.
 			out.MaybeDie(err, "Couldn't read %q", configCacheFile)
 
 			// Decode YAML
-			content := make(map[string]interface{})
-			err = yaml.Unmarshal(f, content)
+			var content clusterConfig
+			err = yaml.Unmarshal(f, &content)
 			out.MaybeDie(err, "Couldn't parse %q: %v", configCacheFile, err)
 
 			// Snip out the value we are resetting


### PR DESCRIPTION
A custom unmarshal is needed because go-yaml parses the string "YYYY-MM-DD" as a full timestamp,
writing "YYYY-MM-DD HH:MM:SS +0000 UTC" instead of a short timestamp, so we are going to treat
timestamps as strings.

See: https://github.com/go-yaml/yaml/issues/770

Fixes #8334

## Backports Required
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  ### Bug Fixes

  * rpk: avoid treating the string "YYYY-MM-DD" as a full timestamp when using `rpk cluster config edit/import`
