### PR TITLE
tx: Fix initialization of timeout_ms in fetch_tx_reply

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -421,14 +421,14 @@ struct fetch_tx_reply
     model::producer_identity pid;
     model::producer_identity last_pid;
     model::tx_seq tx_seq;
-    std::chrono::milliseconds timeout_ms;
+    std::chrono::milliseconds timeout_ms{};
     tx_status status;
     std::vector<tx_partition> partitions;
     std::vector<tx_group> groups;
 
     fetch_tx_reply() noexcept = default;
 
-    fetch_tx_reply(tx_errc ec)
+    explicit fetch_tx_reply(tx_errc ec)
       : ec(ec) {}
 
     fetch_tx_reply(

--- a/tests/rptest/tests/compaction_e2e_test.py
+++ b/tests/rptest/tests/compaction_e2e_test.py
@@ -37,8 +37,7 @@ class CompactionE2EIdempotencyTest(RedpandaTest):
 
         return [len(p.segments) for p in topic_partitions]
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8491
-    # https://github.com/redpanda-data/redpanda/issues/8486
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8486
     @cluster(num_nodes=4)
     @matrix(
         initial_cleanup_policy=[


### PR DESCRIPTION
When using fetch_tx_reply c'tor which doesn't explicitly initialize timeout_ms, it may not be initialized resulting in UB on access. When serde serializing it for RPC, resulting clamping to nanoseconds may cause an underflow occasionally.

Fixes #8491

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
