### PR TITLE
rpk: Fix container panic when using Podman

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -126,6 +126,9 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 	if err != nil {
 		return nil, err
 	}
+	if containerJSON.NetworkSettings == nil || containerJSON.ContainerJSONBase == nil {
+		return nil, fmt.Errorf("unable to inspect the container %v, please make sure you have Docker installed and running", Name(nodeID))
+	}
 	var ipAddress string
 	network, exists := containerJSON.NetworkSettings.Networks[redpandaNetwork]
 	if exists {

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -54,10 +54,6 @@ type NodeState struct {
 	ContainerID   string
 }
 
-func HostAddr(port uint) string {
-	return net.JoinHostPort("127.0.0.1", fmt.Sprint(port))
-}
-
 func ListenAddresses(ip string, internalPort, externalPort uint) string {
 	return fmt.Sprintf(
 		"internal://%s,external://%s",


### PR DESCRIPTION
When we have a running cluster we try to inspect
the running containers and use some properties
from the client response (IP, status, etc...).

However, some clients (e.g Podman) might return
an empty container object and that produced a
panic in rpk because we were not properly
handling the objects.

## Backports Required

- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x


## Release Notes
  ### Bug Fixes

  * rpk: Fix a panic when using `rpk container` with Podman 