### PR TITLE
tests: install librdkafka 2.0.2

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -60,7 +60,7 @@ function install_kafka_tools() {
 
 function install_librdkafka() {
   mkdir /opt/librdkafka
-  curl -SL "https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
+  curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.0.2.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
   cd /opt/librdkafka
   ./configure
   make -j$(nproc)


### PR DESCRIPTION
We are seeing failures to pip install
confluent_rdkafka==2.0.2.  Maybe this system-wide
installed librdkafka is confusing the python
package's native code part.


## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

* none
