### PR TITLE
debug

### DIFF
--- a/src/v/cloud_storage_clients/test_client/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/test_client/CMakeLists.txt
@@ -1,9 +1,9 @@
 # s3_client
 add_executable(s3_test_client s3_test_client_main.cc)
-target_link_libraries(s3_test_client PUBLIC v::model v::net v::http v::cloud_storage_clients v::cloud_roles)
+target_link_libraries(s3_test_client PUBLIC v::model v::net v::http v::cloud_storage_clients v::cloud_roles v::ssx)
 set_property(TARGET s3_test_client PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # abs_client
 add_executable(abs_test_client abs_test_client_main.cc)
-target_link_libraries(abs_test_client PUBLIC v::model v::net v::http v::cloud_storage_clients v::cloud_roles)
+target_link_libraries(abs_test_client PUBLIC v::model v::net v::http v::cloud_storage_clients v::cloud_roles v::ssx)
 set_property(TARGET abs_test_client PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/v/cluster/self_test/tests/CMakeLists.txt
+++ b/src/v/cluster/self_test/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ rp_test(
     BINARY_NAME self_test_test
     SOURCES self_test_request_test.cc
     DEFINITIONS BOOST_TEST_DYN_LINK
-    LIBRARIES v::seastar_testing_main v::cluster
+    LIBRARIES v::seastar_testing_main v::cluster v::ssx
     LABELS self_test
 )
 
@@ -10,6 +10,6 @@ rp_test(
     BINARY_NAME self_test_framework_test
     SOURCES self_test_config_test.cc
     DEFINITIONS BOOST_TEST_DYN_LINK
-    LIBRARIES Boost::unit_test_framework v::cluster
+    LIBRARIES Boost::unit_test_framework v::cluster v::ssx
     LABELS self_test
 )

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -93,7 +93,7 @@ rp_test(
   BINARY_NAME leader_balancer_test
   SOURCES leader_balancer_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES Boost::unit_test_framework v::cluster
+  LIBRARIES Boost::unit_test_framework v::cluster v::ssx
   LABELS cluster
 )
 
@@ -102,7 +102,7 @@ rp_test(
   BINARY_NAME leader_balancer_bench
   SOURCES leader_balancer_bench.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES Seastar::seastar_perf_testing v::cluster
+  LIBRARIES Seastar::seastar_perf_testing v::cluster v::ssx
   LABELS cluster
 )
 
@@ -111,6 +111,6 @@ rp_test(
   BINARY_NAME metrics_reporter_test
   SOURCES metrics_reporter_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES Boost::unit_test_framework v::cluster
+  LIBRARIES Boost::unit_test_framework v::cluster v::ssx
   LABELS cluster
 )

--- a/src/v/http/demo/CMakeLists.txt
+++ b/src/v/http/demo/CMakeLists.txt
@@ -1,5 +1,5 @@
 # client
 add_executable(http_demo_client client.cc)
-target_link_libraries(http_demo_client PUBLIC v::model v::rpc v::http)
+target_link_libraries(http_demo_client PUBLIC v::model v::rpc v::http v::ssx)
 set_property(TARGET http_demo_client PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ rp_test(
     topic_utils_test.cc
     handler_interface_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES Boost::unit_test_framework v::kafka v::coproc
+  LIBRARIES Boost::unit_test_framework v::kafka v::coproc v::ssx
   LABELS kafka
 )
 
@@ -36,7 +36,7 @@ rp_test(
   FIXTURE_TEST
   BINARY_NAME kafka_server
   SOURCES ${srcs}
-  LIBRARIES v::seastar_testing_main v::application v::raft v::kafka v::config v::storage_test_utils
+  LIBRARIES v::seastar_testing_main v::application v::raft v::kafka v::config v::storage_test_utils v::ssx
   ARGS "-- -c 1"
   LABELS kafka
 )

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -640,7 +640,7 @@ private:
 
     /// all raft operations must happen exclusively since the common case
     /// is for the operation to touch the disk
-    mutex _op_lock;
+    mutex _op_lock{"raft/op_lock"};
     /// used for notifying when commits happened to log
     event_manager _event_manager;
     probe _probe;

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ rp_test(
     BINARY_NAME consensus_utils_test
     SOURCES consensus_utils_test.cc
     DEFINITIONS BOOST_TEST_DYN_LINK
-    LIBRARIES Boost::unit_test_framework v::raft v::storage_test_utils v::model_test_utils
+    LIBRARIES Boost::unit_test_framework v::raft v::storage_test_utils v::model_test_utils v::ssx
     LABELS raft
 )
 

--- a/src/v/rp_util/CMakeLists.txt
+++ b/src/v/rp_util/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Packages utilities exposed by core that are useful to clients.
 add_executable(rp_util main.cc)
 set_property(TARGET rp_util PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(rp_util PUBLIC v::clientutil v::compat)
+target_link_libraries(rp_util PUBLIC v::clientutil v::compat v::ssx)
 install(TARGETS rp_util DESTINATION bin)

--- a/src/v/ssx/CMakeLists.txt
+++ b/src/v/ssx/CMakeLists.txt
@@ -4,6 +4,8 @@ v_cc_library(
   HDRS
     "future-util.h"
     "metrics.h"
+  SRCS
+    "logger.cc"
   DEPS
     Seastar::seastar
   )

--- a/src/v/ssx/logger.cc
+++ b/src/v/ssx/logger.cc
@@ -1,0 +1,13 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "ssx/logger.h"
+
+namespace ssx {
+    ss::logger ssxlogger{"ssx"};
+}

--- a/src/v/ssx/logger.h
+++ b/src/v/ssx/logger.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/print.hh>
+#include <seastar/util/log.hh>
+
+
+namespace ssx {
+    extern ss::logger ssxlogger;
+}

--- a/src/v/test_utils/CMakeLists.txt
+++ b/src/v/test_utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 v_cc_library(
   NAME seastar_testing_main
   SRCS seastar_testing_main.cc
-  DEPS Seastar::seastar_testing)
+  DEPS Seastar::seastar_testing v::ssx)
 
 add_subdirectory(tests)

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -37,6 +37,9 @@ public:
     mutex()
       : _sem(1, "mutex") {}
 
+    mutex(ss::sstring name)
+      : _sem(1, std::move(name)) {}
+
     template<typename Func>
     auto with(Func&& func) noexcept {
         return ss::with_semaphore(_sem, 1, std::forward<Func>(func));

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ rp_test(
     delta_for_test.cc
     token_bucket_test.cc
     uuid_test.cc
-  LIBRARIES v::seastar_testing_main v::utils v::bytes absl::flat_hash_set
+  LIBRARIES v::seastar_testing_main v::utils v::bytes absl::flat_hash_set v::ssx
   ARGS "-- -c 1"
   LABELS utils
 )


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
