### PR TITLE
cloud_storage: azure shared key live reload

### DIFF
--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -82,6 +82,9 @@ public:
     void maybe_start_auth_refresh_op(
       cloud_roles::credentials_update_cb_t credentials_update_cb);
 
+    cloud_storage_clients::client_configuration get_client_config() const;
+    void set_client_config(cloud_storage_clients::client_configuration conf);
+
 private:
     void do_start_auth_refresh_op(
       cloud_roles::credentials_update_cb_t credentials_update_cb);
@@ -406,6 +409,8 @@ private:
     remote_probe _probe;
 
     intrusive_list<event_filter, &event_filter::_hook> _filters;
+
+    config::binding<std::optional<ss::sstring>> _azure_shared_key_binding;
 };
 
 } // namespace cloud_storage

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1334,7 +1334,7 @@ configuration::configuration()
       "configured Azure storage account (see "
       "'cloud_storage_azure_storage_account)'. Note that Redpanda expects this "
       "string to be Base64 encoded.",
-      {.needs_restart = needs_restart::yes,
+      {.needs_restart = needs_restart::no,
        .visibility = visibility::user,
        .secret = is_secret::yes},
       std::nullopt)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -278,8 +278,11 @@ class SISettings:
 
     DEDICATED_NODE_KEY = "dedicated_nodes"
 
-    # The account to use with local Azurite testing
+    # The account and key to use with local Azurite testing.
+    # These are the default Azurite (Azure emulator) storage account and shared key.
+    # Both are readily available in the docs.
     ABS_AZURITE_ACCOUNT = "devstoreaccount1"
+    ABS_AZURITE_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
 
     def __init__(self,
                  test_context,
@@ -335,9 +338,7 @@ class SISettings:
             self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
             self.cloud_storage_api_endpoint_port = cloud_storage_api_endpoint_port
         elif self.cloud_storage_type == CloudStorageType.ABS:
-            # These are the default Azurite (Azure emulator) storage account and shared key.
-            # Both are readily available in the docs.
-            self.cloud_storage_azure_shared_key = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
+            self.cloud_storage_azure_shared_key = self.ABS_AZURITE_KEY
             self.cloud_storage_azure_storage_account = self.ABS_AZURITE_ACCOUNT
 
             self._cloud_storage_azure_container = f'panda-container-{uuid.uuid1()}'


### PR DESCRIPTION
Previously, updating the shared key used for Azure auth required a
cluster restart. This is incovenient for customers that wish to rotate
keys.

This PR makes the shared key reload without a restart by listening
for changes on the configuration property and rebuilding the static
credentials accordingly.

If the property becomes unset (likely a user error), we keep using the
current key until the cluster is re-started.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
### Features
* Azure shared key is now reloadable without a restart via `cloud_storage_azure_shared_key`. This makes rotating keys more convenient.