### PR TITLE
tests: made decommission waiter not vulnerable to errors

### DIFF
--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -124,11 +124,16 @@ class NodeDecommissionWaiter():
                 decommission_status = self.admin.get_decommission_status(
                     self.node_id, self._not_decommissioned_node())
             except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 400:
-                    time.sleep(1)
-                    continue
-                else:
-                    raise e
+                self.logger.info(
+                    f"unable to get decommission status, HTTP error",
+                    exc_info=True)
+                time.sleep(1)
+                continue
+            except Exception as e:
+                self.logger.warn(f"unable to get decommission status",
+                                 exc_info=True)
+                time.sleep(1)
+                continue
 
             self.logger.debug(
                 f"Node {self.node_id} decommission status: {decommission_status}"


### PR DESCRIPTION
During the decommission tests we are injecting failures that may cause get decommission status API to fail. Made waiter more robust when asking about decommission status. When decommission status will not be updated for longer time then the test will eventually fail because lack of progress.

Fixes: #8576

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
  * none