### PR TITLE
rptest: use non-batch blob delete for Azurite

### DIFF
--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -72,20 +72,27 @@ class ABSClient:
         blob_service = BlobServiceClient.from_connection_string(self.conn_str)
         blob_service.delete_container(name)
 
-    def empty_bucket(self, name: str, parallel=True):
+    def empty_bucket(self, name: str, parallel=False):
         container_client = ContainerClient.from_connection_string(
             self.conn_str, container_name=name)
         blob_names_generator = container_client.list_blob_names()
 
-        def chunks(generator):
-            it = iter(generator)
-            # 'delete_blobs' can only handle batches
-            # of up to 256 elements
-            while (batch := list(islice(it, 256))):
-                yield batch
+        if parallel:
 
-        for chunk in chunks(blob_names_generator):
-            container_client.delete_blobs(*chunk)
+            def chunks(generator):
+                it = iter(generator)
+                # 'delete_blobs' can only handle batches
+                # of up to 256 elements
+                while (batch := list(islice(it, 256))):
+                    yield batch
+
+            for chunk in chunks(blob_names_generator):
+                container_client.delete_blobs(*chunk)
+        else:
+            for blob in blob_names_generator:
+                container_client.delete_blob(blob)
+
+        return []
 
     def delete_object(self, bucket: str, key: str, verify=False):
         blob_client = BlobClient.from_connection_string(self.conn_str,


### PR DESCRIPTION
Azurite hardcodes `disableProductStyleUrl` to true for batch requests (as Abhijat pointed out a while back), which means that it fails to parse the request. For this reason, this commit updates ABSClient.empty_bucket to use sequential deletion when running against Azurite.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
* none
