### PR TITLE
Fix accidental roll back of the metadata cache

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1348,7 +1348,11 @@ ss::future<std::error_code> controller_backend::dispatch_update_finished(
 
 ss::future<> controller_backend::finish_partition_update(
   model::ntp ntp, const partition_assignment& current, model::revision_id rev) {
-    vlog(clusterlog.trace, "[{}] processing finished update command", ntp);
+    vlog(
+      clusterlog.trace,
+      "[{}] processing finished update command, revision: {}",
+      ntp,
+      rev);
     // if there is no local replica in replica set but,
     // partition with requested ntp exists on this broker core
     // it has to be removed after new configuration is stable
@@ -1363,7 +1367,12 @@ ss::future<> controller_backend::finish_partition_update(
     if (!partition) {
         return ss::make_ready_future<>();
     }
-    vlog(clusterlog.trace, "[{}] removing partition replica", ntp);
+
+    vlog(
+      clusterlog.trace,
+      "[{}] removing partition replica, revision: {}",
+      ntp,
+      rev);
     return delete_partition(
       std::move(ntp), rev, partition_removal_mode::local_only);
 }
@@ -1774,25 +1783,21 @@ ss::future<std::error_code> controller_backend::shutdown_on_current_shard(
 
 ss::future<> controller_backend::delete_partition(
   model::ntp ntp, model::revision_id rev, partition_removal_mode mode) {
-    auto part = _partition_manager.local().get(ntp);
-    auto is_partition_replicated_locally = part.get() != nullptr;
-
     // The partition leaders table contains partition leaders for all
     // partitions accross the cluster. For this reason, when deleting a
     // partition (i.e. removal mode is global), we need to delete from the table
     // regardless of whether a replica of 'ntp' is present on the node.
-    if (
-      mode == partition_removal_mode::global
-      || is_partition_replicated_locally) {
+    if (mode == partition_removal_mode::global) {
         co_await _partition_leaders_table.invoke_on_all(
           [ntp, rev](partition_leaders_table& leaders) {
               leaders.remove_leader(ntp, rev);
           });
     }
 
+    auto part = _partition_manager.local().get(ntp);
     // partition is not replicated locally or it was already recreated with
     // greater rev, do nothing
-    if (!is_partition_replicated_locally || part->get_revision_id() > rev) {
+    if (part.get() == nullptr || part->get_revision_id() > rev) {
         co_return;
     }
 

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -446,6 +446,7 @@ health_monitor_backend::maybe_refresh_cluster_health(
     // if current node is not the controller leader and we need a refresh we
     // refresh metadata cache
     if (need_refresh) {
+        vlog(clusterlog.trace, "refreshing cluster health");
         try {
             auto f = refresh_cluster_health_cache(refresh);
             auto err = co_await ss::with_timeout(deadline, std::move(f));

--- a/src/v/cluster/metadata_dissemination_handler.cc
+++ b/src/v/cluster/metadata_dissemination_handler.cc
@@ -71,6 +71,7 @@ metadata_dissemination_handler::update_leadership_v2(
 ss::future<update_leadership_reply>
 metadata_dissemination_handler::do_update_leadership(
   std::vector<ntp_leader_revision> leaders) {
+    vlog(clusterlog.trace, "Received a metadata update");
     return _leaders
       .invoke_on_all(
         [leaders = std::move(leaders)](partition_leaders_table& pl) mutable {

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -82,8 +82,10 @@ void metadata_dissemination_service::disseminate_leadership(
   std::optional<model::node_id> leader_id) {
     vlog(
       clusterlog.trace,
-      "Dissemination request for {}, leader {}",
+      "Dissemination request for {}, revision {}, term {}, leader {}",
       ntp,
+      revision,
+      term,
       leader_id.value());
 
     _requests.emplace_back(std::move(ntp), term, leader_id, revision);
@@ -177,6 +179,7 @@ ss::future<> metadata_dissemination_service::apply_leadership_notification(
     return ss::with_gate(
       _bg, [this, ntp = std::move(ntp), lid, revision, term]() mutable {
           // update partition leaders
+          vlog(clusterlog.trace, "updating {} leadership locally", ntp);
           auto f = _leaders.invoke_on_all(
             [ntp, lid, revision, term](partition_leaders_table& leaders) {
                 leaders.update_partition_leader(ntp, revision, term, lid);
@@ -251,6 +254,7 @@ ss::future<> metadata_dissemination_service::process_get_update_reply(
         return ss::make_ready_future<>();
     }
     // Update all NTP leaders
+    vlog(clusterlog.trace, "updating leadership from get_metadata");
     return _leaders
       .invoke_on_all([reply = std::move(reply_result.value())](
                        partition_leaders_table& leaders) mutable {
@@ -315,12 +319,15 @@ void metadata_dissemination_service::cleanup_finished_updates() {
     auto brokers = _members_table.local().node_ids();
     for (auto& [node_id, meta] : _pending_updates) {
         auto it = std::find(brokers.begin(), brokers.end(), node_id);
-        if (meta.finished || it == brokers.end()) {
+        if (meta.finished) {
+            vlog(clusterlog.trace, "node {} update finished", node_id);
+            _to_remove.push_back(node_id);
+        } else if (it == brokers.end()) {
+            vlog(clusterlog.trace, "node {} isn't found", node_id);
             _to_remove.push_back(node_id);
         }
     }
     for (auto id : _to_remove) {
-        vlog(clusterlog.trace, "node {} update finished", id);
         _pending_updates.erase(id);
     }
 }
@@ -331,6 +338,7 @@ ss::future<> metadata_dissemination_service::dispatch_disseminate_leadership() {
      * information. If report would contain stale data they will be ignored by
      * term check in partition leaders table
      */
+    vlog(clusterlog.trace, "disseminating leadership info");
     return _health_monitor.local()
       .get_cluster_health(
         cluster_report_filter{},
@@ -365,6 +373,7 @@ ss::future<> metadata_dissemination_service::dispatch_disseminate_leadership() {
 
 ss::future<> metadata_dissemination_service::update_leaders_with_health_report(
   cluster_health_report report) {
+    vlog(clusterlog.trace, "updating leadership from health report");
     for (const auto& node_report : report.node_reports) {
         co_await _leaders.invoke_on_all(
           [&node_report](partition_leaders_table& leaders) {
@@ -458,6 +467,10 @@ ss::future<> metadata_dissemination_service::dispatch_one_update(
       })
       .then([target_id, &meta](result<update_leadership_reply> r) {
           if (r) {
+              vlog(
+                clusterlog.trace,
+                "Got ack to metadata update from {}",
+                target_id);
               meta.finished = true;
               return;
           }

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -76,14 +76,9 @@ public:
         }
     }
 
-    void remove_leader(const model::ntp& ntp, model::revision_id revision) {
-        auto it = _leaders.find(
-          leader_key_view{model::topic_namespace_view(ntp), ntp.tp.partition});
-        // ignore updates with old revision
-        if (it != _leaders.end() && it->second.partition_revision <= revision) {
-            _leaders.erase(it);
-        }
-    }
+    void remove_leader(const model::ntp&, model::revision_id);
+
+    void reset();
 
     void update_partition_leader(
       const model::ntp&, model::term_id, std::optional<model::node_id>);
@@ -93,8 +88,6 @@ public:
       model::revision_id,
       model::term_id,
       std::optional<model::node_id>);
-
-    void reset() { _leaders.clear(); }
 
     struct leader_info_t {
         model::topic_namespace tp_ns;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -238,41 +238,13 @@ ss::future<> tx_gateway_frontend::stop() {
 
 ss::future<std::optional<model::node_id>>
 tx_gateway_frontend::find_coordinator(kafka::transactional_id) {
-    auto has_topic = ss::make_ready_future<bool>(true);
-
-    if (!_metadata_cache.local().contains(
-          model::tx_manager_nt, model::tx_manager_ntp.tp.partition)) {
-        has_topic = try_create_tx_topic();
+    if (!_metadata_cache.local().contains(model::tx_manager_nt)) {
+        if (!co_await try_create_tx_topic()) {
+            co_return std::nullopt;
+        }
     }
 
-    auto timeout = ss::lowres_clock::now()
-                   + config::shard_local_cfg().wait_for_leader_timeout_ms();
-
-    return has_topic.then([this, timeout](bool does_topic_exist) {
-        if (!does_topic_exist) {
-            return ss::make_ready_future<std::optional<model::node_id>>(
-              std::nullopt);
-        }
-
-        auto md = _metadata_cache.local().contains(model::tx_manager_nt);
-        if (!md) {
-            return ss::make_ready_future<std::optional<model::node_id>>(
-              std::nullopt);
-        }
-        return _metadata_cache.local()
-          .get_leader(model::tx_manager_ntp, timeout)
-          .then([](model::node_id leader) {
-              return std::optional<model::node_id>(leader);
-          })
-          .handle_exception([](std::exception_ptr e) {
-              vlog(
-                txlog.warn,
-                "can't find find a leader of tx manager's topic {}",
-                e);
-              return ss::make_ready_future<std::optional<model::node_id>>(
-                std::nullopt);
-          });
-    });
+    co_return _metadata_cache.local().get_leader_id(model::tx_manager_ntp);
 }
 
 ss::future<fetch_tx_reply> tx_gateway_frontend::fetch_tx_locally(

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1342,7 +1342,8 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
             bool expected_ec = br.ec == tx_errc::leader_not_found
                                || br.ec == tx_errc::shard_not_found
                                || br.ec == tx_errc::stale
-                               || br.ec == tx_errc::timeout;
+                               || br.ec == tx_errc::timeout
+                               || br.ec == tx_errc::partition_not_exists;
             should_abort = should_abort
                            || (br.ec != tx_errc::none && !expected_ec);
             should_retry = should_retry || expected_ec;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -236,7 +236,8 @@ ss::future<> tx_gateway_frontend::stop() {
       [] { vlog(txlog.debug, "Tx coordinator is stopped"); });
 }
 
-ss::future<std::optional<model::node_id>> tx_gateway_frontend::get_tx_broker() {
+ss::future<std::optional<model::node_id>>
+tx_gateway_frontend::find_coordinator(kafka::transactional_id) {
     auto has_topic = ss::make_ready_future<bool>(true);
 
     if (!_metadata_cache.local().contains(

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -39,7 +39,8 @@ public:
       ss::sharded<features::feature_table>&,
       ss::sharded<cluster::tm_stm_cache>&);
 
-    ss::future<std::optional<model::node_id>> get_tx_broker();
+    ss::future<std::optional<model::node_id>>
+      find_coordinator(kafka::transactional_id);
     ss::future<fetch_tx_reply>
       fetch_tx_locally(kafka::transactional_id, model::term_id);
     ss::future<try_abort_reply> try_abort(

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -75,34 +75,27 @@ ss::future<response_ptr> find_coordinator_handler::handle(
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
 
-    if (request.data.key_type == coordinator_type::group) {
-        if (!ctx.authorized(
-              security::acl_operation::describe, group_id(request.data.key))) {
-            return ctx.respond(find_coordinator_response(
-              error_code::group_authorization_failed));
-        }
-    } else if (request.data.key_type == coordinator_type::transaction) {
-        if (!ctx.authorized(
-              security::acl_operation::describe,
-              transactional_id(request.data.key))) {
-            return ctx.respond(find_coordinator_response(
-              error_code::transactional_id_authorization_failed));
-        }
-    }
-
     if (request.data.key_type == coordinator_type::transaction) {
         if (!ctx.are_transactions_enabled()) {
             return ctx.respond(
               find_coordinator_response(error_code::unsupported_version));
         }
 
+        transactional_id tx_id(request.data.key);
+
+        if (!ctx.authorized(security::acl_operation::describe, tx_id)) {
+            return ctx.respond(find_coordinator_response(
+              error_code::transactional_id_authorization_failed));
+        }
+
         return ss::do_with(
           std::move(ctx),
-          [request = std::move(request)](request_context& ctx) mutable {
-              return ctx.tx_gateway_frontend().get_tx_broker().then(
-                [&ctx](std::optional<model::node_id> tx_id) {
-                    if (tx_id) {
-                        return handle_leader(ctx, *tx_id);
+          [request = std::move(request),
+           tx_id = std::move(tx_id)](request_context& ctx) mutable {
+              return ctx.tx_gateway_frontend().find_coordinator(tx_id).then(
+                [&ctx](std::optional<model::node_id> leader) {
+                    if (leader) {
+                        return handle_leader(ctx, *leader);
                     }
                     return ctx.respond(find_coordinator_response(
                       error_code::coordinator_not_available));
@@ -110,10 +103,15 @@ ss::future<response_ptr> find_coordinator_handler::handle(
           });
     }
 
-    // other types include txn coordinators which are unsupported
     if (request.data.key_type != coordinator_type::group) {
         return ctx.respond(
           find_coordinator_response(error_code::unsupported_version));
+    }
+
+    if (!ctx.authorized(
+          security::acl_operation::describe, group_id(request.data.key))) {
+        return ctx.respond(
+          find_coordinator_response(error_code::group_authorization_failed));
     }
 
     return ss::do_with(


### PR DESCRIPTION
Fixes #8939 by avoiding resetting leadership metadata cache when a partition is still present in the cluster

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* none

## Release Notes

* none

-----

**UPD:**
 - [rolled back](https://github.com/redpanda-data/redpanda/compare/d9c9c0f9da8f42e70c6d0bb9142937ddfa74136e..0a8f07768afcf7c8c7b9a71485568ffe4b90553b) irrelevant change; suspecting it was causing ci-failures 