### PR TITLE
rpk: force rewrite when parsing old seedServers

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -20,8 +20,8 @@ import (
 func getValidConfig() *Config {
 	conf := DevDefault()
 	conf.Redpanda.SeedServers = []SeedServer{
-		{SocketAddress{"127.0.0.1", 33145}},
-		{SocketAddress{"127.0.0.1", 33146}},
+		{Host: SocketAddress{"127.0.0.1", 33145}},
+		{Host: SocketAddress{"127.0.0.1", 33146}},
 	}
 	conf.Redpanda.DeveloperMode = false
 	conf.Rpk = RpkConfig{

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -294,6 +294,19 @@ func (c *Config) isSameLoaded() bool {
 		return false
 	}
 
+	// If we have a file with an older version of the SeedServer, we should
+	// write the file to disk even if the contents are the same. This is
+	// necessary because Redpanda no longer parses older SeedServer versions.
+	//
+	// For more information, see github.com/redpanda-data/redpanda/issues/8915.
+	if init != nil {
+		for _, s := range init.Redpanda.SeedServers {
+			if s.untabbed {
+				return false
+			}
+		}
+	}
+
 	return reflect.DeepEqual(init, final)
 }
 

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -107,6 +107,14 @@ type KafkaClient struct {
 
 type SeedServer struct {
 	Host SocketAddress `yaml:"host,omitempty" json:"host"`
+
+	// The SeedServer in older versions of redpanda was untabbed, but we support
+	// these older versions using a custom unmarshaller. We track whether the
+	// SeedServer field has been modified from the older version using this
+	// unexported field.
+	//
+	// See see github.com/redpanda-data/redpanda/issues/8915.
+	untabbed bool
 }
 
 type SocketAddress struct {

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -573,6 +573,8 @@ func (ss *SeedServer) UnmarshalYAML(n *yaml.Node) error {
 			return errors.New("redpanda.yaml redpanda.seed_server: nested host differs from address and port fields; only one must be set")
 		}
 
+		ss.untabbed = true // This means that we are unmarshalling an older version.
+
 		ss.Host = embedded
 		if embeddedZero {
 			ss.Host = nested

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -649,7 +649,18 @@ func TestSeedServers(t *testing.T) {
     port: 80
 `,
 			exp: []SeedServer{
-				{SocketAddress{"0.0.0.1", 80}},
+				{Host: SocketAddress{"0.0.0.1", 80}},
+			},
+		},
+		{
+			name: "list of single seed server with old tabbing",
+			data: `test_server:
+  - host:
+    address: "0.0.0.1"
+    port: 80
+`,
+			exp: []SeedServer{
+				{Host: SocketAddress{"0.0.0.1", 80}, untabbed: true},
 			},
 		},
 		{
@@ -663,8 +674,8 @@ func TestSeedServers(t *testing.T) {
       port: 90
 `,
 			exp: []SeedServer{
-				{SocketAddress{"0.0.0.1", 80}},
-				{SocketAddress{"0.0.0.2", 90}},
+				{Host: SocketAddress{"0.0.0.1", 80}},
+				{Host: SocketAddress{"0.0.0.2", 90}},
 			},
 		},
 		{
@@ -713,7 +724,7 @@ func TestSeedServer(t *testing.T) {
     port: 33145
 `,
 			exp: SeedServer{
-				SocketAddress{"192.168.10.1", 33145},
+				Host: SocketAddress{"192.168.10.1", 33145},
 			},
 		},
 		{
@@ -724,7 +735,7 @@ func TestSeedServer(t *testing.T) {
         port: 80
 `,
 			exp: SeedServer{
-				SocketAddress{"0.0.0.1", 80},
+				Host: SocketAddress{"0.0.0.1", 80},
 			},
 		},
 		{
@@ -734,7 +745,8 @@ func TestSeedServer(t *testing.T) {
     port: 80
 `,
 			exp: SeedServer{
-				SocketAddress{"1.0.0.1", 80},
+				Host:     SocketAddress{"1.0.0.1", 80},
+				untabbed: true,
 			},
 		},
 		{
@@ -747,7 +759,8 @@ func TestSeedServer(t *testing.T) {
   port: 80
 `,
 			exp: SeedServer{
-				SocketAddress{"0.0.0.1", 80},
+				Host:     SocketAddress{"0.0.0.1", 80},
+				untabbed: true,
 			},
 		},
 		{
@@ -798,7 +811,8 @@ func TestSeedServer(t *testing.T) {
   address: "0.0.0.1"
 `,
 			exp: SeedServer{
-				SocketAddress{Address: "0.0.0.1"},
+				Host:     SocketAddress{Address: "0.0.0.1"},
+				untabbed: true,
 			},
 		},
 		{
@@ -809,7 +823,8 @@ func TestSeedServer(t *testing.T) {
   port: 82
 `,
 			exp: SeedServer{
-				SocketAddress{Port: 82},
+				Host:     SocketAddress{Port: 82},
+				untabbed: true,
 			},
 		},
 	} {
@@ -999,7 +1014,7 @@ rpk:
 						{"redpanda-0.my.domain.com.", 9093, "external"},
 					},
 					SeedServers: []SeedServer{
-						{SocketAddress{"192.168.0.1", 33145}},
+						{Host: SocketAddress{"192.168.0.1", 33145}, untabbed: true},
 					},
 					Other: map[string]interface{}{
 						"enable_admin_api": true,
@@ -1149,7 +1164,7 @@ redpanda:
 						{"redpanda-0.my.domain.com.", 9093, "external"},
 					},
 					SeedServers: []SeedServer{
-						{SocketAddress{"192.168.0.1", 33145}},
+						{Host: SocketAddress{"192.168.0.1", 33145}, untabbed: true},
 					},
 					Other: map[string]interface{}{
 						"enable_admin_api": true,
@@ -1321,9 +1336,9 @@ rpk:
 						{"redpanda-0.my.domain.com.", 9093, "external"},
 					},
 					SeedServers: []SeedServer{
-						{SocketAddress{"192.168.0.1", 33145}},
-						{SocketAddress{"192.168.0.1", 33145}},
-						{SocketAddress{"192.168.0.1", 33145}},
+						{Host: SocketAddress{"192.168.0.1", 33145}},
+						{Host: SocketAddress{"192.168.0.1", 33145}},
+						{Host: SocketAddress{"192.168.0.1", 33145}, untabbed: true},
 					},
 					Other: map[string]interface{}{
 						"enable_admin_api": true,


### PR DESCRIPTION
If we have a file with an older version of the
SeedServer, we should rewrite the file to disk
even if the contents are the same. This is
necessary because Redpanda no longer parses older
SeedServer versions.

Older version could be in the form of:

```yaml
redpanda:
  seed_servers:
    - address: {address}
      port: {port}
```

Now is:

```yaml
redpanda:
  seed_servers:
    - host:
        address: {address}
        port: {port}
```
Fixes #8915.

## Backports Required
- [ ] none - issue does not exist in previous branches

This was introduced 5 days ago and is not released yet.

## Release Notes
  * none

