### PR TITLE
Use fragmented vector for metadata response

### DIFF
--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -265,8 +265,8 @@ consumer::get_subscribed_topic_metadata() {
           std::vector<metadata_response::topic> topics;
           topics.reserve(_subscribed_topics.size());
           std::set_intersection(
-            res.data.topics.begin(),
-            res.data.topics.end(),
+            std::make_move_iterator(res.data.topics.begin()),
+            std::make_move_iterator(res.data.topics.end()),
             _subscribed_topics.begin(),
             _subscribed_topics.end(),
             std::back_inserter(topics),

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -108,7 +108,6 @@ metadata_response::topic make_topic_response_from_topic_metadata(
   const cluster::topic_metadata& tp_md,
   const is_node_isolated_or_decommissioned is_node_isolated) {
     metadata_response::topic tp;
-    tp.partitions.reserve(tp_md.get_assignments().size());
     tp.error_code = error_code::none;
     model::topic_namespace_view tp_ns = tp_md.get_configuration().tp_ns;
     tp.name = tp_md.get_configuration().tp_ns.tp;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -188,7 +188,8 @@ static ss::future<metadata_response::topic> create_topic(
               metadata_response::topic t;
               t.name = std::move(res[0].tp_ns.tp);
               t.error_code = map_topic_error_code(res[0].ec);
-              return ss::make_ready_future<metadata_response::topic>(t);
+              return ss::make_ready_future<metadata_response::topic>(
+                std::move(t));
           }
           auto tp_md = md_cache.get_topic_metadata(res[0].tp_ns);
 
@@ -196,7 +197,8 @@ static ss::future<metadata_response::topic> create_topic(
               metadata_response::topic t;
               t.name = std::move(res[0].tp_ns.tp);
               t.error_code = error_code::invalid_topic_exception;
-              return ss::make_ready_future<metadata_response::topic>(t);
+              return ss::make_ready_future<metadata_response::topic>(
+                std::move(t));
           }
 
           return wait_for_topics(

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -182,6 +182,7 @@ public:
         iter operator-(difference_type offset) { return iter{*this} -= offset; }
 
         bool operator==(const iter&) const = default;
+        auto operator<=>(const iter&) const = default;
 
         friend ssize_t operator-(const iter& a, const iter& b) {
             return a._index - b._index;

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -267,3 +267,10 @@ private:
     size_t _capacity{0};
     std::vector<std::vector<T>> _frags;
 };
+
+/**
+ * An alias for a fragmented_vector using a larger fragment size, close
+ * to the limit of the maximum contiguous allocation size.
+ */
+template<typename T>
+using large_fragment_vector = fragmented_vector<T, 32 * 1024>;

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -105,6 +105,34 @@ public:
         return _frags.size() * (sizeof(_frags[0]) + elems_per_frag * sizeof(T));
     }
 
+    /**
+     * Assign from a std::vector.
+     */
+    fragmented_vector& operator=(const std::vector<T>& rhs) noexcept {
+        clear();
+
+        for (auto& e : rhs) {
+            push_back(e);
+        }
+
+        return *this;
+    }
+
+    /**
+     * Remove all elements from the vector.
+     *
+     * Unlike std::vector, this also releases all the memory from
+     * the vector (since this vector already the same pointer
+     * and iterator stability guarantees that std::vector provides
+     * based on non-reallocation and capacity()).
+     */
+    void clear() {
+        // do the swap dance to actually clear the memory held by the vector
+        std::vector<std::vector<T>>{}.swap(_frags);
+        _size = 0;
+        _capacity = 0;
+    }
+
     template<bool C>
     class iter {
     public:

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -129,10 +129,17 @@ public:
             return *this;
         }
 
-        bool operator==(const const_iterator&) const = default;
+        const iter operator++(int) {
+            auto tmp = *this;
+            ++*this;
+            return tmp;
+        }
 
-        friend ssize_t
-        operator-(const const_iterator& a, const const_iterator& b) {
+        const iter operator--(int) {
+            auto tmp = *this;
+            --*this;
+            return tmp;
+        }
             return a._index - b._index;
         }
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -212,6 +212,17 @@ public:
     const_iterator cbegin() const { return const_iterator(this, 0); }
     const_iterator cend() const { return const_iterator(this, _size); }
 
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const fragmented_vector& v) {
+        os << "[";
+        for (auto& e : v) {
+            os << e << ",";
+        }
+        os << "]";
+        return os;
+    }
+
 private:
     fragmented_vector(const fragmented_vector&) noexcept = default;
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -123,6 +123,11 @@ public:
             return *this;
         }
 
+        iter& operator-=(ssize_t n) {
+            _index -= n;
+            return *this;
+        }
+
         iter& operator++() {
             ++_index;
             return *this;
@@ -144,6 +149,9 @@ public:
             --*this;
             return tmp;
         }
+
+        iter operator+(difference_type offset) { return iter{*this} += offset; }
+        iter operator-(difference_type offset) { return iter{*this} -= offset; }
 
         bool operator==(const iter&) const = default;
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -36,10 +36,6 @@
  */
 template<typename T, size_t fragment_size = 8192>
 class fragmented_vector {
-    static_assert(
-      (fragment_size & (fragment_size - 1)) == 0,
-      "fragment size must be a power of 2");
-    static_assert(fragment_size % sizeof(T) == 0);
     static constexpr size_t elems_per_frag = fragment_size / sizeof(T);
     static_assert(elems_per_frag >= 1);
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -114,6 +114,8 @@ public:
         using pointer = value_type*;
         using reference = value_type&;
 
+        iter() = default;
+
         reference operator*() const { return _vec->operator[](_index); }
 
         iter& operator+=(ssize_t n) {
@@ -157,8 +159,8 @@ public:
           : _index(index)
           , _vec(vec) {}
 
-        size_t _index;
-        vec_type* _vec;
+        size_t _index{};
+        vec_type* _vec{};
     };
 
     using const_iterator = iter<true>;

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -15,7 +15,12 @@
 #include <cstddef>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 #include <vector>
+
+namespace test_details {
+struct fragmented_vector_accessor;
+}
 
 /**
  * A very very simple fragmented vector that provides random access like a
@@ -243,6 +248,7 @@ public:
     const_iterator cbegin() const { return const_iterator(this, 0); }
     const_iterator cend() const { return const_iterator(this, _size); }
 
+    friend test_details::fragmented_vector_accessor;
 
     friend std::ostream&
     operator<<(std::ostream& os, const fragmented_vector& v) {

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -97,6 +97,13 @@ public:
         return o._frags == _frags;
     }
 
+    /**
+     * Returns the approximate in-memory size of this vector in bytes.
+     */
+    size_t memory_size() const {
+        return _frags.size() * (sizeof(_frags[0]) + elems_per_frag * sizeof(T));
+    }
+
     class const_iterator {
     public:
         using iterator_category = std::random_access_iterator_tag;

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -14,7 +14,83 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <initializer_list>
+#include <limits>
+#include <type_traits>
 #include <vector>
+
+using fv_int = fragmented_vector<int>;
+
+static_assert(std::forward_iterator<fv_int::iterator>);
+static_assert(std::forward_iterator<fv_int::const_iterator>);
+
+namespace test_details {
+
+struct fragmented_vector_accessor {
+    // perform an internal consistency check of the vector structure
+    template<typename T, size_t S>
+    static void check_consistency(const fragmented_vector<T, S>& v) {
+        BOOST_REQUIRE(v._size <= v._capacity);
+        BOOST_REQUIRE(v.size() < std::numeric_limits<size_t>::max() / 2);
+        BOOST_REQUIRE(v._capacity < std::numeric_limits<size_t>::max() / 2);
+
+        size_t calc_size = 0, calc_cap = 0;
+
+        for (size_t i = 0; i < v._frags.size(); ++i) {
+            auto& f = v._frags[i];
+
+            calc_size += f.size();
+            calc_cap += f.capacity();
+
+            if (i + 1 < v._frags.size()) {
+                if (f.size() < v.elems_per_frag) {
+                    throw std::runtime_error(fmt::format(
+                      "fragment {} is undersized ({} < {})",
+                      i,
+                      f.size(),
+                      v.elems_per_frag));
+                }
+            }
+        }
+
+        if (calc_size != v.size()) {
+            throw std::runtime_error(fmt::format(
+              "calculated size is wrong ({} != {})", calc_size, v.size()));
+        }
+
+        if (calc_cap != v._capacity) {
+            throw std::runtime_error(fmt::format(
+              "calculated capacity is wrong ({} != {})",
+              calc_size,
+              v._capacity));
+        }
+    }
+};
+} // namespace test_details
+
+/**
+ * Proxy that applies a consistency check before deference
+ */
+template<typename T, size_t S>
+struct checker {
+    using underlying = fragmented_vector<T, S>;
+
+    underlying* operator->() {
+        test_details::fragmented_vector_accessor::check_consistency(u);
+        return &u;
+    }
+
+    underlying& get() { return *operator->(); }
+
+    auto operator<=>(const checker&) const = default;
+
+    friend std::ostream& operator<<(std::ostream& os, const checker& c) {
+        os << c.u;
+        return os;
+    }
+
+    underlying u;
+};
 
 template<typename T>
 static void
@@ -114,4 +190,128 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_test) {
         BOOST_REQUIRE_EQUAL(
           std::distance(it, truth.end()), std::distance(it2, other.end()));
     }
+}
+
+template<typename T = int, size_t S = 8>
+static checker<T, S> make(std::initializer_list<T> in) {
+    checker<T, S> ret;
+    for (auto& e : in) {
+        ret->push_back(e);
+    }
+    return ret;
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_types) {
+    using vtype = fragmented_vector<int64_t, 8>;
+    using iter = vtype::iterator;
+    using citer = vtype::const_iterator;
+    auto v = vtype{};
+
+    // const and non-const iterators should be different!
+    static_assert(!std::is_same_v<iter, citer>);
+
+    static_assert(std::is_same_v<decltype(v.begin()), iter>);
+    static_assert(
+      std::is_same_v<decltype(v.cbegin()), decltype(v)::const_iterator>);
+    static_assert(std::is_same_v<
+                  decltype(std::as_const(v).begin()),
+                  decltype(v)::const_iterator>);
+}
+
+/**
+ * Get a fragmented vector for elements of size E, with max_fragment_size F.
+ */
+template<size_t ES, size_t F>
+using sized_frag = fragmented_vector<std::array<char, ES>, F>;
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_fragment_sizing) {
+    BOOST_CHECK_EQUAL((sized_frag<7, 32>::elements_per_fragment()), 4);
+    BOOST_CHECK_EQUAL((sized_frag<8, 32>::elements_per_fragment()), 4);
+    BOOST_CHECK_EQUAL((sized_frag<9, 32>::elements_per_fragment()), 2);
+    BOOST_CHECK_EQUAL((sized_frag<31, 32>::elements_per_fragment()), 1);
+    BOOST_CHECK_EQUAL((sized_frag<32, 32>::elements_per_fragment()), 1);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_arithmetic) {
+    auto v = make<int64_t, 8>({0, 1, 2, 3});
+
+    auto b = v->begin();
+
+    BOOST_CHECK_EQUAL(*(b + 0), 0);
+    BOOST_CHECK_EQUAL(*(b + 1), 1);
+    BOOST_CHECK_EQUAL(*(b + 2), 2);
+    BOOST_CHECK_EQUAL(*(b + 3), 3);
+
+    auto e = v->end();
+
+    BOOST_CHECK((e - 0) == e);
+
+    BOOST_CHECK_EQUAL(*(e - 1), 3);
+    BOOST_CHECK_EQUAL(*(e - 2), 2);
+    BOOST_CHECK_EQUAL(*(e - 3), 1);
+    BOOST_CHECK_EQUAL(*(e - 4), 0);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_comparison) {
+    auto v = make<int64_t, 8>({0, 1, 2, 3});
+
+    auto b = v->begin();
+
+    BOOST_CHECK(b == b);
+    BOOST_CHECK(b <= b);
+    BOOST_CHECK(!(b < b));
+    BOOST_CHECK(!(b > b));
+    BOOST_CHECK(!(b != b));
+
+    auto b1 = b + 1;
+
+    BOOST_CHECK(b <= b1);
+    BOOST_CHECK(b < b1);
+    BOOST_CHECK(b1 >= b);
+    BOOST_CHECK(b1 > b);
+    BOOST_CHECK(b1 >= b);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_sort) {
+    auto v = make<int64_t, 8>({3, 2, 1});
+    auto expected = make<int64_t, 8>({1, 2, 3});
+
+    std::sort(v->begin(), v->end());
+
+    BOOST_CHECK_EQUAL(v, expected);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_vector_clear) {
+    auto v = make<int, 8>({});
+
+    BOOST_CHECK_EQUAL(v->size(), 0);
+
+    v->push_back(0);
+    BOOST_CHECK_EQUAL(v->size(), 1);
+
+    v->push_back(1);
+    BOOST_CHECK_EQUAL(v->size(), 2);
+
+    v->clear();
+    BOOST_CHECK_EQUAL(v->size(), 0);
+
+    v = make<int, 8>({5, 5, 5, 5});
+    BOOST_CHECK_EQUAL(v->size(), 4);
+
+    v.u = std::vector{1, 2, 3};
+    BOOST_CHECK_EQUAL(v->size(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_vector_assign) {
+    std::vector vin0{1, 2, 3};
+    std::vector vin1{4, 5};
+
+    checker<int, 8> v;
+    BOOST_CHECK_EQUAL(v, (make({})));
+
+    v.get() = std::vector{1};
+    BOOST_CHECK_EQUAL(v, (make({1})));
+
+    v.get() = std::vector{2, 3, 4};
+    BOOST_CHECK_EQUAL(v, (make({2, 3, 4})));
 }


### PR DESCRIPTION
This series improves (I think) the fragmented vector class and uses it to
handle metadata responses which can be very large (multiple MB) when
there are many partitions and/or topics.

This helps prevent a fragmentation-implicated OOM, where we may fail to 
allocate a large metadata response even though we have more than 1 GB
free memory.

The individual commits have additional details.

Fixes #8355, Fixes #8100

## Backports Required

- [x] none - not confident this is important enough to backport

## Release Notes

 * none