### PR TITLE
storage: share `storage_target_replay_bytes` amongst all shards

### DIFF
--- a/src/v/storage/storage_resources.h
+++ b/src/v/storage/storage_resources.h
@@ -104,7 +104,7 @@ private:
 
     size_t _partition_count{9};
     config::binding<size_t> _segment_fallocation_step;
-    config::binding<uint64_t> _target_replay_bytes;
+    config::binding<uint64_t> _global_target_replay_bytes;
     config::binding<uint64_t> _max_concurrent_replay;
     config::binding<uint64_t> _compaction_index_mem_limit;
     size_t _append_chunk_size;


### PR DESCRIPTION
'storage_target_replay_bytes' is a configuration option that represents
a soft limit of how many dirty bytes the state machines on a node can
have in total at any given point. It is meant to be shared between the shards.

This PR fixes a bug due to which this target was not being shared
between shards. The impact is that we were replaying more data (up to
the 64MiB hard-coded limit) from the log on restarts as the latest
snapshot was further in the past.

The issue was more apparent on nodes with higher shard counts. This is
because each shard would host less partitions (hence have fewer STMs),
so the resulting limit would be higher than on smaller nodes.

The `storage_resources_test.StorageResourceRestartTest.test_recovery_reads.clean_shutdown=True`
test was failing reliably in my Azure CDT runs (hosts have 8 cores each) and these patches
fix it. 

Fixes https://github.com/redpanda-data/redpanda/issues/7256
Related https://github.com/redpanda-data/redpanda/issues/6854

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v22.3.x
- [X] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Bug Fixes
* Improve enforcement of `storage_target_replay_bytes` by ensuring the limit
is shared amongst all shards.


