### PR TITLE
Use raft disk i/o timeout in recovery stm

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -751,7 +751,7 @@ configuration::configuration()
       *this,
       "raft_io_timeout_ms",
       "Raft I/O timeout",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10'000ms)
   , join_retry_timeout_ms(
       *this,

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -91,7 +91,7 @@ public:
       timeout_jitter,
       storage::log,
       scheduling_config,
-      model::timeout_clock::duration disk_timeout,
+      config::binding<std::chrono::milliseconds> disk_timeout,
       consensus_client_protocol,
       leader_cb_t,
       storage::api&,
@@ -593,7 +593,7 @@ private:
     storage::log _log;
     offset_translator _offset_translator;
     scheduling_config _scheduling;
-    model::timeout_clock::duration _disk_timeout;
+    config::binding<std::chrono::milliseconds> _disk_timeout;
     consensus_client_protocol _client_protocol;
     leader_cb_t _leader_notification;
 

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -40,7 +40,7 @@ public:
     struct configuration {
         config::binding<std::chrono::milliseconds> heartbeat_interval;
         config::binding<std::chrono::milliseconds> heartbeat_timeout;
-        std::chrono::milliseconds raft_io_timeout_ms;
+        config::binding<std::chrono::milliseconds> raft_io_timeout_ms;
     };
     using config_provider_fn = ss::noncopyable_function<configuration()>;
 

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -220,47 +220,48 @@ recovery_stm::read_range_for_recovery(
     vlog(_ctxlog.trace, "Reading batches, starting from: {}", start_offset);
     auto reader = co_await _ptr->_log.make_reader(cfg);
     try {
-    auto batches = co_await model::consume_reader_to_memory(
-       std::move(reader), _ptr->_disk_timeout() + model::timeout_clock::now());
+        auto batches = co_await model::consume_reader_to_memory(
+          std::move(reader),
+          _ptr->_disk_timeout() + model::timeout_clock::now());
 
-    if (batches.empty()) {
-        vlog(_ctxlog.trace, "Read no batches for recovery, stopping");
-        _stop_requested = true;
-        co_return std::nullopt;
-    }
-    vlog(
-      _ctxlog.trace,
-      "Read batches in range [{},{}] for recovery",
-      batches.front().base_offset(),
-      batches.back().last_offset());
-
-    auto gap_filled_batches = details::make_ghost_batches_in_gaps(
-      start_offset, std::move(batches));
-    _base_batch_offset = gap_filled_batches.begin()->base_offset();
-    _last_batch_offset = gap_filled_batches.back().last_offset();
-
-    if (is_learner && _ptr->_recovery_throttle) {
-        const auto size = std::accumulate(
-          gap_filled_batches.cbegin(),
-          gap_filled_batches.cend(),
-          size_t{0},
-          [](size_t acc, const auto& batch) {
-              return acc + batch.size_bytes();
-          });
+        if (batches.empty()) {
+            vlog(_ctxlog.trace, "Read no batches for recovery, stopping");
+            _stop_requested = true;
+            co_return std::nullopt;
+        }
         vlog(
           _ctxlog.trace,
-          "Requesting throttle for {} bytes, available in throttle: {}",
-          size,
-          _ptr->_recovery_throttle->get().available());
-        co_await _ptr->_recovery_throttle->get()
-          .throttle(size, _ptr->_as)
-          .handle_exception_type([this](const ss::broken_semaphore&) {
-              vlog(_ctxlog.info, "Recovery throttling has stopped");
-          });
-    }
+          "Read batches in range [{},{}] for recovery",
+          batches.front().base_offset(),
+          batches.back().last_offset());
 
-    co_return model::make_foreign_memory_record_batch_reader(
-        std::move(gap_filled_batches));
+        auto gap_filled_batches = details::make_ghost_batches_in_gaps(
+          start_offset, std::move(batches));
+        _base_batch_offset = gap_filled_batches.begin()->base_offset();
+        _last_batch_offset = gap_filled_batches.back().last_offset();
+
+        if (is_learner && _ptr->_recovery_throttle) {
+            const auto size = std::accumulate(
+              gap_filled_batches.cbegin(),
+              gap_filled_batches.cend(),
+              size_t{0},
+              [](size_t acc, const auto& batch) {
+                  return acc + batch.size_bytes();
+              });
+            vlog(
+              _ctxlog.trace,
+              "Requesting throttle for {} bytes, available in throttle: {}",
+              size,
+              _ptr->_recovery_throttle->get().available());
+            co_await _ptr->_recovery_throttle->get()
+              .throttle(size, _ptr->_as)
+              .handle_exception_type([this](const ss::broken_semaphore&) {
+                  vlog(_ctxlog.info, "Recovery throttling has stopped");
+              });
+        }
+
+        co_return model::make_foreign_memory_record_batch_reader(
+          std::move(gap_filled_batches));
     } catch (const ss::timed_out_error& e) {
         vlog(
           _ctxlog.error,

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -82,7 +82,8 @@ struct mux_state_machine_fixture {
                   = config::mock_binding<std::chrono::milliseconds>(100ms),
                   .heartbeat_timeout
                   = config::mock_binding<std::chrono::milliseconds>(2000ms),
-                  .raft_io_timeout_ms = 30s,
+                  .raft_io_timeout_ms
+                  = config::mock_binding<std::chrono::milliseconds>(30s),
                 };
             },
             [] {

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -165,7 +165,7 @@ struct raft_node {
           raft::scheduling_config(
             seastar::default_scheduling_group(),
             seastar::default_priority_class()),
-          std::chrono::seconds(10),
+          config::mock_binding<std::chrono::milliseconds>(10s),
           raft::make_rpc_client_protocol(self_id, cache),
           [this](raft::leadership_status st) { leader_callback(st); },
           storage.local(),

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -995,7 +995,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
               .heartbeat_timeout
               = config::shard_local_cfg().raft_heartbeat_timeout_ms.bind(),
               .raft_io_timeout_ms
-              = config::shard_local_cfg().raft_io_timeout_ms()};
+              = config::shard_local_cfg().raft_io_timeout_ms.bind()};
         },
         [] {
             return raft::recovery_memory_quota::configuration{

--- a/tests/rptest/scale_tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/scale_tests/node_operations_fuzzy_test.py
@@ -95,7 +95,10 @@ class NodeOperationFuzzyTest(EndToEndTest):
             # make segments small to ensure that they are compacted during
             # the test (only sealed i.e. not being written segments are compacted)
             "compacted_log_segment_size": 5 * (2**20),
-            "raft_learner_recovery_rate": 512 * (1024 * 1024)
+            "raft_learner_recovery_rate": 512 * (1024 * 1024),
+            # set disk timeout to value greater than max suspend time
+            # not to emit spurious errors
+            "raft_io_timeout_ms": 20000,
         }
         if num_to_upgrade > 0:
             # Use the deprecated config to bootstrap older nodes.

--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -35,14 +35,17 @@ class AvailabilityTests(EndToEndFinjectorTest):
 
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_availability_when_one_node_failed(self):
-        self.redpanda = RedpandaService(self.test_context,
-                                        3,
-                                        extra_rp_conf={
-                                            "partition_autobalancing_mode":
-                                            "node_add",
-                                            "group_topic_partitions": 1,
-                                            "default_topic_replications": 3,
-                                        })
+        self.redpanda = RedpandaService(
+            self.test_context,
+            3,
+            extra_rp_conf={
+                "partition_autobalancing_mode": "node_add",
+                "group_topic_partitions": 1,
+                "default_topic_replications": 3,
+                # set disk timeout to value greater than max suspend time
+                # not to emit spurious errors
+                "raft_io_timeout_ms": 20000,
+            })
 
         self.redpanda.start()
         spec = TopicSpec(name="test-topic",
@@ -63,14 +66,17 @@ class AvailabilityTests(EndToEndFinjectorTest):
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_recovery_after_catastrophic_failure(self):
 
-        self.redpanda = RedpandaService(self.test_context,
-                                        3,
-                                        extra_rp_conf={
-                                            "partition_autobalancing_mode":
-                                            "node_add",
-                                            "group_topic_partitions": 1,
-                                            "default_topic_replications": 3,
-                                        })
+        self.redpanda = RedpandaService(
+            self.test_context,
+            3,
+            extra_rp_conf={
+                "partition_autobalancing_mode": "node_add",
+                "group_topic_partitions": 1,
+                "default_topic_replications": 3,
+                # set disk timeout to value greater than max suspend time
+                # not to emit spurious errors
+                "raft_io_timeout_ms": 20000,
+            })
 
         self.redpanda.start()
         spec = TopicSpec(name="test-topic",

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -55,6 +55,9 @@ class PartitionBalancerService(EndToEndTest):
                 "partition_autobalancing_node_availability_timeout_sec": 10,
                 "partition_autobalancing_tick_interval_ms": 5000,
                 "raft_learner_recovery_rate": 100_000_000,
+                # set disk timeout to value greater than max suspend time
+                # not to emit spurious errors
+                "raft_io_timeout_ms": 30000,
             },
             **kwargs,
         )

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -60,6 +60,9 @@ class RandomNodeOperationsTest(EndToEndTest):
             "default_topic_replications": 3,
             "raft_learner_recovery_rate": 512 * (1024 * 1024),
             "partition_autobalancing_mode": "node_add",
+            # set disk timeout to value greater than max suspend time
+            # not to emit spurious errors
+            "raft_io_timeout_ms": 20000,
         }
 
         self.redpanda = RedpandaService(self.test_context,


### PR DESCRIPTION
We saw an intermittent hang when reading batches in recovery stm. Added
a timeout when reading batches to send to the follower. When timeout
occur an error is logged. This way it will be easier to track the issue
in tests and real deployments.

Fixes: #8724
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
### Improvements
- easier debugging of long reads during recovery
