### PR TITLE
rpk: small wording change and update deprecated commands

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const FeedbackMsg = `We'd love to hear about your experience with redpanda:
+const FeedbackMsg = `We'd love to hear about your experience with Redpanda:
 https://redpanda.com/feedback`
 
 func Deprecated(newCmd *cobra.Command, newUse string) *cobra.Command {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/tune.go
@@ -219,7 +219,7 @@ func tune(
 	if rebootRequired {
 		red := color.New(color.FgRed).SprintFunc()
 		fmt.Printf(
-			"%s: Reboot system and run 'rpk tune %s' again\n",
+			"%s: Reboot system and run 'rpk redpanda tune %s' again\n",
 			red("IMPORTANT"),
 			strings.Join(tunerNames, ","),
 		)


### PR DESCRIPTION
Small wording change and update deprecated commands

Fixes #7811

## Backports Required
- [ ] none - papercut/not impactful enough to backport


## Release Notes
  * none

