### PR TITLE
storage: ignore "configuration segments" when performing time-queries

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -135,6 +135,7 @@ void index_state::serde_write(iobuf& out) const {
     write(tmp, position_index.copy());
     write(tmp, batch_timestamps_are_monotonic);
     write(tmp, with_offset);
+    write(tmp, non_data_timestamps);
 
     crc::crc32c crc;
     crc_extend_iobuf(crc, tmp);
@@ -213,6 +214,7 @@ void read_nested(
     } else {
         read_nested(p, st.batch_timestamps_are_monotonic, 0U);
         read_nested(p, st.with_offset, 0U);
+        read_nested(p, st.non_data_timestamps, 0U);
     }
 }
 

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -88,6 +88,7 @@ private:
    [] position_index
    1 byte  - batch_timestamps_are_monotonic
    1 byte  - with_offset
+   1 byte  - non_data_timestamps
  */
 struct index_state
   : serde::envelope<index_state, serde::version<5>, serde::compat_version<4>> {
@@ -126,6 +127,9 @@ struct index_state
 
     // flag indicating whether the relative time index has been offset
     offset_delta_time with_offset{false};
+
+    // flag indicating whether this segment contains non user-data timestamps
+    bool non_data_timestamps{false};
 
     size_t size() const { return relative_offset_index.size(); }
 
@@ -200,8 +204,6 @@ struct index_state
     friend void read_nested(iobuf_parser&, index_state&, const size_t);
 
 private:
-    bool non_data_timestamps{false};
-
     index_state(const index_state& o) noexcept
       : bitflags(o.bitflags)
       , base_offset(o.base_offset)

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -76,6 +76,7 @@ public:
     bool batch_timestamps_are_monotonic() const {
         return _state.batch_timestamps_are_monotonic;
     }
+    bool non_data_timestamps() const { return _state.non_data_timestamps; }
 
     ss::future<bool> materialize_index();
     ss::future<> flush();

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -82,16 +82,6 @@ struct needle_in_range {
         // must use max_offset
         return o <= s.offsets().dirty_offset && o >= s.offsets().base_offset;
     }
-
-    bool operator()(Iterator ptr, model::timestamp t) {
-        auto& s = **ptr;
-        if (s.empty()) {
-            return false;
-        }
-        // must use max_offset
-        return t <= s.index().max_timestamp()
-               && t >= s.index().base_timestamp();
-    }
 };
 
 template<typename Iterator, typename Needle>
@@ -141,12 +131,6 @@ segment_set::lower_bound(model::offset offset) const {
 segment_set::iterator segment_set::lower_bound(model::timestamp needle) {
     return std::lower_bound(
       std::begin(_handles), std::end(_handles), needle, segment_ordering{});
-}
-
-segment_set::const_iterator
-segment_set::lower_bound(model::timestamp needle) const {
-    return segments_lower_bound(
-      std::cbegin(_handles), std::cend(_handles), needle);
 }
 
 segment_set::iterator segment_set::upper_bound(model::term_id term) {

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -217,7 +217,6 @@ BOOST_AUTO_TEST_CASE(offset_time_index_test) {
     //                    |             |
     // After offsetting:  [2^31, ..., 2 ^ 32 - 1]
 
-    const uint32_t offset = storage::offset_time_index::offset;
     const uint32_t max_delta = storage::offset_time_index::delta_time_max;
 
     std::vector<uint32_t> deltas_before{

--- a/src/v/utils/filtered_lower_bound.h
+++ b/src/v/utils/filtered_lower_bound.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <span>
+
+/// \brief: Perfom lower bound on a span while excluding certain entries.
+/// It's a standard binary search, but if we land on an element that
+/// has to be filtered out we iterate backwards (and then forwards)
+/// and attempt to find an element which is included.
+///
+/// Note that the elements which pass the filter should be sorted for
+/// this function to return correct results.
+///
+///
+/// \param span: the span to search inside
+/// \param needle: the value to search for
+/// \param comp: the comparator to use; only elements that pass the 'filter'
+/// will be used
+/// \param filter: callable that returns 'true' if the element should be
+/// considered and 'false' otherwise
+/// \return iterator to the result; the result should be the same as using
+/// std::lower_bound on the filtered span. Should be equivalent to the
+/// result of:
+/// std::erase_if(begin, end, std::not_fn(filter))
+/// std::lower_bound(begin, end, comp);
+///
+/// TODO(vlad): Come back and make  this more elegant when not in a rush.
+template<typename Iterator, typename Needle, typename Compare, typename Filter>
+inline Iterator filtered_lower_bound(
+  Iterator begin, Iterator end, Needle needle, Compare comp, Filter filter) {
+    auto container_end = end;
+
+    while (begin != container_end && !filter(*begin)) {
+        ++begin;
+    }
+
+    while (begin != end) {
+        auto step = std::distance(begin, end) / 2;
+
+        Iterator middle = begin + step;
+        bool nothing_backwards = false;
+        if (!filter(*middle)) {
+            auto backwards = container_end;
+            for (auto iter = middle;; --iter) {
+                if (filter(*iter)) {
+                    backwards = iter;
+                    break;
+                }
+
+                if (iter == begin) {
+                    backwards = end;
+                    nothing_backwards = true;
+                    break;
+                }
+            }
+
+            if (backwards != end) {
+                middle = backwards;
+            } else {
+                auto forwards = end;
+                for (auto iter = middle; iter != end; ++iter) {
+                    if (filter(*iter)) {
+                        forwards = iter;
+                        break;
+                    }
+                }
+
+                if (forwards != end) {
+                    middle = forwards;
+                } else {
+                    // Search area contains no elements that pass the filtering
+                    return container_end;
+                }
+            }
+        }
+
+        if (comp(*middle, needle)) {
+            begin = middle + 1;
+            while (begin != end && !filter(*begin)) {
+                ++begin;
+            }
+        } else {
+            if (nothing_backwards) {
+                begin = middle;
+                end = middle;
+            } else {
+                end = middle;
+            }
+        }
+    }
+
+    return begin;
+}

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ rp_test(
     fragmented_vector_test.cc
     tracking_allocator_tests.cc
     bottomless_token_bucket_test.cc
+    filtered_lower_bound_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::utils absl::flat_hash_map
   LABELS utils

--- a/src/v/utils/tests/filtered_lower_bound_test.cc
+++ b/src/v/utils/tests/filtered_lower_bound_test.cc
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "seastarx.h"
+#include "utils/filtered_lower_bound.h"
+#include "vlog.h"
+
+#include <seastar/util/log.hh>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_log.hpp>
+
+#include <optional>
+#include <random>
+
+static ss::logger test_log("test_logger");
+
+struct optional_filter {
+    bool operator()(const std::optional<int>& opt) const {
+        return opt.has_value();
+    }
+};
+
+struct optional_compare {
+    bool operator()(
+      const std::optional<int>& lhs, const std::optional<int>& rhs) const {
+        BOOST_CHECK(lhs.has_value());
+        BOOST_CHECK(rhs.has_value());
+
+        return *lhs < *rhs;
+    }
+
+    bool operator()(const std::optional<int>& lhs, int rhs) const {
+        BOOST_CHECK(lhs.has_value());
+
+        return *lhs < rhs;
+    }
+};
+
+std::string print(const std::optional<int>& opt) {
+    return opt ? std::to_string(opt.value()) : "'null'";
+}
+
+std::string print(std::vector<std::optional<int>>& to_search) {
+    std::string res = "";
+    for (size_t i = 0; i < to_search.size(); ++i) {
+        if (i == 0) {
+            res += "[" + print(to_search[i]) + ", ";
+        } else if (i == to_search.size() - 1) {
+            res += print(to_search[i]) + "]";
+        } else {
+            res += print(to_search[i]) + ", ";
+        }
+    }
+
+    return res;
+}
+
+void validate(std::vector<std::optional<int>>& to_search, int searched_value) {
+    auto found_iter = filtered_lower_bound(
+      to_search.begin(),
+      to_search.end(),
+      searched_value,
+      optional_compare{},
+      optional_filter{});
+
+    auto linear_search_result = to_search.end();
+    for (auto iter = to_search.begin(); iter != to_search.end(); ++iter) {
+        if (iter->has_value() && iter->value() >= searched_value) {
+            linear_search_result = iter;
+            break;
+        }
+    }
+
+    auto found_dist = std::distance(to_search.begin(), found_iter);
+    auto expected_dist = std::distance(to_search.begin(), linear_search_result);
+
+    if (found_dist != expected_dist) {
+        vlog(
+          test_log.info,
+          "Failure detected: to_search={} searched_value={}, "
+          "expected_index={}, found_index={}",
+          print(to_search),
+          searched_value,
+          expected_dist,
+          found_dist);
+    }
+
+    BOOST_CHECK_EQUAL(found_dist, expected_dist);
+}
+
+BOOST_AUTO_TEST_CASE(filtered_lower_bound_test) {
+    std::vector<std::optional<int>> case1 = {1, 3, 5, std::nullopt, 7, 9};
+    for (auto val : {0, 1, 3, 5, 6, 7, 9, 100}) {
+        validate(case1, val);
+    }
+
+    std::vector<std::optional<int>> case2 = {
+      1, 3, 5, std::nullopt, std::nullopt, 7, 9};
+    for (auto val : {0, 1, 3, 5, 6, 7, 9, 100}) {
+        validate(case2, val);
+    }
+
+    std::vector<std::optional<int>> case3 = {
+      1, 3, 5, std::nullopt, std::nullopt, std::nullopt, 7, 9};
+    for (auto val : {0, 1, 3, 5, 6, 7, 9, 100}) {
+        validate(case3, val);
+    }
+
+    std::vector<std::optional<int>> case4 = {
+      1, std::nullopt, 3, 5, std::nullopt, std::nullopt, std::nullopt, 7, 9};
+    for (auto val : {0, 1, 3, 5, 6, 7, 9, 100}) {
+        validate(case4, val);
+    }
+
+    std::vector<std::optional<int>> case5 = {
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt};
+    for (auto val : {0, 1}) {
+        validate(case5, val);
+    }
+
+    std::vector<std::optional<int>> case6 = {
+      0, std::nullopt, std::nullopt, std::nullopt, std::nullopt};
+    for (auto val : {-1, 0, 1}) {
+        validate(case6, val);
+    }
+
+    std::vector<std::optional<int>> case7 = {
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, 1};
+    for (auto val : {-1, 0, 1}) {
+        validate(case7, val);
+    }
+
+    std::vector<std::optional<int>> case8 = {
+      std::nullopt, 0, 1, std::nullopt, 2, 3, 4, std::nullopt, std::nullopt, 5};
+    for (auto val : {-1, 0, 1, 2, 3, 4, 5, 6}) {
+        validate(case8, val);
+    }
+
+    std::vector<std::optional<int>> case9 = {
+      std::nullopt,
+      0,
+      std::nullopt,
+      std::nullopt,
+      1,
+      2,
+      3,
+      std::nullopt,
+      std::nullopt,
+      4};
+    validate(case9, -1);
+}
+
+BOOST_AUTO_TEST_CASE(fuzz_test) {
+    std::vector<size_t> sizes = {10, 100, 1000};
+    std::vector<double> null_probability = {0, 0.1, 0.25, 0.5, 0.9};
+
+    std::random_device rd;
+    auto seed = rd();
+    std::mt19937 gen(seed);
+    std::uniform_real_distribution<> dis(0.0, 1.0);
+
+    vlog(test_log.info, "SEED={}", seed);
+
+    for (size_t size : sizes) {
+        for (auto prob : null_probability) {
+            vlog(test_log.info, "SIZE={} PROB={}", size, prob);
+            for (size_t i = 0; i < 100; ++i) {
+                std::vector<std::optional<int>> values;
+                int last_inserted = 0;
+                for (size_t i = 0; i < size; ++i) {
+                    auto local_prob = dis(gen);
+                    if (local_prob < prob) {
+                        values.push_back(std::nullopt);
+                    } else {
+                        values.push_back(last_inserted++);
+                    }
+                }
+
+                vlog(test_log.info, "CASE={}", print(values));
+                for (int i = -1; i <= last_inserted; ++i) {
+                    validate(values, i);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is a follow-up to https://github.com/redpanda-data/redpanda/pull/8509, which
improved consistency of timequery on the intra-segment part of the search.

In this set of patches, we target the inter-segment part. The first step when
serving a time query is to find the segment that contains the timestamp required.
This was done by looking at the `max_timestamp` associated with each segment in the
index and performing a `std::lower_bound` search. The problem with that approach
is that segments that only contain configuration batches end up with a wall timestamp
generated by Redpanda. If the client is using producer provided timestamps, they may
differ wildly with what Redpanda generates and throw off the time-query.

In order to fix this, we keep track of whether a given segment has only configuration bathes,
and, if that's the case, we exclude it from the search. The later part is done via a filtered
binary search that is added in this PR.

Note that timequery may still yield the wrong result if the user provided timestamps
are not monotonic at the segment level, but that's what Kafka does too in the name
of speed.

Fixes https://github.com/redpanda-data/redpanda/issues/4035

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x
## Release Notes
* none
