### PR TITLE
tests: fixes for tiered storage tests

### DIFF
--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -192,7 +192,7 @@ class CloudRetentionTest(PreallocNodesTest):
 
         # Write more data than we intend to retain.
         msg_size = 4 * 1024
-        msg_count = int(5 * 1024 * 1024 / msg_size)
+        msg_count = int(num_partitions * 1024 * 1024 / msg_size)
         producer = KgoVerifierProducer(self.test_context,
                                        self.redpanda,
                                        self.topic_name,

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -178,17 +178,15 @@ class CloudRetentionTest(PreallocNodesTest):
         self.redpanda.add_extra_rp_conf(extra_rp_conf)
         self.redpanda.start()
         rpk = RpkTool(self.redpanda)
-        rpk.create_topic(
-            topic=self.topic_name,
-            partitions=num_partitions,
-            replicas=3,
-            config={
-                "cleanup.policy": TopicSpec.CLEANUP_DELETE,
-                # Intentionally sabotage Redpanda to use lower
-                # retention than a single segment.
-                "retention.bytes": int(small_segment_size / 2),
-                "retention.local.target.bytes": 2 * small_segment_size,
-            })
+        rpk.create_topic(topic=self.topic_name,
+                         partitions=num_partitions,
+                         replicas=3,
+                         config={
+                             "cleanup.policy":
+                             TopicSpec.CLEANUP_DELETE,
+                             "retention.local.target.bytes":
+                             2 * small_segment_size,
+                         })
 
         # Write more data than we intend to retain.
         msg_size = 4 * 1024

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -214,7 +214,7 @@ class CloudRetentionTest(PreallocNodesTest):
                 size = s3_snapshot.cloud_log_size_for_ntp(
                     self.topic_name, partition)
                 if size == 0:
-                    self.logger.info("Partition {} has size 0", partition)
+                    self.logger.info(f"Partition {partition} has size 0")
                     return False
 
             return True

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -157,9 +157,10 @@ class CloudRetentionTest(PreallocNodesTest):
         assert consumer.consumer_status.validator.valid_reads > \
             segment_size * num_partitions / msg_size
 
-    @skip_debug_mode
     @cluster(num_nodes=4)
-    def test_gc_entire_manifest(self):
+    @skip_debug_mode
+    @matrix(cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    def test_gc_entire_manifest(self, cloud_storage_type):
         """
         Regression test for #8945, where GCing all cloud segments could prevent
         further uploads from taking place.

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -15,6 +15,7 @@ from ducktape.utils.util import wait_until
 from ducktape.mark import matrix, parametrize
 from requests.exceptions import HTTPError
 
+from rptest.utils.mode_checks import skip_debug_mode
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.clients.offline_log_viewer import OfflineLogViewer
@@ -270,6 +271,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                    timeout_sec=30,
                    backoff_sec=1)
 
+    @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(
         num_nodes=3,
         log_allow_list=[


### PR DESCRIPTION
A series of small test fixes, bundled together in one PR to avoid doing N CI runs:

- tests: add ABS mode to test_gc_entire_manifest
- tests: fix initial retention.bytes in cloud_retention_test
- tests: fix a format string in cloud_retention_test
- tests: update data size in CloudRetentionTest.test_gc_entire_manifest
- tests: skip topic_delete_unavailable_test in debug mode

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none

