### PR TITLE
Remove duplicate responses sent by offset_fetch request handler

### DIFF
--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -774,7 +774,6 @@ offset_fetch_handler::handle(request_context ctx, ss::smp_service_group) {
             auto& partition = topic.partitions.emplace_back();
             partition.partition_index = partition_index;
             partition.error_code = error_code::group_authorization_failed;
-            topic.partitions.push_back(std::move(partition));
         }
     }
 


### PR DESCRIPTION
- This request handler returns a response that contains an array of topics and within each topic, another array of partitions.

- Within each array of partitions, a duplicate entry was being created, since push_back was invoked right after emplace_back, twice for each iteration of the loop to intitialize all partitions.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  ### Bug Fixes

  * Removes duplicate responses in OffsetFetch requests

