### PR TITLE
tools: revise group_id_mapper to align with __consumer_offsets

### DIFF
--- a/tools/group_id_mapper/mapper.py
+++ b/tools/group_id_mapper/mapper.py
@@ -13,10 +13,11 @@ def main():
         parser.add_argument('group_id',
                             type=str,
                             help='Id of the group to map')
-        parser.add_argument('--partition_count',
-                            type=int,
-                            help='Number of consumer group topic partitions',
-                            required=True)
+        parser.add_argument(
+            '--partition_count',
+            type=int,
+            help='Number of __consumer_offsets topic partitions',
+            required=True)
 
         return parser
 
@@ -27,7 +28,7 @@ def main():
     xx.update(options.group_id)
 
     partition_id = jump.hash(xx.intdigest(), options.partition_count)
-    print(f"kafka_internal/group/{partition_id}")
+    print(f"kafka/__consumer_offsets/{partition_id}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
group_id_mapper needs to align with `__consumer_offsets` since `kafka_internal/group` is replaced with it.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

None

## Release Notes

  * none

