### PR TITLE
tests: add missing dependency to central script

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -27,9 +27,7 @@ RUN /opt/ducktape-deps.sh install_java_client_deps && \
 # Install kafka streams examples.  This is a very slow step (tens of minutes), doing
 # many maven dependency downloads without any parallelism.  To avoid re-running it
 # on unrelated changes in other steps, this step is as early on the Dockerfile as possible.
-RUN git -C /opt clone https://github.com/redpanda-data/kafka-streams-examples.git && \
-    cd /opt/kafka-streams-examples && git reset --hard 913d08c8351c74ee454b79f8e0c1f48ca9b562a5 && \
-    mvn -DskipTests=true clean package
+RUN /opt/ducktape-deps.sh install_kafka_streams_examples
 
 # Install the OMB tool
 RUN /opt/ducktape-deps.sh install_omb

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -140,4 +140,11 @@ function install_addr2line() {
     chmod +x /opt/scripts/seastar-addr2line
 }
 
+function install_kafka_streams_examples() {
+  git -C /opt clone https://github.com/redpanda-data/kafka-streams-examples.git
+  cd /opt/kafka-streams-examples
+  git reset --hard 913d08c8351c74ee454b79f8e0c1f48ca9b562a5
+  mvn -DskipTests=true clean package
+}
+
 $@


### PR DESCRIPTION
`kafka_streams_examples` dependency was missing from the `ducktape-deps.sh` script.

ref https://github.com/redpanda-data/vtools/issues/1451


## Backports Required

- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none