### PR TITLE
storage: fix race between timequery and local log GC

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -388,11 +388,40 @@ ss::future<> partition::stop() {
 
 ss::future<std::optional<storage::timequery_result>>
 partition::timequery(storage::timequery_config cfg) {
+    const bool is_read_replica
+      = _raft->log_config().is_read_replica_mode_enabled();
+    const bool query_before_raft_log_start = _raft->log().start_timestamp()
+                                             > cfg.time;
+
     std::optional<storage::timequery_result> result;
-    bool is_read_replica = _raft->log_config().is_read_replica_mode_enabled();
-    if (
-      _cloud_storage_partition && _cloud_storage_partition->is_data_available()
-      && (is_read_replica || _raft->log().start_timestamp() >= cfg.time)) {
+
+    if (is_read_replica || query_before_raft_log_start) {
+        // We have data in the remote partition, and all the data in the raft
+        // log is ahead of the query timestamp or the topic is a read replica,
+        // so proceed to query the remote partition to try and find the earliest
+        // data that has timestamp >= the query time.
+        co_return co_await cloud_storage_timequery(cfg);
+    }
+
+    result = co_await local_timequery(cfg);
+
+    // It's possible that during the query, our local log was GCed, and the
+    // result may not actually reflect the correct offset for this
+    // partition. If the local log doesn't look like it can serve the query
+    // anymore, query the remote log.
+    if (_raft->log().start_timestamp() > cfg.time) {
+        co_return co_await cloud_storage_timequery(cfg);
+    } else {
+        co_return result;
+    }
+}
+
+ss::future<std::optional<storage::timequery_result>>
+partition::cloud_storage_timequery(storage::timequery_config cfg) {
+    const bool may_read_from_cloud
+      = _cloud_storage_partition
+        && _cloud_storage_partition->is_data_available();
+    if (may_read_from_cloud) {
         // We have data in the remote partition, and all the data in the raft
         // log is ahead of the query timestamp or the topic is a read replica,
         // so proceed to query the remote partition to try and find the earliest
@@ -406,15 +435,25 @@ partition::timequery(storage::timequery_config cfg) {
 
         // remote_partition pre-translates offsets for us, so no call into
         // the offset translator here
-        auto cloud_result = co_await _cloud_storage_partition->timequery(cfg);
-        if (cloud_result) {
-            co_return cloud_result;
+        auto result = co_await _cloud_storage_partition->timequery(cfg);
+        if (result) {
+            vlog(
+              clusterlog.debug,
+              "timequery (cloud) {} t={} max_offset(r)={} result(r)={}",
+              _raft->ntp(),
+              cfg.time,
+              cfg.max_offset,
+              result->offset);
         }
 
-        // Fall-through: if cfg.time is ahead of the end of the remote_partition
-        // data, search for it in the local data.
+        co_return result;
     }
 
+    co_return std::nullopt;
+}
+
+ss::future<std::optional<storage::timequery_result>>
+partition::local_timequery(storage::timequery_config cfg) {
     vlog(
       clusterlog.debug,
       "timequery (raft) {} t={} max_offset(k)={}",
@@ -422,10 +461,10 @@ partition::timequery(storage::timequery_config cfg) {
       cfg.time,
       cfg.max_offset);
 
-    // Translate input (kafka) offset into raft offset
     cfg.max_offset = _raft->get_offset_translator_state()->to_log_offset(
       cfg.max_offset);
-    result = co_await _raft->timequery(cfg);
+
+    auto result = co_await _raft->timequery(cfg);
     if (result) {
         vlog(
           clusterlog.debug,
@@ -475,7 +514,8 @@ ss::future<> partition::update_configuration(topic_properties properties) {
     auto& old_ntp_config = _raft->log().config();
     auto new_ntp_config = properties.get_ntp_cfg_overrides();
 
-    // Before applying change, consider whether it changes cloud storage mode
+    // Before applying change, consider whether it changes cloud storage
+    // mode
     bool cloud_storage_changed = false;
     bool new_archival = new_ntp_config.shadow_indexing_mode
                         && model::is_archival_enabled(
@@ -491,8 +531,8 @@ ss::future<> partition::update_configuration(topic_properties properties) {
     co_await _raft->log().update_configuration(new_ntp_config);
 
     // If this partition's cloud storage mode changed, rebuild the archiver.
-    // This must happen after raft update, because it reads raft's ntp_config
-    // to decide whether to construct an archiver.
+    // This must happen after raft update, because it reads raft's
+    // ntp_config to decide whether to construct an archiver.
     if (cloud_storage_changed) {
         vlog(
           clusterlog.debug,
@@ -534,8 +574,8 @@ partition::get_term_last_offset(model::term_id term) const {
     if (!o) {
         return std::nullopt;
     }
-    // Kafka defines leader epoch last offset as a first offset of next leader
-    // epoch
+    // Kafka defines leader epoch last offset as a first offset of next
+    // leader epoch
     return model::next_offset(*o);
 }
 
@@ -545,8 +585,8 @@ partition::get_cloud_term_last_offset(model::term_id term) const {
     if (!o) {
         return std::nullopt;
     }
-    // Kafka defines leader epoch last offset as a first offset of next leader
-    // epoch
+    // Kafka defines leader epoch last offset as a first offset of next
+    // leader epoch
     return model::next_offset(kafka::offset_cast(*o));
 }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -317,6 +317,12 @@ public:
     }
 
 private:
+    ss::future<std::optional<storage::timequery_result>>
+      cloud_storage_timequery(storage::timequery_config);
+
+    ss::future<std::optional<storage::timequery_result>>
+      local_timequery(storage::timequery_config);
+
     consensus_ptr _raft;
     ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;
     ss::lw_shared_ptr<raft::log_eviction_stm> _log_eviction_stm;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3338,14 +3338,7 @@ size_t consensus::get_follower_count() const {
 
 ss::future<std::optional<storage::timequery_result>>
 consensus::timequery(storage::timequery_config cfg) {
-    return _log.timequery(cfg).then(
-      [this](std::optional<storage::timequery_result> res) {
-          if (res) {
-              // do not return offset that is earlier raft start offset
-              res->offset = std::max(res->offset, start_offset());
-          }
-          return res;
-      });
+    return _log.timequery(cfg);
 }
 
 } // namespace raft

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1150,6 +1150,14 @@ disk_log_impl::make_reader(timequery_config config) {
               // timestamps on the batches are monotonically increasing.
               if (segment->index().batch_timestamps_are_monotonic()) {
                   index_entry = segment->index().find_nearest(cfg.time);
+                  vlog(
+                    stlog.debug,
+                    "Batch timestamps have monotonically increasing "
+                    "timestamps; used segment index to find first batch before "
+                    "timestamp {}: offset={} with ts={}",
+                    cfg.time,
+                    index_entry->offset,
+                    index_entry->timestamp);
               }
 
               auto offset_within_segment = index_entry
@@ -1162,7 +1170,7 @@ disk_log_impl::make_reader(timequery_config config) {
 
           vlog(
             stlog.debug,
-            "Starting timequery lookup from offset={} for ts={} in segment "
+            "Starting timequery lookup from offset={} for ts={} in log "
             "with start_offset={}",
             start_offset,
             cfg.time,

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -878,12 +878,12 @@ offset_stats disk_log_impl::offsets() const {
 }
 
 model::timestamp disk_log_impl::start_timestamp() const {
-    if (_segs.empty()) {
+    auto seg = _segs.lower_bound(_start_offset);
+    if (seg == _segs.end()) {
         return model::timestamp{};
     }
 
-    auto& s = _segs.front();
-    return s->index().base_timestamp();
+    return (*seg)->index().base_timestamp();
 }
 
 ss::future<> disk_log_impl::new_segment(


### PR DESCRIPTION
This PR fixes a few latent timequery issues that were surfaced by a test from @andrwng.
The work here builds on Andrew's https://github.com/redpanda-data/redpanda/pull/8857.

The main concern is the interaction between the consensus and storage layers
on eviction. The storage layer will mark segments for eviction, the consensus layer
will then create a snapshot and update the collectible offset. Then the storage layer
will update the disk log's `start_offset` and begin removing segments one by one.

`disk_log_impl::start_timestamp()` used to returned the base timestamp of the first
known segment (it didn't take into account the `start_offset`). This caused two problems:
1. The logic to determine whether to use remote timequery would not be correct
while segments were being deleted. This led us to do local timequery on segments
being removed.
2. While performing a local timequery, eviction can occur and put the result below
the Raft start offset of the log. This is detected by checking `disk_log_impl::start_timestamp`
after the local timequery completes. If such a case occurs, a remote timequery is
done.

Fixes #8291

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x


## Release Notes
### Bug Fixes
* Fix a race between the time-query and truncation logic which caused time-queries to return
offsets marked for deletion/compaction.
