### PR TITLE
cluster: mark methods as const-qualified

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -155,7 +155,9 @@ public:
         });
     }
 
-    model::offset get_commited_index() { return _raft0->committed_offset(); }
+    model::offset get_commited_index() const {
+        return _raft0->committed_offset();
+    }
 
 private:
     friend controller_probe;

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -134,7 +134,9 @@ public:
       ss::abort_source& as,
       std::optional<model::term_id> term = std::nullopt);
 
-    model::offset get_last_applied_offset() { return last_applied_offset(); }
+    model::offset get_last_applied_offset() const {
+        return last_applied_offset();
+    }
 
 private:
     using promise_t = expiring_promise<std::error_code>;

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -110,7 +110,9 @@ protected:
     void set_next(model::offset offset);
     virtual ss::future<> handle_eviction();
 
-    model::offset last_applied_offset() { return model::prev_offset(_next); }
+    model::offset last_applied_offset() const {
+        return model::prev_offset(_next);
+    }
 
     consensus* _raft;
     ss::gate _gate;


### PR DESCRIPTION


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->
  * none

