### PR TITLE
[v22.2.x] storage: clamp max_compacted_segment_size to 1.5 GiB

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -29,6 +29,7 @@
 #include "storage/segment_utils.h"
 #include "storage/types.h"
 #include "storage/version.h"
+#include "units.h"
 #include "utils/gate_guard.h"
 #include "vassert.h"
 #include "vlog.h"
@@ -416,10 +417,16 @@ disk_log_impl::find_compaction_range() {
               return seg->offsets().term == term;
           });
 
+        // Clamp max compacted segment size to 1.5GiB to avoid compaction index
+        // size overflow. See
+        // https://github.com/redpanda-data/redpanda/issues/7647 for details.
+        // This is a workaround for older versions, proper fix is
+        // https://github.com/redpanda-data/redpanda/pull/7687
+        size_t max_compacted_segment_size = std::min(
+          _manager.config().max_compacted_segment_size(), 1536_MiB);
+
         // found a good range if all the tests pass
-        if (
-          same_term
-          && total_size < _manager.config().max_compacted_segment_size()) {
+        if (same_term && total_size < max_compacted_segment_size) {
             break;
         }
 


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/8708 to v22.2.x

## Release Notes
### Bug Fixes
  * Clamp max compacted segment size to 1.5GiB to avoid compaction index size overflow that could lead to hangs when trying to compact large segments.