### PR TITLE
[ducktape] Add retries for admin_api call

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -113,8 +113,10 @@ class NodesDecommissioningTest(EndToEndTest):
 
     def _set_recovery_rate(self, rate):
         # use admin API to leverage the retry policy when controller returns 503
-        patch_result = Admin(self.redpanda).patch_cluster_config(
-            upsert={"raft_learner_recovery_rate": rate})
+        patch_result = Admin(self.redpanda,
+                             retry_codes=[503, 504],
+                             retries_amount=10).patch_cluster_config(
+                                 upsert={"raft_learner_recovery_rate": rate})
         self.logger.debug(
             f"setting recovery rate to {rate} result: {patch_result}")
 

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -534,7 +534,7 @@ class NodesDecommissioningTest(EndToEndTest):
         self.start_producer(1, throughput=self.producer_throughput())
         self.start_consumer(1)
         self.await_startup(min_records=self.records_to_wait(), timeout_sec=180)
-        admin = Admin(self.redpanda)
+        admin = Admin(self.redpanda, retry_codes=[503, 504], retries_amount=10)
 
         to_decommission = random.choice(self.redpanda.nodes)
         node_id = self.redpanda.node_id(to_decommission)

--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -104,7 +104,9 @@ class PartitionMovementMixin():
         return result
 
     def _wait_post_move(self, topic, partition, assignments, timeout_sec):
-        admin = Admin(self.redpanda)
+        admin = Admin(self.redpanda,
+                      retry_codes=[404, 503, 504],
+                      retries_amount=10)
 
         def status_done():
             results = []


### PR DESCRIPTION
Add retries for some timeout codes to admin_api in ducktape tests

Fixes #8673 #8659

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

none

## Release Notes

* none
