### PR TITLE
duck: stop process in node before starting rp with rpk

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1435,6 +1435,14 @@ class RedpandaService(Service):
         this function will not return until redpanda appears to have started
         successfully.
         """
+        self.logger.debug(
+            self.who_am_i() +
+            ": killing processes and attempting to clean up before starting")
+        try:
+            self.stop_node(node)
+        except Exception:
+            pass
+
         if clean_node:
             self.clean_node(node, preserve_current_install=True)
         else:


### PR DESCRIPTION
Unlike the redpanda service starter, the
start_node_with_rpk was not trying to stop all
the other processes running in the node.

  Fixes #7021, Fixes #8952


## Backports Required


- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x


## Release Notes
  * none

