### PR TITLE
Handle semaphore timed out exception in reconnect transport

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -272,6 +272,7 @@ cluster::errc map_update_interruption_error_code(std::error_code ec) {
         case rpc::errc::success:
             return errc::success;
         case rpc::errc::client_request_timeout:
+        case rpc::errc::connection_timeout:
             return errc::timeout;
         case rpc::errc::disconnected_endpoint:
         case rpc::errc::exponential_backoff:

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -845,6 +845,7 @@ ss::future<> admin_server::throw_on_error(
               fmt::format("Not ready: {}", ec.message()),
               ss::httpd::reply::status_type::service_unavailable);
         case rpc::errc::client_request_timeout:
+        case rpc::errc::connection_timeout:
             throw ss::httpd::base_exception(
               fmt::format("Timeout: {}", ec.message()),
               ss::httpd::reply::status_type::gateway_timeout);

--- a/src/v/rpc/errc.h
+++ b/src/v/rpc/errc.h
@@ -24,6 +24,7 @@ enum class errc {
     service_error,
     method_not_found,
     version_not_supported,
+    connection_timeout,
 
     // Used when receiving an undefined errc (e.g. from a newer version of
     // Redpanda).
@@ -46,6 +47,8 @@ struct errc_category final : public std::error_category {
             return "rpc::errc::client_request_timeout";
         case errc::version_not_supported:
             return "rpc::errc::version_not_supported";
+        case errc::connection_timeout:
+            return "rpc::errc::connection_timeout";
         default:
             return "rpc::errc::unknown(" + std::to_string(c) + ")";
         }

--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -65,7 +65,7 @@ private:
 
     rpc::transport _transport;
     rpc::clock_type::time_point _stamp{rpc::clock_type::now()};
-    ssx::semaphore _connected_sem{1, "raft/connected"};
+    ssx::semaphore _connected_sem{1, "rpc/reconnection"};
     ss::gate _dispatch_gate;
     backoff_policy _backoff_policy;
 };


### PR DESCRIPTION
As all the error handling in `rpc::reconnect_transport` is `result`
based user may not handle the exceptions. Handling semaphore timeout
exception and returning `connection timeout` error.
Related: #8751
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
  * none
