### PR TITLE
Implement KIP-496 OffsetDelete

### DIFF
--- a/src/v/kafka/protocol/errors.cc
+++ b/src/v/kafka/protocol/errors.cc
@@ -183,6 +183,8 @@ std::string_view error_code_to_str(error_code error) {
         return "group_max_size_reached";
     case error_code::no_reassignment_in_progress:
         return "no_reassignment_in_progress";
+    case error_code::group_subscribed_to_topic:
+        return "group_subscribed_to_topic";
     case error_code::fenced_instance_id:
         return "fenced_instance_id";
     case error_code::invalid_record:

--- a/src/v/kafka/protocol/errors.h
+++ b/src/v/kafka/protocol/errors.h
@@ -221,6 +221,8 @@ enum class error_code : int16_t {
     // The broker rejected this static consumer since another consumer with the
     // same group.instance.id has registered with a different member.id.
     fenced_instance_id = 82,
+    // The consumer group is actively subscribed to the topic
+    group_subscribed_to_topic = 86,
     // This record has failed the validation on broker and hence be rejected.
     invalid_record = 87,
     // There are unstable offsets that need to be cleared.

--- a/src/v/kafka/protocol/offset_delete.h
+++ b/src/v/kafka/protocol/offset_delete.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/schemata/offset_delete_request.h"
+#include "kafka/protocol/schemata/offset_delete_response.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+
+namespace kafka {
+
+struct offset_delete_request final {
+    using api_type = offset_delete_api;
+
+    offset_delete_request_data data;
+
+    // set during request processing after mapping group to ntp
+    model::ntp ntp;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const offset_delete_request& r) {
+        return os << r.data;
+    }
+};
+
+struct offset_delete_response final {
+    using api_type = offset_delete_api;
+
+    offset_delete_response_data data;
+
+    offset_delete_response(error_code error) { data.error_code = error; }
+
+    offset_delete_response(const offset_delete_request&, error_code error)
+      : offset_delete_response(error) {}
+
+    offset_delete_response(const offset_delete_request& request) {
+        for (const auto& t : request.data.topics) {
+            offset_delete_response_topic tmp{.name = t.name};
+            for (const auto& p : t.partitions) {
+                tmp.partitions.push_back(
+                  {.partition_index = p.partition_index});
+            }
+            data.topics.push_back(std::move(tmp));
+        }
+    }
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const offset_delete_response& r) {
+        return os << r.data;
+    }
+};
+
+} // namespace kafka

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -71,6 +71,8 @@ set(schemata
   create_partitions_response.json
   add_offsets_to_txn_request.json
   add_offsets_to_txn_response.json
+  offset_delete_request.json
+  offset_delete_response.json
   offset_for_leader_epoch_request.json
   offset_for_leader_epoch_response.json
   alter_partition_reassignments_request.json

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -96,6 +96,23 @@ path_type_map = {
             }
         }
     },
+    "OffsetDeleteRequestData": {
+        "GroupId": ("kafka::group_id", "string"),
+        "Topics": {
+            "Partitions": {
+                "PartitionIndex": ("model::partition_id", "int32")
+            }
+        }
+    },
+    "OffsetDeleteResponseData": {
+        "ErrorCode": ("kafka::error_code", "int16"),
+        "Topics": {
+            "Partitions": {
+                "PartitionIndex": ("model::partition_id", "int32"),
+                "ErrorCode": ("kafka::error_code", "int16"),
+            }
+        }
+    },
     "TxnOffsetCommitRequestData": {
         "MemberId": ("kafka::member_id", "string"),
         "GroupInstanceId": ("kafka::group_instance_id", "string"),
@@ -508,6 +525,10 @@ STRUCT_TYPES = [
     "CreatePartitionsTopic",
     "CreatePartitionsTopicResult",
     "CreatePartitionsAssignment",
+    "OffsetDeleteRequestTopic",
+    "OffsetDeleteRequestPartition",
+    "OffsetDeleteResponseTopic",
+    "OffsetDeleteResponsePartition",
     "OffsetForLeaderTopic",
     "OffsetForLeaderPartition",
     "OffsetForLeaderTopicResult",

--- a/src/v/kafka/protocol/schemata/offset_delete_request.json
+++ b/src/v/kafka/protocol/schemata/offset_delete_request.json
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 47,
+  "type": "request",
+  "listeners": ["zkBroker", "broker"],
+  "name": "OffsetDeleteRequest",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
+      "about": "The unique group identifier." },
+    { "name": "Topics", "type": "[]OffsetDeleteRequestTopic", "versions": "0+",
+      "about": "The topics to delete offsets for", "fields": [
+        { "name": "Name",  "type": "string",  "versions": "0+", "mapKey": true, "entityType": "topicName",
+          "about": "The topic name." },
+        { "name": "Partitions", "type": "[]OffsetDeleteRequestPartition", "versions": "0+",
+          "about": "Each partition to delete offsets for.", "fields": [
+            { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+              "about": "The partition index." }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/v/kafka/protocol/schemata/offset_delete_response.json
+++ b/src/v/kafka/protocol/schemata/offset_delete_response.json
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 47,
+  "type": "response",
+  "name": "OffsetDeleteResponse",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code, or 0 if there was no error." },
+    { "name": "ThrottleTimeMs",  "type": "int32",  "versions": "0+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Topics", "type": "[]OffsetDeleteResponseTopic", "versions": "0+",
+      "about": "The responses for each topic.", "fields": [
+        { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
+          "about": "The topic name." },
+        { "name": "Partitions", "type": "[]OffsetDeleteResponsePartition", "versions": "0+",
+          "about": "The responses for each partition in the topic.", "fields": [
+            { "name": "PartitionIndex", "type": "int32", "versions": "0+", "mapKey": true,
+              "about": "The partition index." },
+            { "name": "ErrorCode", "type": "int16", "versions": "0+",
+              "about": "The error code, or 0 if there was no error." }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3533,6 +3533,11 @@ group::get_expired_offsets(std::chrono::seconds retention_period) {
     }
 }
 
+bool group::has_offsets() const {
+    return !_offsets.empty() || !_pending_offset_commits.empty()
+           || !_volatile_txs.empty() || !_tx_seqs.empty();
+}
+
 std::vector<model::topic_partition>
 group::delete_expired_offsets(std::chrono::seconds retention_period) {
     /*
@@ -3547,11 +3552,6 @@ group::delete_expired_offsets(std::chrono::seconds retention_period) {
     /*
      * maybe mark the group as dead
      */
-    const auto has_offsets = [this] {
-        return !_offsets.empty() || !_pending_offset_commits.empty()
-               || !_volatile_txs.empty() || !_tx_seqs.empty();
-    };
-
     if (in_state(group_state::empty) && !has_offsets()) {
         set_state(group_state::dead);
     }

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -657,6 +657,14 @@ public:
     std::vector<model::topic_partition>
     delete_expired_offsets(std::chrono::seconds retention_period);
 
+    /*
+     *  Delete group offsets that do not have subscriptions.
+     *
+     *  Returns the set of offsets that were deleted.
+     */
+    std::vector<model::topic_partition>
+    delete_offsets(std::vector<model::topic_partition> offsets);
+
 private:
     using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
     using protocol_support = absl::node_hash_map<kafka::protocol_name, int>;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -785,6 +785,8 @@ private:
     cluster::abort_origin
     get_abort_origin(const model::producer_identity&, model::tx_seq) const;
 
+    bool has_offsets() const;
+
     bool has_pending_transaction(const model::topic_partition& tp) {
         if (std::any_of(
               _pending_offset_commits.begin(),

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -279,6 +279,11 @@ public:
         return _leader && _leader.value() == member_id;
     }
 
+    /// Check if this is a consumer_group or not
+    bool is_consumer_group() const {
+        return _protocol_type == consumer_group_protocol_type;
+    }
+
     /// Get the group's configured protocol type (if any).
     const std::optional<kafka::protocol_type>& protocol_type() const {
         return _protocol_type;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -282,6 +282,7 @@ ss::future<size_t> group_manager::delete_offsets(
     if (group->in_state(group_state::dead)) {
         auto it = _groups.find(group->id());
         if (it != _groups.end() && it->second == group) {
+            co_await it->second->shutdown();
             _groups.erase(it);
             if (group->generation() > 0) {
                 vlog(

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -251,8 +251,12 @@ ss::future<size_t> group_manager::delete_expired_offsets(
     /*
      * delete expired offsets from the group
      */
-    const auto offsets = group->delete_expired_offsets(retention_period);
+    auto offsets = group->delete_expired_offsets(retention_period);
+    return delete_offsets(group, std::move(offsets));
+}
 
+ss::future<size_t> group_manager::delete_offsets(
+  group_ptr group, std::vector<model::topic_partition> offsets) {
     /*
      * build tombstones to persistent offset deletions. the group itself may
      * also be set to dead state in which case we may be able to delete the

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -19,6 +19,7 @@
 #include "kafka/protocol/leave_group.h"
 #include "kafka/protocol/list_groups.h"
 #include "kafka/protocol/offset_commit.h"
+#include "kafka/protocol/offset_delete.h"
 #include "kafka/protocol/offset_fetch.h"
 #include "kafka/protocol/sync_group.h"
 #include "kafka/protocol/txn_offset_commit.h"
@@ -163,6 +164,9 @@ public:
     /// \brief Handle a OffsetFetch request
     ss::future<offset_fetch_response>
     offset_fetch(offset_fetch_request&& request);
+
+    ss::future<offset_delete_response>
+    offset_delete(offset_delete_request&& request);
 
     // returns the set of registered groups, and an error if one occurred while
     // retrieving the group list (e.g. coordinator_load_in_progress).

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -235,6 +235,9 @@ private:
       ss::lw_shared_ptr<attached_partition>,
       group_recovery_consumer_state);
 
+    ss::future<size_t> delete_offsets(
+      group_ptr group, std::vector<model::topic_partition> offsets);
+
     ss::future<> do_recover_group(
       model::term_id,
       ss::lw_shared_ptr<attached_partition>,

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -261,6 +261,11 @@ group_router::offset_fetch(offset_fetch_request&& request) {
     return route(std::move(request), &group_manager::offset_fetch);
 }
 
+ss::future<offset_delete_response>
+group_router::offset_delete(offset_delete_request&& request) {
+    return route(std::move(request), &group_manager::offset_delete);
+}
+
 group::offset_commit_stages
 group_router::offset_commit(offset_commit_request&& request) {
     return route_stages(std::move(request), &group_manager::offset_commit);

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -70,6 +70,9 @@ public:
     ss::future<offset_fetch_response>
     offset_fetch(offset_fetch_request&& request);
 
+    ss::future<offset_delete_response>
+    offset_delete(offset_delete_request&& request);
+
     group::offset_commit_stages offset_commit(offset_commit_request&& request);
 
     ss::future<txn_offset_commit_response>

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -41,6 +41,7 @@
 #include "kafka/server/handlers/list_transactions.h"
 #include "kafka/server/handlers/metadata.h"
 #include "kafka/server/handlers/offset_commit.h"
+#include "kafka/server/handlers/offset_delete.h"
 #include "kafka/server/handlers/offset_fetch.h"
 #include "kafka/server/handlers/offset_for_leader_epoch.h"
 #include "kafka/server/handlers/produce.h"
@@ -64,6 +65,7 @@ using request_types = make_request_types<
   list_offsets_handler,
   metadata_handler,
   offset_fetch_handler,
+  offset_delete_handler,
   find_coordinator_handler,
   list_groups_handler,
   api_versions_handler,

--- a/src/v/kafka/server/handlers/offset_delete.h
+++ b/src/v/kafka/server/handlers/offset_delete.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/offset_delete.h"
+#include "kafka/server/handlers/handler.h"
+#include "kafka/server/response.h"
+
+namespace kafka {
+
+using offset_delete_handler = single_stage_handler<offset_delete_api, 0, 0>;
+
+} // namespace kafka

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -32,6 +32,7 @@
 #include "kafka/server/handlers/leave_group.h"
 #include "kafka/server/handlers/list_groups.h"
 #include "kafka/server/handlers/offset_commit.h"
+#include "kafka/server/handlers/offset_delete.h"
 #include "kafka/server/handlers/offset_fetch.h"
 #include "kafka/server/handlers/sasl_authenticate.h"
 #include "kafka/server/handlers/sasl_handshake.h"
@@ -774,6 +775,88 @@ offset_fetch_handler::handle(request_context ctx, ss::smp_service_group) {
             partition.partition_index = partition_index;
             partition.error_code = error_code::group_authorization_failed;
             topic.partitions.push_back(std::move(partition));
+        }
+    }
+
+    co_return co_await ctx.respond(std::move(resp));
+}
+
+template<>
+ss::future<response_ptr>
+offset_delete_handler::handle(request_context ctx, ss::smp_service_group) {
+    offset_delete_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    log_request(ctx.header(), request);
+    if (!ctx.authorized(
+          security::acl_operation::remove, request.data.group_id)) {
+        co_return co_await ctx.respond(
+          offset_fetch_response(error_code::group_authorization_failed));
+    }
+
+    /// Remove unauthorized topics from request
+    auto unauthorized_it = std::partition(
+      request.data.topics.begin(),
+      request.data.topics.end(),
+      [&ctx](const offset_delete_request_topic& topic) {
+          return ctx.authorized(security::acl_operation::read, topic.name);
+      });
+
+    std::vector<offset_delete_request_topic> unauthorized(
+      std::make_move_iterator(unauthorized_it),
+      std::make_move_iterator(request.data.topics.end()));
+    request.data.topics.erase(unauthorized_it, request.data.topics.end());
+
+    /// Remove unknown topic_partitions from request
+    std::vector<offset_delete_request_topic> unknowns;
+    for (auto& topic : request.data.topics) {
+        auto unknowns_it = std::partition(
+          topic.partitions.begin(),
+          topic.partitions.end(),
+          [&topic, &ctx](const offset_delete_request_partition& partition) {
+              return ctx.metadata_cache().contains(
+                model::topic_namespace_view(model::kafka_namespace, topic.name),
+                partition.partition_index);
+          });
+        if (std::distance(unknowns_it, topic.partitions.end()) > 0) {
+            unknowns.push_back(offset_delete_request_topic{
+              .name = topic.name,
+              .partitions = std::vector<offset_delete_request_partition>(
+                std::make_move_iterator(unknowns_it),
+                std::make_move_iterator(topic.partitions.end()))});
+            topic.partitions.erase(unknowns_it, topic.partitions.end());
+        }
+    }
+
+    auto resp = co_await ctx.groups().offset_delete(std::move(request));
+
+    /// Re-add unauthorized requests back into the response as errors
+    for (auto& req_topic : unauthorized) {
+        auto& topic = resp.data.topics.emplace_back();
+        topic.name = std::move(req_topic.name);
+        topic.partitions.reserve(req_topic.partitions.size());
+        for (auto& req_part : req_topic.partitions) {
+            auto& partition = topic.partitions.emplace_back();
+            partition.partition_index = req_part.partition_index;
+            partition.error_code = error_code::topic_authorization_failed;
+        }
+    }
+
+    /// Re-add unknown requests back into the response as errors
+    for (auto& req_topic : unknowns) {
+        auto found = std::find_if(
+          resp.data.topics.begin(),
+          resp.data.topics.end(),
+          [&req_topic](const offset_delete_response_topic& resp_topic) {
+              return resp_topic.name == req_topic.name;
+          });
+        auto& topic = (found == resp.data.topics.end())
+                        ? resp.data.topics.emplace_back()
+                        : *found;
+        topic.name = std::move(req_topic.name);
+        for (auto& req_part : req_topic.partitions) {
+            auto& partition = topic.partitions.emplace_back();
+            partition.partition_index = req_part.partition_index;
+            partition.error_code = error_code::unknown_topic_or_partition;
         }
     }
 

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -239,6 +239,7 @@ std::error_condition make_error_condition(std::error_code ec) {
         case kec::operation_not_attempted:
         case kec::kafka_storage_error:
         case kec::unknown_server_error:
+        case kec::group_subscribed_to_topic:
         case kec::unstable_offset_commit:
         case kec::no_reassignment_in_progress:
             return rec::kafka_error;


### PR DESCRIPTION
This pull request adds support for the OffsetDelete API to redpanda. This API allows the user to manually remove offsets that are tracked by redpanda within the `__consumer_groups` topic. The offsets requested to be removed will be removed only if the group in question is in a state of `dead` or there are no active subscriptions for the topic/partitions to be deleted. If there are active subscriptions for a requested offset to be deleted a new kafka error code `group_subscribed_to_topic` is to be returned.

## Backports Required

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes
* none

## Release Notes

  ### Features

  * Support for OffsetDelete introduced.