### PR TITLE
Changing endpoint for google storage and adding a separate suite for GCP & Azure.

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -277,6 +277,7 @@ class SISettings:
 
     GLOBAL_ABS_STORAGE_ACCOUNT = "abs_storage_account"
     GLOBAL_ABS_SHARED_KEY = "abs_shared_key"
+    GLOBAL_CLOUD_PROVIDER = "cloud_provider"
 
     DEDICATED_NODE_KEY = "dedicated_nodes"
 
@@ -340,6 +341,9 @@ class SISettings:
             self._cloud_storage_bucket = f'panda-bucket-{uuid.uuid1()}'
 
             self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
+            if test_context.globals.get(self.GLOBAL_CLOUD_PROVIDER,
+                                        'aws') == 'gcp':
+                self.cloud_storage_api_endpoint = 'storage.googleapis.com'
             self.cloud_storage_api_endpoint_port = cloud_storage_api_endpoint_port
         elif self.cloud_storage_type == CloudStorageType.ABS:
             self.cloud_storage_azure_shared_key = self.ABS_AZURITE_KEY
@@ -422,6 +426,9 @@ class SISettings:
             self.cloud_storage_access_key = cloud_storage_access_key
             self.cloud_storage_secret_key = cloud_storage_secret_key
             self.endpoint_url = None  # None so boto auto-gens the endpoint url
+            if test_context.globals.get(self.GLOBAL_CLOUD_PROVIDER,
+                                        'aws') == 'gcp':
+                self.endpoint_url = 'https://storage.googleapis.com'
             self.cloud_storage_disable_tls = False  # SI will fail to create archivers if tls is disabled
             self.cloud_storage_region = cloud_storage_region
             self.cloud_storage_api_endpoint_port = 443

--- a/tests/rptest/test_suite_gcp_temporary.yml
+++ b/tests/rptest/test_suite_gcp_temporary.yml
@@ -1,0 +1,15 @@
+# TODO work in progress getting clustered mode issues worked out
+gcp:
+  included:
+    - tests
+
+  excluded:
+    - tests/librdkafka_test.py # normally disabled
+    - tests/wasm_filter_test.py # no wasm
+    - tests/wasm_failure_recovery_test.py # no wasm
+    - tests/wasm_identity_test.py # no wasm
+    - tests/wasm_topics_test.py # no wasm
+    - tests/wasm_redpanda_failure_recovery_test.py # no wasm
+    - tests/wasm_partition_movement_test.py # no wasm
+    - tests/e2e_iam_role_test.py # use static credentials
+    - tests/consumer_group_recovery_tool_test.py # use script available in dockerfile


### PR DESCRIPTION
This is PR which is part of larger change to enable ducktape tests on GCP.
This change switches the endpoint API to google storage api while running the tests against GCP.

related to: https://github.com/redpanda-data/vtools/issues/488

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none