### PR TITLE
rpk: capture metrics at two points in time

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle.go
@@ -46,6 +46,7 @@ type bundleParams struct {
 	logsLimitBytes          int
 	controllerLogLimitBytes int
 	timeout                 time.Duration
+	metricsInterval         time.Duration
 }
 
 func NewCommand(fs afero.Fs) *cobra.Command {
@@ -76,7 +77,8 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		controllerLogsSizeLimit string
 		namespace               string
 
-		timeout time.Duration
+		timeout         time.Duration
+		metricsInterval time.Duration
 	)
 	command := &cobra.Command{
 		Use:   "bundle",
@@ -120,6 +122,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 				logsLimitBytes:          int(logsLimit),
 				controllerLogLimitBytes: int(controllerLogsLimit),
 				timeout:                 timeout,
+				metricsInterval:         metricsInterval,
 			}
 
 			// to execute the appropriate bundle we look for
@@ -158,8 +161,14 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	command.Flags().DurationVar(
 		&timeout,
 		"timeout",
-		10*time.Second,
+		12*time.Second,
 		"How long to wait for child commands to execute (e.g. '30s', '1.5m')",
+	)
+	command.Flags().DurationVar(
+		&metricsInterval,
+		"metrics-interval",
+		10*time.Second,
+		"Interval between metrics snapshots (e.g. '30s', '1.5m')",
 	)
 	command.Flags().StringVar(
 		&logsSince,


### PR DESCRIPTION
This commit introduces --metrics-interval which let the user set an interval to capture 2 snapshots of the metrics endpoints.

This is useful because a couple of metrics are counters that need values at two points in time to be useful. 

This also fixes using forbidden characters for filenames in Windows. (e.g a node address is used in filenames and is of the type `0.0.0.0:9644` and the colon `:` is forbidden) https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file, note that this is not a comprehensive check, instead, just a replacement of common characters to "-".

We also changed how the metrics sub-directory is structured, now we use `metrics/<node-address>/<t0,t1 metrics>`
![image](https://user-images.githubusercontent.com/59714880/215619954-f19ab286-1b2f-48b2-9f83-ca6d84163b6d.png)

Fixes #8372 

## Backports Required
- [ ] none - issue does not exist in previous branches

## Release Notes
  ### Features

  * rpk now will capture two snapshots of the metrics in a fixed interval when running `rpk debug bundle`.
