### PR TITLE
tests: use /etc/hosts for azurite DNS

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     - redpanda-test
   azurite:
     container_name: azurite
-    hostname: devstoreaccount1.blob.localhost
     restart: always
     ports:
     - 10000:10000


### PR DESCRIPTION
...instead of a hostname in docker-compose.

The docker-compose route was only working in docker, whereas in podman the .localhost DNS always resolved to ::1.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none

