### PR TITLE
many_partitions_test: address follow-ups with tiered storage

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -673,7 +673,8 @@ class RedpandaService(Service):
                  skip_if_no_redpanda_log: bool = False,
                  pandaproxy_config: Optional[PandaproxyConfig] = None,
                  schema_registry_config: Optional[SchemaRegistryConfig] = None,
-                 enable_kerberos_listener=False):
+                 enable_kerberos_listener=False,
+                 disable_cloud_storage_diagnostics=False):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
         self._extra_rp_conf = extra_rp_conf or dict()
@@ -739,7 +740,11 @@ class RedpandaService(Service):
             self.set_si_settings(si_settings)
         else:
             self._si_settings = None
-        self._disable_cloud_storage_diagnostics = False
+
+        # Disable saving cloud storage diagnostics. This may be useful for
+        # tests that generate millions of objecst, as collecting diagnostics
+        # may take a significant amount of time.
+        self._disable_cloud_storage_diagnostics = disable_cloud_storage_diagnostics
 
         self.cloud_storage_client: Optional[S3Client] = None
 
@@ -1618,14 +1623,6 @@ class RedpandaService(Service):
 
         if crashes:
             raise NodeCrash(crashes)
-
-    def disable_cloud_storage_diagnostics(self):
-        """
-        Disable saving cloud storage diagnostics. This may be useful for tests
-        that generate millions of objecst, as collecting diagnostics may take a
-        significant amount of time.
-        """
-        self._disable_cloud_storage_diagnostica = True
 
     def cloud_storage_diagnostics(self):
         """


### PR DESCRIPTION
This is follow-up to https://github.com/redpanda-data/redpanda/pull/8456

- Fixed the non-tiered storage variants, since we weren't properly setting `si_settings`.
- Clarified the warmup data size to always be related to the target number of cloud segments.
- Changed the topic to use infinite retention, to favor testing with more cloud segments in the cluster.
- Scanned more data with the sequential read workload, targeting reading at least a few segments per partition.
- Some smaller stylistic changes.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
