### PR TITLE
Improvements for isolation node handler

### DIFF
--- a/src/v/cluster/node_isolation_watcher.cc
+++ b/src/v/cluster/node_isolation_watcher.cc
@@ -50,10 +50,11 @@ void node_isolation_watcher::update_isolation_status() {
 ss::future<> node_isolation_watcher::do_update_isolation_status() {
     bool isolated_status = co_await is_node_isolated();
     if (isolated_status != _last_is_isolated_status) {
-        vlog(
-          clusterlog.warn,
-          "Change is_isolated status. Is node isolated: {}",
-          isolated_status);
+        if (isolated_status) {
+            vlog(clusterlog.error, "Node is isolated");
+        } else {
+            vlog(clusterlog.info, "Node is not isolated anymore");
+        }
         co_await _metadata_cache.invoke_on_all(
           [isolated_status](cluster::metadata_cache& mc) {
               mc.set_is_node_isolated_status(isolated_status);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1777,7 +1777,7 @@ configuration::configuration()
       "considering itself to be isolated",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       3000,
-      {.min = 100, .max = 10000}) {}
+      {.min = 100}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/tests/rptest/tests/isolated_decommissioned_node_test.py
+++ b/tests/rptest/tests/isolated_decommissioned_node_test.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import re
+
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from ducktape.utils.util import wait_until
@@ -20,6 +22,11 @@ from ducktape.mark import parametrize
 import time
 import uuid
 import time
+
+LOG_ALLOW_LIST = [
+    # cluster - node_isolation_watcher.cc:54 - Node is isolated"
+    "Node is isolated",
+]
 
 
 def on_delivery(err, msg):
@@ -85,7 +92,7 @@ class IsolatedDecommissionedNodeTest(PreallocNodesTest):
 
         assert num_consumed == self.max_records, f"Can not consume all data. Consumed: {num_consumed}, expected: {self.max_records}"
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=LOG_ALLOW_LIST)
     def create_topic_on_isolated_node_test(self):
         # Idea of this test it to pass only isolated broker to client and expect that client will get another brokers list and will communicate with them
         topic = self.topics[0]
@@ -102,7 +109,7 @@ class IsolatedDecommissionedNodeTest(PreallocNodesTest):
                 admin.NewTopic("123", replication_factor=1, num_partitions=1)
             ])
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=LOG_ALLOW_LIST)
     @parametrize(isolation_handler_mode=True)
     @parametrize(isolation_handler_mode=False)
     def discover_leader_for_topic_test(self, isolation_handler_mode):


### PR DESCRIPTION
Improvements for isolation node handler:

1) Delete max for `node_isolation_heartbeat_timeout`. It allows user switch off isolation handler feature.
2) Use error log level for isolation log message.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes


## Release Notes

 ### Features

  * none
