### PR TITLE
tests/acls: ignore disconnect errror from GnuTls

### DIFF
--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -448,7 +448,10 @@ class AccessControlListTestUpgrade(AccessControlListTest):
 
     # Test that a cluster configured with enable_sasl can be upgraded
     # from v22.1.x, and still have sasl enabled. See PR 5292.
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3,
+             log_allow_list=[
+                 r'rpc - .* The TLS connection was non-properly terminated.*'
+             ])
     def test_upgrade_sasl(self):
         old_version, old_version_str = self.installer.install(
             self.redpanda.nodes, (22, 1))


### PR DESCRIPTION
## Cover letter

Previously the upgrade started on RP v22.1.x but that version does not handle errors from the GnuTls lib. This is what led to a BadLogLines error in https://github.com/redpanda-data/redpanda/issues/7536. The fix is in PR https://github.com/redpanda-data/redpanda/pull/7212 but that is not in v22.1.x. Therefore, this commit adds the log line to the allow list.

Fixes #7536

Changes from force-push `23bbae8`:
- Use the log allow list instead of changing the base binary

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
