### PR TITLE
[v22.2.x] cluster: fix a case where version updates weren't generated

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -80,12 +80,13 @@ ss::future<> feature_manager::start() {
     _health_notify_handle = _hm_backend.local().register_node_callback(
       [this](
         node_health_report const& report,
-        std::optional<std::reference_wrapper<const node_health_report>>
-          old_report) {
+        std::optional<std::reference_wrapper<const node_health_report>>) {
+          // If we did not know the node's version or if the report is
+          // higher, submit an update.
+          auto i = _node_versions.find(report.id);
           if (
-            !old_report
-            || report.local_state.logical_version
-                 != old_report.value().get().local_state.logical_version) {
+            i == _node_versions.end()
+            || i->second < report.local_state.logical_version) {
               update_node_version(
                 report.id, report.local_state.logical_version);
           }
@@ -106,6 +107,11 @@ ss::future<> feature_manager::start() {
             if (group != _raft0_group) {
                 return;
             }
+
+            // On leadership change, clear our map of node versions: this
+            // ensures that we will populate it with fresh data when we next
+            // see a health report from each node.
+            _node_versions.clear();
 
             vlog(
               clusterlog.debug, "Controller leader notification term {}", term);
@@ -252,7 +258,7 @@ void feature_manager::update_node_version(
       update_node,
       v);
 
-    _updates.push_back({update_node, v});
+    _updates.emplace(update_node, v);
     _update_wait.signal();
 }
 

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -110,7 +110,7 @@ private:
     ss::sharded<rpc::connection_cache>& _connection_cache;
     raft::group_id _raft0_group;
 
-    std::vector<std::pair<model::node_id, cluster_version>> _updates;
+    version_map _updates;
     ss::condition_variable _update_wait;
 
     cluster::notification_id_type _leader_notify_handle{


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8902
Fixes https://github.com/redpanda-data/redpanda/issues/8989,