### PR TITLE
Update omb git ref

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -45,7 +45,7 @@ function install_system_deps() {
 function install_omb() {
   git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git
   cd /opt/openmessaging-benchmark
-  git reset --hard 6eba1030cb7c199e03f76676b6c2df9dcc3b219d
+  git reset --hard 2674d62ca2b6fd7f22536e924c0df8a8fa21350d
   mvn clean package -DskipTests
 }
 


### PR DESCRIPTION
CI fails to build omb with an error on protobuf-java. This commit updates the omb git ref with the fixed dependency versions

ref: https://github.com/redpanda-data/devprod/issues/566

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
