### PR TITLE
cloud_storage: serde for segment_meta_cstore 

### DIFF
--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -23,17 +23,14 @@
 using namespace cloud_storage;
 
 using delta_xor_alg = details::delta_xor;
-using delta_xor_frame = segment_meta_column_frame<int64_t, delta_xor_alg>;
+using delta_xor_frame = segment_meta_column_frame<int64_t, delta_xor_alg{}>;
 using delta_delta_alg = details::delta_delta<int64_t>;
-using delta_delta_frame = segment_meta_column_frame<int64_t, delta_delta_alg>;
+using delta_delta_frame = segment_meta_column_frame<int64_t, delta_delta_alg{}>;
 using delta_xor_column = segment_meta_column<int64_t, delta_xor_alg>;
 using delta_delta_column = segment_meta_column<int64_t, delta_delta_alg>;
 
-static const delta_xor_alg initial_xor{};
-static const delta_delta_alg initial_delta{0};
-
 static const delta_xor_frame xor_frame_4K = []() {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     int64_t value = random_generators::get_int(1000);
     for (int64_t i = 0; i < 4096; i++) {
         value += random_generators::get_int(1, 100);
@@ -43,7 +40,7 @@ static const delta_xor_frame xor_frame_4K = []() {
 }();
 
 static const delta_xor_column xor_column_4K = []() {
-    delta_xor_column column(initial_xor);
+    delta_xor_column column{};
     int64_t value = random_generators::get_int(1000);
     for (int64_t i = 0; i < 4096; i++) {
         value += random_generators::get_int(1, 100);
@@ -53,7 +50,7 @@ static const delta_xor_column xor_column_4K = []() {
 }();
 
 static const delta_xor_column xor_column_4M = []() {
-    delta_xor_column column(initial_xor);
+    delta_xor_column column{};
     int64_t value = random_generators::get_int(1000);
     for (int64_t i = 0; i < 4096000; i++) {
         value += random_generators::get_int(1, 100);
@@ -63,7 +60,7 @@ static const delta_xor_column xor_column_4M = []() {
 }();
 
 static const delta_delta_frame delta_frame_4K = []() {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     int64_t value = random_generators::get_int(1000);
     for (int64_t i = 0; i < 4096; i++) {
         value += random_generators::get_int(1, 100);
@@ -73,7 +70,7 @@ static const delta_delta_frame delta_frame_4K = []() {
 }();
 
 static const delta_delta_column delta_column_4K = []() {
-    delta_delta_column column(initial_delta);
+    delta_delta_column column{};
     int64_t value = random_generators::get_int(1000);
     for (int64_t i = 0; i < 4096; i++) {
         value += random_generators::get_int(1, 100);
@@ -83,7 +80,7 @@ static const delta_delta_column delta_column_4K = []() {
 }();
 
 static const delta_delta_column delta_column_4M = []() {
-    delta_delta_column column(initial_delta);
+    delta_delta_column column{};
     int64_t value = random_generators::get_int(1000);
     for (int64_t i = 0; i < 4096000; i++) {
         value += random_generators::get_int(1, 100);
@@ -150,28 +147,28 @@ void at_test(StoreT& store) {
 }
 
 PERF_TEST(cstore_bench, xor_frame_append) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     append_test(frame, 4096);
 }
 
 PERF_TEST(cstore_bench, xor_frame_append_tx) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     append_tx_test(frame, 4096);
 }
 
 PERF_TEST(cstore_bench, xor_column_append) {
-    delta_xor_column column(initial_xor);
+    delta_xor_column column{};
     append_test(column, 4096);
 }
 
 PERF_TEST(cstore_bench, xor_column_append_tx) {
-    delta_xor_column column(initial_xor);
+    delta_xor_column column{};
     append_tx_test(column, 4096);
 }
 
 PERF_TEST(cstore_bench, xor_column_append_tx2) {
     // trigger code path that commits by splicing the list
-    delta_xor_column column(initial_xor);
+    delta_xor_column column{};
     append_tx_test(column, 4097);
 }
 
@@ -186,28 +183,28 @@ PERF_TEST(cstore_bench, xor_column_at_4K) { at_test(xor_column_4K); }
 PERF_TEST(cstore_bench, xor_column_at_4M) { at_test(xor_column_4M); }
 
 PERF_TEST(cstore_bench, delta_frame_append) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     append_test(frame, 4096);
 }
 
 PERF_TEST(cstore_bench, delta_frame_append_tx) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     append_tx_test(frame, 4096);
 }
 
 PERF_TEST(cstore_bench, delta_column_append) {
-    delta_delta_column column(initial_delta);
+    delta_delta_column column{};
     append_test(column, 4096);
 }
 
 PERF_TEST(cstore_bench, delta_column_append_tx) {
-    delta_delta_column column(initial_delta);
+    delta_delta_column column{};
     append_tx_test(column, 4096);
 }
 
 PERF_TEST(cstore_bench, delta_column_append_tx2) {
     // trigger code path that commits by splicing the list
-    delta_delta_column column(initial_delta);
+    delta_delta_column column{};
     append_tx_test(column, 4097);
 }
 
@@ -225,7 +222,7 @@ PERF_TEST(cstore_bench, delta_column_at_4M) { at_test(delta_column_4M); }
 
 PERF_TEST(cstore_bench, xor_frame_at_with_index_4K) {
     std::map<int32_t, delta_xor_frame::hint_t> index;
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     int64_t value = random_generators::get_int(1000);
     for (int64_t i = 0; i < 4096; i++) {
         value += random_generators::get_int(1, 100);
@@ -245,7 +242,7 @@ PERF_TEST(cstore_bench, xor_frame_at_with_index_4K) {
 
 PERF_TEST(cstore_bench, xor_column_at_with_index_4K) {
     std::map<int32_t, delta_xor_column::hint_t> index;
-    delta_xor_column column(initial_xor);
+    delta_xor_column column{};
     int64_t value = random_generators::get_int(1000);
     for (int64_t i = 0; i < 4096; i++) {
         value += random_generators::get_int(1, 100);

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -32,14 +32,11 @@ using namespace cloud_storage;
 static ss::logger test("test-logger-s");
 
 using delta_xor_alg = details::delta_xor;
-using delta_xor_frame = segment_meta_column_frame<int64_t, delta_xor_alg>;
+using delta_xor_frame = segment_meta_column_frame<int64_t, delta_xor_alg{}>;
 using delta_delta_alg = details::delta_delta<int64_t>;
-using delta_delta_frame = segment_meta_column_frame<int64_t, delta_delta_alg>;
+using delta_delta_frame = segment_meta_column_frame<int64_t, delta_delta_alg{}>;
 using delta_xor_column = segment_meta_column<int64_t, delta_xor_alg>;
 using delta_delta_column = segment_meta_column<int64_t, delta_delta_alg>;
-
-static const delta_xor_alg initial_xor{};
-static const delta_delta_alg initial_delta{0};
 
 // The performance of these tests depend on compiler optimizations a lot.
 // The read codepath only works well when the compiler is able to vectorize
@@ -69,22 +66,22 @@ void append_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     append_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     append_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_xor) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     append_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_delta) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     append_test_case(short_test_size, col);
 }
 
@@ -105,22 +102,22 @@ void append_tx_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_tx_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     append_tx_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_tx_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     append_tx_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_tx_xor) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     append_tx_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_tx_delta) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     append_tx_test_case(short_test_size, col);
 }
 
@@ -145,22 +142,22 @@ void iter_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_iter_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     iter_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_iter_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     iter_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_iter_xor) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     iter_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_iter_delta) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     iter_test_case(short_test_size, col);
 }
 
@@ -191,42 +188,42 @@ void find_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     find_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_xor_small) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     find_test_case(random_generators::get_int(1, 16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     find_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_delta_small) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     find_test_case(random_generators::get_int(1, 16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     find_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor_small) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     find_test_case(random_generators::get_int(1, 16), col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_delta) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     find_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_delta_small) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     find_test_case(random_generators::get_int(1, 16), col);
 }
 
@@ -266,42 +263,42 @@ void lower_bound_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     lower_bound_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_xor_small) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     lower_bound_test_case(random_generators::get_int(1, 16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     lower_bound_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_delta_small) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     lower_bound_test_case(random_generators::get_int(1, 16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_xor) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     lower_bound_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_xor_small) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     lower_bound_test_case(random_generators::get_int(1, 16), col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_delta) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     lower_bound_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_delta_small) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     lower_bound_test_case(random_generators::get_int(1, 16), col);
 }
 
@@ -339,42 +336,42 @@ void upper_bound_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     upper_bound_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_xor_small) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     upper_bound_test_case(random_generators::get_int(1, 16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     upper_bound_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_delta_small) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     upper_bound_test_case(random_generators::get_int(1, 16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_xor) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     upper_bound_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_xor_small) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     upper_bound_test_case(random_generators::get_int(1, 16), col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_delta) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     upper_bound_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_delta_small) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     upper_bound_test_case(random_generators::get_int(1, 16), col);
 }
 
@@ -406,42 +403,42 @@ void at_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     at_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_xor_small) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     at_test_case(random_generators::get_int(16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     at_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_delta_small) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     at_test_case(random_generators::get_int(16), frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_xor) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     at_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_xor_small) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     at_test_case(random_generators::get_int(16), col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_delta) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     at_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_delta_small) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     at_test_case(random_generators::get_int(16), col);
 }
 
@@ -488,22 +485,22 @@ void prefix_truncate_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_prefix_truncate_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     prefix_truncate_test_case(10, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_prefix_truncate_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     prefix_truncate_test_case(10, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_prefix_truncate_xor) {
-    delta_xor_column col(initial_xor);
+    delta_xor_column col{};
     prefix_truncate_test_case(10, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_prefix_truncate_delta) {
-    delta_delta_column col(initial_delta);
+    delta_delta_column col{};
     prefix_truncate_test_case(10, col);
 }
 
@@ -563,22 +560,22 @@ void at_with_hint_test_case(const int64_t num_elements, column_t& column) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_with_hint_xor) {
-    delta_xor_frame frame(initial_xor);
+    delta_xor_frame frame{};
     at_with_hint_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_with_hint_delta) {
-    delta_delta_frame frame(initial_delta);
+    delta_delta_frame frame{};
     at_with_hint_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_with_hint_xor) {
-    delta_xor_column column(initial_xor);
+    delta_xor_column column{};
     at_with_hint_test_case(short_test_size, column);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_with_hint_delta) {
-    delta_delta_column column(initial_delta);
+    delta_delta_column column{};
     at_with_hint_test_case(short_test_size, column);
 }
 
@@ -755,7 +752,7 @@ void test_cstore_prefix_truncate(size_t test_size, size_t max_truncate_ix) {
     }
 
     // Truncate the generated manifest and the column store
-    // and check that all operations can be perfomed.
+    // and check that all operations can be performed.
     auto ix = random_generators::get_int(1, (int)max_truncate_ix);
     auto iter = manifest.begin();
     std::advance(iter, ix);
@@ -789,4 +786,38 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_full) {
     test_cstore_prefix_truncate(short_test_size, short_test_size);
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_serde_roundtrip) {
+    segment_meta_cstore store{};
+    auto manifest = generate_metadata(10007);
+    for (auto const& sm : manifest) {
+        store.insert(sm);
+    }
+    {
+        auto [inflated_sz, actual_sz] = store.inflated_actual_size();
+        auto iobuf = store.to_iobuf();
+        auto serialized_sz = iobuf.size_bytes();
+        BOOST_REQUIRE(store.empty());
+        store.from_iobuf(std::move(iobuf));
+        vlog(
+          test.info,
+          "store size inflated:{} in memory:{} serialized:{}",
+          human::bytes(inflated_sz),
+          human::bytes(actual_sz),
+          human::bytes(serialized_sz));
+    }
+
+    BOOST_REQUIRE_EQUAL(store.size(), manifest.size());
+
+    // NOTE: store.begin() returns an interator that can't be copied around.
+    // can't use std::equal needs to copy the iterators around (a quirk of this
+    // implementation) with clang15 we have std::views::ref_view +
+    // std::ranges::subranges that take care of this
+    auto store_it = store.begin();
+    auto store_end = store.end();
+    auto manifest_it = manifest.begin();
+    for (; store_it != store_end; ++store_it, ++manifest_it) {
+        BOOST_REQUIRE_EQUAL(*store_it, *manifest_it);
+    }
 }

--- a/src/v/reflection/type_traits.h
+++ b/src/v/reflection/type_traits.h
@@ -18,6 +18,7 @@
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/util/bool_class.hh>
 
+#include <array>
 #include <optional>
 #include <type_traits>
 #include <vector>
@@ -32,12 +33,20 @@ template<typename T, template<typename...> class C>
 inline constexpr bool is_specialization_of_v
   = is_specialization_of<T, C>::value;
 
+template<class T>
+struct is_std_array_t : std::false_type {};
+template<class T, std::size_t N>
+struct is_std_array_t<std::array<T, N>> : std::true_type {};
+
 } // namespace detail
 
 namespace reflection {
 
 template<typename T>
 concept is_std_vector = ::detail::is_specialization_of_v<T, std::vector>;
+
+template<typename T>
+concept is_std_array = ::detail::is_std_array_t<T>::value;
 
 template<typename T>
 concept is_ss_circular_buffer


### PR DESCRIPTION
This PR builds upon #7898
Fixes #9232

Adds segment_meta_cstore::from_iobuf/to_iobuf via serde of the sub-objects. 
most of the work is done via serde_fields and serde::envelope, but some manual work is done via serde_write/serde_read, to support std::list and absl::btree_map

std::array is added to the list of containers recognized by serde. serialization is done like other sequence containers, as size,[elements...]. Deserialization first checks the serialized size against std::tuple_size<std_array_t> and throws in case of mismatch. this is done to catch bugs where the size of the std::array is changed in code, but the writer didn't add decoding logic for older binary data. it's not meant to be a recoverable error.

a new unit test checks round-trip serialization/deserialization

a benchmark check serialization/deserialization against a memcpy baseline

| test | iterations | median | mad | min | max | allocs | tasks | inst |
| ---- |  ---- |  ---- |  ---- | ---- | ---- | ---- | ---- | ---- |
| cstore_bench.column_store_serialize_baseline | 1553 | 92.628us | 64.712ns | 92.469us | 92.744us | 38.000 | 0.000 | 0.0 |
| cstore_bench.column_store_serialize_result | 217 | 299.284us | 449.493ns | 298.768us | 299.870us | 7644.059 | 0.000 | 0.0 |
| cstore_bench.column_store_deserialize_baseline | 1043 | 272.181us | 11.634ns | 271.952us | 272.606us | 2507.000 | 0.000 | 0.0 |
| cstore_bench.column_store_deserialize_result | 215 | 36.598us | 25.693ns | 36.521us | 36.624us | 283.864 | 0.000 | 0.0 |

 
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
* none