### PR TITLE
Offset retention upgrade test

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -63,10 +63,14 @@ std::string_view to_string_view(feature f) {
         return "node_isolation";
     case feature::group_offset_retention:
         return "group_offset_retention";
+
+    /*
+     * testing features
+     */
     case feature::test_alpha:
         return "__test_alpha";
     case feature::test_bravo:
-        return "__test_alpha";
+        return "__test_bravo";
     }
     __builtin_unreachable();
 }

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -61,6 +61,8 @@ std::string_view to_string_view(feature f) {
         return "partition_move_cancel_revert";
     case feature::node_isolation:
         return "node_isolation";
+    case feature::group_offset_retention:
+        return "group_offset_retention";
     case feature::test_alpha:
         return "__test_alpha";
     case feature::test_bravo:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -218,14 +218,14 @@ constexpr static std::array feature_schema{
     feature::partition_move_revert_cancel,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
-
-  // For testing, a feature that does not auto-activate
   feature_spec{
     cluster::cluster_version{9},
     "node_isolation",
     feature::node_isolation,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
+
+  // For testing, a feature that does not auto-activate
   feature_spec{
     cluster::cluster_version{2001},
     "__test_alpha",

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -51,6 +51,7 @@ enum class feature : std::uint64_t {
     kafka_gssapi = 1ULL << 17U,
     partition_move_revert_cancel = 1ULL << 18U,
     node_isolation = 1ULL << 19U,
+    group_offset_retention = 1ULL << 20U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 62U,
@@ -222,6 +223,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{9},
     "node_isolation",
     feature::node_isolation,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{9},
+    "group_offset_retention",
+    feature::group_offset_retention,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -181,7 +181,10 @@ std::optional<std::chrono::seconds> group_manager::offset_retention_enabled() {
          * effective behavior of infinite retention.
          *
          * this case also handles the early boot-up ambiguity in which the
-         * original version is indeterminate.
+         * original version is indeterminate. when we are here because the
+         * original cluster version is unknown then because legacy support is
+         * disabled by default the decision is conservative. if it is enabled
+         * then it was explicitly requested and the orig version doesn't matter.
          */
         return config::shard_local_cfg()
           .legacy_group_offset_retention_enabled();

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -165,6 +165,17 @@ std::optional<std::chrono::seconds> group_manager::offset_retention_enabled() {
         }
 
         /*
+         * this is a legacy / pre-v23 cluster. wait until all of the nodes have
+         * been upgraded before making a final decision to enable offset
+         * retention in order to avoid anomalies since each node independently
+         * applies offset retention policy.
+         */
+        if (!_feature_table.local().is_active(
+              features::feature::group_offset_retention)) {
+            return false;
+        }
+
+        /*
          * this is a legacy / pre-v23.1 cluster. retention will only be enabled
          * if explicitly requested for legacy systems in order to retain the
          * effective behavior of infinite retention.

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -58,6 +58,14 @@ def int_tuple(str_tuple):
     return (int(str_tuple[0]), int(str_tuple[1]), int(str_tuple[2]))
 
 
+def ver_string(int_tuple):
+    """
+    Converts (1,2,3) into "v1.2.3"
+    """
+    assert len(int_tuple) == 3, int_tuple
+    return f"v{'.'.join(str(i) for i in int_tuple)}"
+
+
 class InstallOptions:
     """
     Options with which to configure the installation of Redpanda in a cluster.

--- a/tests/rptest/tests/offset_retention_test.py
+++ b/tests/rptest/tests/offset_retention_test.py
@@ -9,9 +9,135 @@
 import time
 from rptest.services.cluster import cluster
 from rptest.clients.rpk import RpkTool
+from ducktape.mark import parametrize
+from rptest.services.admin import Admin
 from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions, ver_string
+
+
+class OffsetRetentionDisabledAfterUpgrade(RedpandaTest):
+    """
+    When upgrading to Redpanda v23 or later offset retention should be disabled
+    by default. Offset retention did not exist pre-v23, so existing clusters
+    should have to opt-in after upgrade in order to avoid suprises.
+    """
+    topics = (TopicSpec(), )
+
+    feature_config_timing = {
+        "group_offset_retention_sec",
+        "group_offset_retention_check_ms",
+    }
+    feature_config_legacy = "legacy_group_offset_retention_enabled"
+    feature_config_names = feature_config_timing | {feature_config_legacy}
+
+    def __init__(self, test_context):
+        super(OffsetRetentionDisabledAfterUpgrade,
+              self).__init__(test_context=test_context, num_brokers=3)
+        self.installer = self.redpanda._installer
+
+    def setUp(self):
+        # handled by test case to support parameterization
+        pass
+
+    def _validate_pre_upgrade(self, version):
+        """
+        1. verify starting version of cluster nodes
+        2. verify expected configs of initial cluster
+        """
+        self.installer.install(self.redpanda.nodes, version)
+        super(OffsetRetentionDisabledAfterUpgrade, self).setUp()
+
+        # wait until all nodes are running the same version
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert ver_string(version) in unique_versions
+
+        # sanity check none of feature configs should exist
+        admin = Admin(self.redpanda)
+        config = admin.get_cluster_config()
+        assert config.keys().isdisjoint(self.feature_config_names)
+
+    def _perform_upgrade(self, initial_version, version):
+        """
+        1. verify upgrade of all cluster nodes
+        2. verify expected configs after upgrade
+        """
+        # upgrade all nodes to target version
+        self.installer.install(self.redpanda.nodes, version)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # wait until all nodes are running the same version
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert ver_string(initial_version) not in unique_versions
+
+        # sanity check that all new feature configs exist
+        admin = Admin(self.redpanda)
+        config = admin.get_cluster_config()
+        assert config.keys() > self.feature_config_names
+
+        # configs should all have positive values
+        for name in self.feature_config_timing:
+            assert config[name] > 0
+
+        # after upgrade legacy support should be disabled
+        assert config[self.feature_config_legacy] == False
+
+    def _offset_removal_occurred(self, period):
+        rpk = RpkTool(self.redpanda)
+        group = "hey_group"
+
+        def offsets_exist():
+            desc = rpk.group_describe(group)
+            return len(desc.partitions) > 0
+
+        # consume from the group for twice as long as the retention period
+        # setting and verify that group offsets exist for the entire time.
+        start = time.time()
+        while time.time() - start < (period * 2):
+            rpk.produce(self.topic, "k", "v")
+            rpk.consume(self.topic, n=1, group=group)
+            wait_until(offsets_exist, timeout_sec=1, backoff_sec=1)
+            time.sleep(1)
+
+        # after one half life the offset should still exist
+        time.sleep(period / 2)
+        assert offsets_exist()
+
+        # after waiting for twice the retention period, it should be gone
+        time.sleep(period * 2 - period / 2)
+        return not offsets_exist()
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @parametrize(initial_version=(22, 2, 9))
+    @parametrize(initial_version=(22, 3, 11))
+    def test_upgrade_from_pre_v23(self, initial_version):
+        """
+        1. test that retention feature doesn't work on legacy version
+        2. upgrade cluster and test that feature still doesn't work
+        3. enable legacy support on the cluster
+        4. test that retention works properly
+        """
+        period = 30
+
+        # in old cluster offset retention should not be active
+        self._validate_pre_upgrade(initial_version)
+        assert not self._offset_removal_occurred(period)
+
+        # in cluster upgraded from pre-v23 retention should not be active
+        self._perform_upgrade(initial_version, RedpandaInstaller.HEAD)
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_config_set("group_offset_retention_sec", str(period))
+        rpk.cluster_config_set("group_offset_retention_check_ms", str(1000))
+        assert not self._offset_removal_occurred(period)
+
+        # enable legacy. enablng legacy support takes affect at the next
+        # retention check. since that is configured above to happen every second
+        # then the response time should be adequate.
+        rpk.cluster_config_set("legacy_group_offset_retention_enabled",
+                               str(True))
+        assert self._offset_removal_occurred(period)
 
 
 class OffsetRetentionTest(RedpandaTest):


### PR DESCRIPTION
Adds upgrade tests for kafka offset retention feature.

Fixes: https://github.com/redpanda-data/redpanda/issues/8350

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->
  * none

