### PR TITLE
archival: fix errc condition for logging

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -484,7 +484,7 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
 
     auto batch = std::move(b).build();
     auto ec = co_await do_replicate_commands(std::move(batch), deadline, as);
-    if (!ec) {
+    if (ec) {
         co_return ec;
     }
 


### PR DESCRIPTION
We previously used an incorrect condition to log after adding a segment to the archival STM. This resulted in:
- successful manifest updates not being logged at all
- failed manifest updates incorrectly being logged as successful

Notably, there don't appear to be ill effects on correctness, just on logging.

See also: https://github.com/redpanda-data/redpanda/commit/dab22b422f26bef45de7105413b5d1193f701ccf, which should probably also be backported.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Bug Fixes
* Fixed an incorrect log message indicating the success or failure of archival metadata updates.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
