### PR TITLE
metrics: ensure consistent histogram upper bounds

### DIFF
--- a/src/v/utils/hdr_hist.h
+++ b/src/v/utils/hdr_hist.h
@@ -111,7 +111,8 @@ public:
       int64_t min = 1,
       int32_t significant_figures = 1)
       : _hist(hist_internal::make_unique_hdr_histogram(
-        max_value, min, significant_figures)) {}
+        max_value, min, significant_figures))
+      , _first_discernible_value(min) {}
     hdr_hist(
       std::chrono::microseconds max_value, std::chrono::microseconds min_value)
       : hdr_hist(max_value.count(), min_value.count()) {}
@@ -161,6 +162,7 @@ private:
     hist_internal::hdr_histogram_ptr _hist;
     uint64_t _sample_count{0};
     uint64_t _sample_sum{0};
+    int64_t _first_discernible_value{1};
 
     friend std::ostream& operator<<(std::ostream& o, const hdr_hist& h);
 };

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ rp_test(
     delta_for_test.cc
     token_bucket_test.cc
     uuid_test.cc
+    seastar_histogram_test.cc
   LIBRARIES v::seastar_testing_main v::utils v::bytes absl::flat_hash_set
   ARGS "-- -c 1"
   LABELS utils

--- a/src/v/utils/tests/seastar_histogram_test.cc
+++ b/src/v/utils/tests/seastar_histogram_test.cc
@@ -1,0 +1,22 @@
+#include "utils/hdr_hist.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+SEASTAR_THREAD_TEST_CASE(test_seastar_histograms_match) {
+    using namespace std::chrono_literals;
+
+    hdr_hist a{120s, 1ms};
+    hdr_hist b{120s, 1ms};
+
+    std::chrono::microseconds one_hundred_secs = 100s;
+    a.record(one_hundred_secs.count());
+
+    const auto logform_a = a.seastar_histogram_logform();
+    const auto logform_b = b.seastar_histogram_logform();
+
+    for (size_t idx = 0; idx < logform_a.buckets.size(); ++idx) {
+        BOOST_CHECK_EQUAL(
+          logform_a.buckets[idx].upper_bound,
+          logform_b.buckets[idx].upper_bound);
+    }
+}


### PR DESCRIPTION
Note for reviewer: This stuff is fairly hairy, so if you want to talk about it, I'd be more than happy to.

In order to publish histogram metrics, we convert from our internal HDR histogram representation, to Seastar's histogram type. Seastar expects the histograms of a given metric to always have the same number of buckets, with idential upper bounds.

If that's not the case, it will throw whilst handling the request to fetch metrics. The visible behaviour for this is different depending on the Redpanda version where the issue occurs. For v22.2.x, the connection for the metrics request will be killed, and, therefore the metrics are truncated. For later versions, Redpanda crashes as the exception happens on a noexcept code-path. We've only seen this happen for the `vectorized_internal_rpc_latency` metric as it uses a [funky histogram configuration](https://github.com/redpanda-data/redpanda/blob/dev/src/v/rpc/types.h#L414).

This commit ensures that the upper bounds of Seastar histograms generated from the same HDR histogram are always the same. Previously, the we used `hdr_iter_log_init.iterated_to` as the upper bound for the bucket. However, (due to a bug?) the C HDR histogram implementation, does not update this field under certain condititions. To fix this, we keep track of the value we've iterated to outside of the library's iterator.

I noticed a couple other issues with the conversion logic and they're also fixed by this commit:
* We used the `hdr_iter_log_init.iterated_to` for the upper bound of the Seastar histogram bucket. Internally, HDR histogram uses a representation similar to floating point numbers, which means that it can't actually represent every value in the range, and it treats spans(buckets) of values as equivalent. Therefore, the upper bound we reported was not correct. This has been fixed by reporting the highest equivalent value instead.
* The smallest discernible value is a configurable knob of HDR histogram. When that's set, it doesn't make sense to iterate over the histogram from values smaller than that. We did previously, but it's been fixed by taking the maximum between the requested start value and the configured minimum discernible value.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [X] v22.3.x
- [X] v22.2.x

## Release Notes
### Bug Fixes
* Fix rare histogram metric reporting bug which could lead to Redpanda crashing or terminating
the HTTP connection on which it was serving the metric request. This only occurred when metrics
aggregation was enabled.

