### PR TITLE
serde split read nested

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -750,6 +750,14 @@ read_nested(iobuf_parser& in, iobuf& t, std::size_t const bytes_left_limit) {
     t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
 }
 
+inline void read_nested(
+  iobuf_parser& in, ss::sstring& t, std::size_t const bytes_left_limit) {
+    auto str = ss::uninitialized_string(
+      read_nested<serde_size_t>(in, bytes_left_limit));
+    in.consume_to(str.size(), str.begin());
+    t = str;
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -760,12 +768,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, ss::sstring>) {
-        auto str = ss::uninitialized_string(
-          read_nested<serde_size_t>(in, bytes_left_limit));
-        in.consume_to(str.size(), str.begin());
-        t = str;
-    } else if constexpr (std::is_same_v<Type, bytes>) {
+    if constexpr (std::is_same_v<Type, bytes>) {
         auto str = ss::uninitialized_string<bytes>(
           read_nested<serde_size_t>(in, bytes_left_limit));
         in.consume_to(str.size(), str.begin());

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -668,6 +668,11 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     }
 }
 
+inline void
+read_nested(iobuf_parser& in, bool& t, std::size_t const bytes_left_limit) {
+    t = read_nested<int8_t>(in, bytes_left_limit) != 0;
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -678,9 +683,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, bool>) {
-        t = read_nested<int8_t>(in, bytes_left_limit) != 0;
-    } else if constexpr (serde_is_enum_v<Type>) {
+    if constexpr (serde_is_enum_v<Type>) {
         auto const val = read_nested<serde_enum_serialized_t>(
           in, bytes_left_limit);
         if (unlikely(

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -766,6 +766,11 @@ read_nested(iobuf_parser& in, bytes& t, std::size_t const bytes_left_limit) {
     t = str;
 }
 
+inline void read_nested(
+  iobuf_parser& in, uuid_t& t, std::size_t const /* bytes_left_limit */) {
+    in.consume_to(uuid_t::length, t.mutable_uuid().begin());
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -776,9 +781,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, uuid_t>) {
-        in.consume_to(uuid_t::length, t.mutable_uuid().begin());
-    } else if constexpr (reflection::is_std_optional<Type>) {
+    if constexpr (reflection::is_std_optional<Type>) {
         t = read_nested<bool>(in, bytes_left_limit)
               ? Type{read_nested<typename Type::value_type>(
                 in, bytes_left_limit)}

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -758,6 +758,14 @@ inline void read_nested(
     t = str;
 }
 
+inline void
+read_nested(iobuf_parser& in, bytes& t, std::size_t const bytes_left_limit) {
+    auto str = ss::uninitialized_string<bytes>(
+      read_nested<serde_size_t>(in, bytes_left_limit));
+    in.consume_to(str.size(), str.begin());
+    t = str;
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -768,12 +776,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, bytes>) {
-        auto str = ss::uninitialized_string<bytes>(
-          read_nested<serde_size_t>(in, bytes_left_limit));
-        in.consume_to(str.size(), str.begin());
-        t = str;
-    } else if constexpr (std::is_same_v<Type, uuid_t>) {
+    if constexpr (std::is_same_v<Type, uuid_t>) {
         in.consume_to(uuid_t::length, t.mutable_uuid().begin());
     } else if constexpr (reflection::is_std_optional<Type>) {
         t = read_nested<bool>(in, bytes_left_limit)

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -745,6 +745,11 @@ void read_nested(
     t = ss::bool_class<Tag>{read_nested<int8_t>(in, bytes_left_limit) != 0};
 }
 
+inline void
+read_nested(iobuf_parser& in, iobuf& t, std::size_t const bytes_left_limit) {
+    t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -755,9 +760,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (std::is_same_v<Type, iobuf>) {
-        t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
-    } else if constexpr (std::is_same_v<Type, ss::sstring>) {
+    if constexpr (std::is_same_v<Type, ss::sstring>) {
         auto str = ss::uninitialized_string(
           read_nested<serde_size_t>(in, bytes_left_limit));
         in.consume_to(str.size(), str.begin());

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -921,15 +921,15 @@ inline void read_nested(
     }
 }
 
-template<typename T>
-void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
-    using Type = std::decay_t<T>;
+template<typename Clock, typename Duration>
+void read_nested(
+  iobuf_parser&,
+  std::chrono::time_point<Clock, Duration>& t,
+  std::size_t const /* bytes_left_limit */) {
     static_assert(
-      !is_chrono_time_point<Type>,
+      !is_chrono_time_point<decltype(t)>,
       "Time point serialization is risky and can have unintended "
       "consequences. Check with Redpanda team before fixing this.");
-    static_assert(are_bytes_and_string_different<Type>);
-    static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 }
 
 template<typename T>

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -880,6 +880,47 @@ void read_nested(
     }
 }
 
+inline void read_nested(
+  iobuf_parser& in,
+  ss::net::inet_address& t,
+  std::size_t const bytes_left_limit) {
+    bool is_ipv4 = read_nested<bool>(in, bytes_left_limit);
+    auto address_buf = read_nested<iobuf>(in, bytes_left_limit);
+    auto address_bytes = iobuf_to_bytes(address_buf);
+    if (is_ipv4) {
+        ::in_addr addr{};
+        if (unlikely(address_bytes.size() != sizeof(addr))) {
+            throw serde_exception(fmt_with_ctx(
+              ssx::sformat,
+              "reading type ss::net::inet_address of size {}: {} bytes left - "
+              "unexpected ipv4 "
+              "address size, read: {}, expected: {}",
+              sizeof(ss::net::inet_address),
+              in.bytes_left(),
+              address_bytes.size(),
+              sizeof(addr)));
+        }
+
+        std::memcpy(&addr, address_bytes.c_str(), sizeof(addr));
+        t = ss::net::inet_address(addr);
+    } else {
+        ::in6_addr addr{};
+        if (unlikely(address_bytes.size() != sizeof(addr))) {
+            throw serde_exception(fmt_with_ctx(
+              ssx::sformat,
+              "reading type ss::net::inet_address of size {}: {} bytes left - "
+              "unexpected ipv6 "
+              "address size, read: {}, expected: {}",
+              sizeof(ss::net::inet_address),
+              in.bytes_left(),
+              address_bytes.size(),
+              sizeof(addr)));
+        }
+        std::memcpy(&addr, address_bytes.c_str(), sizeof(addr));
+        t = ss::net::inet_address(addr);
+    }
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -889,44 +930,6 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
       "consequences. Check with Redpanda team before fixing this.");
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
-
-    if constexpr (std::is_same_v<T, ss::net::inet_address>) {
-        bool is_ipv4 = read_nested<bool>(in, bytes_left_limit);
-        auto address_buf = read_nested<iobuf>(in, bytes_left_limit);
-        auto address_bytes = iobuf_to_bytes(address_buf);
-        if (is_ipv4) {
-            ::in_addr addr{};
-            if (unlikely(address_bytes.size() != sizeof(addr))) {
-                throw serde_exception(fmt_with_ctx(
-                  ssx::sformat,
-                  "reading type {} of size {}: {} bytes left - unexpected ipv4 "
-                  "address size, read: {}, expected: {}",
-                  type_str<Type>(),
-                  sizeof(Type),
-                  in.bytes_left(),
-                  address_bytes.size(),
-                  sizeof(addr)));
-            }
-
-            std::memcpy(&addr, address_bytes.c_str(), sizeof(addr));
-            t = ss::net::inet_address(addr);
-        } else {
-            ::in6_addr addr{};
-            if (unlikely(address_bytes.size() != sizeof(addr))) {
-                throw serde_exception(fmt_with_ctx(
-                  ssx::sformat,
-                  "reading type {} of size {}: {} bytes left - unexpected ipv6 "
-                  "address size, read: {}, expected: {}",
-                  type_str<Type>(),
-                  sizeof(Type),
-                  in.bytes_left(),
-                  address_bytes.size(),
-                  sizeof(addr)));
-            }
-            std::memcpy(&addr, address_bytes.c_str(), sizeof(addr));
-            t = ss::net::inet_address(addr);
-        }
-    }
 }
 
 template<typename T>

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -855,6 +855,32 @@ void read_nested(
 }
 
 template<typename T>
+void read_nested(
+  iobuf_parser& in, tristate<T>& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<decltype(t)>;
+
+    int8_t flag = read_nested<int8_t>(in, bytes_left_limit);
+    if (flag == -1) {
+        // disabled
+        t = tristate<T>{};
+    } else if (flag == 0) {
+        // empty
+        t = tristate<T>(std::nullopt);
+    } else if (flag == 1) {
+        t = tristate<T>(read_nested<T>(in, bytes_left_limit));
+    } else {
+        throw serde_exception(fmt_with_ctx(
+          ssx::sformat,
+          "reading type {} of size {}: {} bytes left - unexpected tristate "
+          "state flag: {}, expected states are -1,0,1",
+          type_str<Type>(),
+          sizeof(Type),
+          in.bytes_left(),
+          flag));
+    }
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -864,27 +890,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (reflection::is_tristate<T>) {
-        int8_t flag = read_nested<int8_t>(in, bytes_left_limit);
-        if (flag == -1) {
-            // disabled
-            t = T{};
-        } else if (flag == 0) {
-            // empty
-            t = T(std::nullopt);
-        } else if (flag == 1) {
-            t = T(read_nested<typename T::value_type>(in, bytes_left_limit));
-        } else {
-            throw serde_exception(fmt_with_ctx(
-              ssx::sformat,
-              "reading type {} of size {}: {} bytes left - unexpected tristate "
-              "state flag: {}, expected states are -1,0,1",
-              type_str<Type>(),
-              sizeof(Type),
-              in.bytes_left(),
-              flag));
-        }
-    } else if constexpr (std::is_same_v<T, ss::net::inet_address>) {
+    if constexpr (std::is_same_v<T, ss::net::inet_address>) {
         bool is_ipv4 = read_nested<bool>(in, bytes_left_limit);
         auto address_buf = read_nested<iobuf>(in, bytes_left_limit);
         auto address_bytes = iobuf_to_bytes(address_buf);

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -839,6 +839,21 @@ void read_nested(
     t.shrink_to_fit();
 }
 
+template<class R, class P>
+void read_nested(
+  iobuf_parser& in,
+  std::chrono::duration<R, P>& t,
+  std::size_t const bytes_left_limit) {
+    using Type = std::chrono::duration<R, P>;
+
+    static_assert(
+      !std::is_floating_point_v<R>,
+      "Floating point duration conversions are prone to precision and "
+      "rounding issues.");
+    auto rep = read_nested<int64_t>(in, bytes_left_limit);
+    t = std::chrono::duration_cast<Type>(std::chrono::nanoseconds{rep});
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -849,14 +864,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (is_chrono_duration<Type>) {
-        static_assert(
-          !std::is_floating_point_v<typename Type::rep>,
-          "Floating point duration conversions are prone to precision and "
-          "rounding issues.");
-        auto rep = read_nested<int64_t>(in, bytes_left_limit);
-        t = std::chrono::duration_cast<Type>(std::chrono::nanoseconds{rep});
-    } else if constexpr (reflection::is_tristate<T>) {
+    if constexpr (reflection::is_tristate<T>) {
         int8_t flag = read_nested<int8_t>(in, bytes_left_limit);
         if (flag == -1) {
             // disabled

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -772,6 +772,16 @@ inline void read_nested(
 }
 
 template<typename T>
+void read_nested(
+  iobuf_parser& in, std::optional<T>& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<decltype(t)>;
+
+    t = read_nested<bool>(in, bytes_left_limit)
+          ? Type{read_nested<typename Type::value_type>(in, bytes_left_limit)}
+          : std::nullopt;
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -781,12 +791,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (reflection::is_std_optional<Type>) {
-        t = read_nested<bool>(in, bytes_left_limit)
-              ? Type{read_nested<typename Type::value_type>(
-                in, bytes_left_limit)}
-              : std::nullopt;
-    } else if constexpr (is_absl_node_hash_set<Type>) {
+    if constexpr (is_absl_node_hash_set<Type>) {
         const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
         t.reserve(size);
         for (auto i = 0U; i < size; ++i) {

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -674,6 +674,23 @@ read_nested(iobuf_parser& in, bool& t, std::size_t const bytes_left_limit) {
 }
 
 template<typename T>
+requires serde_is_enum_v<std::decay_t<T>>
+void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<T>;
+
+    auto const val = read_nested<serde_enum_serialized_t>(in, bytes_left_limit);
+    if (unlikely(
+          val > std::numeric_limits<std::underlying_type_t<Type>>::max())) {
+        throw serde_exception(fmt_with_ctx(
+          ssx::sformat,
+          "enum value {} too large for {}",
+          val,
+          type_str<Type>()));
+    }
+    t = static_cast<Type>(val);
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -683,19 +700,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (serde_is_enum_v<Type>) {
-        auto const val = read_nested<serde_enum_serialized_t>(
-          in, bytes_left_limit);
-        if (unlikely(
-              val > std::numeric_limits<std::underlying_type_t<Type>>::max())) {
-            throw serde_exception(fmt_with_ctx(
-              ssx::sformat,
-              "enum value {} too large for {}",
-              val,
-              type_str<Type>()));
-        }
-        t = static_cast<Type>(val);
-    } else if constexpr (std::is_scalar_v<Type>) {
+    if constexpr (std::is_scalar_v<Type>) {
         if (unlikely(in.bytes_left() < sizeof(Type))) {
             throw serde_exception(fmt_with_ctx(
               ssx::sformat,

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -728,6 +728,15 @@ void read_nested(
     }
 }
 
+template<typename T, typename Tag, typename IsConstexpr>
+void read_nested(
+  iobuf_parser& in,
+  ::detail::base_named_type<T, Tag, IsConstexpr>& t,
+  std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<decltype(t)>;
+    t = Type{read_nested<typename Type::type>(in, bytes_left_limit)};
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -738,9 +747,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (reflection::is_rp_named_type<Type>) {
-        t = Type{read_nested<typename Type::type>(in, bytes_left_limit)};
-    } else if constexpr (reflection::is_ss_bool_class<Type>) {
+    if constexpr (reflection::is_ss_bool_class<Type>) {
         t = Type{read_nested<int8_t>(in, bytes_left_limit) != 0};
     } else if constexpr (std::is_same_v<Type, iobuf>) {
         t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -613,6 +613,62 @@ header read_header(iobuf_parser& in, std::size_t const bytes_left_limit) {
 }
 
 template<typename T>
+requires is_envelope<std::decay_t<T>>
+void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<T>;
+
+    auto const h = read_header<Type>(in, bytes_left_limit);
+
+    if constexpr (is_checksum_envelope<Type>) {
+        auto const shared = in.share_no_consume(
+          in.bytes_left() - h._bytes_left_limit);
+        auto read_only_in = iobuf_const_parser{shared};
+        auto crc = crc::crc32c{};
+        read_only_in.consume(
+          read_only_in.bytes_left(), [&crc](char const* src, size_t const n) {
+              crc.extend(src, n);
+              return ss::stop_iteration::no;
+          });
+        if (unlikely(crc.value() != h._checksum)) {
+            throw serde_exception(fmt_with_ctx(
+              ssx::sformat,
+              "serde: envelope {} (ends at bytes_left={}) has bad "
+              "checksum: stored={}, actual={}",
+              type_str<Type>(),
+              h._bytes_left_limit,
+              h._checksum,
+              crc.value()));
+        }
+    }
+
+    if constexpr (has_serde_read<Type>) {
+        t.serde_read(in, h);
+    } else {
+        envelope_for_each_field(t, [&](auto& f) {
+            using FieldType = std::decay_t<decltype(f)>;
+            if (h._bytes_left_limit == in.bytes_left()) {
+                return false;
+            }
+            if (unlikely(in.bytes_left() < h._bytes_left_limit)) {
+                throw serde_exception(fmt_with_ctx(
+                  ssx::sformat,
+                  "field spill over in {}, field type {}: envelope_end={}, "
+                  "in.bytes_left()={}",
+                  type_str<Type>(),
+                  type_str<FieldType>(),
+                  h._bytes_left_limit,
+                  in.bytes_left()));
+            }
+            f = read_nested<FieldType>(in, bytes_left_limit);
+            return true;
+        });
+    }
+    if (in.bytes_left() > h._bytes_left_limit) {
+        in.skip(in.bytes_left() - h._bytes_left_limit);
+    }
+}
+
+template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(
@@ -622,58 +678,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (is_envelope<Type>) {
-        auto const h = read_header<Type>(in, bytes_left_limit);
-
-        if constexpr (is_checksum_envelope<Type>) {
-            auto const shared = in.share_no_consume(
-              in.bytes_left() - h._bytes_left_limit);
-            auto read_only_in = iobuf_const_parser{shared};
-            auto crc = crc::crc32c{};
-            read_only_in.consume(
-              read_only_in.bytes_left(),
-              [&crc](char const* src, size_t const n) {
-                  crc.extend(src, n);
-                  return ss::stop_iteration::no;
-              });
-            if (unlikely(crc.value() != h._checksum)) {
-                throw serde_exception(fmt_with_ctx(
-                  ssx::sformat,
-                  "serde: envelope {} (ends at bytes_left={}) has bad "
-                  "checksum: stored={}, actual={}",
-                  type_str<Type>(),
-                  h._bytes_left_limit,
-                  h._checksum,
-                  crc.value()));
-            }
-        }
-
-        if constexpr (has_serde_read<Type>) {
-            t.serde_read(in, h);
-        } else {
-            envelope_for_each_field(t, [&](auto& f) {
-                using FieldType = std::decay_t<decltype(f)>;
-                if (h._bytes_left_limit == in.bytes_left()) {
-                    return false;
-                }
-                if (unlikely(in.bytes_left() < h._bytes_left_limit)) {
-                    throw serde_exception(fmt_with_ctx(
-                      ssx::sformat,
-                      "field spill over in {}, field type {}: envelope_end={}, "
-                      "in.bytes_left()={}",
-                      type_str<Type>(),
-                      type_str<FieldType>(),
-                      h._bytes_left_limit,
-                      in.bytes_left()));
-                }
-                f = read_nested<FieldType>(in, bytes_left_limit);
-                return true;
-            });
-        }
-        if (in.bytes_left() > h._bytes_left_limit) {
-            in.skip(in.bytes_left() - h._bytes_left_limit);
-        }
-    } else if constexpr (std::is_same_v<Type, bool>) {
+    if constexpr (std::is_same_v<Type, bool>) {
         t = read_nested<int8_t>(in, bytes_left_limit) != 0;
     } else if constexpr (serde_is_enum_v<Type>) {
         auto const val = read_nested<serde_enum_serialized_t>(

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -737,6 +737,14 @@ void read_nested(
     t = Type{read_nested<typename Type::type>(in, bytes_left_limit)};
 }
 
+template<typename Tag>
+void read_nested(
+  iobuf_parser& in,
+  ss::bool_class<Tag>& t,
+  std::size_t const bytes_left_limit) {
+    t = ss::bool_class<Tag>{read_nested<int8_t>(in, bytes_left_limit) != 0};
+}
+
 template<typename T>
 void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
@@ -747,9 +755,7 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     static_assert(are_bytes_and_string_different<Type>);
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    if constexpr (reflection::is_ss_bool_class<Type>) {
-        t = Type{read_nested<int8_t>(in, bytes_left_limit) != 0};
-    } else if constexpr (std::is_same_v<Type, iobuf>) {
+    if constexpr (std::is_same_v<Type, iobuf>) {
         t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
     } else if constexpr (std::is_same_v<Type, ss::sstring>) {
         auto str = ss::uninitialized_string(


### PR DESCRIPTION
Split `serde_read_nested` function as groundwork for introducing `tag_invoke` for serde functions (cf. boost::json).

## Backports Required

- [x] none - not a bug fix

## UX Changes

none

## Release Notes

  * none
