### PR TITLE
Exclude "memory diagnostics" from bad log lines

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1547,7 +1547,9 @@ class RedpandaService(Service):
     def raise_on_bad_logs(self, allow_list=None):
         """
         Raise a BadLogLines exception if any nodes' logs contain errors
-        not permitted by `allow_list`
+        not permitted by `allow_list`. The `allow_list` is a list of
+        unanchored regexes (i.e., they match if they occur anywhere in the
+        line even without leading and trailing wildcards).
 
         :param logger: the test's logger, so that reports of bad lines are
                        prefixed with test name.

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -68,7 +68,12 @@ DEFAULT_LOG_ALLOW_LIST = [
     # This is expected when tests are intentionally run on low memory configurations
     re.compile(r"Memory: '\d+' below recommended"),
     # A client disconnecting is not bad behaviour on redpanda's part
-    re.compile(r"kafka rpc protocol.*(Connection reset by peer|Broken pipe)")
+    re.compile(r"kafka rpc protocol.*(Connection reset by peer|Broken pipe)"),
+
+    # With our current settings (--abort-on-seastar-bad-alloc) this will immediately
+    # be followed by a crash, and we'd rather the "repanda crashed" diagnostic instead
+    # of the bad log lines diagnostic as the failure reason for the test.
+    re.compile(r"Dumping seastar memory diagnostics")
 ]
 
 # Log errors that are expected in tests that restart nodes mid-test


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
