### PR TITLE
rpk: avoid overwriting redpanda.yaml if there are no changes 

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -149,7 +149,9 @@ func TestModeCommand(t *testing.T) {
 			conf, err := new(config.Params).Load(fs)
 			require.NoError(t, err)
 
-			require.Exactly(t, tt.exp, conf.File())
+			expRaw, err := yaml.Marshal(tt.exp)
+			require.NoError(t, err)
+			require.YAMLEq(t, string(expRaw), string(conf.RawFile()))
 		})
 	}
 }

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -200,6 +200,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 		return
 	}
 	cfg = cfg.FileOrDefaults() // we want to check that we correctly load the raw file
+	cfg.rawFile = nil          // we don't want to compare the in-memory raw file
 	require.Equal(t, expCfg, cfg)
 
 	// Write to the file and check we don't mangle the config properties

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -20,6 +20,7 @@ import (
 type Config struct {
 	file         *Config
 	fileLocation string
+	rawFile      []byte
 
 	NodeUUID             string             `yaml:"node_uuid,omitempty" json:"node_uuid"`
 	Organization         string             `yaml:"organization,omitempty" json:"organization"`
@@ -40,6 +41,12 @@ type Config struct {
 // no file was read.
 func (c *Config) File() *Config {
 	return c.file
+}
+
+// RawFile returns the bytes of the actual file on disk, if there was one.
+// The raw bytes must be valid yaml.
+func (c *Config) RawFile() []byte {
+	return c.rawFile
 }
 
 // FileLocation returns the loaded file location; this is the path that


### PR DESCRIPTION
If the contents of the file in rpk redpanda start are the same after running the command, rpk should not write to the file.

In the past, if you have the same content but ordered it in a different manner, rpk will rewrite and reorder the configuration file.

This commit introduces the rawFile field in the config struct, this is an in-memory representation of the loaded raw file.

## Backports Required
- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  ### Bug Fixes

  * rpk will not overwrite the `redpanda.yaml` file when executing the command `rpk redpanda start` if the contents of the file remain unchanged.

