### PR TITLE
Tests: set daemon=True for all background Threads

### DIFF
--- a/tests/rptest/remote_scripts/schema_registry_test_helper.py
+++ b/tests/rptest/remote_scripts/schema_registry_test_helper.py
@@ -28,6 +28,7 @@ schema_template = '{"type":"record","name":"record_%s","fields":[{"type":"string
 class WriteWorker(threading.Thread):
     def __init__(self, name, count, node_names):
         super(WriteWorker, self).__init__()
+        self.daemon = True
         self.name = name
         self.count = count
         self.schema_counter = 1

--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -177,6 +177,7 @@ class ActionInjectorThread(Thread):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        self.daemon = True
         self.disruptive_action = disruptive_action
         self.redpanda = redpanda
         self.config = config

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -432,6 +432,7 @@ class AdminOperationsFuzzer():
     def start(self):
         self.thread = threading.Thread(target=lambda: self.thread_loop(),
                                        args=())
+        self.thread.daemon = True
         # pre-populate cluster with users and topics
         for i in range(0, self.initial_entities):
             tp = CreateTopicOperation(self.prefix, 1, self.min_replication,

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -220,6 +220,7 @@ class StatusThread(threading.Thread):
 
     def __init__(self, parent: Service, node, status_cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.daemon = True
 
         self._parent = parent
         self._node = node

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -1457,6 +1457,7 @@ class User:
 class GetTopics(threading.Thread):
     def __init__(self, user: User, handle):
         threading.Thread.__init__(self)
+        self.daemon = True
         self.user = user
         self._get_topics = handle
         self.result_raw = None

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -310,7 +310,7 @@ class NoDataCase(BaseCase):
 
 
 class EmptySegmentsCase(BaseCase):
-    """Restore topic that has segments in S3, but segments have only non-data 
+    """Restore topic that has segments in S3, but segments have only non-data
     batches (raft configuration, raft configuration).
     """
 
@@ -1040,7 +1040,7 @@ class TopicRecoveryTest(RedpandaTest):
             checksummer = lambda: queue.put(
                 NodeChecksums(node, self._get_data_log_segment_checksums(node))
             )
-            Thread(target=checksummer).start()
+            Thread(target=checksummer, daemon=True).start()
             self.logger.debug(
                 f"Started checksum thread for {node.account.hostname}..")
         for i in range(num_nodes):


### PR DESCRIPTION
If a non-daemon thread remains running for some time at the end of a test (e.g. if an exception was raised), this can lead to mysterious hangs and failures in subsequent tests (due to single-threaded architecture of the ducktape test driver).

Fixes https://github.com/redpanda-data/redpanda/issues/8615

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none