### PR TITLE
Fix policy version

### DIFF
--- a/src/go/k8s/pkg/resources/pdb.go
+++ b/src/go/k8s/pkg/resources/pdb.go
@@ -53,8 +53,6 @@ func NewPDB(
 }
 
 // Ensure will create/update PDB resource based on configuration inside our CR.
-// For now we're creating v1beta1 version of PDB because v1 is available only
-// from k8s version 1.21+
 func (r *PDBResource) Ensure(ctx context.Context) error {
 	if r.pandaCluster.Spec.PodDisruptionBudget == nil || !r.pandaCluster.Spec.PodDisruptionBudget.Enabled {
 		return nil

--- a/src/go/k8s/pkg/resources/pdb.go
+++ b/src/go/k8s/pkg/resources/pdb.go
@@ -86,7 +86,7 @@ func (r *PDBResource) obj() (k8sclient.Object, error) {
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
-			APIVersion: "policy/v1beta1",
+			APIVersion: "policy/v1",
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable:   r.pandaCluster.Spec.PodDisruptionBudget.MinAvailable,

--- a/src/go/k8s/tests/e2e/update/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/00-assert.yaml
@@ -12,7 +12,7 @@ status:
 
 ---
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: update-cluster


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/7222

After bumping in https://github.com/redpanda-data/redpanda/pull/8313 not all places were updated to the new version. It causes issues on k8s 1.25+, where v1beta is not working anymore. This PR fixes skipped API version and remove comments related to the previous beta version.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes
None

## Release Notes

### Bug Fixes

  * Pod distribution budget version v1 is used now in the operator

### Improvements

  * Cleaned up comments.

