### PR TITLE
archival: always use last_offset if available to schedule uploads

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -878,10 +878,16 @@ ntp_archiver::schedule_uploads(model::offset last_stable_offset) {
     // The manifest's last offset contains dirty_offset of the
     // latest uploaded segment but '_policy' requires offset that
     // belongs to the next offset or the gap. No need to do this
-    // if there is no segments.
-    auto start_upload_offset = manifest().size() ? manifest().get_last_offset()
-                                                     + model::offset(1)
-                                                 : model::offset(0);
+    // if we haven't uploaded anything.
+    //
+    // When there are no segments but there is a non-zero 'last_offset', all
+    // cloud segments have been removed for retention. In that case, we still
+    // need to take into accout 'last_offset'.
+    auto last_offset = manifest().get_last_offset();
+    auto start_upload_offset = manifest().size() == 0
+                                   && last_offset == model::offset(0)
+                                 ? model::offset(0)
+                                 : last_offset + model::offset(1);
 
     auto compacted_segments_upload_start = model::next_offset(
       manifest().get_last_uploaded_compacted_offset());

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -156,6 +156,81 @@ class CloudRetentionTest(PreallocNodesTest):
         assert consumer.consumer_status.validator.valid_reads > \
             segment_size * num_partitions / msg_size
 
+    @skip_debug_mode
+    @cluster(num_nodes=4)
+    def test_gc_entire_manifest(self):
+        """
+        Regression test for #8945, where GCing all cloud segments could prevent
+        further uploads from taking place.
+        """
+        small_segment_size = 1024 * 1024
+        num_partitions = 5
+        si_settings = SISettings(self.test_context,
+                                 log_segment_size=small_segment_size)
+        self.redpanda.set_si_settings(si_settings)
+        extra_rp_conf = dict(retention_local_target_bytes_default=self.
+                             default_retention_segments * small_segment_size,
+                             log_segment_size_jitter_percent=5,
+                             group_initial_rebalance_delay=300,
+                             cloud_storage_segment_max_upload_interval_sec=1,
+                             cloud_storage_housekeeping_interval_ms=1000)
+        self.redpanda.add_extra_rp_conf(extra_rp_conf)
+        self.redpanda.start()
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(
+            topic=self.topic_name,
+            partitions=num_partitions,
+            replicas=3,
+            config={
+                "cleanup.policy": TopicSpec.CLEANUP_DELETE,
+                # Intentionally sabotage Redpanda to use lower
+                # retention than a single segment.
+                "retention.bytes": int(small_segment_size / 2),
+                "retention.local.target.bytes": 2 * small_segment_size,
+            })
+
+        # Write more data than we intend to retain.
+        msg_size = 4 * 1024
+        msg_count = int(5 * 1024 * 1024 / msg_size)
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic_name,
+                                       msg_size=msg_size,
+                                       msg_count=msg_count,
+                                       custom_node=self.preallocated_nodes)
+        producer.start(clean=False)
+        producer.wait()
+
+        topics = (TopicSpec(name=self.topic_name,
+                            partition_count=num_partitions), )
+
+        def gced_all_segments():
+            s3_snapshot = S3Snapshot(topics,
+                                     self.redpanda.cloud_storage_client,
+                                     si_settings.cloud_storage_bucket,
+                                     self.logger)
+            try:
+                manifest = s3_snapshot.manifest_for_ntp(self.topic_name, 0)
+            except:
+                return False
+
+            # Wait for the manifest to have uploaded some offsets, but not have
+            # any segments, indicating we truncated.
+            if "last_offset" not in manifest or manifest["last_offset"] == 0:
+                return False
+
+            return "segments" not in manifest
+
+        wait_until(gced_all_segments, timeout_sec=120, backoff_sec=5)
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic_name,
+                                       msg_size=msg_size,
+                                       msg_count=msg_count,
+                                       custom_node=self.preallocated_nodes)
+        producer.start(clean=False)
+        producer.wait()
+
 
 class CloudRetentionTimelyGCTest(RedpandaTest):
     segment_size = 256 * 1024


### PR DESCRIPTION
We previously predicated on whether there were existing segments to choose an upload start offset. This wouldn't work in cases where the manifest is entirely truncated away.

Without this, once attempting to upload after GCing all cloud segments, we could end up with errors like:

```
ERROR 2023-02-16 22:54:19,549 [shard 14] archival - [fiber51 kafka/scale_000000/165] - ntp_archiver_service.cc:184 - upload loop error: std::runtime_error (ntp {kafka/scale_000000/165}: log offset 4085 is outside the translation range (starting at 8830))
```

Fixes #8945

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Bug Fixes
* Fixed an issue that could prevent uploads after all cloud segments have been garbage collected.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
