### PR TITLE
config: Improve wording for kerberos mapping rules

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -908,7 +908,7 @@ configuration::configuration()
   , sasl_kerberos_principal_mapping(
       *this,
       "sasl_kerberos_principal_mapping",
-      "Rules for mapping Kerberos Service Principal Name (SPN) to Redpanda",
+      "Rules for mapping Kerberos Principal Names to Redpanda User Principals",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {"DEFAULT"},
       security::validate_kerberos_mapping_rules)


### PR DESCRIPTION
The Kerberos Principal is typically an SPN or an UPN, clarify the wording.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
