### PR TITLE
features: bump version for 23.2.0 development cycle

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -108,12 +108,13 @@ std::string_view to_string_view(feature_state::state s) {
 //  22.2.1 -> 5  (22.2.6 later proceeds to version 6)
 //  22.3.1 -> 7  (22.3.6 later proceeds to verison 8)
 //  23.1.1 -> 9
+//  23.2.1 -> 10
 //
 // Although some previous stable branches have included feature version
 // bumps, this is _not_ the intended usage, as stable branches are
 // meant to be safely downgradable within the branch, and new features
 // imply that new data formats may be written.
-static constexpr cluster_version latest_version = cluster_version{9};
+static constexpr cluster_version latest_version = cluster_version{10};
 
 // The earliest version we can upgrade from.  This is the version that
 // a freshly initialized node will start at: e.g. a 23.1 Redpanda joining


### PR DESCRIPTION
This is not strictly necessary until we add something that requires a feature flag, but is simplifies upgrade testing to have a different logical version on the tip of dev than on the last stable release.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
