### PR TITLE
test: don't loop consumer in EndToEndTopicRecovery

### DIFF
--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -70,7 +70,8 @@ class EndToEndTopicRecovery(RedpandaTest):
                                                 self.redpanda,
                                                 self.topic,
                                                 msg_size,
-                                                nodes=[self._verifier_node])
+                                                nodes=[self._verifier_node],
+                                                loop=False)
 
     def free_nodes(self):
         super().free_nodes()


### PR DESCRIPTION
This test doesn't need continuous consumer work: it just wants to do a one-shot pass.  Set loop=False to avoid this test bumping into unrelelated issues that come up when kgo-verifier is creating/destroying
franz-go clients in a relatively tight loop.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
