### PR TITLE
[v22.3.x] storage: enforce safe usage of segment_reader_handle in the cloud write path

### DIFF
--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -201,4 +201,19 @@ inline bool is_compactible(const model::record_batch& b) {
       || b.header().type == model::record_batch_type::archival_metadata);
 }
 
+template<typename Func>
+auto with_segment_reader_handle(segment_reader_handle handle, Func func) {
+    static_assert(
+      std::is_nothrow_move_constructible_v<Func>,
+      "Func's move constructor must not throw");
+
+    return ss::do_with(
+      std::move(handle),
+      [func = std::move(func)](segment_reader_handle& handle) {
+          return ss::futurize_invoke(func, handle).finally([&handle] {
+              return handle.close().then(
+                [] { return ss::make_ready_future<>(); });
+          });
+      });
+}
 } // namespace storage::internal


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8842.
Fixes https://github.com/redpanda-data/redpanda/issues/8427.