### PR TITLE
Add exception logging to some background fibers

### DIFF
--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -132,8 +132,13 @@ void health_monitor_frontend::disk_health_tick() {
     }
     ssx::spawn_with_gate(_refresh_gate, [this]() {
         // Ensure that this node's cluster health data is not too stale.
-        return update_disk_health_cache().finally(
-          [this] { _refresh_timer.arm(disk_health_refresh_interval); });
+        return update_disk_health_cache()
+          .handle_exception([](const std::exception_ptr& e) {
+              vlog(
+                clusterlog.warn, "failed to update disk health cache: {}", e);
+          })
+          .finally(
+            [this] { _refresh_timer.arm(disk_health_refresh_interval); });
     });
 }
 

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -366,6 +366,9 @@ ss::future<> metadata_dissemination_service::dispatch_disseminate_leadership() {
             });
       })
       .then([this] { cleanup_finished_updates(); })
+      .handle_exception([](const std::exception_ptr& e) {
+          vlog(clusterlog.warn, "failed to disseminate leadership: {}", e);
+      })
       .finally([this] { _dispatch_timer.arm(_dissemination_interval); });
 }
 


### PR DESCRIPTION
Absence of these had resulted in "exceptional future ignored" errors and one of the rpfixture tests failing

Fixes #8508 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

## Release Notes
* none