### PR TITLE
Assorted improvements to self-test

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
@@ -125,7 +125,7 @@ func assembleTests(onlyDisk bool, onlyNetwork bool, durationDisk uint, durationN
 			SkipRead:    false,
 			DataSize:    1 * units.GiB,
 			RequestSize: 512 * units.KiB,
-			DurationMs:  durationNet,
+			DurationMs:  durationDisk,
 			Parallelism: 2,
 			Type:        admin.DiskcheckTagIdentifier,
 		},

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
@@ -87,9 +87,9 @@ command.`,
 
 	// Collect arguments via command line
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Acknowledge warning prompt skipping read from stdin")
-	cmd.Flags().UintVar(&diskDurationMs, "disk-duration-ms", 5000,
+	cmd.Flags().UintVar(&diskDurationMs, "disk-duration-ms", 30000,
 		"The duration in milliseconds of individual disk test runs")
-	cmd.Flags().UintVar(&netDurationMs, "network-duration-ms", 5000,
+	cmd.Flags().UintVar(&netDurationMs, "network-duration-ms", 30000,
 		"The duration in milliseconds of individual disk test runs")
 	cmd.Flags().IntSliceVar(&onNodes, "participant-node-ids", nil,
 		"ids of nodes that the tests will run on. Omitting this implies all nodes.")

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
@@ -81,7 +81,7 @@ command.`,
 			// Make HTTP POST request to leader that starts the actual test
 			tid, err := cl.StartSelfTest(cmd.Context(), onNodes, tests)
 			out.MaybeDie(err, "unable to start self test: %v", err)
-			fmt.Printf("Redpanda self-test has started, test identifier: %v, To check the status run:\n    rpk redpanda admin self-test status", tid)
+			fmt.Printf("Redpanda self-test has started, test identifier: %v, To check the status run:\n    rpk redpanda admin self-test status\n", tid)
 		},
 	}
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/status.go
@@ -90,6 +90,11 @@ the jobs launched. Possible results are:
 				tw.PrintColumn(header)
 				tw.PrintColumn(strings.Repeat("=", len(header)))
 				tableResults := makeReportTable(report)
+				if len(tableResults) == 0 {
+					tw.PrintColumn("INFO", "No cached results for node")
+					tw.Line()
+					continue
+				}
 				for _, row := range tableResults {
 					all := rowDataAsInterface(row[1:])
 					tw.PrintColumn(row[0], all...)

--- a/src/v/cluster/self_test/netcheck.h
+++ b/src/v/cluster/self_test/netcheck.h
@@ -43,9 +43,16 @@ public:
 
 class netcheck {
 public:
+    using plan_t
+      = absl::flat_hash_map<model::node_id, std::vector<model::node_id>>;
+
     /// Made public for unit testing, only used internally
     ///
     static void validate_options(const netcheck_opts& opts);
+
+    /// Made public for unit testing, only used internally
+    ///
+    static plan_t network_test_plan(std::vector<model::node_id> nodes);
 
     /// Class constructor
     ///

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -40,10 +40,11 @@ ss::future<> self_test_backend::start() {
 }
 
 ss::future<> self_test_backend::stop() {
-    co_await _gate.close();
+    auto f = _gate.close();
     co_await _disk_test.stop();
     co_await _network_test.stop();
     co_await _lock.get_units(); /// Ensure outstanding work is completed
+    co_await std::move(f);
 }
 
 ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -67,7 +67,7 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
             }
         } catch (const std::exception& ex) {
             vlog(
-              clusterlog.warn,
+              clusterlog.error,
               "Disk self test finished with error: {} - options: {}",
               ex.what(),
               dto);
@@ -100,7 +100,7 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
             }
         } catch (const std::exception& ex) {
             vlog(
-              clusterlog.warn,
+              clusterlog.error,
               "Network self test finished with error: {} - options: {}",
               ex.what(),
               nto);

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -108,7 +108,7 @@ struct diskcheck_opts
         fmt::print(
           o,
           "{{name: {} dsync: {} skip_write: {} skip_read: {} data_size: {} "
-          "request_size: {} parallelism: {} duration: {}}}",
+          "request_size: {} duration: {} parallelism: {}}}",
           opts.name,
           opts.dsync,
           opts.skip_write,

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -671,7 +671,6 @@ class RpkTool:
                         network_duration_ms=None,
                         only_disk=False,
                         only_network=False,
-                        only_connectivity=False,
                         node_ids=None):
         cmd = [
             self._rpk_binary(), '--api-urls',
@@ -685,8 +684,6 @@ class RpkTool:
             cmd += ['--only-disk-test']
         if only_network is True:
             cmd += ['--only-network-test']
-        if only_connectivity is True:
-            cmd += ['--only-connectivity-test']
         if node_ids is not None:
             ids = ",".join([str(x) for x in node_ids])
             cmd += ['--participants-node-ids', ids]


### PR DESCRIPTION
This PR fixes some small bugs and adds some quality of life improvements to redpanda `self-test` such as:
- Fixes hang on shutdown bug due to active self-test(s)
- Fixes bug that would start slightly more network test runs then necessary
- Adds unit tests for the above fix
- Fixed bug where rpk sends incorrect test duration to admin_server
- Assorted rpk fixes to do things like have nicer terminal output and fix startup defaults  

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  ### Bug Fixes
   * Fixes hang on shutdown bug due to active self-test(s)
   * Fixes bug that would start slightly more network test runs then necessary
   * Fixed bug where rpk sends incorrect test duration to admin_server
