### PR TITLE
cloud_storage_clients: ABS topic recovery adjustments

### DIFF
--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -489,6 +489,15 @@ signature_abs::get_string_to_sign(http::client::request_header& header) const {
           header_value_view.data(), header_value_view.size()};
 
         boost::trim(header_value);
+
+        // Represent 0 content-size as empty string as per
+        // https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key#content-length-header-in-version-2014-02-14-and-earlier
+        if (
+          std::string_view{header_name} == "Content-Length"
+          && header_value == "0") {
+            header_value = "";
+        }
+
         non_ms_headers += ssx::sformat("{}\n", header_value);
     }
 

--- a/src/v/cloud_storage/recovery_utils.cc
+++ b/src/v/cloud_storage/recovery_utils.cc
@@ -52,10 +52,8 @@ ss::future<> place_download_result(
   retry_chain_node& parent) {
     retry_chain_node fib{&parent};
     auto result_path = generate_result_path(ntp_cfg, result_completed);
-    // The non-empty payload is required for ABS to accept the upload. An empty
-    // file results in an authorization exception.
     auto result = co_await remote.upload_object(
-      bucket, cloud_storage_clients::object_key{result_path}, "result", fib);
+      bucket, cloud_storage_clients::object_key{result_path}, "", fib);
     if (result != upload_result::success) {
         vlog(
           cst_log.error,

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -553,26 +553,17 @@ abs_client::delete_objects(
   std::vector<object_key> keys,
   ss::lowres_clock::duration timeout) {
     abs_client::delete_objects_result delete_objects_result;
-    co_await ss::max_concurrent_for_each(
-      keys, 32, [this, &bucket, &delete_objects_result, timeout](auto key) {
-          return delete_object(bucket, key, timeout)
-            .then_wrapped([&key, &delete_objects_result](auto delete_f) {
-                if (delete_f.failed()) {
-                    try {
-                        std::rethrow_exception(delete_f.get_exception());
-                    } catch (const std::exception& ex) {
-                        delete_objects_result.undeleted_keys.push_back(
-                          {key, ex.what()});
-                    }
-                } else {
-                    auto delete_result = delete_f.get();
-                    if (delete_result.has_error()) {
-                        delete_objects_result.undeleted_keys.push_back(
-                          {key, fmt::format("{}", delete_result.error())});
-                    }
-                }
-            });
-      });
+    for (const auto& key : keys) {
+        try {
+            auto res = co_await delete_object(bucket, key, timeout);
+            if (res.has_error()) {
+                delete_objects_result.undeleted_keys.push_back(
+                  {key, fmt::format("{}", res.error())});
+            }
+        } catch (const std::exception& ex) {
+            delete_objects_result.undeleted_keys.push_back({key, ex.what()});
+        }
+    }
     co_return delete_objects_result;
 }
 

--- a/src/v/cloud_storage_clients/xml_sax_parser.cc
+++ b/src/v/cloud_storage_clients/xml_sax_parser.cc
@@ -31,7 +31,7 @@ struct aws_tags {
 
 struct abs_tags {
     static constexpr std::string_view prefix{"Prefix"};
-    static constexpr std::string_view marker{"Marker"};
+    static constexpr std::string_view next_marker{"NextMarker"};
     static constexpr std::string_view blob{"Blob"};
     static constexpr std::string_view name{"Name"};
     static constexpr std::string_view size{"Content-Length"};
@@ -208,8 +208,8 @@ void abs_parse_impl::handle_start_element(std::string_view element_name) {
         _current_tag = xml_tag::last_modified;
     } else if (element_name == abs_tags::etag && is_in_blob_properties()) {
         _current_tag = xml_tag::etag;
-    } else if (element_name == abs_tags::marker && is_top_level()) {
-        _current_tag = xml_tag::is_truncated;
+    } else if (element_name == abs_tags::next_marker && is_top_level()) {
+        _current_tag = xml_tag::next_continuation_token;
     } else if (element_name == abs_tags::prefix && is_top_level()) {
         _current_tag = xml_tag::prefix;
     }
@@ -218,6 +218,14 @@ void abs_parse_impl::handle_start_element(std::string_view element_name) {
 
 void abs_parse_impl::handle_end_element(std::string_view element_name) {
     _tags.pop_back();
+
+    // ABS returns a non empty NextMarker when the result is truncated. There
+    // is no explicit field for is_truncated, so we infer this value from the
+    // size of NextMarker.
+    if (element_name == abs_tags::next_marker) {
+        _items.is_truncated = !_items.next_continuation_token.empty();
+    }
+
     if (element_name == abs_tags::blob && _current_item) {
         if (!_item_filter || _item_filter.value()(_current_item.value())) {
             _items.contents.push_back(std::move(_current_item.value()));
@@ -263,8 +271,9 @@ void abs_parse_impl::handle_characters(std::string_view characters) {
               "Invalid state: parsing ETag when not in Blob tag"};
         }
         break;
-    case xml_tag::is_truncated:
-        _items.is_truncated = characters == "true";
+    case xml_tag::next_continuation_token:
+        _items.next_continuation_token = {characters.data(), characters.size()};
+        _items.is_truncated = true;
         break;
     case xml_tag::prefix:
         // Parsing prefix at the top level: ListBucketResult -> Prefix
@@ -277,9 +286,8 @@ void abs_parse_impl::handle_characters(std::string_view characters) {
               characters.data(), characters.size());
         }
         break;
-    case xml_tag::next_continuation_token:
-        _items.next_continuation_token = {characters.data(), characters.size()};
-        break;
+    case xml_tag::is_truncated:
+        [[fallthrough]];
     case xml_tag::unset:
         return;
     }


### PR DESCRIPTION
ABS list response contains a next marker which is empty if the result is not truncated. 

If this field has a value then the result is truncated, and the marker value should be used in the next list call to fetch more results. 

This change adjusts the xml parser to correctly store and use the next marker field.

There are two other changes here, part of the same PR to make sure topic recovery works with ABS

1. handle 0 content length correctly when signing: MS requires the 0 value to be represented as empty string
2. delete blobs in sequence when on ABS. this is a limitation which will be fixed when we are able to issue batch deletes via azurite

Fixes https://github.com/redpanda-data/redpanda/issues/8679

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none
