### PR TITLE
rpk: provide a way to override plugin install dir

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cloud/byoc/install.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/byoc/install.go
@@ -38,6 +38,9 @@ func newInstallCommand(fs afero.Fs) *cobra.Command {
 This command downloads the BYOC managed plugin if necessary. The plugin is
 installed by default if you try to run a non-install command, but this command
 exists if you want to download the plugin ahead of time.
+
+You can override the installation directory by setting the $RPK_PLUGIN_DIR 
+environment variable
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {

--- a/src/go/rpk/pkg/plugin/plugin.go
+++ b/src/go/rpk/pkg/plugin/plugin.go
@@ -37,6 +37,9 @@ import (
 // prefix.
 const FlagAutoComplete = "--help-autocomplete"
 
+// EnvPluginDir is the directory in which rpk will download a plugin.
+const EnvPluginDir = "RPK_PLUGIN_DIR"
+
 type pluginName struct {
 	autocomplete bool
 	managed      bool
@@ -150,8 +153,13 @@ func NameToArgs(command string) []string {
 }
 
 // DefaultBinPath returns HOME-DIR/.local/bin where HOME-DIR is the directory
-// returned by os.UserHomeDir.
+// returned by os.UserHomeDir. The default bin path can be overridden by the
+// $RPK_PLUGIN_DIR environment variable.
 func DefaultBinPath() (string, error) {
+	if dir, ok := os.LookupEnv(EnvPluginDir); ok {
+		return dir, nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("unable to get your home directory: %v", err)


### PR DESCRIPTION
Now you can use the environment variable $RPK_PLUGIN_DIR to override the install dir of the plugin.

Fixes #8743

## Backports Required
- [ ] v22.3.x

## Release Notes
  ### Features

  * rpk: now you can override the byoc plugin installation directory by setting the environment variable `RPK_PLUGIN_DIR`.
