### PR TITLE
tests: don't set {assert} logs on shutdown

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1962,8 +1962,8 @@ class RedpandaService(Service):
         For debugging issues around stopping processes: set the log level to
         trace on all loggers.
         """
-        # These tend to be exceptionally chatty.
-        keep_existing = ['exception', 'io', 'seastar_memory']
+        # These tend to be exceptionally chatty, or don't provide much value.
+        keep_existing = ['exception', 'io', 'seastar_memory', 'assert']
         try:
             loggers = self._admin.get_loggers(node)
             for logger in loggers:

--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -23,7 +23,7 @@ class LogLevelTest(RedpandaTest):
         # it will start.
         super().__init__(*args, log_level=self.initial_log_level, **kwargs)
 
-    @cluster(num_nodes=3, log_allow_list=["admin_server.cc.*assert"])
+    @cluster(num_nodes=3)
     def test_get_loggers(self):
         admin = Admin(self.redpanda)
         node = self.redpanda.nodes[0]
@@ -35,6 +35,10 @@ class LogLevelTest(RedpandaTest):
 
         # Any logger we get we should be able to set.
         for logger in loggers:
+            # Skip to avoid bad log lines.
+            if logger == "assert":
+                continue
+
             with self.redpanda.monitor_log(node) as mon:
                 admin.set_log_level(logger, "info")
                 mon.wait_until(f"Set log level for {{{logger}}}: .* -> info",


### PR DESCRIPTION
The {assert} logger space is used for vassert() calls and only logs ERRORs. It's not useful to set it to TRACE, and can result in alarming misdiagnoses as node crashes.

I considered adding a allowed log check for when we use the admin server to set {assert} logs, but this seems like a nicer approach in that it avoids the "bad" logs lines altogether.

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Ecosystem

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

- [ ] needs ansible update
- [ ] needs terraform update
- [ ] needs rpk update
- [ ] needs redpanda console updates
- [ ] needs cloud team sync / control plane
- [ ] needs helm chart update
- [ ] needs k8s operator update

## Release Notes

* none
<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

  * none

-->
