### PR TITLE
[controller] Fix cross core partition movement coordination at bootstrap

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -507,54 +507,89 @@ controller_backend::bootstrap_ntp(const model::ntp& ntp, deltas_t& deltas) {
           "[{}] first bootstrap delta is a cross core update, looking for "
           "initial revision",
           ntp);
-        // find operation that created current partition on this node
-        auto it = std::find_if(
-          deltas.rbegin(), deltas.rend(), [this](const delta_metadata& md) {
-              if (md.delta.type == op_t::add) {
-                  return true;
-              }
-              return md.delta.type == op_t::update_finished
-                     && !contains_node(_self, md.delta.new_assignment.replicas);
+
+        // Check if this update already finished or interrupted.
+        auto first_meta_it = bootstrap_deltas.begin();
+        auto update_finished = std::find_if(
+          first_meta_it,
+          bootstrap_deltas.end(),
+          [&first_meta_it](const delta_metadata& md) {
+              return is_finishing_operation(first_meta_it->delta, md.delta)
+                     || is_interrupting_operation(first_meta_it, md.delta);
           });
 
-        vassert(
-          it != deltas.rend(),
-          "if partition {} was moved from different core it had to exists on "
-          "current node previously",
-          ntp);
-        // if we found update finished operation it is preceding operation that
-        // created partition on current node
-        vlog(
-          clusterlog.trace,
-          "[{}] first operation that doesn't contain current node - {}",
-          ntp,
-          *it);
-        /**
-         * At this point we may have two situations
-         * 1. replica was created on current node shard when partition was
-         *    created, with addition delta, in this case `it` contains this
-         *    addition delta.
-         *
-         * 2. replica was moved to this node with `update` delta type, in this
-         *    case `it` contains either `update_finished` delta from previous
-         *    operation or `add` delta from previous operation. In this case
-         *    operation does not contain current node and we need to execute
-         *    operation that is following the found one as this is the first
-         *    operation that created replica on current node
-         *
-         */
-        if (!contains_node(_self, it->delta.new_assignment.replicas)) {
+        if (update_finished != bootstrap_deltas.end()) {
+            // Cross core move already finished / interrupted. So the current
+            // shard needs to bootstrap the ntp on its own, populate the needed
+            // revision in bootstrap_revisions.
+            vlog(
+              clusterlog.trace,
+              "[{}] Cross core move finished/interrupted with {}",
+              update_finished->delta.ntp,
+              *update_finished);
+
+            // find operation that created current partition on this node
+            auto it = std::find_if(
+              deltas.rbegin(), deltas.rend(), [this](const delta_metadata& md) {
+                  if (md.delta.type == op_t::add) {
+                      return true;
+                  }
+                  return md.delta.type == op_t::update_finished
+                         && !contains_node(
+                           _self, md.delta.new_assignment.replicas);
+              });
+
             vassert(
-              it != deltas.rbegin(),
-              "operation {} must have following operation that created a "
-              "replica on current node",
+              it != deltas.rend(),
+              "if partition {} was moved from different core it had to exists "
+              "on "
+              "current node previously",
+              ntp);
+            // if we found update finished operation it is preceding operation
+            // that created partition on current node
+            vlog(
+              clusterlog.trace,
+              "[{}] first operation that doesn't contain current node - {}",
+              ntp,
               *it);
-            it = std::prev(it);
+            /**
+             * At this point we may have two situations
+             * 1. replica was created on current node shard when partition was
+             *    created, with addition delta, in this case `it` contains this
+             *    addition delta.
+             *
+             * 2. replica was moved to this node with `update` delta type, in
+             * this case `it` contains either `update_finished` delta from
+             * previous operation or `add` delta from previous operation. In
+             * this case operation does not contain current node and we need to
+             * execute operation that is following the found one as this is the
+             * first operation that created replica on current node
+             *
+             */
+            if (!contains_node(_self, it->delta.new_assignment.replicas)) {
+                vassert(
+                  it != deltas.rbegin(),
+                  "operation {} must have following operation that created a "
+                  "replica on current node",
+                  *it);
+                it = std::prev(it);
+            }
+            vlog(
+              clusterlog.trace,
+              "[{}] initial revision source delta: {}",
+              ntp,
+              *it);
+            // persist revision in order to create partition with correct
+            // revision
+            _bootstrap_revisions[ntp] = model::revision_id(it->delta.offset());
+        } else {
+            vlog(
+              clusterlog.trace,
+              "[{}] Detected a pending cross core move via {}, skipping "
+              "bootstrap version generation ",
+              first_meta.delta.ntp,
+              first_meta.delta);
         }
-        vlog(
-          clusterlog.trace, "[{}] initial revision source delta: {}", ntp, *it);
-        // persist revision in order to create partition with correct revision
-        _bootstrap_revisions[ntp] = model::revision_id(it->delta.offset());
     }
     // apply all deltas following the one found previously
     deltas = std::move(bootstrap_deltas);

--- a/tests/rptest/tests/partition_movement_upgrade_test.py
+++ b/tests/rptest/tests/partition_movement_upgrade_test.py
@@ -62,7 +62,8 @@ class PartitionMovementUpgradeTest(PreallocNodesTest, PartitionMovementMixin):
             topic_name,
             self._message_size,
             readers=5,
-            nodes=self.preallocated_nodes)
+            nodes=self.preallocated_nodes,
+            debug_logs=True)
         self.consumer.start(clean=False)
 
     def verify(self):


### PR DESCRIPTION
Bug:

Currently if a cross core update is replayed at startup, the partition is bootstrapped on both the cores, likely at the same time resulting in racy updates to the shard table. For example consider the following sequence of updates for a partition that moved from shard 0 to shard 1

> shard 1: bootstrap ntp
> shard 1: update shard_table ntp -> shard1
> shard 0: bootstrap ntp
> shard 0: update shard_table ntp -> shard0 (overwrite)
> shard 0 : realize that the partition already moved to shard1
> shard 0: remove from shard_table ntp
> shard 1: ... continue with ntp lifecycle.

At this point the shard_table has neither shard0 nor shard1 while the partition is bootstrapped on shard1 successfully.

This is exactly the bug that was causing consumption to timeout because the client RPCs lookup the shard table to find the home shard for the partition.

Fix: This PR fixes the coordination for unfinished/uninterrupted cross core movements by making the the new owner shard wait for the previous shard to do a proper handoff the partition.


Fixes #8229, #8207

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
