### PR TITLE
tests: kgo-repeater improvements

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -142,7 +142,7 @@ function install_kcl() {
 function install_kgo_verifier() {
   git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
   cd /opt/kgo-verifier
-  git reset --hard 358e8dd99247d68a8f1c77ceb0f91f20c757bc64
+  git reset --hard 53d4c21aa86e179aa4b79aeee592e4687d08b569
   go mod tidy
   make
 }

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -34,6 +34,7 @@ class KgoRepeaterService(Service):
                  redpanda: RedpandaService,
                  *,
                  nodes: Optional[list[ClusterNode]] = None,
+                 num_nodes: Optional[int] = None,
                  topic: str,
                  msg_size: Optional[int],
                  workers: int,
@@ -44,8 +45,11 @@ class KgoRepeaterService(Service):
                  use_transactions: bool = False,
                  transaction_abort_rate: Optional[float] = None,
                  msgs_per_transaction: Optional[int] = None):
-        # num_nodes=0 because we're asking it to not allocate any for us
-        super().__init__(context, num_nodes=0 if nodes else 1)
+        if num_nodes is None and nodes is None:
+            # Default: run a single node
+            num_nodes = 1
+
+        super().__init__(context, num_nodes=0 if nodes else num_nodes)
 
         if nodes is not None:
             assert len(nodes) > 0

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -44,7 +44,11 @@ class KgoRepeaterService(Service):
                  mb_per_worker: Optional[int] = None,
                  use_transactions: bool = False,
                  transaction_abort_rate: Optional[float] = None,
+                 rate_limit_bps: Optional[int] = None,
                  msgs_per_transaction: Optional[int] = None):
+        """
+        :param rate_limit_bps: Total rate for all nodes: each node will get an equal share.
+        """
         if num_nodes is None and nodes is None:
             # Default: run a single node
             num_nodes = 1
@@ -60,6 +64,9 @@ class KgoRepeaterService(Service):
         self.msg_size = msg_size
         self.workers = workers
         self.group_name = group_name
+
+        self.rate_limit_bps_per_node = rate_limit_bps // len(
+            self.nodes) if rate_limit_bps else None
 
         # Note: using a port that happens to already be in test environment
         # firewall rules from other use cases.  If changing this, update
@@ -104,6 +111,9 @@ class KgoRepeaterService(Service):
 
         if self.max_buffered_records is not None:
             cmd += f" -max-buffered-records={self.max_buffered_records}"
+
+        if self.rate_limit_bps_per_node is not None:
+            cmd += f" -rate-limit-bps={self.rate_limit_bps_per_node}"
 
         if self.use_transactions:
             cmd += f" -use-transactions"

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager
 from collections import defaultdict
 
 from ducktape.services.service import Service
-from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.tests.test import TestContext
 
@@ -206,7 +205,9 @@ class KgoRepeaterService(Service):
         self.logger.debug(f"Waiting for group {self.group_name} to be ready")
         t1 = time.time()
         try:
-            wait_until(group_ready, timeout_sec=120, backoff_sec=10)
+            self.redpanda.wait_until(group_ready,
+                                     timeout_sec=120,
+                                     backoff_sec=10)
         except:
             # On failure, dump stacks on all workers in case there is an apparent client bug to investigate
             for node in self.nodes:
@@ -286,7 +287,7 @@ class KgoRepeaterService(Service):
         # the system isn't at peak throughput (e.g. when it's just warming up)
         timeout_sec = max(timeout_sec, 60)
 
-        wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
+        self.redpanda.wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
 
 
 @contextmanager

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -178,7 +178,14 @@ class KgoRepeaterService(Service):
 
         def group_ready():
             rpk = RpkTool(self.redpanda)
-            group = rpk.group_describe(self.group_name, summary=True)
+            try:
+                group = rpk.group_describe(self.group_name, summary=True)
+            except Exception as e:
+                self.logger.debug(
+                    f"group_ready: {self.group_name} got exception from describe: {e}"
+                )
+                return False
+
             if group is None:
                 self.logger.debug(
                     f"group_ready: {self.group_name} got None from describe")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1173,11 +1173,15 @@ class RedpandaService(Service):
         a test failure until the end of the timeout, even if redpanda
         already crashed.
         """
+
+        t_initial = time.time()
+        # How long to delay doing redpanda liveness checks, to make short waits more efficient
+        grace_period = 15
+
         def wrapped():
             r = fn()
-            if not r:
-                # If we're going to wait + retry, check the cluster is
-                # up before doing so.
+            if not r and time.time() > t_initial + grace_period:
+                # Check the cluster is up before waiting + retrying
                 assert self.all_up()
             return r
 


### PR DESCRIPTION
These are generally useful changes spun off from ongoing stress test work.

- Pull the latest code
- Enable rate limiting
- Dump stacks on timeout waiting for consumer group membership to stabilize
- Hook into RedpandaService.wait_until for fast-fail on node crash
- Handle connection errors in group describe

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Improvements

* none

