### PR TITLE
Fix for "Expected quota value mismatch" failure in CDT and UTs

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1728,7 +1728,7 @@ configuration::configuration()
       "limit.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt,
-      {.min = ss::smp::count})
+      {.min = 1})
   , kafka_quota_balancer_window(
       *this,
       "kafka_quota_balancer_window_ms",

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -464,10 +464,10 @@ void dispense_equally(std::vector<quota_t>& target, const quota_t value) {
         v += share.quot;
         if (share.rem > 0) {
             v += 1;
-            share.quot -= 1;
+            share.rem -= 1;
         } else if (share.rem < 0) {
             v -= 1;
-            share.quot += 1;
+            share.rem += 1;
         }
     }
 }

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -450,7 +450,7 @@ ss::future<> snc_quota_manager::quota_balancer_step() {
     }
 }
 
-namespace {
+namespace detail {
 
 /// Split \p value between the elements of vector \p target in full, adding them
 /// to the elements already in the vector.
@@ -583,7 +583,8 @@ void dispense_negative_deltas(
     }
 }
 
-} // namespace
+} // namespace detail
+using namespace detail;
 
 ss::future<> snc_quota_manager::quota_balancer_update(
   const ingress_egress_state<std::optional<quota_t>> old_node_quota_default,

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -180,4 +180,17 @@ private:
     snc_quotas_probe _probe;
 };
 
+// Names exposed in this namespace are for unit test integration only
+namespace detail {
+snc_quota_manager::quota_t cap_to_ceiling(
+  snc_quota_manager::quota_t& value, snc_quota_manager::quota_t limit);
+void dispense_negative_deltas(
+  std::vector<snc_quota_manager::quota_t>& schedule,
+  snc_quota_manager::quota_t delta,
+  std::vector<snc_quota_manager::quota_t> quotas);
+void dispense_equally(
+  std::vector<snc_quota_manager::quota_t>& target,
+  snc_quota_manager::quota_t value);
+} // namespace detail
+
 } // namespace kafka

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ rp_test(
     types_conversion_tests.cc
     topic_utils_test.cc
     handler_interface_test.cc
+    quota_managers_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka v::coproc
   LABELS kafka

--- a/src/v/kafka/server/tests/quota_managers_test.cc
+++ b/src/v/kafka/server/tests/quota_managers_test.cc
@@ -1,0 +1,74 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/snc_quota_manager.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <random>
+
+BOOST_AUTO_TEST_CASE(cap_to_ceiling_test) {
+    using namespace kafka::detail;
+    int64_t v;
+    BOOST_CHECK_EQUAL(cap_to_ceiling(v = 0, 0), 0);
+    BOOST_CHECK_EQUAL(v, 0);
+    BOOST_CHECK_EQUAL(cap_to_ceiling(v = 100, 0), 0);
+    BOOST_CHECK_EQUAL(v, 100);
+    BOOST_CHECK_EQUAL(cap_to_ceiling(v = 0, 110), 110);
+    BOOST_CHECK_EQUAL(v, 110);
+    BOOST_CHECK_EQUAL(cap_to_ceiling(v = -53, 0), 53);
+    BOOST_CHECK_EQUAL(v, 0);
+    BOOST_CHECK_EQUAL(
+      cap_to_ceiling(v = -4'110'014, -(-10'725'196)), 10'725'196 + 4'110'014);
+    BOOST_CHECK_EQUAL(v, 10'725'196);
+}
+
+BOOST_AUTO_TEST_CASE(dispense_negative_deltas_test) {
+    using namespace kafka::detail;
+    using quota_vec = std::vector<kafka::snc_quota_manager::quota_t>;
+    {
+        quota_vec schedule{0, 0};
+        dispense_negative_deltas(
+          schedule, -7'436'386'678, quota_vec{8'000'000'000, 8'000'000'000});
+        BOOST_CHECK_EQUAL(
+          schedule, (quota_vec{-3'718'193'339, -3'718'193'339}));
+    }
+    {
+        quota_vec schedule{0, 0};
+        dispense_negative_deltas(
+          schedule, -247'128'089, quota_vec{122'474'653, 124'653'436});
+        BOOST_CHECK_EQUAL(schedule, (quota_vec{-122'474'653, -124'653'436}));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(dispense_equally_test) {
+    using namespace kafka::detail;
+    using quota_t = kafka::snc_quota_manager::quota_t;
+    using quota_vec = std::vector<quota_t>;
+
+    // TBD: add random seed
+    std::default_random_engine reng(1);
+    std::uniform_int_distribution<quota_t> dist(
+      bottomless_token_bucket::min_quota, bottomless_token_bucket::max_quota);
+
+    for (size_t shards_count = 1; shards_count != 65; ++shards_count)
+        for (size_t k = 0; k != 1000; ++k) {
+            quota_vec schedule(shards_count, quota_t{0});
+            quota_t delta;
+            if (k == 0) {
+                delta = 1070810392239;
+            } else {
+                delta = dist(reng);
+            }
+            dispense_equally(schedule, delta);
+            const auto schedule_total = std::reduce(
+              schedule.cbegin(), schedule.cend(), quota_t{0}, std::plus{});
+            BOOST_CHECK_EQUAL(schedule_total, delta);
+        }
+}


### PR DESCRIPTION
Fixes #8613

UTs are added for some specific cases with algorithm used internally by `snc_quota_manager`. An attempt made for random driven generalization in the dispense_equally_test(). The latter also includes a specific value to reproduce #8613.

Also tailgated is a tiny fix for the lower boundary of `kafka_throughput_limit_node_out_bps` cluster property.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none
<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
