### PR TITLE
cloud_storage_clients: handle gate closed

### DIFF
--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -59,6 +59,9 @@ error_outcome handle_client_transport_error(
               "Server disconnected: '{}', retrying HTTP request",
               err.what());
         }
+    } catch (const ss::gate_closed_exception&) {
+        vlog(logger.debug, "Gate closed");
+        throw;
     } catch (const ss::abort_requested_exception&) {
         vlog(logger.debug, "Abort requested");
         throw;


### PR DESCRIPTION
This addresses the below error, which appears to happen when the HTTP client request gate is closed.

WARN  2023-02-21 02:30:29,912 [shard 2] s3 - s3_client.cc:654 - S3 request failed with error: seastar::gate_closed_exception (gate closed) ERROR 2023-02-21 02:30:29,913 [shard 2] s3 - util.cc:66 - Unexpected error seastar::gate_closed_exception (gate closed)

We now catch this at the cloud_storage_client layer, and just bubble up the gate_closed_exception to higher levels rather than logging, since it's a common pattern to expect and handle appropriately gate_closed at shutdown (similar to the handling of abort_requested).

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
