### PR TITLE
tests: run with connection limits enabled

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -631,6 +631,13 @@ class RedpandaService(Service):
         # inspecting storage internals (e.g. number of segments after writing a certain
         # amount of data).
         'log_segment_size_jitter_percent': 0,
+
+        # This is high enough not to interfere with the logic in any tests, while also
+        # providing some background coverage of the connection limit code (i.e. that it
+        # doesn't crash, it doesn't limit when it shouldn't)
+        'kafka_connections_max': 2048,
+        'kafka_connections_max_per_ip': 1024,
+        'kafka_connections_max_overrides': ["1.2.3.4:5"],
     }
 
     logs = {


### PR DESCRIPTION
Use a high limit that tests won't actually hit, but will enable the connection limiting machinery so that any major bug like a crash, or wrongly limiting connections would be visible.

This is just something that I meant to do when the feature was first introduced, then forgot about.  Adding rate limiting to existing tests reminded me.


## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none
