### PR TITLE
features: set original version from bootstrap record on upgrade from 22.3.12

### DIFF
--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -163,6 +163,16 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd) {
               [v = cmd.value.founding_version](features::feature_table& ft) {
                   ft.bootstrap_active_version(v);
               });
+        } else if (
+          _feature_table.local().get_original_version()
+          == cluster::invalid_version) {
+            // Special case for systems pre-dating the original_version field:
+            // they may have loaded a snapshot that doesn't contain an original
+            // version, so must populate it from updates.
+            co_await _feature_table.invoke_on_all(
+              [v = cmd.value.founding_version](features::feature_table& ft) {
+                  ft.bootstrap_original_version(v);
+              });
         }
 
         // If we didn't already save a snapshot, create it so that subsequent

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -245,6 +245,20 @@ void feature_table::bootstrap_active_version(cluster_version v) {
     on_update();
 }
 
+void feature_table::bootstrap_original_version(cluster_version v) {
+    if (ss::this_shard_id() == ss::shard_id{0}) {
+        vlog(
+          featureslog.info,
+          "Set original_version from bootstrap version {}",
+          v);
+    }
+
+    _original_version = v;
+
+    // No on_update() call needed: bootstrap version is only advisory and
+    // does not drive the feature state machines.
+}
+
 /**
  * Call this after changing any state.
  *

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -362,6 +362,10 @@ public:
     // lifetime of a node.
     void bootstrap_active_version(cluster::cluster_version);
 
+    // During upgrades from Redpanda <= 22.3 where the feature table snapshot
+    // does not contain original_version, we infer it from a bootstrap event.
+    void bootstrap_original_version(cluster::cluster_version);
+
     void abort_for_tests() { _as.request_abort(); }
 
     /*

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -19,7 +19,6 @@ from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_v
 from ducktape.errors import TimeoutError as DucktapeTimeoutError
 from ducktape.utils.util import wait_until
 from rptest.util import wait_until_result
-from ducktape.mark import ok_to_fail
 
 
 class FeaturesTestBase(RedpandaTest):
@@ -227,7 +226,6 @@ class FeaturesMultiNodeUpgradeTest(FeaturesTestBase):
         self.installer.install(self.redpanda.nodes, self.previous_version)
         self.redpanda.start()
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8662
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_upgrade(self):
         """


### PR DESCRIPTION
When we backported the change to include cluster version in the bootstrap controller record, we didn't also backport the change to include original_version in feature table snapshots.

Consequently, clusters created with Redpanda 22.3.12 can have a bootstrap message in the log, but no original_version in their feature table snapshot.  This needs special handling, to apply the original_version to feature table when handling a bootstrap record, even if the feature table already has an active version.

Fixes https://github.com/redpanda-data/redpanda/issues/8662

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none

