### PR TITLE
tests/docker: Upgrade MinIO docker image

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - -f
       - http://localhost:9000/minio/health/live
       timeout: 20s
-    image: minio/minio:RELEASE.2021-03-26T00-00-41Z
+    image: minio/minio:RELEASE.2023-01-25T00-19-54Z
     networks:
     - redpanda-test
   azurite:


### PR DESCRIPTION
The MinIO docker image latest version solves a possible race condition related to deleting a prefix at the same time as putting objects in it.

This behavior is supported in the actual cloud storage APIs such as S3 but it may cause issues in older versions of MinIO.

Fixes #8388 

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none
