### PR TITLE
tests: remove spurious config change in TestReadReplicaService

### DIFF
--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -131,10 +131,6 @@ class TestReadReplicaService(EndToEndTest):
                             str(self.producer.last_acked_offsets))
             self.producer.stop()
 
-        # Make original topic upload data to S3
-        rpk = RpkTool(self.redpanda)
-        rpk.alter_topic_config(spec.name, 'redpanda.remote.write', 'true')
-
         self.start_second_cluster()
         # wait until the read replica topic creation succeeds
         wait_until(


### PR DESCRIPTION
This destabilized the test by prompting the upload code to reset, which can cause readers not to see progress when the uploads are reset at just the wrong moment, and no further data is played into the system.

That is a real bug, but it's a niche bug: one has to _stop_ playing data into the system, _and_ make a configuration change or restart a node at just the right moment (when all segments have been uploaded and archival stm is updated, but manifest copy is not yet written to S3)

Related: https://github.com/redpanda-data/redpanda/issues/8959

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes


* none