### PR TITLE
k/alter_partitions: check for undefined topic

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1351,10 +1351,6 @@ topics_frontend::generate_reassignments(
         co_return errc::topic_not_exists;
     }
 
-    if (!tp_metadata.value().get().is_topic_replicable()) {
-        co_return errc::topic_operation_error;
-    }
-
     auto tp_replication_factor
       = tp_metadata.value().get().get_replication_factor();
 

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -14,6 +14,7 @@ import subprocess
 import time
 import itertools
 from typing import Optional
+from ducktape.utils.util import wait_until
 
 KclPartitionOffset = namedtuple(
     'KclPartitionOffset',
@@ -245,7 +246,8 @@ class KCL:
     def alter_partition_reassignments(self,
                                       topics: dict[str, dict[int, list[int]]],
                                       user_cred: Optional[dict[str,
-                                                               str]] = None):
+                                                               str]] = None,
+                                      timeout_s: int = 10):
         """
         :param topics: the key is a topic and the value is a dict that maps partition IDs
                        to new replica assignments
@@ -273,35 +275,54 @@ class KCL:
             reassignment_str += join_partitions
             cmd.append(reassignment_str)
 
-        lines = self._cmd(cmd).splitlines()
-        self._redpanda.logger.debug(lines)
-        ok_re = re.compile(
-            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +OK$")
         no_broker_re = re.compile(
             r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +BROKER_NOT_AVAILABLE.*$"
         )
         bad_rep_factor_re = re.compile(
             r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +INVALID_REPLICATION_FACTOR.*$"
         )
-        for l in lines:
-            l = l.strip()
-            self._redpanda.logger.debug(l)
+        unknown_tp_re = re.compile(
+            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +UNKNOWN_TOPIC_OR_PARTITION:.*$"
+        )
 
-            m = no_broker_re.match(l)
-            # No broker available means the partition did not find any eligible allocation nodes.
-            # See the map from cluster errors to kafka errors in kafka::map_topic_error_code()
-            if m is not None:
-                raise RuntimeError('No eligible allocation nodes')
+        lines = None
 
-            m = bad_rep_factor_re.match(l)
-            # Invalid replication factor means the number of replicas for one (or more) partitions
-            # in a request does not match the replication factor for the topic.
-            if m is not None:
-                raise RuntimeError(
-                    'Number of replicas != topic replication factor')
+        def do_alter_partitions():
+            nonlocal lines
+            lines = self._cmd(cmd).splitlines()
 
-            m = ok_re.match(l)
-            assert m is not None
+            # Check for errors here instead of outside the KCL wrapper
+            # because test writers can use method params to account for their expectations
+            for l in lines:
+                l = l.strip()
+                self._redpanda.logger.debug(l)
+
+                m = no_broker_re.match(l)
+                # No broker available means the partition did not find any eligible allocation nodes.
+                # See the map from cluster errors to kafka errors in kafka::map_topic_error_code()
+                if m is not None:
+                    raise RuntimeError('No eligible allocation nodes')
+
+                # Invalid replication factor means the number of replicas for one (or more) partitions
+                # in a request does not match the replication factor for the topic.
+                m = bad_rep_factor_re.match(l)
+                if m is not None:
+                    raise RuntimeError(
+                        'Number of replicas != topic replication factor')
+
+                # RP may report that the topic does not exist, this can
+                # happen when the recieving broker has out-of-date metadata. So
+                # retry the request.
+                m = unknown_tp_re.match(l)
+                if m is not None:
+                    return False
+
+            return True
+
+        wait_until(do_alter_partitions,
+                   timeout_sec=timeout_s,
+                   backoff_sec=1,
+                   err_msg="Failed to alter partitions")
 
         return lines
 

--- a/tests/rptest/tests/partition_reassignments_test.py
+++ b/tests/rptest/tests/partition_reassignments_test.py
@@ -160,6 +160,23 @@ def check_cancel_reassign_partitions(lines: list[str], reassignments: dict,
         raise RuntimeError(f"Unexpected output: {lines}")
 
 
+def alter_partition_reassignments_with_kcl(
+        kcl: KCL,
+        topics: dict[str, dict[int, list[int]]],
+        user_cred: Optional[dict[str, str]] = None,
+        timeout_s: int = 10):
+    ok_re = re.compile(r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +OK$")
+
+    output = kcl.alter_partition_reassignments(topics,
+                                               user_cred=user_cred,
+                                               timeout_s=timeout_s)
+
+    for line in output:
+        assert ok_re.match(line.strip()) is not None
+
+    return output
+
+
 log_config = LoggingConfig('info',
                            logger_levels={
                                'kafka': 'trace',
@@ -264,6 +281,41 @@ class PartitionReassignmentsTest(RedpandaTest):
 
         return initial_assignments, all_node_idx, producers
 
+    def execute_reassign_partitions(self,
+                                    reassignments: dict,
+                                    timeout_s: int = 10):
+        kafka_tools = KafkaCliTools(self.redpanda)
+        return kafka_tools.reassign_partitions(
+            reassignments=reassignments,
+            operation="execute",
+            # RP may report that the topic does not exist, this can
+            # happen when the recieving broker has out-of-date metadata. So
+            # retry the request a few times.
+            msg_retry="Topic or partition is undefined",
+            timeout_s=timeout_s).splitlines()
+
+    def verify_reassign_partitions(self,
+                                   reassignments: dict,
+                                   msg_retry: Optional[str] = None,
+                                   timeout_s: int = 10):
+        kafka_tools = KafkaCliTools(self.redpanda)
+        return kafka_tools.reassign_partitions(
+            reassignments=reassignments,
+            operation="verify",
+            # Retry the script if there is a reassignment still in progress
+            msg_retry="is still in progress.",
+            timeout_s=timeout_s).splitlines()
+
+    def cancel_reassign_partitions(self,
+                                   reassignments: dict,
+                                   timeout_s: int = 10):
+        kafka_tools = KafkaCliTools(self.redpanda)
+        return kafka_tools.reassign_partitions(
+            reassignments=reassignments,
+            operation="cancel",
+            write_reassignments_to_disk=False,
+            timeout_s=timeout_s).splitlines()
+
     @cluster(num_nodes=6)
     def test_reassignments_kafka_cli(self):
         initial_assignments, all_node_idx, producers = self.initial_setup_steps(
@@ -277,13 +329,12 @@ class PartitionReassignmentsTest(RedpandaTest):
         reassignments_json = self.make_reassignments_for_cli(
             all_node_idx, initial_assignments)
 
-        kafka_tools = KafkaCliTools(self.redpanda)
-        output = kafka_tools.execute_reassign_partitions(
-            reassignments=reassignments_json)
+        output = self.execute_reassign_partitions(
+            reassignments=reassignments_json, timeout_s=30)
         check_execute_reassign_partitions(output, reassignments_json,
                                           self.logger)
 
-        output = kafka_tools.verify_reassign_partitions(
+        output = self.verify_reassign_partitions(
             reassignments=reassignments_json, timeout_s=180)
         check_verify_reassign_partitions(output, reassignments_json,
                                          self.logger)
@@ -317,7 +368,7 @@ class PartitionReassignmentsTest(RedpandaTest):
         self.logger.debug(
             f"Replacing replicas. New assignments: {reassignments}")
         kcl = KCL(self.redpanda)
-        kcl.alter_partition_reassignments(reassignments)
+        alter_partition_reassignments_with_kcl(kcl, reassignments)
 
         all_partition_idx = [p for p in range(self.PARTITION_COUNT)]
 
@@ -373,9 +424,11 @@ class PartitionReassignmentsTest(RedpandaTest):
             f"Even replica count by adding. Expect fail. New assignments: {reassignments}"
         )
 
+        kcl = KCL(self.redpanda)
+
         def try_even_replication_factor(topics):
             try:
-                kcl.alter_partition_reassignments(topics)
+                alter_partition_reassignments_with_kcl(kcl, topics)
                 raise Exception(
                     "Even replica count accepted but it should be rejected")
             except RuntimeError as ex:
@@ -414,14 +467,13 @@ class PartitionReassignmentsTest(RedpandaTest):
         reassignments_json = self.make_reassignments_for_cli(
             all_node_idx, initial_assignments)
 
-        kafka_tools = KafkaCliTools(self.redpanda)
-        output = kafka_tools.execute_reassign_partitions(
-            reassignments=reassignments_json)
+        output = self.execute_reassign_partitions(
+            reassignments=reassignments_json, timeout_s=30)
         check_execute_reassign_partitions(output, reassignments_json,
                                           self.logger)
 
         try:
-            output = kafka_tools.cancel_reassign_partitions(
+            output = self.cancel_reassign_partitions(
                 reassignments=reassignments_json)
             check_cancel_reassign_partitions(output, reassignments_json,
                                              self.logger)
@@ -432,7 +484,7 @@ class PartitionReassignmentsTest(RedpandaTest):
             else:
                 raise
 
-        output = kafka_tools.verify_reassign_partitions(
+        output = self.verify_reassign_partitions(
             reassignments=reassignments_json, timeout_s=30)
         check_verify_reassign_partitions(output, reassignments_json,
                                          self.logger)
@@ -475,15 +527,16 @@ class PartitionReassignmentsACLsTest(RedpandaTest):
         reassignments = {self.topic: {0: [1, 2, 3]}}
         self.logger.debug(f"New replica assignments: {reassignments}")
 
-        kcl = KCL(self.redpanda)
         user_cred = {
             "user": username,
             "passwd": self.password,
             "method": self.algorithm.lower().replace('-', '_')
         }
+        kcl = KCL(self.redpanda)
         try:
-            kcl.alter_partition_reassignments(reassignments,
-                                              user_cred=user_cred)
+            alter_partition_reassignments_with_kcl(kcl,
+                                                   reassignments,
+                                                   user_cred=user_cred)
             raise Exception(
                 f'AlterPartition with user {user_cred} passed. Expected fail.')
         except subprocess.CalledProcessError as e:
@@ -509,7 +562,9 @@ class PartitionReassignmentsACLsTest(RedpandaTest):
             "passwd": super_password,
             "method": super_algorithm.lower().replace('-', '_')
         }
-        kcl.alter_partition_reassignments(reassignments, user_cred=user_cred)
+        alter_partition_reassignments_with_kcl(kcl,
+                                               reassignments,
+                                               user_cred=user_cred)
 
         def reassignments_done():
             responses = kcl.list_partition_reassignments(tps_to_list,


### PR DESCRIPTION
## Cover letter

One of the validators in the AlterPartitionReassignments API relies on topic_metadata to check that the number of new replicas matches the topic replication factor. However, topic_metadata could be stale because the broker does not yet have updated metadata but it will soon. The solution is to return a retriable error and add retry loops to tests.

Fixes #8824
Fixes #8825

Changes from force-push `0c77015`:
- Remove call to `is_topic_replicable` because that is for WASM topics

Changes from force-push `c97e569` and `025bce9`:
- Add a retry loop for `topic_metadata`

Changes from force-push `cc96ddb`:
- Remove call to `is_topic_replicable` in `generate_reassignments`
- Add more logging

Changes from force-push `b756aa6`:
- Remove retry loop for topic metadata in the AlterPartitions handler
- In the check for topic replication factor, return `unknown_topic_or_partition` instead of `invalid_replication_factor`
- Add a unit test for undefined topic
- Add retry loops to DT tests for failed replication factor check.

Changes from force-push `0e56014`:
- Add more context to logging
- Move some post-processing on output to the test file
- Removed commit for JsonParse error. That will go in a separate PR

Changes from force-push `08d3927`:
- Fix syntax issues in ACLs test

Changes from force-push `667823b`:
- Comments fixes
- The check for unknown topic should be a separate validator from invalid replication factor
- Edit unit tests
- In the DT tests, move several regex into the KCL wrapper

Changes from force-push `c4b7ee5`:
- Remove conditional for null replicas in topic metadata check

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none