### PR TITLE
tests: rm err handling when no active reassignment

### DIFF
--- a/tests/rptest/tests/partition_reassignments_test.py
+++ b/tests/rptest/tests/partition_reassignments_test.py
@@ -452,13 +452,13 @@ class PartitionReassignmentsTest(RedpandaTest):
         initial_assignments, all_node_idx, producers = self.initial_setup_steps(
             producer_config={
                 "topics": [self.topics[0].name, self.topics[1].name],
-                "throughput": 512
+                "throughput": 1024
             },
             # Set a low throttle to slowdown partition move enough that there is
             # something to cancel
             recovery_rate=10)
 
-        self.wait_producers(producers, num_messages=1000)
+        self.wait_producers(producers, num_messages=10000)
 
         reassignments_json = self.make_reassignments_for_cli(
             all_node_idx, initial_assignments)
@@ -468,17 +468,10 @@ class PartitionReassignmentsTest(RedpandaTest):
         check_execute_reassign_partitions(output, reassignments_json,
                                           self.logger)
 
-        try:
-            output = self.cancel_reassign_partitions(
-                reassignments=reassignments_json)
-            check_cancel_reassign_partitions(output, reassignments_json,
-                                             self.logger)
-        except subprocess.CalledProcessError as e:
-            self.logger.debug(f"Error {e.returncode}, output {e.output}")
-            if "no_reassignment_in_progress" in e.output:
-                pass
-            else:
-                raise
+        output = self.cancel_reassign_partitions(
+            reassignments=reassignments_json)
+        check_cancel_reassign_partitions(output, reassignments_json,
+                                         self.logger)
 
         output = self.verify_reassign_partitions(
             reassignments=reassignments_json, timeout_s=30)


### PR DESCRIPTION
## Cover letter

This test checks for successfully canceling an on-going partition reassignment. Previously, the test would catch errors when there is no reassignment in progress. This is a problem because it covers-up potential failures. Instead, remove error handling and increase the amount of data in the topic before executing the partition move.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
