### PR TITLE
[v22.2.x] tests: add missing dependency to central script

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -27,9 +27,7 @@ RUN /opt/ducktape-deps.sh install_java_client_deps && \
 # Install kafka streams examples.  This is a very slow step (tens of minutes), doing
 # many maven dependency downloads without any parallelism.  To avoid re-running it
 # on unrelated changes in other steps, this step is as early on the Dockerfile as possible.
-RUN git -C /opt clone https://github.com/redpanda-data/kafka-streams-examples.git && \
-    cd /opt/kafka-streams-examples && git reset --hard da50fa2723840f6388f99a1dae8d58104fd7650d && \
-    mvn -DskipTests=true clean package
+RUN /opt/ducktape-deps.sh install_kafka_streams_examples
 
 # Install our in-tree Java test clientst
 RUN mkdir -p /opt/redpanda-tests

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -135,4 +135,11 @@ function install_addr2line() {
     chmod +x /opt/scripts/seastar-addr2line
 }
 
+function install_kafka_streams_examples() {
+  git -C /opt clone https://github.com/redpanda-data/kafka-streams-examples.git
+  cd /opt/kafka-streams-examples
+  git reset --hard da50fa2723840f6388f99a1dae8d58104fd7650d
+  mvn -DskipTests=true clean package
+}
+
 $@


### PR DESCRIPTION
Backport of #8800


## Release Notes

* none