### PR TITLE
tests/storage: Relaxed deleted segments count

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -420,7 +420,8 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             self.logger.debug(f"Deleted {deleted} segments from the cloud")
             return deleted
 
-        wait_until(lambda: deleted_segments_count() == 10,
+        # https://github.com/redpanda-data/redpanda/issues/8658#issuecomment-1420905967
+        wait_until(lambda: 9 <= deleted_segments_count() <= 10,
                    timeout_sec=10,
                    backoff_sec=1,
                    err_msg=f"Segments were not removed from the cloud")


### PR DESCRIPTION
Per discussion in #8658, this is a quick fix to address the CI failure.

Fixes #8658

Force push `8584874`

* Adjusted upper limit from 11 to 10 deleted segments

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

* none

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

* none
