### PR TITLE
coverage: fix inconsistent enabling option

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -605,7 +605,7 @@ class RedpandaService(Service):
         "admin", "admin", "SCRAM-SHA-256")
 
     COV_KEY = "enable_cov"
-    DEFAULT_COV_OPT = False
+    DEFAULT_COV_OPT = "OFF"
 
     # Where we put a compressed binary if saving it after failure
     EXECUTABLE_SAVE_PATH = "/tmp/redpanda.gz"
@@ -2579,7 +2579,15 @@ class RedpandaService(Service):
         return [make_partition(p) for p in topic["partitions"]]
 
     def cov_enabled(self):
-        return self._context.globals.get(self.COV_KEY, self.DEFAULT_COV_OPT)
+        cov_option = self._context.globals.get(self.COV_KEY,
+                                               self.DEFAULT_COV_OPT)
+        if cov_option == "ON":
+            return True
+        elif cov_option == "OFF":
+            return False
+
+        self.logger.warn(f"{self.COV_KEY} should be one of 'ON', or 'OFF'")
+        return False
 
     def search_log_node(self, node: ClusterNode, pattern: str):
         for line in node.account.ssh_capture(


### PR DESCRIPTION
The redpanda.py service assumes that the option
for enabling code coverage tests is either True
or False; whereas the cmake configuration expects
it to be ON or OFF. This commit fixes this variable inconsistency by allowing ON or OFF as allow-listed values for this option

ref https://github.com/redpanda-data/devprod/issues/548

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x



## Release Notes

* none
