### PR TITLE
Edit self-test help and UX text

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/selftest.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/selftest.go
@@ -29,7 +29,7 @@ func NewSelfTestCommand(fs afero.Fs) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "self-test",
-		Short: "Start, stop and query redpanda self-test runs through the admin listener",
+		Short: "Start, stop and query runs of Redpanda self-test through the Admin API listener",
 		Args:  cobra.ExactArgs(0),
 	}
 
@@ -50,7 +50,7 @@ func NewSelfTestCommand(fs afero.Fs) *cobra.Command {
 		&adminURL,
 		config.FlagAdminHosts2,
 		"",
-		"Comma-separated list of admin API addresses (<IP>:<port>)")
+		"Comma-separated list of Admin API addresses (<IP>:<port>)")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/status.go
@@ -34,17 +34,17 @@ func NewStatusCommand(fs afero.Fs) *cobra.Command {
 	var format string
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Queries status of current self test run or returns last results",
-		Long: `Returns self-test current or previous state.
+		Short: "Queries the status of the currently running or last completed self-test run",
+		Long: `Returns the status of the currently running or last completed self-test run.
 
 Use this command after invoking 'self-test start' to determine the status of
 the jobs launched. Possible results are:
 
 * One or more jobs still running
-  * Node ids of redpanda nodes that are still running self-tests.
+  * Returns the IDs of Redpanda nodes still running self-tests.
 
 * No jobs running:
-  * Last cached results on all nodes returned.
+  * Returns cached results for all nodes of the last completed test.
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {

--- a/src/go/rpk/pkg/cli/cmd/cluster/selftest/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/selftest/stop.go
@@ -23,15 +23,11 @@ import (
 func NewStopCommand(fs afero.Fs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "stop",
-		Short: "Stops the currently executing self test",
-		Long: `Stops all self tests.
+		Short: "Stops the currently executing self-test",
+		Long: `Stops all self-test tests.
 
-For use with the redpanda self-test framework, this command will stop all currently
-executing self-tests cluster wide. The command is synchronous and will return
-when either:
-
-* all jobs have been stopped - success reported
-* broker timeouts have expired - errors reported
+This command stops all currently running self-tests. The command is synchronous and returns
+success when all jobs have been stopped or reports errors if broker timeouts have expired.
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {


### PR DESCRIPTION
Edits the UX/help text of `rpk cluster self-test` of https://github.com/redpanda-data/redpanda/pull/8398, and supports its docs PR https://github.com/redpanda-data/documentation/pull/1152.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* Edits the UX/help text of `rpk cluster self-test`, `rpk cluster self-test start`, `rpk cluster self-test status`, `rpk cluster self-test stop`

## Release Notes

* none
