### PR TITLE
Draft Issue/8486/newstuff

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1248,20 +1248,28 @@ rm_stm::do_mark_expired(model::producer_identity pid) {
     co_return std::error_code(tx_errc::none);
 }
 
-bool rm_stm::check_seq(model::batch_identity bid) {
-    auto& seq = _log_state.seq_table[bid.pid].entry;
+bool rm_stm::check_seq(model::batch_identity bid, model::term_id term) {
+    auto& seq_it = _log_state.seq_table[bid.pid];
     auto last_write_timestamp = model::timestamp::now().value();
 
-    if (!is_sequence(seq.seq, bid.first_seq)) {
+    if (!is_sequence(seq_it.entry.seq, bid.first_seq)) {
+        vlog(
+          _ctx_log.warn,
+          "provided seq:{} for pid:{} isn't a continuation of the last known "
+          "seq:{}",
+          bid.first_seq,
+          bid.pid,
+          seq_it.entry.seq);
         return false;
     }
 
-    seq.update(bid.last_seq, kafka::offset{-1});
+    seq_it.entry.update(bid.last_seq, kafka::offset{-1});
 
-    seq.pid = bid.pid;
-    seq.last_write_timestamp = last_write_timestamp;
+    seq_it.entry.pid = bid.pid;
+    seq_it.entry.last_write_timestamp = last_write_timestamp;
+    seq_it.term = term;
     _oldest_session = std::min(
-      _oldest_session, model::timestamp(seq.last_write_timestamp));
+      _oldest_session, model::timestamp(seq_it.entry.last_write_timestamp));
 
     return true;
 }
@@ -1300,15 +1308,16 @@ void rm_stm::set_seq(model::batch_identity bid, kafka::offset last_offset) {
     }
 }
 
-void rm_stm::reset_seq(model::batch_identity bid) {
+void rm_stm::reset_seq(model::batch_identity bid, model::term_id term) {
     _log_state.erase_pid_from_seq_table(bid.pid);
-    auto& seq = _log_state.seq_table[bid.pid].entry;
-    seq.seq = bid.last_seq;
-    seq.last_offset = kafka::offset{-1};
-    seq.pid = bid.pid;
-    seq.last_write_timestamp = model::timestamp::now().value();
+    auto& seq_it = _log_state.seq_table[bid.pid];
+    seq_it.term = term;
+    seq_it.entry.seq = bid.last_seq;
+    seq_it.entry.last_offset = kafka::offset{-1};
+    seq_it.entry.pid = bid.pid;
+    seq_it.entry.last_write_timestamp = model::timestamp::now().value();
     _oldest_session = std::min(
-      _oldest_session, model::timestamp(seq.last_write_timestamp));
+      _oldest_session, model::timestamp(seq_it.entry.last_write_timestamp));
 }
 
 ss::future<result<kafka_result>>
@@ -1386,27 +1395,66 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
 
     if (_log_state.ongoing_map.contains(bid.pid)) {
         // this isn't the first attempt in the tx we should try dedupe
-        auto cached_offset = known_seq(bid);
-        if (cached_offset) {
-            if (cached_offset.value() < kafka::offset{0}) {
+        auto pid_seq = _log_state.seq_table.find(bid.pid);
+        if (pid_seq == _log_state.seq_table.end()) {
+            if (!check_seq(bid, synced_term)) {
+                co_return errc::sequence_out_of_order;
+            }
+        } else if (pid_seq->second.entry.seq == bid.last_seq) {
+            if (pid_seq->second.entry.last_offset() == -1) {
+                if (pid_seq->second.term == synced_term) {
+                    vlog(
+                      _ctx_log.debug,
+                      "Status of the original attempt pid:{} seq:{} is "
+                      "unknown. Returning not_leader_for_partition to trigger "
+                      "retry.",
+                      bid.pid,
+                      bid.last_seq);
+                    co_return errc::not_leader;
+                } else {
+                    // when the term a tx originated on doesn't match the
+                    // current term it means that the re-election happens; upon
+                    // re-election we sync and it catches up with all records
+                    // replicated in previous term. since the cached offset for
+                    // a given seq is still -1 it means that the replication
+                    // hasn't passed so we updating the term to pretent that the
+                    // retry (seqs match) put it there
+                    pid_seq->second.term = synced_term;
+                }
+            } else {
                 vlog(
-                  _ctx_log.debug,
-                  "Status of the original attempt pid:{} seq:{} is unknown. "
-                  "Returning not_leader_for_partition to trigger retry.",
+                  _ctx_log.trace,
+                  "cache hit for pid:{} seq:{}",
                   bid.pid,
                   bid.last_seq);
-                co_return errc::not_leader;
+                co_return kafka_result{
+                  .last_offset = pid_seq->second.entry.last_offset};
             }
-            vlog(_ctx_log.trace, "cache hit for pid:{}", bid.pid);
-            co_return kafka_result{.last_offset = cached_offset.value()};
-        }
-
-        if (!check_seq(bid)) {
-            co_return errc::sequence_out_of_order;
+        } else {
+            for (auto& entry : pid_seq->second.entry.seq_cache) {
+                if (entry.seq == bid.last_seq) {
+                    if (entry.offset() == -1) {
+                        vlog(
+                          _ctx_log.error,
+                          "cache hit for pid:{} seq:{} resolves to -1 offset",
+                          bid.pid,
+                          entry.seq);
+                    }
+                    vlog(
+                      _ctx_log.trace,
+                      "cache hit for pid:{} seq:{}",
+                      bid.pid,
+                      entry.seq);
+                    co_return kafka_result{.last_offset = entry.offset};
+                }
+            }
+            if (!check_seq(bid, synced_term)) {
+                co_return errc::sequence_out_of_order;
+            }
         }
     } else {
         // this is the first attempt in the tx, reset dedupe cache
-        reset_seq(bid);
+        reset_seq(bid, synced_term);
 
         _mem_state.estimated[bid.pid] = _insync_offset;
     }
@@ -2528,6 +2576,7 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
             _log_state.seq_table.try_emplace(it, pid, std::move(seq));
         } else if (it->second.entry.seq < entry.seq) {
             it->second.entry = std::move(entry);
+            it->second.term = model::term_id(-1);
         }
     }
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -320,10 +320,10 @@ private:
     ss::future<std::optional<abort_snapshot>> load_abort_snapshot(abort_index);
     ss::future<> save_abort_snapshot(abort_snapshot);
 
-    bool check_seq(model::batch_identity);
+    bool check_seq(model::batch_identity, model::term_id);
     std::optional<kafka::offset> known_seq(model::batch_identity) const;
     void set_seq(model::batch_identity, kafka::offset);
-    void reset_seq(model::batch_identity);
+    void reset_seq(model::batch_identity, model::term_id);
     std::optional<int32_t> tail_seq(model::producer_identity) const;
 
     ss::future<result<kafka_result>> do_replicate(
@@ -394,6 +394,7 @@ private:
 
     struct seq_entry_wrapper {
         seq_entry entry;
+        model::term_id term;
         safe_intrusive_list_hook _hook;
 
         seq_entry_wrapper() = default;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -181,7 +181,7 @@ struct try_abort_request
     model::partition_id tm;
     model::producer_identity pid;
     model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout;
+    model::timeout_clock::duration timeout{};
 
     try_abort_request() noexcept = default;
 
@@ -245,9 +245,9 @@ struct init_tm_tx_request
       init_tm_tx_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    kafka::transactional_id tx_id;
-    std::chrono::milliseconds transaction_timeout_ms;
-    model::timeout_clock::duration timeout;
+    kafka::transactional_id tx_id{};
+    std::chrono::milliseconds transaction_timeout_ms{};
+    model::timeout_clock::duration timeout{};
 
     init_tm_tx_request() noexcept = default;
 
@@ -339,7 +339,7 @@ struct fetch_tx_request
     using rpc_adl_exempt = std::true_type;
 
     kafka::transactional_id tx_id{};
-    model::term_id term;
+    model::term_id term{};
 
     fetch_tx_request() noexcept = default;
 
@@ -418,17 +418,17 @@ struct fetch_tx_reply
     };
 
     tx_errc ec{};
-    model::producer_identity pid;
-    model::producer_identity last_pid;
-    model::tx_seq tx_seq;
+    model::producer_identity pid{};
+    model::producer_identity last_pid{};
+    model::tx_seq tx_seq{};
     std::chrono::milliseconds timeout_ms{};
-    tx_status status;
-    std::vector<tx_partition> partitions;
-    std::vector<tx_group> groups;
+    tx_status status{};
+    std::vector<tx_partition> partitions{};
+    std::vector<tx_group> groups{};
 
     fetch_tx_reply() noexcept = default;
 
-    explicit fetch_tx_reply(tx_errc ec)
+    fetch_tx_reply(tx_errc ec)
       : ec(ec) {}
 
     fetch_tx_reply(
@@ -466,7 +466,7 @@ struct begin_tx_request
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
-    std::chrono::milliseconds transaction_timeout_ms;
+    std::chrono::milliseconds transaction_timeout_ms{};
 
     begin_tx_request() noexcept = default;
 
@@ -537,7 +537,7 @@ struct prepare_tx_request
     model::partition_id tm;
     model::producer_identity pid;
     model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout;
+    model::timeout_clock::duration timeout{};
 
     prepare_tx_request() noexcept = default;
 
@@ -569,7 +569,7 @@ struct prepare_tx_request
 struct prepare_tx_reply
   : serde::
       envelope<prepare_tx_reply, serde::version<0>, serde::compat_version<0>> {
-    tx_errc ec;
+    tx_errc ec{};
 
     prepare_tx_reply() noexcept = default;
 
@@ -590,7 +590,7 @@ struct commit_tx_request
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout;
+    model::timeout_clock::duration timeout{};
 
     commit_tx_request() noexcept = default;
 
@@ -616,7 +616,7 @@ struct commit_tx_request
 struct commit_tx_reply
   : serde::
       envelope<commit_tx_reply, serde::version<0>, serde::compat_version<0>> {
-    tx_errc ec;
+    tx_errc ec{};
 
     commit_tx_reply() noexcept = default;
 
@@ -637,7 +637,7 @@ struct abort_tx_request
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout;
+    model::timeout_clock::duration timeout{};
 
     abort_tx_request() noexcept = default;
 
@@ -662,7 +662,7 @@ struct abort_tx_request
 struct abort_tx_reply
   : serde::
       envelope<abort_tx_reply, serde::version<0>, serde::compat_version<0>> {
-    tx_errc ec;
+    tx_errc ec{};
 
     abort_tx_reply() noexcept = default;
 
@@ -686,7 +686,7 @@ struct begin_group_tx_request
     kafka::group_id group_id;
     model::producer_identity pid;
     model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout;
+    model::timeout_clock::duration timeout{};
 
     begin_group_tx_request() noexcept = default;
 
@@ -732,7 +732,7 @@ struct begin_group_tx_reply
       serde::version<0>,
       serde::compat_version<0>> {
     model::term_id etag;
-    tx_errc ec;
+    tx_errc ec{};
 
     begin_group_tx_reply() noexcept = default;
 
@@ -763,7 +763,7 @@ struct prepare_group_tx_request
     model::term_id etag;
     model::producer_identity pid;
     model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout;
+    model::timeout_clock::duration timeout{};
 
     prepare_group_tx_request() noexcept = default;
 
@@ -811,7 +811,7 @@ struct prepare_group_tx_reply
       prepare_group_tx_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    tx_errc ec;
+    tx_errc ec{};
 
     prepare_group_tx_reply() noexcept = default;
 
@@ -837,7 +837,7 @@ struct commit_group_tx_request
     model::producer_identity pid;
     model::tx_seq tx_seq;
     kafka::group_id group_id;
-    model::timeout_clock::duration timeout;
+    model::timeout_clock::duration timeout{};
 
     commit_group_tx_request() noexcept = default;
 
@@ -882,7 +882,7 @@ struct commit_group_tx_reply
       commit_group_tx_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    tx_errc ec;
+    tx_errc ec{};
 
     commit_group_tx_reply() noexcept = default;
 
@@ -908,7 +908,7 @@ struct abort_group_tx_request
     kafka::group_id group_id;
     model::producer_identity pid;
     model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout;
+    model::timeout_clock::duration timeout{};
 
     abort_group_tx_request() noexcept = default;
 
@@ -953,7 +953,7 @@ struct abort_group_tx_reply
       abort_group_tx_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    tx_errc ec;
+    tx_errc ec{};
 
     abort_group_tx_reply() noexcept = default;
 

--- a/tests/java/verifiers/src/main/java/io/vectorized/compaction/App.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/compaction/App.java
@@ -16,13 +16,15 @@ public class App {
     public long min_writes = 0;
     public long min_reads = 0;
 
-    public ArrayList<ConsumerMetrics> consumers = new ArrayList<>();
+    public ArrayList<PartitionMetrics> partitions = new ArrayList<>();
   }
 
-  public static class ConsumerMetrics {
+  public static class PartitionMetrics {
     public int partition;
     public long end_offset = -1;
     public long read_offset = -1;
+    public long read_position = -1;
+    public long written_offset = -1;
     public boolean consumed = false;
   }
 

--- a/tests/rptest/services/compacted_verifier.py
+++ b/tests/rptest/services/compacted_verifier.py
@@ -206,15 +206,12 @@ class CompactedVerifier(Service):
     def remote_wait_consumer(self, timeout_sec=30):
         def check_consumed():
             info = self.remote_info()
-            if len(info["consumers"]) != self._partitions:
-                self._redpanda.logger.debug(
-                    f"Not all consumers have started {len(info['consumers'])} of {self._partitions}"
-                )
+            if len(info["partitions"]) != self._partitions:
                 return False
-            for consumer in info["consumers"]:
-                if not consumer["consumed"]:
+            for partition in info["partitions"]:
+                if not partition["consumed"]:
                     self._redpanda.logger.debug(
-                        f"Consumption of partition {consumer['partition']} isn't finished"
+                        f"Consumption of partition {partition['partition']} isn't finished"
                     )
                     return False
             return True

--- a/tests/rptest/services/compacted_verifier.py
+++ b/tests/rptest/services/compacted_verifier.py
@@ -251,6 +251,8 @@ class CompactedVerifier(Service):
                 return (True, self._remote_info())
             except CrushedException:
                 raise
+            except ConsistencyViolationException:
+                raise
             except:
                 self._redpanda.logger.debug(
                     "Got error on fetching info, retrying?!", exc_info=True)

--- a/tests/rptest/tests/compaction_e2e_test.py
+++ b/tests/rptest/tests/compaction_e2e_test.py
@@ -37,7 +37,6 @@ class CompactionE2EIdempotencyTest(RedpandaTest):
 
         return [len(p.segments) for p in topic_partitions]
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8486
     @cluster(num_nodes=4)
     @matrix(
         initial_cleanup_policy=[


### PR DESCRIPTION
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
