### PR TITLE
resource_mgmt: reduce IO priority of tiered storage reads

### DIFF
--- a/src/v/resource_mgmt/io_priority.h
+++ b/src/v/resource_mgmt/io_priority.h
@@ -48,8 +48,12 @@ private:
           ss::io_priority_class::register_one("compaction", 200))
       , _raft_learner_recovery_priority(
           ss::io_priority_class::register_one("raft-learner-recovery", 100))
+      // User reads via Tiered Storage.  Lower priority than raft writes, to
+      // mitigate promotion to tiered storage cache starving out producers.
       , _shadow_indexing_priority(
-          ss::io_priority_class::register_one("shadow-indexing", 1000))
+          ss::io_priority_class::register_one("shadow-indexing", 500))
+      // Background uploads to tiered storage: not user-visible latency, lowest
+      // priority.
       , _archival_priority(
           ss::io_priority_class::register_one("archival", 200)) {}
 


### PR DESCRIPTION
This is the priority used in cache::put when writing to local disk while promoting segments from object storage to the cache.

Currently, this is done at the same priority as raft writes (i.e. Kafka Producers), and a consumer can easily overwhelm a producer by e.g. consuming from a 20-partition topic on a node with a cold cache: the 20 concurrently-written cache objects dominate disk I/O.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  ### Improvements

* Writes to the tiered storage cache now run with a lower I/O priority than writes from Kafka producers: this may improve performance in some situations on systems using tiered storage.

