### PR TITLE
k8s: Fix secret shared between e2e tests

### DIFF
--- a/src/go/k8s/tests/e2e/update-image-and-node-port/02-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/02-new-image-and-pv.yaml
@@ -4,7 +4,7 @@ data:
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: archival
+  name: archival-update-image-and-node-port
   namespace: default
 ---
 apiVersion: redpanda.vectorized.io/v1alpha1
@@ -18,7 +18,7 @@ spec:
     accessKey: XXX
     secretKeyRef:
       namespace: default
-      name: archival
+      name: archival-update-image-and-node-port
     region: europe-west1
     bucket: X
     apiEndpoint: storage.googleapis.com

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-new-image-and-pv.yaml
@@ -4,7 +4,7 @@ data:
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: archival
+  name: archival-update-image-tls-client-auth
   namespace: default
 ---
 apiVersion: redpanda.vectorized.io/v1alpha1
@@ -18,7 +18,7 @@ spec:
     accessKey: XXX
     secretKeyRef:
       namespace: default
-      name: archival
+      name: archival-update-image-tls-client-auth
     region: europe-west1
     bucket: X
     apiEndpoint: storage.googleapis.com

--- a/src/go/k8s/tests/e2e/update-image-tls/02-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/02-new-image-and-pv.yaml
@@ -4,7 +4,7 @@ data:
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: archival
+  name: archival-update-image-tls
   namespace: default
 ---
 apiVersion: redpanda.vectorized.io/v1alpha1
@@ -18,7 +18,7 @@ spec:
     accessKey: XXX
     secretKeyRef:
       namespace: default
-      name: archival
+      name: archival-update-image-tls
     region: europe-west1
     bucket: X
     apiEndpoint: storage.googleapis.com


### PR DESCRIPTION
The flakynest in the following tests were caused by parallerisation runs:
* update-image-and-node-port
* update-image-tls
* update-image-tls-client-auth

Each tests tries to verify if secret reference for cloud storage config works as expected. Secret was put in default namespace with the same name. Now names changed to be dedicated per test.

Previously test reported the following log line in the operator logs:
```
2023-02-06T10:53:23.704263943Z stderr F 1.6756808037041028e+09	ERROR	controllers.redpanda.Cluster	Failed to reconcile resource	{"redpandacluster": "kuttl-test-selected-buck/up-img", "error": "unable to construct object: cannot retrieve cloud storage secret for data archival: Secret \"archival\" not found"}
```

https://buildkite.com/organizations/redpanda/analytics/suites/redpanda/runs/f60ee633-0997-40a5-8c50-80f0a48a8e8b
https://buildkite.com/organizations/redpanda/analytics/suites/redpanda/runs/746e89f0-5bff-4f83-ad34-cb00fcda4656
https://buildkite.com/organizations/redpanda/analytics/suites/redpanda/runs/7f203e10-fb6c-4ffd-9e48-9df82062ad94

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Bug Fixes

* Fix flakiness of operator e2e tests. 

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
