### PR TITLE
rpk: always print epoch in `rpk topic describe`

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/describe_test.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/describe_test.go
@@ -42,12 +42,13 @@ func TestDescribePartitions(t *testing.T) {
 			expHeaders: []string{
 				"partition",
 				"leader",
+				"epoch",
 				"replicas",
 				"log-start-offset",
 				"high-watermark",
 			},
 			expRows: [][]interface{}{
-				{int32(0), int32(0), []int32{0, 1, 2}, int64(0), int64(1)},
+				{int32(0), int32(0), int32(-1), []int32{0, 1, 2}, int64(0), int64(1)},
 			},
 		},
 
@@ -58,7 +59,7 @@ func TestDescribePartitions(t *testing.T) {
 				{
 					Partition:       1,
 					Leader:          0,
-					ErrorCode:       1, // optional, uised
+					ErrorCode:       1,
 					LeaderEpoch:     0, // optional, used
 					Replicas:        []int32{0, 1},
 					OfflineReplicas: []int32{2, 3}, // optional, used
@@ -109,6 +110,7 @@ func TestDescribePartitions(t *testing.T) {
 			expHeaders: []string{
 				"partition",
 				"leader",
+				"epoch",
 				"replicas",
 				"log-start-offset",
 				"high-watermark",


### PR DESCRIPTION
This was done before redpanda supported KIP-320 which introduced the LeaderEpoch.

Now we can safely always print the epoch even if it's -1, so the output is more predictable.

Fixes #8466 


## Backports Required
- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport

## Release Notes
  * none

