### PR TITLE
cluster: fix a case where version updates weren't generated

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -83,12 +83,13 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
     _health_notify_handle = _hm_backend.local().register_node_callback(
       [this](
         node_health_report const& report,
-        std::optional<std::reference_wrapper<const node_health_report>>
-          old_report) {
+        std::optional<std::reference_wrapper<const node_health_report>>) {
+          // If we did not know the node's version or if the report is
+          // higher, submit an update.
+          auto i = _node_versions.find(report.id);
           if (
-            !old_report
-            || report.local_state.logical_version
-                 != old_report.value().get().local_state.logical_version) {
+            i == _node_versions.end()
+            || i->second < report.local_state.logical_version) {
               update_node_version(
                 report.id, report.local_state.logical_version);
           }
@@ -109,6 +110,11 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
             if (group != _raft0_group) {
                 return;
             }
+
+            // On leadership change, clear our map of node versions: this
+            // ensures that we will populate it with fresh data when we next
+            // see a health report from each node.
+            _node_versions.clear();
 
             vlog(
               clusterlog.debug, "Controller leader notification term {}", term);
@@ -265,7 +271,7 @@ void feature_manager::update_node_version(
       update_node,
       v);
 
-    _updates.push_back({update_node, v});
+    _updates.emplace(update_node, v);
     _update_wait.signal();
 }
 

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -123,7 +123,7 @@ private:
     ss::sharded<rpc::connection_cache>& _connection_cache;
     raft::group_id _raft0_group;
 
-    std::vector<std::pair<model::node_id, cluster_version>> _updates;
+    version_map _updates;
     ss::condition_variable _update_wait;
 
     cluster::notification_id_type _leader_notify_handle{


### PR DESCRIPTION
This could result in clusters failing to activate features after an upgrade, if the controller leadership changed at just the wrong moment.

Fixes: https://github.com/redpanda-data/redpanda/issues/8758

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

None

## Release Notes

### Bug Fixes/
* An issue is fixed where a cluster might not activate new functionality after an upgrade if a controller leadership change happened at a particular point during upgrade
