### PR TITLE
rpk: Modify latency disk test request size to 4k

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/start.go
@@ -124,7 +124,7 @@ func assembleTests(onlyDisk bool, onlyNetwork bool, durationDisk uint, durationN
 			SkipWrite:   false,
 			SkipRead:    false,
 			DataSize:    1 * units.GiB,
-			RequestSize: 512 * units.KiB,
+			RequestSize: 4 * units.KiB,
 			DurationMs:  durationDisk,
 			Parallelism: 2,
 			Type:        admin.DiskcheckTagIdentifier,


### PR DESCRIPTION
Latency disk tests should be using request size of 4k. It had been configured to use a request size of 512k 

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  ### Bug Fixes
  * Fix bug where the request size of a disk self test was 512K. Has been changed to 4k.
