### PR TITLE
archival: fix log messages printing integer errors

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1009,7 +1009,9 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
           error != cluster::errc::success
           && error != cluster::errc::not_leader) {
             vlog(
-              _rtclog.warn, "archival metadata STM update failed: {}", error);
+              _rtclog.warn,
+              "archival metadata STM update failed: {}",
+              error.message());
         }
 
         vlog(
@@ -1165,7 +1167,10 @@ ntp_archiver::maybe_truncate_manifest() {
           ss::lowres_clock::now() + _conf->manifest_upload_timeout,
           _as);
         if (error != cluster::errc::success) {
-            vlog(ctxlog.warn, "archival metadata STM update failed: {}", error);
+            vlog(
+              ctxlog.warn,
+              "archival metadata STM update failed: {}",
+              error.message());
             throw std::system_error(error);
         } else {
             vlog(
@@ -1524,7 +1529,10 @@ ss::future<bool> ntp_archiver::do_upload_local(
     auto error = co_await _parent.archival_meta_stm()->add_segments(
       {meta}, deadline);
     if (error != cluster::errc::success && error != cluster::errc::not_leader) {
-        vlog(_rtclog.warn, "archival metadata STM update failed: {}", error);
+        vlog(
+          _rtclog.warn,
+          "archival metadata STM update failed: {}",
+          error.message());
         co_return false;
     }
     if (


### PR DESCRIPTION
...instead of the string name of the error.

This fixes cases like saying `cluster::errc::13` instead of `timeout`.

Related: https://github.com/redpanda-data/documentation/issues/248

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
