### PR TITLE
gha: generate release notes only on release branches

### DIFF
--- a/.github/workflows/render-draft-release-notes.yml
+++ b/.github/workflows/render-draft-release-notes.yml
@@ -1,7 +1,7 @@
 name: Render Draft Release Notes
 on:
   push:
-    branches: [ dev, 'v[0-9]+.[0-9]+.x' ]
+    branches: [ 'v[0-9]+.[0-9]+.x' ]
 jobs:
   render:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To save on github api requests for generating release notes on dev.

After this merges, the workflow can be re-enabled: https://github.com/redpanda-data/redpanda/actions/workflows/render-draft-release-notes.yml

Related issue: https://github.com/redpanda-data/devprod/issues/554

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none