### PR TITLE
Fix for CI issue in ManyPartitionsTest where DescribeGroups request fails

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -589,9 +589,9 @@ class RpkTool:
                 elif "NOT_COORDINATOR" in e.msg:
                     # Transient, retry
                     return None
-                elif "Kafka replied that group" in e.msg:
+                elif "broker replied that group" in e.msg:
                     # Transient, return None to retry
-                    # e.g. Kafka replied that group repeat01 has broker coordinator 8, but did not reply with that broker in the broker list
+                    # e.g. broker replied that group repeat01 has broker coordinator 8, but did not reply with that broker in the broker list
                     return None
                 elif "connection refused" in e.msg:
                     # Metadata directed us to a broker that is uncontactable, perhaps


### PR DESCRIPTION
Simple fix was to modify the conditions in which the python rpk wrapper client retries its describe_groups requests with. There's a condition which matches a log line that will never occur.  Franz-go will actually never reply with an error that starts with "Kafka replied that..", it will print ["broker replied that..."](https://github.com/twmb/franz-go/blob/master/pkg/kgo/errors.go#L275) modifying this condition will ensure that when these rpk errors are observed the test client will automatically retry.

- Fixes: #8750

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none
