### PR TITLE
tests: bail out of cloud diagnostics when limits are hit

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -141,7 +141,6 @@ class ScaleParameters:
         self.local_retention_after_warmup = self.retention_bytes
 
         if tiered_storage_enabled:
-            redpanda.disable_cloud_storage_diagnostics()
             # When testing with tiered storage, the tuning goals of the test
             # parameters are different: we want to stress the number of
             # uploaded segments.
@@ -319,9 +318,6 @@ class ManyPartitionsTest(PreallocNodesTest):
                                          'raft': 'warn',
                                          'offset_translator': 'warn'
                                      }),
-            # With tiered storage enabled, this test generates millions of
-            # objects, and can be slow to gather diagnostics for.
-            disable_cloud_storage_diagnostics=True,
             **kwargs)
         self.rpk = RpkTool(self.redpanda)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1671,6 +1671,9 @@ class RedpandaService(Service):
                 manifests_to_dump.append(key)
                 manifest_dump_limit -= 1
 
+            if manifest_dump_limit == 0 and key_dump_limit == 0:
+                break
+
         archive_basename = "cloud_diagnostics.zip"
         archive_path = os.path.join(
             TestContext.results_dir(self._context, self._context.test_index),


### PR DESCRIPTION
Currently we complete listing objects until completion, even if we don't log anything.

This removes the existing disabling of cloud diagnostics for many_partitions_test with tiered storage, since we'll now no longer paginate millions of objects.

I left in the option to disable cloud diagnostics in case it is useful in future tiered storage tests (e.g. large partitions).

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
