### PR TITLE
[v22.3.x] Backport of #8689 Remove duplicate responses sent by offset_fetch request handler

### DIFF
--- a/src/v/kafka/server/handlers/offset_fetch.cc
+++ b/src/v/kafka/server/handlers/offset_fetch.cc
@@ -95,7 +95,6 @@ offset_fetch_handler::handle(request_context ctx, ss::smp_service_group) {
             auto& partition = topic.partitions.emplace_back();
             partition.partition_index = partition_index;
             partition.error_code = error_code::group_authorization_failed;
-            topic.partitions.push_back(std::move(partition));
         }
     }
 


### PR DESCRIPTION
Backport of PR #8689 

## Release Notes

  ### Bug Fixes

  * Fix for bug where duplicate responses were sent in offset_fetch responses
