### PR TITLE
[v22.2.x] rpk: avoid mangling timestamp in cluster config

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/import_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/import_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestClusterConfig_UnmarshalYAML(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   string
+		exp  clusterConfig
+	}{
+		{
+			name: "normal map",
+			in: `aggregate_metrics: false
+cloud_storage_access_key:
+cloud_storage_api_endpoint_port: 443
+cloud_storage_cache_size: 21474836480
+cloud_storage_credentials_source: config_file
+`,
+			exp: map[string]interface{}{
+				"aggregate_metrics":                false,
+				"cloud_storage_access_key":         nil,
+				"cloud_storage_api_endpoint_port":  443,
+				"cloud_storage_cache_size":         21474836480,
+				"cloud_storage_credentials_source": "config_file",
+			},
+		}, {
+			name: "normal map with timestamp",
+			in: `cloud_storage_bucket: 2021-08-06
+aggregate_metrics: true
+cloud_storage_access_key:
+cloud_storage_api_endpoint_port: 443
+cloud_storage_cache_size: 21474836480
+cloud_storage_credentials_source: config_file
+`,
+			exp: map[string]interface{}{
+				"cloud_storage_bucket":             "2021-08-06",
+				"aggregate_metrics":                true,
+				"cloud_storage_access_key":         nil,
+				"cloud_storage_api_endpoint_port":  443,
+				"cloud_storage_cache_size":         21474836480,
+				"cloud_storage_credentials_source": "config_file",
+			},
+		}, {
+			name: "map within a map",
+			in: `cloud_storage_bucket: 2021-08-06
+aggregate_metrics: true
+nested_1:
+  cloud_new_time: 2021-08-07
+  int_test: 1234
+  nested_2:
+    another_time: 2023-01-25
+    bool_test: true
+`,
+			exp: map[string]interface{}{
+				"cloud_storage_bucket": "2021-08-06",
+				"aggregate_metrics":    true,
+				"nested_1": map[string]interface{}{
+					"cloud_new_time": "2021-08-07",
+					"int_test":       1234,
+					"nested_2": map[string]interface{}{
+						"another_time": "2023-01-25",
+						"bool_test":    true,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var cfg clusterConfig
+			err := yaml.Unmarshal([]byte(test.in), &cfg)
+			require.NoError(t, err)
+
+			require.Equal(t, test.exp, cfg)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/reset.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/reset.go
@@ -56,8 +56,8 @@ the setting as if it was set to the default.
 			out.MaybeDie(err, "Couldn't read %q", configCacheFile)
 
 			// Decode YAML
-			content := make(map[string]interface{})
-			err = yaml.Unmarshal(f, content)
+			var content clusterConfig
+			err = yaml.Unmarshal(f, &content)
 			out.MaybeDie(err, "Couldn't parse %q: %v", configCacheFile, err)
 
 			// Snip out the value we are resetting

--- a/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/set.go
@@ -21,6 +21,26 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// anySlice represents a slice of any value type.
+type anySlice []interface{}
+
+// A custom unmarshal is needed because go-yaml parse "YYYY-MM-DD" as a full
+// timestamp, writing YYYY-MM-DD HH:MM:SS +0000 UTC when encoding, so we are
+// going to treat timestamps as strings.
+// See: https://github.com/go-yaml/yaml/issues/770
+
+func (s *anySlice) UnmarshalYAML(n *yaml.Node) error {
+	replaceTimestamp(n)
+
+	var a []interface{}
+	err := n.Decode(&a)
+	if err != nil {
+		return err
+	}
+	*s = a
+	return nil
+}
+
 func newSetCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set <key> <value>",
@@ -70,7 +90,7 @@ If an empty string is given as the value, the property is reset to its default.`
 				// are reset to default
 				remove = append(remove, key)
 			} else if meta.Type == "array" {
-				var a []interface{}
+				var a anySlice
 				err = yaml.Unmarshal([]byte(value), &a)
 				out.MaybeDie(err, "invalid list syntax")
 				upsert[key] = a


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8415
Fixes https://github.com/redpanda-data/redpanda/issues/8476,