### PR TITLE
Fixes 8486 (stuck transactions)

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1248,20 +1248,28 @@ rm_stm::do_mark_expired(model::producer_identity pid) {
     co_return std::error_code(tx_errc::none);
 }
 
-bool rm_stm::check_seq(model::batch_identity bid) {
-    auto& seq = _log_state.seq_table[bid.pid].entry;
+bool rm_stm::check_seq(model::batch_identity bid, model::term_id term) {
+    auto& seq_it = _log_state.seq_table[bid.pid];
     auto last_write_timestamp = model::timestamp::now().value();
 
-    if (!is_sequence(seq.seq, bid.first_seq)) {
+    if (!is_sequence(seq_it.entry.seq, bid.first_seq)) {
+        vlog(
+          _ctx_log.warn,
+          "provided seq:{} for pid:{} isn't a continuation of the last known "
+          "seq:{}",
+          bid.first_seq,
+          bid.pid,
+          seq_it.entry.seq);
         return false;
     }
 
-    seq.update(bid.last_seq, kafka::offset{-1});
+    seq_it.entry.update(bid.last_seq, kafka::offset{-1});
 
-    seq.pid = bid.pid;
-    seq.last_write_timestamp = last_write_timestamp;
+    seq_it.entry.pid = bid.pid;
+    seq_it.entry.last_write_timestamp = last_write_timestamp;
+    seq_it.term = term;
     _oldest_session = std::min(
-      _oldest_session, model::timestamp(seq.last_write_timestamp));
+      _oldest_session, model::timestamp(seq_it.entry.last_write_timestamp));
 
     return true;
 }
@@ -1300,15 +1308,16 @@ void rm_stm::set_seq(model::batch_identity bid, kafka::offset last_offset) {
     }
 }
 
-void rm_stm::reset_seq(model::batch_identity bid) {
+void rm_stm::reset_seq(model::batch_identity bid, model::term_id term) {
     _log_state.erase_pid_from_seq_table(bid.pid);
-    auto& seq = _log_state.seq_table[bid.pid].entry;
-    seq.seq = bid.last_seq;
-    seq.last_offset = kafka::offset{-1};
-    seq.pid = bid.pid;
-    seq.last_write_timestamp = model::timestamp::now().value();
+    auto& seq_it = _log_state.seq_table[bid.pid];
+    seq_it.term = term;
+    seq_it.entry.seq = bid.last_seq;
+    seq_it.entry.last_offset = kafka::offset{-1};
+    seq_it.entry.pid = bid.pid;
+    seq_it.entry.last_write_timestamp = model::timestamp::now().value();
     _oldest_session = std::min(
-      _oldest_session, model::timestamp(seq.last_write_timestamp));
+      _oldest_session, model::timestamp(seq_it.entry.last_write_timestamp));
 }
 
 ss::future<result<kafka_result>>
@@ -1386,27 +1395,66 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
 
     if (_log_state.ongoing_map.contains(bid.pid)) {
         // this isn't the first attempt in the tx we should try dedupe
-        auto cached_offset = known_seq(bid);
-        if (cached_offset) {
-            if (cached_offset.value() < kafka::offset{0}) {
+        auto pid_seq = _log_state.seq_table.find(bid.pid);
+        if (pid_seq == _log_state.seq_table.end()) {
+            if (!check_seq(bid, synced_term)) {
+                co_return errc::sequence_out_of_order;
+            }
+        } else if (pid_seq->second.entry.seq == bid.last_seq) {
+            if (pid_seq->second.entry.last_offset() == -1) {
+                if (pid_seq->second.term == synced_term) {
+                    vlog(
+                      _ctx_log.debug,
+                      "Status of the original attempt pid:{} seq:{} is "
+                      "unknown. Returning not_leader_for_partition to trigger "
+                      "retry.",
+                      bid.pid,
+                      bid.last_seq);
+                    co_return errc::not_leader;
+                } else {
+                    // when the term a tx originated on doesn't match the
+                    // current term it means that the re-election happens; upon
+                    // re-election we sync and it catches up with all records
+                    // replicated in previous term. since the cached offset for
+                    // a given seq is still -1 it means that the replication
+                    // hasn't passed so we updating the term to pretent that the
+                    // retry (seqs match) put it there
+                    pid_seq->second.term = synced_term;
+                }
+            } else {
                 vlog(
-                  _ctx_log.debug,
-                  "Status of the original attempt pid:{} seq:{} is unknown. "
-                  "Returning not_leader_for_partition to trigger retry.",
+                  _ctx_log.trace,
+                  "cache hit for pid:{} seq:{}",
                   bid.pid,
                   bid.last_seq);
-                co_return errc::not_leader;
+                co_return kafka_result{
+                  .last_offset = pid_seq->second.entry.last_offset};
             }
-            vlog(_ctx_log.trace, "cache hit for pid:{}", bid.pid);
-            co_return kafka_result{.last_offset = cached_offset.value()};
-        }
-
-        if (!check_seq(bid)) {
-            co_return errc::sequence_out_of_order;
+        } else {
+            for (auto& entry : pid_seq->second.entry.seq_cache) {
+                if (entry.seq == bid.last_seq) {
+                    if (entry.offset() == -1) {
+                        vlog(
+                          _ctx_log.error,
+                          "cache hit for pid:{} seq:{} resolves to -1 offset",
+                          bid.pid,
+                          entry.seq);
+                    }
+                    vlog(
+                      _ctx_log.trace,
+                      "cache hit for pid:{} seq:{}",
+                      bid.pid,
+                      entry.seq);
+                    co_return kafka_result{.last_offset = entry.offset};
+                }
+            }
+            if (!check_seq(bid, synced_term)) {
+                co_return errc::sequence_out_of_order;
+            }
         }
     } else {
         // this is the first attempt in the tx, reset dedupe cache
-        reset_seq(bid);
+        reset_seq(bid, synced_term);
 
         _mem_state.estimated[bid.pid] = _insync_offset;
     }
@@ -2528,6 +2576,7 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
             _log_state.seq_table.try_emplace(it, pid, std::move(seq));
         } else if (it->second.entry.seq < entry.seq) {
             it->second.entry = std::move(entry);
+            it->second.term = model::term_id(-1);
         }
     }
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -320,10 +320,10 @@ private:
     ss::future<std::optional<abort_snapshot>> load_abort_snapshot(abort_index);
     ss::future<> save_abort_snapshot(abort_snapshot);
 
-    bool check_seq(model::batch_identity);
+    bool check_seq(model::batch_identity, model::term_id);
     std::optional<kafka::offset> known_seq(model::batch_identity) const;
     void set_seq(model::batch_identity, kafka::offset);
-    void reset_seq(model::batch_identity);
+    void reset_seq(model::batch_identity, model::term_id);
     std::optional<int32_t> tail_seq(model::producer_identity) const;
 
     ss::future<result<kafka_result>> do_replicate(
@@ -394,6 +394,7 @@ private:
 
     struct seq_entry_wrapper {
         seq_entry entry;
+        model::term_id term;
         safe_intrusive_list_hook _hook;
 
         seq_entry_wrapper() = default;

--- a/tests/java/verifiers/src/main/java/io/vectorized/compaction/App.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/compaction/App.java
@@ -16,13 +16,15 @@ public class App {
     public long min_writes = 0;
     public long min_reads = 0;
 
-    public ArrayList<ConsumerMetrics> consumers = new ArrayList<>();
+    public ArrayList<PartitionMetrics> partitions = new ArrayList<>();
   }
 
-  public static class ConsumerMetrics {
+  public static class PartitionMetrics {
     public int partition;
     public long end_offset = -1;
     public long read_offset = -1;
+    public long read_position = -1;
+    public long written_offset = -1;
     public boolean consumed = false;
   }
 

--- a/tests/rptest/services/compacted_verifier.py
+++ b/tests/rptest/services/compacted_verifier.py
@@ -206,15 +206,12 @@ class CompactedVerifier(Service):
     def remote_wait_consumer(self, timeout_sec=30):
         def check_consumed():
             info = self.remote_info()
-            if len(info["consumers"]) != self._partitions:
-                self._redpanda.logger.debug(
-                    f"Not all consumers have started {len(info['consumers'])} of {self._partitions}"
-                )
+            if len(info["partitions"]) != self._partitions:
                 return False
-            for consumer in info["consumers"]:
-                if not consumer["consumed"]:
+            for partition in info["partitions"]:
+                if not partition["consumed"]:
                     self._redpanda.logger.debug(
-                        f"Consumption of partition {consumer['partition']} isn't finished"
+                        f"Consumption of partition {partition['partition']} isn't finished"
                     )
                     return False
             return True

--- a/tests/rptest/services/compacted_verifier.py
+++ b/tests/rptest/services/compacted_verifier.py
@@ -251,6 +251,8 @@ class CompactedVerifier(Service):
                 return (True, self._remote_info())
             except CrushedException:
                 raise
+            except ConsistencyViolationException:
+                raise
             except:
                 self._redpanda.logger.debug(
                     "Got error on fetching info, retrying?!", exc_info=True)

--- a/tests/rptest/tests/compaction_e2e_test.py
+++ b/tests/rptest/tests/compaction_e2e_test.py
@@ -37,7 +37,6 @@ class CompactionE2EIdempotencyTest(RedpandaTest):
 
         return [len(p.segments) for p in topic_partitions]
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8486
     @cluster(num_nodes=4)
     @matrix(
         initial_cleanup_policy=[


### PR DESCRIPTION
Fixes stuck transactions caused by residual info about the inflight transactions left by the previous tx. The fix is to track the origin of the inflight writes with terms and reset when it doesn't match the current term.

Fixes #8486

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes
### Bug Fixes
  * Fixes availability issue which could led to stuck transactions