### PR TITLE
[v22.3.x] cluster: remember initial logical version & expose in API

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -182,6 +182,12 @@ void feature_state::notify_version(cluster_version v) {
 void feature_table::set_active_version(cluster_version v) {
     _active_version = v;
 
+    if (_original_version == invalid_version) {
+        // Rely on controller log replay to call us first with
+        // the first version the cluster ever agreed upon.
+        _original_version = v;
+    }
+
     for (auto& fs : _feature_state) {
         fs.notify_version(v);
     }

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -324,6 +324,9 @@ private:
 
     // The controller log offset of last batch applied to this state machine
     void set_applied_offset(model::offset o) { _applied_offset = o; }
+    void set_original_version(cluster::cluster_version v) {
+        _original_version = v;
+    }
 
     void on_update();
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -237,6 +237,10 @@ public:
         return _active_version;
     }
 
+    cluster_version get_original_version() const noexcept {
+        return _original_version;
+    }
+
     const std::vector<feature_state>& get_feature_state() const {
         return _feature_state;
     }
@@ -324,6 +328,11 @@ private:
     void on_update();
 
     cluster::cluster_version _active_version{cluster::invalid_version};
+
+    // The earliest version this cluster ever saw: guaranteed that no
+    // on-disk structures were written with an encoding that predates
+    // this.
+    cluster_version _original_version{invalid_version};
 
     std::vector<feature_state> _feature_state;
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -237,7 +237,7 @@ public:
         return _active_version;
     }
 
-    cluster_version get_original_version() const noexcept {
+    cluster::cluster_version get_original_version() const noexcept {
         return _original_version;
     }
 
@@ -332,7 +332,7 @@ private:
     // The earliest version this cluster ever saw: guaranteed that no
     // on-disk structures were written with an encoding that predates
     // this.
-    cluster_version _original_version{invalid_version};
+    cluster::cluster_version _original_version{cluster::invalid_version};
 
     std::vector<feature_state> _feature_state;
 

--- a/src/v/features/feature_table_snapshot.cc
+++ b/src/v/features/feature_table_snapshot.cc
@@ -30,6 +30,7 @@ feature_table_snapshot feature_table_snapshot::from(const feature_table& ft) {
           .name = ss::sstring(name), .state = state._state});
     }
     fts.applied_offset = ft.get_applied_offset();
+    fts.original_version = ft.get_original_version();
 
     return fts;
 }
@@ -59,6 +60,7 @@ void feature_table_snapshot::apply(feature_table& ft) const {
     }
 
     ft.set_applied_offset(applied_offset);
+    ft.set_original_version(original_version);
 
     ft.on_update();
 }

--- a/src/v/features/feature_table_snapshot.h
+++ b/src/v/features/feature_table_snapshot.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/types.h"
 #include "feature_state.h"
 #include "model/fundamental.h"
 #include "security/license.h"
@@ -28,7 +29,10 @@ class feature_table;
  * serialization, rather than encapsulating a reference to a feature_spec.
  */
 struct feature_state_snapshot
-  : serde::envelope<feature_state_snapshot, serde::version<0>> {
+  : serde::envelope<
+      feature_state_snapshot,
+      serde::version<1>,
+      serde::compat_version<0>> {
     ss::sstring name;
     feature_state::state state;
 
@@ -46,9 +50,11 @@ struct feature_table_snapshot
     cluster::cluster_version version{cluster::invalid_version};
     std::optional<security::license> license;
     std::vector<feature_state_snapshot> states;
+    cluster::cluster_version original_version;
 
     auto serde_fields() {
-        return std::tie(applied_offset, version, states, license);
+        return std::tie(
+          applied_offset, version, states, license, original_version);
     }
 
     /// Create a snapshot from a live feature table

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -118,6 +118,10 @@
                     "type": "long",
                     "description": "Logical version of cluster"
                 },
+                "original_cluster_version": {
+                    "type": "long",
+                    "description": "Logical version at time of cluster creation"
+                },
                 "features": {
                     "type": "array",
                     "description": "list of feature_state for each feature",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1801,6 +1801,7 @@ void admin_server::register_features_routes() {
           auto version = ft.get_active_version();
 
           res.cluster_version = version;
+          res.original_cluster_version = ft.get_original_version();
           for (const auto& fs : ft.get_feature_state()) {
               ss::httpd::features_json::feature_state item;
               vlog(


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/4996

CONFLICT:
* git didn't like the serde versioning change, kept the new bumped version

This is useful if you'd like to know whether the cluster
has ever run code before a certain logical version.  It
can be used to know whether on-disk structures might
include data encoded with code from before a certain
logical version.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Improvements
* The `/v1/features` Admin API endpoint now includes an `original_cluster_version` reflecting the logical version at which the cluster was created.
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
