### PR TITLE
Add retries for get_partitions in timeout case

### DIFF
--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -104,7 +104,10 @@ class PartitionMovementMixin():
         return result
 
     def _wait_post_move(self, topic, partition, assignments, timeout_sec):
-        admin = Admin(self.redpanda)
+        # We need to add retries, becasue of eventual consistency. Metadata will be updated but it can take some time.
+        admin = Admin(self.redpanda,
+                      retry_codes=[404, 503, 504],
+                      retries_amount=10)
 
         def status_done():
             results = []


### PR DESCRIPTION
Add retries for timeout codes to admin_api.
Problem is related with metadata eventual consistency the test code should retry in this case.

Fixes #8659

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [ ] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Ecosystem


## Release Notes

* none
