### PR TITLE
cluster: strict upgrade version compatibility check on upgrade

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -142,6 +142,13 @@ node_config::node_config() noexcept
       "operator intervention is needed to startup the broker.",
       {.visibility = visibility::user},
       std::nullopt)
+  , upgrade_override_checks(
+      *this,
+      "upgrade_override_checks",
+      "Whether to violate safety checks when starting a redpanda version newer "
+      "than the cluster's consensus version",
+      {.visibility = visibility::tunable},
+      false)
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -62,6 +62,10 @@ public:
 
     property<std::optional<uint32_t>> crash_loop_limit;
 
+    // If true, permit any version of redpanda to start, even
+    // if potentially incompatible with existing system state.
+    property<bool> upgrade_override_checks;
+
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {
         return data_directory().path / "pid.lock";

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -441,6 +441,9 @@ public:
         return std::move(builder).build();
     }
 
+    // Assert out on startup if we appear to have upgraded too far
+    void assert_compatible_version(bool);
+
 private:
     // Only for use by our friends feature backend & manager
     void set_active_version(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2103,13 +2103,6 @@ void application::load_feature_table_snapshot() {
 #ifndef NDEBUG
         vassert(my_version >= snap.version, "Incompatible downgrade detected");
 #endif
-    } else if (my_version > snap.version) {
-        vlog(
-          _log.info,
-          "Upgrade in progress!  This binary logical version {}, last feature "
-          "table snapshot version {}",
-          my_version,
-          snap.version);
     } else {
         vlog(
           _log.debug,
@@ -2122,4 +2115,8 @@ void application::load_feature_table_snapshot() {
     feature_table
       .invoke_on_all([snap](features::feature_table& ft) { snap.apply(ft); })
       .get();
+
+    // Having loaded a snapshot, do our strict check for version compat.
+    feature_table.local().assert_compatible_version(
+      config::node().upgrade_override_checks);
 }

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -205,6 +205,7 @@ class KgoVerifierService(Service):
         wait_until(lambda: not node.account.exists(f"/proc/{self._pid}"),
                    timeout_sec=10,
                    backoff_sec=0.5)
+        self._pid = None
 
         self.logger.debug(
             f"wait_node {self.who_am_i()}: node={node.name} pid={self._pid} terminated"

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -157,7 +157,7 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
             '__REDPANDA_TEST_FEATURES':
             "ON",
             '__REDPANDA_EARLIEST_LOGICAL_VERSION':
-            f'{feature_alpha_version}',
+            f'{self.head_latest_logical_version}',
             '__REDPANDA_LATEST_LOGICAL_VERSION':
             f'{feature_alpha_version}'
         })

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -170,8 +170,7 @@ class UpgradeBackToBackTest(PreallocNodesTest):
             self.redpanda,
             self.topic,
             self.MSG_SIZE,
-            nodes=self.preallocated_nodes,
-            debug_logs=True)
+            nodes=self.preallocated_nodes)
         self._rand_consumer = KgoVerifierRandomConsumer(
             test_context, self.redpanda, self.topic, self.MSG_SIZE,
             self.RANDOM_READ_COUNT, self.RANDOM_READ_PARALLEL,


### PR DESCRIPTION
This is a follow-on from https://github.com/redpanda-data/redpanda/pull/8282 -- we use the `earliest_logical_version` to do a similar check on startup that we would do on node joins.

Note that while #8282 landed for v23.1.x, this PR will go into v23.2.x -- that will be the first version that will refuse to start if it is installed on a system that has active version lower than earliest version (which is 22.3.x at time of writing)

This check should prevent a user inadvertently damaging
their cluster by trying to skip many feature releases
during an upgrade, which might skip important data migration
or compatibility code.
    
This is not an ultra-strict check that the user is only
hopping one logical version: we will tolerate upgrades
from as far back as the `earliest_logical_version`, which
is currently set to 7 (Redpanda v22.3.1).  Although the software tolerates
this, it does not change our official support policy that clusters must be
upgraded via all intervening feature releases, and may not skip feature
releases.
    
In special circumstances, this check may be skipped by setting
the `upgrade_override_checks` node configuration property to true.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Improvements

* Upgrades from incompatible Redpanda versions without upgrading through intervening versions will now be detected and Redpanda will refuse to start, rather than risking the cluster entering an inoperable state due to incompatible data formats.  For example, attempting to upgrade directly from a 21.11.x Redpanda version will fail.
* Node configuration property `upgrade_override_checks` is added (default false).  Setting this to true enables skipping the safety checks.  This should not be used without expert advice.
