### PR TITLE
[v22.3.x] Backport 8548 (Explicitly deregister log metrics) #8556

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -101,8 +101,8 @@ ss::future<> disk_log_impl::remove() {
           remove_segment_permanently(s, "disk_log_impl::remove()"));
     }
 
-    co_await _readers_cache->stop().then(
-      [this, permanent_delete = std::move(permanent_delete)]() mutable {
+    co_await _readers_cache->stop()
+      .then([this, permanent_delete = std::move(permanent_delete)]() mutable {
           // wait for all futures
           return ss::when_all_succeed(
                    permanent_delete.begin(), permanent_delete.end())
@@ -119,7 +119,8 @@ ss::future<> disk_log_impl::remove() {
                   kvstore::key_space::storage,
                   internal::clean_segment_key(config().ntp()));
             });
-      });
+      })
+      .finally([this] { _probe.clear_metrics(); });
 }
 
 ss::future<std::optional<ss::sstring>> disk_log_impl::close() {
@@ -153,6 +154,8 @@ ss::future<std::optional<ss::sstring>> disk_log_impl::close() {
                 });
           });
     });
+
+    _probe.clear_metrics();
 
     if (_segs.size() && !errors) {
         auto clean_seg = _segs.back()->filename();

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -93,6 +93,11 @@ public:
     void remove_partition_bytes(size_t remove) { _partition_bytes -= remove; }
     void set_compaction_ratio(double r) { _compaction_ratio = r; }
 
+    /**
+     * Clears all probe related metrics
+     */
+    void clear_metrics() { _metrics.clear(); }
+
 private:
     uint64_t _partition_bytes = 0;
     uint64_t _bytes_written = 0;


### PR DESCRIPTION
Backport #8548 

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Bug Fixes
* A rare issue is fixed where rapidly deleting a topic and recreating a topic with the same name could trigger an assertion