### PR TITLE
tests: skip all cloud storage deletion in debug mode

### DIFF
--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -231,6 +231,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             self.si_settings.cloud_storage_bucket, topic=topic_name)
         assert sum(1 for _ in objects) > 0
 
+    @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=3)
     def topic_delete_installed_snapshots_test(self):
         """
@@ -356,6 +357,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         return empty
 
+    @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=3)
     @matrix(disable_delete=[False, True],
             cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
@@ -408,6 +410,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # catch the case where there are segments in S3 not reflected in the
         # manifest.
 
+    @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=4)
     @parametrize(cloud_storage_type=CloudStorageType.ABS)
     @parametrize(cloud_storage_type=CloudStorageType.S3)


### PR DESCRIPTION
All these tests rely on leadership transfers being done gracefully to avoid orphan objects, which is not reliable in debug mode.

This is a more complete followup to
4f9bc2dac2e6910b163ebb470b8f6a4a13899fad

Fixes https://github.com/redpanda-data/redpanda/issues/8496

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

* none
