### PR TITLE
redpanda_installer: update tgz url

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -109,7 +109,7 @@ class RedpandaInstaller:
     # cluster, and that directories therein are only ever created (never
     # deleted) during the lifetime of the RedpandaInstaller.
     INSTALLER_ROOT = "/opt/redpanda_installs"
-    TGZ_URL_TEMPLATE = "https://dl.redpanda.com/qSZR7V26sJx7tCXe/redpanda/raw/names/redpanda-{arch}/versions/{version}/redpanda-{version}-{arch}.tar.gz"
+    TGZ_URL_TEMPLATE = "https://vectorized-public.s3.us-west-2.amazonaws.com/releases/redpanda/{version}/redpanda-{version}-{arch}.tar.gz"
 
     # File path to be used for locking to prevent multiple local test processes
     # from operating on the same volume mounts.


### PR DESCRIPTION
blocked by PR https://github.com/redpanda-data/vtools/pull/1538

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x
- [x] v22.1.x

## UX Changes

* none

## Release Notes

* none