### PR TITLE
Expose status of topic recovery via admin API

### DIFF
--- a/src/v/cloud_storage/recovery_utils.h
+++ b/src/v/cloud_storage/recovery_utils.h
@@ -29,6 +29,9 @@ struct recovery_result {
     model::partition_id partition;
     ss::sstring uuid;
     bool result;
+
+    recovery_result(
+      model::topic_namespace, model::partition_id, ss::sstring, bool);
 };
 
 ss::sstring

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -155,6 +155,7 @@ v_cc_library(
     topic_recovery_status_rpc_handler.cc
     topic_recovery_status_frontend.cc
     node_isolation_watcher.cc
+    topic_recovery_status_types.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/topic_recovery_status_frontend.h
+++ b/src/v/cluster/topic_recovery_status_frontend.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include "cluster/topic_recovery_status_types.h"
 #include "model/metadata.h"
 
 #include <seastar/core/sharded.hh>
@@ -40,6 +41,8 @@ public:
       ss::sharded<cloud_storage::topic_recovery_service>&
         topic_recovery_service,
       skip_this_node skip_source_shard) const;
+
+    ss::future<std::optional<status_response>> status() const;
 
     ss::future<> stop() { return ss::make_ready_future<>(); }
 

--- a/src/v/cluster/topic_recovery_status_rpc_handler.cc
+++ b/src/v/cluster/topic_recovery_status_rpc_handler.cc
@@ -25,11 +25,30 @@ topic_recovery_status_rpc_handler::topic_recovery_status_rpc_handler(
 ss::future<status_response> topic_recovery_status_rpc_handler::get_status(
   status_request&&, rpc::streaming_context&) {
     if (!_topic_recovery_service.local_is_initialized()) {
-        co_return status_response{.is_active = false};
+        co_return status_response{
+          .state = cloud_storage::topic_recovery_service::state::inactive};
     }
 
+    auto current_status
+      = _topic_recovery_service.local().current_recovery_status();
+
+    std::vector<topic_downloads> downloads;
+    downloads.reserve(current_status.download_counts.size());
+
+    for (const auto& [tp_ns, count] : current_status.download_counts) {
+        downloads.push_back(
+          {.tp_ns = tp_ns,
+           .pending_downloads = count.pending_downloads,
+           .successful_downloads = count.successful_downloads,
+           .failed_downloads = count.failed_downloads});
+    }
+
+    recovery_request_params request_params;
+    request_params.populate(current_status.request);
     co_return status_response{
-      .is_active = _topic_recovery_service.local().is_active()};
+      .state = current_status.state,
+      .download_counts = downloads,
+      .request = request_params};
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_recovery_status_types.cc
+++ b/src/v/cluster/topic_recovery_status_types.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/topic_recovery_status_types.h"
+
+namespace cluster {
+
+void recovery_request_params::populate(
+  const std::optional<cloud_storage::recovery_request>& r) {
+    if (r.has_value()) {
+        topic_names_pattern = r->topic_names_pattern();
+        retention_bytes = r->retention_bytes();
+        retention_ms = r->retention_ms();
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const recovery_request_params& req) {
+    fmt::print(
+      "{{topic_names_pattern: {}, retention_bytes: {}, retention_ms: {}}}",
+      req.topic_names_pattern.has_value() ? req.topic_names_pattern.value()
+                                          : "none",
+      req.retention_bytes.has_value()
+        ? fmt::format("{}", req.retention_bytes.value())
+        : "none",
+      req.retention_ms.has_value() ? fmt::format("{}", req.retention_ms.value())
+                                   : "none");
+    return os;
+}
+
+bool status_response::is_active() const {
+    return state != cloud_storage::topic_recovery_service::state::inactive;
+}
+
+} // namespace cluster

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "path": "/v1/cloud_storage/initiate_topic_scan_and_recovery",
+      "path": "/v1/cloud_storage/automated_recovery",
       "operations": [
         {
           "method": "POST",
@@ -59,6 +59,12 @@
               "message": "Topic scan was initiated successfully"
             }
           ]
+        },
+        {
+          "method": "GET",
+          "summary": "Query status of automated topic recovery",
+          "operationId": "query_automated_recovery",
+          "nickname": "query_automated_recovery"
         }
       ]
     }
@@ -71,6 +77,54 @@
         "status": {
           "type": "string",
           "description": "current status of recovery process"
+        }
+      }
+    },
+    "topic_download_counts": {
+      "id": "topic_download_counts",
+      "properties": {
+        "topic_namespace": {
+          "type": "string"
+        },
+        "pending_downloads": {
+          "type": "int"
+        },
+        "successful_downloads": {
+          "type": "int"
+        },
+        "failed_downloads": {
+          "type": "int"
+        }
+      }
+    },
+    "recovery_request_params": {
+      "id": "recovery_request_params",
+      "properties": {
+        "topic_names_pattern": {
+          "type": "string"
+        },
+        "retention_bytes": {
+          "type": "int"
+        },
+        "retention_ms": {
+          "type": "int"
+        }
+      }
+    },
+    "topic_recovery_status": {
+      "id": "topic_recovery_status",
+      "properties": {
+        "state": {
+          "type": "string"
+        },
+        "topic_download_counts": {
+          "type": "array",
+          "items": {
+            "type": "topic_download_counts"
+          }
+        },
+        "request": {
+          "type": "recovery_request_params"
         }
       }
     }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -65,7 +65,8 @@ public:
       ss::sharded<cluster::node_status_table>&,
       ss::sharded<cluster::self_test_frontend>&,
       pandaproxy::schema_registry::api*,
-      ss::sharded<cloud_storage::topic_recovery_service>&);
+      ss::sharded<cloud_storage::topic_recovery_service>&,
+      ss::sharded<cluster::topic_recovery_status_frontend>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -321,9 +322,10 @@ private:
     /// Shadow indexing routes
     ss::future<ss::json::json_return_type>
       sync_local_state_handler(std::unique_ptr<ss::httpd::request>);
-
     ss::future<ss::json::json_return_type>
     initiate_topic_scan_and_recovery(std::unique_ptr<ss::httpd::request> req);
+    ss::future<ss::json::json_return_type>
+    query_automated_recovery(std::unique_ptr<ss::httpd::request> req);
 
     /// Self test routes
     ss::future<ss::json::json_return_type>
@@ -380,4 +382,6 @@ private:
     ss::sharded<cluster::self_test_frontend>& _self_test_frontend;
     pandaproxy::schema_registry::api* _schema_registry;
     ss::sharded<cloud_storage::topic_recovery_service>& _topic_recovery_service;
+    ss::sharded<cluster::topic_recovery_status_frontend>&
+      _topic_recovery_status_frontend;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -804,7 +804,8 @@ void application::configure_admin_server() {
       std::ref(node_status_table),
       std::ref(self_test_frontend),
       _schema_registry.get(),
-      std::ref(topic_recovery_service))
+      std::ref(topic_recovery_service),
+      std::ref(topic_recovery_status_frontend))
       .get();
 }
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -793,14 +793,17 @@ class Admin:
                                          force_acquire_lock: bool = False,
                                          node=None,
                                          **kwargs):
-        path = f"cloud_storage/initiate_topic_scan_and_recovery"
         request_args = {'node': node, **kwargs}
 
-        if force_acquire_lock:
-            request_args['params'] = {'force_acquire_lock': force_acquire_lock}
         if payload:
             request_args['json'] = payload
-        return self._request('post', path, **request_args)
+        return self._request('post', "cloud_storage/automated_recovery",
+                             **request_args)
+
+    def get_topic_recovery_status(self, node=None, **kwargs):
+        request_args = {'node': node, **kwargs}
+        return self._request('get', "cloud_storage/automated_recovery",
+                             **request_args)
 
     def self_test_start(self, options):
         return self._request("POST", "debug/self_test/start", json=options)

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -183,3 +183,10 @@ class SIAdminApiTest(RedpandaTest):
             except requests.exceptions.HTTPError as e:
                 assert e.response.status_code == requests.status_codes.codes[
                     'bad_request'], f'unexpected status code: {response} for {payload}'
+
+    @cluster(num_nodes=3)
+    def test_topic_recovery_status_to_non_controller(self):
+        self.admin.initiate_topic_scan_and_recovery()
+        response = self.admin.get_topic_recovery_status(
+            node=self._get_non_controller_node(), allow_redirects=False)
+        assert response.status_code == requests.status_codes.codes['ok']


### PR DESCRIPTION
Adds an api endpoint to show topic recovery status. While recovery is active in background, the status as well as download counters are shown.

While recovery itself runs only on controller leader, any shard in cluster can respond with status.

Fixes https://github.com/redpanda-data/redpanda/issues/8261

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* None

## Release Notes

 * None
