### PR TITLE
rptest: improve timequery below start offset test

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -141,60 +141,6 @@ class RetentionPolicyTest(RedpandaTest):
                                   partition_idx=0,
                                   count=5)
 
-    @cluster(num_nodes=3)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
-    def test_timequery_after_segments_eviction(self, cloud_storage_type):
-        """
-        Test checking if the offset returned by time based index is
-        valid during applying log cleanup policy
-        """
-        segment_size = 1048576
-
-        # produce until segments have been compacted
-        produce_until_segments(
-            self.redpanda,
-            topic=self.topic,
-            partition_idx=0,
-            count=10,
-            acks=-1,
-        )
-
-        # restart all nodes to force replicating raft configuration
-        self.redpanda.restart_nodes(self.redpanda.nodes)
-
-        kafka_tools = KafkaCliTools(self.redpanda)
-        # Wait for controller, alter configs doesn't have a retry loop
-        kafka_tools.describe_topic(self.topic)
-
-        # change retention bytes to preserve 15 segments
-        self.client().alter_topic_configs(
-            self.topic, {
-                TopicSpec.PROPERTY_RETENTION_BYTES:
-                bytes_for_segments(2, segment_size),
-            })
-
-        def validate_time_query_until_deleted():
-            def done():
-                kcat = KafkaCat(self.redpanda)
-                ts = 1638748800  # 12.6.2021 - old timestamp, query first offset
-                offset = kcat.query_offset(self.topic, 0, ts)
-                # assert that offset is valid
-                assert offset >= 0
-
-                topic_partitions = segments_count(self.redpanda, self.topic, 0)
-                partitions = []
-                for p in topic_partitions:
-                    partitions.append(p <= 5)
-                return all([p <= 5 for p in topic_partitions])
-
-            wait_until(done,
-                       timeout_sec=30,
-                       backoff_sec=5,
-                       err_msg="Segments were not removed")
-
-        validate_time_query_until_deleted()
-
 
 class ShadowIndexingLocalRetentionTest(RedpandaTest):
     segment_size = 1000000  # 1MB


### PR DESCRIPTION
Previously, `test_timequery_after_segments_eviction` expected that timequeries for offsets within a segment would be serviced up until the segment was removed from disk. This assumption is not correct, as we should not serve timequeries that fall below the start offset of the local log (unless cloud storage is enabled and the offset is in the cloud log).

This commit removes the mentioned test, and adds a new test that checks that local timequeries don't return data below the start offset of the local log.

Fixes #8951
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none

