### PR TITLE
storage: fix race between timequery and local log GC

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1150,6 +1150,14 @@ disk_log_impl::make_reader(timequery_config config) {
               // timestamps on the batches are monotonically increasing.
               if (segment->index().batch_timestamps_are_monotonic()) {
                   index_entry = segment->index().find_nearest(cfg.time);
+                  vlog(
+                    stlog.debug,
+                    "Batch timestamps have monotonically increasing "
+                    "timestamps; used segment index to find first batch before "
+                    "timestamp {}: offset={} with ts={}",
+                    cfg.time,
+                    index_entry->offset,
+                    index_entry->timestamp);
               }
 
               auto offset_within_segment = index_entry


### PR DESCRIPTION
This fixes races between timequery and local log GC by doing another check for the log start offset before returning.

This adds a test that reproduces #8291, where local GC racing with timequeries could result in missing some offsets.

TODO: this test is still flaky with the following issue
```
[ERROR - 2023-02-14 01:06:22,858 - timequery_test - query_slices - lineno:299]: Timestamp 1664453160716 returned 12204 instead of 11716
```
```
DEBUG 2023-02-14 01:06:20,832 [shard 1] cluster - partition.cc:426 - timequery (raft) {kafka/tqtopic/0} t={timestamp: 1664453160716} max_offset(k)=12288
DEBUG 2023-02-14 01:06:20,834 [shard 1] storage - disk_log_impl.cc:1156 - Batch timestamps have monotonically increasing timestamps; used segment index to find first batch before timestamp {timestamp: 1664453160716}: offset=11913 with ts={timestamp: 1664453160708}
DEBUG 2023-02-14 01:06:20,834 [shard 1] storage - disk_log_impl.cc:1173 - Starting timequery lookup from offset=11913 for ts={timestamp: 1664453160716} in segment with start_offset=8645
DEBUG 2023-02-14 01:06:20,838 [shard 1] cluster - partition.cc:454 - timequery (raft) {kafka/tqtopic/0} t={timestamp: 1664453160716} max_offset(r)=12630 result(r)=11929

...
TRACE 2023-02-14 01:06:22,810 [shard 1] storage-gc - disk_log_impl.cc:740 - [{kafka/tqtopic/0}] house keeping with configuration from manager: {evicition_time:{timestamp: 1675731982804}, max_bytes:18446744073709551615, max_collectible_offset:12500, should_sanitize:false}
TRACE 2023-02-14 01:06:22,810 [shard 1] storage-gc - disk_log_impl.cc:689 - [{kafka/tqtopic/0}] Overrode retention for topic with remote write enabled: {evicition_time:{timestamp: 1676250382810}, max_bytes:131072, max_collectible_offset:12500, should_sanitize:false}
TRACE 2023-02-14 01:06:22,810 [shard 1] storage-gc - disk_log_impl.cc:769 - [{kafka/tqtopic/0}] applying 'deletion' log cleanup policy with config: {evicition_time:{timestamp: 1676250382810}, max_bytes:131072, max_collectible_offset:12500, should_sanitize:false}
DEBUG 2023-02-14 01:06:22,810 [shard 1] storage-gc - disk_log_impl.cc:797 - [{kafka/tqtopic/0}] retention max bytes: 131072, current partition size: 4066211
DEBUG 2023-02-14 01:06:22,810 [shard 1] storage-gc - disk_log_impl.cc:289 - [{kafka/tqtopic/0}] gc[size_based_retention] requested to remove segments up to 12424 offse
...
DEBUG 2023-02-14 01:06:22,846 [shard 1] cluster - partition.cc:426 - timequery (raft) {kafka/tqtopic/0} t={timestamp: 1664453160716} max_offset(k)=12288
DEBUG 2023-02-14 01:06:22,847 [shard 1] storage - disk_log_impl.cc:1156 - Batch timestamps have monotonically increasing timestamps; used segment index to find first batch before timestamp {timestamp: 1664453160716}: offset=11913 with ts={timestamp: 1664453160708}
DEBUG 2023-02-14 01:06:22,847 [shard 1] storage - disk_log_impl.cc:1173 - Starting timequery lookup from offset=11913 for ts={timestamp: 1664453160716} in segment with start_offset=8645
INFO  2023-02-14 01:06:22,847 [shard 1] storage - disk_log_impl.cc:1241 - Removing "/var/lib/redpanda/data/kafka/tqtopic/0_16/8645-1-v1.log" (remove_prefix_full_segments, {offset_tracker:{term:1, base_offset:8645, committed_offset:8680, dirty_offset:8680}, compacted_segment=0, finished_self_compaction=0, generation={9}, reader={/var/lib/redpanda/data/kafka/tqtopic/0_16/8645-1-v1.log, (38332 bytes)}, writer=nullptr, cache=nullptr, compaction_index:nullopt, closed=0, tombstone=0, index={file:/var/lib/redpanda/data/kafka/tqtopic/0_16/8645-1-v1.base_index, offsets:{8645}, index:{header_bitflags:0, base_offset:{8645}, max_offset:{8680}, base_timestamp:{timestamp: 1664453157496}, max_timestamp:{timestamp: 1664453157531}, batch_timestamps_are_monotonic:1, index(1,1,1)}, step:32768, needs_persistence:0}})
DEBUG 2023-02-14 01:06:22,856 [shard 1] cluster - partition.cc:454 - timequery (raft) {kafka/tqtopic/0} t={timestamp: 1664453160716} max_offset(r)=12630 result(r)=12425
```


<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

 ### Bug Fixes
* Fixed a race between timequeries and local log GC that could result in returning higher offsets for a given timestamp.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

 

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
