### PR TITLE
tests: skip >test_recovery_after_multiple_restarts in debug mode

### DIFF
--- a/tests/rptest/tests/multi_restarts_with_archival_test.py
+++ b/tests/rptest/tests/multi_restarts_with_archival_test.py
@@ -9,6 +9,7 @@
 
 import uuid
 
+from rptest.utils.mode_checks import skip_debug_mode
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import CloudStorageType, SISettings
 from ducktape.mark import parametrize
@@ -34,11 +35,9 @@ class MultiRestartTest(EndToEndTest):
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @parametrize(cloud_storage_type=CloudStorageType.ABS)
     @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @skip_debug_mode
     def test_recovery_after_multiple_restarts(self, cloud_storage_type):
-        # If a debug build has to do a restart across a significant
-        # number of partitions, it gets slow.  Use fewer partitions
-        # on debug builds.
-        partition_count = 10 if self.debug_mode else 60
+        partition_count = 60
 
         si_settings = SISettings(self.test_context,
                                  cloud_storage_max_connections=5,


### PR DESCRIPTION
This test already used fewer partitions in debug mode, but we shouldn't really run tests that do things like waiting for recovery to complete in debug mode at all.  There's no limit on how slow they can be.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
