### PR TITLE
Support CG rebalancing while verifiable consumer with many nodes is shutting down

### DIFF
--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -385,6 +385,12 @@ class EndToEndTest(Test):
                 else:
                     msg += "(There are also %d duplicate messages in the log - but that is an acceptable outcome)\n" % num_duplicates
 
+            consumer_consistency = self.consumer.verify_position_offsets_consistency(
+            )
+            if not consumer_consistency[0]:
+                success = False
+                msg += '\n'.join(consumer_consistency[1]) + '\n'
+
         # Collect all logs if validation fails
         if not success:
             self._collect_all_logs()


### PR DESCRIPTION
When `VerifiableConsumer` is run with `num_nodes`>1, upon shutdown, once the first consumer is killed, consumer group reassignment occurs and the other consumers begin receiving messages from the partitions that were previously assigned to the consumer group of the killed one. However the 1st consumer's worker thread has not processed all its output, and is still receiving messages from before the switch point while the other workers have already started receiving the messages from after the switch point.

The common consumer state is made per-worker so that no conflict occurs in the above scenario.

Fixes #7978

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes
* none
<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes
* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
