### PR TITLE
cluster: fix leader balancer using low level leadership transfer interface

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -382,6 +382,11 @@ private:
     /// change and the archiver is not stopping.
     bool can_update_archival_metadata() const;
 
+    /// Return true if it is permitted to start new uploads: this
+    /// requires can_update_archival_metadata, plus that we are
+    /// not paused.
+    bool may_begin_uploads() const;
+
     /// Helper to generate a segment path from candidate
     remote_segment_path
     segment_path_for_candidate(const upload_candidate& candidate);

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -402,7 +402,7 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             _tp_state.local(),
             _partition_leaders.local(),
             _members_table.local(),
-            _raft_manager.local().raft_client(),
+            std::ref(_connections),
             std::ref(_shard_table),
             std::ref(_partition_manager),
             std::ref(_as),

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -125,6 +125,11 @@
             "name": "cancel_node_partition_movements",
             "input_type": "cancel_node_partition_movements_request",
             "output_type": "cancel_partition_movements_reply"
+        },
+        {
+            "name": "transfer_leadership",
+            "input_type": "transfer_leadership_request",
+            "output_type": "transfer_leadership_reply"
         }
     ]
 }

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -438,4 +438,13 @@ controller_api::get_node_decommission_progress(
     co_return ret;
 }
 
+std::optional<ss::shard_id>
+controller_api::shard_for(const raft::group_id& group) const {
+    if (_shard_table.local().contains(group)) {
+        return _shard_table.local().shard_for(group);
+    } else {
+        return std::nullopt;
+    }
+}
+
 } // namespace cluster

--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -76,6 +76,8 @@ public:
       get_node_decommission_progress(
         model::node_id, model::timeout_clock::time_point);
 
+    std::optional<ss::shard_id> shard_for(const raft::group_id& group) const;
+
 private:
     ss::future<result<bool>> are_ntps_ready(
       absl::node_hash_map<model::node_id, std::vector<model::ntp>>,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -687,6 +687,7 @@ partition::transfer_leadership(std::optional<model::node_id> target) {
           clusterlog.debug,
           "transfer_leadership[{}]: entering archiver prepare",
           ntp());
+
         bool archiver_clean = co_await _archiver->prepare_transfer_leadership(
           archival_timeout.value());
         if (!archiver_clean) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -155,11 +155,6 @@ public:
     ss::future<std::error_code>
     transfer_leadership(std::optional<model::node_id> target);
 
-    ss::future<std::error_code>
-    request_leadership(model::timeout_clock::time_point timeout) {
-        return _raft->request_leadership(timeout);
-    }
-
     ss::future<std::error_code> update_replica_set(
       std::vector<raft::broker_revision> brokers,
       model::revision_id new_revision_id) {

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -10,6 +10,7 @@
  */
 #include "cluster/scheduling/leader_balancer.h"
 
+#include "cluster/controller_service.h"
 #include "cluster/logger.h"
 #include "cluster/members_table.h"
 #include "cluster/partition_leaders_table.h"
@@ -731,9 +732,19 @@ leader_balancer::do_transfer_local(reassignment transfer) const {
     co_return co_await _partition_manager.invoke_on(shard, std::move(func));
 }
 
-ss::future<bool> leader_balancer::do_transfer_remote(reassignment transfer) {
+/**
+ * Deprecated: this method may be removed when we no longer require
+ * compatibility with Redpanda <= 22.3
+ */
+ss::future<bool>
+leader_balancer::do_transfer_remote_legacy(reassignment transfer) {
     raft::transfer_leadership_request req{
       .group = transfer.group, .target = transfer.to.node_id};
+
+    vlog(
+      clusterlog.debug,
+      "Leadership transfer of group {} using legacy RPC",
+      transfer.group);
 
     auto raft_client = raft::make_rpc_client_protocol(
       _raft0->self().id(), _connections);
@@ -762,6 +773,49 @@ ss::future<bool> leader_balancer::do_transfer_remote(reassignment transfer) {
       raft::make_error_code(res.value().result).message());
 
     co_return false;
+}
+
+ss::future<bool> leader_balancer::do_transfer_remote(reassignment transfer) {
+    transfer_leadership_request req{
+      .group = transfer.group, .target = transfer.to.node_id};
+
+    auto res = co_await _connections.local()
+                 .with_node_client<controller_client_protocol>(
+                   _raft0->self().id(),
+                   ss::this_shard_id(),
+                   transfer.from.node_id,
+                   leader_transfer_rpc_timeout,
+                   [req](controller_client_protocol ccp) mutable {
+                       return ccp.transfer_leadership(
+                         std::move(req),
+                         rpc::client_opts(leader_transfer_rpc_timeout));
+                   });
+
+    if (res.has_error() && res.error() == rpc::errc::method_not_found) {
+        // Cluster leadership transfer unavailable: use legacy raw raft leader
+        // transfer API
+        co_return co_await do_transfer_remote_legacy(std::move(transfer));
+    } else if (res.has_error()) {
+        vlog(
+          clusterlog.info,
+          "Leadership transfer of group {} failed with error: {}",
+          transfer.group,
+          res.error().message());
+        co_return false;
+    } else if (res.value().data.success) {
+        vlog(
+          clusterlog.trace,
+          "Leadership transfer of group {} succeeded",
+          transfer.group);
+        co_return true;
+    } else {
+        vlog(
+          clusterlog.info,
+          "Leadership transfer of group {} failed with error: {}",
+          transfer.group,
+          raft::make_error_code(res.value().data.result).message());
+        co_return false;
+    }
 }
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -74,7 +74,7 @@ public:
       topic_table&,
       partition_leaders_table&,
       members_table&,
-      raft::consensus_client_protocol,
+      ss::sharded<rpc::connection_cache>&,
       ss::sharded<shard_table>&,
       ss::sharded<partition_manager>&,
       ss::sharded<ss::abort_source>&,
@@ -179,7 +179,7 @@ private:
     topic_table& _topics;
     partition_leaders_table& _leaders;
     members_table& _members;
-    raft::consensus_client_protocol _client;
+    ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<ss::abort_source>& _as;

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -99,6 +99,7 @@ private:
     ss::future<bool> do_transfer(reassignment);
     ss::future<bool> do_transfer_local(reassignment) const;
     ss::future<bool> do_transfer_remote(reassignment);
+    ss::future<bool> do_transfer_remote_legacy(reassignment);
 
     void on_enable_changed();
 

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -48,7 +48,8 @@ service::service(
   ss::sharded<feature_manager>& feature_manager,
   ss::sharded<features::feature_table>& feature_table,
   ss::sharded<health_monitor_frontend>& hm_frontend,
-  ss::sharded<rpc::connection_cache>& conn_cache)
+  ss::sharded<rpc::connection_cache>& conn_cache,
+  ss::sharded<partition_manager>& partition_manager)
   : controller_service(sg, ssg)
   , _topics_frontend(tf)
   , _members_manager(mm)
@@ -61,7 +62,8 @@ service::service(
   , _feature_manager(feature_manager)
   , _feature_table(feature_table)
   , _hm_frontend(hm_frontend)
-  , _conn_cache(conn_cache) {}
+  , _conn_cache(conn_cache)
+  , _partition_manager(partition_manager) {}
 
 ss::future<join_reply>
 service::join(join_request&& req, rpc::streaming_context& context) {

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -112,6 +112,9 @@ public:
     cancel_node_partition_movements(
       cancel_node_partition_movements_request&&, rpc::streaming_context&) final;
 
+    ss::future<transfer_leadership_reply> transfer_leadership(
+      transfer_leadership_request&& r, rpc::streaming_context&) final;
+
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
     std::

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -38,7 +38,8 @@ public:
       ss::sharded<feature_manager>&,
       ss::sharded<features::feature_table>&,
       ss::sharded<health_monitor_frontend>&,
-      ss::sharded<rpc::connection_cache>&);
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<partition_manager>&);
 
     virtual ss::future<join_reply>
     join(join_request&&, rpc::streaming_context&) override;
@@ -157,5 +158,6 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<health_monitor_frontend>& _hm_frontend;
     ss::sharded<rpc::connection_cache>& _conn_cache;
+    ss::sharded<partition_manager>& _partition_manager;
 };
 } // namespace cluster

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -43,6 +43,9 @@
 namespace cluster {
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 
+using transfer_leadership_request = raft::transfer_leadership_request;
+using transfer_leadership_reply = raft::transfer_leadership_reply;
+
 // A cluster version is a logical protocol version describing the content
 // of the raft0 on disk structures, and available features.  These are
 // passed over the network via the health_manager, and persisted in

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2802,32 +2802,6 @@ consensus::transfer_leadership(transfer_leadership_request req) {
     }
 }
 
-ss::future<std::error_code>
-consensus::request_leadership(model::timeout_clock::time_point timeout) {
-    if (is_elected_leader()) {
-        co_return errc::success;
-    }
-
-    if (!_leader_id) {
-        co_return errc::not_leader;
-    }
-
-    if (!config().is_voter(_self)) {
-        co_return errc::not_voter;
-    }
-
-    auto result = co_await _client_protocol.transfer_leadership(
-      _leader_id->id(),
-      transfer_leadership_request{.group = _group, .target = _self.id()},
-      rpc::client_opts(timeout));
-
-    if (result) {
-        co_return result.value().result;
-    }
-
-    co_return result.error();
-}
-
 /**
  * After we have accepted the request to transfer leadership, carry out
  * preparatory phase before we actually send a timeout_now to the new

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -308,12 +308,6 @@ public:
     ss::future<std::error_code> prepare_transfer_leadership(vnode);
     ss::future<std::error_code>
       do_transfer_leadership(std::optional<model::node_id>);
-    /**
-     * requests leadership to be transferred to the current node. It sends
-     * transer leadership request to the current leader.
-     */
-    ss::future<std::error_code>
-      request_leadership(model::timeout_clock::time_point);
 
     ss::future<> remove_persistent_state();
 

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -82,8 +82,6 @@ public:
         _notifications.unregister_cb(id);
     }
 
-    consensus_client_protocol raft_client() const { return _client; }
-
 private:
     void trigger_leadership_notification(raft::leadership_status);
     void setup_metrics();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1883,7 +1883,8 @@ void application::start_runtime_services(
             std::ref(controller->get_feature_manager()),
             std::ref(controller->get_feature_table()),
             std::ref(controller->get_health_monitor()),
-            std::ref(_connection_cache)));
+            std::ref(_connection_cache),
+            std::ref(controller->get_partition_manager())));
 
           runtime_services.push_back(
             std::make_unique<cluster::metadata_dissemination_handler>(


### PR DESCRIPTION
The behavior in https://github.com/redpanda-data/redpanda/pull/8560 relied on leadership transfers flowing through cluster::partition, but the leader balancer was using an RPC that calls directly into consensus::transfer_leadership.  The cluster::partition path was only being taken on maintenance mode leadership drains and explicit admin API leader transfers.

This would also have meant that the leader balancer was skipping the graceful transfer of transaction state.

In this PR:
- Add debug logging to make it more obvious what is happening if the archiver part of leadership transfer doesn't appear to be working properly.
- Create a new RPC in controller_service to do leadership transfer via cluster::partition
- Use this new RPC from leader balancer, with a fallback to the old RPC if the new one is not available.   This will make upgrades work without requiring a feature flag, which is important to enable backporting this.
- Tweak the logic in ntp_archiver to continue with uploading a manifest after uploading segments, even if in the process of a leadership transfer.

Fixes: #8745

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Bug fixes

* A bug is fixed where background leadership balancing could unexpectedly interrupt transactional workloads.

