### PR TITLE
rpk: remove env from logs in redpanda launcher

### DIFF
--- a/src/go/rpk/pkg/redpanda/launcher.go
+++ b/src/go/rpk/pkg/redpanda/launcher.go
@@ -50,7 +50,6 @@ func (*launcher) Start(installDir string, args *RedpandaArgs) error {
 		return errors.New("Redpanda config file is required")
 	}
 	redpandaArgs := collectRedpandaArgs(args)
-	log.Debugf("Starting '%s' with arguments '%v'", binary, redpandaArgs)
 
 	var rpEnv []string
 	ldLibraryPathPattern := regexp.MustCompile("^LD_LIBRARY_PATH=.*$")
@@ -59,7 +58,7 @@ func (*launcher) Start(installDir string, args *RedpandaArgs) error {
 			rpEnv = append(rpEnv, ev)
 		}
 	}
-	log.Infof("Running:\n%s %s %s", strings.Join(rpEnv, " "), binary, strings.Join(redpandaArgs, " "))
+	log.Infof("Running:\n%s %s", binary, strings.Join(redpandaArgs, " "))
 	return unix.Exec(binary, redpandaArgs, rpEnv)
 }
 


### PR DESCRIPTION

## Backports Required

- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none