### PR TITLE
tests: move intree clients installation to script

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -36,7 +36,8 @@ RUN /opt/ducktape-deps.sh install_omb
 # Install Kafka Java test clients / workloads
 RUN mkdir -p /opt/redpanda-tests/java
 COPY --chown=0:0 tests/java/e2e-verifiers /opt/redpanda-tests/java/e2e-verifiers
-RUN mvn clean package --batch-mode --file /opt/redpanda-tests/java/e2e-verifiers --define buildDir=/opt/e2e-verifiers
+COPY --chown=0:0 tests/java/verifiers /opt/redpanda-tests/java/verifiers
+RUN /opt/ducktape-deps.sh install_java_test_clients
 
 # - install distro-packaged depedencies
 # - allow user env variables in ssh sessions
@@ -72,7 +73,7 @@ RUN /opt/ducktape-deps.sh install_sarama_examples
 
 # Install our in-tree go tests
 COPY --chown=0:0 tests/go /opt/redpanda-tests/go
-RUN cd /opt/redpanda-tests/go/sarama/produce_test && go mod tidy && go build
+RUN /opt/ducktape-deps.sh install_go_test_clients
 
 # Install franz-go
 RUN /opt/ducktape-deps.sh install_franz_bench
@@ -111,10 +112,6 @@ COPY --chown=0:0 tools/offline_log_viewer /opt/scripts/offline_log_viewer
 RUN mkdir -p /opt/scripts/consumer_offsets_recovery
 COPY --chown=0:0 tools/consumer_offsets_recovery /opt/scripts/consumer_offsets_recovery
 RUN python3 -m pip install --force --no-cache-dir -r  /opt/scripts/consumer_offsets_recovery/requirements.txt
-
-# Install our in-tree Java test clients / workloads
-COPY --chown=0:0 tests/java/verifiers /opt/redpanda-tests/java/verifiers
-RUN mvn clean package --batch-mode --file /opt/redpanda-tests/java/verifiers --define buildDir=/opt/verifiers
 
 # Install remote_scripts
 RUN mkdir -p /opt/remote

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -168,4 +168,15 @@ function install_arroyo() {
   python3 -m pip install --force --no-cache-dir -e /opt/arroyo
 }
 
+function install_java_test_clients() {
+  mvn clean package --batch-mode --file /opt/redpanda-tests/java/e2e-verifiers --define buildDir=/opt/e2e-verifiers
+  mvn clean package --batch-mode --file /opt/redpanda-tests/java/verifiers --define buildDir=/opt/verifiers
+}
+
+function install_go_test_clients() {
+  cd /opt/redpanda-tests/go/sarama/produce_test
+  go mod tidy
+  go build
+}
+
 $@


### PR DESCRIPTION
The folder structure and build commands change over time from branches. We need to track these changes through the ducktape-deps.sh script instead of having them in the Dockerfile. Thus, cdt tests can consume the same commands through that script

ref https://github.com/redpanda-data/devprod/issues/601

## Backports Required

- [ ] v22.3.x
- [ ] v22.2.x



## Release Notes

* none