### PR TITLE
rm_stm/seq_table: unlink before destruction

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2529,8 +2529,8 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
         const auto pid = entry.pid;
         auto it = _log_state.seq_table.find(pid);
         if (it == _log_state.seq_table.end()) {
-            seq_entry_wrapper seq{std::move(entry)};
-            _log_state.seq_table.try_emplace(it, pid, std::move(seq));
+            _log_state.seq_table.try_emplace(
+              it, pid, seq_entry_wrapper{.entry = std::move(entry)});
         } else if (it->second.entry.seq < entry.seq) {
             it->second.entry = std::move(entry);
         }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1128,15 +1128,8 @@ ss::future<result<kafka_result>> rm_stm::do_replicate(
 ss::future<> rm_stm::stop() {
     auto_abort_timer.cancel();
     _log_stats_timer.cancel();
-    return raft::state_machine::stop().then([this] {
-        for (const auto& entry : _log_state.seq_table) {
-            _log_state.unlink_lru_pid(entry.second);
-        }
-        vassert(
-          _log_state.lru_idempotent_pids.size() == 0,
-          "Unexpected entries in the lru pid list {}",
-          _log_state.lru_idempotent_pids.size());
-    });
+    return raft::state_machine::stop().then(
+      [this] { _log_state.clear_seq_table(); });
 }
 
 ss::future<> rm_stm::start() {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1128,8 +1128,7 @@ ss::future<result<kafka_result>> rm_stm::do_replicate(
 ss::future<> rm_stm::stop() {
     auto_abort_timer.cancel();
     _log_stats_timer.cancel();
-    return raft::state_machine::stop().then(
-      [this] { _log_state.clear_seq_table(); });
+    return raft::state_machine::stop();
 }
 
 ss::future<> rm_stm::start() {
@@ -2869,7 +2868,7 @@ ss::future<> rm_stm::do_remove_persistent_state() {
 ss::future<> rm_stm::handle_eviction() {
     return _state_lock.hold_write_lock().then(
       [this]([[maybe_unused]] ss::basic_rwlock<>::holder unit) {
-          _log_state = log_state{_tx_root_tracker};
+          _log_state.reset();
           _mem_state = mem_state{_tx_root_tracker};
           set_next(_c->start_offset());
           return ss::now();

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -445,6 +445,12 @@ private:
                        model::producer_identity,
                        expiration_info>(_tracker)) {}
 
+        log_state(log_state&) noexcept = delete;
+        log_state(log_state&&) noexcept = delete;
+        log_state& operator=(log_state&) noexcept = delete;
+        log_state& operator=(log_state&&) noexcept = delete;
+        ~log_state() noexcept { reset(); }
+
         ss::shared_ptr<util::mem_tracker> _tracker;
         // we enforce monotonicity of epochs related to the same producer_id
         // and fence off out of order requests
@@ -545,6 +551,19 @@ private:
             erase_pid_from_seq_table(pid);
             tx_seqs.erase(pid);
             expiration.erase(pid);
+        }
+
+        void reset() {
+            clear_seq_table();
+            fence_pid_epoch.clear();
+            ongoing_map.clear();
+            ongoing_set.clear();
+            prepared.clear();
+            tx_seqs.clear();
+            expiration.clear();
+            aborted.clear();
+            abort_indexes.clear();
+            last_abort_snapshot = {model::offset(-1)};
         }
     };
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -395,24 +395,6 @@ private:
     struct seq_entry_wrapper {
         seq_entry entry;
         safe_intrusive_list_hook _hook;
-
-        seq_entry_wrapper() = default;
-        explicit seq_entry_wrapper(seq_entry&& entry)
-          : entry(std::move(entry)) {}
-        seq_entry_wrapper(const seq_entry_wrapper&) = delete;
-        seq_entry_wrapper& operator=(seq_entry_wrapper&) = delete;
-        ~seq_entry_wrapper() = default;
-
-        seq_entry_wrapper(seq_entry_wrapper&& other) noexcept
-          : entry(std::move(other.entry)) {
-            _hook.swap_nodes(other._hook);
-        }
-
-        seq_entry_wrapper& operator=(seq_entry_wrapper&& other) noexcept {
-            entry = std::move(other.entry);
-            _hook.swap_nodes(other._hook);
-            return *this;
-        }
     };
 
     util::mem_tracker _tx_root_tracker{"tx-mem-root"};


### PR DESCRIPTION
Fixes #8324

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
