### PR TITLE
cloud_storage: Extended status for automated recovery

### DIFF
--- a/src/v/cloud_storage/topic_recovery_service.cc
+++ b/src/v/cloud_storage/topic_recovery_service.cc
@@ -187,11 +187,18 @@ topic_recovery_service::start_recovery(ss::httpd::request req) {
     }
 }
 
-ss::future<> topic_recovery_service::propagate_state(state s) {
-    return container().invoke_on_all([s](auto& svc) {
-        svc._state = s;
-        return ss::make_ready_future<>();
-    });
+void topic_recovery_service::set_state(state s) {
+    _state = s;
+    push_status();
+    if (ss::this_shard_id() != shard_id) {
+        throw std::runtime_error{fmt_with_ctx(
+          fmt::format,
+          "state change to {} on shard {} detected, recovery should only "
+          "run on shard {}",
+          s,
+          ss::this_shard_id(),
+          shard_id)};
+    }
 }
 
 topic_recovery_service::recovery_status
@@ -311,7 +318,7 @@ topic_recovery_service::start_bg_recovery_task(recovery_request request) {
 
     _recovery_request.emplace(request);
 
-    co_await propagate_state(state::scanning_bucket);
+    set_state(state::scanning_bucket);
     vlog(cst_log.debug, "scanning bucket {}", _config.bucket);
     auto bucket_contents_result = co_await collect_manifest_paths(
       _remote.local(), _as, _config);
@@ -322,7 +329,7 @@ topic_recovery_service::start_bg_recovery_task(recovery_request request) {
           recovery_error_code::error_listing_items);
         vlog(cst_log.error, "{}", error.context);
         _recovery_request = std::nullopt;
-        co_await propagate_state(state::inactive);
+        set_state(state::inactive);
         co_return error;
     }
 
@@ -334,7 +341,7 @@ topic_recovery_service::start_bg_recovery_task(recovery_request request) {
     if (manifests.empty()) {
         vlog(cst_log.info, "exiting recovery, no topics to create");
         _recovery_request = std::nullopt;
-        co_await propagate_state(state::inactive);
+        set_state(state::inactive);
         co_return outcome::success();
     }
 
@@ -351,7 +358,7 @@ topic_recovery_service::start_bg_recovery_task(recovery_request request) {
 
     populate_recovery_status();
 
-    co_await propagate_state(state::creating_topics);
+    set_state(state::creating_topics);
     vlog(cst_log.debug, "creating topics");
 
     result<void, recovery_error_ctx> result = outcome::success();
@@ -370,7 +377,7 @@ topic_recovery_service::start_bg_recovery_task(recovery_request request) {
             }
         }
 
-        co_await propagate_state(state::recovering_data);
+        set_state(state::recovering_data);
         start_download_bg_tracker();
     } catch (const ss::timed_out_error& err) {
         result = recovery_error_ctx::make(
@@ -380,7 +387,7 @@ topic_recovery_service::start_bg_recovery_task(recovery_request request) {
 
     if (result.has_error()) {
         _recovery_request = std::nullopt;
-        co_await propagate_state(state::inactive);
+        set_state(state::inactive);
     }
     co_return result;
 }
@@ -659,7 +666,7 @@ ss::future<> topic_recovery_service::do_check_for_downloads() {
     _recovery_request = std::nullopt;
 
     co_await reset_topic_configurations();
-    co_await propagate_state(state::inactive);
+    set_state(state::inactive);
 }
 
 ss::future<> topic_recovery_service::check_for_downloads() {

--- a/src/v/cloud_storage/topic_recovery_service.h
+++ b/src/v/cloud_storage/topic_recovery_service.h
@@ -75,6 +75,8 @@ struct topic_recovery_service
         std::optional<recovery_request> request;
     };
 
+    static constexpr int shard_id = 0;
+
     topic_recovery_service(
       ss::sharded<remote>& remote,
       ss::sharded<cluster::topic_table>& topic_state,
@@ -113,14 +115,7 @@ struct topic_recovery_service
     std::vector<recovery_status> recovery_status_log() const;
 
 private:
-    /// \brief The recovery process runs on a single shard. The status of the
-    /// process is always propagated to all other shards on the node, so that
-    /// admin API requests coming in on any other shard are able to respond with
-    /// the status of the process. This also enables us to reject any incoming
-    /// requests quickly if a recovery is already in process, without making
-    /// calls to the cloud storage API.
-    /// \param state The state to propagate to all shards.
-    ss::future<> propagate_state(state);
+    void set_state(state);
 
     /// \brief Returns a list of manifests for topics to create, filtering
     /// against existing topics in cluster. The manifests are downloaded from

--- a/src/v/cluster/topic_recovery_status_frontend.cc
+++ b/src/v/cluster/topic_recovery_status_frontend.cc
@@ -13,6 +13,7 @@
 #include "cluster/topic_recovery_status_frontend.h"
 
 #include "cloud_storage/topic_recovery_service.h"
+#include "cluster/logger.h"
 #include "cluster/members_table.h"
 #include "cluster/topic_recovery_status_rpc_service.h"
 #include "rpc/connection_cache.h"
@@ -47,6 +48,8 @@ topic_recovery_status_frontend::status(model::node_id node) const {
             });
 
     if (!node_result.has_value()) {
+        vlog(
+          clusterlog.warn, "missing response from controller leader: {}", node);
         co_return std::nullopt;
     }
 

--- a/src/v/cluster/topic_recovery_status_frontend.h
+++ b/src/v/cluster/topic_recovery_status_frontend.h
@@ -42,7 +42,8 @@ public:
         topic_recovery_service,
       skip_this_node skip_source_shard) const;
 
-    ss::future<std::optional<status_response>> status() const;
+    ss::future<std::optional<status_response>>
+    status(model::node_id node) const;
 
     ss::future<> stop() { return ss::make_ready_future<>(); }
 

--- a/src/v/cluster/topic_recovery_status_rpc_handler.cc
+++ b/src/v/cluster/topic_recovery_status_rpc_handler.cc
@@ -29,8 +29,9 @@ ss::future<status_response> topic_recovery_status_rpc_handler::get_status(
           .state = cloud_storage::topic_recovery_service::state::inactive};
     }
 
-    auto current_status
-      = _topic_recovery_service.local().current_recovery_status();
+    auto current_status = co_await _topic_recovery_service.invoke_on(
+      cloud_storage::topic_recovery_service::shard_id,
+      [](auto& svc) { return svc.current_recovery_status(); });
 
     std::vector<topic_downloads> downloads;
     downloads.reserve(current_status.download_counts.size());

--- a/src/v/cluster/topic_recovery_status_rpc_handler.cc
+++ b/src/v/cluster/topic_recovery_status_rpc_handler.cc
@@ -22,34 +22,44 @@ topic_recovery_status_rpc_handler::topic_recovery_status_rpc_handler(
   : topic_recovery_status_rpc_service{sg, ssg}
   , _topic_recovery_service{service} {}
 
+static status_response map_log_to_response(
+  std::vector<cloud_storage::topic_recovery_service::recovery_status>
+    status_log) {
+    status_response response;
+    for (const auto& status : status_log) {
+        std::vector<topic_downloads> downloads;
+        downloads.reserve(status.download_counts.size());
+
+        for (const auto& [tp_ns, count] : status.download_counts) {
+            downloads.push_back(
+              {.tp_ns = tp_ns,
+               .pending_downloads = count.pending_downloads,
+               .successful_downloads = count.successful_downloads,
+               .failed_downloads = count.failed_downloads});
+        }
+
+        recovery_request_params request_params;
+        request_params.populate(status.request);
+        response.status_log.push_back(
+          {.state = status.state,
+           .download_counts = std::move(downloads),
+           .request = std::move(request_params)});
+    }
+    return response;
+}
+
 ss::future<status_response> topic_recovery_status_rpc_handler::get_status(
   status_request&&, rpc::streaming_context&) {
     if (!_topic_recovery_service.local_is_initialized()) {
         co_return status_response{
-          .state = cloud_storage::topic_recovery_service::state::inactive};
+          .status_log = {
+            {.state = cloud_storage::topic_recovery_service::state::inactive}}};
     }
 
-    auto current_status = co_await _topic_recovery_service.invoke_on(
+    auto recovery_status_log = co_await _topic_recovery_service.invoke_on(
       cloud_storage::topic_recovery_service::shard_id,
-      [](auto& svc) { return svc.current_recovery_status(); });
-
-    std::vector<topic_downloads> downloads;
-    downloads.reserve(current_status.download_counts.size());
-
-    for (const auto& [tp_ns, count] : current_status.download_counts) {
-        downloads.push_back(
-          {.tp_ns = tp_ns,
-           .pending_downloads = count.pending_downloads,
-           .successful_downloads = count.successful_downloads,
-           .failed_downloads = count.failed_downloads});
-    }
-
-    recovery_request_params request_params;
-    request_params.populate(current_status.request);
-    co_return status_response{
-      .state = current_status.state,
-      .download_counts = downloads,
-      .request = request_params};
+      [](auto& svc) { return svc.recovery_status_log(); });
+    co_return map_log_to_response(std::move(recovery_status_log));
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_recovery_status_rpc_handler.cc
+++ b/src/v/cluster/topic_recovery_status_rpc_handler.cc
@@ -22,7 +22,7 @@ topic_recovery_status_rpc_handler::topic_recovery_status_rpc_handler(
   : topic_recovery_status_rpc_service{sg, ssg}
   , _topic_recovery_service{service} {}
 
-static status_response map_log_to_response(
+status_response map_log_to_response(
   std::vector<cloud_storage::topic_recovery_service::recovery_status>
     status_log) {
     status_response response;

--- a/src/v/cluster/topic_recovery_status_rpc_handler.h
+++ b/src/v/cluster/topic_recovery_status_rpc_handler.h
@@ -19,6 +19,9 @@ struct topic_recovery_service;
 
 namespace cluster {
 
+status_response map_log_to_response(
+  std::vector<cloud_storage::topic_recovery_service::recovery_status>
+    status_log);
 class topic_recovery_status_rpc_handler final
   : public topic_recovery_status_rpc_service {
 public:

--- a/src/v/cluster/topic_recovery_status_types.cc
+++ b/src/v/cluster/topic_recovery_status_types.cc
@@ -36,7 +36,12 @@ std::ostream& operator<<(std::ostream& os, const recovery_request_params& req) {
 }
 
 bool status_response::is_active() const {
-    return state != cloud_storage::topic_recovery_service::state::inactive;
+    if (status_log.empty()) {
+        return false;
+    }
+
+    return status_log.back().state
+           != cloud_storage::topic_recovery_service::state::inactive;
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_recovery_status_types.h
+++ b/src/v/cluster/topic_recovery_status_types.h
@@ -64,14 +64,27 @@ struct recovery_request_params
 
 std::ostream& operator<<(std::ostream&, const recovery_request_params&);
 
-struct status_response
+struct single_status
   : serde::
-      envelope<status_response, serde::version<0>, serde::compat_version<0>> {
+      envelope<single_status, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     cloud_storage::topic_recovery_service::state state;
     std::vector<topic_downloads> download_counts;
     recovery_request_params request;
     auto serde_fields() { return std::tie(state, download_counts, request); }
+
+    bool is_active() const;
+
+    friend bool operator==(const single_status&, const single_status&)
+      = default;
+};
+
+struct status_response
+  : serde::
+      envelope<status_response, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    std::vector<single_status> status_log;
+    auto serde_fields() { return std::tie(status_log); }
 
     bool is_active() const;
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -802,7 +802,8 @@ class Admin:
 
     def get_topic_recovery_status(self, node=None, **kwargs):
         request_args = {'node': node, **kwargs}
-        return self._request('get', "cloud_storage/automated_recovery",
+        return self._request('get',
+                             "cloud_storage/automated_recovery?extended=true",
                              **request_args)
 
     def self_test_start(self, options):

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -963,9 +963,14 @@ class AdminApiBasedRestore(FastCheck):
         def wait_for_status():
             r = self.admin.get_topic_recovery_status()
             assert r.status_code == requests.status_codes.codes['ok']
-            if r.json()['state'] == 'inactive':
+            response = r.json()
+            self.logger.debug(f'response {response}')
+            if isinstance(response, dict):
                 return False
-            return r.json()
+            for entry in r.json():
+                if entry['state'] != 'inactive':
+                    return entry
+            return False
 
         status = wait_until_result(wait_for_status, timeout_sec=60)
         self.logger.info(f'got status: {status}')


### PR DESCRIPTION
The following changes are introduced in this PR:

1. The topic recovery service previously only stored the latest request. This change enables storing the last five requests and returning them as an optional parameter to the admin API.
2. The status of the service which was previously propagated to all shards in a node, is now only stored on shard 0 of the controller leader. This fixes a potential bug where the full status containing download counts and recovery request were not copied to other shards. The components querying the status such as topic recovery frontend now explicitly invoke queries on shard 0 instead of checking the state on the local shard.
3. Fixes a bug where the recovery ran on _any_ shard on controller leader rather than shard 0.

Fixes https://github.com/redpanda-data/redpanda/issues/8818

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none
