### PR TITLE
cloud_roles: Log error response from IAM roles API

### DIFF
--- a/src/v/test_utils/tee_log.h
+++ b/src/v/test_utils/tee_log.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/tee.hpp>
+
+#include <iostream>
+#include <sstream>
+
+struct tee_wrapper {
+    using device_t
+      = boost::iostreams::tee_device<std::ostream, std::stringstream>;
+
+    using stream_t = boost::iostreams::stream<device_t>;
+
+    tee_wrapper()
+      : sstr{}
+      , device{std::cout, sstr}
+      , stream{device} {}
+
+    tee_wrapper(const tee_wrapper&) = delete;
+    tee_wrapper& operator=(const tee_wrapper&) = delete;
+    tee_wrapper(tee_wrapper&&) = delete;
+    tee_wrapper& operator=(tee_wrapper&&) = delete;
+
+    ~tee_wrapper() {
+        if (stream.is_open()) {
+            stream->flush();
+            stream->close();
+        }
+    }
+
+    std::string string() const { return sstr.str(); }
+
+    std::stringstream sstr;
+    device_t device;
+    stream_t stream;
+};

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -108,7 +108,8 @@ CHAOS_LOG_ALLOW_LIST = [
 # Log errors emitted by refresh credentials system when cloud storage is enabled with IAM roles
 # without a corresponding mock service set up to return credentials
 IAM_ROLES_API_CALL_ALLOW_LIST = [
-    re.compile(r'cloud_roles - .*api request failed')
+    re.compile(r'cloud_roles - .*api request failed'),
+    re.compile(r'cloud_roles - .*failed during IAM credentials refresh:'),
 ]
 
 # Log errors are used in node_operation_fuzzy_test and partition_movement_test


### PR DESCRIPTION
When a request sent to an IAM roles endpoint fails, log the error response to help in troubleshooting the problem.

Adds tests for IAM roles failure handling code paths

Fixes https://github.com/redpanda-data/redpanda/issues/7039

Fixes https://github.com/redpanda-data/redpanda/issues/5386

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

* none