### PR TITLE
[v22.3.x] e2e_topic_recovery_test: have s3 check the delta offset

### DIFF
--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -13,6 +13,7 @@ from ducktape.cluster.cluster_spec import ClusterSpec
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import RedpandaService, SISettings
 from rptest.util import Scale, segments_count, wait_for_local_storage_truncate
+from rptest.utils.mode_checks import skip_debug_mode
 from rptest.clients.rpk import RpkTool
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
@@ -127,14 +128,20 @@ class EndToEndTopicRecovery(RedpandaTest):
                     self._bucket, o.Key)
                 manifest = json.loads(data)
                 last_upl_offset = manifest['last_offset']
-                self.logger.info(
-                    f"Found manifest at {o.Key}, last_offset is {last_upl_offset}"
-                )
-                # We have one partition so this invariant holds
-                # it has to be changed when the number of partitions
-                # will get larger. This will also require different
-                # S3 check.
-                return last_upl_offset >= num_messages
+                if 'segments' in manifest:
+                    segments = manifest['segments']
+                    last_segment = segments[list(segments)[-1]]
+                    last_delta_offset = last_segment['delta_offset_end']
+                    # We have one partition so this invariant holds it has to
+                    # be changed when the number of partitions will get larger.
+                    # This will also require different S3 check.
+                    self.logger.info(
+                        f"Found manifest at {o.Key}, last_offset is {last_upl_offset}, last delta_offset is {last_delta_offset}"
+                    )
+                    return (last_upl_offset - last_delta_offset +
+                            1) >= num_messages
+                else:
+                    return False
         return False
 
     @cluster(num_nodes=4)
@@ -179,6 +186,7 @@ class EndToEndTopicRecovery(RedpandaTest):
         # we just care for the consumer to receive some data
         self._consumer.wait(timeout_sec=100)
 
+    @skip_debug_mode
     @cluster(num_nodes=4)
     @matrix(message_size=[5000],
             num_messages=[100000],
@@ -188,11 +196,6 @@ class EndToEndTopicRecovery(RedpandaTest):
     def test_restore(self, message_size, num_messages, recovery_overrides):
         """Write some data. Remove local data then restore
         the cluster."""
-
-        if self.debug_mode:
-            self.logger.info(
-                "Skipping test in debug mode (requires release build)")
-            return
 
         self.init_producer(message_size, num_messages)
         self._producer.start(clean=False)


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/8856

CONFLICT:
- updated test to use s3_client instead of cloud_storage_client; no functional change

The test currently waits for a target Redpanda offset to be uploaded, and then checks that the correct number of Kafka offsets are consumable. This isn't quite right, since we also need to take into account config batches in our Redpanda offsets.

This updates the test to take into account the 'delta_offset_end' field of the last offset, which should give us an accurate view of the number of Kafka data batches in the topic.

(cherry picked from commit 2cc199c0e64cd8e0293ab3398c7ceef04d7b5bc5)

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
