### PR TITLE
[v22.3.x] Backport #8540

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -185,7 +185,7 @@ void archiver_fixture::wait_for_partition_leadership(const model::ntp& ntp) {
     tests::cooperative_spin_wait_with_timeout(10s, [this, ntp] {
         auto& table = app.controller->get_partition_leaders().local();
         auto self = app.controller->self();
-        ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 100ms;
+        ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 500ms;
         return table.wait_for_leader(ntp, deadline, {}).get0() == self
                && app.partition_manager.local().get(ntp)->is_elected_leader();
     }).get();


### PR DESCRIPTION

To avoid conflicts, this only backports the functional change, not the code cleanup.

Backport of PR #8540


## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none


