### PR TITLE
Fix #8462 by parsing rpk.delete_topic output

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -262,7 +262,26 @@ class RpkTool:
 
     def delete_topic(self, topic):
         cmd = ["delete", topic]
-        return self._run_topic(cmd)
+        output = self._run_topic(cmd)
+        table = parse_rpk_table(output)
+        expected_columns = ["TOPIC", "STATUS"]
+        expected = ",".join(expected_columns)
+        found = ",".join(map(lambda x: x.name, table.columns))
+        if expected != found:
+            raise RpkException(f"expected: {expected}; found: {found}")
+
+        if len(table.rows) != 1:
+            raise RpkException(f"expected one row; found {len(table.rows)}")
+
+        if table.rows[0][1] != "OK":
+            raise RpkException(f"status isn't ok: {table.rows[0][1]}")
+
+        if table.rows[0][0] != topic:
+            raise RpkException(
+                f"output topic {table.rows[0][0]} doesn't match input topic {topic}"
+            )
+
+        return True
 
     def list_topics(self):
         cmd = ["list"]

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -148,9 +148,9 @@ class InternalTopicProtectionTest(RedpandaTest):
         assert pre_produce_hw < post_produce_hw, "wasn't able to produce to topic"
 
     @cluster(num_nodes=3)
-    @parametrize(client_type="rpk", no_exception_on_delete=True)
-    @parametrize(client_type="kafka_tools", no_exception_on_delete=False)
-    def kafka_nodelete_topics_test(self, client_type, no_exception_on_delete):
+    @parametrize(client_type="rpk")
+    @parametrize(client_type="kafka_tools")
+    def kafka_nodelete_topics_test(self, client_type):
         if client_type == "rpk":
             client = self.rpk
         elif client_type == "kafka_tools":
@@ -171,10 +171,11 @@ class InternalTopicProtectionTest(RedpandaTest):
             {"kafka_nodelete_topics": [test_topic]})
         try:
             client.delete_topic(test_topic)
-        except subprocess.CalledProcessError:
+            assert False, "Call to delete topic must fail"
+        except Exception:
+            self.redpanda.logger.info(
+                f"we were expecting delete_topic to fail", exc_info=True)
             pass
-        else:
-            assert no_exception_on_delete, "Call to delete topic returned sucess"
 
         # allow time for any erronous deletion to be propagated
         time.sleep(10)


### PR DESCRIPTION
Parsing the output to fail on anything but success to avoid slipping failures as success

fixes #8462

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes


  * none