### PR TITLE
rpk: show decommissioning status

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -26,6 +26,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	cmd.AddCommand(
 		newListCommand(fs),
 		newDecommissionBroker(fs),
+		newDecommissionBrokerStatus(fs),
 		newRecommissionBroker(fs),
 	)
 	return cmd

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/decommission-status.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/decommission-status.go
@@ -1,0 +1,110 @@
+package brokers
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/types"
+)
+
+func newDecommissionBrokerStatus(fs afero.Fs) *cobra.Command {
+	var (
+		completion int
+		detailed   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "decommission-status [BROKER ID]",
+		Short: "Show the progress of a node decommissioning",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			broker, _ := strconv.Atoi(args[0])
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			cl, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			dbs, err := cl.DecommissionBrokerStatus(cmd.Context(), broker)
+			if he := (*admin.HTTPResponseError)(nil); errors.As(err, &he) {
+				// Special case 400 (validation) errors with friendly output
+				// about the node is not decommissioning
+				if he.Response.StatusCode == 400 {
+					body, bodyErr := he.DecodeGenericErrorBody()
+					if bodyErr == nil {
+						out.Exit("%s", body.Message)
+					}
+				}
+			}
+			out.MaybeDie(err, "unable to request brokers: %v", err)
+
+			if dbs.Finished {
+				if dbs.ReplicasLeft == 0 {
+					out.Exit("Note %d is decommissioned successfully.", broker)
+				} else {
+					out.Exit("Node %d is decommissioned but there are %d replicas left, which may be an issue inside Redpanda. Please describe how you encountered this at https://github.com/redpanda-data/redpanda/issues/new?assignees=&labels=kind%2Fbug&template=01_bug_report.md", broker, dbs.ReplicasLeft)
+				}
+			}
+
+			headers := []string{"Namespace-Topic", "Partition", "Moving-to", "Completion-%", "Partition-size"}
+			if detailed {
+				headers = append(headers, "Bytes-moved", "Bytes-remaining")
+			}
+			f := func(p *admin.DecommissionPartitions) interface{} {
+				nt := p.Ns + "/" + p.Topic
+				if p.PartitionSize > 0 {
+					completion = p.BytesMoved * 100 / p.PartitionSize
+				}
+				if detailed {
+					return struct {
+						NT             string
+						Partition      int
+						MovingTo       int
+						Completion     int
+						PartitionSize  int
+						BytesMoved     int
+						BytesRemaining int
+					}{
+						nt,
+						p.Partition,
+						p.MovingTo.NodeID,
+						completion,
+						p.PartitionSize,
+						p.BytesMoved,
+						p.BytesLeftToMove,
+					}
+				} else {
+					return struct {
+						NT            string
+						Partition     int
+						MovingTo      int
+						Completion    int
+						PartitionSize int
+					}{
+						nt,
+						p.Partition,
+						p.MovingTo.NodeID,
+						completion,
+						p.PartitionSize,
+					}
+				}
+			}
+
+			types.Sort(dbs.Partitions)
+
+			tw := out.NewTable(headers...)
+			defer tw.Flush()
+			for _, p := range dbs.Partitions {
+				tw.PrintStructFields(f(&p))
+			}
+		},
+	}
+	cmd.Flags().BoolVarP(&detailed, "detailed", "d", false, "Print how much data moved and remaining in bytes")
+
+	return cmd
+}


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Features

* Adds the ability to query decommission status of nodes using rpk.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
