### PR TITLE
admin: add the http proxy to the restart endpoint

### DIFF
--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -133,7 +133,7 @@ ss::future<> consumer::stop() {
     _inactive_timer.cancel();
     _inactive_timer.set_callback([]() {});
 
-    _on_stopped(_name);
+    _on_stopped(name());
     if (_as.abort_requested()) {
         return ss::now();
     }

--- a/src/v/pandaproxy/rest/api.cc
+++ b/src/v/pandaproxy/rest/api.cc
@@ -12,6 +12,7 @@
 #include "kafka/client/client.h"
 #include "kafka/client/configuration.h"
 #include "model/metadata.h"
+#include "pandaproxy/logger.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/rest/proxy.h"
@@ -64,6 +65,12 @@ ss::future<> api::stop() {
     co_await _proxy.stop();
     co_await _client_cache.stop();
     co_await _client.stop();
+}
+
+ss::future<> api::restart() {
+    vlog(plog.info, "Restarting the http proxy");
+    co_await stop();
+    co_await start();
 }
 
 ss::future<> api::set_config(ss::sstring name, std::any val) {

--- a/src/v/pandaproxy/rest/api.h
+++ b/src/v/pandaproxy/rest/api.h
@@ -40,6 +40,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    ss::future<> restart();
 
     ss::future<> set_config(ss::sstring name, std::any val);
     ss::future<> set_client_config(ss::sstring name, std::any val);

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3777,45 +3777,38 @@ from_string_view<service_kind>(std::string_view sv) {
       .default_match(std::nullopt);
 }
 
-ss::future<> admin_server::restart_redpanda_service(service_kind service) {
-    if (service == service_kind::schema_registry) {
-        // Checks specific to schema registry
-        if (_schema_registry == nullptr) {
-            throw ss::httpd::server_error_exception(
-              "Schema Registry is undefined. Is it set in the .yaml config "
-              "file?");
-        }
-
-        try {
-            co_await _schema_registry->restart();
-        } catch (const std::exception& ex) {
-            vlog(
-              logger.error,
-              "Unknown issue restarting schema_registry: {}",
-              ex.what());
-            throw ss::httpd::server_error_exception(
-              "Unknown issue restarting schema_registry");
-        }
+namespace {
+template<typename service_t>
+ss::future<>
+try_service_restart(service_t* svc, std::string_view service_str_view) {
+    if (svc == nullptr) {
+        throw ss::httpd::server_error_exception(fmt::format(
+          "{} is undefined. Is it set in the .yaml config file?",
+          service_str_view));
     }
 
-    if (service == service_kind::http_proxy) {
-        // Checks specific to http proxy
-        if (_http_proxy == nullptr) {
-            throw ss::httpd::server_error_exception(
-              "Pandaproxy is undefined. Is it set in the .yaml config "
-              "file?");
-        }
+    try {
+        co_await svc->restart();
+    } catch (const std::exception& ex) {
+        vlog(
+          logger.error,
+          "Unknown issue restarting {}: {}",
+          service_str_view,
+          ex.what());
+        throw ss::httpd::server_error_exception(
+          fmt::format("Unknown issue restarting {}", service_str_view));
+    }
+}
+} // namespace
 
-        try {
-            co_await _http_proxy->restart();
-        } catch (const std::exception& ex) {
-            vlog(
-              logger.error,
-              "Unknown issue restarting http_proxy: {}",
-              ex.what());
-            throw ss::httpd::server_error_exception(
-              "Unknown issue restarting http_proxy");
-        }
+ss::future<> admin_server::restart_redpanda_service(service_kind service) {
+    switch (service) {
+    case service_kind::schema_registry:
+        co_await try_service_restart(_schema_registry, to_string_view(service));
+        break;
+    case service_kind::http_proxy:
+        co_await try_service_restart(_http_proxy, to_string_view(service));
+        break;
     }
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -15,6 +15,7 @@
 #include "config/endpoint_tls_config.h"
 #include "coproc/partition_manager.h"
 #include "model/metadata.h"
+#include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/fwd.h"
 #include "rpc/connection_cache.h"
 #include "seastarx.h"
@@ -39,6 +40,7 @@ struct admin_server_cfg {
 };
 
 enum class service_kind {
+    http_proxy,
     schema_registry,
 };
 
@@ -64,6 +66,7 @@ public:
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<cluster::node_status_table>&,
       ss::sharded<cluster::self_test_frontend>&,
+      pandaproxy::rest::api*,
       pandaproxy::schema_registry::api*,
       ss::sharded<cloud_storage::topic_recovery_service>&,
       ss::sharded<cluster::topic_recovery_status_frontend>&);
@@ -423,6 +426,7 @@ private:
     bool _ready{false};
     ss::sharded<cluster::node_status_table>& _node_status_table;
     ss::sharded<cluster::self_test_frontend>& _self_test_frontend;
+    pandaproxy::rest::api* _http_proxy;
     pandaproxy::schema_registry::api* _schema_registry;
     ss::sharded<cloud_storage::topic_recovery_service>& _topic_recovery_service;
     ss::sharded<cluster::topic_recovery_status_frontend>&

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -825,6 +825,7 @@ void application::configure_admin_server() {
       std::ref(_connection_cache),
       std::ref(node_status_table),
       std::ref(self_test_frontend),
+      _proxy.get(),
       _schema_registry.get(),
       std::ref(topic_recovery_service),
       std::ref(topic_recovery_status_frontend))

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -856,10 +856,13 @@ class Admin:
     def self_test_status(self):
         return self._request("GET", "debug/self_test/status").json()
 
-    def redpanda_services_restart(self, rp_service: Optional[str] = None):
+    def redpanda_services_restart(self,
+                                  rp_service: Optional[str] = None,
+                                  node: Optional[ClusterNode] = None):
         service_param = f"service={rp_service if rp_service is not None else ''}"
         return self._request("PUT",
-                             f"redpanda-services/restart?{service_param}")
+                             f"redpanda-services/restart?{service_param}",
+                             node=node)
 
     def is_node_isolated(self, node):
         return self._request("GET", "debug/is_node_isolated", node=node).json()


### PR DESCRIPTION
## Cover Letter

A class of bugs related to cached data (e.g. stale data, or bugs preventing/delaying cache eviction/refresh) are often solved by restarting a node or waiting. However, as more and more services and sub-systems are added to Redpanda the impact of a restart becomes higher. For example, Redpanda can't cycle the HTTP Proxy without cycling all services.

This PR therefore adds the HTTP Proxy to the restart services endpoint on the Admin API.

Fixes #9103
Fixes #9310 

Changes from force-push `6f349a7` and `d4862c7`:
- Generalize the restart method in admin_server.cc
- Added consumer and consumer offsets to pp restart test
- Added a test to check for undefined configs 

Changes from force-push `236cdee`:
- Typos and small style fixes

Changes from force-push `bf5d978`:
- Include a fix for #9310 
- Edit `admin.py::redpanda_services_restart` to accept DT nodes as parameters
- Edit restart test to issue PP restart on all brokers

Changes from force-push `b14b03d`:
- Edit commits to be more clear
- Cleanup restart_services_test.py

Changes from force-push `c0696df`:
- Use a switch statement instead of if in `admin_server::restart_redpanda_service()`
- Split refactoring into a separate commit
- Rename `_restart_http_proxy` to `_test_http_proxy_restart`

## Backports Required

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* Users can now restart the http proxy by issuing a PUT request to admin/redpanda-services/restart?service=http-proxy. This request will wipe http proxy state.

## Release Notes

### Improvements

* Adds a method to the http proxy that clears state.
