### PR TITLE
Node TP limits: DT on configuration and metrics

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1740,9 +1740,9 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       750ms,
       {.min = 0ms})
-  , kafka_quota_balancer_min_shard_thoughput_ratio(
+  , kafka_quota_balancer_min_shard_throughput_ratio(
       *this,
-      "kafka_quota_balancer_min_shard_thoughput_ratio",
+      "kafka_quota_balancer_min_shard_throughput_ratio",
       "The lowest value of the throughput quota a shard can get in the process "
       "of quota balancing, expressed as a ratio of default shard quota. "
       "0 means there is no minimum, 1 means no quota can be taken away "
@@ -1750,9 +1750,9 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       0.01,
       &validate_0_to_1_ratio)
-  , kafka_quota_balancer_min_shard_thoughput_bps(
+  , kafka_quota_balancer_min_shard_throughput_bps(
       *this,
-      "kafka_quota_balancer_min_shard_thoughput_bps",
+      "kafka_quota_balancer_min_shard_throughput_bps",
       "The lowest value of the throughput quota a shard can get in the process "
       "of quota balancing, in bytes/s. 0 means there is no minimum.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -365,8 +365,8 @@ struct configuration final : public config_store {
     bounded_property<std::chrono::milliseconds> kafka_quota_balancer_window;
     bounded_property<std::chrono::milliseconds>
       kafka_quota_balancer_node_period;
-    property<double> kafka_quota_balancer_min_shard_thoughput_ratio;
-    bounded_property<int64_t> kafka_quota_balancer_min_shard_thoughput_bps;
+    property<double> kafka_quota_balancer_min_shard_throughput_ratio;
+    bounded_property<int64_t> kafka_quota_balancer_min_shard_throughput_bps;
 
     bounded_property<int64_t> node_isolation_heartbeat_timeout;
 

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -65,8 +65,8 @@ quota_t node_to_shard_quota(const std::optional<quota_t> node_quota) {
         if (v > bottomless_token_bucket::max_quota) {
             return bottomless_token_bucket::max_quota;
         }
-        if (v < 1) {
-            return quota_t{1};
+        if (v < bottomless_token_bucket::min_quota) {
+            return bottomless_token_bucket::min_quota;
         }
         return v;
     } else {

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -86,12 +86,12 @@ snc_quota_manager::snc_quota_manager()
       config::shard_local_cfg().kafka_quota_balancer_window.bind())
   , _kafka_quota_balancer_node_period(
       config::shard_local_cfg().kafka_quota_balancer_node_period.bind())
-  , _kafka_quota_balancer_min_shard_thoughput_ratio(
+  , _kafka_quota_balancer_min_shard_throughput_ratio(
       config::shard_local_cfg()
-        .kafka_quota_balancer_min_shard_thoughput_ratio.bind())
-  , _kafka_quota_balancer_min_shard_thoughput_bps(
+        .kafka_quota_balancer_min_shard_throughput_ratio.bind())
+  , _kafka_quota_balancer_min_shard_throughput_bps(
       config::shard_local_cfg()
-        .kafka_quota_balancer_min_shard_thoughput_bps.bind())
+        .kafka_quota_balancer_min_shard_throughput_bps.bind())
   , _node_quota_default{calc_node_quota_default()}
   , _shard_quota{
       .in {node_to_shard_quota(_node_quota_default.in),
@@ -120,9 +120,9 @@ snc_quota_manager::snc_quota_manager()
             arm_balancer_timer();
         }
     });
-    _kafka_quota_balancer_min_shard_thoughput_ratio.watch(
+    _kafka_quota_balancer_min_shard_throughput_ratio.watch(
       [this] { update_shard_quota_minimum(); });
-    _kafka_quota_balancer_min_shard_thoughput_bps.watch(
+    _kafka_quota_balancer_min_shard_throughput_bps.watch(
       [this] { update_shard_quota_minimum(); });
 
     if (ss::this_shard_id() == quota_balancer_shard) {
@@ -261,9 +261,9 @@ void snc_quota_manager::update_shard_quota_minimum() {
         const auto shard_quota_default = node_to_shard_quota(
           node_quota_default);
         return std::max<quota_t>(
-          _kafka_quota_balancer_min_shard_thoughput_ratio()
+          _kafka_quota_balancer_min_shard_throughput_ratio()
             * shard_quota_default,
-          _kafka_quota_balancer_min_shard_thoughput_bps());
+          _kafka_quota_balancer_min_shard_throughput_bps());
     };
     _shard_quota_minimum.in = f(_node_quota_default.in);
     _shard_quota_minimum.eg = f(_node_quota_default.eg);

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -535,7 +535,12 @@ ss::future<> snc_quota_manager::quota_balancer_update(
         // acquired goes towards the node deficit
         const auto total_quota = co_await container().map_reduce0(
           [](const snc_quota_manager& qm) {
-              return qm.get_quota() - qm._shard_quota_minimum;
+              // minimum quota value for a shard is 1, remove that minimum
+              // from the surrenderable quota amount reported
+              return qm.get_quota()
+                     - ingress_egress_state<quota_t>{
+                       bottomless_token_bucket::min_quota,
+                       bottomless_token_bucket::min_quota};
           },
           ingress_egress_state<quota_t>{0, 0},
           std::plus{});

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -417,10 +417,10 @@ ss::future<> snc_quota_manager::quota_balancer_step() {
     using split_t = decltype(std::div(quota_t{}, shard_count_t{}));
     ingress_egress_state<split_t> split{{0, 0}, {0, 0}};
     if (borrowers_count.in > 0) {
-        split.in = std::ldiv(collected.in, borrowers_count.in);
+        split.in = std::div(collected.in, borrowers_count.in);
     }
     if (borrowers_count.eg > 0) {
-        split.eg = std::ldiv(collected.eg, borrowers_count.eg);
+        split.eg = std::div(collected.eg, borrowers_count.eg);
     }
 
     const auto equal_share_or_0 =

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -186,7 +186,7 @@ private:
     ss::lowres_clock::time_point _balancer_timer_last_ran;
     ss::gate _balancer_gate;
     mutex _balancer_mx;
-    ingress_egress_state<quota_t> _node_deficit;
+    ingress_egress_state<quota_t> _node_deficit{0, 0};
 
     // operational, used on each shard
     ingress_egress_state<std::optional<quota_t>> _node_quota_default;

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -95,6 +95,10 @@ public:
     void record_response_tp(
       size_t request_size, clock::time_point now = clock::now()) noexcept;
 
+    const snc_quotas_probe& get_snc_quotas_probe() const noexcept {
+        return _probe;
+    };
+
     /// Return current effective quota values
     ingress_egress_state<quota_t> get_quota() const noexcept;
 

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -33,6 +33,28 @@ struct ingress_egress_state {
     T eg;
 };
 
+class snc_quotas_probe {
+public:
+    snc_quotas_probe(class snc_quota_manager& qm)
+      : _qm(qm) {}
+    snc_quotas_probe(const snc_quotas_probe&) = delete;
+    snc_quotas_probe& operator=(const snc_quotas_probe&) = delete;
+    snc_quotas_probe(snc_quotas_probe&&) = delete;
+    snc_quotas_probe& operator=(snc_quotas_probe&&) = delete;
+    ~snc_quotas_probe() noexcept = default;
+
+    void balancer_step() { ++_balancer_runs; }
+
+    void setup_metrics();
+
+    uint64_t get_balancer_runs() const noexcept { return _balancer_runs; }
+
+private:
+    class snc_quota_manager& _qm;
+    ss::metrics::metric_groups _metrics;
+    uint64_t _balancer_runs = 0;
+};
+
 /// Isolates \ref quota_manager functionality related to
 /// shard/node/cluster (SNC) wide quotas and limits
 class snc_quota_manager
@@ -72,6 +94,12 @@ public:
 
     void record_response_tp(
       size_t request_size, clock::time_point now = clock::now()) noexcept;
+
+    /// Return current effective quota values
+    ingress_egress_state<quota_t> get_quota() const noexcept;
+
+    /// Return current measured throughput values
+    ingress_egress_state<quota_t> get_throughput() const noexcept;
 
 private:
     /// Describes an instruction to the balancer how to alter effective shard
@@ -122,9 +150,6 @@ private:
     /// get_deficiency() and get_surplus() will return actual data
     void refill_buckets(const clock::time_point now) noexcept;
 
-    /// Return current quota values
-    ingress_egress_state<quota_t> get_quota() const noexcept;
-
     /// If the current quota is sufficient for the shard, returns 0,
     /// otherwise returns a positive value
     ingress_egress_state<quota_t> get_deficiency() const noexcept;
@@ -163,6 +188,9 @@ private:
     ingress_egress_state<std::optional<quota_t>> _node_quota_default;
     ingress_egress_state<quota_t> _shard_quota_minimum;
     ingress_egress_state<bottomless_token_bucket> _shard_quota;
+
+    // service
+    snc_quotas_probe _probe;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -149,8 +149,8 @@ private:
     config::binding<std::chrono::milliseconds> _kafka_quota_balancer_window;
     config::binding<std::chrono::milliseconds>
       _kafka_quota_balancer_node_period;
-    config::binding<double> _kafka_quota_balancer_min_shard_thoughput_ratio;
-    config::binding<quota_t> _kafka_quota_balancer_min_shard_thoughput_bps;
+    config::binding<double> _kafka_quota_balancer_min_shard_throughput_ratio;
+    config::binding<quota_t> _kafka_quota_balancer_min_shard_throughput_bps;
 
     // operational, only used in the balancer shard
     ss::timer<ss::lowres_clock> _balancer_timer;

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -33,6 +33,8 @@ struct ingress_egress_state {
     T eg;
 };
 
+/// Isolates \ref quota_manager functionality related to
+/// shard/node/cluster (SNC) wide quotas and limits
 class snc_quota_manager
   : public ss::peering_sharded_service<snc_quota_manager> {
 public:

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -241,7 +241,7 @@ struct throughput_limits_fixure : prod_consume_fixture {
         _rate_minimum = rate_minimum;
         ss::smp::invoke_on_all([rate_minimum] {
             config::shard_local_cfg()
-              .get("kafka_quota_balancer_min_shard_thoughput_bps")
+              .get("kafka_quota_balancer_min_shard_throughput_bps")
               .set_value(rate_minimum);
         }).get0();
     }
@@ -414,7 +414,7 @@ FIXTURE_TEST(test_node_throughput_limits_balanced, throughput_limits_fixure) {
       std::make_optional(rate_limit_out));
     config_set("fetch_max_bytes", batch_size);
     config_set("max_kafka_throttle_delay_ms", 60'000ms);
-    config_set("kafka_quota_balancer_min_shard_thoughput_ratio", 0.);
+    config_set("kafka_quota_balancer_min_shard_throughput_ratio", 0.);
     config_set_window_width(100ms);
     config_set_balancer_period(50ms);
     config_set_rate_minimum(250);

--- a/src/v/tristate.h
+++ b/src/v/tristate.h
@@ -110,7 +110,6 @@ public:
         return o << "{}";
     };
 
-private:
     std::optional<T>& get_optional() {
         return std::get<std::optional<T>>(_value);
     }
@@ -119,6 +118,7 @@ private:
         return std::get<std::optional<T>>(_value);
     }
 
+private:
     using underlying_t = std::variant<std::monostate, std::optional<T>>;
     underlying_t _value;
 };

--- a/src/v/utils/bottomless_token_bucket.cc
+++ b/src/v/utils/bottomless_token_bucket.cc
@@ -23,7 +23,8 @@ void bottomless_token_bucket::use(
 }
 
 void bottomless_token_bucket::set_quota_impl(const quota_t quota) noexcept {
-    vassert(quota > 0, "Token bucket quota must be positive ({})", quota);
+    vassert(
+      quota >= min_quota, "Token bucket quota must be positive ({})", quota);
     vassert(
       quota <= max_quota,
       "Token bucket quota too large ({} > {})",

--- a/src/v/utils/bottomless_token_bucket.h
+++ b/src/v/utils/bottomless_token_bucket.h
@@ -61,6 +61,8 @@ public:
       static_cast<quota_t>(std::numeric_limits<int32_t>::max())
       * time_res_t::period::den};
 
+    static constexpr quota_t min_quota{1};
+
     /// Token bucket is initialized full of tokens
     bottomless_token_bucket(
       const quota_t quota, const time_res_t width) noexcept {

--- a/tests/rptest/tests/throughput_limits_snc_test.py
+++ b/tests/rptest/tests/throughput_limits_snc_test.py
@@ -1,0 +1,190 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random, time, math
+from enum import Enum
+from typing import Tuple
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import MetricsEndpoint
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+from ducktape.tests.test import TestContext
+
+# This file is about throughput limiting that works at shard/node/cluster (SNC)
+# levels, like cluster-wide and node-wide throughput limits
+
+
+class ThroughputLimitsSnc(RedpandaTest):
+    """
+    Throughput limiting that works at shard/node/cluster (SNC)
+    levels, like cluster-wide and node-wide throughput limits
+    """
+
+    # see later if need to split into more classes
+
+    def __init__(self, test_ctx: TestContext, *args, **kwargs):
+        super(ThroughputLimitsSnc, self).__init__(test_ctx,
+                                                  num_brokers=3,
+                                                  *args,
+                                                  **kwargs)
+        rnd_seed_override = test_ctx.globals.get("random_seed")
+        if rnd_seed_override is None:
+            # default seed value is composed from
+            # - current time - the way the default generator ctor does
+            # - hash of the redpanda service instance - to avoid possible
+            #   identical seeds while running multiple tests in parallel
+            #   with --repeat
+            self.rnd_seed = int(time.time() * 1_000_000_000) + hash(
+                self.redpanda.service_id)
+        else:
+            self.rnd_seed = rnd_seed_override
+        self.logger.info(f"Random seed: {self.rnd_seed}")
+        self.rnd = random.Random(self.rnd_seed)
+        self.rpk = RpkTool(self.redpanda)
+
+        self.config = {}
+        for prop in list(self.ConfigProp):
+            val = self.get_config_parameter_random_value(prop)
+            self.config[prop] = val
+            if not val is None:
+                self.redpanda.add_extra_rp_conf({prop.value: val})
+        self.logger.info(
+            f"Initial cluster props: {self.redpanda._extra_rp_conf}")
+
+    class ConfigProp(Enum):
+        QUOTA_NODE_MAX_IN = "kafka_throughput_limit_node_in_bps"
+        QUOTA_NODE_MAX_EG = "kafka_throughput_limit_node_out_bps"
+        THROTTLE_DELAY_MAX_MS = "max_kafka_throttle_delay_ms"
+        BAL_WINDOW_MS = "kafka_quota_balancer_window_ms"
+        BAL_PERIOD_MS = "kafka_quota_balancer_node_period_ms"
+        QUOTA_SHARD_MIN_RATIO = "kafka_quota_balancer_min_shard_throughput_ratio"
+        QUOTA_SHARD_MIN_BPS = "kafka_quota_balancer_min_shard_throughput_bps"
+
+    def get_config_parameter_random_value(self, prop: ConfigProp):
+        if prop in [
+                self.ConfigProp.QUOTA_NODE_MAX_IN,
+                self.ConfigProp.QUOTA_NODE_MAX_EG
+        ]:
+            r = self.rnd.randrange(4)
+            if r == 0:
+                return None
+            if r == 1:
+                return 64  # practical minimum
+            return math.floor(2**(self.rnd.random() * 35 + 5))  # up to 1 TB/s
+
+        if prop == self.ConfigProp.QUOTA_SHARD_MIN_BPS:
+            r = self.rnd.randrange(3)
+            if r == 0:
+                return 0
+            return math.floor(2**(self.rnd.random() * 30))  # up to 1 GB/s
+
+        if prop == self.ConfigProp.QUOTA_SHARD_MIN_RATIO:
+            r = self.rnd.randrange(3)
+            if r == 0:
+                return 0
+            if r == 1:
+                return 1
+            return self.rnd.random()
+
+        if prop == self.ConfigProp.THROTTLE_DELAY_MAX_MS:
+            r = self.rnd.randrange(3)
+            if r == 0:
+                return 0
+            return math.floor(2**(self.rnd.random() * 25))  # up to ~1 year
+
+        if prop == self.ConfigProp.BAL_WINDOW_MS:
+            r = self.rnd.randrange(4)
+            if r == 0:
+                return 1
+            if r == 1:
+                return 2147483647
+            return math.floor(2**(self.rnd.random() * 31))
+
+        if prop == self.ConfigProp.BAL_PERIOD_MS:
+            r = self.rnd.randrange(3)
+            if r == 0:
+                return 0
+            return math.floor(2**(self.rnd.random() * 22))  # up to ~1.5 months
+
+        raise Exception(f"Unsupported ConfigProp: {prop}")
+
+    def current_effective_node_quota(self) -> Tuple[int, int]:
+        metrics = self.redpanda.metrics_sample(
+            "quotas_quota_effective", metrics_endpoint=MetricsEndpoint.METRICS)
+
+        assert metrics, "Effecive quota metric is missing"
+        self.logger.debug(f"Samples: {metrics.samples}")
+
+        node_quota_in = sum(
+            int(s.value) for s in metrics.label_filter({
+                "direction": "ingress"
+            }).samples)
+        node_quota_eg = sum(
+            int(s.value) for s in metrics.label_filter({
+                "direction": "egress"
+            }).samples)
+        return node_quota_in, node_quota_eg
+
+    @cluster(num_nodes=3)
+    def test_configuration(self):
+        """
+        Test various configuration patterns, including extreme ones,
+        verify that it does not wreck havoc onto cluster
+        """
+
+        # TBD: parameterize to run under load or not
+
+        errors = []
+        # 12 passes approximately take 30 secs on a 3-node cluster
+        for _ in range(12):
+
+            change = {}
+            for _ in range(self.rnd.randrange(4)):
+                config_param = self.rnd.choice(list(self.ConfigProp))
+                config_value = self.get_config_parameter_random_value(
+                    config_param)
+                self.config[config_param] = config_value
+                change[config_param.value] = config_value
+            self.logger.info(f"Changing cluster prop: {change}")
+            self.redpanda.set_cluster_config(change)
+
+            # set_cluster_config waits for the prop to be replicated
+            # it takes time so no need for a sleep()
+
+            def check_node_quota_metric(self, config_prop: self.ConfigProp,
+                                        effective_node_quota: int) -> str:
+                config_val = self.config[config_prop]
+                if config_val is None:
+                    return
+                expected_node_quota = config_val * len(self.redpanda.nodes)
+                if effective_node_quota == expected_node_quota:
+                    return
+                e = (
+                    f"Expected quota value mismatch. "
+                    f"Effective {effective_node_quota} != expected {expected_node_quota}. "
+                    f"Direction: {config_prop.name}")
+                self.logger.error(e)
+                return e
+
+            effective_node_quota = self.current_effective_node_quota()
+            self.logger.debug(
+                f"current_effective_node_quota: {effective_node_quota}")
+            errors.append(
+                check_node_quota_metric(self,
+                                        self.ConfigProp.QUOTA_NODE_MAX_IN,
+                                        effective_node_quota[0]))
+            errors.append(
+                check_node_quota_metric(self,
+                                        self.ConfigProp.QUOTA_NODE_MAX_EG,
+                                        effective_node_quota[1]))
+
+        errors = set([e for e in errors if e])
+        assert len(errors) == 0, (
+            f"Test has failed with {len(errors)} distinct errors. "
+            f"{errors}, rnd_seed: {self.rnd_seed}")


### PR DESCRIPTION
This PR adds the first ducktape test that verifies that changes of cluster properties related to node rate limiting do not wreck the cluster, and also verifies that some of them (actual limit properties) have applied correctly via metrics.

It also carries first few metrics (non-public) showing
* effective shard quota (per shard)
* measured shard throughput (per shard)
* balancer runs counter (per node)

Fixes to the issues found during the testing:
* The priority of TP limit setting over minimum shard quota was not implemented while changing node TP limit to a smaller value
* Node deficit value was not initialized
* Initial node wide quota was not distributed between shards in full when it did not divide by the number of shards. Same applied to the cases when limitation was enabled after being disabled. Same applied to minimum shard quota calculation from minimum rate.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* TBD

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
