### PR TITLE
kafka/client: Better system_error handling

### DIFF
--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -82,6 +82,13 @@ public:
                 return ss::make_exception_future<Ret>(
                   broker_error(_node_id, error_code::broker_not_available));
             })
+          .handle_exception_type([this](const std::system_error& e) {
+              if (net::is_reconnect_error(e)) {
+                  return ss::make_exception_future<Ret>(
+                    broker_error(_node_id, error_code::broker_not_available));
+              }
+              return ss::make_exception_future<Ret>(e);
+          })
           .finally([b = shared_from_this()]() {});
     }
 


### PR DESCRIPTION
Fixes #8072.

`broker::dispatch()` will now handle `std::system_error` and, if is a reconnect error, turn it into a `broker_error`.  This will then allow `client::mitigate_error` to attempt a reconnect on the broker that originated the error.

Signed-off-by: Michael Boquard <michael@redpanda.com>

Force push `b8978e9`:

* Fixed linter error

Force push `73b8107`:

* Returned `handle_exception_type` to `client::update_metadata` - was causing unit test failure because meta data fetch retries weren't happening
    * The more important fix was turning the `system_error` into a `broker_error` so the `client::mitigate_error` would be able to disconnect/reconnect the broken broker.

Force push `8785fa8`:

* Updated commit comment

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v22.3.x
- [X] v22.2.x
- [X] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

* none

## Release Notes

### Bug Fixes

* Fixes an issue where nodes would properly reconnect to brokers in `kafka/client`.  Would result in a `500: Internal Server Error` when attempting to access the schema registry.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
