### PR TITLE
tests/node_ops_fuzz: fix previous version to upgrade from.

### DIFF
--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -85,7 +85,8 @@ class NodeOperationFuzzyTest(EndToEndTest):
         extra_rp_conf = {
             # make segments small to ensure that they are compacted during
             # the test (only sealed i.e. not being written segments are compacted)
-            "compacted_log_segment_size": 5 * (2 ^ 20)
+            "compacted_log_segment_size": 5 * (2 ^ 20),
+            "raft_learner_recovery_rate": 512 * (1024 * 1024)
         }
         if num_to_upgrade > 0:
             # Use the deprecated config to bootstrap older nodes.

--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -102,7 +102,10 @@ class NodeOperationFuzzyTest(EndToEndTest):
                                         extra_rp_conf=extra_rp_conf)
         if num_to_upgrade > 0:
             installer = self.redpanda._installer
-            installer.install(self.redpanda.nodes, (22, 1, 4))
+            installer.install(
+                self.redpanda.nodes,
+                installer.highest_from_prior_feature_version(
+                    RedpandaInstaller.HEAD))
             self.redpanda.start()
             installer.install(self.redpanda.nodes[:num_to_upgrade],
                               RedpandaInstaller.HEAD)

--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -141,7 +141,12 @@ class NodeOperationFuzzyTest(EndToEndTest):
                                                  lock)
             fi.start()
 
-        executor = NodeOpsExecutor(self.redpanda, self.logger, lock)
+        # Versions below v22.3.x don't support omitting node ID, so use the old
+        # style of configuration when old nodes are present.
+        executor = NodeOpsExecutor(self.redpanda,
+                                   self.logger,
+                                   lock,
+                                   has_pre_22_3_nodes=num_to_upgrade > 0)
         fi = None
         if enable_failures:
             fi = FailureInjectorBackgroundThread(self.redpanda, self.logger,


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
