### PR TITLE
Add support for deletion of group offsets to rpk

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/group/group.go
+++ b/src/go/rpk/pkg/cli/cmd/group/group.go
@@ -99,6 +99,7 @@ members and their lag), and manage offsets.
 		NewDescribeCommand(fs),
 		newListCommand(fs),
 		newSeekCommand(fs),
+		NewOffsetDeleteCommand(fs),
 	)
 
 	return cmd

--- a/src/go/rpk/pkg/cli/cmd/group/offset_delete.go
+++ b/src/go/rpk/pkg/cli/cmd/group/offset_delete.go
@@ -1,0 +1,126 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package group
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+func NewOffsetDeleteCommand(fs afero.Fs) *cobra.Command {
+	var (
+		fromFile        string
+		topicPartitions []string
+	)
+	cmd := &cobra.Command{
+		Use:   "offset-delete [GROUP] --from-file FILE --topic foo:0,1,2",
+		Short: "Delete offsets for a kafka group",
+		Long: `Forcefully delete offsets for a kafka group.
+
+The broker will only allow the request to succeed if the group is in a dead
+state (no subscriptions) or there are no subscriptions for offsets for
+topic/partitions requested to be deleted.
+
+Use either the --from-file or the --topic option. They are mututally exclusive.
+To indicate which topics or topic partitions you'd like to remove offsets from use
+the --topic (-t) flag, followed by a comma separated list of partition ids. Supplying
+no list will delete all offsets for all partitions for a given topic.
+
+You may also provide a text file to indicate topic/partition tuples. Use the
+--from-file flag for this option. The file must contain lines of topic/partitions
+separated by a tab or space. Example:
+
+topic_a 0
+topic_a 1
+topic_b 0
+`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p, cfg)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			// Parse input from file or command line
+			var topicsSet kadm.TopicsSet
+			if len(topicPartitions) > 0 {
+				topicsSet, err = parseTopicPartitionsArgs(topicPartitions)
+			} else if fromFile != "" {
+				topicsSet, err = parseTopicPartitionsFile(fs, fromFile)
+			} else {
+				err = fmt.Errorf("Must pass at least one command line argument --topic or --from-file")
+			}
+			out.MaybeDieErr(err)
+
+			// For -topic options that didn't include partitions, perform a
+			// lookup for them using a metadata request
+			mdResp, err := adm.Metadata(context.Background(), topicsSet.EmptyTopics()...)
+			out.MaybeDie(err, "unable to make metadata request: %v", err)
+			topicsSet.Merge(mdResp.Topics.TopicsSet())
+
+			responses, err := adm.DeleteOffsets(context.Background(), args[0], topicsSet)
+			out.MaybeDieErr(err)
+
+			tw := out.NewTabWriter()
+			defer tw.Flush()
+			for topic, partitionErrors := range responses {
+				for partition, err := range partitionErrors {
+					msg := "OK"
+					if err != nil {
+						msg = err.Error()
+					}
+					fmt.Fprintf(tw, "%s\t%d\t%s\n", topic, partition, msg)
+				}
+			}
+		},
+	}
+	cmd.Flags().StringVarP(&fromFile, "from-file", "f", "", "File of topic/partition tuples for which to delete offsets for")
+	cmd.Flags().StringArrayVarP(&topicPartitions, "topic", "t", nil, "topic:partition_id (repeatable; e.g. -t foo:0,1,2 )")
+	cmd.MarkFlagsMutuallyExclusive("from-file", "topic")
+	return cmd
+}
+
+func parseTopicPartitionsArgs(list []string) (kadm.TopicsSet, error) {
+	parsed, err := out.ParseTopicPartitions(list)
+	if err == nil {
+		topicsList := make(kadm.TopicsList, len(parsed))
+		for topic, partitions := range parsed {
+			topicsList = append(topicsList, kadm.TopicPartitions{Topic: topic, Partitions: partitions})
+		}
+		return topicsList.IntoSet(), nil
+	}
+	return nil, err
+}
+
+func parseTopicPartitionsFile(fs afero.Fs, file string) (kadm.TopicsSet, error) {
+	parsed, err := out.ParseFileArray[struct {
+		Topic     string
+		Partition int32
+	}](fs, file)
+	if err == nil {
+		topicsSet := make(kadm.TopicsSet)
+		for _, element := range parsed {
+			topicsSet.Add(element.Topic, element.Partition)
+		}
+		return topicsSet, nil
+	}
+	return nil, err
+}

--- a/src/go/rpk/pkg/out/in.go
+++ b/src/go/rpk/pkg/out/in.go
@@ -137,3 +137,28 @@ func parseSpaceLines[T any](r io.Reader) ([]T, error) {
 	}
 	return vs, nil
 }
+
+// ParseTopicPartitions parses a topic:pa,rt,it,io,ns flag.
+func ParseTopicPartitions(list []string) (map[string][]int32, error) {
+	tps := make(map[string][]int32)
+	for _, item := range list {
+		split := strings.SplitN(item, ":", 2)
+		if len(split) == 1 {
+			tps[split[0]] = nil
+			continue
+		}
+
+		strParts := strings.Split(split[1], ",")
+		i32Parts := make([]int32, 0, len(strParts))
+
+		for _, strPart := range strParts {
+			part, err := strconv.ParseInt(strPart, 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("item %q part %q parse err %w", item, strPart, err)
+			}
+			i32Parts = append(i32Parts, int32(part))
+		}
+		tps[split[0]] = i32Parts
+	}
+	return tps, nil
+}


### PR DESCRIPTION
This change adds a new command to rpk, under the `group` meta-command called `offset-delete` which will allow users to delete group offsets. Topic/Partitions can be passed to the command in two ways. 

1. Via the `--from-file` option. Taking an input a filename which is expected to be formatted to contain a list of topic partition tuples, and a group name via command line args.
```
$ cat input.txt
foo 0
bar 0
bar 1
bar 2

$ rpk group offset-delete my-consumer-group1 input.txt
bar  1     UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.
bar  0     UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.
bar  2     UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.
foo  0     OK
```

2. Via the `-topic (-t)` option. This option can be used repeatedly to pass topics or topic/partitions directly to the command. If only topics are used a metadata request will be made to find all the partitions for the topic, alleviating the need for the user to know the number of partitions for a topic if they just want to remove all offsets for a given consumer groups topic:
```
$ rpk group offset-delete my-consumer-group1 -topic foo -topic bar:0,1,2
bar  1     UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.
bar  0     UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.
bar  2     UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.
foo  0     OK
```

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* New command `rpk group offset-delete` will be added to `rpk`

## Release Notes
  ### Features

* New command `rpk group offset-delete` will be added to `rpk`