### PR TITLE
tests: fix license upgrade test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2183,6 +2183,11 @@ class RedpandaService(Service):
                     self._extra_rp_conf))
             conf.update(self._extra_rp_conf)
 
+        if cur_ver != RedpandaInstaller.HEAD and cur_ver < (22, 2, 1):
+            # this configuration property was introduced in 22.2.1, ensure
+            # it doesn't appear in older configurations
+            conf.pop('cloud_storage_credentials_source', None)
+
         if self._security.enable_sasl:
             self.logger.debug("Enabling SASL in cluster configuration")
             conf.update(dict(enable_sasl=True))

--- a/tests/rptest/tests/license_upgrade_test.py
+++ b/tests/rptest/tests/license_upgrade_test.py
@@ -11,7 +11,6 @@ import os
 import re
 import time
 
-from ducktape.mark import ok_to_fail
 from ducktape.utils.util import wait_until
 from rptest.utils.rpenv import sample_license
 from rptest.services.admin import Admin
@@ -49,7 +48,6 @@ class UpgradeToLicenseChecks(RedpandaTest):
             self.redpanda.nodes, (22, 1))
         super(UpgradeToLicenseChecks, self).setUp()
 
-    @ok_to_fail
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_basic_upgrade(self):
         # Modified environment variables apply to processes restarted from this point onwards


### PR DESCRIPTION
fix for the `ok_to_fail` test `license_upgrade_test.UpgradeToLicenseChecks.test_basic_upgrade` in PR #9031

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none
