### PR TITLE
Fixes #8236 (stuck transactions) by aborting expired transactions

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1786,9 +1786,23 @@ cluster::abort_group_tx_reply make_abort_tx_reply(cluster::tx_errc ec) {
 ss::future<cluster::begin_group_tx_reply>
 group::begin_tx(cluster::begin_group_tx_request r) {
     if (_partition->term() != _term) {
+        vlog(
+          _ctx_txlog.trace,
+          "processing name:begin_tx pid:{} tx_seq:{} timeout:{} => stale "
+          "leader",
+          r.pid,
+          r.tx_seq,
+          r.timeout);
         co_return make_begin_tx_reply(cluster::tx_errc::stale);
     }
 
+    vlog(
+      _ctx_txlog.trace,
+      "processing name:begin_tx pid:{} tx_seq:{} timeout:{} in term:{}",
+      r.pid,
+      r.tx_seq,
+      r.timeout,
+      _term);
     auto fence_it = _fence_pid_epoch.find(r.pid.get_id());
     if (fence_it == _fence_pid_epoch.end()) {
         // intentionally empty

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1814,7 +1814,28 @@ group::begin_tx(cluster::begin_group_tx_request r) {
           fence_it->second);
         co_return make_begin_tx_reply(cluster::tx_errc::fenced);
     } else if (r.pid.get_epoch() > fence_it->second) {
-        // TODO: proactively cancel an ongoing txn
+        // there is a fence, it might be that tm_stm failed, forget about
+        // an ongoing transaction, assigned next pid for the same tx.id and
+        // started a new transaction without aborting the previous one.
+        //
+        // at the same time it's possible that it already aborted the old
+        // tx before starting this. do_abort_tx is idempotent so calling it
+        // just in case to proactivly abort the tx instead of waiting for
+        // the timeout
+
+        auto old_pid = model::producer_identity{
+          r.pid.get_id(), fence_it->second};
+        auto ar = co_await do_try_abort_old_tx(old_pid);
+        if (ar != cluster::tx_errc::none) {
+            vlog(
+              _ctx_txlog.trace,
+              "can't begin tx {} because abort of a prev tx {} failed with {}; "
+              "retrying",
+              r.pid,
+              old_pid,
+              ar);
+            co_return make_begin_tx_reply(cluster::tx_errc::stale);
+        }
     }
 
     auto txseq_it = _tx_seqs.find(r.pid.get_id());
@@ -3190,11 +3211,14 @@ ss::future<> group::try_abort_old_tx(model::producer_identity pid) {
             }
         }
 
-        return do_try_abort_old_tx(pid);
+        return do_try_abort_old_tx(pid).discard_result();
     });
 }
 
-ss::future<> group::do_try_abort_old_tx(model::producer_identity pid) {
+ss::future<cluster::tx_errc>
+group::do_try_abort_old_tx(model::producer_identity pid) {
+    vlog(_ctx_txlog.trace, "aborting pid:{}", pid);
+
     auto p_it = _prepared_txs.find(pid);
     if (p_it != _prepared_txs.end()) {
         auto tx_seq = p_it->second.tx_seq;
@@ -3206,7 +3230,7 @@ ss::future<> group::do_try_abort_old_tx(model::producer_identity pid) {
           tx_seq,
           config::shard_local_cfg().rm_sync_timeout_ms.value());
         if (r.ec != cluster::tx_errc::none) {
-            co_return;
+            co_return r.ec;
         }
         if (r.commited) {
             auto res = co_await do_commit(_id, pid);
@@ -3217,6 +3241,7 @@ ss::future<> group::do_try_abort_old_tx(model::producer_identity pid) {
                   pid,
                   res.ec);
             }
+            co_return res.ec;
         } else if (r.aborted) {
             auto res = co_await do_abort(_id, pid, tx_seq);
             if (res.ec != cluster::tx_errc::none) {
@@ -3226,7 +3251,10 @@ ss::future<> group::do_try_abort_old_tx(model::producer_identity pid) {
                   pid,
                   res.ec);
             }
+            co_return res.ec;
         }
+
+        co_return cluster::tx_errc::stale;
     } else {
         model::tx_seq tx_seq;
         if (is_transaction_ga()) {
@@ -3234,7 +3262,7 @@ ss::future<> group::do_try_abort_old_tx(model::producer_identity pid) {
             if (txseq_it == _tx_seqs.end()) {
                 vlog(
                   _ctx_txlog.trace, "skipping pid:{} (can't find tx_seq)", pid);
-                co_return;
+                co_return cluster::tx_errc::none;
             }
             tx_seq = txseq_it->second;
         } else {
@@ -3244,7 +3272,7 @@ ss::future<> group::do_try_abort_old_tx(model::producer_identity pid) {
                   _ctx_txlog.trace,
                   "skipping pid:{} (can't find volatile)",
                   pid);
-                co_return;
+                co_return cluster::tx_errc::none;
             }
             tx_seq = v_it->second.tx_seq;
         }
@@ -3258,6 +3286,7 @@ ss::future<> group::do_try_abort_old_tx(model::producer_identity pid) {
               tx_seq,
               res.ec);
         }
+        co_return res.ec;
     }
 }
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -840,7 +840,7 @@ private:
     void abort_old_txes();
     ss::future<> do_abort_old_txes();
     ss::future<> try_abort_old_tx(model::producer_identity);
-    ss::future<> do_try_abort_old_tx(model::producer_identity);
+    ss::future<cluster::tx_errc> do_try_abort_old_tx(model::producer_identity);
     void try_arm(time_point_type);
     void maybe_rearm_timer();
 

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -187,10 +187,11 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
     vlog(
       cluster::txlog.trace,
       "dispatching name:begin_group_tx, group_id:{}, pid:{}, tx_seq:{}, "
-      "from:{}, to:{}",
+      "timeout:{} from:{}, to:{}",
       group_id,
       pid,
       tx_seq,
+      timeout,
       _self,
       leader);
     auto reply = co_await dispatch_begin_group_tx(
@@ -244,10 +245,12 @@ ss::future<cluster::begin_group_tx_reply>
 rm_group_frontend::begin_group_tx_locally(cluster::begin_group_tx_request req) {
     vlog(
       cluster::txlog.trace,
-      "processing name:begin_group_tx, group_id:{}, pid:{}, tx_seq:{}",
+      "processing name:begin_group_tx, group_id:{}, pid:{}, tx_seq:{}, "
+      "timeout: {}",
       req.group_id,
       req.pid,
-      req.tx_seq);
+      req.tx_seq,
+      req.timeout);
     auto reply = co_await _group_router.local().begin_tx(req);
     vlog(
       cluster::txlog.trace,


### PR DESCRIPTION
In some cases Redpanda doesn't abort expired transactions, fixing it.

Fixes #8236

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes
### Bug Fixes
  * Fixes availability issue which could led to stuck transactions