### PR TITLE
gha: fix guard for merge queue pr

### DIFF
--- a/.github/workflows/render-pr-body-release-notes.yml
+++ b/.github/workflows/render-pr-body-release-notes.yml
@@ -13,7 +13,7 @@ on:
     types: [opened, edited]
 jobs:
   render:
-    if: ${{ ! startsWith(github.event.pull_request.title, 'merge-queue') }}
+    if: ${{ ! ( github.event.pull_request.user.login == 'vbotbuildovich' && startsWith(github.event.pull_request.title, 'merge') ) }}
     runs-on: ubuntu-latest
     steps:
       - name: Curl rpchangelog


### PR DESCRIPTION
Looks like mergify changed the prefix of the PR title that batches PRs together from `merge-queue:` to `merge queue:`. See PR https://github.com/redpanda-data/redpanda/pull/8412

This PR adjusts for that change and future changes (in case they change it back) so the [Render PR Body Release Notes](https://github.com/redpanda-data/redpanda/actions/workflows/render-pr-body-release-notes.yml) action does not run on those batch PRs since they are not merged to `dev` after they run.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
