### PR TITLE
compacted_index: fix parsing of v0 index footers

### DIFF
--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -159,7 +159,7 @@ compacted_index_chunk_reader::load_footer() {
         footer.version = footer_v1.version;
 
         data_size = file_size - compacted_index::footer_v1::footer_size;
-    } else if (footer.version == compacted_index::footer::current_version) {
+    } else if (footer_v1.version == compacted_index::footer::current_version) {
         iobuf_parser parser(std::move(buf));
         footer = reflection::adl<storage::compacted_index::footer>{}.from(
           parser);
@@ -167,7 +167,7 @@ compacted_index_chunk_reader::load_footer() {
         data_size = file_size - compacted_index::footer::footer_size;
     } else {
         throw compacted_index::needs_rebuild_error{
-          fmt::format("incompatible index version: {}", footer.version)};
+          fmt::format("incompatible index version: {}", footer_v1.version)};
     }
 
     _footer = footer;


### PR DESCRIPTION
Previously (due to a typo) v0 indices were parsed as v2 indices, leading to alarming WARN messages in logs. After this fix a needs_rebuild_error exception will be thrown.

Note about v0 index rewrites in 23.1: v1 compacted index format was introduced in https://github.com/redpanda-data/redpanda/pull/5345 (released in 22.2) with the same header format and a different index key format. The rewrite logic there was the following: rewrite v0 indices [only if self-compaction hasn't finished](https://github.com/redpanda-data/redpanda/pull/5345/files#diff-c79a67494746e1dac357cbfc721f6718275cc322e24c34dfc8f8f6cdcae546d9R286). This logic will change in 23.1 to unconditional rewrite.

After a chat with @mmaslankaprv we concluded that the "rewrite v0 indices only if self-compaction hasn't finished" policy is probably wrong for adjacent segment compaction (because we create a concatenated compacted index from individual segment indices and thus can accidentally reuse an index with an old key format). In light of this it is probably for the better to leave the "rewrite v0 unconditionally" policy in place, but I am open to hearing different opinions.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none
