### PR TITLE
tests: add a task queue flush helper + use in unit tests

### DIFF
--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -260,7 +260,7 @@ void conn_quota_fixture::test_borrows(
     // Now that all units are released, we should find that reclaim
     // flag is switched off everywhere.
     vlog(logger.debug, "Checking reclaim status");
-    ss::thread::yield(); // give the backgrounded part of reclaim_to a chance
+    tests::flush_tasks(); // Let background reclaim advancer
     cooperative_spin_wait_with_timeout(5s, [core_count, this]() {
         bool any_in_reclaim = false;
 
@@ -375,9 +375,7 @@ FIXTURE_TEST(test_decrease_limit, conn_quota_fixture) {
     drop_shard_units();
 
     // Drain futures for background cross-core releases
-    for (uint32_t i = 0; i < initial_limit; ++i) {
-        ss::thread::yield();
-    }
+    tests::flush_tasks();
 
     vlog(logger.debug, "Taking 1st unit");
     auto u = take_units(addr1, 1);

--- a/src/v/test_utils/async.h
+++ b/src/v/test_utils/async.h
@@ -17,6 +17,7 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/thread.hh>
 
 #include <chrono>
 
@@ -50,4 +51,32 @@ requires ss::ApplyReturns<Predicate, bool> ||
           });
       }));
 }
+
+// When a test expects that any background fibers should complete promptly,
+// and wants to send a barrier through all the inter-CPU queues to ensure
+// that earlier-submitted tasks have reached their destination cores already.
+//
+// This is useful in tests that know they have put the system into a state where
+// it will get to a known state once all the non-i/o-blocking tasks in flight
+// have completed, such as background release of quota units.
+//
+// **Be aware** that there are assumptions to using this:
+// A) That your test code is using the same default scheduling group that
+//    this routine will run within.
+// B) That debug mode scheduling randomization in seastar does not re-order
+//    things so dramatically that our messages can go between every core and
+//    back before a future that was already ready on some shard gets run.
+inline void flush_tasks() {
+    // Ensure anything in inter-CPU queues before we entered the function
+    // has drained: this is an all-to-all to cover the full mesh of queues
+    // between cores.
+    ss::smp::invoke_on_all([]() {
+        return ss::smp::invoke_on_all([]() { return ss::yield(); });
+    }).get();
+
+    // Yield to anything that ended up runnable on the current core as a result
+    // of the above flush.
+    ss::thread::yield();
+}
+
 }; // namespace tests

--- a/src/v/test_utils/async.h
+++ b/src/v/test_utils/async.h
@@ -66,6 +66,9 @@ requires ss::ApplyReturns<Predicate, bool> ||
 // B) That debug mode scheduling randomization in seastar does not re-order
 //    things so dramatically that our messages can go between every core and
 //    back before a future that was already ready on some shard gets run.
+// C) You are calling from a seastar thread (.get() is used)
+// D) Tasks that have exhausted their scheduling quota and been suspended
+//    can still be running after this returns.
 inline void flush_tasks() {
     // Ensure anything in inter-CPU queues before we entered the function
     // has drained: this is an all-to-all to cover the full mesh of queues


### PR DESCRIPTION

There are some tests that use kludgy mechanisms to try and ensure that ready futures in the background have completed before checking a success condition.  This PR replaces these with a new function that sends tasks all-to-all across cores to ensure any earlier tasks (not blocked on I/O or timers) have completed.

Fixes https://github.com/redpanda-data/redpanda/issues/8364

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none

