### PR TITLE
[v22.3.x] Backport #8703 (tests: make test_retention_with_node_failures more robust )

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -137,7 +137,7 @@ function install_kcl() {
 function install_kgo_verifier() {
   git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
   cd /opt/kgo-verifier
-  git reset --hard a2b3ae780b0dc0bc1b4cf2aa33a9d43d10578b0b
+  git reset --hard 358e8dd99247d68a8f1c77ceb0f91f20c757bc64
   go mod tidy
   make
 }

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -568,7 +568,8 @@ class KgoVerifierProducer(KgoVerifierService):
                  fake_timestamp_ms=None,
                  use_transactions=False,
                  transaction_abort_rate=None,
-                 msgs_per_transaction=None):
+                 msgs_per_transaction=None,
+                 rate_limit_bps=None):
         super(KgoVerifierProducer,
               self).__init__(context, redpanda, topic, msg_size, custom_node,
                              debug_logs, trace_logs)
@@ -579,6 +580,7 @@ class KgoVerifierProducer(KgoVerifierService):
         self._use_transactions = use_transactions
         self._transaction_abort_rate = transaction_abort_rate
         self._msgs_per_transaction = msgs_per_transaction
+        self._rate_limit_bps = rate_limit_bps
 
     @property
     def produce_status(self):
@@ -636,6 +638,9 @@ class KgoVerifierProducer(KgoVerifierService):
 
             if self._transaction_abort_rate is not None:
                 cmd = cmd + f' --transaction-abort-rate {self._transaction_abort_rate}'
+
+        if self._rate_limit_bps is not None:
+            cmd = cmd + f' --produce-throughput-bps {self._rate_limit_bps}'
 
         self.spawn(cmd, node)
 

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -7,17 +7,21 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
+from ducktape.mark import matrix, parametrize
+from ducktape.errors import TimeoutError
+
 from rptest.services.cluster import cluster
 from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
-from rptest.services.redpanda import SISettings, MetricsEndpoint
+from rptest.services.redpanda import SISettings, MetricsEndpoint, CHAOS_LOG_ALLOW_LIST
 from rptest.services.kgo_verifier_services import (
     KgoVerifierConsumerGroupConsumer, KgoVerifierProducer)
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.utils.si_utils import S3Snapshot
+from rptest.services.action_injector import ActionConfig, random_process_kills
 
 
 class CloudRetentionTest(PreallocNodesTest):
@@ -255,3 +259,83 @@ class CloudRetentionTest(PreallocNodesTest):
                                        custom_node=self.preallocated_nodes)
         producer.start(clean=False)
         producer.wait()
+
+
+class CloudRetentionTimelyGCTest(RedpandaTest):
+    segment_size = 256 * 1024
+    retention_bytes = 10 * segment_size
+
+    topics = (TopicSpec(name="panda-topic",
+                        partition_count=1,
+                        replication_factor=3,
+                        retention_bytes=retention_bytes,
+                        segment_bytes=segment_size), )
+
+    def __init__(self, test_context):
+        si_settings = SISettings(log_segment_size=self.segment_size)
+        self.s3_bucket_name = si_settings.cloud_storage_bucket
+        super().__init__(
+            test_context,
+            si_settings=si_settings,
+            extra_rp_conf={'cloud_storage_housekeeping_interval_ms': 1000 * 2})
+
+    @cluster(num_nodes=4, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @skip_debug_mode
+    def test_retention_with_node_failures(self):
+        max_overshoot_percentage = 100
+        runtime = 120
+
+        # Write fast enough that in the test's runtime, we would certainly
+        # overshoot the retention size substantially if retention wasn't working.
+        write_rate = (self.retention_bytes * 4.0) / runtime
+
+        # Write enough data to last the runtime.
+        msg_size = 128
+        msg_count = write_rate * runtime // msg_size
+
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_count=msg_count,
+                                       msg_size=msg_size,
+                                       rate_limit_bps=write_rate)
+        producer.start()
+
+        def cloud_log_size() -> int:
+            s3_snapshot = S3Snapshot(self.topics, self.redpanda.s3_client,
+                                     self.s3_bucket_name, self.logger)
+            if not s3_snapshot.is_ntp_in_manifest(self.topic, 0):
+                self.logger.debug(f"No manifest present yet")
+                return 0
+
+            cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(self.topic, 0)
+            ratio = cloud_log_size / self.retention_bytes
+            overshoot_percentage = max(ratio - 1, 0) * 100
+
+            self.logger.debug(f"Current cloud log size is: {cloud_log_size}")
+            self.logger.debug(f"Overshot by {overshoot_percentage}%")
+
+            if overshoot_percentage > max_overshoot_percentage:
+                raise RuntimeError(
+                    f"Cloud log size {overshoot_percentage}% greater than configured"
+                    f" retention (max allowed {max_overshoot_percentage}%)")
+
+            return cloud_log_size
+
+        pkill_config = ActionConfig(cluster_start_lead_time_sec=10,
+                                    min_time_between_actions_sec=10,
+                                    max_time_between_actions_sec=20)
+        with random_process_kills(self.redpanda, pkill_config) as ctx:
+            try:
+                wait_until(lambda: cloud_log_size() == -1,
+                           timeout_sec=runtime,
+                           backoff_sec=5)
+            except TimeoutError as e:
+                # This is the success path. Timing out means that
+                # we've stayed below the max cloud log size threshold
+                # for the duration of the test.
+                pass
+            finally:
+                producer.stop()
+
+        ctx.assert_actions_triggered()

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -10,7 +10,7 @@ import random
 import time
 
 from ducktape.errors import TimeoutError
-from ducktape.mark import ok_to_fail, parametrize
+from ducktape.mark import parametrize
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
@@ -235,69 +235,6 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
 
             self.start_consumer()
             self.run_validation(consumer_timeout_sec=90)
-        ctx.assert_actions_triggered()
-
-
-class EndToEndCloudRetentionTest(EndToEndShadowIndexingBase):
-    segment_size = EndToEndShadowIndexingBase.segment_size // 4
-    retention_bytes = 10 * segment_size
-    topics = (TopicSpec(name=EndToEndShadowIndexingBase.s3_topic_name,
-                        partition_count=1,
-                        replication_factor=3,
-                        retention_bytes=retention_bytes,
-                        segment_bytes=segment_size), )
-
-    def __init__(self, test_context):
-        super().__init__(test_context,
-                         extra_rp_conf={
-                             'default_topic_replications': self.num_brokers,
-                             'cloud_storage_housekeeping_interval_ms': 1000 * 2
-                         })
-
-    @cluster(num_nodes=4, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    @skip_debug_mode
-    def test_retention_with_node_failures(self):
-        max_overshoot_percentage = 100
-
-        self.start_producer(throughput=10000)
-
-        def cloud_log_size() -> int:
-            s3_snapshot = S3Snapshot(self.topics, self.redpanda.s3_client,
-                                     self.s3_bucket_name, self.logger)
-            if not s3_snapshot.is_ntp_in_manifest(self.topic, 0):
-                self.logger.debug(f"No manifest present yet")
-                return 0
-
-            cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(self.topic, 0)
-            ratio = cloud_log_size / self.retention_bytes
-            overshoot_percentage = max(ratio - 1, 0) * 100
-
-            self.logger.debug(f"Current cloud log size is: {cloud_log_size}")
-            self.logger.debug(f"Overshot by {overshoot_percentage}%")
-
-            if overshoot_percentage > max_overshoot_percentage:
-                raise RuntimeError(
-                    f"Cloud log size {overshoot_percentage}% greater than configured"
-                    f" retention (max allowed {max_overshoot_percentage}%)")
-
-            return cloud_log_size
-
-        pkill_config = ActionConfig(cluster_start_lead_time_sec=10,
-                                    min_time_between_actions_sec=10,
-                                    max_time_between_actions_sec=20)
-        with random_process_kills(self.redpanda, pkill_config) as ctx:
-            try:
-                wait_until(lambda: cloud_log_size() == -1,
-                           timeout_sec=120,
-                           backoff_sec=5)
-            except TimeoutError as e:
-                # This is the success path. Timing out means that
-                # we've stayed below the max cloud log size threshold
-                # for the duration of the test.
-                pass
-            finally:
-                self.producer.stop()
-
         ctx.assert_actions_triggered()
 
 

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -418,7 +418,7 @@ class S3Snapshot:
                                ns: str = 'kafka') -> dict:
         manifest = self.manifest_for_ntp(topic, partition, ns)
         return sum(seg_meta['size_bytes']
-                   for seg_meta in manifest['segments'].values())
+                   for seg_meta in manifest.get('segments', {}).values())
 
     def assert_at_least_n_uploaded_segments_compacted(self,
                                                       topic: str,


### PR DESCRIPTION

Backport of PR #8703

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes

* none
