### PR TITLE
More flexible constraints solver interface 

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -26,15 +26,18 @@ namespace cluster {
 
 namespace {
 
-hard_constraint_evaluator
+hard_constraint
 distinct_from(const absl::flat_hash_set<model::node_id>& nodes) {
-    class impl : public hard_constraint_evaluator::impl {
+    class impl : public hard_constraint::impl {
     public:
         explicit impl(const absl::flat_hash_set<model::node_id>& nodes)
           : _nodes(nodes) {}
 
-        bool evaluate(const allocation_node& node) const final {
-            return !_nodes.contains(node.id());
+        hard_constraint_evaluator
+        make_evaluator(const replicas_t&) const final {
+            return [this](const allocation_node& node) {
+                return !_nodes.contains(node.id());
+            };
         }
 
         ss::sstring name() const final {
@@ -47,7 +50,7 @@ distinct_from(const absl::flat_hash_set<model::node_id>& nodes) {
         const absl::flat_hash_set<model::node_id>& _nodes;
     };
 
-    return hard_constraint_evaluator(std::make_unique<impl>(nodes));
+    return hard_constraint(std::make_unique<impl>(nodes));
 }
 
 } // namespace
@@ -213,28 +216,27 @@ partition_constraints partition_balancer_planner::get_partition_constraints(
 
     // Add constraint on least disk usage
     allocation_constraints.soft_constraints.push_back(
-      ss::make_lw_shared<soft_constraint_evaluator>(
+      ss::make_lw_shared<soft_constraint>(
         least_disk_filled(max_disk_usage_ratio, rrs.node_disk_reports)));
 
     // Add constraint on partition max_disk_usage_ratio overfill
     size_t upper_bound_for_partition_size = partition_size
                                             + _config.segment_fallocation_step;
     allocation_constraints.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint_evaluator>(
-        disk_not_overflowed_by_partition(
-          max_disk_usage_ratio,
-          upper_bound_for_partition_size,
-          rrs.node_disk_reports)));
+      ss::make_lw_shared<hard_constraint>(disk_not_overflowed_by_partition(
+        max_disk_usage_ratio,
+        upper_bound_for_partition_size,
+        rrs.node_disk_reports)));
 
     // Add constraint on unavailable nodes
     allocation_constraints.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint_evaluator>(
+      ss::make_lw_shared<hard_constraint>(
         distinct_from(rrs.timed_out_unavailable_nodes)));
 
     // Add constraint on decommissioning nodes
     if (!rrs.decommissioning_nodes.empty()) {
         allocation_constraints.hard_constraints.push_back(
-          ss::make_lw_shared<hard_constraint_evaluator>(
+          ss::make_lw_shared<hard_constraint>(
             distinct_from(rrs.decommissioning_nodes)));
     }
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -16,6 +16,9 @@
 #include "cluster/partition_balancer_types.h"
 #include "cluster/scheduling/constraints.h"
 #include "cluster/scheduling/types.h"
+#include "ssx/sformat.h"
+
+#include <seastar/core/sstring.hh>
 
 #include <optional>
 
@@ -34,9 +37,8 @@ distinct_from(const absl::flat_hash_set<model::node_id>& nodes) {
             return !_nodes.contains(node.id());
         }
 
-        void print(std::ostream& o) const final {
-            fmt::print(
-              o,
+        ss::sstring name() const final {
+            return ssx::sformat(
               "distinct from nodes: {}",
               std::vector(_nodes.begin(), _nodes.end()));
         }

--- a/src/v/cluster/scheduling/allocation_strategy.h
+++ b/src/v/cluster/scheduling/allocation_strategy.h
@@ -26,6 +26,7 @@ public:
          * constraints in the specified domain
          */
         virtual result<model::broker_shard> allocate_replica(
+          const replicas_t&,
           const allocation_constraints&,
           allocation_state&,
           partition_allocation_domain)
@@ -38,10 +39,11 @@ public:
       : _impl(std::move(impl)) {}
 
     result<model::broker_shard> allocate_replica(
+      const replicas_t& current_replicas,
       const allocation_constraints& ac,
       allocation_state& state,
       const partition_allocation_domain domain) {
-        return _impl->allocate_replica(ac, state, domain);
+        return _impl->allocate_replica(current_replicas, ac, state, domain);
     }
 
 private:

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -24,17 +24,18 @@ class allocation_state;
  * max score for nodes that matches the soft constraint and 0 for
  * the ones that not
  */
-soft_constraint_evaluator make_soft_constraint(hard_constraint_evaluator);
+soft_constraint make_soft_constraint(hard_constraint);
 
-hard_constraint_evaluator not_fully_allocated();
-hard_constraint_evaluator is_active();
+hard_constraint not_fully_allocated();
+hard_constraint is_active();
 
-hard_constraint_evaluator on_node(model::node_id);
+hard_constraint on_node(model::node_id);
 
-hard_constraint_evaluator on_nodes(const std::vector<model::node_id>&);
+hard_constraint on_nodes(const std::vector<model::node_id>&);
 
-hard_constraint_evaluator
-distinct_from(const std::vector<model::broker_shard>&);
+hard_constraint distinct_from(const std::vector<model::broker_shard>&);
+
+hard_constraint distinct_nodes();
 
 /*
  * constraint checks that new partition won't violate max_disk_usage_ratio
@@ -42,7 +43,7 @@ distinct_from(const std::vector<model::broker_shard>&);
  * assigned_reallocation_sizes is sizes of partitions that are going to be
  * allocated on node
  */
-hard_constraint_evaluator disk_not_overflowed_by_partition(
+hard_constraint disk_not_overflowed_by_partition(
   const double max_disk_usage_ratio,
   const size_t partition_size,
   const absl::flat_hash_map<model::node_id, node_disk_space>&
@@ -52,7 +53,7 @@ hard_constraint_evaluator disk_not_overflowed_by_partition(
  * scores nodes based on free overall allocation capacity left
  * returning `0` for fully allocated nodes and `max_capacity` for empty nodes
  */
-soft_constraint_evaluator least_allocated();
+soft_constraint least_allocated();
 
 /*
  * scores nodes based on allocation capacity used by priority partitions
@@ -60,26 +61,22 @@ soft_constraint_evaluator least_allocated();
  * and `max_capacity` for nodes without any priority partitions
  * non-priority partition allocations are ignored
  */
-soft_constraint_evaluator
-  least_allocated_in_domain(partition_allocation_domain);
+soft_constraint least_allocated_in_domain(partition_allocation_domain);
 
 /*
  * constraint scores nodes on free disk space
  * assigned_reallocation_sizes is sizes of partitions that are going to be
  * allocated on node
  */
-soft_constraint_evaluator least_disk_filled(
+soft_constraint least_disk_filled(
   const double max_disk_usage_ratio,
   const absl::flat_hash_map<model::node_id, node_disk_space>&
     node_disk_reports);
 
-hard_constraint_evaluator
-distinct_rack(const std::vector<model::broker_shard>&, const allocation_state&);
+hard_constraint distinct_rack(const allocation_state&);
 
-inline soft_constraint_evaluator distinct_rack_preferred(
-  const std::vector<model::broker_shard>& replicas,
-  const allocation_state& state) {
-    return make_soft_constraint(distinct_rack(replicas, state));
+inline soft_constraint distinct_rack_preferred(const allocation_state& state) {
+    return make_soft_constraint(distinct_rack(state));
 }
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -145,6 +145,9 @@ private:
       partition_allocation_domain,
       const std::vector<model::broker_shard>&);
 
+    allocation_constraints
+    default_constraints(const partition_allocation_domain);
+
     std::unique_ptr<allocation_state> _state;
     allocation_strategy _allocation_strategy;
     ss::sharded<members_table>& _members;

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -16,6 +16,8 @@
 #include "model/fundamental.h"
 #include "vassert.h"
 
+#include <seastar/util/noncopyable_function.hh>
+
 #include <absl/container/node_hash_set.h>
 
 namespace cluster {
@@ -29,82 +31,80 @@ class allocation_state;
  * https://github.com/Netflix/Fenzo/blob/master/fenzo-core/src/main/java/com/netflix/fenzo/VMTaskFitnessCalculator.java
  *
  */
+using replicas_t = std::vector<model::broker_shard>;
+using hard_constraint_evaluator
+  = ss::noncopyable_function<bool(const allocation_node&)>;
 
-class hard_constraint_evaluator final {
+using soft_constraint_evaluator
+  = ss::noncopyable_function<uint64_t(const allocation_node&)>;
+
+class hard_constraint {
 public:
     struct impl {
-        virtual bool evaluate(const allocation_node&) const = 0;
+        virtual hard_constraint_evaluator
+        make_evaluator(const replicas_t& current_replicas) const = 0;
+
         virtual ss::sstring name() const = 0;
         virtual ~impl() = default;
     };
 
-    explicit hard_constraint_evaluator(std::unique_ptr<impl> impl) noexcept
+    explicit hard_constraint(std::unique_ptr<impl> impl) noexcept
       : _impl(std::move(impl)) {}
 
-    hard_constraint_evaluator(hard_constraint_evaluator&&) noexcept = default;
-    hard_constraint_evaluator(const hard_constraint_evaluator&) = delete;
+    hard_constraint(hard_constraint&&) noexcept = default;
+    hard_constraint(const hard_constraint&) = delete;
 
-    hard_constraint_evaluator&
-    operator=(hard_constraint_evaluator&&) noexcept = default;
-    hard_constraint_evaluator&
-    operator=(const hard_constraint_evaluator&) noexcept = delete;
+    hard_constraint& operator=(hard_constraint&&) noexcept = default;
+    hard_constraint& operator=(const hard_constraint&) noexcept = delete;
 
-    ~hard_constraint_evaluator() noexcept = default;
+    ~hard_constraint() noexcept = default;
 
-    bool evaluate(const allocation_node& node) const {
-        return _impl->evaluate(node);
+    hard_constraint_evaluator
+    make_evaluator(const replicas_t& current_replicas) const {
+        return _impl->make_evaluator(current_replicas);
     }
 
     ss::sstring name() const { return _impl->name(); }
 
 private:
-    friend std::ostream&
-    operator<<(std::ostream& o, const hard_constraint_evaluator& e) {
-        fmt::print("hard constraint: [{}]", e.name());
+    friend std::ostream& operator<<(std::ostream& o, const hard_constraint& c) {
+        fmt::print("hard constraint: [{}]", c.name());
         return o;
     }
-
     std::unique_ptr<impl> _impl;
 };
 
-class soft_constraint_evaluator final {
+class soft_constraint final {
 public:
     static constexpr uint64_t max_score = 10'000'000;
     struct impl {
-        virtual uint64_t score(const allocation_node&) const = 0;
+        virtual soft_constraint_evaluator
+        make_evaluator(const replicas_t& current_replicas) const = 0;
         virtual ss::sstring name() const = 0;
         virtual ~impl() = default;
     };
 
-    explicit soft_constraint_evaluator(std::unique_ptr<impl> impl) noexcept
+    explicit soft_constraint(std::unique_ptr<impl> impl) noexcept
       : _impl(std::move(impl)) {}
 
-    soft_constraint_evaluator(soft_constraint_evaluator&&) noexcept = default;
-    soft_constraint_evaluator(const soft_constraint_evaluator&) = delete;
+    soft_constraint(soft_constraint&&) noexcept = default;
+    soft_constraint(const soft_constraint&) = delete;
 
-    soft_constraint_evaluator&
-    operator=(soft_constraint_evaluator&&) noexcept = default;
-    soft_constraint_evaluator&
-    operator=(const soft_constraint_evaluator&) noexcept = delete;
+    soft_constraint& operator=(soft_constraint&&) noexcept = default;
+    soft_constraint& operator=(const soft_constraint&) noexcept = delete;
 
-    ~soft_constraint_evaluator() noexcept = default;
+    ~soft_constraint() noexcept = default;
 
-    uint64_t score(const allocation_node& node) const {
-        auto ret = _impl->score(node);
-        vassert(
-          ret <= max_score,
-          "Score returned from soft constraint evaluator must be in range of "
-          "[0, 10'000'000]. Returned score: {}",
-          ret);
-        return ret;
+    soft_constraint_evaluator
+    make_evaluator(const replicas_t& current_replicas) const {
+        return _impl->make_evaluator(current_replicas);
     };
 
     ss::sstring name() const { return _impl->name(); }
 
 private:
-    friend std::ostream&
-    operator<<(std::ostream& o, const soft_constraint_evaluator& e) {
-        fmt::print("soft constraint: [{}]", e.name());
+    friend std::ostream& operator<<(std::ostream& o, const soft_constraint& c) {
+        fmt::print("soft constraint: [{}]", c.name());
         return o;
     }
 
@@ -118,11 +118,11 @@ private:
  */
 struct allocation_constraints {
     // we store pointers in here to make allocation constraints copyable
-    using soft_constraint_ev_ptr = ss::lw_shared_ptr<soft_constraint_evaluator>;
-    using hard_constraint_ev_ptr = ss::lw_shared_ptr<hard_constraint_evaluator>;
+    using soft_constraint_ptr = ss::lw_shared_ptr<soft_constraint>;
+    using hard_constraint_ptr = ss::lw_shared_ptr<hard_constraint>;
 
-    std::vector<soft_constraint_ev_ptr> soft_constraints;
-    std::vector<hard_constraint_ev_ptr> hard_constraints;
+    std::vector<soft_constraint_ptr> soft_constraints;
+    std::vector<hard_constraint_ptr> hard_constraints;
 
     void add(allocation_constraints);
     friend std::ostream&

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -34,7 +34,7 @@ class hard_constraint_evaluator final {
 public:
     struct impl {
         virtual bool evaluate(const allocation_node&) const = 0;
-        virtual void print(std::ostream&) const = 0;
+        virtual ss::sstring name() const = 0;
         virtual ~impl() = default;
     };
 
@@ -55,10 +55,12 @@ public:
         return _impl->evaluate(node);
     }
 
+    ss::sstring name() const { return _impl->name(); }
+
 private:
     friend std::ostream&
     operator<<(std::ostream& o, const hard_constraint_evaluator& e) {
-        e._impl->print(o);
+        fmt::print("hard constraint: [{}]", e.name());
         return o;
     }
 
@@ -70,7 +72,7 @@ public:
     static constexpr uint64_t max_score = 10'000'000;
     struct impl {
         virtual uint64_t score(const allocation_node&) const = 0;
-        virtual void print(std::ostream&) const = 0;
+        virtual ss::sstring name() const = 0;
         virtual ~impl() = default;
     };
 
@@ -97,10 +99,12 @@ public:
         return ret;
     };
 
+    ss::sstring name() const { return _impl->name(); }
+
 private:
     friend std::ostream&
     operator<<(std::ostream& o, const soft_constraint_evaluator& e) {
-        e._impl->print(o);
+        fmt::print("soft constraint: [{}]", e.name());
         return o;
     }
 

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -436,8 +436,8 @@ cluster::hard_constraint_evaluator make_throwning_hard_evaluator() {
         bool evaluate(const cluster::allocation_node&) const final {
             throw std::runtime_error("evaluation exception");
         }
-        void print(std::ostream& o) const final {
-            fmt::print(o, "exception throwing hard constraint evaluator");
+        ss::sstring name() const final {
+            return "exception throwing hard constraint evaluator";
         }
     };
 
@@ -449,8 +449,8 @@ cluster::hard_constraint_evaluator make_false_evaluator() {
         bool evaluate(const cluster::allocation_node&) const final {
             return false;
         }
-        void print(std::ostream& o) const final {
-            fmt::print(o, "false returning constraint evaluator");
+        ss::sstring name() const final {
+            return "false returning constraint evaluator";
         }
     };
 
@@ -462,9 +462,7 @@ cluster::hard_constraint_evaluator make_nop_evaluator() {
         bool evaluate(const cluster::allocation_node&) const final {
             return true;
         }
-        void print(std::ostream& o) const final {
-            fmt::print(o, "false returning constraint evaluator");
-        }
+        ss::sstring name() const final { return "NOP evaluator"; }
     };
 
     return cluster::hard_constraint_evaluator(std::make_unique<impl>());

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -415,8 +415,7 @@ make_allocation_request(const custom_assignable_topic_configuration& ca_cfg) {
         for (auto& cas : ca_cfg.custom_assignments) {
             allocation_constraints constraints;
             constraints.hard_constraints.push_back(
-              ss::make_lw_shared<hard_constraint_evaluator>(
-                on_nodes(cas.replicas)));
+              ss::make_lw_shared<hard_constraint>(on_nodes(cas.replicas)));
 
             req.partitions.emplace_back(
               cas.id, cas.replicas.size(), std::move(constraints));
@@ -1139,25 +1138,22 @@ partition_constraints topics_frontend::get_partition_constraints(
 
     // Add constraint on least disk usage
     allocation_constraints.soft_constraints.push_back(
-      ss::make_lw_shared<soft_constraint_evaluator>(
+      ss::make_lw_shared<soft_constraint>(
         least_disk_filled(max_disk_usage_ratio, info.node_disk_reports)));
 
     auto partition_size_it = info.ntp_sizes.find(id);
     if (partition_size_it == info.ntp_sizes.end()) {
-        return partition_constraints(
-          id, new_replication_factor, std::move(allocation_constraints));
+        return {id, new_replication_factor, std::move(allocation_constraints)};
     }
 
     // Add constraint on partition max_disk_usage_ratio overfill
     allocation_constraints.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint_evaluator>(
-        disk_not_overflowed_by_partition(
-          max_disk_usage_ratio,
-          partition_size_it->second,
-          info.node_disk_reports)));
+      ss::make_lw_shared<hard_constraint>(disk_not_overflowed_by_partition(
+        max_disk_usage_ratio,
+        partition_size_it->second,
+        info.node_disk_reports)));
 
-    return partition_constraints(
-      id, new_replication_factor, std::move(allocation_constraints));
+    return {id, new_replication_factor, std::move(allocation_constraints)};
 }
 
 ss::future<std::error_code> topics_frontend::increase_replication_factor(
@@ -1336,7 +1332,7 @@ allocation_request make_allocation_request(
     req.partitions.reserve(1);
     allocation_constraints constraints;
     constraints.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint_evaluator>(on_nodes(new_replicas)));
+      ss::make_lw_shared<hard_constraint>(on_nodes(new_replicas)));
     req.partitions.emplace_back(
       ntp.tp.partition, tp_replication_factor, std::move(constraints));
     return req;


### PR DESCRIPTION
Made interface of `hard_constraint` and `soft_constraint` more flexible.
Previously an instance of a constraint evaluator was immutable and were
not modified during the whole allocation process this made some
constraints tightly coupled with the allocation process as they had to
be aware of intermediate allocations. f.e. rack awareness constraint.

Change constraint interface to be a factory for constraint evaluator.
Each time an allocation is required a constraint interface
`make_evaluator` method is called with current replica set. This way a
factory is able to make some preliminary calculations before evaluating
constraint for the possible set of options. Additionally constraints are
now decoupled from an intermediate allocation making it possible to
create them outside of `partition_allocator` itself, even if they relay
on intermediate allocations.

This implementation will make it possible to define all constraint types
per partition instead of relaying on partition_allocator to decide which
constraints to use.
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
  * none