### PR TITLE
test: ok_to_fail FeaturesMultiNodeUpgradeTest.test_upgrade

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -19,6 +19,7 @@ from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_v
 from ducktape.errors import TimeoutError as DucktapeTimeoutError
 from ducktape.utils.util import wait_until
 from rptest.util import wait_until_result
+from ducktape.mark import ok_to_fail
 
 
 class FeaturesTestBase(RedpandaTest):
@@ -226,6 +227,7 @@ class FeaturesMultiNodeUpgradeTest(FeaturesTestBase):
         self.installer.install(self.redpanda.nodes, self.previous_version)
         self.redpanda.start()
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8662
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_upgrade(self):
         """


### PR DESCRIPTION
Related: https://github.com/redpanda-data/redpanda/issues/8662

## Backports Required


- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none