### PR TITLE
ducktape: NodeOpsExecutor ensure node not empty before DE_RECOMMISSION

### DIFF
--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -354,6 +354,9 @@ class NodeOpsExecutor():
             if operation.wait_for_finish:
                 self.wait_for_rebalanced(operation.node)
         elif operation.type == OperationType.DE_RECOMMISSION:
+            # If node is empty decommission will finish immediately and we won't
+            # be able to recommission it
+            self.wait_for_rebalanced(operation.node)
             self.decommission(operation.node)
 
             self.recommission(operation.node)


### PR DESCRIPTION
If node is empty decommission will finish immediately and we won't be able to recommission it.
Node will be removed from cluster before recommission is called

Fixes #8383
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
