### PR TITLE
treewide: Remove #include <seastar/core/std-coroutine.hh>

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -16,7 +16,6 @@
 #include "net/dns.h"
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/std-coroutine.hh>
 
 namespace kafka::client {
 

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -35,7 +35,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
-#include <seastar/core/std-coroutine.hh>
 #include <seastar/coroutine/exception.hh>
 
 #include <absl/container/node_hash_map.h>

--- a/src/v/kafka/client/client_fetch_batch_reader.cc
+++ b/src/v/kafka/client/client_fetch_batch_reader.cc
@@ -17,7 +17,6 @@
 #include "kafka/protocol/kafka_batch_adapter.h"
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/std-coroutine.hh>
 
 namespace kafka::client {
 

--- a/src/v/kafka/protocol/batch_reader.cc
+++ b/src/v/kafka/protocol/batch_reader.cc
@@ -17,7 +17,6 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/loop.hh>
-#include <seastar/core/std-coroutine.hh>
 
 namespace kafka {
 

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -45,7 +45,6 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/std-coroutine.hh>
 #include <seastar/http/reply.hh>
 
 #include <absl/container/flat_hash_map.h>

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -31,7 +31,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/std-coroutine.hh>
 
 #include <exception>
 #include <limits>

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -38,7 +38,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/memory.hh>
-#include <seastar/core/std-coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/http/api_docs.hh>
 #include <seastar/http/exception.hh>

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -26,7 +26,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/smp.hh>
-#include <seastar/core/std-coroutine.hh>
 
 #include <functional>
 

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -32,7 +32,6 @@
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/std-coroutine.hh>
 
 namespace pandaproxy::schema_registry {
 

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -17,7 +17,6 @@
 #include "pandaproxy/reply.h"
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/std-coroutine.hh>
 #include <seastar/http/function_handlers.hh>
 #include <seastar/http/reply.hh>
 

--- a/src/v/pandaproxy/test/one_shot.cc
+++ b/src/v/pandaproxy/test/one_shot.cc
@@ -22,7 +22,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/sleep.hh>
-#include <seastar/core/std-coroutine.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/later.hh>
 

--- a/src/v/ssx/thread_worker.h
+++ b/src/v/ssx/thread_worker.h
@@ -24,7 +24,6 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
-#include <seastar/core/std-coroutine.hh>
 
 #include <sys/eventfd.h>
 


### PR DESCRIPTION
It hasn't been required since clang-14, gcc-11

It's also going away: https://github.com/scylladb/seastar/commit/42299f8556851f85d79050b61c6c6972a31785ce

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
