### PR TITLE
rpk: commands for automated topic recovery

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_cloud_storage.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage.go
@@ -1,0 +1,37 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"context"
+	"net/http"
+)
+
+// RecoveryRequestParams represents the request body schema for the automated recovery API endpoint.
+type RecoveryRequestParams struct {
+	TopicNamesPattern string `json:"topic_names_pattern"`
+	RetentionBytes    int    `json:"retention_bytes"`
+	RetentionMs       int    `json:"retention_ms"`
+}
+
+type RecoveryStartResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// StartAutomatedRecovery starts the automated recovery process by sending a request to the automated recovery API endpoint.
+func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context, topicNamesPattern string) (RecoveryStartResponse, error) {
+	requestParams := &RecoveryRequestParams{
+		TopicNamesPattern: topicNamesPattern,
+	}
+	var response RecoveryStartResponse
+
+	return response, a.sendAny(ctx, http.MethodPost, "/v1/cloud_storage/automated_recovery", requestParams, &response)
+}

--- a/src/go/rpk/pkg/api/admin/api_cloud_storage.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage.go
@@ -26,6 +26,21 @@ type RecoveryStartResponse struct {
 	Message string `json:"message"`
 }
 
+// TopicDownloadCounts represents the count of downloads for a topic.
+type TopicDownloadCounts struct {
+	TopicNamespace      string `json:"topic_namespace"`
+	PendingDownloads    int    `json:"pending_downloads"`
+	SuccessfulDownloads int    `json:"successful_downloads"`
+	FailedDownloads     int    `json:"failed_downloads"`
+}
+
+// TopicRecoveryStatus represents the status of the automated recovery for a topic.
+type TopicRecoveryStatus struct {
+	State           string                `json:"state"`
+	TopicDownloads  []TopicDownloadCounts `json:"topic_download_counts"`
+	RecoveryRequest RecoveryRequestParams `json:"request"`
+}
+
 // StartAutomatedRecovery starts the automated recovery process by sending a request to the automated recovery API endpoint.
 func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context, topicNamesPattern string) (RecoveryStartResponse, error) {
 	requestParams := &RecoveryRequestParams{
@@ -34,4 +49,10 @@ func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context, topicNamesPattern
 	var response RecoveryStartResponse
 
 	return response, a.sendAny(ctx, http.MethodPost, "/v1/cloud_storage/automated_recovery", requestParams, &response)
+}
+
+// PollAutomatedRecoveryStatus polls the automated recovery status API endpoint to retrieve the latest status of the recovery process.
+func (a *AdminAPI) PollAutomatedRecoveryStatus(ctx context.Context) (*TopicRecoveryStatus, error) {
+	var response TopicRecoveryStatus
+	return &response, a.sendAny(ctx, http.MethodGet, "/v1/cloud_storage/automated_recovery", http.NoBody, &response)
 }

--- a/src/go/rpk/pkg/api/admin/api_cloud_storage_test.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage_test.go
@@ -1,0 +1,81 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartAutomatedRecovery(t *testing.T) {
+	type testCase struct {
+		name   string
+		testFn func(t *testing.T) http.HandlerFunc
+		exp    RecoveryStartResponse
+	}
+
+	successfulStartResponse := RecoveryStartResponse{
+		Code:    200,
+		Message: "Automated recovery started",
+	}
+
+	runTest := func(t *testing.T, test testCase) {
+		server := httptest.NewServer(test.testFn(t))
+		defer server.Close()
+
+		client, err := NewAdminAPI([]string{server.URL}, BasicCredentials{}, nil)
+		assert.NoError(t, err)
+
+		response, err := client.StartAutomatedRecovery(context.Background(), ".*")
+
+		assert.NoError(t, err)
+		assert.Equal(t, test.exp, response)
+	}
+
+	tests := []testCase{
+		{
+			name: "should call the correct endpoint",
+			testFn: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "/v1/cloud_storage/automated_recovery", r.URL.Path)
+					w.WriteHeader(http.StatusOK)
+					resp, err := json.Marshal(successfulStartResponse)
+					assert.NoError(t, err)
+					w.Write(resp)
+				}
+			},
+			exp: successfulStartResponse,
+		},
+		{
+			name: "should have content-type application-json",
+			testFn: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+					w.WriteHeader(http.StatusOK)
+					resp, err := json.Marshal(successfulStartResponse)
+					assert.NoError(t, err)
+					w.Write(resp)
+				}
+			},
+			exp: successfulStartResponse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runTest(t, test)
+		})
+	}
+}

--- a/src/go/rpk/pkg/api/admin/api_cloud_storage_test.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage_test.go
@@ -79,3 +79,78 @@ func TestStartAutomatedRecovery(t *testing.T) {
 		})
 	}
 }
+
+func TestPollAutomatedRecoveryStatus(t *testing.T) {
+	type testCase struct {
+		name   string
+		testFn func(t *testing.T) http.HandlerFunc
+		exp    *TopicRecoveryStatus
+	}
+
+	pendingResponse := &TopicRecoveryStatus{
+		State: "pending",
+		TopicDownloads: []TopicDownloadCounts{
+			{
+				TopicNamespace:      "test-namespace",
+				PendingDownloads:    1,
+				SuccessfulDownloads: 0,
+				FailedDownloads:     0,
+			},
+		},
+		RecoveryRequest: RecoveryRequestParams{
+			TopicNamesPattern: ".*",
+		},
+	}
+
+	runTest := func(t *testing.T, test testCase) {
+		server := httptest.NewServer(test.testFn(t))
+		defer server.Close()
+
+		client, err := NewAdminAPI([]string{server.URL}, BasicCredentials{}, nil)
+		assert.NoError(t, err)
+
+		resp, err := client.PollAutomatedRecoveryStatus(context.Background())
+		assert.NoError(t, err)
+
+		assert.Equal(t, resp, test.exp)
+	}
+
+	tests := []testCase{
+		{
+			name: "should return TopicRecoveryStatus when server returns 200",
+			testFn: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+
+					respBodyBytes, err := json.Marshal(pendingResponse)
+					assert.NoError(t, err)
+
+					w.Write(respBodyBytes)
+				}
+			},
+			exp: pendingResponse,
+		},
+		{
+			name: "should call the correct endpoint",
+			testFn: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "/v1/cloud_storage/automated_recovery", r.URL.Path)
+
+					w.WriteHeader(http.StatusOK)
+
+					resp, err := json.Marshal(pendingResponse)
+					assert.NoError(t, err)
+
+					w.Write(resp)
+				}
+			},
+			exp: pendingResponse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runTest(t, test)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/maintenance"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/partitions"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/selftest"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/storage"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/group"
 	"github.com/spf13/afero"
@@ -65,6 +66,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		maintenance.NewMaintenanceCommand(fs),
 		partitions.NewPartitionsCommand(fs),
 		selftest.NewSelfTestCommand(fs),
+		storage.NewCommand(fs),
 		offsets,
 	)
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/recovery.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/recovery.go
@@ -1,0 +1,34 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package recovery
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "recovery",
+		Short: "Interact with the topic recovery process",
+		Long: `Interact with the topic recovery process.
+		
+This command is used to restore topics from the archival bucket, which can be useful for disaster recovery or if a topic was accidentally deleted.
+
+To begin the recovery process, use the "recovery start" command. Note that this process can take a while to complete, so the command will exit after starting it.
+`,
+	}
+
+	cmd.AddCommand(
+		newStartCommand(fs),
+	)
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/recovery.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/recovery.go
@@ -22,7 +22,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		
 This command is used to restore topics from the archival bucket, which can be useful for disaster recovery or if a topic was accidentally deleted.
 
-To begin the recovery process, use the "recovery start" command. Note that this process can take a while to complete, so the command will exit after starting it.
+To begin the recovery process, use the "recovery start" command. Note that this process can take a while to complete, so the command will exit after starting it. If you want the command to wait for the process to finish, use the "--wait" or "-w" flag.
 
 You can check the status of the recovery process with the "recovery status" command after it has been started.
 `,

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/recovery.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/recovery.go
@@ -23,11 +23,14 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 This command is used to restore topics from the archival bucket, which can be useful for disaster recovery or if a topic was accidentally deleted.
 
 To begin the recovery process, use the "recovery start" command. Note that this process can take a while to complete, so the command will exit after starting it.
+
+You can check the status of the recovery process with the "recovery status" command after it has been started.
 `,
 	}
 
 	cmd.AddCommand(
 		newStartCommand(fs),
+		newStatusCommand(fs),
 	)
 
 	return cmd

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/start.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package recovery
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newStartCommand(fs afero.Fs) *cobra.Command {
+	var topicNamePattern string
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the topic recovery process",
+		Long: `Start the topic recovery process.
+		
+This command starts the process of restoring topics from the archival bucket.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			client, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			_, err = client.StartAutomatedRecovery(cmd.Context(), topicNamePattern)
+			var he *admin.HTTPResponseError
+			if errors.As(err, &he) {
+				if he.Response.StatusCode == 404 {
+					body, bodyErr := he.DecodeGenericErrorBody()
+					if bodyErr == nil {
+						out.Die("Not found: %s", body.Message)
+					}
+				} else if he.Response.StatusCode == 400 {
+					body, bodyErr := he.DecodeGenericErrorBody()
+					if bodyErr == nil {
+						out.Die("Cannot start topic recovery: %s", body.Message)
+					}
+				}
+			}
+
+			out.MaybeDie(err, "error starting topic recovery: %v", err)
+			fmt.Println("Successfully started topic recovery")
+		},
+	}
+
+	cmd.Flags().StringVar(&topicNamePattern, "topic-name-pattern", ".*", "A regex pattern to match topic names against. Only topics whose names match this pattern will be restored. If not passed, all topics will be restored.")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/status.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package recovery
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newStatusCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Fetch the status of the topic recovery process",
+		Long: `Fetch the status of the topic recovery process.
+		
+This command fetches the status of the process of restoring topics from the archival bucket.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			client, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			status, err := client.PollAutomatedRecoveryStatus(cmd.Context())
+			out.MaybeDie(err, "unable to fetch topic recovery status: %v", err)
+
+			fmt.Printf("Topic recovery status: %s\n", status.State)
+		},
+	}
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/storage.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/storage.go
@@ -1,0 +1,28 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package storage
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "storage",
+		Short: "Manage the cluster storage",
+	}
+
+	cmd.AddCommand(
+		recovery.NewCommand(fs),
+	)
+	return cmd
+}


### PR DESCRIPTION
Redpanda v23.1 will introduce automated topic recovery from an archival bucket.
This PR adds the functionality to trigger such auto-restore using `rpk cluster storage recovery start` and check the status with `rpk cluster storage recovery status`.

Additionally there is a wait flag for the start command (`--wait`/`-w`), which will configure the command to poll the admin API until there no longer are any pending replica partitions.

## Backports Required

- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

### Features

* Add `rpk cluster storage recovery` sub-command to `rpk`. The command can start automated topic recovery from an archival bucket and poll the status of an on-going recovery process