### PR TITLE
tests: fail fast on crashes in ManyClientsTest

### DIFF
--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -22,12 +22,7 @@ resource_settings = ResourceSettings(
 
     # Set a low memory size, such that there is only ~100k of memory available
     # for dealing with each client.
-    memory_mb=768,
-
-    # Test nodes and developer workstations may have slow fsync.  For this test
-    # we need things to be consistently fast, so disable fsync (this test
-    # has nothing to do with verifying the correctness of the storage layer)
-    bypass_fsync=True)
+    memory_mb=768)
 
 
 class ManyClientsTest(RedpandaTest):

--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -105,7 +105,7 @@ class ManyClientsTest(RedpandaTest):
             )
             return consumer_a.message_count + consumer_b.message_count >= expect
 
-        wait_until(complete,
-                   timeout_sec=30,
-                   backoff_sec=1,
-                   err_msg="Consumers didn't see all messages")
+        self.redpanda.wait_until(complete,
+                                 timeout_sec=30,
+                                 backoff_sec=1,
+                                 err_msg="Consumers didn't see all messages")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -230,7 +230,7 @@ class ResourceSettings:
             memory_mb = self._memory_mb
 
         if self._bypass_fsync is None and not dedicated_node:
-            bypass_fsync = False
+            bypass_fsync = True
         else:
             bypass_fsync = self._bypass_fsync
 


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
