### PR TITLE
cluster: report logical versions in metrics_reporter

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -460,6 +460,7 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_tp_state),
             std::ref(_hm_frontend),
             std::ref(_config_frontend),
+            std::ref(_feature_table),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -16,6 +16,7 @@
 #include "cluster/members_table.h"
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
+#include "features/fwd.h"
 #include "http/client.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
@@ -56,6 +57,7 @@ public:
         uint32_t cpu_count;
         bool is_alive;
         ss::sstring version;
+        cluster_version logical_version{invalid_version};
         std::vector<node_disk_space> disks;
         uint64_t uptime_ms;
     };
@@ -68,6 +70,9 @@ public:
         uint32_t topic_count;
         uint32_t partition_count;
 
+        cluster_version active_logical_version{invalid_version};
+        cluster_version original_logical_version{invalid_version};
+
         std::vector<node_metrics> nodes;
         bool has_kafka_gssapi;
     };
@@ -79,6 +84,7 @@ public:
       ss::sharded<topic_table>&,
       ss::sharded<health_monitor_frontend>&,
       ss::sharded<config_frontend>&,
+      ss::sharded<features::feature_table>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<> start();
@@ -100,6 +106,7 @@ private:
     ss::sharded<topic_table>& _topics;
     ss::sharded<health_monitor_frontend>& _health_monitor;
     ss::sharded<config_frontend>& _config_frontend;
+    ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<ss::abort_source>& _as;
     model::timestamp _creation_timestamp;
     prefix_logger _logger;


### PR DESCRIPTION
This is useful for knowing the "logical age" of a cluster to understand how much of the deployed footprint is newer clusters vs. clusters that have lived through upgrades.

Reporting the per-node logical version also enables detecting mid-upgrade systems (or detecting systems which have been incorrectly left in a mixed-version state)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

