### PR TITLE
storage: use index for timequeries and support negative time deltas

### DIFF
--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -23,6 +23,7 @@ struct local_monitor_fixture {
     ~local_monitor_fixture();
 
     std::filesystem::path _test_path;
+    ss::sharded<features::feature_table> _feature_table;
     ss::sharded<storage::api> _storage_api;
     ss::sharded<storage::node_api> _storage_node_api;
     cluster::node::local_monitor _local_monitor;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -89,7 +89,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "3600000",
        .visibility = visibility::user},
-      std::nullopt,
+      std::chrono::weeks{2},
       {.min = 60s})
   , log_segment_ms_min(
       *this,

--- a/src/v/model/timestamp.h
+++ b/src/v/model/timestamp.h
@@ -65,6 +65,16 @@ public:
 
     auto operator<=>(const timestamp&) const = default;
 
+    timestamp& operator-=(const timestamp& rhs) {
+        _v -= rhs();
+        return *this;
+    }
+
+    friend timestamp operator-(timestamp lhs, const timestamp& rhs) {
+        lhs -= rhs;
+        return lhs;
+    }
+
     friend std::ostream& operator<<(std::ostream&, timestamp);
 
     // ADL helpers for interfacing with the serde library.

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -55,7 +55,8 @@ struct mux_state_machine_fixture {
         _storage
           .start(
             [kv_conf]() { return kv_conf; },
-            [this]() { return default_log_cfg(); })
+            [this]() { return default_log_cfg(); },
+            std::ref(_feature_table))
           .get0();
         _storage.invoke_on_all(&storage::api::start).get0();
         _connections.start().get0();

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -128,7 +128,8 @@ struct raft_node {
                   storage_dir,
                   segment_size,
                   storage::debug_sanitize_files::yes);
-            })
+            },
+            std::ref(feature_table))
           .get();
         storage.invoke_on_all(&storage::api::start).get();
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1486,7 +1486,8 @@ void application::wire_up_bootstrap_services() {
           log_cfg.reclaim_opts.background_reclaimer_sg
             = _scheduling_groups.cache_background_reclaim_sg();
           return log_cfg;
-      })
+      },
+      std::ref(feature_table))
       .get();
 
     // Hook up local_monitor to update storage_resources when disk state changes

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -110,9 +110,13 @@ private:
 class copy_data_segment_reducer : public compaction_reducer {
 public:
     copy_data_segment_reducer(
-      compacted_offset_list l, segment_appender* a, bool internal_topic)
+      compacted_offset_list l,
+      segment_appender* a,
+      bool internal_topic,
+      offset_delta_time apply_offset)
       : _list(std::move(l))
       , _appender(a)
+      , _idx(index_state::make_empty_index(apply_offset))
       , _internal_topic(internal_topic) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -54,13 +54,18 @@ using namespace std::literals::chrono_literals;
 namespace storage {
 
 disk_log_impl::disk_log_impl(
-  ntp_config cfg, log_manager& manager, segment_set segs, kvstore& kvstore)
+  ntp_config cfg,
+  log_manager& manager,
+  segment_set segs,
+  kvstore& kvstore,
+  ss::sharded<features::feature_table>& feature_table)
   : log::impl(std::move(cfg))
   , _manager(manager)
   , _segment_size_jitter(
       internal::random_jitter(_manager.config().segment_size_jitter))
   , _segs(std::move(segs))
   , _kvstore(kvstore)
+  , _feature_table(feature_table)
   , _start_offset(read_start_offset())
   , _lock_mngr(_segs)
   , _max_segment_size(compute_max_segment_size())
@@ -522,7 +527,7 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
     auto staging_path = target->reader().path().to_compaction_staging();
     auto [replacement, generations]
       = co_await storage::internal::make_concatenated_segment(
-        staging_path, segments, cfg, _manager.resources());
+        staging_path, segments, cfg, _manager.resources(), _feature_table);
 
     // compact the combined data in the replacement segment. the partition size
     // tracking needs to be adjusted as compaction routines assume the segment
@@ -1652,9 +1657,13 @@ std::ostream& operator<<(std::ostream& o, const disk_log_impl& d) {
 }
 
 log make_disk_backed_log(
-  ntp_config cfg, log_manager& manager, segment_set segs, kvstore& kvstore) {
+  ntp_config cfg,
+  log_manager& manager,
+  segment_set segs,
+  kvstore& kvstore,
+  ss::sharded<features::feature_table>& feature_table) {
     auto ptr = ss::make_shared<disk_log_impl>(
-      std::move(cfg), manager, std::move(segs), kvstore);
+      std::move(cfg), manager, std::move(segs), kvstore, feature_table);
     return log(ptr);
 }
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -394,7 +394,8 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
           cfg,
           _probe,
           *_readers_cache,
-          _manager.resources());
+          _manager.resources(),
+          storage::internal::should_apply_delta_time_offset(_feature_table));
 
         vlog(
           gclog.debug,
@@ -540,7 +541,8 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
       cfg,
       _probe,
       *_readers_cache,
-      _manager.resources());
+      _manager.resources(),
+      storage::internal::should_apply_delta_time_offset(_feature_table));
     _probe.delete_segment(*replacement.get());
     vlog(gclog.debug, "Final compacted segment {}", replacement);
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "storage/disk_log_appender.h"
 #include "storage/failure_probes.h"
@@ -53,7 +54,12 @@ public:
      */
     static constexpr size_t segment_size_hard_limit = 3_GiB;
 
-    disk_log_impl(ntp_config, log_manager&, segment_set, kvstore&);
+    disk_log_impl(
+      ntp_config,
+      log_manager&,
+      segment_set,
+      kvstore&,
+      ss::sharded<features::feature_table>& feature_table);
     ~disk_log_impl() override;
     disk_log_impl(disk_log_impl&&) noexcept = default;
     disk_log_impl& operator=(disk_log_impl&&) noexcept = delete;
@@ -184,6 +190,7 @@ private:
     float _segment_size_jitter;
     segment_set _segs;
     kvstore& _kvstore;
+    ss::sharded<features::feature_table>& _feature_table;
     model::offset _start_offset;
     // Used to serialize updates to _start_offset. See the update_start_offset
     // method.

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -68,6 +68,8 @@ struct index_state
     // of this segment are monontonically increasing.
     bool batch_timestamps_are_monotonic{true};
 
+    size_t size() const { return relative_offset_index.size(); }
+
     bool empty() const { return relative_offset_index.empty(); }
 
     void

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -12,15 +12,67 @@
 #pragma once
 
 #include "bytes/iobuf.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
 #include "serde/envelope.h"
 #include "utils/fragmented_vector.h"
 
+#include <seastar/core/sharded.hh>
+
 #include <cstdint>
 #include <optional>
 
 namespace storage {
+
+using offset_delta_time = ss::bool_class<struct offset_delta_time_tag>;
+
+/*
+ * In order to be able to represent negative time deltas (required for
+ * out of order timestamps, the time delta stored in 'index_state' is
+ * offset by 2^31. The 'offset_time_index' class below deals with
+ * this translation. The range for time deltas is roughly from -596h to +596h.
+ */
+class offset_time_index {
+public:
+    static constexpr model::timestamp::type offset = 2147483648; // 2^31
+    static constexpr model::timestamp::type delta_time_min = -offset;
+    static constexpr model::timestamp::type delta_time_max = offset - 1;
+
+    offset_time_index(model::timestamp ts, offset_delta_time with_offset)
+      : _with_offset(with_offset) {
+        if (_with_offset == offset_delta_time::yes) {
+            _val = static_cast<uint32_t>(
+              std::clamp(ts(), delta_time_min, delta_time_max) + offset);
+        } else {
+            _val = _val = static_cast<uint32_t>(std::clamp(
+              ts(),
+              model::timestamp::type{std::numeric_limits<uint32_t>::min()},
+              model::timestamp::type{std::numeric_limits<uint32_t>::max()}));
+        }
+    }
+
+    uint32_t operator()() const {
+        if (_with_offset == offset_delta_time::yes) {
+            return _val - static_cast<uint32_t>(offset);
+        } else {
+            return _val;
+        }
+    }
+
+private:
+    offset_time_index(uint32_t val, offset_delta_time with_offset)
+      : _with_offset(with_offset)
+      , _val(val) {}
+
+    uint32_t raw_value() const { return _val; }
+
+    offset_delta_time _with_offset;
+    uint32_t _val;
+
+    friend struct index_state;
+};
+
 /* Fileformat:
    1 byte  - version
    4 bytes - size - does not include the version or size
@@ -35,12 +87,16 @@ namespace storage {
    [] relative_time_index
    [] position_index
    1 byte  - batch_timestamps_are_monotonic
+   1 byte  - with_offset
  */
 struct index_state
   : serde::envelope<index_state, serde::version<5>, serde::compat_version<4>> {
     static constexpr auto monotonic_timestamps_version = 5;
 
+    static index_state make_empty_index(offset_delta_time with_offset);
+
     index_state() = default;
+
     index_state(index_state&&) noexcept = default;
     index_state& operator=(index_state&&) noexcept = default;
     index_state& operator=(const index_state&) = delete;
@@ -68,14 +124,17 @@ struct index_state
     // of this segment are monontonically increasing.
     bool batch_timestamps_are_monotonic{true};
 
+    // flag indicating whether the relative time index has been offset
+    offset_delta_time with_offset{false};
+
     size_t size() const { return relative_offset_index.size(); }
 
     bool empty() const { return relative_offset_index.empty(); }
 
-    void
-    add_entry(uint32_t relative_offset, uint32_t relative_time, uint64_t pos) {
+    void add_entry(
+      uint32_t relative_offset, offset_time_index relative_time, uint64_t pos) {
         relative_offset_index.push_back(relative_offset);
-        relative_time_index.push_back(relative_time);
+        relative_time_index.push_back(relative_time.raw_value());
         position_index.push_back(pos);
     }
     void pop_back() {
@@ -86,9 +145,37 @@ struct index_state
             non_data_timestamps = false;
         }
     }
-    std::tuple<uint32_t, uint32_t, uint64_t> get_entry(size_t i) {
+    std::tuple<uint32_t, offset_time_index, uint64_t> get_entry(size_t i) {
         return {
-          relative_offset_index[i], relative_time_index[i], position_index[i]};
+          relative_offset_index[i],
+          offset_time_index{relative_time_index[i], with_offset},
+          position_index[i]};
+    }
+
+    std::optional<std::tuple<uint32_t, offset_time_index, uint64_t>>
+    find_entry(model::timestamp ts) {
+        const auto idx = offset_time_index{ts, with_offset};
+
+        auto it = std::lower_bound(
+          std::begin(relative_time_index),
+          std::end(relative_time_index),
+          idx.raw_value(),
+          std::less<uint32_t>{});
+        if (it == relative_offset_index.end()) {
+            return std::nullopt;
+        }
+
+        const auto dist = std::distance(relative_offset_index.begin(), it);
+
+        // lower_bound will place us on the first batch in the index that has
+        // 'max_timestamp' greater than 'ts'. Since not every batch is indexed,
+        // it's not guaranteed* that 'ts' will be present in the batch
+        // (i.e. 'ts > first_timestamp'). For this reason, we go back one batch.
+        //
+        // *In the case where lower_bound places on the first batch, we'll
+        // start the timequery from the beggining of the segment as the user
+        // data batch is always indexed.
+        return get_entry(dist > 0 ? dist - 1 : 0);
     }
 
     bool maybe_index(
@@ -124,7 +211,8 @@ private:
       , relative_offset_index(o.relative_offset_index.copy())
       , relative_time_index(o.relative_time_index.copy())
       , position_index(o.position_index.copy())
-      , batch_timestamps_are_monotonic(o.batch_timestamps_are_monotonic) {}
+      , batch_timestamps_are_monotonic(o.batch_timestamps_are_monotonic)
+      , with_offset(o.with_offset) {}
 };
 
 } // namespace storage

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -99,7 +99,10 @@ public:
         /* your sub-system here */
     };
 
-    explicit kvstore(kvstore_config kv_conf, storage_resources&);
+    explicit kvstore(
+      kvstore_config kv_conf,
+      storage_resources&,
+      ss::sharded<features::feature_table>& feature_table);
 
     ss::future<> start();
     ss::future<> stop();
@@ -116,6 +119,7 @@ public:
 private:
     kvstore_config _conf;
     storage_resources& _resources;
+    ss::sharded<features::feature_table>& _feature_table;
     ntp_config _ntpc;
     ss::gate _gate;
     ss::abort_source _as;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
@@ -222,6 +223,11 @@ class log_manager;
 class segment_set;
 class kvstore;
 log make_memory_backed_log(ntp_config);
-log make_disk_backed_log(ntp_config, log_manager&, segment_set, kvstore&);
+log make_disk_backed_log(
+  ntp_config,
+  log_manager&,
+  segment_set,
+  kvstore&,
+  ss::sharded<features::feature_table>& feature_table);
 
 } // namespace storage

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "config/property.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "random/simple_time_jitter.h"
 #include "seastarx.h"
@@ -154,7 +155,10 @@ struct log_config {
 class log_manager {
 public:
     explicit log_manager(
-      log_config, kvstore& kvstore, storage_resources&) noexcept;
+      log_config,
+      kvstore& kvstore,
+      storage_resources&,
+      ss::sharded<features::feature_table>&) noexcept;
 
     ss::future<log> manage(ntp_config);
 
@@ -229,6 +233,7 @@ private:
     log_config _config;
     kvstore& _kvstore;
     storage_resources& _resources;
+    ss::sharded<features::feature_table>& _feature_table;
     simple_time_jitter<ss::lowres_clock> _jitter;
     ss::timer<ss::lowres_clock> _housekeeping_timer;
     logs_type _logs;

--- a/src/v/storage/log_replayer.cc
+++ b/src/v/storage/log_replayer.cc
@@ -62,6 +62,8 @@ public:
         if (is_valid_batch_crc()) {
             _cfg.last_offset = _header.last_offset();
             _cfg.truncate_file_pos = _file_pos_to_end_of_batch;
+            _cfg.last_max_timestamp = std::max(
+              _header.first_timestamp, _header.max_timestamp);
             const auto physical_base_offset = _file_pos_to_end_of_batch
                                               - _header.size_bytes;
             _seg->index().maybe_track(_header, physical_base_offset);

--- a/src/v/storage/log_replayer.h
+++ b/src/v/storage/log_replayer.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "model/fundamental.h"
+#include "model/timestamp.h"
 #include "seastarx.h"
 #include "storage/fwd.h"
 
@@ -28,8 +29,9 @@ public:
     struct checkpoint {
         std::optional<model::offset> last_offset;
         std::optional<size_t> truncate_file_pos;
+        std::optional<model::timestamp> last_max_timestamp;
         explicit operator bool() const {
-            return last_offset && truncate_file_pos;
+            return last_offset && truncate_file_pos && last_max_timestamp;
         }
     };
 

--- a/src/v/storage/offset_to_filepos.h
+++ b/src/v/storage/offset_to_filepos.h
@@ -31,10 +31,14 @@ namespace internal {
 
 class offset_to_filepos_consumer {
 public:
-    using type = std::optional<std::pair<model::offset, size_t>>;
+    using type
+      = std::optional<std::tuple<model::offset, size_t, model::timestamp>>;
 
     offset_to_filepos_consumer(
-      model::offset log_start_offset, model::offset target, size_t initial);
+      model::offset log_start_offset,
+      model::offset target,
+      size_t initial,
+      model::timestamp initial_timestamp);
 
     ss::future<ss::stop_iteration> operator()(::model::record_batch batch);
 
@@ -44,6 +48,7 @@ private:
     type _filepos;
     model::offset _target_last_offset;
     model::offset _prev_batch_last_offset;
+    model::timestamp _prev_batch_max_timestamp;
     size_t _accumulator;
     size_t _prev;
 };

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -25,6 +25,7 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/rwlock.hh>
+#include <seastar/core/sharded.hh>
 
 #include <exception>
 #include <optional>
@@ -262,7 +263,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
   unsigned read_ahead,
-  storage_resources&);
+  storage_resources&,
+  ss::sharded<features::feature_table>& feature_table);
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
   const ntp_config& ntpc,
@@ -274,7 +276,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   unsigned read_ahead,
   debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
-  storage_resources&);
+  storage_resources&,
+  ss::sharded<features::feature_table>& feature_table);
 
 // bitflags operators
 [[gnu::always_inline]] inline segment::bitflags

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -90,7 +90,8 @@ public:
     ss::future<> close();
     ss::future<> flush();
     ss::future<> release_appender(readers_cache*);
-    ss::future<> truncate(model::offset, size_t physical);
+    ss::future<> truncate(
+      model::offset, size_t physical, model::timestamp new_max_timestamp);
 
     /// main write interface
     /// auto indexes record_batch
@@ -181,7 +182,10 @@ private:
     void set_close();
     void cache_truncate(model::offset offset);
     void check_segment_not_closed(const char* msg);
-    ss::future<> do_truncate(model::offset prev_last_offset, size_t physical);
+    ss::future<> do_truncate(
+      model::offset prev_last_offset,
+      size_t physical,
+      model::timestamp new_max_timestamp);
     ss::future<> do_close();
     ss::future<> do_flush();
     ss::future<> do_release_appender(

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -48,6 +48,8 @@ segment_index::segment_index(
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
+  , _state(index_state::make_empty_index(
+      storage::internal::should_apply_delta_time_offset(_feature_table)))
   , _sanitize(sanitize) {
     _state.base_offset = base;
 }
@@ -61,6 +63,8 @@ segment_index::segment_index(
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
+  , _state(index_state::make_empty_index(
+      storage::internal::should_apply_delta_time_offset(_feature_table)))
   , _mock_file(mock_file) {
     _state.base_offset = base;
 }

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -42,17 +42,24 @@ segment_index::segment_index(
   segment_full_path path,
   model::offset base,
   size_t step,
+  ss::sharded<features::feature_table>& feature_table,
   debug_sanitize_files sanitize)
   : _path(std::move(path))
   , _step(step)
+  , _feature_table(std::ref(feature_table))
   , _sanitize(sanitize) {
     _state.base_offset = base;
 }
 
 segment_index::segment_index(
-  segment_full_path path, ss::file mock_file, model::offset base, size_t step)
+  segment_full_path path,
+  ss::file mock_file,
+  model::offset base,
+  size_t step,
+  ss::sharded<features::feature_table>& feature_table)
   : _path(std::move(path))
   , _step(step)
+  , _feature_table(std::ref(feature_table))
   , _mock_file(mock_file) {
     _state.base_offset = base;
 }

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -182,8 +182,11 @@ ss::future<> segment_index::truncate(model::offset o) {
             _state.max_timestamp = _state.base_timestamp;
             _state.max_offset = _state.base_offset;
         } else {
-            _state.max_timestamp = model::timestamp(
-              _state.relative_time_index.back() + _state.base_timestamp());
+            const auto last_entry = _state.get_entry(_state.size() - 1);
+            const auto translated_entry = translate_index_entry(
+              _state, last_entry);
+
+            _state.max_timestamp = translated_entry.timestamp;
             _state.max_offset = o;
         }
     }

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -29,11 +29,12 @@
 namespace storage {
 
 static inline segment_index::entry translate_index_entry(
-  const index_state& s, std::tuple<uint32_t, uint32_t, uint64_t> entry) {
+  const index_state& s,
+  std::tuple<uint32_t, offset_time_index, uint64_t> entry) {
     auto [relative_offset, relative_time, filepos] = entry;
     return segment_index::entry{
       .offset = model::offset(relative_offset + s.base_offset()),
-      .timestamp = model::timestamp(relative_time + s.base_timestamp()),
+      .timestamp = model::timestamp(relative_time() + s.base_timestamp()),
       .filepos = filepos,
     };
 }
@@ -76,8 +77,10 @@ ss::future<ss::file> segment_index::open() {
 
 void segment_index::reset() {
     auto base = _state.base_offset;
-    _state = {};
+    _state = index_state::make_empty_index(
+      storage::internal::should_apply_delta_time_offset(_feature_table));
     _state.base_offset = base;
+
     _acc = 0;
 }
 
@@ -118,17 +121,14 @@ segment_index::find_nearest(model::timestamp t) {
     if (_state.empty()) {
         return std::nullopt;
     }
-    const uint32_t i = t() - _state.base_timestamp();
-    auto it = std::lower_bound(
-      std::begin(_state.relative_time_index),
-      std::end(_state.relative_time_index),
-      i,
-      std::less<uint32_t>{});
-    if (it == _state.relative_offset_index.end()) {
+
+    const auto delta = t - _state.base_timestamp;
+    const auto entry = _state.find_entry(delta);
+    if (!entry) {
         return std::nullopt;
     }
-    auto dist = std::distance(_state.relative_offset_index.begin(), it);
-    return translate_index_entry(_state, _state.get_entry(dist));
+
+    return translate_index_entry(_state, *entry);
 }
 
 std::optional<segment_index::entry>

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -90,6 +90,11 @@ void segment_index::swap_index_state(index_state&& o) {
 void segment_index::maybe_track(
   const model::record_batch_header& hdr, size_t filepos) {
     _acc += hdr.size_bytes;
+
+    _state.update_batch_timestamps_are_monotonic(
+      hdr.max_timestamp >= _last_batch_max_timestamp);
+    _last_batch_max_timestamp = hdr.max_timestamp;
+
     if (_state.maybe_index(
           _acc,
           _step,

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -73,6 +73,9 @@ public:
     model::offset max_offset() const { return _state.max_offset; }
     model::timestamp max_timestamp() const { return _state.max_timestamp; }
     model::timestamp base_timestamp() const { return _state.base_timestamp; }
+    bool batch_timestamps_are_monotonic() const {
+        return _state.batch_timestamps_are_monotonic;
+    }
 
     ss::future<bool> materialize_index();
     ss::future<> flush();
@@ -105,6 +108,8 @@ private:
     bool _needs_persistence{false};
     index_state _state;
     debug_sanitize_files _sanitize;
+
+    model::timestamp _last_batch_max_timestamp;
 
     /** Constructor with mock file content for unit testing */
     segment_index(

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -79,7 +79,7 @@ public:
 
     ss::future<bool> materialize_index();
     ss::future<> flush();
-    ss::future<> truncate(model::offset);
+    ss::future<> truncate(model::offset, model::timestamp);
 
     ss::future<ss::file> open();
 

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -84,6 +84,7 @@ public:
     ss::future<ss::file> open();
 
     const segment_full_path& path() const { return _path; }
+    size_t size() const { return _state.size(); }
 
     /// \brief erases the underlying file and resets the index
     /// this is used during compacted index recovery, as we must first

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/timestamp.h"
@@ -18,6 +19,7 @@
 #include "storage/types.h"
 
 #include <seastar/core/file.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/unaligned.hh>
 
 #include <memory>
@@ -54,6 +56,7 @@ public:
       segment_full_path path,
       model::offset base,
       size_t step,
+      ss::sharded<features::feature_table>& feature_table,
       debug_sanitize_files);
 
     ~segment_index() noexcept = default;
@@ -97,6 +100,7 @@ private:
 
     segment_full_path _path;
     size_t _step;
+    std::reference_wrapper<ss::sharded<features::feature_table>> _feature_table;
     size_t _acc{0};
     bool _needs_persistence{false};
     index_state _state;
@@ -107,7 +111,8 @@ private:
       segment_full_path path,
       ss::file mock_file,
       model::offset base,
-      size_t step);
+      size_t step,
+      ss::sharded<features::feature_table>& feature_table);
 
     // For unit testing only.  If this is set, then open() returns
     // the contents of mock_file instead of opening the path in _name.

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -306,7 +306,8 @@ static ss::future<segment_set> unsafe_do_recover(
             }
             s->truncate(
                recovered.last_offset.value(),
-               recovered.truncate_file_pos.value())
+               recovered.truncate_file_pos.value(),
+               recovered.last_max_timestamp.value())
               .get();
             // persist index
             s->index().flush().get();

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -99,6 +99,7 @@ ss::future<segment_set> recover_segments(
   size_t read_buf_size,
   unsigned read_readahead_count,
   std::optional<ss::sstring> last_clean_segment,
-  storage_resources&);
+  storage_resources&,
+  ss::sharded<features::feature_table>& feature_table);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -340,7 +340,8 @@ ss::future<storage::index_state> do_copy_segment_data(
   compaction_config cfg,
   storage::probe& pb,
   ss::rwlock::holder h,
-  storage_resources& resources) {
+  storage_resources& resources,
+  offset_delta_time apply_offset) {
     auto idx_path = s->reader().path().to_compacted_index();
     return make_reader_handle(idx_path, cfg.sanitize)
       .then([s, cfg, idx_path](ss::file f) {
@@ -351,7 +352,7 @@ ss::future<storage::index_state> do_copy_segment_data(
                 return reader.close().then_wrapped([](ss::future<>) {});
             });
       })
-      .then([cfg, s, &pb, h = std::move(h), &resources](
+      .then([cfg, s, &pb, h = std::move(h), &resources, apply_offset](
               compacted_offset_list list) mutable {
           const auto tmpname = s->reader().path().to_staging();
           return make_segment_appender(
@@ -362,11 +363,19 @@ ss::future<storage::index_state> do_copy_segment_data(
                    std::nullopt,
                    cfg.iopc,
                    resources)
-            .then([l = std::move(list), &pb, h = std::move(h), cfg, s, tmpname](
-                    segment_appender_ptr w) mutable {
+            .then([l = std::move(list),
+                   &pb,
+                   h = std::move(h),
+                   cfg,
+                   s,
+                   tmpname,
+                   apply_offset](segment_appender_ptr w) mutable {
                 auto raw = w.get();
                 auto red = copy_data_segment_reducer(
-                  std::move(l), raw, s->path().is_internal_topic());
+                  std::move(l),
+                  raw,
+                  s->path().is_internal_topic(),
+                  apply_offset);
                 auto r = create_segment_full_reader(s, cfg, pb, std::move(h));
                 vlog(
                   gclog.trace,
@@ -445,7 +454,8 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
   compaction_config cfg,
   storage::probe& pb,
   storage::readers_cache& readers_cache,
-  storage_resources& resources) {
+  storage_resources& resources,
+  offset_delta_time apply_offset) {
     vlog(gclog.trace, "self compacting segment {}", s->reader().path());
     auto read_holder = co_await s->read_lock();
     auto segment_generation = s->get_generation_id();
@@ -458,7 +468,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
     // copy the bytes after segment is good - note that we
     // need to do it with the READ-lock, not the write lock
     auto idx = co_await do_copy_segment_data(
-      s, cfg, pb, std::move(read_holder), resources);
+      s, cfg, pb, std::move(read_holder), resources, apply_offset);
 
     auto rdr_holder = co_await readers_cache.evict_segment_readers(s);
 
@@ -549,7 +559,8 @@ ss::future<compaction_result> self_compact_segment(
   compaction_config cfg,
   storage::probe& pb,
   storage::readers_cache& readers_cache,
-  storage_resources& resources) {
+  storage_resources& resources,
+  offset_delta_time apply_offset) {
     if (s->has_appender()) {
         throw std::runtime_error(fmt::format(
           "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s));
@@ -573,7 +584,7 @@ ss::future<compaction_result> self_compact_segment(
     case compacted_index::recovery_state::index_recovered: {
         auto sz_before = s->size_bytes();
         auto sz_after = co_await do_self_compact_segment(
-          s, cfg, pb, readers_cache, resources);
+          s, cfg, pb, readers_cache, resources, apply_offset);
         // compaction wasn't executed, return
         if (!sz_after) {
             co_return compaction_result(sz_before);
@@ -604,7 +615,7 @@ ss::future<compaction_result> self_compact_segment(
           "rebuilt index: {}, attempting compaction again",
           idx_path);
         co_return co_await self_compact_segment(
-          s, stm_manager, cfg, pb, readers_cache, resources);
+          s, stm_manager, cfg, pb, readers_cache, resources, apply_offset);
     }
     }
     __builtin_unreachable();
@@ -898,6 +909,13 @@ bytes clean_segment_key(model::ntp ntp) {
     iobuf buf;
     reflection::serialize(buf, kvstore_key_type::clean_segment, std::move(ntp));
     return iobuf_to_bytes(buf);
+}
+
+offset_delta_time should_apply_delta_time_offset(
+  ss::sharded<features::feature_table>& feature_table) {
+    return offset_delta_time{
+      feature_table.local_is_initialized()
+      && feature_table.local().is_active(features::feature::node_isolation)};
 }
 
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -62,7 +62,8 @@ make_concatenated_segment(
   segment_full_path,
   std::vector<ss::lw_shared_ptr<segment>>,
   compaction_config,
-  storage_resources& resources);
+  storage_resources& resources,
+  ss::sharded<features::feature_table>& feature_table);
 
 ss::future<> write_concatenated_compacted_index(
   std::filesystem::path,

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -37,7 +37,8 @@ ss::future<compaction_result> self_compact_segment(
   storage::compaction_config,
   storage::probe&,
   storage::readers_cache&,
-  storage::storage_resources&);
+  storage::storage_resources&,
+  offset_delta_time apply_offset);
 
 /*
  * Concatentate segments into a minimal new segment.
@@ -199,5 +200,8 @@ inline bool is_compactible(const model::record_batch& b) {
       b.header().type == model::record_batch_type::raft_configuration
       || b.header().type == model::record_batch_type::archival_metadata);
 }
+
+offset_delta_time should_apply_delta_time_offset(
+  ss::sharded<features::feature_table>& feature_table);
 
 } // namespace storage::internal

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ v_cc_library(
     "utils/disk_log_builder.cc"
     "utils/log_gap_analysis.cc"
   DEPS
-    v::storage v::model_test_utils
+    v::storage v::model_test_utils v::features
 )
 
 rp_test(

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -7,20 +7,34 @@
 
 #include <boost/test/unit_test.hpp>
 
-static storage::index_state make_random_index_state() {
-    storage::index_state st;
+static storage::index_state make_random_index_state(
+  storage::offset_delta_time apply_offset = storage::offset_delta_time::yes) {
+    auto st = storage::index_state::make_empty_index(apply_offset);
     st.bitflags = random_generators::get_int<uint32_t>();
     st.base_offset = model::offset(random_generators::get_int<int64_t>());
     st.max_offset = model::offset(random_generators::get_int<int64_t>());
     st.base_timestamp = model::timestamp(random_generators::get_int<int64_t>());
     st.max_timestamp = model::timestamp(random_generators::get_int<int64_t>());
+    st.batch_timestamps_are_monotonic = apply_offset
+                                        == storage::offset_delta_time::yes;
 
     const auto n = random_generators::get_int(1, 10000);
     for (auto i = 0; i < n; ++i) {
         st.add_entry(
           random_generators::get_int<uint32_t>(),
-          random_generators::get_int<uint32_t>(),
+          storage::offset_time_index{
+            model::timestamp{random_generators::get_int<int64_t>()},
+            apply_offset},
           random_generators::get_int<uint64_t>());
+    }
+
+    if (apply_offset == storage::offset_delta_time::no) {
+        fragmented_vector<uint32_t> time_index;
+        for (auto i = 0; i < n; ++i) {
+            time_index.push_back(random_generators::get_int<uint32_t>());
+        }
+
+        std::swap(st.relative_time_index, time_index);
     }
 
     return st;
@@ -43,6 +57,10 @@ BOOST_AUTO_TEST_CASE(serde_basic) {
         // objects are equal
         const auto buf = serde::to_iobuf(std::move(input));
         auto output = serde::from_iobuf<storage::index_state>(buf.copy());
+
+        BOOST_REQUIRE(output.batch_timestamps_are_monotonic == true);
+        BOOST_REQUIRE(output.with_offset == storage::offset_delta_time::yes);
+
         BOOST_REQUIRE_EQUAL(output, input_copy);
 
         // round trip back to equal iobufs
@@ -51,20 +69,52 @@ BOOST_AUTO_TEST_CASE(serde_basic) {
     }
 }
 
-// accept decoding supported old version
-BOOST_AUTO_TEST_CASE(serde_supported_deprecated) {
+BOOST_AUTO_TEST_CASE(serde_no_time_offseting_for_existing_indices) {
     for (int i = 0; i < 100; ++i) {
-        auto input = make_random_index_state();
-        const auto output = serde::from_iobuf<storage::index_state>(
-          storage::serde_compat::index_state_serde::encode(input));
-        BOOST_REQUIRE_EQUAL(output, input);
+        // Create index without time offsetting
+        auto input = make_random_index_state(storage::offset_delta_time::no);
+        const auto input_copy = input.copy();
+        auto buf = serde::to_iobuf(std::move(input));
+        set_version(buf, 4);
+
+        // Read the index and check that time offsetting was not applied
+        auto output = serde::from_iobuf<storage::index_state>(buf.copy());
+
+        BOOST_REQUIRE(output.batch_timestamps_are_monotonic == false);
+        BOOST_REQUIRE(output.with_offset == storage::offset_delta_time::no);
+
+        auto output_copy = output.copy();
+
+        BOOST_REQUIRE_EQUAL(input_copy, output);
+
+        // Re-encode with version 5 and verify that there is still no offsetting
+        const auto buf2 = serde::to_iobuf(std::move(output));
+        auto output2 = serde::from_iobuf<storage::index_state>(buf2.copy());
+        BOOST_REQUIRE_EQUAL(output_copy, output2);
+
+        BOOST_REQUIRE(output2.batch_timestamps_are_monotonic == false);
+        BOOST_REQUIRE(output2.with_offset == storage::offset_delta_time::no);
     }
 }
 
-// reject decoding unsupported old versions
+// accept decoding supported old version
+BOOST_AUTO_TEST_CASE(serde_supported_deprecated) {
+    for (int i = 0; i < 100; ++i) {
+        auto input = make_random_index_state(storage::offset_delta_time::no);
+        const auto output = serde::from_iobuf<storage::index_state>(
+          storage::serde_compat::index_state_serde::encode(input));
+
+        BOOST_REQUIRE(output.batch_timestamps_are_monotonic == false);
+        BOOST_REQUIRE(output.with_offset == storage::offset_delta_time::no);
+
+        BOOST_REQUIRE_EQUAL(input, output);
+    }
+}
+
+// reject decoding unsupported old versins
 BOOST_AUTO_TEST_CASE(serde_unsupported_deprecated) {
     auto test = [](int version) {
-        auto input = make_random_index_state();
+        auto input = make_random_index_state(storage::offset_delta_time::no);
         auto buf = storage::serde_compat::index_state_serde::encode(input);
         set_version(buf, version);
 
@@ -85,7 +135,7 @@ BOOST_AUTO_TEST_CASE(serde_unsupported_deprecated) {
 
 // decoding should fail if all the data isn't available
 BOOST_AUTO_TEST_CASE(serde_clipped) {
-    auto input = make_random_index_state();
+    auto input = make_random_index_state(storage::offset_delta_time::no);
     auto buf = serde::to_iobuf(std::move(input));
 
     // trim off some data from the end
@@ -103,7 +153,7 @@ BOOST_AUTO_TEST_CASE(serde_clipped) {
 
 // decoding deprecated format should fail if not all data is available
 BOOST_AUTO_TEST_CASE(serde_deprecated_clipped) {
-    auto input = make_random_index_state();
+    auto input = make_random_index_state(storage::offset_delta_time::no);
     auto buf = storage::serde_compat::index_state_serde::encode(input);
 
     // trim off some data from the end
@@ -139,7 +189,7 @@ BOOST_AUTO_TEST_CASE(serde_crc) {
 }
 
 BOOST_AUTO_TEST_CASE(serde_deprecated_crc) {
-    auto input = make_random_index_state();
+    auto input = make_random_index_state(storage::offset_delta_time::no);
     auto good_buf = storage::serde_compat::index_state_serde::encode(input);
 
     auto bad_bytes = iobuf_to_bytes(good_buf);
@@ -158,4 +208,32 @@ BOOST_AUTO_TEST_CASE(serde_deprecated_crc) {
                                   != std::string_view::npos;
           return is_crc || is_out_of_bounds;
       });
+}
+
+BOOST_AUTO_TEST_CASE(offset_time_index_test) {
+    // Before offsetting: [0, ..., 2 ^ 31 - 1, ..., 2 ^ 32 - 1]
+    //                    |             |              |
+    //                    |             |______________|
+    //                    |             |
+    // After offsetting:  [2^31, ..., 2 ^ 32 - 1]
+
+    const uint32_t offset = storage::offset_time_index::offset;
+    const uint32_t max_delta = storage::offset_time_index::delta_time_max;
+
+    std::vector<uint32_t> deltas_before{
+      0, 1, max_delta - 1, max_delta, std::numeric_limits<uint32_t>::max()};
+    for (uint32_t delta_before : deltas_before) {
+        auto offset_delta = storage::offset_time_index{
+          model::timestamp{delta_before}, storage::offset_delta_time::yes};
+        auto non_offset_delta = storage::offset_time_index{
+          model::timestamp{delta_before}, storage::offset_delta_time::no};
+
+        BOOST_REQUIRE(non_offset_delta() == delta_before);
+
+        if (delta_before >= max_delta) {
+            BOOST_REQUIRE(offset_delta() == max_delta);
+        } else {
+            BOOST_REQUIRE(offset_delta() == delta_before);
+        }
+    }
 }

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -19,6 +19,7 @@
 #include "storage/segment_index.h"
 #include "storage/segment_reader.h"
 #include "utils/file_sanitizer.h"
+#include "features/feature_table.h"
 
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>
@@ -31,6 +32,7 @@ using namespace storage; // NOLINT
 namespace storage {
 class log_replayer_fixture {
 public:
+    ss::sharded<features::feature_table> _feature_table;
     ss::lw_shared_ptr<segment> _seg;
     std::optional<log_replayer> replayer_opt;
     storage::storage_resources resources;
@@ -38,6 +40,12 @@ public:
                             + random_generators::gen_alphanum_string(20);
 
     void initialize(model::offset base) {
+        _feature_table.start().get();
+        _feature_table
+          .invoke_on_all(
+            [](features::feature_table& f) { f.testing_activate_all(); })
+          .get();
+
         auto fd = ss::open_file_dma(
                     base_name, ss::open_flags::create | ss::open_flags::rw)
                     .get0();
@@ -56,7 +64,8 @@ public:
           segment_full_path::mock(base_name + ".index"),
           std::move(fidx),
           base,
-          4096);
+          4096,
+          _feature_table);
         auto reader = segment_reader(
           segment_full_path::mock(base_name),
           128_KiB,
@@ -74,7 +83,10 @@ public:
         replayer_opt = log_replayer(*_seg);
     }
 
-    ~log_replayer_fixture() { _seg->close().get(); }
+    ~log_replayer_fixture() {
+        _seg->close().get();
+        _feature_table.stop().get();
+    }
 
     void write_garbage() { do_write_garbage(base_name); }
 

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "features/feature_table.h"
 #include "model/record_utils.h"
 #include "model/tests/random_batch.h"
 #include "random/generators.h"
@@ -19,7 +20,6 @@
 #include "storage/segment_index.h"
 #include "storage/segment_reader.h"
 #include "utils/file_sanitizer.h"
-#include "features/feature_table.h"
 
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -133,7 +133,7 @@ FIXTURE_TEST(bucket_truncate, offset_index_utils_fixture) {
     _idx->maybe_track(
       modify_get(model::offset{948}, 1667), 727007); // not indexed
     // test range truncation next
-    _idx->truncate(model::offset(926)).get();
+    _idx->truncate(model::offset(926), model::timestamp{100}).get();
     index_entry_expect(879, 323968);
     index_entry_expect(901, 458048);
     {
@@ -148,4 +148,6 @@ FIXTURE_TEST(bucket_truncate, offset_index_utils_fixture) {
         BOOST_REQUIRE_EQUAL(p->offset, model::offset(901));
         BOOST_REQUIRE_EQUAL(p->filepos, 458048);
     }
+
+    BOOST_REQUIRE(_idx->max_timestamp() == model::timestamp{100});
 }

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -30,7 +30,17 @@ public:
           segment_full_path::mock("In memory iobuf"),
           ss::file(ss::make_shared(tmpbuf_file(_data))),
           _base_offset,
-          storage::segment_index::default_data_buffer_step));
+          storage::segment_index::default_data_buffer_step,
+          _feature_table));
+    }
+
+    ~offset_index_utils_fixture() { _feature_table.stop().get(); }
+
+    ss::future<> start() {
+        return _feature_table.start().then([this]() {
+            return _feature_table.invoke_on_all(
+              [](features::feature_table& f) { f.testing_activate_all(); });
+        });
     }
 
     const model::record_batch_header
@@ -52,10 +62,13 @@ public:
     model::record_batch_header _base_hdr;
     storage::segment_index_ptr _idx;
     tmpbuf_file::store_t _data;
+    ss::sharded<features::feature_table> _feature_table;
 };
 } // namespace storage
 
 FIXTURE_TEST(index_round_trip, offset_index_utils_fixture) {
+    start().get();
+
     BOOST_CHECK(true);
     info("index: {}", _idx);
     for (uint32_t i = 0; i < 1024; ++i) {
@@ -75,6 +88,8 @@ FIXTURE_TEST(index_round_trip, offset_index_utils_fixture) {
 }
 
 FIXTURE_TEST(bucket_bug1, offset_index_utils_fixture) {
+    start().get();
+
     info("index: {}", _idx);
     info("Testing bucket find");
     _idx->maybe_track(modify_get(model::offset{824}, 155103), 0); // indexed
@@ -102,6 +117,8 @@ FIXTURE_TEST(bucket_bug1, offset_index_utils_fixture) {
     }
 }
 FIXTURE_TEST(bucket_truncate, offset_index_utils_fixture) {
+    start().get();
+
     info("index: {}", _idx);
     info("Testing bucket truncate");
     _idx->maybe_track(modify_get(model::offset{824}, 155103), 0); // indexed

--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -14,6 +14,27 @@
 
 #include <seastar/core/file.hh>
 
+namespace {
+
+// Make a batch that is big enough to trigger the indexing threshold.
+model::record_batch
+make_random_batch(model::offset o, bool big_enough_for_index = true) {
+    auto batch_size = storage::segment_index::default_data_buffer_step + 1;
+    if (!big_enough_for_index) {
+        batch_size = 1024;
+    }
+
+    return model::test::make_random_batch(
+      model::offset(o),
+      1,
+      false,
+      model::record_batch_type::raft_data,
+      std::vector<size_t>{batch_size},
+      std::nullopt);
+}
+
+} // namespace
+
 FIXTURE_TEST(timequery, log_builder_fixture) {
     using namespace storage; // NOLINT
 
@@ -22,8 +43,7 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
     // seg0: timestamps 0..99, offset = timestamp
     b | add_segment(0);
     for (auto ts = 0; ts < 100; ts++) {
-        auto batch = model::test::make_random_batch(
-          model::offset(ts), 1, false);
+        auto batch = make_random_batch(model::offset(ts));
         batch.header().first_timestamp = model::timestamp(ts);
         batch.header().max_timestamp = model::timestamp(ts);
         b | add_batch(std::move(batch));
@@ -32,14 +52,19 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
     // seg1: [(offset, ts)..]
     //  - (100, 100), (101, 100), ... (104, 100)
     //  - (105, 101), (105, 101), ... (109, 101)
+    //  ...
+    //  - (195, 119), (196, 119), ... (200, 119)
     b | add_segment(100);
     for (auto offset = 100; offset <= 200; offset++) {
         auto ts = 100 + (offset - 100) / 5;
-        auto batch = model::test::make_random_batch(
-          model::offset(offset), 1, false);
+        auto batch = make_random_batch(model::offset(offset));
         batch.header().first_timestamp = model::timestamp(ts);
         batch.header().max_timestamp = model::timestamp(ts);
         b | add_batch(std::move(batch));
+    }
+
+    for (const auto& seg : b.get_log_segments()) {
+        BOOST_TEST(seg->index().batch_timestamps_are_monotonic());
     }
 
     // in the first segment check that query(ts) -> batch.offset = ts.
@@ -93,8 +118,7 @@ FIXTURE_TEST(timequery_single_value, log_builder_fixture) {
     // seg0: timestamps [1000...1099], offsets = [0...99]
     b | add_segment(0);
     for (auto offset = 0; offset < 100; ++offset) {
-        auto batch = model::test::make_random_batch(
-          model::offset(offset), 1, false);
+        auto batch = make_random_batch(model::offset(offset));
         batch.header().first_timestamp = model::timestamp(offset + 1000);
         batch.header().max_timestamp = model::timestamp(offset + 1000);
         b | add_batch(std::move(batch));
@@ -118,5 +142,196 @@ FIXTURE_TEST(timequery_single_value, log_builder_fixture) {
     BOOST_TEST(res);
     BOOST_TEST(res->time == model::timestamp(1000));
     BOOST_TEST(res->offset == model::offset(0));
+    b | stop();
+}
+
+FIXTURE_TEST(timequery_sparse_index, log_builder_fixture) {
+    using namespace storage;
+
+    b | start();
+
+    b | add_segment(0);
+    auto batch1 = make_random_batch(model::offset(0));
+    batch1.header().first_timestamp = model::timestamp(1000);
+    batch1.header().max_timestamp = model::timestamp(1000);
+    b | add_batch(std::move(batch1));
+
+    // This batch will not be indexed.
+    auto batch2 = make_random_batch(model::offset(1), false);
+    batch2.header().first_timestamp = model::timestamp(1600);
+    batch2.header().max_timestamp = model::timestamp(1600);
+    b | add_batch(std::move(batch2));
+
+    auto batch3 = make_random_batch(model::offset(2));
+    batch3.header().first_timestamp = model::timestamp(2000);
+    batch3.header().max_timestamp = model::timestamp(2000);
+    b | add_batch(std::move(batch3));
+
+    const auto& seg = b.get_log_segments().front();
+    BOOST_TEST(seg->index().batch_timestamps_are_monotonic());
+    BOOST_TEST(seg->index().size() == 2);
+
+    auto log = b.get_log();
+    storage::timequery_config config(
+      model::timestamp(1600),
+      log.offsets().dirty_offset,
+      ss::default_priority_class(),
+      std::nullopt);
+
+    auto res = log.timequery(config).get0();
+    BOOST_TEST(res);
+    BOOST_TEST(res->time == model::timestamp(1600));
+    BOOST_TEST(res->offset == model::offset(1));
+
+    b | stop();
+}
+
+FIXTURE_TEST(timequery_one_element_index, log_builder_fixture) {
+    using namespace storage;
+
+    b | start();
+
+    b | add_segment(0);
+
+    // This batch doesn't trigger the size indexing threshold,
+    // but it's the first one so it gets indexed regardless.
+    auto batch = make_random_batch(model::offset(0), false);
+    batch.header().first_timestamp = model::timestamp(1000);
+    batch.header().max_timestamp = model::timestamp(1000);
+    b | add_batch(std::move(batch));
+
+    const auto& seg = b.get_log_segments().front();
+    BOOST_TEST(seg->index().batch_timestamps_are_monotonic());
+    BOOST_TEST(seg->index().size() == 1);
+
+    auto log = b.get_log();
+    storage::timequery_config config(
+      model::timestamp(1000),
+      log.offsets().dirty_offset,
+      ss::default_priority_class(),
+      std::nullopt);
+
+    auto res = log.timequery(config).get0();
+    BOOST_TEST(res);
+    BOOST_TEST(res->time == model::timestamp(1000));
+    BOOST_TEST(res->offset == model::offset(0));
+
+    b | stop();
+}
+
+FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
+    using namespace storage; // NOLINT
+
+    b | start();
+
+    // seg0:
+    // timestamps = [1000, 1001, 1002, 1003, 1002, 1005, 1006, 1007, 1008, 1009]
+    // offsets =    [0,    1,    2,    3,    4,    5,    6,    7,    8,    9   ]
+    std::vector<std::pair<model::offset, model::timestamp>> batch_spec = {
+      {model::offset(0), model::timestamp(1000)},
+      {model::offset(1), model::timestamp(1001)},
+      {model::offset(2), model::timestamp(1002)},
+      {model::offset(3), model::timestamp(1003)},
+      {model::offset(4), model::timestamp(1002)},
+      {model::offset(5), model::timestamp(1005)},
+      {model::offset(6), model::timestamp(1006)},
+      {model::offset(7), model::timestamp(1007)},
+      {model::offset(8), model::timestamp(1008)},
+      {model::offset(9), model::timestamp(1009)},
+    };
+
+    b | add_segment(0);
+    for (const auto& [offset, ts] : batch_spec) {
+        auto batch = make_random_batch(model::offset(offset));
+        batch.header().first_timestamp = model::timestamp(ts);
+        batch.header().max_timestamp = model::timestamp(ts);
+        b | add_batch(std::move(batch));
+    }
+
+    const auto& segs = b.get_log_segments();
+    BOOST_TEST(segs.size() == 1);
+    BOOST_TEST(segs.front()->index().batch_timestamps_are_monotonic() == false);
+
+    auto log = b.get_log();
+    for (const auto& [offset, ts] : batch_spec) {
+        storage::timequery_config config(
+          model::timestamp(ts),
+          log.offsets().dirty_offset,
+          ss::default_priority_class(),
+          std::nullopt);
+
+        auto res = log.timequery(config).get0();
+
+        if (offset == model::offset(4)) {
+            // A timequery will always return from within the
+            // first batch that satifies: `batch_max_timestamp >= needle`.
+            // So, in this case we pick the first batch with timestamp
+            // greater or equal to 1002.
+            BOOST_TEST(res);
+            BOOST_TEST(res->time == model::timestamp(1002));
+            BOOST_TEST(res->offset == model::offset(2));
+        } else {
+            BOOST_TEST(res);
+            BOOST_TEST(res->time == ts);
+            BOOST_TEST(res->offset == offset);
+        }
+    }
+
+    // Query for a bogus, really small timestamp.
+    // We should return the first element in the log
+    storage::timequery_config config(
+      model::timestamp(-5000),
+      log.offsets().dirty_offset,
+      ss::default_priority_class(),
+      std::nullopt);
+
+    auto res = log.timequery(config).get0();
+
+    BOOST_TEST(res);
+    BOOST_TEST(res->offset == model::offset(0));
+
+    b | stop();
+}
+
+FIXTURE_TEST(timequery_clamp, log_builder_fixture) {
+    using namespace storage; // NOLINT
+
+    b | start();
+
+    // The relative time values in `index_state` are clamped at
+    // `delta_time_max`. Check that indexed lookups still work in this case.
+    std::vector<std::pair<model::offset, model::timestamp>> batch_spec = {
+      {model::offset(0), model::timestamp(0)},
+      {model::offset(1),
+       model::timestamp(storage::offset_time_index::delta_time_max + 1)},
+      {model::offset(2),
+       model::timestamp(storage::offset_time_index::delta_time_max * 2 + 1)},
+    };
+
+    b | add_segment(0);
+    for (const auto& [offset, ts] : batch_spec) {
+        auto batch = make_random_batch(model::offset(offset));
+        batch.header().first_timestamp = model::timestamp(ts);
+        batch.header().max_timestamp = model::timestamp(ts);
+        b | add_batch(std::move(batch));
+    }
+
+    const auto& segs = b.get_log_segments();
+    BOOST_TEST(segs.size() == 1);
+    BOOST_TEST(segs.front()->index().batch_timestamps_are_monotonic() == true);
+
+    auto log = b.get_log();
+    storage::timequery_config config(
+      model::timestamp(storage::offset_time_index::delta_time_max * 2 + 1),
+      log.offsets().dirty_offset,
+      ss::default_priority_class(),
+      std::nullopt);
+
+    const auto& [expected_offset, expected_ts] = batch_spec.back();
+    auto res = log.timequery(config).get0();
+    BOOST_TEST(res);
+    BOOST_TEST(res->time == expected_ts);
+    BOOST_TEST(res->offset == expected_offset);
+
     b | stop();
 }

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
@@ -395,6 +396,7 @@ private:
       const log_append_config& config,
       should_flush_after flush);
 
+    ss::sharded<features::feature_table> _feature_table;
     storage::log_config _log_config;
     storage::api _storage;
     std::optional<log> _log;

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -145,7 +145,7 @@ class DescribeTopicsTest(RedpandaTest):
             "segment.ms":
             ConfigProperty(
                 config_type="LONG",
-                value="-1",
+                value="1209600000",  # 2 weeks in ms
                 doc_string=
                 "Default log segment lifetime in ms for topics which do not set segment.ms"
             )


### PR DESCRIPTION
This set of patches brings the following improvements to time-queries:

1. The relative time index is used whenever possible (i.e. the batches in the segments
have monotonic timestamps). The index was previously _not used_ for time-queries.
Should be quite a bit faster, but I didn't get a chance to benchmark yet.
2. Support out of order user provided timestamps by offsetting the relative time index
by 2^31. This gives us the rough representable range of: `-596h...+596h`. This PR also
sets the default maximum time a segment can not roll for to `2 weeks`, which ensures
that the timestamps will always be in range (when users don't provide them).
3. Improve the heuristic for finding the maximum timestamp on truncation. Previously,
we simply took the last entry in the index which could be off by 64KB. Now, we take the
timestamp from the batch preceding the truncation point.

Generally, these changes make the semantics for timequery stronger:
"a timequery for timestamp 'needle' will return the first offset in the log where 'timestamp >= needle'".

Related https://github.com/redpanda-data/redpanda/issues/4035
This PR does not address the mixing of timestamps between configuration and raft batches
in the segment index. I think everything else from https://github.com/redpanda-data/redpanda/issues/4035
should be addressed.

## Backports Required

Not sure if it will be possible to backport this.

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
### Improvements
* Handle user provided timestamps on the timequery read path more gracefully. 
* Sped up time queries by using indexing.
* Improved heuristic for determining the maximum timestamp on index truncation. This should result
in more precise time retention enforcement.