### PR TITLE
Miniscule typo in the `rpk topic consume` help

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/consume.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/consume.go
@@ -751,7 +751,7 @@ Percent encoding prints record fields, fetch partition fields, or extra values:
     %T    topic length
     %k    key
     %K    key length
-    %v    topic
+    %v    value
     %V    value length
     %h    begin the header specification
     %H    number of headers


### PR DESCRIPTION
This fixes up a tiny nit in the `rpk topic consume` help text.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

I was a first-time user of the `--format` flag yesterday. The help text is great, but this jumped out.

## Release Notes

  * none
