### PR TITLE
tests: trace logs in KgoVerifierSelfTest

### DIFF
--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -101,7 +101,8 @@ class KgoVerifierSelfTest(PreallocNodesTest):
             100,
             2,
             nodes=self.preallocated_nodes,
-            debug_logs=True)
+            debug_logs=True,
+            trace_logs=True)
         rand_consumer.start(clean=False)
 
         seq_consumer = KgoVerifierSeqConsumer(self.test_context,
@@ -109,7 +110,8 @@ class KgoVerifierSelfTest(PreallocNodesTest):
                                               topic,
                                               16384,
                                               nodes=self.preallocated_nodes,
-                                              debug_logs=True)
+                                              debug_logs=True,
+                                              trace_logs=True)
         seq_consumer.start(clean=False)
 
         group_consumer = KgoVerifierConsumerGroupConsumer(
@@ -119,7 +121,8 @@ class KgoVerifierSelfTest(PreallocNodesTest):
             16384,
             2,
             nodes=self.preallocated_nodes,
-            debug_logs=True)
+            debug_logs=True,
+            trace_logs=True)
         group_consumer.start(clean=False)
 
         producer.wait(timeout_sec=60)


### PR DESCRIPTION
This test is short, so the cost of using trace logs is low.

It is suspected that this test is triggering a client bug, where only trace logs will tell us what's going on.

Related: https://github.com/redpanda-data/redpanda/issues/7231


## Backports Required


- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
