### PR TITLE
tests: do not create ACLs when authz is enabled

### DIFF
--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -9,7 +9,7 @@
 import socket
 import time
 from ducktape.errors import TimeoutError
-from ducktape.mark import parametrize, matrix, ok_to_fail
+from ducktape.mark import parametrize, matrix
 from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
@@ -257,7 +257,6 @@ class AccessControlListTest(RedpandaTest):
         client_auth - Controls the value of require_client_auth RP config
     '''
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8202
     @cluster(num_nodes=3, log_allow_list=["Validation errors in node config"])
     @matrix(use_tls=[True, False],
             use_sasl=[True, False],
@@ -321,7 +320,6 @@ class AccessControlListTest(RedpandaTest):
     # * redpanda.service.admin: the default admin client
     # * admin: used for acl bootstrap
     # * cluster_describe: the principal under test
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8202
     @cluster(num_nodes=3)
     # DEFAULT: The whole SAN
     @parametrize(rules="DEFAULT", fail=True)

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -118,16 +118,15 @@ class AccessControlListTest(RedpandaTest):
             # has successfully confirmed that redpanda failed to start.
             return
 
-        # base case user is not a superuser and has no configured ACLs
-        if self.security.sasl_enabled() or enable_authz:
+        if self.security.sasl_enabled():
+            # base case user is not a superuser and has no configured ACLs
             self.admin.create_user("base", self.password, self.algorithm)
 
-        # only grant cluster describe permission to user cluster_describe
-        if self.security.sasl_enabled() or enable_authz:
+            # only grant cluster describe permission to user cluster_describe
             self.admin.create_user("cluster_describe", self.password,
                                    self.algorithm)
-        client = self.get_super_client()
-        client.acl_create_allow_cluster("cluster_describe", "describe")
+            client = self.get_super_client()
+            client.acl_create_allow_cluster("cluster_describe", "describe")
 
         # Hack: create a user, so that we can watch for this user in order to
         # confirm that all preceding controller log writes landed: this is
@@ -142,7 +141,7 @@ class AccessControlListTest(RedpandaTest):
                 users = self.admin.list_users(node=node)
                 if checkpoint_user not in users:
                     return False
-                elif self.security.sasl_enabled() or enable_authz:
+                elif self.security.sasl_enabled():
                     assert "base" in users and "cluster_describe" in users
             return True
 


### PR DESCRIPTION
## Cover letter

#8202 reveleaed that this test was setting ACLs when authz is enabled but no authn_method was given. This results in authz failures because the cluster attempts to authz with the anon user instead of:
1. Authorizing with a different user such as admin. This is when TLS or SASL are enabled.
2. Not authorize at all. This is when authn_method is unset

Fixes #8202


## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none