### PR TITLE
Improve operator e2e tests report

### DIFF
--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v22.1.10"
+  version: "v22.1.11"
   replicas: 3
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-tls/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/02-assert.yaml
@@ -103,6 +103,30 @@ collectors:
 
 ---
 
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk redpanda admin brokers list
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk redpanda admin brokers list
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk redpanda admin brokers list
+    namespaced: true
+
+---
+
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:

--- a/src/go/k8s/tests/e2e/update-image-tls/02-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/02-new-image-and-pv.yaml
@@ -12,7 +12,7 @@ kind: Cluster
 metadata:
   name: up-img
 spec:
-  version: "v22.2.8"
+  version: "v22.2.10"
   cloudStorage:
     enabled: true
     accessKey: XXX

--- a/src/go/k8s/tests/e2e/update-image-tls/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/03-assert.yaml
@@ -55,6 +55,30 @@ collectors:
 
 ---
 
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk redpanda admin brokers list
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk redpanda admin brokers list
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk redpanda admin brokers list
+    namespaced: true
+
+---
+
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:

--- a/src/go/k8s/tests/e2e/update-image-tls/03-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/03-new-image.yaml
@@ -4,4 +4,4 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v22.3.4"
+  version: "v22.3.13"

--- a/src/go/k8s/tests/e2e/update-image-tls/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/04-assert.yaml
@@ -55,6 +55,30 @@ collectors:
 
 ---
 
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk redpanda admin brokers list
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk redpanda admin brokers list
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk redpanda admin brokers list
+    namespaced: true
+
+---
+
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:

--- a/src/go/k8s/tests/e2e/update-image-tls/05-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/05-assert.yaml
@@ -97,6 +97,30 @@ collectors:
 
 ---
 
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk cluster maintenance status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk cluster config status
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-0 -- rpk redpanda admin brokers list
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-1 -- rpk redpanda admin brokers list
+    namespaced: true
+  - command: kubectl -n $NAMESPACE exec -ti up-img-2 -- rpk redpanda admin brokers list
+    namespaced: true
+
+---
+
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:


### PR DESCRIPTION
The following error prevented update-image-tls e2e to finish:
```
RequeueAfterError putting node (up-img-2) into maintenance mode: enabling maintenance mode: request PUT https://up-img-2.up-img.kuttl-test-moral-wasp.svc.cluster.local.:9644/v1/brokers/2/maintenance failed: Bad Request, body: "{\"message\": \"can not update broker 2 state, invalid state transition requested\", \"code\": 400}"
```

The `invalid state transition requested` is not detailed enough, so that
TestAssert could help report Redpanda problem.

The problem was reproted in the following CI pipelines:
* https://buildkite.com/redpanda/redpanda/builds/23693#018677c2-e822-44f6-a0ba-d11c25277cbd
* https://buildkite.com/redpanda/redpanda/builds/23606#01867126-398a-42f1-a0a6-8332fc1ea3d0

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None
<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
