### PR TITLE
tests: improve unit test runtime

### DIFF
--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ rp_test(
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cloud_storage v::storage_test_utils
   LABELS cloud_storage
+  ARGS "-- -c 8"
 )
 
 rp_test(

--- a/src/v/compression/tests/CMakeLists.txt
+++ b/src/v/compression/tests/CMakeLists.txt
@@ -11,4 +11,5 @@ rp_test(
   SOURCES zstd_tests.cc
   LIBRARIES v::seastar_testing_main v::compression v::rprandom
   LABELS compression
+  ARGS "-- -c 1"
   )

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1328,9 +1328,11 @@ ss::future<> consensus::do_start() {
                 _hbeat = clock_type::time_point::min();
                 auto conf = _configuration_manager.get_latest().brokers();
                 if (!conf.empty() && _self.id() == conf.begin()->id()) {
-                    // for single node scenarios arm immediate election,
-                    // use standard election timeout otherwise.
-                    if (conf.size() > 1) {
+                    // Arm immediate election for single node scenarios
+                    // or for the very first start of the preferred leader
+                    // in a multi-node group.  Otherwise use standard election
+                    // timeout.
+                    if (conf.size() > 1 && _term > model::term_id{0}) {
                         next_election += _jit.next_duration();
                     }
                 } else {

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ rp_test(
     DEFINITIONS BOOST_TEST_DYN_LINK
     LIBRARIES Boost::unit_test_framework v::raft v::storage_test_utils v::model_test_utils
     LABELS raft
+    ARGS "-- -c 8"
 )
 
 rp_test(
@@ -14,6 +15,7 @@ rp_test(
     DEFINITIONS BOOST_TEST_DYN_LINK
     LIBRARIES Boost::unit_test_framework v::raft
     LABELS raft
+    ARGS "-- -c 8"
 )
 
 
@@ -41,6 +43,7 @@ rp_test(
   SOURCES ${srcs}
   LIBRARIES v::seastar_testing_main v::raft v::storage_test_utils v::model_test_utils v::features
   LABELS raft
+  ARGS "-- -c 8"
 )
 
 rp_test(
@@ -49,4 +52,5 @@ rp_test(
   SOURCES offset_translator_tests.cc
   LIBRARIES v::seastar_testing_main v::raft v::storage_test_utils
   LABELS kafka
+  ARGS "-- -c 8"
 )

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ rp_test(
     snapshot_test.cc
   LIBRARIES v::seastar_testing_main v::storage_test_utils
   LABELS storage
+  ARGS "-- -c 8"
 )
 
 # this test is only run on release builds because non-release builds use the

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2525,7 +2525,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                  .get0();
 
     int cnt = 0;
-    int max = 500;
+    int max = 50;
     bool done = false;
     mutex log_mutex;
     auto produce

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -199,11 +199,15 @@ class TestRunner():
 
         if "rpunit" in binary or "rpfixture" in binary:
             unit_args = [
-                "--overprovisioned", "--unsafe-bypass-fsync 1",
+                "--unsafe-bypass-fsync 1",
                 f"--default-log-level={log_level}",
                 "--logger-log-level='io=debug'",
                 "--logger-log-level='exception=debug'"
             ] + COMMON_TEST_ARGS
+
+            if self.ci:
+                unit_args.append("--overprovisioned")
+
             if "--" in args:
                 args = args + unit_args
             else:

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -197,6 +197,12 @@ class TestRunner():
         # selectively re-run failing tests with more logging if needed.
         log_level = 'trace' if self.ci else 'info'
 
+        def has_flag(flag, *synonyms):
+            """Check if the args list already contains a particularly CLI flag,
+            optionally pass a list of synonyms"""
+            all_flags = [flag] + list(synonyms)
+            return any(any(a.startswith(f) for f in all_flags) for a in args)
+
         if "rpunit" in binary or "rpfixture" in binary:
             unit_args = [
                 "--unsafe-bypass-fsync 1", f"--default-log-level={log_level}",
@@ -207,8 +213,9 @@ class TestRunner():
             if self.ci:
                 unit_args.append("--overprovisioned")
 
-            # Unit tests should never need all the node's memory
-            if "rpunit" in binary:
+            # Unit tests should never need all the node's memory.  Set a fixed
+            # memory size if one was not already provided
+            if "rpunit" in binary and not has_flag("-m", "--memory"):
                 args.append("-m1G")
 
             if "--" in args:

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -199,14 +199,17 @@ class TestRunner():
 
         if "rpunit" in binary or "rpfixture" in binary:
             unit_args = [
-                "--unsafe-bypass-fsync 1",
-                f"--default-log-level={log_level}",
+                "--unsafe-bypass-fsync 1", f"--default-log-level={log_level}",
                 "--logger-log-level='io=debug'",
                 "--logger-log-level='exception=debug'"
             ] + COMMON_TEST_ARGS
 
             if self.ci:
                 unit_args.append("--overprovisioned")
+
+            # Unit tests should never need all the node's memory
+            if "rpunit" in binary:
+                args.append("-m1G")
 
             if "--" in args:
                 args = args + unit_args

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -218,6 +218,11 @@ class TestRunner():
             if "rpunit" in binary and not has_flag("-m", "--memory"):
                 args.append("-m1G")
 
+            if "rpunit" in binary and not has_flag("-c", "--smp"):
+                raise RuntimeError(
+                    f"Test {self.binary} run without -c flag: set it in CMakeLists for the test"
+                )
+
             if "--" in args:
                 args = args + unit_args
             else:


### PR DESCRIPTION
- Remove `--overprovisioned` from unit test arguments: this was making tests run substantially slower, especially when running some of the more I/O intensive tests in parallel.
- Dial down the runtime of one particularly long running test case in storage.
- Run tests at INFO level logs when not in CI: for local testing, developers can always bump up the log level as needed.
- Add a special case to raft code to skip the election wait on first start on the preferred leader
- Add an explicit memory size for unit test execution, to prevent seastar trying to grab the whole node's memory.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

  * none