### PR TITLE
[v22.3.x] k/topic_utils: do not return an error when waiting for leaders failed

### DIFF
--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -79,7 +79,11 @@ ss::future<> wait_for_topics(
                    })
             .then([&md_cache, &results, timeout]() {
                 return wait_for_leaders(md_cache, results, timeout)
-                  .discard_result();
+                  .discard_result()
+                  .handle_exception_type([](const ss::timed_out_error&) {
+                      // discard timed out exception, even tho waiting failed
+                      // the topic is created
+                  });
             });
       });
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8224
Fixes https://github.com/redpanda-data/redpanda/issues/8631,