### PR TITLE
cluster: fix self test unit test build

### DIFF
--- a/src/v/cluster/self_test/tests/CMakeLists.txt
+++ b/src/v/cluster/self_test/tests/CMakeLists.txt
@@ -1,15 +1,19 @@
 rp_test(
+    UNIT_TEST
     BINARY_NAME self_test_test
     SOURCES self_test_request_test.cc
     DEFINITIONS BOOST_TEST_DYN_LINK
     LIBRARIES v::seastar_testing_main v::cluster
     LABELS self_test
+    ARGS "-- -c 1"
 )
 
 rp_test(
+    UNIT_TEST
     BINARY_NAME self_test_framework_test
     SOURCES self_test_config_test.cc
     DEFINITIONS BOOST_TEST_DYN_LINK
     LIBRARIES Boost::unit_test_framework v::cluster
     LABELS self_test
+    ARGS "-- -c 1"
 )


### PR DESCRIPTION
These were being built without the _rpunit suffix, therefore not running in `rp:unit-tests`


## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
