### PR TITLE
rpc: guarantee that resource_units don't outlive the request

### DIFF
--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -429,10 +429,47 @@ FIXTURE_TEST(timeout_test_cleanup_resources, rpc_integration_fixture) {
     BOOST_REQUIRE_EQUAL(
       echo_resp.get0().error(), rpc::errc::client_request_timeout);
     // Verify that the resources are released correctly after timeout.
-    tests::cooperative_spin_wait_with_timeout(5s, [&] {
-        return lock.try_get_units().has_value();
-    }).get();
+    BOOST_REQUIRE(lock.try_get_units().has_value());
     client.stop().get();
+}
+
+FIXTURE_TEST(test_cleanup_on_timeout_before_sending, rpc_integration_fixture) {
+    configure_server();
+    register_services();
+    start_server();
+
+    rpc::client<echo::echo_client_protocol> client(client_config());
+    client.connect(model::no_timeout).get();
+    auto stop_client = ss::defer([&] { client.stop().get(); });
+
+    size_t num_reqs = 10;
+
+    // Dispatch several requests with zero timeout. Presumably, some of them
+    // will timeout before even sending a message to the server. Even in this
+    // case resource units must be returned before the request finishes.
+    std::vector<ss::future<>> requests;
+    for (size_t i = 0; i < num_reqs; ++i) {
+        auto lock = ss::make_lw_shared<::mutex>();
+
+        auto units = lock->try_get_units();
+        BOOST_REQUIRE(units);
+        std::vector<ssx::semaphore_units> units_vec;
+        units_vec.push_back(std::move(*units));
+        auto opts = rpc::client_opts(rpc::clock_type::now());
+        opts.resource_units = ss::make_foreign(
+          ss::make_lw_shared(std::move(units_vec)));
+
+        auto f = client.sleep_for(echo::sleep_req{.secs = 1}, std::move(opts))
+                   .then([lock, i](auto result) {
+                       info("finished request {}", i);
+                       BOOST_REQUIRE_EQUAL(
+                         result.error(), rpc::errc::client_request_timeout);
+                       BOOST_REQUIRE(lock->ready());
+                   });
+        requests.push_back(std::move(f));
+    }
+
+    ss::when_all_succeed(requests.begin(), requests.end()).get();
 }
 
 FIXTURE_TEST(rpc_mixed_compression, rpc_integration_fixture) {

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -139,7 +139,6 @@ private:
     using sequence_t = named_type<uint64_t, struct sequence_tag>;
     struct entry {
         std::unique_ptr<ss::scattered_message<char>> scattered_message;
-        client_opts::resource_units_t resource_units;
         uint32_t correlation_id;
     };
     using requests_queue_t
@@ -157,7 +156,7 @@ private:
     void dispatch_send();
 
     ss::future<result<std::unique_ptr<streaming_context>>>
-    make_response_handler(netbuf&, const rpc::client_opts&, sequence_t);
+    make_response_handler(netbuf&, rpc::client_opts&, sequence_t);
 
     ssx::semaphore _memory;
 
@@ -174,10 +173,11 @@ private:
     timing_info* get_timing(uint32_t correlation);
 
     /**
-     * @brief Holds the response handler and timing information for an
-     * outstanding request.
+     * @brief Holds resource units from client_opts, the response handler and
+     * timing information for an outstanding request.
      */
     struct response_entry {
+        client_opts::resource_units_t resource_units;
         internal::response_handler handler;
         timing_info timing;
     };


### PR DESCRIPTION
An important RPC invariant is that resource_units supplied by the caller must not outlive the request (otherwise it is possible that corresponding semaphores are already destroyed by the time we try to return resource_units).

Previously breaking this invariant was possible if the request timed out while resource_units were owned by the lambda emplacing the request to _requests_queue (this lambda can wait for the _memory semaphore units for substantial time).

This commit makes it easier to guarantee this invariant by storing resource_units in _correlations instead of _requests_queue. This way if we complete the request due to timeout or disconnect, resource_units are automatically released when we remove the entry from _correlations.

Fixes https://github.com/redpanda-data/redpanda/issues/8421
Fixes https://github.com/redpanda-data/redpanda/issues/8619

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
* none