### PR TITLE
archival: store dirty status of archival_metadata_stm & revise upload logic

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1320,6 +1320,9 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
 
     auto total_successful_uploads = non_compacted_result.num_succeeded
                                     + compacted_result.num_succeeded;
+    if (total_successful_uploads > 0) {
+        _last_segment_upload_time = ss::lowres_clock::now();
+    }
     vlog(
       _rtclog.trace,
       "Segment uploads complete: {} successful uploads",

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -95,7 +95,10 @@ ntp_archiver::ntp_archiver(
   , _local_segment_merger(
       maybe_make_adjacent_segment_merger(*this, _rtclog, parent.log().config()))
   , _segment_merging_enabled(
-      config::shard_local_cfg().cloud_storage_enable_segment_merging.bind()) {
+      config::shard_local_cfg().cloud_storage_enable_segment_merging.bind())
+  , _manifest_upload_interval(
+      config::shard_local_cfg()
+        .cloud_storage_manifest_max_upload_interval_sec.bind()) {
     _start_term = _parent.term();
     // Override bucket for read-replica
     if (_parent.is_read_replica_mode_enabled()) {

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -90,6 +90,16 @@ public:
     /// Get revision id
     model::initial_revision_id get_revision_id() const;
 
+    /// Get time when partition manifest was last uploaded
+    const ss::lowres_clock::time_point get_last_manfiest_upload_time() const {
+        return _last_manifest_upload_time;
+    }
+
+    /// Get time when a data segment was last uploaded
+    const ss::lowres_clock::time_point get_last_segment_upload_time() const {
+        return _last_segment_upload_time;
+    }
+
     /// Download manifest from pre-defined S3 locatnewion
     ///
     /// \return future that returns true if the manifest was found in S3
@@ -432,6 +442,9 @@ private:
 
     // When we last wrote the partition manifest to object storage
     ss::lowres_clock::time_point _last_manifest_upload_time;
+
+    // When we last wrote a segment
+    ss::lowres_clock::time_point _last_segment_upload_time;
 
     // Used during leadership transfer: instructs the archiver to
     // not proceed with uploads, even if it has leadership.

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -33,6 +33,9 @@
 
 namespace archival {
 
+// Forward declaration for test class that we will befriend
+class archival_fixture;
+
 using namespace std::chrono_literals;
 
 enum class segment_upload_kind { compacted, non_compacted };
@@ -473,6 +476,8 @@ private:
     // then upload at the next opportunity.
     config::binding<std::optional<std::chrono::seconds>>
       _manifest_upload_interval;
+
+    friend class archival_fixture;
 };
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -454,6 +454,11 @@ private:
     // NTP level adjacent segment merging job
     std::unique_ptr<housekeeping_job> _local_segment_merger;
     config::binding<bool> _segment_merging_enabled;
+
+    // If this duration has elapsed since _last_manifest_upload_time,
+    // then upload at the next opportunity.
+    config::binding<std::optional<std::chrono::seconds>>
+      _manifest_upload_interval;
 };
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -357,7 +357,9 @@ private:
 
     /// Upload manifest if it is dirty.  Proceed without raising on issues,
     /// in the expectation that we will be called again in the main upload loop.
-    ss::future<std::optional<model::offset>> maybe_upload_manifest();
+    /// Returns true if something was uploaded (_projected_manifest_clean_at
+    /// will have been updated if so)
+    ss::future<bool> maybe_upload_manifest();
 
     /// If we have a projected manifest clean offset, then flush it to
     /// the persistent stm clean offset.

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -103,6 +103,7 @@ public:
         auto operator<=>(const upload_group_result&) const = default;
     };
 
+    // The result of a group of parallel uploads
     struct batch_result {
         upload_group_result non_compacted_upload_result;
         upload_group_result compacted_upload_result;
@@ -319,7 +320,8 @@ private:
     /// the upload.
     ss::future<ntp_archiver::upload_group_result> wait_uploads(
       std::vector<scheduled_upload> scheduled,
-      segment_upload_kind segment_kind);
+      segment_upload_kind segment_kind,
+      bool inline_manifest);
 
     /// Upload individual segment to S3.
     ///
@@ -342,7 +344,7 @@ private:
 
     /// Upload manifest if it is dirty.  Proceed without raising on issues,
     /// in the expectation that we will be called again in the main upload loop.
-    ss::future<> maybe_upload_manifest();
+    ss::future<std::optional<model::offset>> maybe_upload_manifest();
 
     /// Upload manifest to the pre-defined S3 location
     ss::future<cloud_storage::upload_result> upload_manifest(

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -145,7 +145,8 @@ FIXTURE_TEST(test_archival_stm_happy_path, archival_metadata_stm_fixture) {
       == cluster::archival_metadata_stm::state_dirty::dirty);
 
     // Replicate add_segment_cmd command that adds segment with offset 0
-    archival_stm->add_segments(m, ss::lowres_clock::now() + 10s).get();
+    archival_stm->add_segments(m, std::nullopt, ss::lowres_clock::now() + 10s)
+      .get();
     BOOST_REQUIRE(archival_stm->manifest().size() == 1);
     BOOST_REQUIRE(
       archival_stm->manifest().begin()->second.base_offset == model::offset(0));
@@ -184,7 +185,8 @@ FIXTURE_TEST(
       .archiver_term = model::term_id(1),
       .segment_term = model::term_id(1),
     });
-    archival_stm->add_segments(m, ss::lowres_clock::now() + 10s).get();
+    archival_stm->add_segments(m, std::nullopt, ss::lowres_clock::now() + 10s)
+      .get();
     BOOST_REQUIRE_EQUAL(archival_stm->manifest().size(), 1);
     BOOST_REQUIRE_EQUAL(
       archival_stm->manifest().get_last_uploaded_compacted_offset(),
@@ -208,7 +210,8 @@ FIXTURE_TEST(test_archival_stm_segment_replace, archival_metadata_stm_fixture) {
       .archiver_term = model::term_id(1),
       .segment_term = model::term_id(1)});
     // Replicate add_segment_cmd command that adds segment with offset 0
-    archival_stm->add_segments(m1, ss::lowres_clock::now() + 10s).get();
+    archival_stm->add_segments(m1, std::nullopt, ss::lowres_clock::now() + 10s)
+      .get();
     archival_stm->sync(10s).get();
     BOOST_REQUIRE(archival_stm->manifest().size() == 2);
     BOOST_REQUIRE(archival_stm->get_start_offset() == model::offset(0));
@@ -220,7 +223,8 @@ FIXTURE_TEST(test_archival_stm_segment_replace, archival_metadata_stm_fixture) {
       .committed_offset = model::offset(999),
       .archiver_term = model::term_id(1),
       .segment_term = model::term_id(1)});
-    archival_stm->add_segments(m2, ss::lowres_clock::now() + 10s).get();
+    archival_stm->add_segments(m2, std::nullopt, ss::lowres_clock::now() + 10s)
+      .get();
     archival_stm->sync(10s).get();
     BOOST_REQUIRE(archival_stm->manifest().size() == 2);
     BOOST_REQUIRE(archival_stm->manifest().replaced_segments().size() == 1);
@@ -351,7 +355,8 @@ FIXTURE_TEST(
         pm.add(name, s);
     }
     pm.advance_insync_offset(model::offset{4});
-    archival_stm->add_segments(m, ss::lowres_clock::now() + 10s).get();
+    archival_stm->add_segments(m, std::nullopt, ss::lowres_clock::now() + 10s)
+      .get();
     BOOST_REQUIRE(archival_stm->manifest().size() == 4);
     BOOST_REQUIRE(archival_stm->get_start_offset() == model::offset(0));
     BOOST_REQUIRE(archival_stm->manifest() == pm);

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -703,7 +703,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
         old_segments.push_back(s.second);
     }
     part->archival_meta_stm()
-      ->add_segments(old_segments, ss::lowres_clock::now() + 1s)
+      ->add_segments(old_segments, std::nullopt, ss::lowres_clock::now() + 1s)
       .get();
 
     part->stop_archiver().get();
@@ -902,7 +902,7 @@ static void test_partial_upload_impl(
         all_segments.push_back(s.second);
     }
     part->archival_meta_stm()
-      ->add_segments(all_segments, ss::lowres_clock::now() + 1s)
+      ->add_segments(all_segments, std::nullopt, ss::lowres_clock::now() + 1s)
       .get();
 
     segment_name s2name{

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -19,6 +19,8 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 
+using namespace archival;
+
 inline ss::logger test_log("test");
 
 static constexpr std::string_view manifest = R"json({

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -42,17 +42,19 @@
 
 #include <optional>
 
-using namespace std::chrono_literals;
-
-inline ss::logger fixt_log("fixture"); // NOLINT
-
 /// For http_imposter to run this binary with a unique port
 uint16_t unit_test_httpd_port_number() { return 4441; }
 
 namespace archival {
 
+using namespace std::chrono_literals;
+
+inline ss::logger fixt_log("fixture"); // NOLINT
+
 archiver_fixture::archiver_fixture()
-  : redpanda_thread_fixture(redpanda_thread_fixture::init_cloud_storage_tag{}) {
+  : http_imposter_fixture()
+  , redpanda_thread_fixture(
+      redpanda_thread_fixture::init_cloud_storage_no_archiver_tag{}) {
     ss::smp::invoke_on_all([port = httpd_port_number()]() {
         auto& cfg = config::shard_local_cfg();
         cfg.cloud_storage_enabled.set_value(true);
@@ -67,6 +69,12 @@ archiver_fixture::archiver_fixture()
           std::optional<ss::sstring>{"us-east1"});
         cfg.cloud_storage_bucket.set_value(
           std::optional<ss::sstring>{"test-bucket"});
+
+        // Disable time-based manifest upload, to enable tests to
+        // deterministically assert on what manifest uploads happen for a given
+        // set of segment uploads
+        cfg.cloud_storage_manifest_max_upload_interval_sec.set_value(
+          std::optional<std::chrono::seconds>());
     }).get0();
 }
 
@@ -287,8 +295,6 @@ void archiver_fixture::initialize_shard(
         } else {
             defaults
               = std::make_unique<storage::ntp_config::default_overrides>();
-            defaults->shadow_indexing_mode
-              = model::shadow_indexing_mode::archival;
         }
         app.partition_manager.local()
           .manage(
@@ -299,6 +305,7 @@ void archiver_fixture::initialize_shard(
           .get();
         BOOST_CHECK_EQUAL(
           api.log_mgr().get(ntp.first)->segment_count(), ntp.second);
+
         vlog(fixt_log.trace, "storage log {}", *api.log_mgr().get(ntp.first));
     }
     BOOST_CHECK(all_ntp.size() <= api.log_mgr().size()); // NOLINT
@@ -463,7 +470,8 @@ void populate_log(storage::disk_log_builder& b, const log_spec& spec) {
     }
 }
 
-ss::future<archival::ntp_archiver::batch_result> do_upload_next(
+ss::future<archival::ntp_archiver::batch_result>
+archiver_fixture::do_upload_next(
   archival::ntp_archiver& archiver,
   std::optional<model::offset> lso,
   model::timeout_clock::time_point deadline) {
@@ -480,13 +488,14 @@ ss::future<archival::ntp_archiver::batch_result> do_upload_next(
     co_return co_await do_upload_next(archiver, lso, deadline);
 }
 
-ss::future<archival::ntp_archiver::batch_result> upload_next_with_retries(
+ss::future<archival::ntp_archiver::batch_result>
+archiver_fixture::upload_next_with_retries(
   archival::ntp_archiver& archiver, std::optional<model::offset> lso) {
     auto deadline = model::timeout_clock::now() + 10s;
     return ss::with_timeout(deadline, do_upload_next(archiver, lso, deadline));
 }
 
-void upload_and_verify(
+void archiver_fixture::upload_and_verify(
   archival::ntp_archiver& archiver,
   archival::ntp_archiver::batch_result expected,
   std::optional<model::offset> lso) {

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -49,6 +49,8 @@ inline ss::logger fixt_log("fixture"); // NOLINT
 /// For http_imposter to run this binary with a unique port
 uint16_t unit_test_httpd_port_number() { return 4441; }
 
+namespace archival {
+
 archiver_fixture::archiver_fixture()
   : redpanda_thread_fixture(redpanda_thread_fixture::init_cloud_storage_tag{}) {
     ss::smp::invoke_on_all([port = httpd_port_number()]() {
@@ -461,15 +463,6 @@ void populate_log(storage::disk_log_builder& b, const log_spec& spec) {
     }
 }
 
-storage::disk_log_builder make_log_builder(std::string_view data_path) {
-    return storage::disk_log_builder{storage::log_config{
-      storage::log_config::storage_type::disk,
-      {data_path.data(), data_path.size()},
-      4_KiB,
-      storage::debug_sanitize_files::yes,
-    }};
-}
-
 ss::future<archival::ntp_archiver::batch_result> do_upload_next(
   archival::ntp_archiver& archiver,
   std::optional<model::offset> lso,
@@ -506,3 +499,5 @@ void upload_and_verify(
       })
       .get0();
 }
+
+} // namespace archival

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -32,6 +32,8 @@
 #include <map>
 #include <vector>
 
+namespace archival {
+
 struct segment_desc {
     model::ntp ntp;
     model::offset base_offset;
@@ -189,8 +191,6 @@ struct log_spec {
     size_t last_segment_num_records;
 };
 
-storage::disk_log_builder make_log_builder(std::string_view data_path);
-
 void populate_log(storage::disk_log_builder& b, const log_spec& spec);
 
 ss::future<archival::ntp_archiver::batch_result> upload_next_with_retries(
@@ -205,3 +205,5 @@ void upload_and_verify(
 /// each other without gaps.
 segment_layout write_random_batches_with_single_record(
   ss::lw_shared_ptr<storage::segment> seg, size_t num_batches);
+
+} // namespace archival

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -157,6 +157,19 @@ public:
         return layouts.find(ntp)->second;
     }
 
+    ss::future<archival::ntp_archiver::batch_result> do_upload_next(
+      archival::ntp_archiver& archiver,
+      std::optional<model::offset> lso,
+      model::timeout_clock::time_point deadline);
+
+    ss::future<archival::ntp_archiver::batch_result> upload_next_with_retries(
+      archival::ntp_archiver&, std::optional<model::offset> lso = std::nullopt);
+
+    void upload_and_verify(
+      archival::ntp_archiver&,
+      archival::ntp_archiver::batch_result,
+      std::optional<model::offset> lso = std::nullopt);
+
 private:
     void initialize_shard(
       storage::api& api,
@@ -166,11 +179,6 @@ private:
 
     std::unordered_map<model::ntp, std::vector<segment_layout>> layouts;
 };
-
-std::tuple<
-  ss::lw_shared_ptr<archival::configuration>,
-  cloud_storage::configuration>
-get_configurations();
 
 cloud_storage::partition_manifest load_manifest(std::string_view v);
 
@@ -192,14 +200,6 @@ struct log_spec {
 };
 
 void populate_log(storage::disk_log_builder& b, const log_spec& spec);
-
-ss::future<archival::ntp_archiver::batch_result> upload_next_with_retries(
-  archival::ntp_archiver&, std::optional<model::offset> lso = std::nullopt);
-
-void upload_and_verify(
-  archival::ntp_archiver&,
-  archival::ntp_archiver::batch_result,
-  std::optional<model::offset> lso = std::nullopt);
 
 /// Creates num_batches with a single record each, used to fit segments close to
 /// each other without gaps.

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -340,7 +340,9 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
           r.duration);
     }
     // Move parts to final destinations
-    co_await move_parts(part);
+    if (part.num_files > 0) {
+        co_await move_parts(part);
+    }
 
     log_recovery_result result{
       .completed = true,

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -124,6 +124,18 @@ remote_probe::remote_probe(
              sm::description("Number of receive errors"),
              {direction_label("rx")})
              .aggregate({sm::shard_label}),
+           sm::make_counter(
+             "partition_manifest_uploads_total",
+             [this] { return get_partition_manifest_uploads(); },
+             sm::description("Successful partition manifest uploads"),
+             {})
+             .aggregate({sm::shard_label}),
+           sm::make_counter(
+             "segment_uploads_total",
+             [this] { return get_successful_uploads(); },
+             sm::description("Successful data segment uploads"),
+             {})
+             .aggregate({sm::shard_label}),
            sm::make_gauge(
              "active_segments",
              [&ms] { return ms.current_segments(); },

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -91,6 +91,7 @@ public:
     /// wait until it is applied to the STM.
     ss::future<std::error_code> add_segments(
       std::vector<cloud_storage::segment_meta>,
+      std::optional<model::offset> clean_offset,
       ss::lowres_clock::time_point deadline,
       std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
 
@@ -163,6 +164,7 @@ private:
 
     ss::future<std::error_code> do_add_segments(
       std::vector<cloud_storage::segment_meta>,
+      std::optional<model::offset> clean_offset,
       ss::lowres_clock::time_point deadline,
       std::optional<std::reference_wrapper<ss::abort_source>>);
 

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -153,11 +153,14 @@ public:
 
     // If state_dirty::dirty is returned the manifest should be uploaded
     // to object store at the next opportunity.
-    state_dirty get_dirty() const;
+    state_dirty get_dirty(
+      std::optional<model::offset> projected_clean = std::nullopt) const;
 
     // Users of the stm need to know insync offset in order to pass
     // the proper value to mark_clean
     model::offset get_insync_offset() const { return _insync_offset; }
+
+    model::offset get_last_clean_at() const { return _last_clean_at; };
 
 private:
     bool cleanup_needed() const;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -643,19 +643,6 @@ ss::future<> partition::remove_remote_persistent_state(ss::abort_source& as) {
     }
 }
 
-ss::future<> partition::stop_archiver() {
-    if (_archiver) {
-        _upload_housekeeping.local().deregister_jobs(
-          _archiver->get_housekeeping_jobs());
-        return _archiver->stop().then([this] {
-            // Drop it so that we don't end up double-stopping on shutdown
-            _archiver = nullptr;
-        });
-    } else {
-        return ss::now();
-    }
-}
-
 uint64_t partition::upload_backlog_size() const {
     if (_archiver) {
         return _archiver->estimate_backlog_size();

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -289,10 +289,6 @@ public:
         }
     }
 
-    /// Fixture testing hook, for tests that would like to stop the
-    /// usual archiver and start their own
-    ss::future<> stop_archiver();
-
     uint64_t upload_backlog_size() const;
 
     /**

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1235,6 +1235,14 @@ configuration::configuration()
       "remote storage (sec)",
       {.visibility = visibility::tunable},
       std::nullopt)
+  , cloud_storage_manifest_max_upload_interval_sec(
+      *this,
+      "cloud_storage_manifest_max_upload_interval_sec",
+      "Wait at least this long between partition manifest uploads. Actual time "
+      "between uploads may be greater than this interval. If this is null, "
+      "metadata will be updated after each segment upload.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      60s)
   , cloud_storage_readreplica_manifest_sync_timeout_ms(
       *this,
       "cloud_storage_readreplica_manifest_sync_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -252,6 +252,8 @@ struct configuration final : public config_store {
       cloud_storage_max_connection_idle_time_ms;
     property<std::optional<std::chrono::seconds>>
       cloud_storage_segment_max_upload_interval_sec;
+    property<std::optional<std::chrono::seconds>>
+      cloud_storage_manifest_max_upload_interval_sec;
     property<std::chrono::milliseconds>
       cloud_storage_readreplica_manifest_sync_timeout_ms;
     property<std::chrono::milliseconds> cloud_storage_metadata_sync_timeout_ms;

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -72,6 +72,12 @@ http_imposter_fixture::get_latest_request(const ss::sstring& url) const {
     }
 }
 
+size_t http_imposter_fixture::get_request_count(const ss::sstring& url) const {
+    auto [begin, end] = get_targets().equal_range(url);
+    size_t len = std::distance(begin, end);
+    return len;
+}
+
 const std::multimap<ss::sstring, ss::httpd::request>&
 http_imposter_fixture::get_targets() const {
     return _targets;

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -61,6 +61,17 @@ http_imposter_fixture::get_requests() const {
     return _requests;
 }
 
+std::optional<std::reference_wrapper<const ss::httpd::request>>
+http_imposter_fixture::get_latest_request(const ss::sstring& url) const {
+    auto i = _targets.upper_bound(url);
+    if (i == _targets.begin()) {
+        return std::nullopt;
+    } else {
+        --i;
+        return std::ref(i->second);
+    }
+}
+
 const std::multimap<ss::sstring, ss::httpd::request>&
 http_imposter_fixture::get_targets() const {
     return _targets;

--- a/src/v/http/tests/http_imposter.h
+++ b/src/v/http/tests/http_imposter.h
@@ -48,6 +48,10 @@ public:
     /// Access all http requests ordered by time
     const std::vector<ss::httpd::request>& get_requests() const;
 
+    /// Get the latest request to a particular URL
+    std::optional<std::reference_wrapper<const ss::httpd::request>>
+    get_latest_request(const ss::sstring& url) const;
+
     /// Access all http requests ordered by target url
     const std::multimap<ss::sstring, ss::httpd::request>& get_targets() const;
 

--- a/src/v/http/tests/http_imposter.h
+++ b/src/v/http/tests/http_imposter.h
@@ -52,6 +52,9 @@ public:
     std::optional<std::reference_wrapper<const ss::httpd::request>>
     get_latest_request(const ss::sstring& url) const;
 
+    /// Get the number of requests to a particular URL
+    size_t get_request_count(const ss::sstring& url) const;
+
     /// Access all http requests ordered by target url
     const std::multimap<ss::sstring, ss::httpd::request>& get_targets() const;
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -184,6 +184,29 @@ public:
         get_archival_config(),
         get_cloud_config(port)) {}
 
+    struct init_cloud_storage_no_archiver_tag {};
+
+    // Start redpanda with shadow indexing enabled, but do not enable
+    // tiered storage by default: this enables constructing topics without
+    // the upload code, to later set it up manually in a test.
+    explicit redpanda_thread_fixture(
+      init_cloud_storage_no_archiver_tag,
+      std::optional<uint16_t> port = std::nullopt)
+      : redpanda_thread_fixture(
+        model::node_id(1),
+        9092,
+        33145,
+        8082,
+        8081,
+        43189,
+        {},
+        ssx::sformat("test.dir_{}", time(0)),
+        std::nullopt,
+        true,
+        get_s3_config(port),
+        get_archival_config(),
+        std::nullopt) {}
+
     ~redpanda_thread_fixture() {
         shutdown();
         if (remove_on_shutdown) {

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -487,6 +487,7 @@ class RpkTool:
                 partition=None,
                 fetch_max_bytes=None,
                 quiet=False,
+                format=None,
                 timeout=None):
         cmd = ["consume", topic]
         if group is not None:
@@ -498,11 +499,13 @@ class RpkTool:
         if fetch_max_bytes is not None:
             cmd += ["--fetch-max-bytes", str(fetch_max_bytes)]
         if offset is not None:
-            cmd += ["-o", f"{n}"]
+            cmd += ["-o", f"{offset}"]
         if partition is not None:
             cmd += ["-p", f"{partition}"]
         if quiet:
             cmd += ["-f", "_\\n"]
+        elif format is not None:
+            cmd += ["-f", format]
 
         return self._run_topic(cmd, timeout=timeout)
 

--- a/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
@@ -1,0 +1,202 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import SISettings, MetricsEndpoint
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.utils.si_utils import BucketView
+import time
+
+
+class TieredStorageSinglePartitionTest(RedpandaTest):
+    log_segment_size = 128 * 1024 * 1024
+    segment_upload_interval = 30
+    manifest_upload_interval = 10
+
+    topics = (TopicSpec(replication_factor=3, partition_count=1), )
+
+    def __init__(self, test_context, *args, **kwargs):
+        self.si_settings = SISettings(
+            test_context=test_context,
+            log_segment_size=self.log_segment_size,
+        )
+        kwargs['si_settings'] = self.si_settings
+
+        # Use interval uploads so that at end of test we may do an "everything
+        # was uploaded" success condition.
+        kwargs['extra_rp_conf'] = {
+            # We do not intend to do interval-triggered uploads during produce,
+            # but we set this property so that at the end of the test we may
+            # do a simple "everything was uploaded" check after the interval.
+            'cloud_storage_segment_max_upload_interval_sec':
+            self.segment_upload_interval,
+            # The test will assert that the number of manifest uploads does
+            # not exceed what we would expect based on this interval.
+            'cloud_storage_manifest_max_upload_interval_sec':
+            self.manifest_upload_interval,
+        }
+        super().__init__(test_context, *args, **kwargs)
+
+    @cluster(num_nodes=4)
+    def throughput_test(self):
+        """
+        Stress the tiered storage upload path on a single partition.  This
+        corresponds to a workload in which the user does not create many
+        partitions, and consequently will upload segments very frequently
+        from a single partition.
+
+        We are looking to ensure that the uploads keep up, and that the
+        manifest uploads are done efficiently (e.g. not re-uploading
+        the manifest with each segment).
+        """
+
+        rpk = RpkTool(self.redpanda)
+
+        produce_byte_rate = 50 * 1024 * 1024
+
+        # Large messages, this is a bandwith test for uploads, we do not
+        # want CPU handling of small records to be a bottleneck
+        msg_size = 32768
+
+        # Enough data to run for >5min to see some kind of steady state
+        target_runtime = 300
+        write_bytes = produce_byte_rate * target_runtime
+
+        msg_count = write_bytes // msg_size
+
+        # The producer should achieve throughput within this factor of what we asked for:
+        # if this is violated then it is something wrong with the client or test environment.
+        throughput_tolerance_factor = 2
+
+        expect_duration = (write_bytes //
+                           produce_byte_rate) * throughput_tolerance_factor
+
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=msg_size,
+                                       msg_count=msg_count,
+                                       batch_max_bytes=512 * 1024,
+                                       rate_limit_bps=produce_byte_rate)
+
+        self.logger.info(f"Producing {msg_count} msgs ({write_bytes} bytes)")
+        t1 = time.time()
+        producer.start()
+        producer.wait(timeout_sec=expect_duration)
+        produce_duration = time.time() - t1
+        actual_byte_rate = (write_bytes / produce_duration)
+        mbps = int(actual_byte_rate / (1024 * 1024))
+        self.logger.info(
+            f"Produced {write_bytes} in {produce_duration}s, {mbps}MiB/s")
+
+        # Producer should be within a factor of two of the intended byte rate, or something
+        # is wrong with the test (running on nodes that can't keep up?) or with Redpanda
+        # (some instability interrupted produce?)
+        assert actual_byte_rate > produce_byte_rate / throughput_tolerance_factor
+        # Check the workload is respecting rate limit
+        assert actual_byte_rate < produce_byte_rate * throughput_tolerance_factor
+
+        # Read the highest timestamp in local storage
+        partition_describe = next(rpk.describe_topic(self.topic,
+                                                     tolerant=True))
+        hwm = partition_describe.high_watermark
+        assert hwm >= msg_count
+        consume_out = rpk.consume(topic=self.topic,
+                                  n=1,
+                                  offset=hwm - 1,
+                                  partition=0,
+                                  format="%d\\n")
+        local_ts = int(consume_out.strip())
+        self.logger.info(f"Max local ts = {local_ts}")
+
+        # Measure how far behind the tiered storage uploads are: success condition
+        # should be that they are within some time range of the most recently
+        # produced data
+        bucket = BucketView(self.redpanda)
+        manifest = bucket.manifest_for_ntp(self.topic, 0)
+        uploaded_ts = list(manifest['segments'].values())[-1]['max_timestamp']
+        self.logger.info(f"Max uploaded ts = {uploaded_ts}")
+
+        lag_seconds = (local_ts - uploaded_ts) / 1000.0
+        self.logger.info(f"Upload lag: {lag_seconds}s")
+        assert lag_seconds < (self.manifest_upload_interval +
+                              (self.log_segment_size / actual_byte_rate))
+
+        # Wait for all uploads to complete: this should take roughly segment_max_upload_interval_sec
+        # plus manifest_max_upload_interval_sec
+        def all_uploads_done():
+            bucket.reset()
+            manifest = bucket.manifest_for_ntp(self.topic, 0)
+            top_segment = list(manifest['segments'].values())[-1]
+            uploaded_ts = top_segment['max_timestamp']
+            self.logger.info(f"Remote ts {uploaded_ts}, local ts {local_ts}")
+            uploaded_raft_offset = top_segment['committed_offset']
+            uploaded_kafka_offset = uploaded_raft_offset - top_segment[
+                'delta_offset_end']
+            self.logger.info(
+                f"Remote HWM {uploaded_kafka_offset} (raft {uploaded_raft_offset}), local hwm {hwm}"
+            )
+
+            # -1 because uploaded offset is inclusive, hwm is exclusive
+            return uploaded_kafka_offset >= (hwm - 1)
+
+        self.redpanda.wait_until(all_uploads_done,
+                                 timeout_sec=self.manifest_upload_interval +
+                                 self.segment_upload_interval,
+                                 backoff_sec=5)
+
+        # Check manifest upload metrics:
+        #  - we should not have uploaded the manifest more times
+        #    then there were manifest upload intervals in the runtime.
+        manifest_uploads = self.redpanda.metric_sum(
+            metric_name=
+            "redpanda_cloud_storage_partition_manifest_uploads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        segment_uploads = self.redpanda.metric_sum(
+            metric_name="redpanda_cloud_storage_segment_uploads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        self.logger.info(
+            f"Upload counts: {manifest_uploads} manifests, {segment_uploads} segments"
+        )
+        assert manifest_uploads > 0
+        assert segment_uploads > 0
+
+        # Check the kafka-raft offset delta: this is an indication of how
+        # many extra raft records we wrote for archival_metadata_stm.
+        #
+        # At the maximum, this should be:
+        # - 1 per segment (although could be as low as 1 for every four segments
+        #   due to ntp_archiver::_concurrency)
+        # - 1 per upload round (i.e. per 1-4 segments) for marking the manifest
+        #   clean.
+        # - 1 per raft term, for raft config batches written by new leaders
+        #
+        # This helps to assure us that ntp_archiver and archival_metadata_stm
+        # are doing an efficient job of keeping the state machine up to date.
+        manifest = bucket.manifest_for_ntp(self.topic, 0)
+        top_segment = list(manifest['segments'].values())[-1]
+        offset_delta = top_segment['delta_offset_end']
+        segment_count = len(manifest['segments'])
+        last_term = top_segment['segment_term']
+        self.logger.info(
+            f"Delta: {offset_delta}, Segments: {segment_count}, Last term {last_term}"
+        )
+        assert offset_delta <= (2 * segment_count + last_term)
+
+        # +3 because:
+        # - 1 empty upload at start
+        # - 1 extra upload from runtime % upload interval
+        # - 1 extra upload after the final interval_sec driven uploads
+        expect_manifest_uploads = (
+            (int(produce_duration) // self.manifest_upload_interval) + 3)
+
+        assert manifest_uploads <= expect_manifest_uploads

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -304,10 +304,17 @@ class SISettings:
                  cloud_storage_disable_tls: bool = True,
                  cloud_storage_segment_max_upload_interval_sec: Optional[
                      int] = None,
+                 cloud_storage_manifest_max_upload_interval_sec: Optional[
+                     int] = None,
                  cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
                      int] = None,
                  bypass_bucket_creation: bool = False,
-                 cloud_storage_housekeeping_interval_ms: Optional[int] = None):
+                 cloud_storage_housekeeping_interval_ms: Optional[int] = None,
+                 fast_uploads=False):
+        """
+        :param fast_uploads: if true, set low upload intervals to help tests run
+                             quickly when they wait for uploads to complete.
+        """
 
         self.cloud_storage_type = CloudStorageType.AUTO
         if hasattr(test_context, 'injected_args') \
@@ -362,10 +369,15 @@ class SISettings:
         self.cloud_storage_max_connections = cloud_storage_max_connections
         self.cloud_storage_disable_tls = cloud_storage_disable_tls
         self.cloud_storage_segment_max_upload_interval_sec = cloud_storage_segment_max_upload_interval_sec
+        self.cloud_storage_manifest_max_upload_interval_sec = cloud_storage_manifest_max_upload_interval_sec
         self.cloud_storage_readreplica_manifest_sync_timeout_ms = cloud_storage_readreplica_manifest_sync_timeout_ms
         self.endpoint_url = f'http://{self.cloud_storage_api_endpoint}:{self.cloud_storage_api_endpoint_port}'
         self.bypass_bucket_creation = bypass_bucket_creation
         self.cloud_storage_housekeeping_interval_ms = cloud_storage_housekeeping_interval_ms
+
+        if fast_uploads:
+            self.cloud_storage_segment_max_upload_interval_sec = 10
+            self.cloud_storage_manifest_max_upload_interval_sec = 1
 
     def load_context(self, logger, test_context):
         if self.cloud_storage_type == CloudStorageType.S3:
@@ -495,6 +507,9 @@ class SISettings:
         if self.cloud_storage_segment_max_upload_interval_sec:
             conf[
                 'cloud_storage_segment_max_upload_interval_sec'] = self.cloud_storage_segment_max_upload_interval_sec
+        if self.cloud_storage_manifest_max_upload_interval_sec:
+            conf[
+                'cloud_storage_manifest_max_upload_interval_sec'] = self.cloud_storage_manifest_max_upload_interval_sec
         if self.cloud_storage_housekeeping_interval_ms:
             conf[
                 'cloud_storage_housekeeping_interval_ms'] = self.cloud_storage_housekeeping_interval_ms

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -519,13 +519,13 @@ class ArchivalTest(RedpandaTest):
     def _verify_manifest(self, ntp, manifest, remote):
         """Check that all segments that present in manifest are available
         in remote storage"""
-        for key, meta in manifest['segments'].items():
+        for key, meta in manifest.get('segments', {}).items():
             segment_name = gen_segment_name_from_meta(meta, key=key)
             spath = f"{ntp.ns}/{ntp.topic}/{ntp.partition}_{ntp.revision}/{segment_name}"
             self.logger.info(f"validating manifest path {spath}")
             assert spath in remote
         ranges = [(int(m['base_offset']), int(m['committed_offset']))
-                  for m in manifest['segments'].values()]
+                  for m in manifest.get('segments', {}).values()]
         ranges = sorted(ranges, key=lambda x: x[0])
         last_offset = -1
         num_gaps = 0

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1423,10 +1423,9 @@ class ClusterConfigAzureSharedKey(RedpandaTest):
     ), )
 
     def __init__(self, test_context):
-        self.si_settings = SISettings(
-            test_context,
-            log_segment_size=self.segment_size,
-            cloud_storage_segment_max_upload_interval_sec=1)
+        self.si_settings = SISettings(test_context,
+                                      log_segment_size=self.segment_size,
+                                      fast_uploads=True)
         super().__init__(test_context,
                          log_level="trace",
                          si_settings=self.si_settings,

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -56,6 +56,7 @@ class EndToEndShadowIndexingBase(EndToEndTest):
             test_context,
             cloud_storage_max_connections=5,
             log_segment_size=self.segment_size,  # 1MB
+            fast_uploads=True,
         )
         self.s3_bucket_name = self.si_settings.cloud_storage_bucket
         self.si_settings.load_context(self.logger, test_context)
@@ -447,7 +448,8 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
                                  log_segment_size=self.segment_size,
                                  cloud_storage_cache_size=20 * 2**30,
                                  cloud_storage_enable_remote_read=False,
-                                 cloud_storage_enable_remote_write=False)
+                                 cloud_storage_enable_remote_write=False,
+                                 fast_uploads=True)
 
         super(ShadowIndexingWhileBusyTest,
               self).__init__(test_context=test_context,

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -55,7 +55,8 @@ class TestReadReplicaService(EndToEndTest):
                 cloud_storage_max_connections=5,
                 log_segment_size=TestReadReplicaService.log_segment_size,
                 cloud_storage_readreplica_manifest_sync_timeout_ms=500,
-                cloud_storage_segment_max_upload_interval_sec=5))
+                cloud_storage_segment_max_upload_interval_sec=5,
+                fast_uploads=True))
 
         # Read reaplica shouldn't have it's own bucket.
         # We're adding 'none' as a bucket name without creating

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -22,7 +22,8 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
         super().__init__(test_context)
         self.num_brokers = 3
         self.si_settings = SISettings(test_context,
-                                      cloud_storage_max_connections=5)
+                                      cloud_storage_max_connections=5,
+                                      fast_uploads=True)
         extra_rp_conf = dict(
             enable_leader_balancer=False,
             partition_autobalancing_mode="off",

--- a/tests/rptest/tests/storage_resources_test.py
+++ b/tests/rptest/tests/storage_resources_test.py
@@ -176,7 +176,7 @@ class StorageResourceRestartTest(RedpandaTest):
             rpk.consume(self.topic,
                         partition=p.id,
                         n=1,
-                        offset=p.high_watermark,
+                        offset=p.high_watermark - 1,
                         quiet=True)
 
     def _sum_metrics(self, metric_name):

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -190,7 +190,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
     def __init__(self, test_context):
         self.si_settings = SISettings(test_context,
-                                      log_segment_size=1024 * 1024)
+                                      log_segment_size=1024 * 1024,
+                                      fast_uploads=True)
         super().__init__(
             test_context=test_context,
             # Use all nodes as brokers: enables each test to set num_nodes

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -842,7 +842,7 @@ class TimeBasedRetention(BaseCase):
             data = self._s3.get_object_data(self._bucket, id)
             self.logger.info(f"patching manifest {id}, content: {data}")
             obj = json.loads(data)
-            segments = obj['segments']
+            segments = obj.get('segments', {})
             segment_attr = []
             for name_or_path, attrs in segments.items():
                 max_timestamp = attrs['max_timestamp']
@@ -1006,7 +1006,8 @@ class TopicRecoveryTest(RedpandaTest):
                                  cloud_storage_max_connections=5,
                                  cloud_storage_segment_max_upload_interval_sec=
                                  CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC,
-                                 log_segment_size=default_log_segment_size)
+                                 log_segment_size=default_log_segment_size,
+                                 fast_uploads=True)
 
         self.s3_bucket = si_settings.cloud_storage_bucket
 


### PR DESCRIPTION
### Adding the dirty flag to archival_metadata_stm 

This eliminates a class of issues where interruptions to leaders could result in segments being written to archival_metadata_stm without being reflected in the manifest uploaded to object storage.

There is an extra behavior change here, in that new partitions will now generate manifest uploads before uploading any segments, because a  newly constructed archival_metadata_stm is not considered clean until marked as such.  This avoids ambiguity over the state of a partition (is something wrong, or does it just have no data?) and should help read replica clusters avoid having to ignore so many 404 responses when trying to read manifests for topics that haven't had any data uploads yet.

The new `mark_clean_cmd::key` is upgrade-safe (no feature flag) because the `switch(key)` in apply() is not marked as exhaustive: if an old version node sees the new key, it will just ignore it.

### Changes to upload path

When possible, the manifest is now uploaded in parallel with segment uploads rather than sequentially in between rounds of segment uploads.  This enables higher throughput at peak.

There are now a few different ways the manifest gets uploaded, depending on whether the system is at high throughput, low throughput, or idle: the following explanation is also in a comment on maybe_upload_manifest()

#### 1. High throughput partition

If the stm is dirty while we are uploading segments, we may upload
the manifest concurrently with segment uploads, and mark_clean the stm
in the same batch as we add the uploaded segments to the stm, but the clean
offset is the offset _before_ this round of uploads.  The stm is left in a
dirty state, but that is okay: we will soon do more rounds of segment
uploads, and after manifest_upload_interval has elapsed, we will inline a
manifest upload in another round of segment uploads.

In those mode we do zero extra stm I/Os for the marking the manifest clean,
and zero sequential waits for manifest uploads between segment uploads.

#### 2. Low throughput partition

If the stm is clean while we are uploading segments, then we may
upload the manifest sequentially _after_ we are done with segment uploads.
The _projected_manifest_clean_at is set to the offset reflected in the
uploaded manifest, but we do not write a mark_clean to the stm yet, to
avoid generating an additional write to the raft log.  We are in a
"projected clean" state where we will not do more manifest uploads
ourselves, but if we crashed or did an unsafe leader transfer, then
on restart the stm would look dirty and the manifest would be re-uploaded.

In this mode we incur some sequential delay from uploading the manifest
sequentially with respect to segment uploads, but that is okay because
the upload loop is not saturated (that would hit case 1 above).  We only
rarely write extra mark_clean batches to the stm, in the case of a graceful
leadership transfer.

#### 3. Fallback

In cases where we have not run through a happy path (e.g. I/O errors,
unclean restarts, unclean leadership transfers), if the stm is dirty
then we will do an upload + mark_clean in the main upload loop, even
if we did not upload any segments.

## Backports Required

(In earlier releases this bug was hidden by another bug that caused redundant manifest uploads https://github.com/redpanda-data/redpanda/pull/8991)

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

### Improvements

* Tiered storage manifest uploads are now done less frequently on partitions experiencing high throughput.  The new cluster configuration property `cloud_storage_manifest_max_upload_interval_sec` controls how often a manifest will be uploaded (uploading a manifest makes stored data written to read replicas).  The default is 60 seconds.

### Bug Fixes

* A bug is fixed where tiered storage topics might delay uploading manifests when partition leadership changes shortly after segments are uploaded.
