### PR TITLE
.github: update PR template (add 23.1.x backport option, streamline template)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,24 @@
 <!--
-
 See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
 for more details and examples of what is expected in a PR body.
 
-Content in this top section is REQUIRED.
-
-Describe, in plain language, the motivation behind the change (bug fix,
-feature, improvement) in this PR and how the included commits address it.
+Content in this top section is REQUIRED. Describe, in plain language, the motivation
+behind the change (bug fix, feature, improvement) in this PR and how the included
+commits address it.
 
 Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
-
   Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...
 
 If this PR is a backport, link to the original with `Backport of PR`, e.g.
-
   Backport of PR #PR-NUMBER
-
 -->
 
 ## Backports Required
 
-<!--
-
-Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.
-
--->
+<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->
 
 - [ ] none - not a bug fix
+- [ ] none - this is a backport
 - [ ] none - issue does not exist in previous branches
 - [ ] none - papercut/not impactful enough to backport
 - [ ] v23.1.x
@@ -58,29 +50,28 @@ visible changes.
 ## Release Notes
 
 <!--
+If the changes in this PR do not need to be mentioned in the release
+notes, then don't add a sub-section and simply list `none`, e.g.
 
-Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
+* none
+
+Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
 If this is a backport PR, adding contents to this section will override
 the release notes section inherited from the original PR to dev.
 
 Add one or more of the sub-sections with a short description bullet
 point of the change, e.g.
 
-  ### Bug Fixes
+### Bug Fixes
 
-  * Short description of the bug fix if this is a PR to `dev` branch.
+* Short description of the bug fix if this is a PR to `dev` branch.
 
-  ### Features
+### Features
 
-  * Short description of the feature. Explain how to configure.
+* Short description of the feature. Explain how to configure.
 
-  ### Improvements
+### Improvements
 
-  * Short description of how this PR improves existing behavior.
-
-If the changes in this PR do not need to be mentioned in the release
-notes, then don't add a sub-section and simply list `none`, e.g.
-
-  * none
+* Short description of how this PR improves existing behavior.
 
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,9 +29,9 @@ Checking at least one of the checkboxes is REQUIRED if this PR is not a backport
 - [ ] none - not a bug fix
 - [ ] none - issue does not exist in previous branches
 - [ ] none - papercut/not impactful enough to backport
+- [ ] v23.1.x
 - [ ] v22.3.x
 - [ ] v22.2.x
-- [ ] v22.1.x
 
 ## Ecosystem
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,28 +25,6 @@ If this PR is a backport, link to the original with `Backport of PR`, e.g.
 - [ ] v22.3.x
 - [ ] v22.2.x
 
-## Ecosystem
-
-<!--
-
-Content in this section is OPTIONAL.
-
-Describe, in plain language, how this PR affects an end-user. Explain
-topic flags, configuration flags, command line flags, deprecation
-policies, etc. that are added or modified. Don't ship user breaking
-changes. Ask the @redpanda-data/product team if you need help with user
-visible changes.
-
--->
-
-- [ ] needs ansible update
-- [ ] needs terraform update
-- [ ] needs rpk update
-- [ ] needs redpanda console updates
-- [ ] needs cloud team sync / control plane
-- [ ] needs helm chart update
-- [ ] needs k8s operator update
-
 ## Release Notes
 
 <!--


### PR DESCRIPTION

- Remove spurious whitespace, so that one doesn't have to
      scroll around so much in the PR description box when filling
      this out
- De-indent the examples in the Release Notes section, so that
      one does not have to de-intent them by hand when upening a PR
- Add a backport box for "none - this is a backport" for use when
      opening backport PRs.
- .github: add 23.1.x and remove 21.1.x to PR template


## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

None

## Release Notes

* none
