### PR TITLE
operator: fix bad deletiontimestamp check

### DIFF
--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -861,7 +861,7 @@ spec:
                       when stopping and exit maintenance mode when up again
                     type: boolean
                   underReplicatedPartitionThreshold:
-                    description: "UnderReplicatedPartitionThreshold regulate when
+                    description: "UnderReplicatedPartitionThreshold controls when
                       rolling update will continue with restarts. The procedure can
                       be described as follows: \n 1. Rolling update checks if Pod
                       specification needs to be replaced and deletes it 2. Deleted

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -119,11 +119,6 @@ func (r *ClusterReconciler) Reconcile(
 		}
 		return ctrl.Result{}, fmt.Errorf("unable to retrieve Cluster resource: %w", err)
 	}
-	if redpandaCluster.GetDeletionTimestamp() != nil {
-		log.Info("not reconciling deleted Cluster")
-		return ctrl.Result{}, nil
-	}
-
 	// if the cluster is being deleted, delete finalizers
 	if !redpandaCluster.GetDeletionTimestamp().IsZero() {
 		return r.handleClusterDeletion(ctx, &redpandaCluster, log)


### PR DESCRIPTION
Fix some bad deletiontimestamp checks I added in #8346

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
