### PR TITLE
[v22.3.x] storage: fix race between timequery and local log GC

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -357,11 +357,40 @@ ss::future<> partition::stop() {
 
 ss::future<std::optional<storage::timequery_result>>
 partition::timequery(storage::timequery_config cfg) {
+    const bool is_read_replica
+      = _raft->log_config().is_read_replica_mode_enabled();
+    const bool query_before_raft_log_start = _raft->log().start_timestamp()
+                                             > cfg.time;
+
     std::optional<storage::timequery_result> result;
-    bool is_read_replica = _raft->log_config().is_read_replica_mode_enabled();
-    if (
-      _cloud_storage_partition && _cloud_storage_partition->is_data_available()
-      && (is_read_replica || _raft->log().start_timestamp() >= cfg.time)) {
+
+    if (is_read_replica || query_before_raft_log_start) {
+        // We have data in the remote partition, and all the data in the raft
+        // log is ahead of the query timestamp or the topic is a read replica,
+        // so proceed to query the remote partition to try and find the earliest
+        // data that has timestamp >= the query time.
+        co_return co_await cloud_storage_timequery(cfg);
+    }
+
+    result = co_await local_timequery(cfg);
+
+    // It's possible that during the query, our local log was GCed, and the
+    // result may not actually reflect the correct offset for this
+    // partition. If the local log doesn't look like it can serve the query
+    // anymore, query the remote log.
+    if (_raft->log().start_timestamp() > cfg.time) {
+        co_return co_await cloud_storage_timequery(cfg);
+    } else {
+        co_return result;
+    }
+}
+
+ss::future<std::optional<storage::timequery_result>>
+partition::cloud_storage_timequery(storage::timequery_config cfg) {
+    const bool may_read_from_cloud
+      = _cloud_storage_partition
+        && _cloud_storage_partition->is_data_available();
+    if (may_read_from_cloud) {
         // We have data in the remote partition, and all the data in the raft
         // log is ahead of the query timestamp or the topic is a read replica,
         // so proceed to query the remote partition to try and find the earliest
@@ -375,15 +404,25 @@ partition::timequery(storage::timequery_config cfg) {
 
         // remote_partition pre-translates offsets for us, so no call into
         // the offset translator here
-        auto cloud_result = co_await _cloud_storage_partition->timequery(cfg);
-        if (cloud_result) {
-            co_return cloud_result;
+        auto result = co_await _cloud_storage_partition->timequery(cfg);
+        if (result) {
+            vlog(
+              clusterlog.debug,
+              "timequery (cloud) {} t={} max_offset(r)={} result(r)={}",
+              _raft->ntp(),
+              cfg.time,
+              cfg.max_offset,
+              result->offset);
         }
 
-        // Fall-through: if cfg.time is ahead of the end of the remote_partition
-        // data, search for it in the local data.
+        co_return result;
     }
 
+    co_return std::nullopt;
+}
+
+ss::future<std::optional<storage::timequery_result>>
+partition::local_timequery(storage::timequery_config cfg) {
     vlog(
       clusterlog.debug,
       "timequery (raft) {} t={} max_offset(k)={}",
@@ -391,10 +430,10 @@ partition::timequery(storage::timequery_config cfg) {
       cfg.time,
       cfg.max_offset);
 
-    // Translate input (kafka) offset into raft offset
     cfg.max_offset = _raft->get_offset_translator_state()->to_log_offset(
       cfg.max_offset);
-    result = co_await _raft->timequery(cfg);
+
+    auto result = co_await _raft->timequery(cfg);
     if (result) {
         vlog(
           clusterlog.debug,
@@ -421,8 +460,8 @@ partition::get_term_last_offset(model::term_id term) const {
     if (!o) {
         return std::nullopt;
     }
-    // Kafka defines leader epoch last offset as a first offset of next leader
-    // epoch
+    // Kafka defines leader epoch last offset as a first offset of next
+    // leader epoch
     return model::next_offset(*o);
 }
 
@@ -432,8 +471,8 @@ partition::get_cloud_term_last_offset(model::term_id term) const {
     if (!o) {
         return std::nullopt;
     }
-    // Kafka defines leader epoch last offset as a first offset of next leader
-    // epoch
+    // Kafka defines leader epoch last offset as a first offset of next
+    // leader epoch
     return model::next_offset(kafka::offset_cast(*o));
 }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -272,6 +272,12 @@ public:
     consensus_ptr raft() const { return _raft; }
 
 private:
+    ss::future<std::optional<storage::timequery_result>>
+      cloud_storage_timequery(storage::timequery_config);
+
+    ss::future<std::optional<storage::timequery_result>>
+      local_timequery(storage::timequery_config);
+
     consensus_ptr _raft;
     ss::lw_shared_ptr<raft::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3305,14 +3305,7 @@ size_t consensus::get_follower_count() const {
 
 ss::future<std::optional<storage::timequery_result>>
 consensus::timequery(storage::timequery_config cfg) {
-    return _log.timequery(cfg).then(
-      [this](std::optional<storage::timequery_result> res) {
-          if (res) {
-              // do not return offset that is earlier raft start offset
-              res->offset = std::max(res->offset, start_offset());
-          }
-          return res;
-      });
+    return _log.timequery(cfg);
 }
 
 } // namespace raft

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -875,12 +875,12 @@ offset_stats disk_log_impl::offsets() const {
 }
 
 model::timestamp disk_log_impl::start_timestamp() const {
-    if (_segs.empty()) {
+    auto seg = _segs.lower_bound(_start_offset);
+    if (seg == _segs.end()) {
         return model::timestamp{};
     }
 
-    auto& s = _segs.front();
-    return s->index().base_timestamp();
+    return (*seg)->index().base_timestamp();
 }
 
 ss::future<> disk_log_impl::new_segment(

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -7,7 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import concurrent.futures
 import re
+import time
+import threading
 
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
@@ -34,15 +37,12 @@ from rptest.utils.mode_checks import skip_debug_mode
 
 
 class BaseTimeQuery:
-    def _test_timequery(self, cluster, cloud_storage: bool, batch_cache: bool):
-        local_retain_segments = 4
-        total_segments = 12
-        record_size = 1024
-
+    def _create_and_produce(self, cluster, cloud_storage,
+                            local_retain_segments, base_ts, record_size,
+                            msg_count):
         topic = TopicSpec(name="tqtopic",
                           partition_count=1,
                           replication_factor=3)
-
         self.client().create_topic(topic)
 
         if cloud_storage:
@@ -71,8 +71,6 @@ class BaseTimeQuery:
 
         # Produce a run of messages with CreateTime-style timestamps, each
         # record having a timestamp 1ms greater than the last.
-        msg_count = (self.log_segment_size * total_segments) // record_size
-        base_ts = 1664453149000
         producer = KgoVerifierProducer(
             context=self.test_context,
             redpanda=cluster,
@@ -89,6 +87,24 @@ class BaseTimeQuery:
             fake_timestamp_ms=base_ts)
         producer.start()
         producer.wait()
+
+        # We know timestamps, they are generated linearly from the
+        # base we provided to kgo-verifier
+        timestamps = dict((i, base_ts + i) for i in range(0, msg_count))
+        return topic, timestamps
+
+    def _test_timequery(self, cluster, cloud_storage: bool, batch_cache: bool):
+        local_retain_segments = 4
+        total_segments = 12
+        record_size = 1024
+        base_ts = 1664453149000
+        msg_count = (self.log_segment_size * total_segments) // record_size
+        topic, timestamps = self._create_and_produce(cluster, cloud_storage,
+                                                     local_retain_segments,
+                                                     base_ts, record_size,
+                                                     msg_count)
+        for k, v in timestamps.items():
+            self.logger.debug(f"  Offset {k} -> Timestamp {v}")
 
         # Confirm messages written
         rpk = RpkTool(cluster)
@@ -107,12 +123,6 @@ class BaseTimeQuery:
         # Identify partition leader for use in our metrics checks
         leader_node = cluster.get_node(
             next(rpk.describe_topic(topic.name)).leader)
-
-        # We know timestamps, they are generated linearly from the
-        # base we provided to kgo-verifier
-        timestamps = dict((i, base_ts + i) for i in range(0, msg_count))
-        for k, v in timestamps.items():
-            self.logger.debug(f"  Offset {k} -> Timestamp {v}")
 
         # Class defining expectations of timequery results to be checked
         class ex:
@@ -209,7 +219,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         # test parameter to set cluster configs before starting.
         pass
 
-    def _do_test_timequery(self, cloud_storage: bool, batch_cache: bool):
+    def set_up_cluster(self, cloud_storage: bool, batch_cache: bool):
         self.redpanda.set_extra_rp_conf({
             # Testing with batch cache disabled is important, because otherwise
             # we won't touch the path in skipping_consumer that applies
@@ -219,6 +229,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
             # Our time bounds on segment removal depend on the leadership
             # staying in one place.
             'enable_leader_balancer': False,
+            'log_segment_size_min': 32 * 1024,
         })
 
         if cloud_storage:
@@ -235,16 +246,72 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
 
         self.redpanda.start()
 
-        return self._test_timequery(cluster=self.redpanda,
-                                    cloud_storage=cloud_storage,
-                                    batch_cache=batch_cache)
+    def _do_test_timequery(self, cloud_storage: bool, batch_cache: bool):
+        self.set_up_cluster(cloud_storage, batch_cache)
+        self._test_timequery(cluster=self.redpanda,
+                             cloud_storage=cloud_storage,
+                             batch_cache=batch_cache)
 
     @cluster(num_nodes=4)
     @parametrize(cloud_storage=True, batch_cache=False)
     @parametrize(cloud_storage=False, batch_cache=True)
     @parametrize(cloud_storage=False, batch_cache=False)
     def test_timequery(self, cloud_storage: bool, batch_cache: bool):
-        return self._do_test_timequery(cloud_storage, batch_cache)
+        self._do_test_timequery(cloud_storage, batch_cache)
+
+    @cluster(num_nodes=4)
+    def test_timequery_with_local_gc(self):
+        # Reduce the segment size so we generate more segments and are more
+        # likely to race timequeries with GC.
+        self.log_segment_size = int(self.log_segment_size / 32)
+        total_segments = 32 * 12
+        self.set_up_cluster(cloud_storage=True, batch_cache=False)
+        local_retain_segments = 4
+        record_size = 1024
+        base_ts = 1664453149000
+        msg_count = (self.log_segment_size * total_segments) // record_size
+
+        topic, timestamps = self._create_and_produce(self.redpanda, True,
+                                                     local_retain_segments,
+                                                     base_ts, record_size,
+                                                     msg_count)
+
+        # While waiting for local GC to occur, run several concurrent
+        # timequeries all across the keyspace at once.
+        num_threads = 4
+        num_offsets_per_thread = int(msg_count / num_threads)
+        errors = [0 for _ in range(num_threads)]
+        should_stop = threading.Event()
+
+        def query_slices(tid):
+            kcat = KafkaCat(self.redpanda)
+            while not should_stop.is_set():
+                start_idx = tid * num_offsets_per_thread
+                end_idx = start_idx + num_offsets_per_thread
+                # Step 100 offsets at a time so we only end up with a few dozen
+                # queries per thread at a time.
+                for idx in range(start_idx, end_idx, 100):
+                    expected_offset = idx
+                    ts = timestamps[idx]
+                    offset = kcat.query_offset(topic.name, 0, ts)
+                    if expected_offset != offset:
+                        self.logger.exception(
+                            f"Timestamp {ts} returned {offset} instead of {expected_offset}"
+                        )
+                        errors[tid] += 1
+
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=num_threads) as executor:
+            try:
+                # Evaluate the futures with list().
+                executor.map(query_slices, range(num_threads))
+                wait_for_segments_removal(redpanda=self.redpanda,
+                                          topic=topic.name,
+                                          partition_idx=0,
+                                          count=local_retain_segments)
+            finally:
+                should_stop.set()
+        assert not any([e > 0 for e in errors])
 
 
 class TimeQueryKafkaTest(Test, BaseTimeQuery):


### PR DESCRIPTION
Backport of PR #8900.
We'll also have to backport https://github.com/redpanda-data/redpanda/pull/8955.