### PR TITLE
Add additional ducktape assertions for self-test

### DIFF
--- a/tests/rptest/utils/functional.py
+++ b/tests/rptest/utils/functional.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from functools import reduce
+
+
+def flat_map(fn, input_list):
+    """
+    Expect a function `fn` that accepts 1 argument and returns a list.
+
+    Returns the appended results of all of the invocations of fn(x) against
+    each argument in `input_list`.
+    """
+    return reduce(lambda acc, x: acc + fn(x), input_list, [])


### PR DESCRIPTION
Adding some assertions about the result set returned from successful self-test runs. Asserting the number of disk and the combinations of network tests run are within expected parameters. 

## Backports Required

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none
