### PR TITLE
archival: Turn assertion into exception

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -289,11 +289,13 @@ static ss::future<std::optional<std::error_code>> get_file_range(
       "Invalid upload candidate {}",
       upl);
     upl->content_length = upl->final_file_offset - upl->file_offset;
-    vassert(
-      upl->content_length <= segment->reader().file_size(),
-      "Incorrect content length in {}, file size {}",
-      upl,
-      fsize);
+    if (upl->content_length > segment->reader().file_size()) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "Incorrect content length in {}, file size {}",
+          upl,
+          segment->reader().file_size()));
+    }
     vlog(
       archival_log.debug,
       "Partial segment upload {}, original file size: {}",


### PR DESCRIPTION
The search for upload candidate can be restarted so there is no need to bring the process down.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

* none
