### PR TITLE
Multiple admin hosts in `rpk debug bundle`

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
@@ -38,7 +37,6 @@ type bundleParams struct {
 	fs                      afero.Fs
 	cfg                     *config.Config
 	cl                      *kgo.Client
-	admin                   *admin.AdminAPI
 	logsSince               string
 	logsUntil               string
 	path                    string
@@ -92,15 +90,6 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 
-			// We use NewHostClient because we want to talk to
-			// localhost, and some of out API requests require
-			// choosing the host to talk to. With params of
-			// rpk.admin_api preferring localhost first IF no
-			// rpk.admin_api is actually in the underlying file, we
-			// can always just pick the first host.
-			admin, err := admin.NewHostClient(fs, cfg, "0")
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
-
 			cl, err := kafka.NewFranzClient(fs, p, cfg)
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer cl.Close()
@@ -114,7 +103,6 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 				fs:                      fs,
 				cfg:                     cfg,
 				cl:                      cl,
-				admin:                   admin,
 				logsSince:               logsSince,
 				logsUntil:               logsUntil,
 				path:                    path,

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
@@ -222,15 +222,15 @@ func saveSingleAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, c
 					return requestAndSave(ctx, ps, fmt.Sprintf("admin/cluster_view_%v.json", aName), cl.ClusterView)
 				},
 				func() error {
-					err := requestAndSave(ctx, ps, fmt.Sprintf("metrics/%v/t0_metric.txt", aName), cl.PrometheusMetrics)
+					err := requestAndSave(ctx, ps, fmt.Sprintf("metrics/%v/t0_metrics.txt", aName), cl.PrometheusMetrics)
 					if err != nil {
 						return err
 					}
 					select {
 					case <-time.After(metricsInterval):
-						return requestAndSave(ctx, ps, fmt.Sprintf("metrics/%v/t1_metric.txt", aName), cl.PrometheusMetrics)
+						return requestAndSave(ctx, ps, fmt.Sprintf("metrics/%v/t1_metrics.txt", aName), cl.PrometheusMetrics)
 					case <-ctx.Done():
-						return requestAndSave(ctx, ps, fmt.Sprintf("metrics/%v/t1_metric.txt", aName), cl.PrometheusMetrics)
+						return requestAndSave(ctx, ps, fmt.Sprintf("metrics/%v/t1_metrics.txt", aName), cl.PrometheusMetrics)
 					}
 				},
 				func() error {

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -35,11 +35,9 @@ class RpkRemoteTool:
     def debug_bundle(self, output_file):
         # Run the bundle command.  It outputs into pwd, so switch to working dir first
         return self._execute([
-            self._rpk_binary(),
-            'debug',
-            'bundle',
-            "--output",
-            output_file,
+            self._rpk_binary(), 'debug', 'bundle', "--output", output_file,
+            "--api-urls",
+            self._redpanda.admin_endpoints()
         ])
 
     def cluster_config_force_reset(self, property_name):

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -71,6 +71,8 @@ class RpkRemoteTool:
         return self._execute(cmd, timeout=timeout)
 
     def _execute(self, cmd, timeout=30):
+        self._redpanda.logger.debug("Executing command: %s", cmd)
+
         return self._node.account.ssh_output(
             ' '.join(cmd),
             timeout_sec=timeout,

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -107,7 +107,25 @@ class RpkClusterTest(RedpandaTest):
         files = zf.namelist()
         assert 'redpanda.yaml' in files
         assert 'redpanda.log' in files
-        assert 'prometheus-metrics.txt' in files
+
+        # At least the first controller log is being saved:
+        assert 'controller/0-1-v1.log' in files
+
+        # Cluster admin API calls:
+        assert 'admin/brokers.json' in files
+        assert 'admin/cluster_config.json' in files
+        assert 'admin/health_overview.json' in files
+
+        # Per-node admin API calls:
+        for n in self.redpanda.started_nodes():
+            # rpk will save 2 snapsots per metrics endpoint:
+            assert f'metrics/{n.account.hostname}-9644/t0_metrics.txt' in files
+            assert f'metrics/{n.account.hostname}-9644/t1_metrics.txt' in files
+            assert f'metrics/{n.account.hostname}-9644/t0_public_metrics.txt' in files
+            assert f'metrics/{n.account.hostname}-9644/t1_public_metrics.txt' in files
+            # and 1 cluster_view and node_config per node:
+            assert f'admin/cluster_view_{n.account.hostname}-9644.json' in files
+            assert f'admin/node_config_{n.account.hostname}-9644.json' in files
 
     @cluster(num_nodes=3)
     def test_get_config(self):


### PR DESCRIPTION
This PR solves multiple issues at once, to achieve parity between the K8S bundle and bare-metal bundles:

- It adds more admin API calls to debug bundle, the same admin API calls introduced for the K8S debug bundle.
- Now bare-metal debug bundle saves 2 metrics snapshots in a given time.
- It adds the ability to create multiple admin API clients depending on the number of addresses passed to rpk, and issue the request in each of them
- Ducktape tests checking the above + controller logs being added to the bundle.


Fixes #9004, Fixes #9005, Fixes #9007 

## Backports Required
- [x] none - issue does not exist in previous branches


## Release Notes
  ### Improvements
  * `rpk debug bundle` now saves more admin API calls to the debug bundle in bare-metal deployments.
