### PR TITLE
tests: raise on HTTP errors in installer

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -298,6 +298,7 @@ class RedpandaInstaller:
         # releases when requested.
         releases_resp = requests.get(
             "https://api.github.com/repos/redpanda-data/redpanda/releases")
+        releases_resp.raise_for_status()
         try:
             self._released_versions = [
                 int_tuple(VERSION_RE.findall(f["tag_name"])[0])


### PR DESCRIPTION
This happens if you get e.g. a 403 for rate limiting.

Previously we'd get a nondescript exception trying to read an attribute off the response.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none