### PR TITLE
tests: add parallel arg to ABSClient.empty_bucket

### DIFF
--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -72,7 +72,9 @@ class ABSClient:
         blob_service = BlobServiceClient.from_connection_string(self.conn_str)
         blob_service.delete_container(name)
 
-    def empty_bucket(self, name: str):
+    def empty_bucket(self, name: str, parallel=False):
+        # TODO: implement `parallel` as/when we start running any scale tests
+        # on Azure
         container_client = ContainerClient.from_connection_string(
             self.conn_str, container_name=name)
         blob_names_generator = container_client.list_blob_names()


### PR DESCRIPTION
This is to make it match the S3Client interface, even though we don't implement it yet.  This was added to S3Client to get faster cleanup in scale tests.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none