### PR TITLE
security/gssapi: Enable kafka_gssapi feature by default

### DIFF
--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -211,7 +211,7 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{9},
     "kafka_gssapi",
     feature::kafka_gssapi,
-    feature_spec::available_policy::explicit_only,
+    feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{9},

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -93,11 +93,6 @@ class RedpandaKerberosTest(RedpandaKerberosTestBase):
                   fail: bool):
 
         self.client.add_primary(primary="client")
-        feature_name = "kafka_gssapi"
-        self.redpanda.logger.info(f"Principals: {self.kdc.list_principals()}")
-        admin = Admin(self.redpanda)
-        admin.put_feature(feature_name, {"state": "active"})
-        self.redpanda.await_feature_active(feature_name, timeout_sec=30)
 
         username, password, mechanism = self.redpanda.SUPERUSER_CREDENTIALS
         super_rpk = RpkTool(self.redpanda,
@@ -218,12 +213,6 @@ class RedpandaKerberosRulesTesting(RedpandaKerberosTestBase):
                                     kerberos_principal: str, rp_user: str,
                                     expected_topics: [str], acl: [(str, str)]):
         self.client.add_primary(primary=kerberos_principal)
-        feature_name = "kafka_gssapi"
-        self.redpanda.logger.info(f"Principals: {self.kdc.list_principals()}")
-        admin = Admin(self.redpanda)
-        admin.put_feature(feature_name, {"state": "active"})
-
-        self.redpanda.await_feature_active(feature_name, timeout_sec=30)
 
         username, password, mechanism = self.redpanda.SUPERUSER_CREDENTIALS
         super_rpk = RpkTool(self.redpanda,
@@ -294,13 +283,8 @@ class RedpandaKerberosConfigTest(RedpandaKerberosTestBase):
     def test_non_default(self):
         req_principal = "client"
         self.client.add_primary(primary=req_principal)
-        feature_name = "kafka_gssapi"
-        self.redpanda.logger.info(f"Principals: {self.kdc.list_principals()}")
+
         admin = Admin(self.redpanda)
-        admin.put_feature(feature_name, {"state": "active"})
-
-        self.redpanda.await_feature_active(feature_name, timeout_sec=5)
-
         keytab = admin.get_cluster_config()['sasl_kerberos_keytab']
 
         def keytab_not_found():


### PR DESCRIPTION
Enable the `kafka_gssapi` feature by default.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

#8092 introduced support for GSSAPI, which required activation of the feature. It is now enabled by default.

To enable the feature:
```sh
curl -sv -X PUT http://127.0.0.1:9644/v1/features/kafka_gssapi -d '{"state":"active"}'
```
To disable the feature:
```sh
curl -sv -X PUT http://127.0.0.1:9644/v1/features/kafka_gssapi -d '{"state":"disabled"}'
```

## Release Notes

* none
