### PR TITLE
Always allow canceled operation to be executed

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1438,6 +1438,13 @@ ss::future<std::error_code> controller_backend::cancel_replica_set_update(
             current_cfg, replicas);
           const auto already_moved = are_configuration_replicas_up_to_date(
             current_cfg, previous_replicas);
+          vlog(
+            clusterlog.trace,
+            "[{}] not reconfiguring: {}, not yet moved: {}, already_moved: {}",
+            ntp,
+            raft_not_reconfiguring,
+            not_yet_moved,
+            already_moved);
           // raft already finished its part, we need to move replica back
           if (raft_not_reconfiguring) {
               // move hasn't yet requested

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1436,9 +1436,6 @@ ss::future<std::error_code> controller_backend::cancel_replica_set_update(
 
           const auto raft_not_reconfiguring
             = current_cfg.get_state() == raft::configuration_state::simple;
-          // TODO: emit revert command when we have learners in an old
-          // configuration of raft group as they are about to be removed.
-
           const auto not_yet_moved = are_configuration_replicas_up_to_date(
             current_cfg, replicas);
           const auto already_moved = are_configuration_replicas_up_to_date(

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -66,6 +66,7 @@ enum class errc : int16_t {
     throttling_quota_exceeded,
     cluster_already_exists,
     no_partition_assignments,
+    failed_to_create_partition,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -189,6 +190,8 @@ struct errc_category final : public std::error_category {
                    "created";
         case errc::no_partition_assignments:
             return "No replica assignments for the requested partition";
+        case errc::failed_to_create_partition:
+            return "Failed to create partition replica instance";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -82,6 +82,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::unknown_update_interruption_error:
     case cluster::errc::cluster_already_exists:
     case cluster::errc::no_partition_assignments:
+    case cluster::errc::failed_to_create_partition:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/raft/group_configuration.cc
+++ b/src/v/raft/group_configuration.cc
@@ -224,8 +224,10 @@ bool group_configuration::is_allowed_to_request_votes(vnode id) const {
     if (old_it != _old->voters.cend()) {
         return true;
     }
+    // look in learners
+    old_it = std::find(_old->learners.cbegin(), _old->learners.cend(), id);
 
-    return false;
+    return old_it != _old->learners.cend();
 }
 
 bool group_configuration::contains_broker(model::node_id id) const {

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1842,10 +1842,12 @@ class RedpandaService(Service):
 
         self._stop_duration_seconds = time.time() - self._stop_time
 
-    def stop_node(self, node, timeout=None):
+    def stop_node(self, node, timeout=None, forced=False):
         pids = self.pids(node)
         for pid in pids:
-            node.account.signal(pid, signal.SIGTERM, allow_fail=False)
+            node.account.signal(pid,
+                                signal.SIGKILL if forced else signal.SIGTERM,
+                                allow_fail=False)
 
         if timeout is None:
             timeout = 30


### PR DESCRIPTION
Executing canceled operation may be required to create an initial replica for changed partition. After introduction of reverting cancel operation it is not always the case that the canceled operation may be skipped. If the cancel operation was reverted we MUST not skip execution of update operation. Change the way how partition operations are interrupted. Now they are interrupted after the initial update was executed. This way when canceling an operation the partition replica created by update operation will be instantiated.

Fixes: #8657

## Note on reverted e1c89ecc3531f61b43e39b67beaa8fcdf6d94b79. 

The change might caused issues with single replica partitions. 

Change introduced in this commit was incorrect as it would lead to situation in which partition might not make progress when learner in old joint configuration is the only node allowed to be a leader. This may be the case as demoting learner in old configuration is a step that comes after it was a voter i.e. a node being a leader demoted to a learner will 'see' that change as a first one. In case of a failure the change may not be able to propagate to other nodes leaving the learner the only node eligible to become a leader. 

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

  * none