### PR TITLE
Enable large allocation warnings in DT tests

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -149,6 +149,12 @@ node_config::node_config() noexcept
       "than the cluster's consensus version",
       {.visibility = visibility::tunable},
       false)
+  , memory_allocation_warning_threshold(
+      *this,
+      "memory_allocation_warning_threshold",
+      "Enables log messages for allocations greater than the given size.",
+      {.visibility = visibility::tunable},
+      std::nullopt)
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -65,6 +65,7 @@ public:
     // If true, permit any version of redpanda to start, even
     // if potentially incompatible with existing system state.
     property<bool> upgrade_override_checks;
+    property<std::optional<size_t>> memory_allocation_warning_threshold;
 
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -76,6 +76,7 @@ public:
       std::optional<scheduling_groups> = std::nullopt);
     void check_environment();
     void wire_up_and_start(::stop_signal&, bool test_mode = false);
+    void post_start_tasks();
 
     void check_for_crash_loop();
     void schedule_crash_tracker_file_cleanup();

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -44,7 +44,7 @@ from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.services import tls
 from rptest.services.admin import Admin
-from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.services.redpanda_installer import RedpandaInstaller, VERSION_RE as RI_VERSION_RE, int_tuple as ri_int_tuple
 from rptest.services.rolling_restarter import RollingRestarter
 from rptest.services.storage import ClusterStorage, NodeStorage
 from rptest.services.utils import BadLogLines, NodeCrash
@@ -1967,6 +1967,10 @@ class RedpandaService(Service):
         assert len(version_lines) == 1, version_lines
         return VERSION_LINE_RE.findall(version_lines[0])[0]
 
+    def get_version_int_tuple(self, node):
+        version_str = self.get_version(node)
+        return ri_int_tuple(RI_VERSION_RE.findall(version_str)[0])
+
     def stop(self, **kwargs):
         """
         Override default stop() to execude stop_node in parallel
@@ -2189,6 +2193,17 @@ class RedpandaService(Service):
         # resolution
         fqdn = self.get_node_fqdn(node)
 
+        try:
+            cur_ver = self.get_version_int_tuple(node)
+        except:
+            cur_ver = None
+
+        # This node property isn't available on versions of RP older than 23.2.
+        if cur_ver and cur_ver >= (23, 2, 0):
+            memory_allocation_warning_threshold_bytes = 256 * 1024  # 256 KiB
+        else:
+            memory_allocation_warning_threshold_bytes = None
+
         conf = self.render("redpanda.yaml",
                            node=node,
                            data_dir=RedpandaService.DATA_DIR,
@@ -2206,7 +2221,9 @@ class RedpandaService(Service):
                            superuser=self._superuser,
                            sasl_enabled=self.sasl_enabled(),
                            endpoint_authn_method=self.endpoint_authn_method(),
-                           auto_auth=self._security.auto_auth)
+                           auto_auth=self._security.auto_auth,
+                           memory_allocation_warning_threshold=
+                           memory_allocation_warning_threshold_bytes)
 
         if override_cfg_params or self._extra_node_conf[node]:
             doc = yaml.full_load(conf)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -15,6 +15,9 @@ redpanda:
 {% if node_id is not none %}
   node_id: {{node_id}}
 {% endif %}
+{% if memory_allocation_warning_threshold is not none %}
+  memory_allocation_warning_threshold: {{memory_allocation_warning_threshold}}
+{% endif %}
   rpc_server:
     address: "{{node.account.hostname}}"
     port: 33145


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->
Allows for large allocation warnings to be configured as a node property and enables them by default in DT tests. 

These large allocation warnings if enabled are rate limited. The first warning will be for any allocation greater than or equal to the configured threshold then the threshold is raised by 1.618x the current threshold for every subsequent warning. 

In DT tests these warnings are treated as purely informational and will not cause tests to fail when generated.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
 ### Features
* Adds a `large_allocation_warning_threshold` node config option to enable warnings to be logged on large allocations.