### PR TITLE
rpk: bugfix - stop requiring HOME in unrelated cmd

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/plugin/install.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/install.go
@@ -145,9 +145,7 @@ command %q!
 		},
 	}
 
-	var err error
-	dir, err = plugin.DefaultBinPath()
-	out.MaybeDieErr(err)
+	dir, _ = plugin.DefaultBinPath()
 
 	cmd.Flags().StringVar(&dir, "dir", dir, "Destination directory to save the installed plugin (defaults to $HOME/.local/bin)")
 	cmd.Flags().BoolVarP(&update, "update", "u", false, "Update a locally installed plugin if it differs from the current remote version")


### PR DESCRIPTION
This change fixes a bug in which rpk will fail to run any command if the user's $HOME environment variable is not set.

We chose to ignore the error here since either way an empty string is a valid input (defaults to the pwd).

Fixes #8764


## Backports Required
- [ ] v22.3.x

## Release Notes
  ### Bug Fixes
  *  fixes a bug in which rpk will fail to run any command if the user's $HOME environment variable is not set.
