### PR TITLE
Cleanup ok_to_fail marks

### DIFF
--- a/tests/rptest/tests/controller_log_limiting_test.py
+++ b/tests/rptest/tests/controller_log_limiting_test.py
@@ -10,7 +10,6 @@
 import time
 import json
 from subprocess import CalledProcessError
-from ducktape.mark import ok_to_fail
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.end_to_end import EndToEndTest

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -11,7 +11,7 @@ import random
 import time
 
 from ducktape.errors import TimeoutError
-from ducktape.mark import ok_to_fail, parametrize, matrix
+from ducktape.mark import parametrize, matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -11,7 +11,6 @@ import random
 import time
 from math import ceil
 
-from ducktape.mark import ok_to_fail
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from rptest.util import wait_until_result

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -9,7 +9,6 @@ from rptest.services.cluster import cluster
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix, parametrize
-from ducktape.mark import ok_to_fail
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -21,7 +21,7 @@ from rptest.util import (wait_until, segments_count, wait_for_segments_removal)
 
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 
-from ducktape.mark import (parametrize, ok_to_fail)
+from ducktape.mark import parametrize
 
 from rptest.services.kafka import KafkaServiceAdapter
 from kafkatest.services.kafka import KafkaService

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -12,7 +12,7 @@ import json
 from typing import Optional
 
 from ducktape.utils.util import wait_until
-from ducktape.mark import matrix, parametrize, ok_to_fail
+from ducktape.mark import matrix, parametrize
 from requests.exceptions import HTTPError
 
 from rptest.services.cluster import cluster

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -16,8 +16,6 @@ from rptest.wasm.wasm_script import WasmScript
 from rptest.wasm.wasm_build_tool import WasmTemplateRepository
 from rptest.services.redpanda import DEFAULT_LOG_ALLOW_LIST
 
-from ducktape.mark import ok_to_fail
-
 WASM_LOG_ALLOW_LIST = DEFAULT_LOG_ALLOW_LIST + [
     "Wasm engine failed to reply to heartbeat", "Failed to connect wasm engine"
 ]
@@ -218,7 +216,6 @@ class WasmAllInputsToAllOutputsIdentityTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4061
     @cluster(num_nodes=6, log_allow_list=WASM_LOG_ALLOW_LIST)
     def verify_materialized_topics_test(self):
         # Cannot compare topics to topics, can only verify # of records

--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -14,7 +14,6 @@ from rptest.services.verifiable_consumer import VerifiableConsumer
 
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
-from ducktape.mark import ok_to_fail
 
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.clients.rpk import RpkTool
@@ -172,7 +171,6 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         # Since the identity copro was deployed, contents of logs should be identical
         assert set(self.records_consumed) == set(self.result_data)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/4052
     @cluster(
         num_nodes=6,
         log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS + RESTART_LOG_ALLOW_LIST +

--- a/tests/rptest/tests/wasm_topics_test.py
+++ b/tests/rptest/tests/wasm_topics_test.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark import ok_to_fail
 from rptest.services.cluster import cluster
 from rptest.tests.wasm_identity_test import WasmIdentityTest
 from rptest.wasm.wasm_script import WasmScript
@@ -28,7 +27,6 @@ class WasmCreateTopicsTest(WasmIdentityTest):
                        script=WasmTemplateRepository.IDENTITY_TRANSFORM)
         ]
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/3858
     @cluster(num_nodes=4)
     def verify_materialized_topics_test(self):
         super().verify_materialized_topics_test()


### PR DESCRIPTION
Removes unused ok_to_fail mark imports, and marks from wasm tests that are all already disabled explicitly in yaml test suites. This has the effect of reducing noise when looking for what is disabled.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->
  * none

