### PR TITLE
Add parsing of v1 compaction index footers

### DIFF
--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -83,6 +83,12 @@ struct compacted_index {
         // version *must* be the last field
         int8_t version{current_version};
 
+        static constexpr size_t footer_size = sizeof(size) + sizeof(keys)
+                                              + sizeof(size_deprecated)
+                                              + sizeof(keys_deprecated)
+                                              + sizeof(flags) + sizeof(crc)
+                                              + sizeof(version);
+
         friend std::ostream&
         operator<<(std::ostream& o, const compacted_index::footer& f) {
             return o << "{size:" << f.size << ", keys:" << f.keys
@@ -90,6 +96,19 @@ struct compacted_index {
                      << ", version: " << (int)f.version << "}";
         }
     };
+
+    struct footer_v1 {
+        uint32_t size{0};
+        uint32_t keys{0};
+        footer_flags flags{0};
+        uint32_t crc{0}; // crc32
+        int8_t version{1};
+
+        static constexpr size_t footer_size = sizeof(size) + sizeof(keys)
+                                              + sizeof(flags) + sizeof(crc)
+                                              + sizeof(version);
+    };
+
     enum class recovery_state {
         /**
          * Index may be missing when either was deleted or not stored when
@@ -109,10 +128,6 @@ struct compacted_index {
          */
         index_recovered
     };
-    static constexpr size_t footer_size
-      = sizeof(footer::size) + sizeof(footer::keys)
-        + sizeof(footer::size_deprecated) + sizeof(footer::keys_deprecated)
-        + sizeof(footer::flags) + sizeof(footer::crc) + sizeof(footer::version);
 
     struct needs_rebuild_error final : public std::runtime_error {
     public:

--- a/src/v/storage/compacted_index_chunk_reader.h
+++ b/src/v/storage/compacted_index_chunk_reader.h
@@ -52,7 +52,8 @@ private:
     ss::io_priority_class _iopc;
     size_t _max_chunk_memory{0};
     size_t _byte_index{0};
-    std::optional<size_t> _file_size;
+    // file size minus footer size
+    std::optional<size_t> _data_size;
     std::optional<compacted_index::footer> _footer;
     bool _end_of_stream{false};
     std::optional<ss::input_stream<char>> _cursor;

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -317,7 +317,7 @@ ss::future<> spill_key_index::close() {
         _footer.crc = _crc.value();
         auto footer_buf = reflection::to_iobuf(_footer);
         vassert(
-          footer_buf.size_bytes() == compacted_index::footer_size,
+          footer_buf.size_bytes() == compacted_index::footer::footer_size,
           "Footer is bigger than expected: {}",
           footer_buf);
 

--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -9,11 +9,15 @@
 
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda_installer import RedpandaInstaller
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.util import produce_until_segments
+
+import os.path
 
 
 class CompactionRecoveryTest(RedpandaTest):
@@ -97,3 +101,119 @@ class CompactionRecoveryTest(RedpandaTest):
                    err_msg="Segments not found")
 
         return partitions
+
+
+class CompactionRecoveryUpgradeTest(RedpandaTest):
+    OLD_VERSION = (22, 2, 8)
+    SEGMENT_SIZE = 1048576
+
+    topics = (TopicSpec(partition_count=1,
+                        replication_factor=3,
+                        cleanup_policy=TopicSpec.CLEANUP_COMPACT), )
+
+    def __init__(self, *args, **kwargs):
+        super(CompactionRecoveryUpgradeTest, self).__init__(
+            *args,
+            extra_rp_conf=dict(compacted_log_segment_size=self.SEGMENT_SIZE,
+                               log_compaction_interval_ms=1000,
+                               max_compacted_log_segment_size=1,
+                               compaction_ctrl_min_shares=1000,
+                               compaction_ctrl_max_shares=1000),
+            **kwargs)
+
+    def setUp(self):
+        self.installer = self.redpanda._installer
+        self.installer.install(self.redpanda.nodes, self.OLD_VERSION)
+        super(CompactionRecoveryUpgradeTest, self).setUp()
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_index_recovery_after_upgrade(self):
+        """
+        Test compatibility between v1 and v2 compaction index footers.
+        * Redpanda version with v2 footers should be able to recover
+          v1 footers without rebuilding them.
+        * Old redpanda version with v1 footers is not able to recover
+          v2 footers, but at least it should be able to rebuild them.
+        """
+        def get_storage_partition(node):
+            storage = self.redpanda.node_storage(node, sizes=True)
+            partitions = storage.partitions('kafka', self.topic)
+            assert len(partitions) == 1
+            return partitions[0]
+
+        def produce_and_wait_for_compaction(node, count):
+            initial_count = len(get_storage_partition(node).segments)
+
+            # count + 1 in case we haven't had a segment open
+            produce_until_segments(self.redpanda,
+                                   self.topic,
+                                   partition_idx=0,
+                                   count=initial_count + count + 1,
+                                   record_size=1024,
+                                   batch_size=2048)
+
+            def no_big_closed_segments():
+                partition = get_storage_partition(node)
+                return not any(
+                    seg.base_index and seg.size > (self.SEGMENT_SIZE / 2)
+                    for seg in partition.segments.values())
+
+            wait_until(no_big_closed_segments, timeout_sec=30, backoff_sec=2)
+
+        def get_closed_segment2mtime(node):
+            partition = get_storage_partition(node)
+
+            seg2mtime = dict()
+            for sname, seg in partition.segments.items():
+                if seg.base_index:
+                    path = os.path.join(partition.path, seg.data_file)
+                    out = partition.node.account.ssh_capture(
+                        f"stat --format=%Y {path}")
+                    mtime = ''.join(out).strip()
+                    seg2mtime[path] = int(mtime)
+
+            for k, v in sorted(seg2mtime.items()):
+                self.logger.debug(f"mtime for closed segment {k}: {v}")
+
+            return seg2mtime
+
+        # Restart only 1 node so that cluster feature version doesn't increase
+        # and we can go back to the previous redpanda version.
+        to_restart = self.redpanda.nodes[0]
+        self.logger.info(f"will test node {to_restart.account.hostname}")
+
+        produce_and_wait_for_compaction(to_restart, 2)
+        seg2mtime_1 = get_closed_segment2mtime(to_restart)
+        assert len(seg2mtime_1) >= 2
+
+        self.installer.install([to_restart], RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes([to_restart])
+        self.redpanda.wait_for_membership(first_start=False)
+
+        # After restart we produce and wait for the new segments to be compacted.
+        # Because redpanda compacts segments from the beginning, this means that
+        # all earlier segments have been either recovered or rebuilt after restart.
+        produce_and_wait_for_compaction(to_restart, 2)
+        seg2mtime_2 = get_closed_segment2mtime(to_restart)
+        assert len(seg2mtime_2) >= len(seg2mtime_1) + 2
+
+        for index in seg2mtime_1.keys():
+            # v1 compacted segments should be left intact
+            assert index in seg2mtime_2
+            assert seg2mtime_1[index] == seg2mtime_2[index]
+
+        self.installer.install([to_restart], self.OLD_VERSION)
+        self.redpanda.restart_nodes([to_restart])
+        self.redpanda.wait_for_membership(first_start=False)
+
+        produce_and_wait_for_compaction(to_restart, 2)
+        seg2mtime_3 = get_closed_segment2mtime(to_restart)
+        assert len(seg2mtime_3) >= len(seg2mtime_2) + 2
+        for index in seg2mtime_2.keys():
+            assert index in seg2mtime_3
+            if index in seg2mtime_1:
+                # v1-compacted segments should not be rewritten
+                assert seg2mtime_3[index] == seg2mtime_2[index]
+            else:
+                # old version should rebuild v2 indices and re-compact segments
+                assert seg2mtime_3[index] > seg2mtime_2[index]

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -124,14 +124,18 @@ def produce_until_segments(redpanda,
                            partition_idx,
                            count,
                            acks=-1,
-                           record_size=1024):
+                           record_size=1024,
+                           batch_size=10000):
     """
     Produce into the topic until given number of segments will appear
     """
     kafka_tools = KafkaCliTools(redpanda)
 
     def done():
-        kafka_tools.produce(topic, 10000, record_size=record_size, acks=acks)
+        kafka_tools.produce(topic,
+                            batch_size,
+                            record_size=record_size,
+                            acks=acks)
         topic_partitions = segments_count(redpanda, topic, partition_idx)
         partitions = []
         for p in topic_partitions:


### PR DESCRIPTION
A followup to #7687

An unfortunate side effect of introducing v2 compaction footers was that perfectly good indices with v1 footers would have to be rebuilt and the segment re-compacted (after restart we have to verify index integrity to determine it the segment is already compacted and indices with v1 footers failed the version check). This PR adds compatibility code for v1 footer parsing.

Also added an end-to-end upgrade test that verifies that the new version doesn't re-compact segments processed by the old version, and the old version correctly re-compacts the segments compacted by the new version.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none
