### PR TITLE
[v22.3.x] Backport #8090 (partially)

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -462,7 +462,9 @@ ss::future<upload_result> remote::upload_segment(
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 permit.delay));
             _probe.upload_backoff();
-            co_await ss::sleep_abortable(permit.delay, _as);
+            if (!lazy_abort_source.abort_requested()) {
+                co_await ss::sleep_abortable(permit.delay, _as);
+            }
             permit = fib.retry();
             break;
         case error_outcome::notfound:

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -222,11 +222,17 @@ def wait_for_local_storage_truncate(redpanda,
         storage = redpanda.storage(sizes=True)
         sizes = []
         for node_partition in storage.partitions("kafka", topic):
+            if node_partition.num != partition_idx:
+                continue
             total_size = sum(s.size if s.size else 0
                              for s in node_partition.segments.values())
             redpanda.logger.debug(
                 f"  {topic}/{partition_idx} node {node_partition.node.name} local size {total_size} ({len(node_partition.segments)} segments)"
             )
+            for s in node_partition.segments.values():
+                redpanda.logger.debug(
+                    f"    {topic}/{partition_idx} node {node_partition.node.name} {s.name} {s.size}"
+                )
             sizes.append(total_size)
 
         return all(s <= target_bytes for s in sizes)


### PR DESCRIPTION
The overall PR is too invasive to backport, because it depends on the big refactor of ntp_archiver to be part of cluster::partition, but the test fixes should make sense on v22.3.x.

Backport of PR #8090

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none

