### PR TITLE
Fix interleaving bug with log_manager::_housekeeping_timer rearming

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -145,22 +145,23 @@ log_manager::log_manager(
         _jitter = simple_time_jitter<ss::lowres_clock>{
           _config.compaction_interval()};
         if (_housekeeping_timer.cancel()) {
+            // rearm is behind the result of cancel, to ensure that no more
+            // than one trigger_housekeeping is in flight
             _housekeeping_timer.rearm(_jitter());
         }
     });
 }
 void log_manager::trigger_housekeeping() {
     ssx::background = ssx::spawn_with_gate_then(_open_gate, [this] {
-                          auto next_housekeeping = _jitter();
-                          return housekeeping().finally(
-                            [this, next_housekeeping] {
-                                // all of these *MUST* be in the finally
-                                if (_open_gate.is_closed()) {
-                                    return;
-                                }
-
-                                _housekeeping_timer.rearm(next_housekeeping);
-                            });
+                          return housekeeping().finally([this] {
+                              // all of these *MUST* be in the finally
+                              if (_open_gate.is_closed()) {
+                                  return;
+                              }
+                              // _jitter is queried in the same execution
+                              // context to fix an interleaving bug issue/8492
+                              _housekeeping_timer.rearm(_jitter());
+                          });
                       }).handle_exception([](std::exception_ptr e) {
         vlog(stlog.info, "Error processing housekeeping(): {}", e);
     });


### PR DESCRIPTION
Fixes #8492

as @VladLazar pointed out,
trigger_housekeeping calls _jitter() before a suspension point, and rearm _housekeeping_timer with this value.
if compaction_interval is updated while a housekeeping loop is running, a new _jitter value is computed, but trigger_housekeeping will rearm the timer with the old value.

For the test:
The sporadic nature of the failures means that previously the check could miss one node not passing the test

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
 * none
