### PR TITLE
[v22.3.x] scaling_up_test: clean node before starting

### DIFF
--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -148,6 +148,7 @@ class ScalingUpTest(EndToEndTest):
         self.await_startup(min_records=5 * throughput, timeout_sec=120)
         # add three nodes at once
         for n in self.redpanda.nodes[3:]:
+            self.redpanda.clean_node(n)
             self.redpanda.start_node(n)
 
         self.wait_for_partitions_rebalanced(total_replicas=total_replicas,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/7760
Fixes https://github.com/redpanda-data/redpanda/issues/8928,