### PR TITLE
s/segment_reader: gate in-flight operations

### DIFF
--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -166,6 +166,8 @@ private:
     unsigned _read_ahead{0};
     debug_sanitize_files _sanitize;
 
+    // Keeps track of operations that cannot be pre-empted by close()
+    ss::gate _gate;
     // Acquire a handle to use the underlying file handle
     ss::future<segment_reader_handle> get();
 


### PR DESCRIPTION
This commit introduces a gate that guards against the closing of the
'segment_reader' while there are in-flight operations that cannot be pre-empted
(for instance, creating new 'segment_reader_handle').

Previously, we ran into use-after-free scenarios where the 'segment'
(and implicitly the 'segment_reader') was removed with oustanding
futures in the reader. This could happen if we were attempting to
create a 'segment_reader_handle' while the segment was destroyed.

We've seen this scenario occur during compaction either due to the
segment getting erased (adjacent compaction) or due to the reader being
swapped out.

Fixes #8510

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
* none