### PR TITLE
archival: skip noop housekeeping manifest uploads

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1295,24 +1295,28 @@ ss::future<> ntp_archiver::housekeeping() {
             // external housekeeping jobs from upload_housekeeping_service
             // and retention/GC
             auto units = co_await ss::get_units(_mutex, 1, _as);
-            co_await apply_retention();
-            co_await garbage_collect();
-            co_await upload_manifest();
+            const auto retention_updated_manifest = co_await apply_retention();
+            const auto gc_updated_manifest = co_await garbage_collect();
+            if (retention_updated_manifest || gc_updated_manifest) {
+                co_await upload_manifest();
+            }
         }
     } catch (std::exception& e) {
         vlog(_rtclog.warn, "Error occured during housekeeping", e.what());
     }
 }
 
-ss::future<> ntp_archiver::apply_retention() {
+ss::future<ntp_archiver::manifest_updated> ntp_archiver::apply_retention() {
+    manifest_updated updated = manifest_updated::no;
+
     if (!may_begin_uploads()) {
-        co_return;
+        co_return updated;
     }
 
     auto retention_calculator = retention_calculator::factory(
       manifest(), _parent.get_ntp_config());
     if (!retention_calculator) {
-        co_return;
+        co_return updated;
     }
 
     auto next_start_offset = retention_calculator->next_start_offset();
@@ -1328,7 +1332,9 @@ ss::future<> ntp_archiver::apply_retention() {
         auto deadline = ss::lowres_clock::now() + sync_timeout;
         auto error = co_await _parent.archival_meta_stm()->truncate(
           *next_start_offset, deadline, _as);
-        if (error != cluster::errc::success) {
+        if (error == cluster::errc::success) {
+            updated = manifest_updated::yes;
+        } else {
             vlog(
               _rtclog.warn,
               "Failed to update archival metadata STM start offest according "
@@ -1341,14 +1347,18 @@ ss::future<> ntp_archiver::apply_retention() {
           "{} Retention policies are already met.",
           retention_calculator->strategy_name());
     }
+
+    co_return updated;
 }
 
 // Garbage collection can be improved as follows:
 // * issue #6843: delete via DeleteObjects S3 api instead of deleting individual
 // segments
-ss::future<> ntp_archiver::garbage_collect() {
+ss::future<ntp_archiver::manifest_updated> ntp_archiver::garbage_collect() {
+    manifest_updated updated = manifest_updated::no;
+
     if (!may_begin_uploads()) {
-        co_return;
+        co_return updated;
     }
 
     const auto to_remove
@@ -1399,7 +1409,9 @@ ss::future<> ntp_archiver::garbage_collect() {
         auto error = co_await _parent.archival_meta_stm()->cleanup_metadata(
           deadline, _as);
 
-        if (error != cluster::errc::success) {
+        if (error == cluster::errc::success) {
+            updated = manifest_updated::yes;
+        } else {
             vlog(
               _rtclog.info,
               "Failed to clean up metadata after garbage collection: {}",
@@ -1415,6 +1427,8 @@ ss::future<> ntp_archiver::garbage_collect() {
     _probe->segments_deleted(static_cast<int64_t>(successful_deletes));
     vlog(
       _rtclog.debug, "Deleted {} segments from the cloud", successful_deletes);
+
+    co_return updated;
 }
 
 ss::future<cloud_storage::upload_result>
@@ -1635,8 +1649,8 @@ ntp_archiver::prepare_transfer_leadership(ss::lowres_clock::duration timeout) {
         // the next manifest written by the new leader will not refer to
         // this object.
         //
-        // This is not a correctness issue, but consumes some disk space, and
-        // these objects may also be left behind when the topic is later
+        // This is not a correctness issue, but consumes some disk space,
+        // and these objects may also be left behind when the topic is later
         // deleted.
         co_return false;
     }

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -131,18 +131,20 @@ public:
     ss::future<std::optional<cloud_storage::partition_manifest>>
     maybe_truncate_manifest();
 
+    using manifest_updated = ss::bool_class<struct manifest_updated_tag>;
+
     /// \brief Perform housekeeping operations.
     ss::future<> housekeeping();
 
     /// \brief Advance the start offest for the remote partition
     /// according to the retention policy specified by the partition
     /// configuration. This function does *not* delete any data.
-    ss::future<> apply_retention();
+    ss::future<manifest_updated> apply_retention();
 
     /// \brief Remove segments that are no longer queriable by:
     /// segments that are below the current start offset and segments
     /// that have been replaced with their compacted equivalent.
-    ss::future<> garbage_collect();
+    ss::future<manifest_updated> garbage_collect();
 
     virtual ~ntp_archiver() = default;
 


### PR DESCRIPTION
Previously, the partition manifest was re-uploaded at the end of each housekeeping iteration.
This happened even when the housekeeping loop did not update the manifest.
This PR updates housekeeping to  skip the manifest re-upload when it's not required.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none
