### PR TITLE
schema_registry/protobuf: Early exit recursion if file exists

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -173,6 +173,9 @@ build_file(pb::DescriptorPool& dp, const pb::FileDescriptorProto& fdp) {
 ss::future<const pb::FileDescriptor*> build_file_with_refs(
   pb::DescriptorPool& dp, sharded_store& store, canonical_schema schema) {
     for (const auto& ref : schema.refs()) {
+        if (dp.FindFileByName(ref.name)) {
+            continue;
+        }
         auto dep = co_await store.get_subject_schema(
           ref.sub, ref.version, include_deleted::no);
         co_await build_file_with_refs(

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
@@ -44,3 +44,15 @@ message Test3 {
   Test2 id =  1;
 })",
   pps::schema_type::protobuf};
+
+const auto imported_twice = pps::canonical_schema_definition{
+  R"(
+syntax = "proto3";
+
+import "simple";
+import "imported";
+
+message Test3 {
+  Test2 id =  1;
+})",
+  pps::schema_type::protobuf};


### PR DESCRIPTION
During a depth-first search for references, it's possible for a reference to be looked up and added to the `DescriptorPool` multiple times, which fails.

If the `DescriptorPool` contains the reference already, early exit without a looking up the referenced schema, and adding it to the dp.

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

* none

## Release Notes

### Bug Fixes

* Schema Registry: Improve protobuf support