### PR TITLE
cloud_storage: Add randomized tests back

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1120,7 +1120,7 @@ ss::future<> partition_manifest::update(ss::input_stream<char> is) {
           cst_log.debug, "Failed to parse manifest: {}", result.hexdump(2048));
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
-          "Failed to parse topic manifest {}: {} at offset {}",
+          "Failed to parse partition manifest {}: {} at offset {}",
           get_manifest_path(),
           rapidjson::GetParseError_En(e),
           o));

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -800,7 +800,7 @@ SEASTAR_THREAD_TEST_CASE(test_no_closing_bracket_meta) {
       std::runtime_error,
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
-                   "Failed to parse topic manifest "
+                   "Failed to parse partition manifest "
                    "{\"b0000000/meta///-2147483648_-9223372036854775808/"
                    "manifest.json\"}: Missing a comma or '}' after an object "
                    "member. at offset 325")

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -167,6 +167,7 @@ make_segment(model::offset base, const std::vector<batch_t>& batches) {
     s.sname = segment_name(fmt::format("{}-1-v1.log", s.base_offset()));
     s.num_config_batches = num_config_batches;
     s.num_config_records = num_config_records;
+    s.delta_offset_overlap = 0;
     return s;
 }
 
@@ -297,9 +298,7 @@ static std::vector<in_memory_segment> make_segments(
         for (int i = 0; i < segments.size(); i++) {
             const auto& batches = segments[i];
             auto body = make_segment(base_offset, batches);
-            if (
-              base_offset != model::offset(0) && prev.headers.size() > 0
-              && body.headers.size() > 0) {
+            if (i > 0) {
                 auto merged = merge_in_memory_segments(prev, body);
                 auto truncated = copy_subsegment(
                   merged, prev.headers.size() - 1, body.headers.size() + 1);
@@ -313,6 +312,7 @@ static std::vector<in_memory_segment> make_segments(
                       : 0;
                 s.push_back(std::move(truncated));
             } else {
+                BOOST_REQUIRE(body.delta_offset_overlap == 0);
                 prev = copy_in_memory_segment(body);
                 s.push_back(std::move(body));
             }
@@ -2240,6 +2240,216 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
                        });
     ss::with_timeout(model::timeout_clock::now() + 60s, std::move(close_fut))
       .get();
+}
+
+/// This test scans the partition with overlapping segments
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_overlap_1, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 10;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    batch_t data = {
+      .num_records = 1, .type = model::record_batch_type::raft_data};
+    batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+    };
+
+    auto num_conf_batches = 0;
+    for (const auto& segment : batch_types) {
+        for (const auto& b : segment) {
+            if (b.type == model::record_batch_type::raft_configuration) {
+                num_conf_batches++;
+            }
+        }
+    }
+
+    auto segments = setup_s3_imposter(
+      *this, batch_types, manifest_inconsistency::overlapping_segments);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    for (size_t sz : client_batch_sizes) {
+        auto headers_read = scan_remote_partition_incrementally(
+          *this, base, max, sz);
+
+        BOOST_REQUIRE_EQUAL(
+          headers_read.size(), total_batches - num_conf_batches);
+    }
+}
+
+/// This test scans the partition with duplicates
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_with_duplicates_1,
+  cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 10;
+    constexpr int num_segments_with_duplicates = num_segments * 2;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+    };
+
+    auto num_conf_batches = 0;
+    auto num_data_batches = 0;
+    for (const auto& segment : batch_types) {
+        for (const auto& b : segment) {
+            if (b.type == model::record_batch_type::raft_configuration) {
+                num_conf_batches++;
+            } else {
+                num_data_batches++;
+            }
+        }
+    }
+
+    auto segments = setup_s3_imposter(
+      *this, batch_types, manifest_inconsistency::duplicate_offset_ranges);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments_with_duplicates - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    for (size_t bsize : client_batch_sizes) {
+        auto headers_read = scan_remote_partition_incrementally(
+          *this, base, max, bsize);
+        if (headers_read.size() != num_data_batches) {
+            vlog(
+              test_log.error,
+              "Number of headers read: {}, expected: {}",
+              headers_read.size(),
+              total_batches - num_conf_batches);
+            for (const auto& hdr : headers_read) {
+                vlog(
+                  test_log.info,
+                  "base offset: {}, last offset: {}",
+                  hdr.base_offset,
+                  hdr.last_offset());
+            }
+        }
+        BOOST_REQUIRE(headers_read.size() == num_data_batches);
+    }
+}
+
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_with_duplicates_2,
+  cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 10;
+    constexpr int num_segments_with_duplicates = num_segments * 2;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+      {conf, data, data, conf, data, data, conf, data, data, conf},
+    };
+
+    auto num_conf_batches = 0;
+    auto num_data_batches = 0;
+    for (const auto& segment : batch_types) {
+        for (const auto& b : segment) {
+            if (b.type == model::record_batch_type::raft_configuration) {
+                num_conf_batches++;
+            } else {
+                num_data_batches++;
+            }
+        }
+    }
+
+    auto segments = setup_s3_imposter(
+      *this, batch_types, manifest_inconsistency::duplicate_offset_ranges);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments_with_duplicates - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    for (size_t bsize : client_batch_sizes) {
+        auto headers_read = scan_remote_partition_incrementally(
+          *this, base, max, bsize);
+        if (headers_read.size() != num_data_batches) {
+            vlog(
+              test_log.error,
+              "Number of headers read: {}, expected: {}",
+              headers_read.size(),
+              total_batches - num_conf_batches);
+            for (const auto& hdr : headers_read) {
+                vlog(
+                  test_log.info,
+                  "base offset: {}, last offset: {}",
+                  hdr.base_offset,
+                  hdr.last_offset());
+            }
+        }
+        BOOST_REQUIRE(headers_read.size() == num_data_batches);
+    }
+}
+
+FIXTURE_TEST(
+  test_remote_partition_scan_incrementally_random_with_overlaps,
+  cloud_storage_fixture) {
+    constexpr int num_segments = 1000;
+    const auto [batch_types, num_data_batches] = generate_segment_layout(
+      num_segments, 42);
+    auto segments = setup_s3_imposter(
+      *this, batch_types, manifest_inconsistency::overlapping_segments);
+    auto base = segments[0].base_offset;
+    auto max = segments.back().max_offset;
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+
+    scan_remote_partition_incrementally(*this, base, max);
+}
+
+FIXTURE_TEST(
+  test_remote_partition_scan_incrementally_random_with_duplicates,
+  cloud_storage_fixture) {
+    constexpr int num_segments = 500;
+    const auto [batch_types, num_data_batches] = generate_segment_layout(
+      num_segments, 42);
+    auto segments = setup_s3_imposter(
+      *this, batch_types, manifest_inconsistency::duplicate_offset_ranges);
+    auto base = segments[0].base_offset;
+    auto max = segments.back().max_offset;
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+
+    scan_remote_partition_incrementally(*this, base, max);
 }
 
 FIXTURE_TEST(

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ rp_test(
     readers_cache_test.cc
     concat_segment_reader_test.cc
     offset_to_filepos_test.cc
+    offset_translator_state_test.cc
   LIBRARIES v::seastar_testing_main v::storage_test_utils v::model_test_utils
   LABELS storage
   ARGS "-- -c 1"

--- a/src/v/storage/tests/offset_translator_state_test.cc
+++ b/src/v/storage/tests/offset_translator_state_test.cc
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "model/fundamental.h"
+#include "storage/offset_translator_state.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <cstdint>
+#include <stdexcept>
+
+static const model::ntp ntp;
+
+/// Convert to redpanda log offset
+constexpr model::offset operator"" _rp(unsigned long long o) {
+    return model::offset((int64_t)o);
+}
+
+constexpr model::offset_delta operator"" _do(unsigned long long o) {
+    return model::offset_delta((int64_t)o);
+}
+
+SEASTAR_THREAD_TEST_CASE(offset_translator_state_add_normal) {
+    storage::offset_translator_state state(ntp);
+
+    // base offset
+    // segment 1 |[10...gap...14] data [18..gap..19]|
+    // segment 2 |20          25..gap...28          |
+
+    // segment 1
+    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    state.add_gap(10_rp, 14_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    state.add_gap(18_rp, 19_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 12_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 19_rp);
+
+    // segment 2
+    BOOST_REQUIRE(!state.add_absolute_delta(20_rp, 12));
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 12_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 19_rp);
+    state.add_gap(25_rp, 28_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 16_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 28_rp);
+}
+
+SEASTAR_THREAD_TEST_CASE(offset_translator_state_overlap_non_data_batch) {
+    storage::offset_translator_state state(ntp);
+
+    // base offset
+    // segment 1 |[10...gap...14] data [18..gap..20]|
+    // segment 2 |[18...gap...20] data              |
+
+    // segment 1
+    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    state.add_gap(10_rp, 14_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    state.add_gap(18_rp, 20_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+
+    // segment 2
+    BOOST_REQUIRE(!state.add_absolute_delta(
+      18_rp, 10)); // delta_offset is set to 10 because archival metadata
+                   // doesn't take overlap into account and doesn't know about
+                   // offset 20 in the first segment.
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+    state.add_gap(18_rp, 20_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+}
+
+SEASTAR_THREAD_TEST_CASE(offset_translator_state_duplicate) {
+    storage::offset_translator_state state(ntp);
+
+    // base offset
+    // segment 1 |[10...gap...14] data [18..gap..20]|
+    // segment 2 |[10...gap...14] data [18..gap..20]|
+
+    // segment 1
+    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    state.add_gap(10_rp, 14_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    state.add_gap(18_rp, 20_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+
+    // segment 2
+    BOOST_REQUIRE(!state.add_absolute_delta(10_rp, 5));
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+    state.add_gap(10_rp, 14_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+    state.add_gap(18_rp, 20_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+}
+
+SEASTAR_THREAD_TEST_CASE(offset_translator_state_inconsistency_1) {
+    storage::offset_translator_state state(ntp);
+
+    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    state.add_gap(10_rp, 14_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    state.add_gap(18_rp, 20_rp);
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+    BOOST_REQUIRE_THROW(
+      state.add_absolute_delta(10_rp, 50), std::runtime_error);
+}
+
+SEASTAR_THREAD_TEST_CASE(offset_translator_state_inconsistency_2) {
+    storage::offset_translator_state state(ntp);
+
+    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
+    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
+    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    state.add_gap(20_rp, 30_rp);
+    BOOST_REQUIRE_THROW(state.add_gap(15_rp, 20_rp), std::runtime_error);
+}


### PR DESCRIPTION
Add the tests that check tiered storage read path with presence of inconsistencies (like overlaps between segments).
Modify `offset_translator_state` so it could tolerate seeing gaps out of order.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
  ### Improvements

  * Make tiered-storage robust in presence of inconsistencies in data in the object store