### PR TITLE
[v22.2.x] TS timequeries: bail on if segment not found

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -249,7 +249,8 @@ private:
         remote_partition::iterator iter;
     };
 
-    /// Find the starting segment for a reader
+    /// Find the starting segment for a reader or _partition->end() if
+    /// no suitable segement exists.
     remote_partition::iterator
     seek_segment(const storage::log_reader_config& config) {
         if (config.first_timestamp) {
@@ -272,6 +273,13 @@ private:
         }
 
         auto it = seek_segment(config);
+
+        if (it == _partition->end()) {
+            // this can happen, for example, when a timequery is made with a
+            // time point after our latest message
+            return std::nullopt;
+        }
+
         auto reader = _partition->borrow_reader(config, it->first, it->second);
         // Here we know the exact type of the reader_state because of
         // the invariant of the borrow_reader


### PR DESCRIPTION
In the case a timequery is made with a timestamp later than any segment in the TS index, we return an end iterator from seek_segment and do not check for this condition subsequently in find_cached_reader which causes an assert when an end() iterator is de-referenced.

This change checks for an end() iterator and bails out, treating it the same way as other early exist conditions such as if the partition has no associated segments. This will fall back to the local log to satisfy the time query.

Fixes #8811.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->
- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [x] v22.1.x


## Release Notes

 * None
