### PR TITLE
rpk: trim controllers logs in debug bundle

### DIFF
--- a/src/go/rpk/pkg/os/file_all.go
+++ b/src/go/rpk/pkg/os/file_all.go
@@ -14,8 +14,6 @@ package os
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"regexp"
 	"syscall"
 
 	"github.com/spf13/afero"
@@ -33,26 +31,4 @@ func PreserveUnixOwnership(fs afero.Fs, stat os.FileInfo, file string) error {
 		}
 	}
 	return nil
-}
-
-// DirSize returns the size of a directory. It will exclude the size of the
-// files that match the 'exclude' regexp.
-func DirSize(path string, exclude *regexp.Regexp) (int64, error) {
-	var size int64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			if exclude != nil {
-				if !exclude.MatchString(info.Name()) {
-					size += info.Size()
-				}
-			} else {
-				size += info.Size()
-			}
-		}
-		return err
-	})
-	return size, err
 }


### PR DESCRIPTION
If the total size of the logs exceeds the
specified limit, we will reduce the size of the
controller log directory. Specifically, we will
keep the first and last 'limit/2' bytes of the
log files, discarding the middle section to bring
the total size of the logs under the limit.

This behavior is for bare-metal and k8s.

Fixes #8033

## Backports Required
- [x] none - not a bug fix

Saving the controller logs is not released yet.

## Release Notes
  * none
