### PR TITLE
Add config properties to metrics report

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -459,6 +459,9 @@ void rjson_serialize(
     w.EndArray();
     w.Key("has_kafka_gssapi");
     w.Bool(snapshot.has_kafka_gssapi);
+
+    w.Key("config");
+    config::shard_local_cfg().to_json_for_metrics(w);
     w.EndObject();
 }
 

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -136,6 +136,36 @@ public:
         w.EndObject();
     }
 
+    void to_json_for_metrics(json::Writer<json::StringBuffer>& w) {
+        w.StartObject();
+
+        for (const auto& [name, property] : _properties) {
+            if (property->get_visibility() == visibility::deprecated) {
+                continue;
+            }
+
+            if (property->type_name() == "boolean") {
+                w.Key(name.data(), name.size());
+                property->to_json(w, redact_secrets::yes);
+                continue;
+            }
+
+            if (property->is_nullable()) {
+                w.Key(name.data(), name.size());
+                w.String(property->is_default() ? "default" : "[value]");
+                continue;
+            }
+
+            if (!property->enum_values().empty()) {
+                w.Key(name.data(), name.size());
+                property->to_json(w, redact_secrets::yes);
+                continue;
+            }
+        }
+
+        w.EndObject();
+    }
+
     std::set<std::string_view> property_names() const {
         std::set<std::string_view> result;
         for (const auto& i : _properties) {

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -33,6 +33,7 @@ class MetricsReporterTest(RedpandaTest):
                 "metrics_reporter_report_interval": 1000,
                 "enable_metrics_reporter": True,
                 "metrics_reporter_url": f"{self.http.url}/metrics",
+                "retention_bytes": 20000,
             })
 
     def setUp(self):
@@ -82,6 +83,8 @@ class MetricsReporterTest(RedpandaTest):
         assert_fields_are_the_same(metadata, 'cluster_created_ts')
         # Configuration should be the same across requests
         assert_fields_are_the_same(metadata, 'has_kafka_gssapi')
+        # cluster config should be the same
+        assert_fields_are_the_same(metadata, 'config')
         # get the last report
         last = metadata.pop()
         assert last['topic_count'] == total_topics
@@ -113,6 +116,13 @@ class MetricsReporterTest(RedpandaTest):
                    backoff_sec=1)
         assert_fields_are_the_same(metadata, 'cluster_uuid')
         assert_fields_are_the_same(metadata, 'cluster_created_ts')
+
+        # Check config values
+        assert last["config"]["retention_bytes"] == "[value]"
+        assert last["config"]["enable_metrics_reporter"] == True
+        assert last["config"]["auto_create_topics_enabled"] == False
+        assert "metrics_reporter_tick_interval" not in last["config"]
+        assert last["config"]["log_message_timestamp_type"] == "CreateTime"
 
 
 class MultiNodeMetricsReporterTest(MetricsReporterTest):


### PR DESCRIPTION
## Idea
Redpanda should report cluster config during metrics reporter. But it should hide sensitive information about clutter settings.
## Filter for config param
Redpanda will report several type of config param.:
* Boolean -> Check property type
* Optional: Only 2 possible values [“nullopt”, [“value”]] -> check is_nullable
* Enum -> check enum_values return not empty array

Boolean and optional will signal are some features switched on (enable_sasl, cloud_storage_enable). Also enum is not sensitive and redpanda can provide it in metrics.

We do not report string and integer fields, because some ‘string’ properties can contains sensitive information (for example: cloud_storage_access_key, some sasl options). And Integer fields can also contains some internal info like timeouts, internal topics replication factor etc.

Possible config value inside and could be:
* For bool -> "true", "false"
* For optional -> "default", "value"
* For enum -> one of posible enum values


## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes


## Release Notes


  ### Improvements

  * Some of cluster config properties are reported in metrics
