### PR TITLE
archival: Double check jobs_available

### DIFF
--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -287,6 +287,14 @@ ss::future<> housekeeping_workflow::run_jobs_bg() {
         // backlog size reaches zero. After that the status changes to idle and
         // backlog size to the total number of housekeeping jobs.
         co_await _cvar.wait([this] { return jobs_available(); });
+        // There is a scheduling event between the predicate (jobs_available())
+        // returning true and the ss::condition_variable::wait method returning,
+        // meaning that upon the return from this method, there is no guarantee
+        // that the predicate is still true. This issue was seen in
+        // https://github.com/redpanda-data/redpanda/issues/8964.
+        if (!jobs_available()) {
+            continue;
+        }
         if (_as.abort_requested()) {
             co_return;
         }


### PR DESCRIPTION
There is a scheduling event that occurs between the predicate in
`ss::condition_variable::wait` returning true and the `wait` method
returning, meaning that upon return from that method, there is no
guarantee that the predicate is true anymore.

Adding an additional check for `jobs_available()` to avoid the
`vassert`.

Fixes: #8964 

Push force `745395a`:

* Updated comment and commit message to more accurately reflect what the issue is

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

* none

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

* none
