### PR TITLE
Scale tests: enable node wide thoughput limits

### DIFF
--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -46,6 +46,9 @@ class ManyClientsTest(RedpandaTest):
             # produce at a much higher rate and cause RP to run out of memory.
             'target_quota_byte_rate':
             31460000,  # 30MiB/s of throughput per shard
+            # Same intention as above but utilizing node-wide throughput limit
+            'kafka_throughput_limit_node_in_bps':
+            104857600,  # 100MiB/s per node
         }
         super().__init__(*args, **kwargs)
 

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -771,6 +771,16 @@ class ManyPartitionsTest(PreallocNodesTest):
             f"Running partition scale test with {n_partitions} partitions on {n_topics} topics"
         )
 
+        # Enable large node-wide thoughput limits to verify they work at scale
+        # To avoid affecting the result of the test with the limit, set them
+        # somewhat above expect_bandwidth value per node
+        self.redpanda.add_extra_rp_conf({
+            'kafka_throughput_limit_node_in_bps':
+            int(scale.expect_bandwidth / len(self.redpanda.nodes) * 3),
+            'kafka_throughput_limit_node_out_bps':
+            int(scale.expect_bandwidth / len(self.redpanda.nodes) * 3)
+        })
+
         self.redpanda.start(parallel=True)
 
         self.logger.info("Entering topic creation")


### PR DESCRIPTION
Node wide TP limits are enabled in:

ManyClientsTest: node TP limit is set at approximately the same level as the exising per-client limit, with intent to supercede it in future, to guard against memory overflows in redpanda when clients are on larger instances

ManyPartitionTest: node TP limit is set at 3 times of expected_bandwidth per node. This is done in hope that (1) this limit will not impact the test results, and (2) the limit will be reached occassionally and the quota balancer will be doing its job. If that does not happen, the factor of 3 may be lowered.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none
<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
