### PR TITLE
many_partitions_test: add tiered storage parameters

### DIFF
--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -127,7 +127,7 @@ class S3Client:
         # out the keyspace, then run using a fixed number of workers.  Worker
         # count has to be modest to avoid hitting a lot of AWS SlowDown responses.
         max_workers = 4 if parallel else 1
-        hash_prefixes = list(f"{i:2x}" for i in range(0, 256))
+        hash_prefixes = list(f"{i:02x}" for i in range(0, 256))
         prefixes = hash_prefixes if parallel else [""]
 
         def empty_bucket_prefix(prefix):

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -282,6 +282,11 @@ class ManyPartitionsTest(PreallocNodesTest):
                 # size isn't productive.
                 'cloud_storage_segment_size_min': 1,
                 'log_segment_size_min': 1024,
+
+                # Disable segment merging: when we create many small segments
+                # to pad out tiered storage metadata, we don't want them to
+                # get merged together.
+                'cloud_storage_enable_segment_merging': False,
             },
             # Configure logging the same way a user would when they have
             # very many partitions: set logs with per-partition messages

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -8,9 +8,11 @@
 # by the Apache License, Version 2.0
 
 import time
+import signal
 import concurrent.futures
 from collections import Counter
 
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until, TimeoutError
 import numpy
 
@@ -18,7 +20,7 @@ from rptest.services.cluster import cluster
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.services.rpk_consumer import RpkConsumer
-from rptest.services.redpanda import ResourceSettings, RESTART_LOG_ALLOW_LIST, LoggingConfig
+from rptest.services.redpanda import ResourceSettings, RESTART_LOG_ALLOW_LIST, SISettings, LoggingConfig, MetricsEndpoint
 from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer, KgoVerifierRandomConsumer
 from rptest.services.kgo_repeater_service import KgoRepeaterService, repeater_traffic
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
@@ -49,10 +51,19 @@ PARTITIONS_PER_SHARD = 1000
 # on the test.
 DOCKER_PARTITION_LIMIT = 128
 
+# Large volume of data to write. If tiered storage is enabled this is the
+# amount of data to retain total. Otherwise, this can be used as a large volume
+# of data to write.
+STRESS_DATA_SIZE = 1024 * 1024 * 1024 * 100
+
 
 class ScaleParameters:
-    def __init__(self, redpanda, replication_factor):
+    def __init__(self,
+                 redpanda,
+                 replication_factor,
+                 tiered_storage_enabled=False):
         self.redpanda = redpanda
+        self.tiered_storage_enabled = tiered_storage_enabled
 
         node_count = len(self.redpanda.nodes)
 
@@ -106,14 +117,51 @@ class ScaleParameters:
         # as they like without risking filling the disk.
         partition_replicas_per_node = int(
             (self.partition_limit * replication_factor) / node_count)
+
         self.retention_bytes = int(
             (node_disk_free / 2) / partition_replicas_per_node)
+        self.local_retention_bytes = None
 
         # Choose an appropriate segment size to enable retention
         # rules to kick in promptly.
         # TODO: redpanda should figure this out automatically by
         #       rolling segments pre-emptively if low on disk space
         self.segment_size = int(self.retention_bytes / 4)
+
+        if tiered_storage_enabled:
+            # When testing with tiered storage, the tuning goals of the test
+            # parameters are different: we want to stress the number of
+            # uploaded segments.
+
+            # Set our segment size low to encourage uploads to cloud storage.
+            # This segment size will form the foundation of a simulated
+            # workload of storing a week of data in cloud, uploading every
+            # hour. Keep it small to ensure we can get a high enough segment
+            # count per partition without uploading so much data.
+            self.segment_size = 32 * 1024
+
+            # Locally retain as many segments as a full day.
+
+            # Retain as much data in cloud as one big batch of data.
+            # NOTE: we consider the existing `retention_bytes` (computed above)
+            # so the test doesn't take too much space on disk.
+            self.local_retention_bytes = min(self.retention_bytes,
+                                             self.segment_size * 24)
+            self.retention_bytes = int(STRESS_DATA_SIZE / self.partition_limit)
+
+            # Set a max upload interval such that won't swamp S3 -- we should
+            # already be uploading somewhat frequently given the segment size.
+            cloud_storage_segment_max_upload_interval_sec = 300
+            cloud_storage_housekeeping_interval_ms = cloud_storage_segment_max_upload_interval_sec * 1000
+
+            self.si_settings = SISettings(
+                redpanda._context,
+                log_segment_size=self.segment_size,
+                cloud_storage_segment_max_upload_interval_sec=
+                cloud_storage_segment_max_upload_interval_sec,
+                cloud_storage_housekeeping_interval_ms=
+                cloud_storage_housekeeping_interval_ms,
+            )
 
         # The expect_bandwidth is just for calculating sensible
         # timeouts when waiting for traffic: it is not a scientific
@@ -134,9 +182,9 @@ class ScaleParameters:
             self.expect_bandwidth = 5 * 1024 * 1024
             self.expect_single_bandwidth = 10E6
 
-        self.logger.info(
-            f"Selected retention.bytes={self.retention_bytes}, segment.bytes={self.segment_size}"
-        )
+        if tiered_storage_enabled:
+            self.expect_bandwidth /= 2
+            self.expect_single_bandwidth /= 2
 
         mb_per_partition = 1
         if not self.redpanda.dedicated_nodes:
@@ -163,6 +211,10 @@ class ScaleParameters:
             # as a success condition.
             self.redpanda.set_resource_settings(
                 ResourceSettings(reactor_stall_threshold=100))
+
+        self.logger.info(
+            f"Selected retention.bytes={self.retention_bytes}, retention.local.target.bytes={self.local_retention_bytes}, segment.bytes={self.segment_size}"
+        )
 
         # Should not happen on the expected EC2 instance types where
         # the cores-RAM ratio is sufficient to meet our shards-per-core
@@ -231,6 +283,12 @@ class ManyPartitionsTest(PreallocNodesTest):
                 # Enable segment size jitter as this is a stress test and does not
                 # rely on exact segment counts.
                 'log_segment_size_jitter_percent': 5,
+
+                # In testing tiered storage, we care about creating as many
+                # cloud segments as possible. To that end, bounding the segment
+                # size isn't productive.
+                'cloud_storage_segment_size_min': 1,
+                'log_segment_size_min': 1024,
             },
             # Configure logging the same way a user would when they have
             # very many partitions: set logs with per-partition messages
@@ -368,6 +426,22 @@ class ManyPartitionsTest(PreallocNodesTest):
                        backoff_sec=5)
             consumer.stop()
             consumer.free()
+
+    def nodes_report_cloud_segments(self, target_segments):
+        """
+        Returns true if the nodes in the cluster collectively report having
+        above the given number of segments.
+
+        NOTE: we're explicitly not checking the manifest via cloud client
+        because we expect the number of items in our bucket to be quite large,
+        and for associated ListObjects calls to take a long time.
+        """
+        num_segments = self.redpanda.metric_sum(
+            "redpanda_cloud_storage_segments",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        self.logger.info(
+            f"Cluster metrics report {num_segments} cloud segments")
+        return num_segments >= target_segments
 
     def setUp(self):
         # defer redpanda startup to the test, it might want to tweak
@@ -529,6 +603,9 @@ class ManyPartitionsTest(PreallocNodesTest):
             write_bytes_per_topic = int(1E9 / len(topic_names))
 
         msg_size = 128 * 1024
+        if scale.tiered_storage_enabled:
+            msg_size = 32 * 1024
+
         msg_count_per_topic = int((write_bytes_per_topic / msg_size))
 
         # Approx time to write or read all messages, for timeouts
@@ -557,7 +634,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             )
 
         stress_msg_size = 32768
-        stress_data_size = 1024 * 1024 * 1024 * 100
+        stress_data_size = STRESS_DATA_SIZE
 
         if not self.redpanda.dedicated_nodes:
             stress_data_size = 2E9
@@ -578,9 +655,19 @@ class ManyPartitionsTest(PreallocNodesTest):
                    timeout_sec=30,
                    backoff_sec=1.0)
 
+        # Read workloads will likely compete with cloud segment uploads, so
+        # also wait until there's a reasonable number of cloud segments per
+        # partition, to exercise a realistic workload.
+        if scale.tiered_storage_enabled:
+            target_cloud_segments = 24 * 7 * self.partition_limit
+            wait_until(lambda: self.nodes_report_cloud_segments(
+                target_cloud_segments),
+                       timeout_sec=60,
+                       backoff_sec=5)
+
         rand_ios = 100
         rand_parallel = 100
-        if not self.redpanda.dedicated_nodes:
+        if scale.tiered_storage_enabled or self.redpanda.dedicated_nodes:
             rand_parallel = 10
             rand_ios = 10
 
@@ -609,7 +696,12 @@ class ManyPartitionsTest(PreallocNodesTest):
         seq_consumer.start(clean=False)
         seq_consumer.wait()
         assert seq_consumer.consumer_status.validator.invalid_reads == 0
-        assert seq_consumer.consumer_status.validator.valid_reads >= fast_producer.produce_status.acked + msg_count_per_topic
+        if scale.tiered_storage_enabled:
+            # TODO: investigate a stronger guarantee.
+            assert seq_consumer.consumer_status.validator.valid_reads > 0
+        else:
+            assert seq_consumer.consumer_status.validator.valid_reads >= fast_producer.produce_status.acked + msg_count_per_topic, \
+            f"{seq_consumer.consumer_status.validator.valid_reads} >= {fast_producer.produce_status.acked} + {msg_count_per_topic}"
 
         self.free_preallocated_nodes()
 
@@ -715,6 +807,12 @@ class ManyPartitionsTest(PreallocNodesTest):
         self._test_many_partitions(compacted=False)
 
     @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @matrix(compacted=[False])
+    def test_many_partitions_tiered_storage(self, compacted):
+        self._test_many_partitions(compacted=compacted,
+                                   tiered_storage_enabled=True)
+
+    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_omb(self):
         scale = ScaleParameters(self.redpanda, replication_factor=3)
         self.redpanda.start(parallel=True)
@@ -723,7 +821,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         # peak partition count.
         self._run_omb(scale)
 
-    def _test_many_partitions(self, compacted):
+    def _test_many_partitions(self, compacted, tiered_storage_enabled):
         """
         Validate that redpanda works with partition counts close to its resource
         limits.
@@ -756,7 +854,9 @@ class ManyPartitionsTest(PreallocNodesTest):
 
         replication_factor = 3
 
-        scale = ScaleParameters(self.redpanda, replication_factor)
+        scale = ScaleParameters(self.redpanda,
+                                replication_factor,
+                                tiered_storage_enabled=tiered_storage_enabled)
 
         # Run with one huge topic: it is more stressful for redpanda when clients
         # request the metadata for many partitions at once, and the simplest way
@@ -770,6 +870,8 @@ class ManyPartitionsTest(PreallocNodesTest):
         self.logger.info(
             f"Running partition scale test with {n_partitions} partitions on {n_topics} topics"
         )
+        if scale.si_settings:
+            self.redpanda.set_si_settings(scale.si_settings)
 
         # Enable large node-wide thoughput limits to verify they work at scale
         # To avoid affecting the result of the test with the limit, set them
@@ -792,8 +894,17 @@ class ManyPartitionsTest(PreallocNodesTest):
                 'segment.bytes': scale.segment_size,
                 'retention.bytes': scale.retention_bytes
             }
+            if scale.local_retention_bytes:
+                config[
+                    'retention.local.target.bytes'] = scale.local_retention_bytes
+
             if compacted:
-                config['cleanup.policy'] = 'compact'
+                if tiered_storage_enabled:
+                    config['cleanup.policy'] = 'compact,delete'
+                else:
+                    config['cleanup.policy'] = 'compact'
+            else:
+                config['cleanup.policy'] = 'delete'
 
             self.rpk.create_topic(tn,
                                   partitions=n_partitions,
@@ -836,16 +947,23 @@ class ManyPartitionsTest(PreallocNodesTest):
         # Main test phase: with continuous background traffic, exercise restarts and
         # any other cluster changes that might trip up at scale.
         repeater_msg_size = 16384
+        max_buffered_records = 64
+        if scale.tiered_storage_enabled:
+            max_buffered_records = 1
         with repeater_traffic(context=self._ctx,
                               redpanda=self.redpanda,
                               nodes=self.preallocated_nodes,
                               topic=topic_names[0],
                               msg_size=repeater_msg_size,
                               workers=workers,
-                              max_buffered_records=64,
+                              max_buffered_records=max_buffered_records,
                               cleanup=lambda: self.free_preallocated_nodes(),
                               **repeater_kwargs) as repeater:
             repeater_await_bytes = 1E9
+            if scale.tiered_storage_enabled or not self.dedicated_nodes:
+                # Be much more lenient when tiered storage is enabled, since
+                # the repeater incurs reads.
+                repeater_await_bytes = 1E8
             repeater_await_msgs = int(repeater_await_bytes / repeater_msg_size)
 
             def progress_check():
@@ -885,7 +1003,9 @@ class ManyPartitionsTest(PreallocNodesTest):
 
             # Done with restarts, now do a longer traffic soak
             self.logger.info(f"Entering traffic soak phase")
-            soak_await_bytes = 100E9
+
+            # Normalize by the max_buffered_records.
+            soak_await_bytes = int(100E9 / 64 * max_buffered_records)
             if not self.redpanda.dedicated_nodes:
                 soak_await_bytes = 10E9
 

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -141,6 +141,7 @@ class ScaleParameters:
         self.local_retention_after_warmup = self.retention_bytes
 
         if tiered_storage_enabled:
+            redpanda.disable_cloud_storage_diagnostics()
             # When testing with tiered storage, the tuning goals of the test
             # parameters are different: we want to stress the number of
             # uploaded segments.

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -588,10 +588,15 @@ class KgoVerifierProducer(KgoVerifierService):
             return True
 
         self.logger.debug(f"{self.who_am_i()} wait: awaiting message count")
-        self._redpanda.wait_until(lambda: self._status_thread.errored or self.
-                                  _status.acked >= self._msg_count,
-                                  timeout_sec=timeout_sec,
-                                  backoff_sec=self._status_thread.INTERVAL)
+        try:
+            self._redpanda.wait_until(lambda: self._status_thread.errored or
+                                      self._status.acked >= self._msg_count,
+                                      timeout_sec=timeout_sec,
+                                      backoff_sec=self._status_thread.INTERVAL)
+        except:
+            self.stop_node(node)
+            raise
+
         self._status_thread.raise_on_error()
 
         return super().wait_node(node, timeout_sec=timeout_sec)

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import os
+import time
 import threading
 import requests
 
@@ -131,11 +132,26 @@ class KgoVerifierService(Service):
         node.account.remove("valid_offsets*json", True)
         node.account.remove(f"/tmp/{self.__class__.__name__}*")
 
-    def _remote(self, node, action):
+    def _remote(self, node, action, timeout=60):
+        """
+        Send a request to the node to perform the given action, retrying
+        periodically up to the given timeout.
+        """
         url = self._remote_url(node, action)
         self._redpanda.logger.info(f"{self.who_am_i()} remote call: {url}")
-        r = requests.get(url)
-        r.raise_for_status()
+        deadline = time.time() + timeout
+        last_error = None
+        while time.time() < deadline:
+            try:
+                r = requests.get(url, timeout=10)
+                r.raise_for_status()
+                return
+            except Exception as e:
+                last_error = e
+                self._redpanda.logger.warn(
+                    f"{self.who_am_i()} remote call failed, {e}")
+        if last_error:
+            raise last_error
 
     def wait_node(self, node, timeout_sec=None):
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -290,7 +290,8 @@ class SISettings:
                      int] = None,
                  cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
                      int] = None,
-                 bypass_bucket_creation: bool = False):
+                 bypass_bucket_creation: bool = False,
+                 cloud_storage_housekeeping_interval_ms=None):
         self.cloud_storage_type = CloudStorageType.S3
         if hasattr(test_context, 'injected_args') \
         and test_context.injected_args is not None \
@@ -328,6 +329,7 @@ class SISettings:
         self.cloud_storage_readreplica_manifest_sync_timeout_ms = cloud_storage_readreplica_manifest_sync_timeout_ms
         self.endpoint_url = f'http://{self.cloud_storage_api_endpoint}:{self.cloud_storage_api_endpoint_port}'
         self.bypass_bucket_creation = bypass_bucket_creation
+        self.cloud_storage_housekeeping_interval_ms = cloud_storage_housekeeping_interval_ms
 
     def load_context(self, logger, test_context):
         if self.cloud_storage_type == CloudStorageType.S3:
@@ -446,6 +448,10 @@ class SISettings:
         if self.cloud_storage_segment_max_upload_interval_sec:
             conf[
                 'cloud_storage_segment_max_upload_interval_sec'] = self.cloud_storage_segment_max_upload_interval_sec
+        if self.cloud_storage_housekeeping_interval_ms:
+            conf[
+                'cloud_storage_housekeeping_interval_ms'] = self.cloud_storage_housekeeping_interval_ms
+
         return conf
 
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1484,7 +1484,9 @@ class RedpandaService(Service):
         assert self.cloud_storage_client is not None
 
         failed_deletions = self.cloud_storage_client.empty_bucket(
-            self._si_settings.cloud_storage_bucket)
+            self._si_settings.cloud_storage_bucket,
+            # If on dedicate nodes, assume tests may be high scale and do parallel deletion
+            parallel=self.dedicated_nodes)
         assert len(failed_deletions) == 0
         self.cloud_storage_client.delete_bucket(
             self._si_settings.cloud_storage_bucket)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1712,7 +1712,7 @@ class RedpandaService(Service):
             self.logger.info(
                 f"Scanning node {node.account.hostname} log for errors...")
 
-            match_errors = "-e ERROR" if self._raise_on_errors else ""
+            match_errors = "-e ^ERROR" if self._raise_on_errors else ""
             for line in node.account.ssh_capture(
                     f"grep {match_errors} -e Segmentation\ fault -e [Aa]ssert {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
             ):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -739,6 +739,7 @@ class RedpandaService(Service):
             self.set_si_settings(si_settings)
         else:
             self._si_settings = None
+        self._disable_cloud_storage_diagnostics = False
 
         self.cloud_storage_client: Optional[S3Client] = None
 
@@ -1618,6 +1619,14 @@ class RedpandaService(Service):
         if crashes:
             raise NodeCrash(crashes)
 
+    def disable_cloud_storage_diagnostics(self):
+        """
+        Disable saving cloud storage diagnostics. This may be useful for tests
+        that generate millions of objecst, as collecting diagnostics may take a
+        significant amount of time.
+        """
+        self._disable_cloud_storage_diagnostica = True
+
     def cloud_storage_diagnostics(self):
         """
         When a cloud storage test fails, it is often useful to know what
@@ -1628,6 +1637,9 @@ class RedpandaService(Service):
         limit) into the ducktape log, and writes a zip file into the ducktape
         results directory containing a sample of the manifest.json files.
         """
+        if self._disable_cloud_storage_diagnostics:
+            self.logger.debug("Skipping cloud diagnostics, disabled")
+            return
         if not self._si_settings:
             self.logger.debug("Skipping cloud diagnostics, no SI settings")
             return


### PR DESCRIPTION
Note to reviewers:
* This PR has a few changes from John incorporated in it. Probably best to just look at the files changed, rather than each commit.

This commit adds a variant of `many_partitions_test` with tiered storage. Before running through the normal run of the test body, the test warms up the topic with enough segments to simulate a week of retention uploading hourly, by using a small segment size.

There are a couple issues found with this test[1][2], but I'm opting to mark the test as `ok_to_fail` and proceed with merging so we can get more of a signal before the upcoming release.

Some notes about this test as is:
* I'm still trying to stabilize this with compaction enabled, but I've run through it a few times without issues as is without compactions.
* The test takes ~40 minutes to run, and generates 2M cloud segments. This is on the expensive side of things that run nightly, but we can explore ways to pare this down (e.g. using 6 nodes instead of 12).

[1] https://redpandadata.slack.com/archives/C04ASNM2ZLK/p1675912245733099
[2]
```
[ERROR - 2023-02-09 04:11:50,587 - kgo_repeater_service - await_group_ready - lineno:209]:   ip-172-31-0-208: missing {36}
[ERROR - 2023-02-09 04:11:50,587 - kgo_repeater_service - await_group_ready - lineno:209]:   ip-172-31-12-168: missing set()
[ERROR - 2023-02-09 04:11:50,587 - kgo_repeater_service - await_group_ready - lineno:209]:   ip-172-31-2-180: missing set()
[ERROR - 2023-02-09 04:11:50,587 - kgo_repeater_service - repeater_traffic - lineno:277]: Exception during repeater_traffic region                                                                                                                                                                                                                                          Traceback (most recent call last):
  File "/home/ubuntu/redpanda/tests/rptest/services/kgo_repeater_service.py", line 272, in repeater_traffic                                                                                                                                                                                                                                                                     yield svc
  File "/home/ubuntu/redpanda/tests/rptest/scale_tests/many_partitions_test.py", line 1062, in _test_many_partitions
    self._restart_stress(scale, topic_names, n_partitions,
  File "/home/ubuntu/redpanda/tests/rptest/scale_tests/many_partitions_test.py", line 567, in _restart_stress
    inter_restart_check()
  File "/home/ubuntu/redpanda/tests/rptest/scale_tests/many_partitions_test.py", line 1039, in progress_check
    repeater.await_group_ready()                                                                                                                                                                                                                                                                                                                                              File "/home/ubuntu/redpanda/tests/rptest/services/kgo_repeater_service.py", line 188, in await_group_ready
    wait_until(group_ready, timeout_sec=120, backoff_sec=10)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/ducktape/utils/util.py", line 58, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
```

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
