### PR TITLE
Automated recovery ABS support

### DIFF
--- a/src/v/cloud_storage/recovery_utils.cc
+++ b/src/v/cloud_storage/recovery_utils.cc
@@ -52,8 +52,10 @@ ss::future<> place_download_result(
   retry_chain_node& parent) {
     retry_chain_node fib{&parent};
     auto result_path = generate_result_path(ntp_cfg, result_completed);
+    // The non-empty payload is required for ABS to accept the upload. An empty
+    // file results in an authorization exception.
     auto result = co_await remote.upload_object(
-      bucket, cloud_storage_clients::object_key{result_path}, "", fib);
+      bucket, cloud_storage_clients::object_key{result_path}, "result", fib);
     if (result != upload_result::success) {
         vlog(
           cst_log.error,

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -173,13 +173,17 @@ public:
       const object_key& key,
       ss::lowres_clock::duration timeout) override;
 
+    /// Issue multiple Delete Blob requests. Note that the timeout is used for
+    /// each individual delete call, so there is a multiplication at work here.
+    /// For example a timeout of 1 second with 100 objects to delete means that
+    /// the timeout is expanded to 100 seconds.
+    /// \param bucket is a container name
+    /// \param keys is a list of blob ids
+    /// \param timeout is a timeout of the operation
     ss::future<result<delete_objects_result, error_outcome>> delete_objects(
       const bucket_name& bucket,
       std::vector<object_key> keys,
-      ss::lowres_clock::duration timeout) override {
-        vassert(false, "abs_client::delete_objects is not implemented");
-        co_return error_outcome::fail;
-    }
+      ss::lowres_clock::duration timeout) override;
 
 private:
     template<typename T>


### PR DESCRIPTION
There are two things that are required for automated recovery to work with ABS:

1. The result file uploaded to the bucket is zero bytes in size. There are issues seen with zero size file in testing, the size is made non zero to avoid this issue with a static payload.
2. The ABS API does not support multiple deletes in one call, but this is expected at one point during recovery. So a wrapper for single delete calls is added here which deletes multiple objects one at a time.

Fixes https://github.com/redpanda-data/redpanda/issues/8601

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none
