### PR TITLE
rpk: parse version with release cut

### DIFF
--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -22,7 +22,7 @@ func VersionFromString(s string) (Version, error) {
 	//   - index 1: the Year
 	//   - index 2: the Feature
 	//   - index 3: the Patch
-	vMatch := regexp.MustCompile(`^v?(\d{2})\.(\d{1,2})\.(\d{1,2})(?:\s|$)`).FindStringSubmatch(s)
+	vMatch := regexp.MustCompile(`^v?(\d{2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|$)`).FindStringSubmatch(s)
 
 	if len(vMatch) == 0 {
 		return Version{}, fmt.Errorf("unable to get the redpanda version from %q", s)

--- a/src/go/rpk/pkg/redpanda/version_test.go
+++ b/src/go/rpk/pkg/redpanda/version_test.go
@@ -15,8 +15,12 @@ func TestVersionFromString(t *testing.T) {
 	}{
 		{name: "with v", in: "v22.3.4", exp: Version{22, 3, 4}},
 		{name: "with v and text", in: "v22.3.4 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{22, 3, 4}},
+		{name: "with v and rc", in: "v22.3.13-rc1", exp: Version{22, 3, 13}},
+		{name: "with v, with rc and text", in: "v22.3.13-rc1 - 29e2b111d1d94d6d1f6cc591457ed03119edf0e6-dirty", exp: Version{22, 3, 13}},
 		{name: "without v", in: "22.3.4", exp: Version{22, 3, 4}},
 		{name: "without v and text", in: "22.3.4 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{22, 3, 4}},
+		{name: "without v and rc", in: "22.3.13-rc1", exp: Version{22, 3, 13}},
+		{name: "without v, with rc and text", in: "22.3.13-rc1 - 29e2b111d1d94d6d1f6cc591457ed03119edf0e6-dirty", exp: Version{22, 3, 13}},
 		{name: "incomplete", in: "22.3", expErr: true},
 		{name: "random string", in: "random", expErr: true},
 		{name: "3 digits year", in: "v222.11.1", expErr: true},


### PR DESCRIPTION
rpk now can parse version that includes the
release cut in the version string.

Fixes #8905

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
  * none

