### PR TITLE
tests: improvements to tiered storage test infra via #8978

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -91,8 +91,7 @@ struct errc_category final : public std::error_category {
         case errc::topic_already_exists:
             return "The topic has already been created";
         case errc::replication_error:
-            return "Controller was unable to replicate given state across "
-                   "cluster nodes";
+            return "Unable to replicate given state across cluster nodes";
         case errc::shutting_down:
             return "Application is shutting down";
         case errc::no_leader_controller:

--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -170,8 +170,7 @@ class CloudStorageCompactionTest(EndToEndTest):
                  "Cannot validate Kafka record batch. Missmatching CRC",
                  "batch has invalid CRC"
              ])
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
     def test_read_from_replica(self, cloud_storage_type):
         self.start_workload()
         self.start_consumer(num_nodes=2,

--- a/tests/rptest/scale_tests/extreme_recovery_test.py
+++ b/tests/rptest/scale_tests/extreme_recovery_test.py
@@ -171,8 +171,7 @@ class ExtremeRecoveryTest(TopicRecoveryTest):
         super(ExtremeRecoveryTest, self).tearDown()
 
     @cluster(num_nodes=8, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
     def test_recovery_scale(self, cloud_storage_type):
         # This test requires dedicated system resources
         assert self.redpanda.dedicated_nodes

--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -226,14 +226,12 @@ class KgoVerifierWithSiTest(KgoVerifierBase):
 
 class KgoVerifierWithSiTestLargeSegments(KgoVerifierWithSiTest):
     @cluster(num_nodes=4, log_allow_list=KGO_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
     def test_si_without_timeboxed(self, cloud_storage_type):
         self.without_timeboxed()
 
     @cluster(num_nodes=4, log_allow_list=KGO_RESTART_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
     def test_si_with_timeboxed(self, cloud_storage_type):
         self.with_timeboxed()
 
@@ -242,13 +240,11 @@ class KgoVerifierWithSiTestSmallSegments(KgoVerifierWithSiTest):
     segment_size = 20 * 2**20
 
     @cluster(num_nodes=4, log_allow_list=KGO_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
     def test_si_without_timeboxed(self, cloud_storage_type):
         self.without_timeboxed()
 
     @cluster(num_nodes=4, log_allow_list=KGO_RESTART_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
     def test_si_with_timeboxed(self, cloud_storage_type):
         self.with_timeboxed()

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -64,7 +64,13 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                     # gate_closed etc errors to our allow list.
                     # TODO: extend this to cover shutdown logging too, and
                     # clean up redpanda to not log so many errors on shutdown.
-                    self.redpanda.raise_on_bad_logs(allow_list=log_allow_list)
+                    try:
+                        self.redpanda.raise_on_bad_logs(
+                            allow_list=log_allow_list)
+                    except:
+                        self.redpanda.cloud_storage_diagnostics()
+                        raise
+
                 self.redpanda.trim_logs()
                 return r
 


### PR DESCRIPTION
These are changes that I made while looking into #8978 :
- The failure wasn't generating a cloud_diagnostics.zip file
- Running scale tests locally runs against ABS+minio, which is a bit redundant for the purpose of these tests, and on dedicated nodes we're always OFAILing one of those: replace the CloudStorageTypes on these tests with a new AUTO type.
- An error on replicating archival_metadata_stm confusingly mentions the controller

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
