### PR TITLE
storage: fix disk space stats to be gauges

### DIFF
--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -37,12 +37,12 @@ void node_probe::setup_node_metrics() {
     _public_metrics.add_group(
       prometheus_sanitize::metrics_name("storage:disk"),
       {
-        sm::make_total_bytes(
+        sm::make_gauge(
           "total_bytes",
           [this] { return _disk.total_bytes; },
           sm::description("Total size of attached storage, in bytes."))
           .aggregate({sm::shard_label}),
-        sm::make_total_bytes(
+        sm::make_gauge(
           "free_bytes",
           [this] { return _disk.free_bytes; },
           sm::description("Disk storage bytes free."))


### PR DESCRIPTION
These should never have been counters.

Fixes https://github.com/redpanda-data/redpanda/issues/9014

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Bug Fixes

* The type of metrics `redpanda_storage_disk_free_bytes` and `redpanda_storage_disk_total_bytes` is corrected from 
