### PR TITLE
cloud_storage: try to quiesce uploaders before leadership transfer

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -617,6 +617,17 @@ void partition::set_topic_config(
     }
 }
 
+ss::future<std::error_code>
+partition::transfer_leadership(std::optional<model::node_id> target) {
+    if (_rm_stm) {
+        return _rm_stm->transfer_leadership(target);
+    } else if (_tm_stm) {
+        return _tm_stm->transfer_leadership(target);
+    } else {
+        return _raft->do_transfer_leadership(target);
+    }
+}
+
 std::ostream& operator<<(std::ostream& o, const partition& x) {
     return o << x._raft;
 }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -153,15 +153,7 @@ public:
     }
 
     ss::future<std::error_code>
-    transfer_leadership(std::optional<model::node_id> target) {
-        if (_rm_stm) {
-            return _rm_stm->transfer_leadership(target);
-        } else if (_tm_stm) {
-            return _tm_stm->transfer_leadership(target);
-        } else {
-            return _raft->do_transfer_leadership(target);
-        }
-    }
+    transfer_leadership(std::optional<model::node_id> target);
 
     ss::future<std::error_code>
     request_leadership(model::timeout_clock::time_point timeout) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1091,13 +1091,8 @@ ss::future<result<kafka_result>> rm_stm::replicate(
     return do_replicate(bid, std::move(r), opts, enqueued);
 }
 
-ss::future<std::error_code>
-rm_stm::transfer_leadership(std::optional<model::node_id> target) {
-    return _state_lock.hold_write_lock().then(
-      [this, target](ss::basic_rwlock<>::holder unit) {
-          return _c->do_transfer_leadership(target).finally(
-            [u = std::move(unit)] {});
-      });
+ss::future<ss::basic_rwlock<>::holder> rm_stm::prepare_transfer_leadership() {
+    co_return co_await _state_lock.hold_write_lock();
 }
 
 ss::future<result<kafka_result>> rm_stm::do_replicate(

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -216,8 +216,7 @@ public:
       model::record_batch_reader,
       raft::replicate_options);
 
-    ss::future<std::error_code>
-      transfer_leadership(std::optional<model::node_id>);
+    ss::future<ss::basic_rwlock<>::holder> prepare_transfer_leadership();
 
     ss::future<> stop() override;
 

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -262,17 +262,13 @@ ss::future<> tm_stm::checkpoint_ongoing_txs() {
       txes_to_checkpoint.size());
 }
 
-ss::future<std::error_code>
-tm_stm::transfer_leadership(std::optional<model::node_id> target) {
-    vlog(
-      txlog.trace,
-      "transfering leadership to {}",
-      target.value_or(model::node_id(-1)));
+ss::future<ss::basic_rwlock<>::holder> tm_stm::prepare_transfer_leadership() {
+    vlog(txlog.trace, "Preparing for leadership transfer");
     auto units = co_await _cache.local().write_lock();
     // This is a best effort basis, we checkpoint as many as we can
     // and stop at the first error.
     co_await checkpoint_ongoing_txs();
-    co_return co_await _c->do_transfer_leadership(target);
+    co_return units;
 }
 
 ss::future<checked<model::term_id, tm_stm::op_status>>

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -113,8 +113,7 @@ public:
 
     ss::future<> checkpoint_ongoing_txs();
 
-    ss::future<std::error_code>
-      transfer_leadership(std::optional<model::node_id>);
+    ss::future<ss::basic_rwlock<>::holder> prepare_transfer_leadership();
 
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       reset_tx_ready(model::term_id, kafka::transactional_id);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1306,6 +1306,14 @@ configuration::configuration()
       "cloud_storage_segment_size_target/2",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
+  , cloud_storage_graceful_transfer_timeout_ms(
+      *this,
+      "cloud_storage_graceful_transfer_timeout",
+      "Time limit on waiting for uploads to complete before a leadership "
+      "transfer.  If this is null, leadership transfers will proceed without "
+      "waiting.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5s)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -263,6 +263,8 @@ struct configuration final : public config_store {
     property<size_t> cloud_storage_recovery_temporary_retention_bytes_default;
     property<std::optional<size_t>> cloud_storage_segment_size_target;
     property<std::optional<size_t>> cloud_storage_segment_size_min;
+    property<std::optional<std::chrono::milliseconds>>
+      cloud_storage_graceful_transfer_timeout_ms;
 
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;


### PR DESCRIPTION
This substantially reduces the probability of leaving orphaned
objects in the object store when partitions change leadership
under load, e.g. during upgrades or leader balancing.
    
This fixes a test failure that indirectly detects orphan
objects by checking that topic deletion clears all objects.
    
Fixes https://github.com/redpanda-data/redpanda/issues/8496

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Improvements

* Partition leadership transfers now wait for tiered storage uploads to finish, resulting in a lower probability of orphan objects in the object storage bucket.  These objects are not a data integrity issue, but could result in a small amount of extra space used.
* Cluster configuration property `cloud_storage_graceful_transfer_timeout_ms` is added, with a default of 5000ms.  Setting this property to null disables the new behavior of waiting for uploads to complete before transferring leadership.
