### PR TITLE
tests: update confluent_kafka to 2.0.2

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'ducktape@git+https://github.com/redpanda-data/ducktape.git@505e388f7a9cc7b235c20ce1272d75344fcd5e08',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
-        'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
+        'crc32c==2.2', 'confluent-kafka==2.0.2', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.3', 'fastavro==1.4.9',
         'psutil==5.9.0', 'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
         'jump-consistent-hash==3.2.0', 'azure-storage-blob==12.14.1',


### PR DESCRIPTION
Recent container builds have been seen to fail building 1.7, apparently due to a bad rdkafka version.

## Backports Required

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
