### PR TITLE
cloud_storage: fix test not checking success of upload

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -452,7 +452,12 @@ static void reupload_compacted_segments(
         delta = delta + model::offset(s.num_config_records);
 
         if (!s.do_not_reupload) {
+            // We are updating manifest before uploading segment: this is not
+            // what the real upload path would do.  It is important that we
+            // assert out if the upload doesn't succeed, to avoid manifest
+            // and object store state getting out of sync.
             m.add(s.sname, meta);
+
             auto url = m.generate_segment_path(*m.get(meta.base_offset));
             vlog(test_log.debug, "reuploading segment {}", url);
             retry_chain_node rtc(never_abort, 10s, 1s);
@@ -465,15 +470,16 @@ static void reupload_compacted_segments(
                   std::make_unique<storage::segment_reader_handle>(
                     make_iobuf_input_stream(bytes_to_iobuf(body))));
             };
-            api
-              .upload_segment(
-                cloud_storage_clients::bucket_name("bucket"),
-                url,
-                meta.size_bytes,
-                std::move(reset_stream),
-                rtc,
-                always_continue)
-              .get();
+            auto result = api
+                            .upload_segment(
+                              cloud_storage_clients::bucket_name("bucket"),
+                              url,
+                              meta.size_bytes,
+                              std::move(reset_stream),
+                              rtc,
+                              always_continue)
+                            .get();
+            BOOST_REQUIRE_EQUAL(result, cloud_storage::upload_result::success);
         }
     }
     m.advance_insync_offset(m.get_last_offset());


### PR DESCRIPTION
This led to a subsequent GET failure if the upload had not succeeded, for example in the case of a timeout connecting to s3_imposter.

The timeout issue is still unresolved: there appears to be an issue with retries that is causing the test code to drop out the first time it fails to connect.  This PR just makes the failure cleaner and more obvious.

Related: https://github.com/redpanda-data/redpanda/issues/7548


## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
