### PR TITLE
rpk: use survey type password for cloud login

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cloud/auth/auth.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/auth/auth.go
@@ -118,14 +118,14 @@ func validateToken(auth0Endpoint auth0.Endpoint, token, clientID string) (expire
 func promptClientCfg() (clientID, clientSecret string, err error) {
 	fmt.Println("What is your client ID and secret? You can retrieve these in the Redpanda Cloud UI user panel.")
 	for _, prompt := range []struct {
-		name string
-		dst  *string
+		name  string
+		input survey.Prompt
+		dst   *string
 	}{
-		{"Client ID", &clientID},
-		{"Client secret", &clientSecret},
+		{name: "Client ID", input: &survey.Input{Message: "Client ID:"}, dst: &clientID},
+		{name: "Client secret", input: &survey.Password{Message: "Client Secret:"}, dst: &clientSecret},
 	} {
-		input := &survey.Input{Message: prompt.name + ":"}
-		if err := survey.AskOne(input, prompt.dst, survey.WithValidator(survey.Required)); err != nil {
+		if err := survey.AskOne(prompt.input, prompt.dst, survey.WithValidator(survey.Required)); err != nil {
 			return "", "", fmt.Errorf("failed to retrieve %s: %w", prompt.name, err)
 		}
 	}

--- a/src/go/rpk/pkg/cli/cmd/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/login.go
@@ -46,7 +46,8 @@ credentials can be provided in three ways, in order of preference:
 If none of these are provided, login will prompt you for the client ID and
 client secret and will save them to the __cloud.yaml file. If you specify
 environment variables or flags, they will not be synced to the __cloud.yaml
-file. The cloud authorization token is always synced.
+file unless the --save flag is passed. The cloud authorization token is always 
+synced.
 `,
 		Run: func(cmd *cobra.Command, _ []string) {
 			cfg, err := params.Load(fs)


### PR DESCRIPTION
Use survey type password for cloud login, this is for interactive mode (which is not mentioned in the cloud UI) but worth using this type so we hide the password when the user is typing it:

![image](https://user-images.githubusercontent.com/59714880/216441043-f47fd83d-98e3-409a-b39d-06fdc3a1fd3a.png)

## Backports Required

- [ ] v22.3.x


## Release Notes
  * none
