### PR TITLE
Remove a catch of std::bad_alloc from chunk cache

### DIFF
--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -93,13 +93,9 @@ private:
             return c;
         }
         if (_size_total < _size_limit) {
-            try {
-                auto c = ss::make_lw_shared<chunk>(_chunk_size, alignment);
-                _size_total += _chunk_size;
-                return c;
-            } catch (const std::bad_alloc& e) {
-                vlog(stlog.debug, "chunk allocation failed: {}", e);
-            }
+            auto c = ss::make_lw_shared<chunk>(_chunk_size, alignment);
+            _size_total += _chunk_size;
+            return c;
         }
         return nullptr;
     }


### PR DESCRIPTION
Simplifies the code and avoids confusion about how this class will behave under memory exhaustion given that we generally abort on exhaustion as of 23.1 anyway.

Issue redpanda-data/core-internal#99.



## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
