### PR TITLE
[v22.3.x] Skip moving partition on node addition if movement is already in progress

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -1016,6 +1016,10 @@ ss::future<> members_backend::reallocate_replica_set(
               meta.current_replica_set,
               meta.new_replica_set,
               error.message());
+            if (error == errc::update_in_progress) {
+                // Skip meta for this partition as it as already moving
+                meta.state = reallocation_state::finished;
+            }
             co_return;
         }
         // success, update state and move on


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8182
Fixes https://github.com/redpanda-data/redpanda/issues/8759,