### PR TITLE
storage: handle+log ENOENT errors removing snapshots

### DIFF
--- a/tests/rptest/tests/tx_abort_index_test.py
+++ b/tests/rptest/tests/tx_abort_index_test.py
@@ -106,7 +106,11 @@ class TxAbortSnapshotTest(RedpandaTest):
                     segments[node.account.hostname].append(m.group(1))
         return segments
 
-    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    # FIXME: once issue https://github.com/redpanda-data/redpanda/issues/9091 is resolved, remove
+    # the log_allow_list entry for snapshot removal race.
+    @cluster(num_nodes=3,
+             log_allow_list=RESTART_LOG_ALLOW_LIST +
+             ["Raced removing snapshot abort.idx"])
     def test_index_removal(self) -> None:
         self.fill_idx(self.topics[0].name)
         segments = self.find_segments(self.topics[0].name)


### PR DESCRIPTION
It is an error for a state machine to try and delete the same snapshot twice at the same time, but we should not allow this to propagate as an unhandled exceptional future.  Catch it and log an error instead.

This handles the case of https://github.com/redpanda-data/redpanda/issues/9091 more neatly, although it is probably still necessary to fix the underlying state machine logic to not try and delete the same snapshot twice.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
