### PR TITLE
Add bounded property constraints to cluster config schema

### DIFF
--- a/src/v/config/base_property.cc
+++ b/src/v/config/base_property.cc
@@ -44,6 +44,17 @@ std::string_view to_string_view(visibility v) {
     return "{invalid}";
 }
 
+std::string_view to_string_view(odd_even_constraint v) {
+    switch (v) {
+    case odd_even_constraint::even:
+        return "even";
+    case odd_even_constraint::odd:
+        return "odd";
+    }
+
+    return "{invalid}";
+}
+
 /**
  * Helper for property methods that should only be used
  * on live-settable properties.

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -57,6 +57,7 @@ enum class odd_even_constraint {
 };
 
 std::string_view to_string_view(visibility v);
+std::string_view to_string_view(odd_even_constraint v);
 
 class base_property {
 public:
@@ -117,6 +118,18 @@ public:
     virtual bool is_array() const = 0;
     virtual std::optional<std::string_view> example() const = 0;
     virtual std::vector<ss::sstring> enum_values() const { return {}; };
+    virtual std::optional<ss::sstring> min_value() const {
+        return std::nullopt;
+    }
+    virtual std::optional<ss::sstring> max_value() const {
+        return std::nullopt;
+    }
+    virtual std::optional<ss::sstring> align_value() const {
+        return std::nullopt;
+    }
+    virtual std::optional<odd_even_constraint> oddeven_value() const {
+        return std::nullopt;
+    }
 
     /**
      * Validation of a proposed new value before it has been assigned

--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -178,6 +178,31 @@ public:
         }
     }
 
+    std::optional<ss::sstring> min_value() const override {
+        if (_bounds.min.has_value()) {
+            return ss::format("{}", _bounds.min.value());
+        }
+        return std::nullopt;
+    }
+
+    std::optional<ss::sstring> max_value() const override {
+        if (_bounds.max.has_value()) {
+            return ss::format("{}", _bounds.max.value());
+        }
+        return std::nullopt;
+    }
+
+    std::optional<ss::sstring> align_value() const override {
+        if (_bounds.align.has_value()) {
+            return ss::format("{}", _bounds.align.value());
+        }
+        return std::nullopt;
+    }
+
+    std::optional<odd_even_constraint> oddeven_value() const override {
+        return _bounds.oddeven;
+    }
+
 private:
     /*
      * Pre-generate an example for docs/api, if the explicit property

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -208,6 +208,26 @@
           "type": "cluster_config_property_metadata_items",
           "description": "Type of items in an array",
           "nullable": true
+        },
+        "min": {
+          "type": "string",
+          "description": "Minimum value of the property (stringized)",
+          "nullable": true
+        },
+        "max": {
+          "type": "string",
+          "description": "Maximum value of the property (stringized)",
+          "nullable": true
+        },
+        "align": {
+          "type": "string",
+          "description": "The factor the property value can only be a multiple of (stringized)",
+          "nullable": true
+        },
+        "oddeven": {
+          "type": "string",
+          "description": "One of odd|even if the value can only be odd or even",
+          "nullable": true
         }
       }
     }

--- a/src/v/redpanda/cluster_config_schema_util.cc
+++ b/src/v/redpanda/cluster_config_schema_util.cc
@@ -71,6 +71,20 @@ util::generate_json_schema(const config::configuration& conf) {
         if (units.has_value()) {
             pm.units = ss::sstring(units.value());
         }
+
+        if (p.max_value().has_value()) {
+            pm.max = p.max_value().value();
+        }
+        if (p.min_value().has_value()) {
+            pm.min = p.min_value().value();
+        }
+        if (p.align_value().has_value()) {
+            pm.align = p.align_value().value();
+        }
+        if (p.oddeven_value().has_value()) {
+            pm.oddeven = ss::sstring{
+              config::to_string_view(p.oddeven_value().value())};
+        }
     });
 
     std::map<ss::sstring, property_map> response = {


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
