### PR TITLE
tests: improve CloudRetentionTest.test_gc_entire_manifest

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1656,7 +1656,7 @@ class RedpandaService(Service):
         # In case it's a big test, do not exhaustively log every object
         # or dump every manifest
         key_dump_limit = 10000
-        manifest_dump_limit = 10
+        manifest_dump_limit = 128
 
         self.logger.info(
             f"Gathering cloud storage diagnostics in bucket {self._si_settings.cloud_storage_bucket}"

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -165,7 +165,7 @@ class CloudRetentionTest(PreallocNodesTest):
         further uploads from taking place.
         """
         small_segment_size = 1024 * 1024
-        num_partitions = 5
+        num_partitions = 16
         si_settings = SISettings(self.test_context,
                                  log_segment_size=small_segment_size)
         self.redpanda.set_si_settings(si_settings)
@@ -205,24 +205,59 @@ class CloudRetentionTest(PreallocNodesTest):
         topics = (TopicSpec(name=self.topic_name,
                             partition_count=num_partitions), )
 
+        def uploaded_all_partitions():
+            s3_snapshot = S3Snapshot(topics,
+                                     self.redpanda.cloud_storage_client,
+                                     si_settings.cloud_storage_bucket,
+                                     self.logger)
+            for partition in range(0, num_partitions):
+                size = s3_snapshot.cloud_log_size_for_ntp(
+                    self.topic_name, partition)
+                if size == 0:
+                    self.logger.info("Partition {} has size 0", partition)
+                    return False
+
+            return True
+
+        wait_until(uploaded_all_partitions,
+                   timeout_sec=60,
+                   backoff_sec=5,
+                   err_msg="Waiting for all parents to upload cloud data")
+
         def gced_all_segments():
             s3_snapshot = S3Snapshot(topics,
                                      self.redpanda.cloud_storage_client,
                                      si_settings.cloud_storage_bucket,
                                      self.logger)
-            try:
-                manifest = s3_snapshot.manifest_for_ntp(self.topic_name, 0)
-            except:
-                return False
+            for partition in range(0, num_partitions):
+                try:
+                    manifest = s3_snapshot.manifest_for_ntp(
+                        self.topic_name, partition)
+                except:
+                    self.logger.info(
+                        f"Partition {partition} has no uploaded manifest")
+                    return False
 
-            # Wait for the manifest to have uploaded some offsets, but not have
-            # any segments, indicating we truncated.
-            if "last_offset" not in manifest or manifest["last_offset"] == 0:
-                return False
+                # Wait for the manifest to have uploaded some offsets, but not have
+                # any segments, indicating we truncated.
+                if "last_offset" not in manifest or manifest[
+                        "last_offset"] == 0:
+                    self.logger.info(
+                        f"Partition {partition} doesn't have last_offset")
+                    return False
 
-            return "segments" not in manifest
+                if not "segments" not in manifest:
+                    self.logger.info(
+                        f"Partition {partition} still has segments")
+                    return False
 
-        wait_until(gced_all_segments, timeout_sec=120, backoff_sec=5)
+            return True
+
+        rpk.alter_topic_config(self.topic_name, "retention.bytes", "1")
+        wait_until(gced_all_segments,
+                   timeout_sec=120,
+                   backoff_sec=5,
+                   err_msg="Waiting for all cloud segments to be GC")
         producer = KgoVerifierProducer(self.test_context,
                                        self.redpanda,
                                        self.topic_name,


### PR DESCRIPTION
Make the test added in https://github.com/redpanda-data/redpanda/pull/8968 more robust.
   
- Use a higher partition count to improve reproducability
      of non-deterministic failures
- Set retention to 1 byte instead of half a segment: this fixes
      the case where a leadership transfer happends and results in
      tiny segments.
- In success condition, check all partitions, not just partition 0.
- Do separate wait_until for all partitions to upload some data
      first, then set retention tiny and start waiting for the cloud
      GC to happen.
    
Fixes https://github.com/redpanda-data/redpanda/issues/8977

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
