### PR TITLE
cluster: add health reporting for under replicated partitions

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_cluster.go
+++ b/src/go/rpk/pkg/api/admin/api_cluster.go
@@ -16,11 +16,12 @@ import (
 
 // Health overview data structure.
 type ClusterHealthOverview struct {
-	IsHealthy            bool     `json:"is_healthy"`
-	ControllerID         int      `json:"controller_id"`
-	AllNodes             []int    `json:"all_nodes"`
-	NodesDown            []int    `json:"nodes_down"`
-	LeaderlessPartitions []string `json:"leaderless_partitions"`
+	IsHealthy                 bool     `json:"is_healthy"`
+	ControllerID              int      `json:"controller_id"`
+	AllNodes                  []int    `json:"all_nodes"`
+	NodesDown                 []int    `json:"nodes_down"`
+	LeaderlessPartitions      []string `json:"leaderless_partitions"`
+	UnderReplicatedPartitions []string `json:"under_replicated_partitions"`
 }
 
 // PartitionBalancerStatus is the status of the partition auto balancer.

--- a/src/go/rpk/pkg/cli/cmd/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/health.go
@@ -92,10 +92,11 @@ following conditions are met:
 func printHealthOverview(hov *admin.ClusterHealthOverview) {
 	out.Section("CLUSTER HEALTH OVERVIEW")
 	overviewFormat := `Healthy:               %v
-Controller ID:         %v
-All nodes:             %v
-Nodes down:            %v
-Leaderless partitions: %v
+Controller ID:               %v
+All nodes:                   %v
+Nodes down:                  %v
+Leaderless partitions:       %v
+Under-replicated partitions: %v
 `
-	fmt.Printf(overviewFormat, hov.IsHealthy, hov.ControllerID, hov.AllNodes, hov.NodesDown, hov.LeaderlessPartitions)
+	fmt.Printf(overviewFormat, hov.IsHealthy, hov.ControllerID, hov.AllNodes, hov.NodesDown, hov.LeaderlessPartitions, hov.UnderReplicatedPartitions)
 }

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -640,6 +640,7 @@ struct ntp_report {
     model::ntp ntp;
     ntp_leader leader;
     size_t size_bytes;
+    std::optional<uint8_t> under_replicated_replicas;
 };
 
 partition_status to_partition_status(const ntp_report& ntpr) {
@@ -649,7 +650,7 @@ partition_status to_partition_status(const ntp_report& ntpr) {
       .leader_id = ntpr.leader.leader_id,
       .revision_id = ntpr.leader.revision_id,
       .size_bytes = ntpr.size_bytes,
-    };
+      .under_replicated_replicas = ntpr.under_replicated_replicas};
 }
 
 std::vector<ntp_report> collect_shard_local_reports(
@@ -671,6 +672,7 @@ std::vector<ntp_report> collect_shard_local_reports(
                   .revision_id = p.second->get_revision_id(),
                 },
                 .size_bytes = p.second->size_bytes() + p.second->non_log_disk_size_bytes(),
+                .under_replicated_replicas = p.second->get_under_replicated(),
               };
           });
     } else {
@@ -684,6 +686,7 @@ std::vector<ntp_report> collect_shard_local_reports(
                   .revision_id = partition->get_revision_id(),
                 },
                 .size_bytes = partition->size_bytes(),
+                .under_replicated_replicas = partition->get_under_replicated(),
                 });
             }
         }
@@ -773,12 +776,27 @@ health_monitor_backend::get_cluster_health_overview(
             ret.nodes_down.push_back(id);
         }
     }
+
+    // The size of the health status must be bounded: if all partitions
+    // on a system with 50k partitions are under-replicated, it is not helpful
+    // to try and cram all 50k NTPs into a vector here.
+    size_t max_partitions_report = 128;
+
     absl::node_hash_set<model::ntp> leaderless;
+    absl::node_hash_set<model::ntp> under_replicated;
+
     for (const auto& [_, report] : _reports) {
         for (const auto& [tp_ns, partitions] : report.topics) {
             for (const auto& partition : partitions) {
-                if (!partition.leader_id.has_value()) {
+                if (
+                  !partition.leader_id.has_value()
+                  && leaderless.size() < max_partitions_report) {
                     leaderless.emplace(tp_ns.ns, tp_ns.tp, partition.id);
+                }
+                if (
+                  partition.under_replicated_replicas.value_or(0) > 0
+                  && under_replicated.size() < max_partitions_report) {
+                    under_replicated.emplace(tp_ns.ns, tp_ns.tp, partition.id);
                 }
             }
         }
@@ -788,9 +806,17 @@ health_monitor_backend::get_cluster_health_overview(
       leaderless.begin(),
       leaderless.end(),
       std::back_inserter(ret.leaderless_partitions));
+
+    ret.under_replicated_partitions.reserve(under_replicated.size());
+    std::move(
+      under_replicated.begin(),
+      under_replicated.end(),
+      std::back_inserter(ret.under_replicated_partitions));
+
     ret.controller_id = _raft0->get_leader_id();
 
     ret.is_healthy = ret.nodes_down.empty() && ret.leaderless_partitions.empty()
+                     && ret.under_replicated_partitions.empty()
                      && ret.controller_id && !ec;
 
     co_return ret;

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -86,12 +86,14 @@ std::ostream& operator<<(std::ostream& o, const cluster_health_report& r) {
 std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
     fmt::print(
       o,
-      "{{id: {}, term: {}, leader_id: {}, revision_id: {}, size_bytes: {}}}",
+      "{{id: {}, term: {}, leader_id: {}, revision_id: {}, size_bytes: {}, "
+      "under_replicated: {}}}",
       ps.id,
       ps.term,
       ps.leader_id,
       ps.revision_id,
-      ps.size_bytes);
+      ps.size_bytes,
+      ps.under_replicated_replicas);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -55,7 +55,7 @@ struct node_state
 
 struct partition_status
   : serde::
-      envelope<partition_status, serde::version<0>, serde::compat_version<0>> {
+      envelope<partition_status, serde::version<1>, serde::compat_version<0>> {
     /**
      * We increase a version here 'backward' since incorrect assertion would
      * cause older redpanda versions to crash.
@@ -79,9 +79,16 @@ struct partition_status
     std::optional<model::node_id> leader_id;
     model::revision_id revision_id;
     size_t size_bytes;
+    std::optional<uint8_t> under_replicated_replicas;
 
     auto serde_fields() {
-        return std::tie(id, term, leader_id, revision_id, size_bytes);
+        return std::tie(
+          id,
+          term,
+          leader_id,
+          revision_id,
+          size_bytes,
+          under_replicated_replicas);
     }
 
     friend std::ostream& operator<<(std::ostream&, const partition_status&);
@@ -200,6 +207,7 @@ struct cluster_health_overview {
     std::vector<model::node_id> all_nodes;
     std::vector<model::node_id> nodes_down;
     std::vector<model::ntp> leaderless_partitions;
+    std::vector<model::ntp> under_replicated_partitions;
 };
 
 using include_partitions_info = ss::bool_class<struct include_partitions_tag>;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -176,6 +176,10 @@ public:
         return _raft->get_leader_id();
     }
 
+    std::optional<uint8_t> get_under_replicated() const {
+        return _raft->get_under_replicated();
+    }
+
     model::offset get_latest_configuration_offset() const {
         return _raft->get_latest_configuration_offset();
     }

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -98,13 +98,7 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
         sm::make_gauge(
           "under_replicated_replicas",
           [this] {
-              auto metrics = _partition.raft()->get_follower_metrics();
-              return std::count_if(
-                metrics.cbegin(),
-                metrics.cend(),
-                [](const raft::follower_metrics& fm) {
-                    return fm.under_replicated;
-                });
+              return _partition.raft()->get_under_replicated().value_or(0);
           },
           sm::description("Number of under replicated replicas"),
           labels)

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3326,4 +3326,24 @@ consensus::timequery(storage::timequery_config cfg) {
     return _log.timequery(cfg);
 }
 
+std::optional<uint8_t> consensus::get_under_replicated() const {
+    if (!is_leader()) {
+        return std::nullopt;
+    }
+
+    uint8_t count = 0;
+    for (const auto& f : _fstats) {
+        auto f_metrics = build_follower_metrics(
+          f.first.id(),
+          _log.offsets(),
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+            _jit.base_duration()),
+          f.second);
+        if (f_metrics.under_replicated) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -146,6 +146,13 @@ public:
     std::optional<model::node_id> get_leader_id() const {
         return _leader_id ? std::make_optional(_leader_id->id()) : std::nullopt;
     }
+
+    /**
+     * On leader, return the number of under replicated followers.  On
+     * followers, return nullopt
+     */
+    std::optional<uint8_t> get_under_replicated() const;
+
     /**
      * Sends a round of heartbeats to followers, when majority of followers
      * replied with success to either this of any following request all reads up

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -101,6 +101,13 @@
                         "type": "string"
                     },
                     "description": "list of partitions for which no leader is elected"
+                },
+                "under_replicated_partitions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "list of partitions where one or more replicas has not replicated all data"
                 }
             }
         },

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -26,6 +26,21 @@
             ]
         },
         {
+            "path": "/v1/partitions/local_summary",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Summarize the status of partitions with a replica on this node",
+                    "type": "partition_local_summary",
+                    "nickname": "get_partitions_local_summary",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/partitions/{namespace}/{topic}/{partition}",
             "operations": [
                 {
@@ -343,6 +358,24 @@
                 "leader": {
                     "type": "long",
                     "description": "Latest known leader (or -1 if unknown)"
+                }
+            }
+        },
+        "partitions_local_summary": {
+            "id": "partitions_local_summary",
+            "description": "Summarize status of partitions with a replica on this node",
+            "properties": {
+                "count": {
+                    "type": "long",
+                    "description": "Number of partitions with a replica on this node"
+                },
+                "leaderless": {
+                    "type": "long",
+                    "description": "Number of partitions with a replica on this node that report no known raft leader"
+                },
+                "under_replicated": {
+                    "type": "long",
+                    "description": "Number of partitions with leadership on this node, reporting one or more under-replicated followers"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3463,12 +3463,17 @@ void admin_server::register_cluster_routes() {
                 ret.all_nodes._set = true;
                 ret.nodes_down._set = true;
                 ret.leaderless_partitions._set = true;
+                ret.under_replicated_partitions._set = true;
 
                 ret.all_nodes = health_overview.all_nodes;
                 ret.nodes_down = health_overview.nodes_down;
 
                 for (auto& ntp : health_overview.leaderless_partitions) {
                     ret.leaderless_partitions.push(fmt::format(
+                      "{}/{}/{}", ntp.ns(), ntp.tp.topic(), ntp.tp.partition));
+                }
+                for (auto& ntp : health_overview.under_replicated_partitions) {
+                    ret.under_replicated_partitions.push(fmt::format(
                       "{}/{}/{}", ntp.ns(), ntp.tp.topic(), ntp.tp.partition));
                 }
                 if (health_overview.controller_id) {


### PR DESCRIPTION

Installers need to be able to check the health of the system to do maintenance safely, including knowing if there are any under-replicated partitions.  This is because if a 3 node system has 2 up to date replicas A,B and 1 under replicated replica C, then taking node B down for maintenance puts the system in a high risk state where it would become unavailable if node A went offline.

Installers had been using a brute force prometheus scrape to get at the under replicated partition count from each node.

This is addressed with two changes:
- An admin API at /v1/partitions/local_summary that provides a direct way to query the under replicated count and leaderless count without having to scrape it out of prometheus output (which is potentially huge, and is not a stable interface).  This is suitable for installers that will hit each node separately to check the status of partition replicas on that node.
- An extension to the existing cluster health api and `rpk cluster health` command, to report under replicated partitions in the same way that leaderless partitions are reported.  This is suitable for simpler logic that simply checks the the global boolean value for cluster health, although may not be quite as robust as checking each node directly, due to delays in propagation of health state.

While making this change, the health API is also updated to apply a cap to the number of partitions that will be reported in either of the unhealthy states: this resolves an issue where this API could become impractical on systems with very large numbers of partitions.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Improvements

* `rpk cluster health` now reports under replicated partitions, and considers the cluster unhealthy if any partitions are under replicated.
* A new admin API `/v1/partitions/local_summary` reports the count, leaderless count and under-replicated count for partitions with replicas on the node serving the request.  This replaces the use of the prometheus endpoint for programs that previously used that to read the `vectorized_cluster_partition_under_replicated_replicas` metric.
