### PR TITLE
rpk: small help text fixes

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/config/config.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/config/config.go
@@ -55,7 +55,7 @@ different redpanda version that does not recognize certain properties.`,
 		&adminURL,
 		config.FlagAdminHosts2,
 		"",
-		"Comma-separated list of admin API addresses (<IP>:<port>")
+		"Comma-separated list of admin API addresses (<IP>:<port>)")
 
 	common.AddAdminAPITLSFlags(command,
 		&adminEnableTLS,

--- a/src/go/rpk/pkg/cli/cmd/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/health.go
@@ -75,7 +75,7 @@ following conditions are met:
 		&adminURL,
 		config.FlagAdminHosts2,
 		"",
-		"Comma-separated list of admin API addresses (<IP>:<port>")
+		"Comma-separated list of admin API addresses (<IP>:<port>)")
 
 	common.AddAdminAPITLSFlags(cmd,
 		&adminEnableTLS,

--- a/src/go/rpk/pkg/cli/cmd/cluster/license/license.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/license/license.go
@@ -19,7 +19,7 @@ func NewLicenseCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "license",
 		Args:  cobra.ExactArgs(0),
-		Short: "Manage cluster license.",
+		Short: "Manage cluster license",
 	}
 
 	common.AddAdminAPITLSFlags(cmd,

--- a/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/maintenance/maintenance.go
@@ -54,7 +54,7 @@ Currently leadership is not transferred for partitions with one replica.
 		&adminURL,
 		config.FlagAdminHosts2,
 		"",
-		"Comma-separated list of admin API addresses (<IP>:<port>")
+		"Comma-separated list of admin API addresses (<IP>:<port>)")
 
 	common.AddAdminAPITLSFlags(cmd,
 		&adminEnableTLS,

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/recovery.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/recovery.go
@@ -20,11 +20,16 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		Short: "Interact with the topic recovery process",
 		Long: `Interact with the topic recovery process.
 		
-This command is used to restore topics from the archival bucket, which can be useful for disaster recovery or if a topic was accidentally deleted.
+This command is used to restore topics from the archival bucket, which can be 
+useful for disaster recovery or if a topic was accidentally deleted.
 
-To begin the recovery process, use the "recovery start" command. Note that this process can take a while to complete, so the command will exit after starting it. If you want the command to wait for the process to finish, use the "--wait" or "-w" flag.
+To begin the recovery process, use the "recovery start" command. Note that this 
+process can take a while to complete, so the command will exit after starting 
+it. If you want the command to wait for the process to finish, use the "--wait"
+or "-w" flag.
 
-You can check the status of the recovery process with the "recovery status" command after it has been started.
+You can check the status of the recovery process with the "recovery status" 
+command after it has been started.
 `,
 	}
 

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/start.go
@@ -105,9 +105,9 @@ recovery process until it's finished.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&topicNamePattern, "topic-name-pattern", ".*", "A regex pattern to match topic names against. Only topics whose names match this pattern will be restored. If not passed, all topics will be restored")
+	cmd.Flags().StringVar(&topicNamePattern, "topic-name-pattern", ".*", "A regex pattern that restores any matching topics")
 	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "Wait until auto-restore is complete")
-	cmd.Flags().DurationVar(&pollingInterval, "polling-interval", 5*time.Second, "The interval in-between each status check (format: \"300ms\", \"1.5s\", \"1m45s\", etc). Ignored if --wait is not passed")
+	cmd.Flags().DurationVar(&pollingInterval, "polling-interval", 5*time.Second, "The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/start.go
@@ -105,9 +105,9 @@ recovery process until it's finished.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&topicNamePattern, "topic-name-pattern", ".*", "A regex pattern to match topic names against. Only topics whose names match this pattern will be restored. If not passed, all topics will be restored.")
-	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "Wait until auto-restore is complete.")
-	cmd.Flags().DurationVar(&pollingInterval, "polling-interval", 5*time.Second, "The interval in-between each status check (format: \"300ms\", \"1.5s\", \"1m45s\", etc). Ignored if --wait is not passed.")
+	cmd.Flags().StringVar(&topicNamePattern, "topic-name-pattern", ".*", "A regex pattern to match topic names against. Only topics whose names match this pattern will be restored. If not passed, all topics will be restored")
+	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "Wait until auto-restore is complete")
+	cmd.Flags().DurationVar(&pollingInterval, "polling-interval", 5*time.Second, "The interval in-between each status check (format: \"300ms\", \"1.5s\", \"1m45s\", etc). Ignored if --wait is not passed")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/status.go
@@ -25,7 +25,8 @@ func newStatusCommand(fs afero.Fs) *cobra.Command {
 		Short: "Fetch the status of the topic recovery process",
 		Long: `Fetch the status of the topic recovery process.
 		
-This command fetches the status of the process of restoring topics from the archival bucket.`,
+This command fetches the status of the process of restoring topics from the 
+archival bucket.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle.go
@@ -246,9 +246,12 @@ func (e *S3EndpointError) Error() string {
 
 const bundleHelpText = `'rpk debug bundle' collects environment data that can help debug and diagnose
 issues with a redpanda cluster, a broker, or the machine it's running on. It
-then bundles the collected data into a zip file.
+then bundles the collected data into a ZIP file, called a diagnostics bundle.
 
-The following are the data sources that are bundled in the compressed file:
+The files and directories in the diagnostics bundle differ depending on the 
+environment in which Redpanda is running:
+
+COMMON FILES
 
  - Kafka metadata: Broker configs, topic configs, start/committed/end offsets,
    groups, group commits.
@@ -271,18 +274,23 @@ The following are the data sources that are bundled in the compressed file:
  - Clock drift: The ntp clock delta (using pool.ntp.org as a reference) & round
    trip time.
 
- - Kernel logs: The kernel logs ring buffer (syslog).
+ - Admin API calls: Cluster and broker configurations, cluster health data, and 
+   license key information.
 
- - Broker metrics: The local broker's Prometheus metrics, fetched through its
-   admin API.
+ - Broker metrics: The broker's Prometheus metrics, fetched through its
+   admin API (/metrics and /public_metrics).
+
+BARE-METAL
+
+ - Kernel logs: The kernel logs ring buffer (syslog).
 
  - DNS: The DNS info as reported by 'dig', using the hosts in
    /etc/resolv.conf.
 
  - Disk usage: The disk usage for the data directory, as output by 'du'.
 
- - redpanda logs: The redpanda logs written to journald. If --logs-since or
-   --logs-until are passed, then only the logs within the resulting time frame
+ - redpanda logs: The node's redpanda logs written to journald. If --logs-since 
+   or --logs-until are passed, then only the logs within the resulting time frame
    will be included.
 
  - Socket info: The active sockets data output by 'ss'.
@@ -297,4 +305,17 @@ The following are the data sources that are bundled in the compressed file:
 
  - dmidecode: The DMI table contents. Only included if this command is run
    as root.
+
+KUBERNETES
+
+ - Kubernetes Resources: Kubernetes manifests for all resources in the given 
+   Kubernetes namespace (via --namespace).
+
+ - redpanda logs: Logs of each Pod in the the given Kubernetes namespace. If 
+   --logs-since is passed, only the logs within the given timeframe are 
+   included.
+
+
+If you have an upload URL from the Redpanda support team, provide it in the 
+--upload-url flag to upload your diagnostics bundle to Redpanda.
 `

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/partitions/partitions.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Vectorized, Inc.
+// Copyright 2021 Redpanda Data, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md


### PR DESCRIPTION
A few minor nits and fixes in the help text (commands and flags) + adds the missing help text of debug bundle.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport



## Release Notes
  * none

