### PR TITLE
cloud_roles: use net::unresolved_address instead of host+port

### DIFF
--- a/src/v/cloud_roles/aws_refresh_impl.h
+++ b/src/v/cloud_roles/aws_refresh_impl.h
@@ -20,8 +20,7 @@ public:
     static constexpr uint16_t default_port = 80;
 
     aws_refresh_impl(
-      seastar::sstring api_host,
-      uint16_t api_port,
+      net::unresolved_address address,
       aws_region_name region,
       ss::abort_source& as,
       retry_params retry_params = default_retry_params);

--- a/src/v/cloud_roles/aws_sts_refresh_impl.h
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.h
@@ -20,8 +20,7 @@ public:
     static constexpr uint16_t default_port = 443;
 
     aws_sts_refresh_impl(
-      seastar::sstring api_host,
-      uint16_t api_port,
+      net::unresolved_address address,
       aws_region_name region,
       ss::abort_source& as,
       retry_params retry_params = default_retry_params);

--- a/src/v/cloud_roles/gcp_refresh_impl.cc
+++ b/src/v/cloud_roles/gcp_refresh_impl.cc
@@ -36,13 +36,12 @@ struct gcp_response_schema {
 };
 
 gcp_refresh_impl::gcp_refresh_impl(
-  ss::sstring api_host,
-  uint16_t api_port,
+  net::unresolved_address address,
   aws_region_name region,
   ss::abort_source& as,
   retry_params retry_params)
   : refresh_credentials::impl(
-    std::move(api_host), api_port, std::move(region), as, retry_params) {}
+    std::move(address), std::move(region), as, retry_params) {}
 
 ss::future<api_response> gcp_refresh_impl::fetch_credentials() {
     http::client::request_header oauth_req;
@@ -80,8 +79,7 @@ api_response_parse_result gcp_refresh_impl::parse_response(iobuf response) {
 }
 
 std::ostream& gcp_refresh_impl::print(std::ostream& os) const {
-    fmt::print(
-      os, "gcp_refresh_impl{{host:{}, port:{}}}", api_host(), api_port());
+    fmt::print(os, "gcp_refresh_impl{{address:{}}}", address());
     return os;
 }
 

--- a/src/v/cloud_roles/gcp_refresh_impl.h
+++ b/src/v/cloud_roles/gcp_refresh_impl.h
@@ -20,8 +20,7 @@ public:
     static constexpr uint16_t default_port = 80;
 
     gcp_refresh_impl(
-      ss::sstring api_host,
-      uint16_t api_port,
+      net::unresolved_address address,
       aws_region_name region,
       ss::abort_source& as,
       retry_params retry_params = default_retry_params);

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -123,7 +123,6 @@ public:
 
     refresh_credentials(
       std::unique_ptr<impl> impl,
-      ss::gate& gate,
       ss::abort_source& as,
       credentials_update_cb_t creds_update,
       aws_region_name region);
@@ -135,6 +134,8 @@ public:
     ss::future<api_response> fetch_credentials() {
         return _impl->fetch_credentials();
     }
+
+    ss::future<> stop();
 
 private:
     ss::future<> do_start();
@@ -154,7 +155,7 @@ private:
 
 private:
     std::unique_ptr<impl> _impl;
-    ss::gate& _gate;
+    ss::gate _gate;
     ss::abort_source& _as;
     credentials_update_cb_t _credentials_update;
     aws_region_name _region;
@@ -168,7 +169,6 @@ static constexpr retry_params default_retry_params{
 
 template<typename CredentialsProvider>
 refresh_credentials make_refresh_credentials(
-  ss::gate& gate,
   ss::abort_source& as,
   credentials_update_cb_t creds_update_cb,
   aws_region_name region,
@@ -182,14 +182,13 @@ refresh_credentials make_refresh_credentials(
       as,
       retry_params);
     return refresh_credentials{
-      std::move(impl), gate, as, std::move(creds_update_cb), std::move(region)};
+      std::move(impl), as, std::move(creds_update_cb), std::move(region)};
 }
 
 /// Builds a refresh_credentials object based on the credentials source set in
 /// configuration.
 refresh_credentials make_refresh_credentials(
   model::cloud_credentials_source cloud_credentials_source,
-  ss::gate& gate,
   ss::abort_source& as,
   credentials_update_cb_t creds_update_cb,
   aws_region_name region,

--- a/src/v/cloud_roles/tests/CMakeLists.txt
+++ b/src/v/cloud_roles/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ rp_test(
     categorization_tests.cc
     fetch_credentials_tests.cc
     credential_tests.cc
+    env_override_tests.cc
     DEFINITIONS BOOST_TEST_DYN_LINK
     LIBRARIES
     v::seastar_testing_main

--- a/src/v/cloud_roles/tests/categorization_tests.cc
+++ b/src/v/cloud_roles/tests/categorization_tests.cc
@@ -10,7 +10,6 @@
 
 #include "cloud_roles/apply_credentials.h"
 #include "cloud_roles/refresh_credentials.h"
-#include "config/node_config.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
@@ -31,7 +30,7 @@ BOOST_AUTO_TEST_CASE(test_refresh_client_built_according_to_source) {
           [](auto) { return ss::now(); },
           region);
         BOOST_REQUIRE_EQUAL(
-          "gcp_refresh_impl{host:169.254.169.254, port:80}",
+          "gcp_refresh_impl{address:{host: 169.254.169.254, port: 80}}",
           ssx::sformat("{}", rc));
     }
 
@@ -43,7 +42,7 @@ BOOST_AUTO_TEST_CASE(test_refresh_client_built_according_to_source) {
           [](auto) { return ss::now(); },
           region);
         BOOST_REQUIRE_EQUAL(
-          "aws_refresh_impl{host:169.254.169.254, port:80}",
+          "aws_refresh_impl{address:{host: 169.254.169.254, port: 80}}",
           ssx::sformat("{}", rc));
     }
 
@@ -58,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_refresh_client_built_according_to_source) {
           [](auto) { return ss::now(); },
           region);
         BOOST_REQUIRE_EQUAL(
-          "aws_sts_refresh_impl{host:sts.amazonaws.com, port:443}",
+          "aws_sts_refresh_impl{address:{host: sts.amazonaws.com, port: 443}}",
           ssx::sformat("{}", rc));
     }
 

--- a/src/v/cloud_roles/tests/categorization_tests.cc
+++ b/src/v/cloud_roles/tests/categorization_tests.cc
@@ -19,13 +19,11 @@
 inline ss::logger test_log("test"); // NOLINT
 
 BOOST_AUTO_TEST_CASE(test_refresh_client_built_according_to_source) {
-    ss::gate gate;
     ss::abort_source as;
     cloud_roles::aws_region_name region{"atlantis"};
     {
         auto rc = cloud_roles::make_refresh_credentials(
           model::cloud_credentials_source::gcp_instance_metadata,
-          gate,
           as,
           [](auto) { return ss::now(); },
           region);
@@ -37,7 +35,6 @@ BOOST_AUTO_TEST_CASE(test_refresh_client_built_according_to_source) {
     {
         auto rc = cloud_roles::make_refresh_credentials(
           model::cloud_credentials_source::aws_instance_metadata,
-          gate,
           as,
           [](auto) { return ss::now(); },
           region);
@@ -52,7 +49,6 @@ BOOST_AUTO_TEST_CASE(test_refresh_client_built_according_to_source) {
 
         auto rc = cloud_roles::make_refresh_credentials(
           model::cloud_credentials_source::sts,
-          gate,
           as,
           [](auto) { return ss::now(); },
           region);
@@ -64,7 +60,6 @@ BOOST_AUTO_TEST_CASE(test_refresh_client_built_according_to_source) {
     BOOST_REQUIRE_THROW(
       cloud_roles::make_refresh_credentials(
         model::cloud_credentials_source::config_file,
-        gate,
         as,
         [](auto) { return ss::now(); },
         region),

--- a/src/v/cloud_roles/tests/env_override_tests.cc
+++ b/src/v/cloud_roles/tests/env_override_tests.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/refresh_credentials.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(test_override_address) {
+    ss::abort_source as;
+    cloud_roles::aws_region_name region{"atlantis"};
+
+    setenv("RP_SI_CREDS_API_ADDRESS", "localhost:1234", 1);
+
+    auto undo = ss::defer([] { unsetenv("RP_SI_CREDS_API_ADDRESS"); });
+
+    for (const auto& [kind, name] : {
+           std::pair{
+             model::cloud_credentials_source::aws_instance_metadata,
+             "aws_refresh_impl"},
+           std::pair{
+             model::cloud_credentials_source::gcp_instance_metadata,
+             "gcp_refresh_impl"},
+         }) {
+        auto rc = cloud_roles::make_refresh_credentials(
+          kind, as, [](auto) { return ss::now(); }, region);
+        BOOST_REQUIRE_EQUAL(
+          std::string(name) + "{address:{host: localhost, port: 1234}}",
+          ssx::sformat("{}", rc));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_override_address_fails_on_bad_address) {
+    ss::abort_source as;
+    cloud_roles::aws_region_name region{"atlantis"};
+
+    {
+        setenv("RP_SI_CREDS_API_ADDRESS", "localhost:", 1);
+        auto undo = ss::defer([] { unsetenv("RP_SI_CREDS_API_ADDRESS"); });
+        BOOST_REQUIRE_EXCEPTION(
+          cloud_roles::make_refresh_credentials(
+            model::cloud_credentials_source::aws_instance_metadata,
+            as,
+            [](auto) { return ss::now(); },
+            region),
+          std::invalid_argument,
+          [](const auto& ex) {
+              ss::sstring what{ex.what()};
+              return what.find("found: localhost:") != what.npos;
+          });
+    }
+
+    {
+        setenv("RP_SI_CREDS_API_ADDRESS", ":1234", 1);
+        auto undo = ss::defer([] { unsetenv("RP_SI_CREDS_API_ADDRESS"); });
+        BOOST_REQUIRE_EXCEPTION(
+          cloud_roles::make_refresh_credentials(
+            model::cloud_credentials_source::aws_instance_metadata,
+            as,
+            [](auto) { return ss::now(); },
+            region),
+          std::invalid_argument,
+          [](const auto& ex) {
+              ss::sstring what{ex.what()};
+              return what.find("found: :1234") != what.npos;
+          });
+    }
+
+    {
+        setenv("RP_SI_CREDS_API_ADDRESS", "localhost", 1);
+        auto undo = ss::defer([] { unsetenv("RP_SI_CREDS_API_ADDRESS"); });
+        BOOST_REQUIRE_EXCEPTION(
+          cloud_roles::make_refresh_credentials(
+            model::cloud_credentials_source::aws_instance_metadata,
+            as,
+            [](auto) { return ss::now(); },
+            region),
+          std::invalid_argument,
+          [](const auto& ex) {
+              ss::sstring what{ex.what()};
+              return what.find("found: localhost") != what.npos;
+          });
+    }
+
+    {
+        setenv("RP_SI_CREDS_API_ADDRESS", "localhost:1234xxx", 1);
+        auto undo = ss::defer([] { unsetenv("RP_SI_CREDS_API_ADDRESS"); });
+        BOOST_REQUIRE_EXCEPTION(
+          cloud_roles::make_refresh_credentials(
+            model::cloud_credentials_source::aws_instance_metadata,
+            as,
+            [](auto) { return ss::now(); },
+            region),
+          std::invalid_argument,
+          [](const auto& ex) {
+              ss::sstring what{ex.what()};
+              return what.find("failed to convert 1234xxx") != what.npos;
+          });
+    }
+
+    {
+        setenv("RP_SI_CREDS_API_ADDRESS", "localhost:axxx", 1);
+        auto undo = ss::defer([] { unsetenv("RP_SI_CREDS_API_ADDRESS"); });
+        BOOST_REQUIRE_EXCEPTION(
+          cloud_roles::make_refresh_credentials(
+            model::cloud_credentials_source::aws_instance_metadata,
+            as,
+            [](auto) { return ss::now(); },
+            region),
+          std::invalid_argument,
+          [](const auto& ex) {
+              ss::sstring what{ex.what()};
+              return what.find("failed to convert axxx") != what.npos;
+          });
+    }
+}

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -87,7 +87,7 @@ FIXTURE_TEST(test_get_oauth_token, http_imposter_fixture) {
       as,
       s,
       cloud_roles::aws_region_name{""},
-      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+      address());
 
     refresh.start();
     gate.close().get();
@@ -116,7 +116,7 @@ FIXTURE_TEST(test_token_refresh_on_expiry, http_imposter_fixture) {
       as,
       s,
       cloud_roles::aws_region_name{""},
-      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+      address());
 
     refresh.start();
     gate.close().get();
@@ -152,7 +152,7 @@ FIXTURE_TEST(test_aws_credentials, http_imposter_fixture) {
       as,
       s,
       cloud_roles::aws_region_name{""},
-      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+      address());
 
     refresh.start();
     gate.close().get();
@@ -207,7 +207,7 @@ FIXTURE_TEST(test_short_lived_aws_credentials, http_imposter_fixture) {
       as,
       s,
       cloud_roles::aws_region_name{""},
-      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+      address());
 
     refresh.start();
     gate.close().get();
@@ -252,7 +252,7 @@ FIXTURE_TEST(test_sts_credentials, http_imposter_fixture) {
       as,
       s,
       cloud_roles::aws_region_name{""},
-      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+      address());
 
     refresh.start();
     gate.close().get();
@@ -315,7 +315,7 @@ FIXTURE_TEST(test_short_lived_sts_credentials, http_imposter_fixture) {
       as,
       s,
       cloud_roles::aws_region_name{""},
-      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+      address());
 
     refresh.start();
     gate.close().get();
@@ -353,7 +353,7 @@ FIXTURE_TEST(test_client_closed_on_error, http_imposter_fixture) {
       as,
       s,
       cloud_roles::aws_region_name{""},
-      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+      address());
 
     refresh.start();
     gate.close().get();
@@ -383,7 +383,7 @@ FIXTURE_TEST(test_handle_temporary_timeout, http_imposter_fixture) {
       as,
       s,
       cloud_roles::aws_region_name{""},
-      net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
+      address());
 
     config::shard_local_cfg()
       .cloud_storage_roles_operation_timeout_ms.set_value(

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -8,7 +8,6 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
-#include "bytes/iobuf.h"
 #include "cloud_roles/logger.h"
 #include "cloud_roles/refresh_credentials.h"
 #include "cloud_roles/tests/test_definitions.h"
@@ -19,6 +18,7 @@
 #include "test_utils/tee_log.h"
 
 #include <seastar/core/file.hh>
+#include <seastar/util/defer.hh>
 
 #include <fmt/chrono.h>
 
@@ -30,39 +30,33 @@ uint16_t unit_test_httpd_port_number() { return 4444; }
 /// Helps test the credential fetch operation by triggering abort after a single
 /// credential is fetched.
 struct one_shot_fetch {
-    one_shot_fetch(
-      std::optional<cloud_roles::credentials>& credentials,
-      ss::abort_source& as)
-      : credentials(credentials)
-      , as(as) {}
+    explicit one_shot_fetch(
+      std::optional<cloud_roles::credentials>& credentials)
+      : credentials(credentials) {}
     std::optional<cloud_roles::credentials>& credentials;
-    ss::abort_source& as;
 
     ss::future<> operator()(cloud_roles::credentials c) {
         credentials.emplace(std::move(c));
-        as.request_abort();
         return ss::now();
     }
 };
 
 /// Helper to assert refresh calls, aborts after two fetches.
 struct two_fetches {
-    two_fetches(
-      std::optional<cloud_roles::credentials>& credentials,
-      ss::abort_source& as)
-      : credentials(credentials)
-      , as(as) {}
+    using counter = ss::shared_ptr<uint8_t>;
 
-    uint8_t count{};
+    explicit two_fetches(std::optional<cloud_roles::credentials>& credentials)
+      : credentials(credentials)
+      , count{ss::make_shared<uint8_t>(0)} {}
+
     std::optional<cloud_roles::credentials>& credentials;
-    ss::abort_source& as;
+    counter count;
+
+    counter get_counter() { return count; }
 
     ss::future<> operator()(cloud_roles::credentials c) {
-        ++count;
+        (*count)++;
         credentials.emplace(std::move(c));
-        if (count == 2) {
-            as.request_abort();
-        }
         return ss::now();
     }
 };
@@ -76,21 +70,23 @@ FIXTURE_TEST(test_get_oauth_token, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    one_shot_fetch s(c, as);
+    one_shot_fetch s(c);
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::gcp_instance_metadata,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       address());
 
     refresh.start();
-    gate.close().get();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
+
+    tests::cooperative_spin_wait_with_timeout(10s, [&c] {
+        return c.has_value();
+    }).get();
 
     BOOST_REQUIRE_EQUAL(
       "a-token",
@@ -106,20 +102,24 @@ FIXTURE_TEST(test_token_refresh_on_expiry, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    two_fetches s(c, as);
+    two_fetches s(c);
+    auto count = s.get_counter();
+
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::gcp_instance_metadata,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       address());
 
     refresh.start();
-    gate.close().get();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
+
+    tests::cooperative_spin_wait_with_timeout(30s, [count] {
+        return *count >= 2;
+    }).get();
 
     BOOST_REQUIRE_EQUAL(
       "a-token",
@@ -141,21 +141,23 @@ FIXTURE_TEST(test_aws_credentials, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    one_shot_fetch s(c, as);
+    one_shot_fetch s(c);
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::aws_instance_metadata,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       address());
 
     refresh.start();
-    gate.close().get();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
+
+    tests::cooperative_spin_wait_with_timeout(10s, [&c] {
+        return c.has_value();
+    }).get();
 
     auto aws_creds = std::get<cloud_roles::aws_credentials>(c.value());
     BOOST_REQUIRE_EQUAL("my-key", aws_creds.access_key_id());
@@ -196,21 +198,24 @@ FIXTURE_TEST(test_short_lived_aws_credentials, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    two_fetches s(c, as);
+    two_fetches s(c);
+    auto count = s.get_counter();
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::aws_instance_metadata,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       address());
 
     refresh.start();
-    gate.close().get();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
+
+    tests::cooperative_spin_wait_with_timeout(30s, [count] {
+        return *count >= 2;
+    }).get();
 
     auto aws_creds = std::get<cloud_roles::aws_credentials>(c.value());
     BOOST_REQUIRE_EQUAL("my-key", aws_creds.access_key_id());
@@ -234,10 +239,9 @@ FIXTURE_TEST(test_sts_credentials, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    one_shot_fetch s(c, as);
+    one_shot_fetch s(c);
 
     auto token_f = ss::open_file_dma(
                      "test_sts_creds_f",
@@ -248,14 +252,17 @@ FIXTURE_TEST(test_sts_credentials, http_imposter_fixture) {
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::sts,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       address());
 
     refresh.start();
-    gate.close().get();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
+
+    tests::cooperative_spin_wait_with_timeout(10s, [&c] {
+        return c.has_value();
+    }).get();
 
     token_f.close().get0();
     ss::remove_file("test_sts_creds_f").get0();
@@ -297,10 +304,10 @@ FIXTURE_TEST(test_short_lived_sts_credentials, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    two_fetches s(c, as);
+    two_fetches s(c);
+    auto count = s.get_counter();
 
     auto token_f = ss::open_file_dma(
                      "test_short_sts_f",
@@ -311,14 +318,17 @@ FIXTURE_TEST(test_short_lived_sts_credentials, http_imposter_fixture) {
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::sts,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       address());
 
     refresh.start();
-    gate.close().get();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
+
+    tests::cooperative_spin_wait_with_timeout(30s, [count] {
+        return *count >= 2;
+    }).get();
 
     token_f.close().get0();
     ss::remove_file("test_short_sts_f").get0();
@@ -342,23 +352,23 @@ FIXTURE_TEST(test_client_closed_on_error, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    one_shot_fetch s(c, as);
+    one_shot_fetch s(c);
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::aws_instance_metadata,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       address());
 
     refresh.start();
-    gate.close().get();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
 
-    BOOST_REQUIRE(has_call(cloud_role_tests::aws_role_query_url));
+    tests::cooperative_spin_wait_with_timeout(10s, [this] {
+        return has_call(cloud_role_tests::aws_role_query_url);
+    }).get();
 
     // Assert that the error response body is logged
     BOOST_REQUIRE(wrapper.string().find("not found") != std::string::npos);
@@ -372,14 +382,12 @@ FIXTURE_TEST(test_handle_temporary_timeout, http_imposter_fixture) {
     tee_wrapper wrapper;
     cloud_roles::clrl_log.set_ostream(wrapper.stream);
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    one_shot_fetch s(c, as);
+    one_shot_fetch s(c);
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::aws_instance_metadata,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
@@ -389,6 +397,7 @@ FIXTURE_TEST(test_handle_temporary_timeout, http_imposter_fixture) {
       .cloud_storage_roles_operation_timeout_ms.set_value(
         std::chrono::milliseconds{100ms});
     refresh.start();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
 
     tests::cooperative_spin_wait_with_timeout(5s, [&wrapper] {
         return wrapper.string().find(
@@ -396,7 +405,6 @@ FIXTURE_TEST(test_handle_temporary_timeout, http_imposter_fixture) {
                  "period): timedout")
                != std::string::npos;
     }).get();
-    gate.close().get();
 }
 
 FIXTURE_TEST(test_handle_bad_response, http_imposter_fixture) {
@@ -411,27 +419,29 @@ FIXTURE_TEST(test_handle_bad_response, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    one_shot_fetch s(c, as);
+    one_shot_fetch s(c);
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::aws_instance_metadata,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
 
     refresh.start();
-    gate.close().get();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
 
-    auto log = wrapper.string();
+    tests::cooperative_spin_wait_with_timeout(10s, [&wrapper] {
+        return wrapper.string().find("retrying after cool-off")
+               != wrapper.string().npos;
+    }).get();
+
     BOOST_REQUIRE(
-      log.find("failed during IAM credentials refresh: Can't parse the request")
-      != log.npos);
-    BOOST_REQUIRE(log.find("retrying after cool-off") != log.npos);
+      wrapper.string().find(
+        "failed during IAM credentials refresh: Can't parse the request")
+      != wrapper.string().npos);
 }
 
 FIXTURE_TEST(test_intermittent_error, http_imposter_fixture) {
@@ -460,28 +470,25 @@ FIXTURE_TEST(test_intermittent_error, http_imposter_fixture) {
     listen();
 
     ss::abort_source as;
-    ss::gate gate;
     std::optional<cloud_roles::credentials> c;
 
-    two_fetches s(c, as);
+    two_fetches s(c);
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::aws_instance_metadata,
-      gate,
       as,
       s,
       cloud_roles::aws_region_name{""},
       net::unresolved_address{httpd_host_name.data(), httpd_port_number()});
 
     refresh.start();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
 
-    tests::cooperative_spin_wait_with_timeout(10s, [&c]() {
+    tests::cooperative_spin_wait_with_timeout(30s, [&c]() {
         return c.has_value()
                && std::holds_alternative<cloud_roles::aws_credentials>(
                  c.value());
     }).get();
-
-    gate.close().get();
 
     auto log = wrapper.string();
 

--- a/src/v/cloud_roles/tests/role_client_tests.cc
+++ b/src/v/cloud_roles/tests/role_client_tests.cc
@@ -34,8 +34,7 @@ FIXTURE_TEST(test_simple_token_request, http_imposter_fixture) {
     listen();
     ss::abort_source as;
 
-    auto cl = cloud_roles::gcp_refresh_impl{
-      httpd_host_name.data(), httpd_port_number(), region, as};
+    auto cl = cloud_roles::gcp_refresh_impl{address(), region, as};
     auto resp = cl.fetch_credentials().get0();
     BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
     BOOST_REQUIRE_EQUAL(
@@ -47,8 +46,7 @@ FIXTURE_TEST(test_bad_response_handling, http_imposter_fixture) {
     listen();
     ss::abort_source as;
 
-    auto cl = cloud_roles::gcp_refresh_impl{
-      httpd_host_name.data(), httpd_port_number(), region, as};
+    auto cl = cloud_roles::gcp_refresh_impl{address(), region, as};
     auto resp = cl.fetch_credentials().get0();
     BOOST_REQUIRE(std::holds_alternative<cloud_roles::api_request_error>(resp));
     auto error = std::get<cloud_roles::api_request_error>(resp);
@@ -64,8 +62,7 @@ FIXTURE_TEST(test_gateway_down, http_imposter_fixture) {
     listen();
     ss::abort_source as;
 
-    auto cl = cloud_roles::gcp_refresh_impl{
-      httpd_host_name.data(), httpd_port_number(), region, as};
+    auto cl = cloud_roles::gcp_refresh_impl{address(), region, as};
     auto resp = cl.fetch_credentials().get0();
     BOOST_REQUIRE(std::holds_alternative<cloud_roles::api_request_error>(resp));
     auto error = std::get<cloud_roles::api_request_error>(resp);
@@ -84,8 +81,7 @@ FIXTURE_TEST(test_aws_role_fetch_on_startup, http_imposter_fixture) {
     listen();
     ss::abort_source as;
 
-    auto cl = cloud_roles::aws_refresh_impl{
-      httpd_host_name.data(), httpd_port_number(), region, as};
+    auto cl = cloud_roles::aws_refresh_impl{address(), region, as};
     auto resp = cl.fetch_credentials().get0();
     // assert that calls are made in order:
     // 1. to find the role
@@ -119,8 +115,7 @@ FIXTURE_TEST(test_sts_credentials_fetch, http_imposter_fixture) {
     auto wrote = token_f.dma_write(0, token.data(), token.size()).get0();
     BOOST_REQUIRE_EQUAL(wrote, token.size());
 
-    auto cl = cloud_roles::aws_sts_refresh_impl{
-      httpd_host_name.data(), httpd_port_number(), region, as};
+    auto cl = cloud_roles::aws_sts_refresh_impl{address(), region, as};
     auto resp = cl.fetch_credentials().get0();
 
     token_f.close().get0();

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -130,6 +130,7 @@ ss::future<> remote::stop() {
     co_await _materialized->stop();
     co_await _pool.stop();
     co_await _gate.close();
+    co_await _auth_refresh_bg_op.stop();
     cst_log.debug("Stopped remote...");
 }
 
@@ -1055,7 +1056,6 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
               _client_conf);
             _refresh_credentials.emplace(cloud_roles::make_refresh_credentials(
               _cloud_credentials_source,
-              _gate,
               _as,
               std::move(credentials_update_cb),
               region_name));
@@ -1106,6 +1106,14 @@ cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
           }
       },
       _client_conf);
+}
+
+ss::future<> auth_refresh_bg_op::stop() {
+    if (
+      ss::this_shard_id() == auth_refresh_shard_id
+      && _refresh_credentials.has_value()) {
+        co_await _refresh_credentials.value().stop();
+    }
 }
 
 cloud_storage_clients::object_tag_formatter

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -85,6 +85,8 @@ public:
     cloud_storage_clients::client_configuration get_client_config() const;
     void set_client_config(cloud_storage_clients::client_configuration conf);
 
+    ss::future<> stop();
+
 private:
     void do_start_auth_refresh_op(
       cloud_roles::credentials_update_cb_t credentials_update_cb);

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -28,14 +28,18 @@ static ss::logger http_imposter_log("http_imposter"); // NOLINT
 extern uint16_t unit_test_httpd_port_number();
 
 http_imposter_fixture::http_imposter_fixture()
-  : _server_addr{
-    ss::ipv4_addr{httpd_host_name.data(), unit_test_httpd_port_number()}} {
+  : _server_addr{ss::ipv4_addr{
+    httpd_host_name.data(), unit_test_httpd_port_number()}}
+  , _address{
+      {httpd_host_name.data(), httpd_host_name.size()},
+      unit_test_httpd_port_number()} {
     _id = fmt::format("{}", uuid_t::create());
     _server.start().get();
 }
 
 http_imposter_fixture::http_imposter_fixture(net::unresolved_address address)
-  : _server_addr{ss::ipv4_addr{address.host().data(), address.port()}} {
+  : _server_addr{ss::ipv4_addr{address.host().data(), address.port()}}
+  , _address{address} {
     _id = fmt::format("{}", uuid_t::create());
     _server.start().get();
 }

--- a/src/v/http/tests/http_imposter.h
+++ b/src/v/http/tests/http_imposter.h
@@ -53,7 +53,7 @@ public:
 
     /// Starting point for URL registration fluent API
     /// Example usage:
-    /// when().when("/foo")
+    /// when("/foo")
     ///     .with_method(POST)
     ///     .then_return("bar");
     http_test_utils::registered_urls& when() { return _urls; }
@@ -113,6 +113,8 @@ public:
       http_test_utils::response canned_response,
       ss::lowres_clock::duration duration);
 
+    net::unresolved_address address() const { return _address; }
+
 private:
     struct request_masking {
         http_test_utils::response canned_response;
@@ -137,4 +139,6 @@ private:
     absl::flat_hash_map<size_t, http_test_utils::response> _fail_responses;
     ss::sstring _id;
     std::optional<request_masking> _masking_active;
+
+    net::unresolved_address _address;
 };

--- a/tests/rptest/services/mock_iam_roles_server.py
+++ b/tests/rptest/services/mock_iam_roles_server.py
@@ -30,8 +30,9 @@ class MockIamRolesServer(HttpServer):
         self.port = port
         self.stop_timeout_sec = stop_timeout_sec
         self.requests = []
-        self.url = f'http://{self.nodes[0].account.hostname}:{self.port}'
         self.hostname = self.nodes[0].account.hostname
+        self.address = f'{self.hostname}:{self.port}'
+        self.url = f'http://{self.address}'
         self.remote_script_path = None
         self.mock_target = mock_target
 

--- a/tests/rptest/tests/e2e_iam_role_test.py
+++ b/tests/rptest/tests/e2e_iam_role_test.py
@@ -17,8 +17,8 @@ class AWSRoleFetchTests(EndToEndShadowIndexingBase):
         super().__init__(test_context,
                          extra_rp_conf,
                          environment={
-                             'RP_SI_CREDS_API_HOST': self.iam_server.hostname,
-                             'RP_SI_CREDS_API_PORT': self.iam_server.port,
+                             'RP_SI_CREDS_API_ADDRESS':
+                             self.iam_server.address,
                          })
         self.redpanda.add_extra_rp_conf(
             {'cloud_storage_credentials_source': 'aws_instance_metadata'})
@@ -86,8 +86,8 @@ class STSRoleFetchTests(EndToEndShadowIndexingBase):
         super().__init__(test_context,
                          extra_rp_conf,
                          environment={
-                             'RP_SI_CREDS_API_HOST': self.iam_server.hostname,
-                             'RP_SI_CREDS_API_PORT': self.iam_server.port,
+                             'RP_SI_CREDS_API_ADDRESS':
+                             self.iam_server.address,
                              'AWS_ROLE_ARN': self.role,
                              'AWS_WEB_IDENTITY_TOKEN_FILE': self.token_path,
                          })
@@ -154,8 +154,8 @@ class ShortLivedCredentialsTests(EndToEndShadowIndexingBase):
         super().__init__(test_context,
                          extra_rp_conf,
                          environment={
-                             'RP_SI_CREDS_API_HOST': self.iam_server.hostname,
-                             'RP_SI_CREDS_API_PORT': self.iam_server.port,
+                             'RP_SI_CREDS_API_ADDRESS':
+                             self.iam_server.address,
                              'AWS_ROLE_ARN': self.role,
                              'AWS_WEB_IDENTITY_TOKEN_FILE': self.token_path,
                          })


### PR DESCRIPTION
The objects in cloud roles pass around a host+port pair, which is changed to use `net::unresolved_address` here.

The env variable used to override these two values is combined into one: `RP_SI_CREDS_API_ADDRESS`, to be set as: `localhost:1234`

Changes `refresh_credentials` to manage its own gate and adds corresponding stop method.

Fixes: https://github.com/redpanda-data/redpanda/issues/5383

Fixes: https://github.com/redpanda-data/redpanda/issues/5385

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

  * none
