### PR TITLE
tests: update kgo-verifier

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -129,7 +129,7 @@ function install_kcl() {
 
 function install_kgo_verifier() {
   git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git &&
-    cd /opt/kgo-verifier && git reset --hard a2b3ae780b0dc0bc1b4cf2aa33a9d43d10578b0b &&
+    cd /opt/kgo-verifier && git reset --hard ea8347abf3ee630ce4ccae7ae7d4a626d5453741 &&
     go mod tidy && make
 }
 


### PR DESCRIPTION
...to pull in https://github.com/redpanda-data/kgo-verifier/pull/20

This closes a possible source of strange behavior when the client is recreated after seeing produced messages land at an unexpected offset.

Related: https://github.com/redpanda-data/redpanda/issues/8289

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none