### PR TITLE
Return retryable error when method not found during bootstrap

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -279,6 +279,7 @@ cluster::errc map_update_interruption_error_code(std::error_code ec) {
         case rpc::errc::service_error:
         case rpc::errc::method_not_found:
         case rpc::errc::version_not_supported:
+        case rpc::errc::unknown:
             return errc::replication_error;
         }
         __builtin_unreachable();

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -63,6 +63,8 @@ std::string_view to_string_view(feature f) {
         return "node_isolation";
     case feature::group_offset_retention:
         return "group_offset_retention";
+    case feature::rpc_transport_unknown_errc:
+        return "rpc_transport_unknown_errc";
 
     /*
      * testing features

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -14,6 +14,8 @@
 #include "cluster/types.h"
 #include "features/logger.h"
 
+#include <seastar/core/abort_source.hh>
+
 // The feature table is closely related to cluster and uses many types from it
 using namespace cluster;
 
@@ -357,6 +359,25 @@ ss::future<> feature_table::await_feature(feature f, ss::abort_source& as) {
           "Waiting for feature active {}",
           to_string_view(f));
         return _waiters_active.await(f, as);
+    }
+}
+
+ss::future<>
+feature_table::await_feature_then(feature f, std::function<void(void)> fn) {
+    try {
+        co_await await_feature(f);
+        fn();
+    } catch (ss::abort_requested_exception&) {
+        // Shutting down
+    } catch (...) {
+        // Should never happen, abort is the only exception that await_feature
+        // can throw, other than perhaps bad_alloc.
+        vlog(
+          featureslog.error,
+          "Unexpected error awaiting {} feature: {} {}",
+          to_string_view(f),
+          std::current_exception(),
+          ss::current_backtrace());
     }
 }
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -52,6 +52,7 @@ enum class feature : std::uint64_t {
     partition_move_revert_cancel = 1ULL << 18U,
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
+    rpc_transport_unknown_errc = 1ULL << 21U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 62U,
@@ -229,6 +230,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{9},
     "group_offset_retention",
     feature::group_offset_retention,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{9},
+    "rpc_transport_unknown_errc",
+    feature::rpc_transport_unknown_errc,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -317,6 +317,15 @@ public:
      */
     ss::future<> await_feature(feature f) { return await_feature(f, _as); };
 
+    /**
+     * Like await_feature, but runs the given function once the feature is
+     * successfully activated.
+     *
+     * If the feature never activates (i.e. if shutting down while waiting),
+     * the given function is not run.
+     */
+    ss::future<> await_feature_then(feature f, std::function<void(void)> fn);
+
     ss::future<> await_feature_preparing(feature f, ss::abort_source& as);
 
     ss::future<> stop();
@@ -351,6 +360,8 @@ public:
     // feature table to the desired version synchronously, early in the
     // lifetime of a node.
     void bootstrap_active_version(cluster::cluster_version);
+
+    void abort_for_tests() { _as.request_abort(); }
 
 private:
     // Only for use by our friends feature backend & manager

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -847,6 +847,7 @@ ss::future<> admin_server::throw_on_error(
         case rpc::errc::missing_node_rpc_client:
         case rpc::errc::method_not_found:
         case rpc::errc::version_not_supported:
+        case rpc::errc::unknown:
             throw ss::httpd::server_error_exception(
               fmt::format("Unexpected error: {}", ec.message()));
         }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1740,28 +1740,13 @@ void application::start_runtime_services(
   cluster::cluster_discovery& cd, ::stop_signal& app_signal) {
     ssx::background = feature_table.invoke_on_all(
       [this](features::feature_table& ft) {
-          return ft.await_feature(features::feature::rpc_v2_by_default)
-            .then([this] {
+          return ft.await_feature_then(
+            features::feature::rpc_v2_by_default, [this] {
                 if (ss::this_shard_id() == 0) {
                     vlog(_log.info, "Activating RPC protocol v2");
                 }
                 _connection_cache.local().set_default_transport_version(
                   rpc::transport_version::v2);
-            })
-            .handle_exception([this](const std::exception_ptr& e) {
-                try {
-                    std::rethrow_exception(e);
-                } catch (ss::abort_requested_exception&) {
-                    // Shutting down
-                } catch (...) {
-                    // Should never happen, abort is the only exception that
-                    // await_feature can throw, other than perhaps bad_alloc.
-                    vlog(
-                      _log.error,
-                      "Unexpected error awaiting RPCv2 feature: {} {}",
-                      std::current_exception(),
-                      ss::current_backtrace());
-                }
             });
       });
 

--- a/src/v/rpc/errc.h
+++ b/src/v/rpc/errc.h
@@ -24,6 +24,10 @@ enum class errc {
     service_error,
     method_not_found,
     version_not_supported,
+
+    // Used when receiving an undefined errc (e.g. from a newer version of
+    // Redpanda).
+    unknown = std::numeric_limits<uint8_t>::max(),
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "rpc::errc"; }
@@ -43,7 +47,7 @@ struct errc_category final : public std::error_category {
         case errc::version_not_supported:
             return "rpc::errc::version_not_supported";
         default:
-            return "rpc::errc::unknown";
+            return "rpc::errc::unknown(" + std::to_string(c) + ")";
         }
     }
 };

--- a/src/v/rpc/rpc_server.h
+++ b/src/v/rpc/rpc_server.h
@@ -35,9 +35,16 @@ public:
     rpc_server(const rpc_server&) = delete;
     rpc_server& operator=(const rpc_server&) = delete;
 
+    void set_all_services_added() { _all_services_added = true; }
+
+    void set_use_service_unavailable() { _service_unavailable_allowed = true; }
+
     // Adds the given services to the protocol.
     // May be called whether or not the server has already been started.
     void add_services(std::vector<std::unique_ptr<service>> services) {
+        vassert(
+          !_all_services_added,
+          "Adding service after all services already added");
         if (!config::shard_local_cfg().disable_metrics()) {
             for (auto& s : services) {
                 s->setup_metrics();
@@ -64,6 +71,9 @@ private:
     ss::future<> send_reply(ss::lw_shared_ptr<server_context_impl>, netbuf);
     ss::future<>
       send_reply_skip_payload(ss::lw_shared_ptr<server_context_impl>, netbuf);
+
+    bool _all_services_added{false};
+    bool _service_unavailable_allowed{false};
     std::vector<std::unique_ptr<service>> _services;
 };
 

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -111,6 +111,11 @@ public:
           _sg, _ssg, std::forward<Args>(args)...);
     }
 
+    T& server() {
+        check_server();
+        return *_server;
+    }
+
 private:
     void check_server() override {
         if (!_server) {

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -238,6 +238,8 @@ inline errc map_server_error(status status) {
         return errc::method_not_found;
     case status::version_not_supported:
         return errc::version_not_supported;
+    case status::service_unavailable:
+        return errc::exponential_backoff;
     default:
         return errc::unknown;
     };

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -232,12 +232,14 @@ inline errc map_server_error(status status) {
         return errc::success;
     case status::request_timeout:
         return errc::client_request_timeout;
-    case rpc::status::server_error:
+    case status::server_error:
         return errc::service_error;
     case status::method_not_found:
         return errc::method_not_found;
     case status::version_not_supported:
         return errc::version_not_supported;
+    default:
+        return errc::unknown;
     };
 };
 

--- a/src/v/rpc/types.cc
+++ b/src/v/rpc/types.cc
@@ -61,6 +61,8 @@ std::ostream& operator<<(std::ostream& o, const status& s) {
         return o << "rpc::status::server_error";
     case status::version_not_supported:
         return o << "rpc::status::version_not_supported";
+    case status::service_unavailable:
+        return o << "rpc::status::service_unavailable";
     default:
         return o << "rpc::status::unknown";
     }

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -182,6 +182,11 @@ enum class status : uint32_t {
     request_timeout = 408,
     server_error = 500,
     version_not_supported = 505,
+
+    // NOTE: Redpanda versions <= 22.3.x won't properly parse error codes they
+    // don't know about; error codes below should be used only if
+    // feature::rpc_transport_unknown_errc is active.
+    service_unavailable = 503,
 };
 
 enum class transport_version : uint8_t {


### PR DESCRIPTION
We previously saw issues where during bootstrap, a server would return
`method_not_found` upon receiving RPCs from other nodes, and that code
could result in an unexpected error (e.g. in the case of the admin
server, it resulted in a 500 code being sent back to the client).

This commit adds an explicit period where method_not_found errors don't
get returned if a method isn't found. Instead, the new
service_unavailable error is returned, indicating a request to retry.

Once the RPC subsystem has had all services registered, the behavior
reverts to always returning `method_not_found`.

This PR also addresses potential UB when adding a new status -- `rpc::transport` handles error codes it doesn't know about, making it difficult to extend `rpc::status`.

Related https://github.com/redpanda-data/redpanda/issues/8406

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Improvements

* Redpanda will now return a retriable status when its internal RPC subsystem is bootstrapping.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
