### PR TITLE
rptest: parametrise all relevant SI tests to run against ABS

### DIFF
--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -13,7 +13,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RedpandaService, MetricsEndpoint, SISettings
+from rptest.services.redpanda import CloudStorageType, RedpandaService, MetricsEndpoint, SISettings
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import wait_until
 
@@ -170,6 +170,8 @@ class CloudStorageCompactionTest(EndToEndTest):
                  "Cannot validate Kafka record batch. Missmatching CRC",
                  "batch has invalid CRC"
              ])
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
     def test_read_from_replica(self):
         self.start_workload()
         self.start_consumer(num_nodes=2,

--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -172,7 +172,7 @@ class CloudStorageCompactionTest(EndToEndTest):
              ])
     @parametrize(cloud_storage_type=CloudStorageType.ABS)
     @parametrize(cloud_storage_type=CloudStorageType.S3)
-    def test_read_from_replica(self):
+    def test_read_from_replica(self, cloud_storage_type):
         self.start_workload()
         self.start_consumer(num_nodes=2,
                             redpanda_cluster=self.rr_cluster,

--- a/tests/rptest/scale_tests/extreme_recovery_test.py
+++ b/tests/rptest/scale_tests/extreme_recovery_test.py
@@ -2,12 +2,13 @@ from logging import Logger
 from time import time
 from typing import Callable, Sequence
 
-from ducktape.mark import ignore
+from ducktape.mark import ignore, parametrize
 from ducktape.tests.test import TestContext
 from rptest.archival.s3_client import S3Client
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import CloudStorageType
 from rptest.services.cluster import cluster
 from rptest.services.franz_go_verifiable_services import \
     FranzGoVerifiableProducer, \
@@ -170,7 +171,9 @@ class ExtremeRecoveryTest(TopicRecoveryTest):
         super(ExtremeRecoveryTest, self).tearDown()
 
     @cluster(num_nodes=8, log_allow_list=TRANSIENT_ERRORS)
-    def test_recovery_scale(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_recovery_scale(self, cloud_storage_type):
         # This test requires dedicated system resources
         assert self.redpanda.dedicated_nodes
 

--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -10,6 +10,7 @@
 import os
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import parametrize
 
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
@@ -20,7 +21,7 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierRandomConsumer,
     KgoVerifierConsumerGroupConsumer,
 )
-from rptest.services.redpanda import SISettings, RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda import CloudStorageType, SISettings, RESTART_LOG_ALLOW_LIST
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.utils.mode_checks import skip_debug_mode
 
@@ -225,11 +226,15 @@ class KgoVerifierWithSiTest(KgoVerifierBase):
 
 class KgoVerifierWithSiTestLargeSegments(KgoVerifierWithSiTest):
     @cluster(num_nodes=4, log_allow_list=KGO_LOG_ALLOW_LIST)
-    def test_si_without_timeboxed(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_si_without_timeboxed(self, cloud_storage_type):
         self.without_timeboxed()
 
     @cluster(num_nodes=4, log_allow_list=KGO_RESTART_LOG_ALLOW_LIST)
-    def test_si_with_timeboxed(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_si_with_timeboxed(self, cloud_storage_type):
         self.with_timeboxed()
 
 
@@ -237,9 +242,13 @@ class KgoVerifierWithSiTestSmallSegments(KgoVerifierWithSiTest):
     segment_size = 20 * 2**20
 
     @cluster(num_nodes=4, log_allow_list=KGO_LOG_ALLOW_LIST)
-    def test_si_without_timeboxed(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_si_without_timeboxed(self, cloud_storage_type):
         self.without_timeboxed()
 
     @cluster(num_nodes=4, log_allow_list=KGO_RESTART_LOG_ALLOW_LIST)
-    def test_si_with_timeboxed(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_si_with_timeboxed(self, cloud_storage_type):
         self.with_timeboxed()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -403,10 +403,6 @@ class SISettings:
         elif self.cloud_storage_type == CloudStorageType.ABS:
             return self._cloud_storage_azure_container
 
-    @cloud_storage_bucket.setter
-    def cloud_storage_bucket(self, bucket: str):
-        self._cloud_storage_bucket = bucket
-
     # Call this to update the extra_rp_conf
     def update_rp_conf(self, conf) -> dict[str, Any]:
         if self.cloud_storage_type == CloudStorageType.S3:

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -16,7 +16,7 @@ from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
-from rptest.services.redpanda import SISettings, MetricsEndpoint, CloudStorageType, CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import CloudStorageType, SISettings, MetricsEndpoint, CloudStorageType, CHAOS_LOG_ALLOW_LIST
 from rptest.services.kgo_verifier_services import (
     KgoVerifierConsumerGroupConsumer, KgoVerifierProducer)
 from rptest.utils.mode_checks import skip_debug_mode
@@ -39,9 +39,10 @@ class CloudRetentionTest(PreallocNodesTest):
         pass
 
     @cluster(num_nodes=4)
-    @matrix(max_consume_rate_mb=[20, None])
+    @matrix(max_consume_rate_mb=[20, None],
+            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
     @skip_debug_mode
-    def test_cloud_retention(self, max_consume_rate_mb):
+    def test_cloud_retention(self, max_consume_rate_mb, cloud_storage_type):
         """
         Test cloud retention with an ongoing workload. The consume load comes
         in two flavours:

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -3,11 +3,12 @@ import pprint
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings, RedpandaService, LoggingConfig
+from rptest.services.redpanda import CloudStorageType, SISettings, RedpandaService, LoggingConfig
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import wait_until_segments, wait_for_removal_of_n_segments
 from rptest.utils.si_utils import S3Snapshot
 from ducktape.utils.util import wait_until
+from ducktape.mark import parametrize
 
 
 class ShadowIndexingCompactedTopicTest(EndToEndTest):
@@ -45,7 +46,9 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
                 })
 
     @cluster(num_nodes=4)
-    def test_upload(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_upload(self, cloud_storage_type):
         # Set compaction to happen infrequently initially, so we have several log segments.
         self._rpk_client.cluster_config_set("log_compaction_interval_ms",
                                             f'{1000 * 60 * 60}')

--- a/tests/rptest/tests/shadow_indexing_firewall_test.py
+++ b/tests/rptest/tests/shadow_indexing_firewall_test.py
@@ -6,9 +6,10 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
+from ducktape.mark import parametrize
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool, RpkException
@@ -50,7 +51,9 @@ class ShadowIndexingFirewallTest(RedpandaTest):
         self.rpk = RpkTool(self.redpanda)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    def test_consume_from_blocked_s3(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_consume_from_blocked_s3(self, cloud_storage_type):
         produce_until_segments(redpanda=self.redpanda,
                                topic=self.s3_topic_name,
                                partition_idx=0,

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -7,8 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from ducktape.mark import parametrize
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
@@ -50,8 +51,10 @@ class ShadowIndexingTxTest(RedpandaTest):
             rpk.alter_topic_config(topic.name, 'redpanda.remote.read', 'true')
 
     @cluster(num_nodes=4)
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
     @skip_debug_mode
-    def test_shadow_indexing_aborted_txs(self):
+    def test_shadow_indexing_aborted_txs(self, cloud_storage_type):
         """Check that messages belonging to aborted transaction are not seen by clients
         when fetching from remote segments."""
         msg_size = 16384

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -445,7 +445,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         log_allow_list=[
             'exception while executing partition operation: {type: deletion'
         ])
-    def topic_delete_unavailable_test(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def topic_delete_unavailable_test(self, cloud_storage_type):
         """
         Test deleting while the S3 backend is unavailable: we should see
         that local deletion proceeds, and remote deletion eventually

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1320,7 +1320,9 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=3,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    def test_no_data(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_no_data(self, cloud_storage_type):
         """If we're trying to recovery a topic which didn't have any data
         in old cluster the empty topic should be created. We should be able
         to produce to the topic."""
@@ -1331,7 +1333,9 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=3,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    def test_empty_segments(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_empty_segments(self, cloud_storage_type):
         """Test case in which the segments are uploaded but they doesn't
         have any data batches but they do have configuration batches."""
         test_case = EmptySegmentsCase(self.cloud_storage_client,
@@ -1342,7 +1346,9 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=3,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    def test_missing_topic_manifest(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_missing_topic_manifest(self, cloud_storage_type):
         """If we're trying to recovery a topic which didn't have any data
         in old cluster the empty topic should be created. We should be able
         to produce to the topic."""
@@ -1354,7 +1360,9 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=4,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    def test_missing_partition(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_missing_partition(self, cloud_storage_type):
         """Test situation when one of the partition manifests are missing.
         The partition manifest is missing if it doesn't exist in the bucket
         in the expected place (defined by revision id) or in the alternative
@@ -1369,7 +1377,9 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=4,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    def test_missing_segment(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_missing_segment(self, cloud_storage_type):
         """Test the handling of the missing segment. The segment is
         missing if it's present in the manifest but deleted from the
         bucket."""
@@ -1379,7 +1389,9 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
-    def test_fast1(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_fast1(self, cloud_storage_type):
         """Basic recovery test. This test stresses successful recovery
         of the topic with different set of data."""
         topics = [
@@ -1393,7 +1405,9 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
-    def test_fast2(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_fast2(self, cloud_storage_type):
         """Basic recovery test. This test stresses successful recovery
         of the topic with different set of data."""
         topics = [
@@ -1410,7 +1424,9 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
-    def test_fast3(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_fast3(self, cloud_storage_type):
         """Basic recovery test. This test stresses successful recovery
         of the topic with different set of data."""
         topics = [
@@ -1430,7 +1446,9 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=3, log_allow_list=TRANSIENT_ERRORS)
-    def test_size_based_retention(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_size_based_retention(self, cloud_storage_type):
         """Test topic recovery with size based retention policy.
         It's tests handling of the situation when only subset of the data needs to
         be recovered due to retention."""
@@ -1446,7 +1464,9 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=3, log_allow_list=TRANSIENT_ERRORS)
-    def test_time_based_retention(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_time_based_retention(self, cloud_storage_type):
         """Test topic recovery with time based retention policy.
         It's tests handling of the situation when only subset of the data needs to
         be recovered due to retention. This test uses manifests with max_timestamp
@@ -1463,7 +1483,10 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=3, log_allow_list=TRANSIENT_ERRORS)
-    def test_time_based_retention_with_legacy_manifest(self):
+    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    def test_time_based_retention_with_legacy_manifest(self,
+                                                       cloud_storage_type):
         """Test topic recovery with time based retention policy.
         It's tests handling of the situation when only subset of the data needs to
         be recovered due to retention. This test uses manifests without max_timestamp


### PR DESCRIPTION
This PR parametrises most of the remaining shadow indexing tests
(scale tests included) to run against Azure and Azurite. Some tests were
intentionally omitted as they don't actually test interaction with the cloud
storage API (e.g. topic_creation_test.py).

Fixes #8640 

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
* none