### PR TITLE
archival: clean up + fix over-optimistic timeout waiting for leadership

### DIFF
--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -13,7 +13,6 @@ else()
         ntp_archiver_reupload_test.cc 
         retention_strategy_test.cc
         archival_metadata_stm_test.cc
-        upload_housekeeping_service_test.cc
       DEFINITIONS BOOST_TEST_DYN_LINK
       LIBRARIES 
         v::seastar_testing_main 

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -216,7 +216,7 @@ void archiver_fixture::wait_for_partition_leadership(const model::ntp& ntp) {
     tests::cooperative_spin_wait_with_timeout(10s, [this, ntp] {
         auto& table = app.controller->get_partition_leaders().local();
         auto self = app.controller->self();
-        ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 100ms;
+        ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 500ms;
         return table.wait_for_leader(ntp, deadline, {}).get0() == self
                && app.partition_manager.local().get(ntp)->is_elected_leader();
     }).get();

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -141,10 +141,6 @@ public:
     /// Wait unill all information will be replicated and the local node
     /// will become a leader for 'ntp'.
     void wait_for_partition_leadership(const model::ntp& ntp);
-    void delete_topic(model::ns ns, model::topic topic);
-    void wait_for_topic_deletion(const model::ntp& ntp);
-    void add_topic_with_random_data(const model::ntp& ntp, int num_batches);
-    void wait_for_lso(const model::ntp&);
     /// Provides access point for segment_matcher CRTP template
     storage::api& get_local_storage_api();
     /// \brief Init storage api for tests that require only storage
@@ -158,19 +154,6 @@ public:
     std::vector<segment_layout> get_layouts(const model::ntp& ntp) const {
         return layouts.find(ntp)->second;
     }
-
-    ss::future<> add_topic_with_single_partition(model::ntp ntp) {
-        co_await wait_for_controller_leadership();
-        co_await add_topic(model::topic_namespace_view(
-          model::topic_namespace(ntp.ns, ntp.tp.topic)));
-    }
-
-    ss::future<> add_topic_with_archival_enabled(
-      model::topic_namespace_view tp_ns, int partitions = 1);
-
-    ss::future<> create_archival_snapshot(
-      const storage::ntp_config& cfg,
-      cloud_storage::partition_manifest manifest);
 
 private:
     void initialize_shard(


### PR DESCRIPTION
- Bump the timeout on leadership election in archival tests from 100ms to 500ms
- Clean up unused code
- Clean up a file that was linked into two different test binaries

Fixes #8143 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none

