### PR TITLE
rpc/conn_cache: eager cleanup of connection cache on shutdown

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -192,7 +192,7 @@ auto do_with_client_one_shot(
           return transport->connect(connection_timeout)
             .then([transport, f = std::forward<Func>(f)]() mutable {
                 return ss::futurize_invoke(
-                  std::forward<Func>(f), Proto(*transport));
+                  std::forward<Func>(f), Proto(transport));
             })
             .finally([transport] {
                 transport->shutdown();

--- a/src/v/cluster/node_status_backend.h
+++ b/src/v/cluster/node_status_backend.h
@@ -51,7 +51,8 @@ public:
       ss::sharded<members_table>&,
       ss::sharded<features::feature_table>&,
       ss::sharded<node_status_table>&,
-      config::binding<std::chrono::milliseconds>);
+      config::binding<std::chrono::milliseconds>,
+      ss::sharded<ss::abort_source>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -100,6 +101,8 @@ private:
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics{
       ssx::metrics::public_metrics_handle};
+
+    ss::sharded<ss::abort_source>& _as;
 
     friend class node_status_rpc_handler;
 };

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -114,7 +114,8 @@ private:
     ss::future<> process_reply(process_batch_reply);
     void notify_waiters();
 
-    ss::future<ss::stop_iteration> process_send_write(rpc::transport*);
+    ss::future<ss::stop_iteration>
+      process_send_write(ss::lw_shared_ptr<rpc::transport>);
 
 private:
     /// State to track in-progress ntp modifications

--- a/src/v/coproc/script_dispatcher.cc
+++ b/src/v/coproc/script_dispatcher.cc
@@ -360,7 +360,7 @@ script_dispatcher::do_heartbeat(int8_t connect_attempts) {
         }
         co_return co_await do_heartbeat(connect_attempts - 1);
     }
-    supervisor_client_protocol client(*transport.value());
+    supervisor_client_protocol client(transport.value());
     co_return co_await client.heartbeat(
       empty_request(), rpc::client_opts(timeout));
 }
@@ -400,7 +400,7 @@ script_dispatcher::get_client() {
             co_await ss::sleep(dur);
             dur = std::min(model::timeout_clock::duration(10s), dur * 2);
         } else {
-            co_return supervisor_client_protocol(*transport.value());
+            co_return supervisor_client_protocol(transport.value());
         }
     }
 }

--- a/src/v/raft/rpc_client_protocol.cc
+++ b/src/v/raft/rpc_client_protocol.cc
@@ -98,8 +98,8 @@ ss::future<> rpc_client_protocol::reset_backoff(model::node_id n) {
 
 ss::future<bool> rpc_client_protocol::ensure_disconnect(model::node_id n) {
     struct resetter {
-        rpc::transport& transport;
-        resetter(rpc::transport& t)
+        ss::lw_shared_ptr<rpc::transport> transport;
+        resetter(ss::lw_shared_ptr<rpc::transport> t)
           : transport(t) {}
     };
 
@@ -112,9 +112,9 @@ ss::future<bool> rpc_client_protocol::ensure_disconnect(model::node_id n) {
         [](resetter r) {
             // Give the caller a bool clue as to whether we really shut
             // anything down (false indicates this was a no-op)
-            bool was_valid = r.transport.is_valid();
+            bool was_valid = r.transport->is_valid();
 
-            r.transport.shutdown();
+            r.transport->shutdown();
             return was_valid;
         })
       .then([]([[maybe_unused]] result<bool> r) {

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -60,7 +60,8 @@ struct mux_state_machine_fixture {
             std::ref(_feature_table))
           .get0();
         _storage.invoke_on_all(&storage::api::start).get0();
-        _connections.start().get0();
+        _as.start().get();
+        _connections.start(std::ref(_as)).get0();
         _recovery_throttle
           .start(
             ss::sharded_parameter([] { return config::mock_binding(100_MiB); }))
@@ -128,6 +129,10 @@ struct mux_state_machine_fixture {
 
     void stop_all() {
         if (_started) {
+            _as
+              .invoke_on_all(
+                [](auto& local) noexcept { local.request_abort(); })
+              .get();
             _recovery_throttle.stop().get();
             _group_mgr.stop().get0();
             if (_raft) {
@@ -136,6 +141,7 @@ struct mux_state_machine_fixture {
             _connections.stop().get0();
             _feature_table.stop().get0();
             _storage.stop().get0();
+            _as.stop().get();
         }
     }
 
@@ -184,6 +190,7 @@ struct mux_state_machine_fixture {
 
     ss::sstring _data_dir;
     cluster::consensus_ptr _raft;
+    ss::sharded<ss::abort_source> _as;
     ss::sharded<rpc::connection_cache> _connections;
     ss::sharded<storage::api> _storage;
     ss::sharded<features::feature_table> _feature_table;

--- a/src/v/raft/tests/state_removal_test.cc
+++ b/src/v/raft/tests/state_removal_test.cc
@@ -75,6 +75,7 @@ void stop_node(raft_node& node) {
     node.log.reset();
     node.storage.stop().get0();
     node.feature_table.stop().get0();
+    node.as_service.stop().get();
 
     node.started = false;
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1000,7 +1000,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
 
     // cluster
     syschecks::systemd_message("Initializing connection cache").get();
-    construct_service(_connection_cache).get();
+    construct_service(_connection_cache, std::ref(_as)).get();
     syschecks::systemd_message("Building shard-lookup tables").get();
     construct_service(shard_table).get();
 
@@ -1171,7 +1171,8 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(feature_table),
       std::ref(node_status_table),
       ss::sharded_parameter(
-        [] { return config::shard_local_cfg().node_status_interval.bind(); }))
+        [] { return config::shard_local_cfg().node_status_interval.bind(); }),
+      std::ref(_as))
       .get();
 
     syschecks::systemd_message("Creating kafka metadata cache").get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -358,6 +358,7 @@ int application::run(int ac, char** av) {
                 wire_up_and_start(app_signal);
                 post_start_tasks();
                 app_signal.wait().get();
+                trigger_abort_source();
                 vlog(_log.info, "Stopping...");
             } catch (const ss::abort_requested_exception&) {
                 vlog(_log.info, "Redpanda startup aborted");
@@ -1551,6 +1552,10 @@ application::set_proxy_client_config(ss::sstring name, std::any val) {
     return _proxy->set_client_config(std::move(name), std::move(val));
 }
 
+void application::trigger_abort_source() {
+    _as.invoke_on_all([](auto& local_as) { local_as.request_abort(); }).get();
+}
+
 void application::wire_up_bootstrap_services() {
     // Wire up local storage.
     ss::smp::invoke_on_all([] {
@@ -1801,6 +1806,10 @@ void application::start_bootstrap_services() {
 }
 
 void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
+    // Setup the app level abort service
+    construct_service(_as).get();
+
+    // Bootstrap services.
     wire_up_bootstrap_services();
     start_bootstrap_services();
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -168,6 +168,8 @@ private:
 
     void load_feature_table_snapshot();
 
+    void trigger_abort_source();
+
     // Starts the services meant for Redpanda runtime. Must be called after
     // having constructed the subsystems via the corresponding `wire_up` calls.
     void start_runtime_services(cluster::cluster_discovery&, ::stop_signal&);
@@ -261,6 +263,8 @@ private:
 
     // run these first on destruction
     deferred_actions _deferred;
+
+    ss::sharded<ss::abort_source> _as;
 };
 
 namespace debug {

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -17,8 +17,13 @@
 
 namespace rpc {
 
-connection_cache::connection_cache(std::optional<connection_cache_label> label)
-  : _label(std::move(label)) {}
+connection_cache::connection_cache(
+  ss::sharded<ss::abort_source>& as,
+  std::optional<connection_cache_label> label)
+  : _label(std::move(label)) {
+    _as_subscription = as.local().subscribe(
+      [this]() mutable noexcept { shutdown(); });
+}
 
 /// \brief needs to be a future, because mutations may come from different
 /// fibers and they need to be synchronized

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -61,11 +61,14 @@ ss::future<> connection_cache::remove(model::node_id n) {
 /// \brief closes all client connections
 ss::future<> connection_cache::stop() {
     auto units = co_await _mutex.get_units();
-    co_await parallel_for_each(_cache, [](auto& it) {
+    // Exchange ensures the cache is invalidated and concurrent
+    // accesses wait on the mutex to populate new entries.
+    auto cache = std::exchange(_cache, {});
+    co_await parallel_for_each(cache, [](auto& it) {
         auto& [_, cli] = it;
         return cli->stop();
     });
-    _cache.clear();
+    cache.clear();
     // mark mutex as broken to prevent new connections from being created
     // after stop
     _mutex.broken();

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -59,7 +59,7 @@ ss::future<> connection_cache::remove(model::node_id n) {
 }
 
 /// \brief closes all client connections
-ss::future<> connection_cache::stop() {
+ss::future<> connection_cache::do_shutdown() {
     auto units = co_await _mutex.get_units();
     // Exchange ensures the cache is invalidated and concurrent
     // accesses wait on the mutex to populate new entries.
@@ -72,6 +72,15 @@ ss::future<> connection_cache::stop() {
     // mark mutex as broken to prevent new connections from being created
     // after stop
     _mutex.broken();
+}
+
+void connection_cache::shutdown() {
+    ssx::spawn_with_gate(_gate, [this] { return do_shutdown(); });
+}
+
+ss::future<> connection_cache::stop() {
+    shutdown();
+    return _gate.close();
 }
 
 } // namespace rpc

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -97,13 +97,14 @@ public:
               return cache.get(node_id)
                 ->get_connected(connection_timeout.timeout_at())
                 .then([f = std::forward<Func>(f)](
-                        result<rpc::transport*> transport) mutable {
+                        result<ss::lw_shared_ptr<rpc::transport>>
+                          transport) mutable {
                     if (!transport) {
                         // Connection error
                         return ss::futurize<ret_t>::convert(transport.error());
                     }
                     return ss::futurize<ret_t>::convert(
-                      f(Protocol(*transport.value())));
+                      f(Protocol(transport.value())));
                 });
           });
     }

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -41,6 +41,7 @@ public:
       ss::shard_id max_shards = ss::smp::count);
 
     explicit connection_cache(
+      ss::sharded<ss::abort_source>&,
       std::optional<connection_cache_label> label = std::nullopt);
 
     bool contains(model::node_id n) const {
@@ -148,6 +149,7 @@ private:
     underlying _cache;
     transport_version _default_transport_version{transport_version::v2};
     ss::gate _gate;
+    ss::optimized_optional<ss::abort_source::subscription> _as_subscription;
 };
 inline ss::shard_id connection_cache::shard_for(
   model::node_id self,

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -57,6 +57,9 @@ public:
     ss::future<> remove(model::node_id n);
 
     /// \brief closes all connections
+    ss::future<> do_shutdown();
+    void shutdown();
+
     ss::future<> stop();
 
     /**
@@ -144,6 +147,7 @@ private:
     mutex _mutex; // to add/remove nodes
     underlying _cache;
     transport_version _default_transport_version{transport_version::v2};
+    ss::gate _gate;
 };
 inline ss::shard_id connection_cache::shard_for(
   model::node_id self,

--- a/src/v/rpc/reconnect_transport.cc
+++ b/src/v/rpc/reconnect_transport.cc
@@ -34,29 +34,30 @@ static inline bool has_backoff_expired(
 }
 
 ss::future<> reconnect_transport::stop() {
-    return _dispatch_gate.close().then([this] { return _transport.stop(); });
+    return _dispatch_gate.close().then([this] { return _transport->stop(); });
 }
-ss::future<result<transport*>>
+ss::future<result<reconnect_transport::underlying_transport_ptr>>
 reconnect_transport::get_connected(clock_type::duration connection_timeout) {
     return get_connected(clock_type::now() + connection_timeout);
 }
 
-ss::future<result<transport*>>
+ss::future<result<reconnect_transport::underlying_transport_ptr>>
 reconnect_transport::get_connected(clock_type::time_point connection_timeout) {
     if (is_valid()) {
-        return ss::make_ready_future<result<transport*>>(&_transport);
+        return ss::make_ready_future<result<underlying_transport_ptr>>(
+          _transport);
     }
     return reconnect(connection_timeout);
 }
 
-ss::future<result<rpc::transport*>>
+ss::future<result<reconnect_transport::underlying_transport_ptr>>
 reconnect_transport::reconnect(clock_type::duration connection_timeout) {
     return reconnect(clock_type::now() + connection_timeout);
 }
 
-ss::future<result<transport*>>
+ss::future<result<reconnect_transport::underlying_transport_ptr>>
 reconnect_transport::reconnect(clock_type::time_point connection_timeout) {
-    using ret_t = result<transport*>;
+    using ret_t = result<underlying_transport_ptr>;
     if (!has_backoff_expired(
           _stamp, _backoff_policy.current_backoff_duration())) {
         return ss::make_ready_future<ret_t>(errc::exponential_backoff);
@@ -77,22 +78,22 @@ reconnect_transport::reconnect(clock_type::time_point connection_timeout) {
                    connection_timeout_duration,
                    [this, connection_timeout] {
                        if (is_valid()) {
-                           return ss::make_ready_future<ret_t>(&_transport);
+                           return ss::make_ready_future<ret_t>(_transport);
                        }
                        vlog(
                          rpclog.trace,
                          "connecting to {}",
-                         _transport.server_address());
-                       return _transport.connect(connection_timeout)
+                         _transport->server_address());
+                       return _transport->connect(connection_timeout)
                          .then_wrapped([this](ss::future<> f) {
                              try {
                                  f.get();
                                  rpclog.debug(
                                    "connected to {}",
-                                   _transport.server_address());
+                                   _transport->server_address());
                                  _backoff_policy.reset();
                                  return ss::make_ready_future<ret_t>(
-                                   &_transport);
+                                   _transport);
                              } catch (...) {
                                  _backoff_policy.next_backoff();
                                  rpclog.trace(

--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -31,6 +31,8 @@ namespace rpc {
  * reconnecting if the underlying transport has become invalid.
  */
 class reconnect_transport {
+    using underlying_transport_ptr = ss::lw_shared_ptr<rpc::transport>;
+
 public:
     // Instantiates an underlying rpc::transport, using the given node ID (if
     // provided) to distinguish client metrics that target the same server and
@@ -40,19 +42,22 @@ public:
       backoff_policy backoff_policy,
       const std::optional<connection_cache_label>& label = std::nullopt,
       const std::optional<model::node_id>& node_id = std::nullopt)
-      : _transport(std::move(c), std::move(label), std::move(node_id))
+      : _transport(
+        ss::make_lw_shared<rpc::transport>(std::move(c), label, node_id))
       , _backoff_policy(std::move(backoff_policy)) {}
 
-    bool is_valid() const { return _transport.is_valid(); }
+    bool is_valid() const { return _transport->is_valid(); }
 
-    rpc::transport& get() { return _transport; }
+    ss::lw_shared_ptr<rpc::transport> get() { return _transport; }
 
     /// safe client connect - attempts to reconnect if not connected
-    ss::future<result<transport*>> get_connected(clock_type::time_point);
-    ss::future<result<transport*>> get_connected(clock_type::duration);
+    ss::future<result<underlying_transport_ptr>>
+      get_connected(clock_type::time_point);
+    ss::future<result<underlying_transport_ptr>>
+      get_connected(clock_type::duration);
 
     const net::unresolved_address& server_address() const {
-        return _transport.server_address();
+        return _transport->server_address();
     }
 
     void reset_backoff() { _backoff_policy.reset(); }
@@ -60,10 +65,12 @@ public:
     ss::future<> stop();
 
 private:
-    ss::future<result<rpc::transport*>> reconnect(clock_type::time_point);
-    ss::future<result<rpc::transport*>> reconnect(clock_type::duration);
+    ss::future<result<underlying_transport_ptr>>
+      reconnect(clock_type::time_point);
+    ss::future<result<underlying_transport_ptr>>
+      reconnect(clock_type::duration);
 
-    rpc::transport _transport;
+    ss::lw_shared_ptr<rpc::transport> _transport;
     rpc::clock_type::time_point _stamp{rpc::clock_type::now()};
     ssx::semaphore _connected_sem{1, "rpc/reconnection"};
     ss::gate _dispatch_gate;

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -154,7 +154,7 @@ using {{service_name}}_service = {{service_name}}_service_base<rpc::default_mess
 
 class {{service_name}}_client_protocol {
 public:
-    explicit {{service_name}}_client_protocol(rpc::transport& t)
+    explicit {{service_name}}_client_protocol(ss::lw_shared_ptr<rpc::transport> t)
       : _transport(t) {
     }
 
@@ -163,13 +163,13 @@ public:
     {%- for method in methods %}
     virtual inline ss::future<result<rpc::client_context<{{method.output_type}}>>>
     {{method.name}}({{method.input_type}}&& r, rpc::client_opts opts) {
-       return _transport.send_typed<{{method.input_type}}, {{method.output_type}}>(std::move(r),
+       return _transport->send_typed<{{method.input_type}}, {{method.output_type}}>(std::move(r),
               {{service_name}}_service::{{method.name}}_method, std::move(opts));
     }
     {%- endfor %}
 
 private:
-    rpc::transport& _transport;
+    ss::lw_shared_ptr<rpc::transport> _transport;
 };
 
 template<typename Codec>

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -154,7 +154,14 @@ FIXTURE_TEST(echo_from_cache, rpc_integration_fixture) {
     configure_server();
     register_services();
     start_server();
-    rpc::connection_cache cache;
+    ss::sharded<ss::abort_source> as;
+    as.start().get();
+    rpc::connection_cache cache(as);
+
+    auto deferred = ss::defer([&] {
+        cache.stop().get();
+        as.stop().get();
+    });
 
     // Check that we can create connections from a cache, and moreover that we
     // can run several clients targeted at the same server, if we provide
@@ -178,7 +185,6 @@ FIXTURE_TEST(echo_from_cache, rpc_integration_fixture) {
         BOOST_REQUIRE(transport_res.has_value());
         auto transport = transport_res.value();
         echo::echo_client_protocol client(*transport);
-        auto cleanup = ss::defer([&transport] { transport->stop().get(); });
         auto f = client.echo(
           echo::echo_req{.str = payload},
           rpc::client_opts(rpc::clock_type::now() + 100ms));

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -194,6 +194,41 @@ FIXTURE_TEST(echo_from_cache, rpc_integration_fixture) {
     }
 }
 
+FIXTURE_TEST(rpc_abort_from_cache, rpc_integration_fixture) {
+    configure_server();
+    register_services();
+    start_server();
+    ss::sharded<ss::abort_source> as;
+    as.start().get();
+    rpc::connection_cache cache(as);
+    auto deferred = ss::defer([&] {
+        cache.stop().get();
+        as.stop().get();
+    });
+
+    constexpr auto node_id = model::node_id(0);
+    cache
+      .emplace(
+        node_id,
+        client_config(),
+        rpc::make_exponential_backoff_policy<rpc::clock_type>(
+          std::chrono::milliseconds(1), std::chrono::milliseconds(1)))
+      .get();
+    auto reconnect_transport = cache.get(node_id);
+    auto transport_res
+      = reconnect_transport->get_connected(rpc::clock_type::now() + 5s).get();
+    BOOST_REQUIRE(transport_res.has_value());
+    auto transport = transport_res.value();
+    echo::echo_client_protocol client(transport);
+    // Long sleep + no timeout
+    auto f = client.sleep_for(
+      {.secs = 100}, rpc::client_opts(rpc::timeout_spec::none));
+    // Trigger an abort to fail outstanding RPC requests.
+    as.invoke_on_all([](auto& local) { local.request_abort(); }).get();
+    BOOST_REQUIRE_EQUAL(f.get().error(), rpc::errc::disconnected_endpoint);
+    BOOST_REQUIRE_EQUAL(cache.contains(node_id), false);
+}
+
 FIXTURE_TEST(echo_round_trip_tls, rpc_integration_fixture) {
     auto creds_builder = config::tls_config(
                            true,

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -371,33 +371,40 @@ transport::send_typed_versioned(
 }
 
 template<typename Protocol>
-concept RpcClientProtocol = std::constructible_from<Protocol, rpc::transport&>;
+concept RpcClientProtocol
+  = std::constructible_from<Protocol, ss::lw_shared_ptr<rpc::transport>>;
 
 template<typename... Protocol>
 requires(RpcClientProtocol<Protocol>&&...) class client : public Protocol... {
 public:
-    explicit client(
-      transport_configuration cfg,
-      const std::optional<model::node_id>& node_id = std::nullopt)
-      : Protocol(_transport)...
-      , _transport(std::move(cfg), std::nullopt, node_id) {}
+    explicit client(ss::lw_shared_ptr<rpc::transport> transport)
+      : Protocol(transport)...
+      , _transport(transport) {}
 
     ss::future<> connect(rpc::clock_type::time_point connection_timeout) {
-        return _transport.connect(connection_timeout);
+        return _transport->connect(connection_timeout);
     }
-    ss::future<> stop() { return _transport.stop(); };
-    void shutdown() { _transport.shutdown(); }
+    ss::future<> stop() { return _transport->stop(); };
+    void shutdown() { _transport->shutdown(); }
 
     [[gnu::always_inline]] bool is_valid() const {
-        return _transport.is_valid();
+        return _transport->is_valid();
     }
 
     const net::unresolved_address& server_address() const {
-        return _transport.server_address();
+        return _transport->server_address();
     }
 
 private:
-    rpc::transport _transport;
+    ss::lw_shared_ptr<rpc::transport> _transport{nullptr};
 };
 
+template<typename... Protocol>
+rpc::client<Protocol...> make_client(
+  transport_configuration cfg,
+  std::optional<connection_cache_label> label = std::nullopt,
+  const std::optional<model::node_id> node_id = std::nullopt) {
+    return client<Protocol...>(ss::make_lw_shared<rpc::transport>(
+      std::move(cfg), std::move(label), node_id));
+}
 } // namespace rpc


### PR DESCRIPTION
At shutdown, eager cleanup of connection cache entries can result in faster termination of RPCs/connections to suspended nodes. This patch includes two main changes.

* Hooks up an app level abort source with connection cache that triggers the cleanup function on notification
* Removes the use of naked transport pointers in protocol and elsewhere as it is prone to UAF bugs.

Fixes #7981

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
