### PR TITLE
rptest: skip cloud storage upgrade test in Azure CDT

### DIFF
--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -11,7 +11,7 @@ import os
 from typing import Sequence
 
 from ducktape.tests.test import Test
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, CloudStorageType
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.default import DefaultClient
 from rptest.util import Scale
@@ -90,6 +90,10 @@ class RedpandaTest(Test):
         developer environments (e.g. laptops) but apply stricter checks in CI.
         """
         return os.environ.get('CI', None) != 'false'
+
+    @property
+    def azure_blob_storage(self):
+        return self.si_settings.cloud_storage_type == CloudStorageType.ABS
 
     @property
     def cloud_storage_client(self):

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -24,6 +24,7 @@ from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.services.rpk_producer import RpkProducer
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.util import wait_for_segments_removal, expect_exception
+from rptest.utils.mode_checks import skip_azure_blob_storage
 from rptest.clients.kcl import KCL
 
 from ducktape.utils.util import wait_until
@@ -478,7 +479,15 @@ class CreateTopicUpgradeTest(RedpandaTest):
         self.installer = self.redpanda._installer
         self.rpk = RpkTool(self.redpanda)
 
+    # This test starts the Redpanda service inline (see 'install_and_start') at the beginning
+    # of the test body. By default, in the Azure CDT env, the service startup
+    # logic attempts to set the azure specific cluster configs.
+    # However, these did not exist prior to v23.1 and the test would fail
+    # before it can be skipped.
     def setUp(self):
+        pass
+
+    def install_and_start(self):
         self.installer.install(
             self.redpanda.nodes,
             (22, 2),
@@ -491,12 +500,14 @@ class CreateTopicUpgradeTest(RedpandaTest):
         wait_for_segments_removal(self.redpanda, topic_name, 0, 1)
 
     @cluster(num_nodes=3)
+    @skip_azure_blob_storage
     def test_cloud_storage_sticky_enablement_v22_2_to_v22_3(self):
         """
         In Redpanda 22.3, the cluster defaults for cloud storage change
         from being applied at runtime to being sticky at creation time,
         or at upgrade time.
         """
+        self.install_and_start()
 
         # Switch on tiered storage using cluster properties, not topic properties
         self.redpanda.set_cluster_config(
@@ -555,7 +566,10 @@ class CreateTopicUpgradeTest(RedpandaTest):
         assert described['redpanda.remote.read'] == ('false', 'DEFAULT_CONFIG')
 
     @cluster(num_nodes=3)
+    @skip_azure_blob_storage
     def test_retention_config_on_upgrade_from_v22_2_to_v22_3(self):
+        self.install_and_start()
+
         self.rpk.create_topic("test-topic-with-retention",
                               config={"retention.bytes": 10000})
 
@@ -729,11 +743,14 @@ class CreateTopicUpgradeTest(RedpandaTest):
             assert len(deleted_objects) == 0
 
     @cluster(num_nodes=3)
+    @skip_azure_blob_storage
     def test_retention_upgrade_with_cluster_remote_write(self):
         """
         Validate how the cluster-wide cloud_storage_enable_remote_write
         is handled on upgrades from <=22.2
         """
+        self.install_and_start()
+
         self.redpanda.set_cluster_config(
             {"cloud_storage_enable_remote_write": "true"}, expect_restart=True)
 

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -63,3 +63,35 @@ def skip_debug_mode(func):
         return func(*args, **kwargs)
 
     return f
+
+
+def skip_azure_blob_storage(func):
+    """
+    Decorator applied to a test class method. The property `azure_blob_storage` should be present
+    on the object.
+
+    If set to true, the wrapped function call is skipped, and a cleanup action
+    is performed instead.
+
+    If set to false, the wrapped function (usually a test case) is called.
+    """
+    @functools.wraps(func)
+    def f(*args, **kwargs):
+        assert args, 'skip_azure_blob_storage must be placed on a test method in a class'
+
+        caller = args[0]
+
+        assert hasattr(
+            caller, 'azure_blob_storage'
+        ), 'skip_azure_blob_storage called on object which does not have azure_blob_storage attribute'
+        assert hasattr(
+            caller, 'logger'
+        ), 'skip_azure_blob_storage called on object which has no logger'
+        if caller.azure_blob_storage:
+            caller.logger.info(
+                "Skipping Azure Blob Storage test in (requires S3)")
+            cleanup_on_early_exit(caller)
+            return None
+        return func(*args, **kwargs)
+
+    return f


### PR DESCRIPTION
By default, the RedpandaService start-up logic is going to set the correct cluster configurations for the cloud the test is running in. This means that, it will set the azure cloud storage cluster configs when running in Azure. This is problematic for upgrade tests that start from a version which predates Azure.

This commit skips all cloud storage upgrade tests when running in Azure CDT by moving the redpanda service start-up in the body of the test and using a new skip decorator.


## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none
