### PR TITLE
archival: quieten a noisy INFO-level message

### DIFF
--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -34,7 +34,7 @@ segment_collector::segment_collector(
 void segment_collector::collect_segments(segment_collector_mode mode) {
     if (_manifest.size() == 0) {
         vlog(
-          archival_log.info,
+          archival_log.debug,
           "No segments to collect for ntp {}, manifest empty",
           _manifest.get_ntp());
         return;


### PR DESCRIPTION
On a system with numerous tiered storage topics,
this message was very frequent at the default
log level setting.

## Backports Required


- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Improvements

* A frequent "No segments to collect for ntp" log message is now reduced to DEBUG severity.