### PR TITLE
rpk: use random number for replaceFile

### DIFF
--- a/src/go/rpk/pkg/os/file.go
+++ b/src/go/rpk/pkg/os/file.go
@@ -11,6 +11,7 @@ package os
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
@@ -25,9 +26,10 @@ func ReplaceFile(fs afero.Fs, filename string, contents []byte, newPerms os.File
 	if err != nil {
 		return fmt.Errorf("unable to determine if file %q exists: %v", filename, err)
 	}
+
 	// Create a temp file first.
-	layout := "20060102150405" // year-month-day-hour-min-sec
-	bFilename := "redpanda-" + time.Now().Format(layout)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bFilename := fmt.Sprintf("redpanda-%v", r.Int())
 	temp := filepath.Join(filepath.Dir(filename), bFilename)
 
 	err = afero.WriteFile(fs, temp, contents, newPerms)


### PR DESCRIPTION
Now instead of naming the temporary file `redpanda-<timestamp>` now we will use a pseudo-random number to mark the file: `redpanda-<rand int>`

This is to avoid racing for the same temporary file when running multiple instances of rpk concurrently.

Fixes #8743

## Backports Required
- [ ] v22.3.x


## Release Notes
  * none

