### PR TITLE
tests: fail on abandoned failed futures

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1819,9 +1819,14 @@ class RedpandaService(Service):
             self.logger.info(
                 f"Scanning node {node.account.hostname} log for errors...")
 
-            match_errors = "-e ^ERROR" if self._raise_on_errors else ""
+            # List of regexes we will fail the test on if they appear in the log
+            match_terms = ["Segmentation fault", "[Aa]ssert"]
+            if self._raise_on_errors:
+                match_terms.append("^ERROR")
+            match_expr = " ".join(f"-e \"{t}\"" for t in match_terms)
+
             for line in node.account.ssh_capture(
-                    f"grep {match_errors} -e Segmentation\ fault -e [Aa]ssert {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
+                    f"grep {match_expr} {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
             ):
                 line = line.strip()
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1819,8 +1819,10 @@ class RedpandaService(Service):
             self.logger.info(
                 f"Scanning node {node.account.hostname} log for errors...")
 
-            # List of regexes we will fail the test on if they appear in the log
-            match_terms = ["Segmentation fault", "[Aa]ssert"]
+            # List of regexes that will fail the test on if they appear in the log
+            match_terms = [
+                "Segmentation fault", "[Aa]ssert", "Exceptional future ignored"
+            ]
             if self._raise_on_errors:
                 match_terms.append("^ERROR")
             match_expr = " ".join(f"-e \"{t}\"" for t in match_terms)


### PR DESCRIPTION
This is the integration test equivalent of `--fail-on-abandoned-failed-futures` in unit tests.

This message is always a bug, albeit not always a severe one.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none