### PR TITLE
security/gssapi: Allow configurable location of `krb5.conf`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -887,6 +887,12 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {"SCRAM"},
       validate_sasl_mechanisms)
+  , sasl_kerberos_config(
+      *this,
+      "sasl_kerberos_config",
+      "The location of the Kerberos krb5.conf file for Redpanda",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      "/etc/krb5.conf")
   , sasl_kerberos_keytab(
       *this,
       "sasl_kerberos_keytab",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -186,6 +186,7 @@ struct configuration final : public config_store {
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
     property<std::vector<ss::sstring>> sasl_mechanisms;
+    property<ss::sstring> sasl_kerberos_config;
     property<ss::sstring> sasl_kerberos_keytab;
     property<ss::sstring> sasl_kerberos_principal;
     property<std::vector<ss::sstring>> sasl_kerberos_principal_mapping;

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -119,6 +119,7 @@ server::server(
       config::shard_local_cfg().kafka_mtls_principal_mapping_rules.bind())
   , _gssapi_principal_mapper(
       config::shard_local_cfg().sasl_kerberos_principal_mapping.bind())
+  , _krb_configurator(config::shard_local_cfg().sasl_kerberos_config.bind())
   , _thread_worker(tw) {
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -22,6 +22,7 @@
 #include "net/server.h"
 #include "security/fwd.h"
 #include "security/gssapi_principal_mapper.h"
+#include "security/krb5_configurator.h"
 #include "security/mtls.h"
 #include "ssx/fwd.h"
 #include "utils/ema.h"
@@ -168,6 +169,7 @@ private:
     kafka::fetch_metadata_cache _fetch_metadata_cache;
     security::tls::principal_mapper _mtls_principal_mapper;
     security::gssapi_principal_mapper _gssapi_principal_mapper;
+    security::krb5::configurator _krb_configurator;
 
     class latency_probe _probe;
     ssx::thread_worker& _thread_worker;

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     mtls.cc
     license.cc
     krb5.cc
+    krb5_configurator.cc
     gssapi_principal_mapper.cc
   DEPS
     v::bytes

--- a/src/v/security/krb5_configurator.cc
+++ b/src/v/security/krb5_configurator.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "security/krb5_configurator.h"
+
+#include "config/property.h"
+
+namespace security::krb5 {
+
+configurator::configurator(config::binding<ss::sstring>&& krb5_config)
+  : _krb5_config(std::move(krb5_config)) {
+    if (ss::this_shard_id() == ss::shard_id{0}) {
+        krb5_config_setter();
+        _krb5_config.watch(krb5_config_setter());
+    }
+}
+
+std::function<void()> configurator::krb5_config_setter() {
+    return [this]() { setenv("KRB5_CONFIG", _krb5_config().c_str(), 1); };
+}
+
+} // namespace security::krb5

--- a/src/v/security/krb5_configurator.h
+++ b/src/v/security/krb5_configurator.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "config/property.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace security::krb5 {
+
+class configurator {
+public:
+    explicit configurator(config::binding<ss::sstring>&& krb5_config);
+
+private:
+    std::function<void()> krb5_config_setter();
+    config::binding<ss::sstring> _krb5_config;
+};
+
+} // namespace security::krb5

--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -47,7 +47,7 @@ KRB5KDC_PID_PATH = "/var/run/krb5kdc.pid"
 KADMIND_PID_PATH = "/var/run/kadmind.pid"
 KDC_DB_PATH = "/var/lib/krb5kdc/principal"
 
-REMOTE_KADMIN_TMPL = 'kadmin -r {realm} -p {principal} -w {password} -q "{command}"'
+REMOTE_KADMIN_TMPL = 'KRB5_CONFIG={krb5_conf_path} kadmin -r {realm} -p {principal} -w {password} -q "{command}"'
 LOCAL_KADMIN_TMPL = 'kadmin.local -q "{cmd}"'
 ADD_PRINCIPAL_TMPL = 'add_principal {keytype} {principal}'
 KTADD_TMPL = 'ktadd -k {keytab_file} {principal}'
@@ -74,14 +74,19 @@ class AuthenticationError(Exception):
         return repr(self.message)
 
 
-def render_krb5_config(kdc_node, realm: str, file_path: str = KRB5_CONF_PATH):
+def render_krb5_config(kdc_node, realm: str):
     return KRB5_CONF_TMPL.format(node=kdc_node, realm=realm)
 
 
-def render_remote_kadmin_command(command, realm, principal, password):
+def render_remote_kadmin_command(command,
+                                 realm,
+                                 principal,
+                                 password,
+                                 krb5_conf_path=KRB5_CONF_PATH):
     return REMOTE_KADMIN_TMPL.format(realm=realm,
                                      principal=principal,
                                      password=password,
+                                     krb5_conf_path=krb5_conf_path,
                                      command=command)
 
 
@@ -431,6 +436,7 @@ class RedpandaKerberosNode(RedpandaService):
             kdc: KrbKdc,
             realm: str,
             keytab_file=f"{RedpandaService.PERSISTENT_ROOT}/redpanda.keytab",
+            krb5_conf_path=KRB5_CONF_PATH,
             *args,
             **kwargs):
         super(RedpandaKerberosNode,
@@ -441,10 +447,13 @@ class RedpandaKerberosNode(RedpandaService):
         self.kdc = kdc
         self.realm = realm
         self.keytab_file = keytab_file
+        self.krb5_conf_path = krb5_conf_path
 
     def clean_node(self, node, **kwargs):
         super().clean_node(node, **kwargs)
         node.account.ssh(f"rm -fr {self.keytab_file}", allow_fail=True)
+        if self.krb5_conf_path != KRB5_CONF_PATH:
+            node.account.ssh(f"rm -fr {self.krb5_conf_path}", allow_fail=True)
 
     def start_node(self, node, **kwargs):
         self.logger.debug(
@@ -452,8 +461,10 @@ class RedpandaKerberosNode(RedpandaService):
         )
         krb5_config = render_krb5_config(kdc_node=self.kdc.nodes[0],
                                          realm=self.kdc.realm)
-        self.logger.debug(f"KRB5 config to {KRB5_CONF_PATH}: {krb5_config}")
-        node.account.create_file(KRB5_CONF_PATH, krb5_config)
+        self.logger.debug(
+            f"KRB5 config to {self.krb5_conf_path}: {krb5_config}")
+        node.account.ssh(f"mkdir -p {os.path.dirname(self.krb5_conf_path)}")
+        node.account.create_file(self.krb5_conf_path, krb5_config)
         principal = self._service_principal(node)
         self.logger.debug(f"Principal for {node.name}: {principal}")
         self.logger.debug(f"Adding principal {principal} to KDC")
@@ -461,7 +472,8 @@ class RedpandaKerberosNode(RedpandaService):
             command=render_add_principal_command(principal=principal),
             realm=self.kdc.realm,
             principal=self.kdc.kadmin_principal,
-            password=self.kdc.kadmin_password)
+            password=self.kdc.kadmin_password,
+            krb5_conf_path=self.krb5_conf_path)
         self.logger.debug(f"principal add command: {cmd}")
         node.account.ssh(cmd=cmd, allow_fail=False)
         self.logger.debug(
@@ -470,7 +482,8 @@ class RedpandaKerberosNode(RedpandaService):
             principal=principal, keytab_file=self.keytab_file),
                                            realm=self.kdc.realm,
                                            principal=self.kdc.kadmin_principal,
-                                           password=self.kdc.kadmin_password)
+                                           password=self.kdc.kadmin_password,
+                                           krb5_conf_path=self.krb5_conf_path)
         self.logger.debug(f"ktadd command: {cmd}")
         node.account.ssh(f"mkdir -p {os.path.dirname(self.keytab_file)}")
         node.account.ssh(cmd=cmd, allow_fail=False)

--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -346,6 +346,7 @@ class KrbClient(Service):
         node.account.ssh(
             f"rm -fr {self.redpanda.PERSISTENT_ROOT}/client.keytab /etc/krb5.keytab",
             allow_fail=True)
+        node.account.ssh(f"rm -fr /tmp/*.krb5ccache", allow_fail=True)
 
     def add_primary(self, primary: str, realm: str = None):
         self.logger.info(

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -105,7 +105,6 @@ class RedpandaKerberosTest(RedpandaKerberosTestBase):
                             sasl_mechanism=mechanism)
 
         client_user_principal = f"User:client"
-        super_rpk.sasl_create_user(client_user_principal, "rp123", mechanism)
 
         # Create a topic that's visible to "client" iff acl = True
         super_rpk.create_topic("needs_acl")
@@ -230,8 +229,6 @@ class RedpandaKerberosRulesTesting(RedpandaKerberosTestBase):
                             username=username,
                             password=password,
                             sasl_mechanism=mechanism)
-
-        super_rpk.sasl_create_user(f"User:{rp_user}", "rp123", mechanism)
 
         for topic, principal in acl:
             super_rpk.create_topic(topic)

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -20,8 +20,8 @@ from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.kerberos import KrbKdc, KrbClient, RedpandaKerberosNode, AuthenticationError
-from rptest.services.redpanda import LoggingConfig, SecurityConfig
+from rptest.services.kerberos import KrbKdc, KrbClient, RedpandaKerberosNode, AuthenticationError, KRB5_CONF_PATH
+from rptest.services.redpanda import LoggingConfig, RedpandaService, SecurityConfig
 
 LOG_CONFIG = LoggingConfig('info',
                            logger_levels={
@@ -37,11 +37,14 @@ class RedpandaKerberosTestBase(Test):
     """
     Base class for tests that use the Redpanda service with Kerberos
     """
-    def __init__(self,
-                 test_context,
-                 num_nodes=5,
-                 sasl_mechanisms=["SCRAM", "GSSAPI"],
-                 **kwargs):
+    def __init__(
+            self,
+            test_context,
+            num_nodes=5,
+            sasl_mechanisms=["SCRAM", "GSSAPI"],
+            keytab_file=f"{RedpandaService.PERSISTENT_ROOT}/redpanda.keytab",
+            krb5_conf_path=KRB5_CONF_PATH,
+            **kwargs):
         super(RedpandaKerberosTestBase, self).__init__(test_context, **kwargs)
 
         self.kdc = KrbKdc(test_context, realm=REALM)
@@ -53,6 +56,8 @@ class RedpandaKerberosTestBase(Test):
         self.redpanda = RedpandaKerberosNode(test_context,
                                              kdc=self.kdc,
                                              realm=REALM,
+                                             keytab_file=keytab_file,
+                                             krb5_conf_path=krb5_conf_path,
                                              num_brokers=num_nodes - 2,
                                              log_config=LOG_CONFIG,
                                              security=security,


### PR DESCRIPTION
Allow the location of `krb.conf` to be configurable.

Note: I'm getting some timeouts, description in the last commit.

Note2: I can drop the last commit later, if there are no review comments.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

To configure the location of `krb5.conf`:
```
rpk cluster config set sasl_kerberos_config /etc/krb5.conf
```

## Release Notes

* none
