### PR TITLE
Add `version_epoch` batch type and use it for offset retention feature

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -446,6 +446,20 @@ void feature_table::testing_activate_all() {
     on_update();
 }
 
+feature_table::version_fence
+feature_table::decode_version_fence(model::record_batch batch) {
+    auto records = batch.copy_records();
+    if (records.empty()) {
+        throw std::runtime_error("");
+    }
+    auto& rec = records.front();
+    auto key = serde::from_iobuf<ss::sstring>(rec.release_key());
+    if (key != version_fence_batch_key) {
+        throw std::runtime_error("");
+    }
+    return serde::from_iobuf<version_fence>(rec.release_value());
+}
+
 } // namespace features
 
 namespace cluster {

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -157,6 +157,13 @@ public:
         kafka::leader_epoch committed_leader_epoch;
         model::timestamp commit_timestamp;
         std::optional<model::timestamp> expiry_timestamp;
+        /*
+         * this is an offset that was written prior to upgrading to redpanda
+         * with offset retention support. because these offsets did not
+         * persistent retention metadata we act conservatively and skip
+         * automatic reclaim. offset delete api can be used to remove them.
+         */
+        bool non_reclaimable{false};
 
         friend std::ostream& operator<<(std::ostream&, const offset_metadata&);
     };

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -25,6 +25,7 @@
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "model/record.h"
+#include "raft/types.h"
 #include "resource_mgmt/io_priority.h"
 #include "ssx/future-util.h"
 
@@ -663,6 +664,21 @@ ss::future<> group_manager::recover_partition(
   model::term_id term,
   ss::lw_shared_ptr<attached_partition> p,
   group_recovery_consumer_state ctx) {
+    /*
+     * write the offset retention feature fence. this is done in the background
+     * because we need to await the offset retention feature. however, if that
+     * is done  inline here then we'll prevent consumer group partition from
+     * recovering and operating during a mix-version rolling upgrade.
+     */
+    if (!ctx.has_offset_retention_feature_fence) {
+        vlog(
+          klog.info,
+          "Scheduling write of offset retention feature fence for partition {}",
+          p->partition);
+        ssx::spawn_with_gate(
+          _gate, [this, term, p] { return write_version_fence(term, p); });
+    }
+
     static constexpr size_t group_batch_size = 64;
     for (auto& [_, group] : _groups) {
         if (group->partition()->ntp() == p->partition->ntp()) {
@@ -744,6 +760,75 @@ ss::future<> group_manager::do_recover_group(
         }
     }
     co_return;
+}
+
+ss::future<> group_manager::write_version_fence(
+  model::term_id term, ss::lw_shared_ptr<attached_partition> p) {
+    // how long to delay retrying a fence write if an error occurs
+    constexpr auto fence_write_retry_delay = 10s;
+
+    co_await _feature_table.local().await_feature(
+      features::feature::group_offset_retention, p->as);
+
+    while (true) {
+        if (p->as.abort_requested() || _gate.is_closed()) {
+            break;
+        }
+
+        auto batch = _feature_table.local().encode_version_fence(
+          cluster::cluster_version{9});
+        auto reader = model::make_memory_record_batch_reader(std::move(batch));
+
+        try {
+            auto result = co_await p->partition->raft()->replicate(
+              term,
+              std::move(reader),
+              raft::replicate_options(raft::consistency_level::quorum_ack));
+
+            if (result) {
+                vlog(
+                  klog.info,
+                  "Prepared partition {} for consumer offset retention feature "
+                  "during upgrade",
+                  p->partition->ntp());
+                break;
+
+            } else if (result.error() == raft::errc::shutting_down) {
+                vlog(
+                  klog.debug,
+                  "Cannot write offset retention version fence for partition "
+                  "{}: shutting down",
+                  p->partition->ntp());
+                break;
+
+            } else if (result.error() == raft::errc::not_leader) {
+                vlog(
+                  klog.debug,
+                  "Cannot write offset retention version fence for partition "
+                  "{}: not leader",
+                  p->partition->ntp());
+                break;
+
+            } else {
+                vlog(
+                  klog.warn,
+                  "Could not write offset retention feature fence for "
+                  "partition {}: {} {}",
+                  p->partition->ntp(),
+                  result.error().message(),
+                  result.error());
+            }
+        } catch (...) {
+            vlog(
+              klog.error,
+              "Exception occurred writing offset retention feature fence for "
+              "partition {}: {}",
+              p->partition,
+              std::current_exception());
+        }
+
+        co_await ss::sleep_abortable(fence_write_retry_delay, p->as);
+    }
 }
 
 group::join_group_stages group_manager::join_group(join_group_request&& r) {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -734,6 +734,7 @@ ss::future<> group_manager::do_recover_group(
                 .metadata = meta.metadata.metadata,
                 .commit_timestamp = meta.metadata.commit_timestamp,
                 .expiry_timestamp = expiry_timestamp,
+                .non_reclaimable = meta.metadata.non_reclaimable,
               });
         }
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -408,6 +408,12 @@ ss::future<> group_manager::do_detach_partition(model::ntp ntp) {
         }
         ++g_it;
     }
+    // if p has background work that won't complete without an abort being
+    // requested, then do that now because once the partition is removed from
+    // the _partitions container it won't be available in group_manager::stop.
+    if (!p->as.abort_requested()) {
+        p->as.request_abort();
+    }
     _partitions.erase(ntp);
     _partitions.rehash(0);
 

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -230,6 +230,9 @@ private:
       ss::lw_shared_ptr<attached_partition>,
       std::optional<model::node_id> leader_id);
 
+    ss::future<> write_version_fence(
+      model::term_id, ss::lw_shared_ptr<attached_partition>);
+
     ss::future<> recover_partition(
       model::term_id,
       ss::lw_shared_ptr<attached_partition>,

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -147,6 +147,13 @@ struct offset_metadata_value {
     // present only in version 1
     model::timestamp expiry_timestamp{-1};
 
+    /*
+     * this field is not written, and is only meaningful when filled in by the
+     * the consumer offset recovery process. see group::offset_metadata for more
+     * information on how it is used.
+     */
+    bool non_reclaimable{true};
+
     friend std::ostream&
     operator<<(std::ostream&, const offset_metadata_value&);
     friend bool

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -138,7 +138,6 @@ struct offset_metadata_key {
  */
 struct offset_metadata_value {
     static constexpr group_metadata_version latest_version{3};
-    group_metadata_version version = latest_version;
     model::offset offset;
     // present only in version >= 3
     kafka::leader_epoch leader_epoch = invalid_leader_epoch;

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -111,6 +111,13 @@ group_recovery_consumer::operator()(model::record_batch batch) {
     } else if (batch.header().type == model::record_batch_type::tx_fence) {
         apply_tx_fence(std::move(batch));
         co_return ss::stop_iteration::no;
+    } else if (batch.header().type == model::record_batch_type::version_fence) {
+        auto fence = features::feature_table::decode_version_fence(
+          std::move(batch));
+        if (fence.active_version >= cluster::cluster_version{9}) {
+            _state.has_offset_retention_feature_fence = true;
+        }
+        co_return ss::stop_iteration::no;
     } else {
         vlog(klog.trace, "ignoring batch with type {}", batch.header().type);
         co_return ss::stop_iteration::no;

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -227,6 +227,9 @@ void group_recovery_consumer::handle_offset_metadata(offset_metadata_kv md) {
         // always take the latest entry in the log.
         auto [group_it, _] = _state.groups.try_emplace(
           md.key.group_id, group_stm());
+        if (_state.has_offset_retention_feature_fence) {
+            md.value->non_reclaimable = false;
+        }
         group_it->second.update_offset(
           tp, _batch_base_offset, std::move(*md.value));
     } else {

--- a/src/v/kafka/server/group_recovery_consumer.h
+++ b/src/v/kafka/server/group_recovery_consumer.h
@@ -24,9 +24,11 @@ namespace kafka {
 struct group_recovery_consumer_state {
     absl::node_hash_map<kafka::group_id, group_stm> groups;
     /*
-     * set to true if during recovery an offset retention feature fence is
-     * observed. after recovery, if the fence has not been observed, then the
-     * fence will be written following activation of offset retention feature.
+     * recovered committed offsets are by default non-reclaimable, and marked as
+     * reclaimable if this flag is set to true. the flag is set to true if and
+     * when the fence is observed during recovery. after recovery, if the fence
+     * has not been observed, then the fence will be written once the offset
+     * retention feature is activated. see group::offset_metadata for more info.
      */
     bool has_offset_retention_feature_fence{false};
 };

--- a/src/v/kafka/server/group_recovery_consumer.h
+++ b/src/v/kafka/server/group_recovery_consumer.h
@@ -23,6 +23,12 @@ namespace kafka {
 
 struct group_recovery_consumer_state {
     absl::node_hash_map<kafka::group_id, group_stm> groups;
+    /*
+     * set to true if during recovery an offset retention feature fence is
+     * observed. after recovery, if the fence has not been observed, then the
+     * fence will be written following activation of offset retention feature.
+     */
+    bool has_offset_retention_feature_fence{false};
 };
 
 class group_recovery_consumer {

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -62,9 +62,10 @@ struct handler_template {
       const request_header& header, const typename api::request_type& request) {
         vlog(
           klog.trace,
-          "[client_id: {}] handling {} request {}",
+          "[client_id: {}] handling {} v{} request {}",
           header.client_id,
           api::name,
+          header.version(),
           request);
     }
 };

--- a/src/v/kafka/server/tests/group_metadata_serialization_test.cc
+++ b/src/v/kafka/server/tests/group_metadata_serialization_test.cc
@@ -114,12 +114,13 @@ FIXTURE_TEST(metadata_rt_test, fixture) {
     roundtrip_test(offset_key);
     // version 1
     kafka::offset_metadata_value offset_md_v1;
-    offset_md_v1.version = kafka::group_metadata_version(1);
 
     offset_md_v1.offset = random_named_int<model::offset>();
     offset_md_v1.metadata = random_named_string<ss::sstring>();
     offset_md_v1.commit_timestamp = model::timestamp::now();
     offset_md_v1.expiry_timestamp = model::timestamp::now();
+    // a non-{-1} timestamp results in v1 being chosen
+    vassert(offset_md_v1.expiry_timestamp != model::timestamp(-1), "force v1");
 
     roundtrip_test(offset_md_v1);
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -353,6 +353,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::feature_update";
     case record_batch_type::cluster_bootstrap_cmd:
         return o << "batch_type::cluster_bootstrap_cmd";
+    case record_batch_type::version_fence:
+        return o << "batch_type::version_fence";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -40,6 +40,7 @@ enum class record_batch_type : int8_t {
     cluster_config_cmd = 20,         // cluster config deltas and status
     feature_update = 21,             // Node logical versions updates
     cluster_bootstrap_cmd = 22,      // cluster bootsrap command
+    version_fence = 23,              // version fence/epoch
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -77,7 +77,8 @@ offset_translator_batch_types(const model::ntp& ntp) {
     if (ntp.ns == model::kafka_namespace) {
         return {
           model::record_batch_type::raft_configuration,
-          model::record_batch_type::archival_metadata};
+          model::record_batch_type::archival_metadata,
+          model::record_batch_type::version_fence};
     } else {
         return {};
     }

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -198,7 +198,8 @@ struct clean_segment_value
 inline bool is_compactible(const model::record_batch& b) {
     return !(
       b.header().type == model::record_batch_type::raft_configuration
-      || b.header().type == model::record_batch_type::archival_metadata);
+      || b.header().type == model::record_batch_type::archival_metadata
+      || b.header().type == model::record_batch_type::version_fence);
 }
 
 offset_delta_time should_apply_delta_time_offset(

--- a/tests/rptest/tests/offset_retention_test.py
+++ b/tests/rptest/tests/offset_retention_test.py
@@ -23,8 +23,24 @@ class OffsetRetentionDisabledAfterUpgrade(RedpandaTest):
     When upgrading to Redpanda v23 or later offset retention should be disabled
     by default. Offset retention did not exist pre-v23, so existing clusters
     should have to opt-in after upgrade in order to avoid suprises.
+
+    When a cluster upgrades to v23 then only newly committed offsets are
+    reclaimed automatically. Offsets written prior to the upgrade must be
+    manually removed using the kafka delete offset api.
+
+    Offsets committed prior to v23 that are normally non-reclaimable become
+    reclaimable if they are updated following the upgrade.
     """
-    topics = (TopicSpec(), )
+    topics = (TopicSpec(), TopicSpec(), TopicSpec(), TopicSpec(), TopicSpec())
+
+    # pre-defined named topics used to simulate use of topics that are used only
+    # pre-v23, both pre and post upgrade, and only after upgrade to v23. the
+    # idle variants stop receiving updates prior to enabling legacy support.
+    pre_v23_topic = topics[0].name
+    prepost_v23_topic = topics[1].name
+    prepost_v23_topic_idle = topics[2].name
+    post_v23_topic = topics[3].name
+    post_v23_topic_idle = topics[4].name
 
     feature_config_timing = {
         "group_offset_retention_sec",
@@ -84,30 +100,92 @@ class OffsetRetentionDisabledAfterUpgrade(RedpandaTest):
         # after upgrade legacy support should be disabled
         assert config[self.feature_config_legacy] == False
 
-    def _offset_removal_occurred(self, period):
+    def _offset_removal_occurred(self, period, pre_upgrade,
+                                 pre_legacy_support):
         rpk = RpkTool(self.redpanda)
         group = "hey_group"
 
-        def offsets_exist():
+        def offsets_exist(include_idle):
+            """
+            Note to future ci-failure investigators. If you were to ever observe
+            a failure in which it appeared that prepost/post topic offsets were
+            not removed it could be because the following occurred:
+
+              1) the version fence was not written for some reason
+              2) so some of the offsets were incorrectly marked as legacy
+              3) something else happened like updates to commits also failing
+
+            it's unlikely that this would happen, but if it does, the proper fix
+            would be to update the test to check for this condition (may be
+            non-trivial to automate this check) and then retry the test.
+
+            in real-world scenarios if this were to happen then it is expected
+            that offset delete api is used to clean up any offsets that lose
+            this race condition that exists during an upgrade.
+            """
             desc = rpk.group_describe(group)
-            return len(desc.partitions) > 0
+            if len(desc.partitions) == 0:
+                return False
+
+            pre = any(p.topic == self.pre_v23_topic for p in desc.partitions)
+            prepost = any(p.topic == self.prepost_v23_topic
+                          for p in desc.partitions)
+            prepost_idle = any(p.topic == self.prepost_v23_topic_idle
+                               for p in desc.partitions)
+            post = any(p.topic == self.post_v23_topic for p in desc.partitions)
+            post_idle = any(p.topic == self.post_v23_topic_idle
+                            for p in desc.partitions)
+
+            assert pre, "pre-topic offsets should never be reclaimed"
+
+            # prior to upgrade, the only offsets that should exist are for the
+            # pre and prepost topics.
+            if pre_upgrade:
+                assert not post, "post-topic has not yet been written"
+                return prepost and prepost_idle
+
+            if include_idle:
+                return prepost and post and prepost_idle and post_idle
+            return prepost and post
 
         # consume from the group for twice as long as the retention period
         # setting and verify that group offsets exist for the entire time.
         start = time.time()
         while time.time() - start < (period * 2):
-            rpk.produce(self.topic, "k", "v")
-            rpk.consume(self.topic, n=1, group=group)
-            wait_until(offsets_exist, timeout_sec=1, backoff_sec=1)
+            if pre_upgrade:
+                # pre-v23
+                rpk.produce(self.pre_v23_topic, "k", "v")
+                rpk.consume(self.pre_v23_topic, n=1, group=group)
+            else:
+                # post-v23
+                rpk.produce(self.post_v23_topic, "k", "v")
+                rpk.consume(self.post_v23_topic, n=1, group=group)
+                if pre_legacy_support:
+                    rpk.produce(self.post_v23_topic_idle, "k", "v")
+                    rpk.consume(self.post_v23_topic_idle, n=1, group=group)
+
+            # pre/post-v23
+            rpk.produce(self.prepost_v23_topic, "k", "v")
+            rpk.consume(self.prepost_v23_topic, n=1, group=group)
+            if pre_legacy_support:
+                rpk.produce(self.prepost_v23_topic_idle, "k", "v")
+                rpk.consume(self.prepost_v23_topic_idle, n=1, group=group)
+
+            wait_until(lambda: offsets_exist(pre_legacy_support),
+                       timeout_sec=1,
+                       backoff_sec=1)
             time.sleep(1)
 
-        # after one half life the offset should still exist
+        # after one half life the offset should still exist. prior to legacy
+        # support being enabled include idle / be strict. after it is enabled
+        # then it's possible the idle topics get reclaimed so relax this check.
         time.sleep(period / 2)
-        assert offsets_exist()
+        assert offsets_exist(pre_legacy_support)
 
-        # after waiting for twice the retention period, it should be gone
+        # after waiting for twice the retention period, it should be gone.
+        # always be strict on this check and include idle topics.
         time.sleep(period * 2 - period / 2)
-        return not offsets_exist()
+        return not offsets_exist(True)
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(initial_version=(22, 2, 9))
@@ -123,21 +201,21 @@ class OffsetRetentionDisabledAfterUpgrade(RedpandaTest):
 
         # in old cluster offset retention should not be active
         self._validate_pre_upgrade(initial_version)
-        assert not self._offset_removal_occurred(period)
+        assert not self._offset_removal_occurred(period, True, True)
 
         # in cluster upgraded from pre-v23 retention should not be active
         self._perform_upgrade(initial_version, RedpandaInstaller.HEAD)
         rpk = RpkTool(self.redpanda)
         rpk.cluster_config_set("group_offset_retention_sec", str(period))
         rpk.cluster_config_set("group_offset_retention_check_ms", str(1000))
-        assert not self._offset_removal_occurred(period)
+        assert not self._offset_removal_occurred(period, False, True)
 
         # enable legacy. enablng legacy support takes affect at the next
         # retention check. since that is configured above to happen every second
         # then the response time should be adequate.
         rpk.cluster_config_set("legacy_group_offset_retention_enabled",
                                str(True))
-        assert self._offset_removal_occurred(period)
+        assert self._offset_removal_occurred(period, False, False)
 
 
 class OffsetRetentionTest(RedpandaTest):


### PR DESCRIPTION
* Introduces a new `version_fence` batch type that can be used to establish an epoch within a partition for the purposes of reasoning about the age of batches with respect to the activation of features and upgrades.
* Uses the `version_fence` within consumer group partitions to identify committed offsets that were written prior to upgrading to v23.
* Disables offset retention for committed offsets written prior to v23 as a conservative policy that addresses the omission of key metadata in prior committed offsets that make evaluating the age of said offsets ambiguous within the context of the retention policy.

Fixes: https://github.com/redpanda-data/redpanda/issues/8348

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.
-->

### Features

Offset retention will be enabled in v23 which enables automatic deletion of old committed offsets. The policy is the same as Kafka. Behavior of retention differs for offsets committed prior to upgrading.

* If an offset was committed prior to upgrade then it is not automatically reclaimed under any policy. To remove such offsets use the Kafka Delete Offset API.
* If an offset was committed prior to upgrade, and later re-committed / written after upgrade then behavior is identical to a committed offset that was initially written after the upgrade. Namely, normal offset retention policy is active.
* Legacy systems must explicitly enable offset retention following an upgrade. It is important to note the behavior of the system in this case. Offsets committed after upgrade, but before offset retention is enabled, will behave as if retention had always been enabled. For example, if an offset were committed the same day as an upgrade with default retention time of 7 days, and then legacy support was enabled 5 days later, the offset would be reclaimed 2 days after.