### PR TITLE
cloud_storage: downgrade DeleteObject 404 message to debug

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -686,7 +686,7 @@ ss::future<upload_result> remote::delete_object(
             break;
         case error_outcome::notfound:
             vlog(
-              ctxlog.info,
+              ctxlog.debug,
               "Unexpected NoSuchKey error response from DeleteObject {} will "
               "be ignored",
               path);


### PR DESCRIPTION
This message is frequent on GCS backends: INFO is too verbose, and the message does not indicate an issue that users should pay attention to.

This is a bespoke change for v22.3.x, because on `dev` the code has already been revised in a way that changed this along with more invasive changes.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Bug Fixes

* Harmless "Unexpected NoSuchKey error" log message is downgraded from INFO to DEBUG severity.  This message appears frequently on object stores that do not implement the S3 DeleteObject verb in a way that matches the AWS interface, such as GCS.

