### PR TITLE
gha: bump goreleaser action version for rpk workflow

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -67,7 +67,7 @@ jobs:
          echo "" > /tmp/empty_notes
 
       - name: Invoke goreleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         env:
           QUILL_SIGN_P12: ${{ secrets.QUILL_SIGN_P12_BASE64 }}
           QUILL_SIGN_PASSWORD: ${{ secrets.QUILL_SIGN_PASSWORD }}


### PR DESCRIPTION
fix for rpk github action workflow

fixes #8484 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x


## Release Notes

 * none