### PR TITLE
[v22.3.x] cluster/archival_metadata_stm: std::vector -> fragmented_vector

### DIFF
--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -129,8 +129,8 @@ public:
       model::offset lo,
       model::offset lco,
       model::offset insync,
-      const std::vector<segment_t>& segments,
-      const std::vector<segment_t>& replaced)
+      const fragmented_vector<segment_t>& segments,
+      const fragmented_vector<segment_t>& replaced)
       : _ntp(std::move(ntp))
       , _rev(rev)
       , _last_offset(lo)

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -175,10 +175,10 @@ private:
 
     friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
 
-    static std::vector<segment>
+    static fragmented_vector<segment>
     segments_from_manifest(const cloud_storage::partition_manifest& manifest);
 
-    static std::vector<segment> replaced_segments_from_manifest(
+    static fragmented_vector<segment> replaced_segments_from_manifest(
       const cloud_storage::partition_manifest& manifest);
 
     void apply_add_segment(const segment& segment);

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -14,7 +14,83 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <initializer_list>
+#include <limits>
+#include <type_traits>
 #include <vector>
+
+using fv_int = fragmented_vector<int>;
+
+static_assert(std::forward_iterator<fv_int::iterator>);
+static_assert(std::forward_iterator<fv_int::const_iterator>);
+
+namespace test_details {
+
+struct fragmented_vector_accessor {
+    // perform an internal consistency check of the vector structure
+    template<typename T, size_t S>
+    static void check_consistency(const fragmented_vector<T, S>& v) {
+        BOOST_REQUIRE(v._size <= v._capacity);
+        BOOST_REQUIRE(v.size() < std::numeric_limits<size_t>::max() / 2);
+        BOOST_REQUIRE(v._capacity < std::numeric_limits<size_t>::max() / 2);
+
+        size_t calc_size = 0, calc_cap = 0;
+
+        for (size_t i = 0; i < v._frags.size(); ++i) {
+            auto& f = v._frags[i];
+
+            calc_size += f.size();
+            calc_cap += f.capacity();
+
+            if (i + 1 < v._frags.size()) {
+                if (f.size() < v.elems_per_frag) {
+                    throw std::runtime_error(fmt::format(
+                      "fragment {} is undersized ({} < {})",
+                      i,
+                      f.size(),
+                      v.elems_per_frag));
+                }
+            }
+        }
+
+        if (calc_size != v.size()) {
+            throw std::runtime_error(fmt::format(
+              "calculated size is wrong ({} != {})", calc_size, v.size()));
+        }
+
+        if (calc_cap != v._capacity) {
+            throw std::runtime_error(fmt::format(
+              "calculated capacity is wrong ({} != {})",
+              calc_size,
+              v._capacity));
+        }
+    }
+};
+} // namespace test_details
+
+/**
+ * Proxy that applies a consistency check before deference
+ */
+template<typename T, size_t S>
+struct checker {
+    using underlying = fragmented_vector<T, S>;
+
+    underlying* operator->() {
+        test_details::fragmented_vector_accessor::check_consistency(u);
+        return &u;
+    }
+
+    underlying& get() { return *operator->(); }
+
+    auto operator<=>(const checker&) const = default;
+
+    friend std::ostream& operator<<(std::ostream& os, const checker& c) {
+        os << c.u;
+        return os;
+    }
+
+    underlying u;
+};
 
 template<typename T>
 static void
@@ -114,4 +190,128 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_test) {
         BOOST_REQUIRE_EQUAL(
           std::distance(it, truth.end()), std::distance(it2, other.end()));
     }
+}
+
+template<typename T = int, size_t S = 8>
+static checker<T, S> make(std::initializer_list<T> in) {
+    checker<T, S> ret;
+    for (auto& e : in) {
+        ret->push_back(e);
+    }
+    return ret;
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_types) {
+    using vtype = fragmented_vector<int64_t, 8>;
+    using iter = vtype::iterator;
+    using citer = vtype::const_iterator;
+    auto v = vtype{};
+
+    // const and non-const iterators should be different!
+    static_assert(!std::is_same_v<iter, citer>);
+
+    static_assert(std::is_same_v<decltype(v.begin()), iter>);
+    static_assert(
+      std::is_same_v<decltype(v.cbegin()), decltype(v)::const_iterator>);
+    static_assert(std::is_same_v<
+                  decltype(std::as_const(v).begin()),
+                  decltype(v)::const_iterator>);
+}
+
+/**
+ * Get a fragmented vector for elements of size E, with max_fragment_size F.
+ */
+template<size_t ES, size_t F>
+using sized_frag = fragmented_vector<std::array<char, ES>, F>;
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_fragment_sizing) {
+    BOOST_CHECK_EQUAL((sized_frag<7, 32>::elements_per_fragment()), 4);
+    BOOST_CHECK_EQUAL((sized_frag<8, 32>::elements_per_fragment()), 4);
+    BOOST_CHECK_EQUAL((sized_frag<9, 32>::elements_per_fragment()), 2);
+    BOOST_CHECK_EQUAL((sized_frag<31, 32>::elements_per_fragment()), 1);
+    BOOST_CHECK_EQUAL((sized_frag<32, 32>::elements_per_fragment()), 1);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_arithmetic) {
+    auto v = make<int64_t, 8>({0, 1, 2, 3});
+
+    auto b = v->begin();
+
+    BOOST_CHECK_EQUAL(*(b + 0), 0);
+    BOOST_CHECK_EQUAL(*(b + 1), 1);
+    BOOST_CHECK_EQUAL(*(b + 2), 2);
+    BOOST_CHECK_EQUAL(*(b + 3), 3);
+
+    auto e = v->end();
+
+    BOOST_CHECK((e - 0) == e);
+
+    BOOST_CHECK_EQUAL(*(e - 1), 3);
+    BOOST_CHECK_EQUAL(*(e - 2), 2);
+    BOOST_CHECK_EQUAL(*(e - 3), 1);
+    BOOST_CHECK_EQUAL(*(e - 4), 0);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_comparison) {
+    auto v = make<int64_t, 8>({0, 1, 2, 3});
+
+    auto b = v->begin();
+
+    BOOST_CHECK(b == b);
+    BOOST_CHECK(b <= b);
+    BOOST_CHECK(!(b < b));
+    BOOST_CHECK(!(b > b));
+    BOOST_CHECK(!(b != b));
+
+    auto b1 = b + 1;
+
+    BOOST_CHECK(b <= b1);
+    BOOST_CHECK(b < b1);
+    BOOST_CHECK(b1 >= b);
+    BOOST_CHECK(b1 > b);
+    BOOST_CHECK(b1 >= b);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_sort) {
+    auto v = make<int64_t, 8>({3, 2, 1});
+    auto expected = make<int64_t, 8>({1, 2, 3});
+
+    std::sort(v->begin(), v->end());
+
+    BOOST_CHECK_EQUAL(v, expected);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_vector_clear) {
+    auto v = make<int, 8>({});
+
+    BOOST_CHECK_EQUAL(v->size(), 0);
+
+    v->push_back(0);
+    BOOST_CHECK_EQUAL(v->size(), 1);
+
+    v->push_back(1);
+    BOOST_CHECK_EQUAL(v->size(), 2);
+
+    v->clear();
+    BOOST_CHECK_EQUAL(v->size(), 0);
+
+    v = make<int, 8>({5, 5, 5, 5});
+    BOOST_CHECK_EQUAL(v->size(), 4);
+
+    v.u = std::vector{1, 2, 3};
+    BOOST_CHECK_EQUAL(v->size(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_vector_assign) {
+    std::vector vin0{1, 2, 3};
+    std::vector vin1{4, 5};
+
+    checker<int, 8> v;
+    BOOST_CHECK_EQUAL(v, (make({})));
+
+    v.get() = std::vector{1};
+    BOOST_CHECK_EQUAL(v, (make({1})));
+
+    v.get() = std::vector{2, 3, 4};
+    BOOST_CHECK_EQUAL(v, (make({2, 3, 4})));
 }


### PR DESCRIPTION
partial Backport of PR #8469 for utils/fragmented_vector
Backport of PR #9019
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->

* none