### PR TITLE
cloud_storage: track cloud log size in partition manifest 

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -98,7 +98,8 @@ ntp_archiver::ntp_archiver(
       config::shard_local_cfg().cloud_storage_enable_segment_merging.bind())
   , _manifest_upload_interval(
       config::shard_local_cfg()
-        .cloud_storage_manifest_max_upload_interval_sec.bind()) {
+        .cloud_storage_manifest_max_upload_interval_sec.bind())
+  , _feature_table(parent.feature_table()) {
     _start_term = _parent.term();
     // Override bucket for read-replica
     if (_parent.is_read_replica_mode_enabled()) {
@@ -780,6 +781,16 @@ ss::future<> ntp_archiver::maybe_flush_manifest_clean_offset() {
 
 ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
   std::optional<std::reference_wrapper<retry_chain_node>> source_rtc) {
+    if (!_feature_table.local().is_active(
+          features::feature::cloud_storage_manifest_format_v2)) {
+        vlog(
+          archival_log.info,
+          "Skipping manifest upload until all nodes in the cluster have been "
+          "upgraded.");
+
+        co_return cloud_storage::upload_result::cancelled;
+    }
+
     gate_guard guard{_gate};
     auto rtc = source_rtc.value_or(std::ref(_rtcnode));
     retry_chain_node fib(

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -492,6 +492,8 @@ private:
     config::binding<std::optional<std::chrono::seconds>>
       _manifest_upload_interval;
 
+    ss::sharded<features::feature_table>& _feature_table;
+
     friend class archival_fixture;
 };
 

--- a/src/v/archival/retention_calculator.cc
+++ b/src/v/archival/retention_calculator.cc
@@ -65,7 +65,7 @@ std::optional<retention_calculator> retention_calculator::factory(
     if (ntp_config.retention_bytes()) {
         auto total_retention_bytes = ntp_config.retention_bytes();
 
-        auto cloud_log_size = manifest.cloud_log_size();
+        auto cloud_log_size = manifest.compute_cloud_log_size();
         if (cloud_log_size > *total_retention_bytes) {
             auto overshot_by = cloud_log_size - *total_retention_bytes;
             strats.push_back(

--- a/src/v/archival/retention_calculator.cc
+++ b/src/v/archival/retention_calculator.cc
@@ -65,7 +65,7 @@ std::optional<retention_calculator> retention_calculator::factory(
     if (ntp_config.retention_bytes()) {
         auto total_retention_bytes = ntp_config.retention_bytes();
 
-        auto cloud_log_size = manifest.compute_cloud_log_size();
+        auto cloud_log_size = manifest.cloud_log_size();
         if (cloud_log_size > *total_retention_bytes) {
             auto overshot_by = cloud_log_size - *total_retention_bytes;
             strats.push_back(

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1436,16 +1436,6 @@ void partition_manifest::serialize_end(serialization_cursor_ptr cursor) const {
     cursor->epilogue_done = true;
 }
 
-bool partition_manifest::delete_permanently(
-  const partition_manifest::key& key) {
-    auto it = _segments.find(key);
-    if (it != _segments.end()) {
-        _segments.erase(it);
-        return true;
-    }
-    return false;
-}
-
 partition_manifest::const_iterator
 partition_manifest::segment_containing(model::offset o) const {
     if (o > _last_offset || _segments.empty()) {

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -421,7 +421,7 @@ size_t partition_manifest::segments_metadata_bytes() const {
     return _mem_tracker->consumption();
 }
 
-uint64_t partition_manifest::cloud_log_size() const {
+uint64_t partition_manifest::compute_cloud_log_size() const {
     auto start_iter = find(_start_offset);
 
     // No addresable segments

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -164,6 +164,7 @@ public:
               nm.name);
             nm.meta.segment_term = maybe_key->term;
             _segments.insert(std::make_pair(nm.meta.base_offset, nm.meta));
+            _cloud_log_size_bytes += nm.meta.size_bytes;
         }
     }
 
@@ -220,10 +221,9 @@ public:
     // manifest, or 0 if the memory is not being tracked.
     size_t segments_metadata_bytes() const;
 
-    // Computes the size in bytes of all segments available to clients
+    // Returns the cached size in bytes of all segments available to clients.
     // (i.e. all segments after and including the segment that starts at
     // the current _start_offset).
-    uint64_t compute_cloud_log_size() const;
     uint64_t cloud_log_size() const;
 
     /// Check if the manifest contains particular segment
@@ -313,12 +313,20 @@ public:
     ss::shared_ptr<util::mem_tracker> mem_tracker() { return _mem_tracker; }
 
 private:
+    void subtract_from_cloud_log_size(size_t to_subtract);
+
+    // Computes the size in bytes of all segments available to clients
+    // (i.e. all segments after and including the segment that starts at
+    // the current _start_offset).
+    uint64_t compute_cloud_log_size() const;
+
     /// Update manifest content from json document that supposed to be generated
     /// from manifest.json file
     void update(partition_manifest_handler&& handler);
 
     /// Move segments from _segments to _replaced
-    void move_aligned_offset_range(
+    /// Returns the total size in bytes of the replaced segments
+    size_t move_aligned_offset_range(
       model::offset begin_inclusive, model::offset end_inclusive);
 
     friend class serialization_cursor_data_source;
@@ -356,6 +364,7 @@ private:
     model::offset _start_offset;
     model::offset _last_uploaded_compacted_offset;
     model::offset _insync_offset;
+    size_t _cloud_log_size_bytes{0};
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -223,6 +223,7 @@ public:
     // Computes the size in bytes of all segments available to clients
     // (i.e. all segments after and including the segment that starts at
     // the current _start_offset).
+    uint64_t compute_cloud_log_size() const;
     uint64_t cloud_log_size() const;
 
     /// Check if the manifest contains particular segment

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -286,12 +286,6 @@ public:
                && _replaced == other._replaced;
     }
 
-    /// Remove segment record from manifest
-    ///
-    /// \param name is a segment name
-    /// \return true on success, false on failure (no such segment)
-    bool delete_permanently(const key& name);
-
     manifest_type get_manifest_type() const override {
         return manifest_type::partition;
     };

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -309,6 +309,10 @@ public:
         }
     }
 
+    ss::sharded<features::feature_table>& feature_table() const {
+        return _feature_table;
+    }
+
 private:
     ss::future<std::optional<storage::timequery_result>>
       cloud_storage_timequery(storage::timequery_config);

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -73,6 +73,8 @@ std::string_view to_string_view(feature f) {
         return "membership_change_controller_cmds";
     case feature::controller_snapshots:
         return "controller_snapshots";
+    case feature::cloud_storage_manifest_format_v2:
+        return "cloud_storage_manifest_format_v2";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -56,6 +56,7 @@ enum class feature : std::uint64_t {
     rpc_transport_unknown_errc = 1ULL << 21U,
     membership_change_controller_cmds = 1ULL << 22U,
     controller_snapshots = 1ULL << 23U,
+    cloud_storage_manifest_format_v2 = 1ULL << 24U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 62U,
@@ -252,6 +253,12 @@ constexpr static std::array feature_schema{
     "controller_snapshots",
     feature::controller_snapshots,
     feature_spec::available_policy::explicit_only,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{10},
+    "cloud_storage_manifest_format_v2",
+    feature::cloud_storage_manifest_format_v2,
+    feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 
   // For testing, a feature that does not auto-activate


### PR DESCRIPTION
This PR introduces a new field to the prologue of the partition
manifest. 'cloud_log_size_bytes' tracks the size of the cloud log (i.e.
sum of the sizes of uploaded log segments).

All operations on the cloud log are supported: addition, truncation,
compaction and merging. Truncation, compaction and merging decrease the
size of the cloud log. This decrease is reflected in the manifest
*before* the files have been deleted from cloud storage.

In order to understand this decision, consider the following:
* The cloud log size will be used in our billing infra, so it's vital to
  avoid over-counting.
* Currently, the cloud storage housekeeping loop updates the partition
  manifest (via the STM) only after all the desired deletes succeeded.

Assuming that all deletions have succeeded apart from one, and we get
queried by the billing service at the wrong time, we would over-report
the amount of bytes in S3.

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
* none
