### PR TITLE
Abort on out-of-memory (OOM)

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1619,6 +1619,14 @@ configuration::configuration()
       "the data directory. Redpanda will refuse to start if it is not found.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , memory_abort_on_alloc_failure(
+      *this,
+      "memory_abort_on_alloc_failure",
+      "If true, the redpanda process will terminate immediately when an "
+      "allocation cannot be satisfied due to memory exhasution. If false, an "
+      "exception is thrown instead.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
   , enable_metrics_reporter(
       *this,
       "enable_metrics_reporter",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -333,6 +333,10 @@ struct configuration final : public config_store {
     bounded_property<size_t> storage_space_alert_free_threshold_bytes;
     bounded_property<size_t> storage_min_free_bytes;
     property<bool> storage_strict_data_init;
+
+    // memory related settings
+    property<bool> memory_abort_on_alloc_failure;
+
     // metrics reporter
     property<bool> enable_metrics_reporter;
     property<std::chrono::milliseconds> metrics_reporter_tick_interval;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -154,6 +154,11 @@ public:
         return *this;
     }
 
+    /**
+     * Returns a binding<T> object which offers live access to the
+     * value of the property as well as the ability to watch for
+     * changes to the property.
+     */
     binding<T> bind() {
         assert_live_settable();
         return {*this};
@@ -320,9 +325,11 @@ public:
      * the configuration value will be marked 'invalid' in the node's
      * configuration status, but the new value will still be set.
      *
-     * Ensure that the callback remains valid for as long as this binding:
-     * the simplest way to  accomplish this is to make both the callback
-     * and the binding attributes of the same object
+     * The callback is moved into this binding, and so will live as long as
+     * the binding. This means that callers must ensure
+     * that any objects referenced by the callback remain valid for as long as
+     * this binding: the simplest way to  accomplish this is to make both
+     * the callback and the binding attributes of the same object.
      */
     void watch(std::function<void()>&& f) {
         oncore_debug_verify(_verify_shard);

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -287,7 +287,8 @@ public:
         _value = rhs._value;
         _parent = rhs._parent;
         _on_change = rhs._on_change;
-        if (_parent && this != &rhs) {
+        _hook.unlink();
+        if (_parent) {
             _parent->_bindings.push_back(*this);
         }
         return *this;

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -229,6 +229,8 @@ private:
     scheduling_groups_probe _scheduling_groups_probe;
     ss::logger _log;
 
+    std::optional<config::binding<bool>> _abort_on_oom;
+
     ss::sharded<rpc::connection_cache> _connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<rpc::rpc_server> _rpc;


### PR DESCRIPTION
By default, seastar applications throw on bad_alloc, but this
behavior can be changed by passing a command line argument
--abort-on-seastar-bad-alloc.

This change makes this behavior configurable instead using a
cluster config property:

memory_abort_on_alloc_failure

and also sets this propert to true by default. After this change
we will abort on out of memory, unless the cluster has this
property explicitly set to false (perhaps as a workaround to
an unexpected but recoverable OOM).

Issue redpanda-data/core-internal#99

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

### Improvements

 * Redpanda will abort immediately with a diagnostic when an hard memory allocation failure occurs (a hard failure is an allocation one which cannot be satisfied even by reclaiming memory from in-memory caches).