### PR TITLE
config: add "legacy defaults" capability and decrease partitions per shard default

### DIFF
--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -14,6 +14,7 @@
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "seastarx.h"
+#include "utils/named_type.h"
 
 #include <seastar/util/bool_class.hh>
 
@@ -55,6 +56,10 @@ enum class odd_even_constraint {
     even,
     odd,
 };
+
+// This is equivalent to cluster::cluster_version, but defined here to
+// avoid a dependency between config/ and cluster/
+using legacy_version = named_type<int64_t, struct legacy_version_tag>;
 
 std::string_view to_string_view(visibility v);
 
@@ -125,6 +130,12 @@ public:
     virtual std::optional<validation_error> validate(YAML::Node) const = 0;
     virtual base_property& operator=(const base_property&) = 0;
     virtual ~base_property() noexcept = default;
+
+    /**
+     * Notify the property of the cluster's original logical version, in case
+     * it has alternative defaults for old clusters.
+     */
+    virtual void notify_original_version(legacy_version) = 0;
 
 private:
     friend std::ostream& operator<<(std::ostream&, const base_property&);

--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -120,7 +120,8 @@ public:
       std::string_view desc,
       base_property::metadata meta,
       T def,
-      numeric_bounds<I> bounds)
+      numeric_bounds<I> bounds,
+      std::optional<legacy_default<T>> legacy = std::nullopt)
       : property<T>(
         conf,
         name,
@@ -141,7 +142,8 @@ public:
             } else {
                 return _bounds.validate(new_value);
             }
-        })
+        },
+        legacy)
       , _bounds(bounds)
       , _example(generate_example()) {}
 

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -153,6 +153,12 @@ public:
         return o;
     }
 
+    void notify_original_version(legacy_version ov) {
+        for (const auto& [name, property] : _properties) {
+            property->notify_original_version(ov);
+        }
+    }
+
     virtual ~config_store() noexcept = default;
 
 private:

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -188,7 +188,7 @@ configuration::configuration()
       "Maximum number of partitions which may be allocated to one shard (CPU "
       "core)",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      7000,
+      1000,
       {
         .min = 16,    // Forbid absurdly small values that would prevent most
                       // practical workloads from running
@@ -196,7 +196,8 @@ configuration::configuration()
                       // systems will most likely hit issues far before reaching
                       // this.  This property is principally intended to be
                       // tuned downward from the default, not upward.
-      })
+      },
+      legacy_default<uint32_t>(7000, legacy_version{9}))
   , topic_partitions_reserve_shard0(
       *this,
       "topic_partitions_reserve_shard0",

--- a/src/v/features/CMakeLists.txt
+++ b/src/v/features/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
   DEPS
     Seastar::seastar
     v::model
+    v::config
   )
 
 add_dependencies(v_features kafka_codegen_headers)

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -242,7 +242,7 @@ void feature_table::set_active_version(
       && _original_version == invalid_version) {
         // Rely on controller log replay to call us first with
         // the first version the cluster ever agreed upon.
-        _original_version = v;
+        set_original_version(v);
     }
 
     for (auto& fs : _feature_state) {
@@ -296,7 +296,7 @@ void feature_table::bootstrap_original_version(cluster_version v) {
           v);
     }
 
-    _original_version = v;
+    set_original_version(v);
 
     // No on_update() call needed: bootstrap version is only advisory and
     // does not drive the feature state machines.
@@ -518,6 +518,14 @@ feature_table::decode_version_fence(model::record_batch batch) {
           key));
     }
     return serde::from_iobuf<version_fence>(rec.release_value());
+}
+
+void feature_table::set_original_version(cluster::cluster_version v) {
+    _original_version = v;
+    if (v != cluster::invalid_version) {
+        config::shard_local_cfg().notify_original_version(
+          config::legacy_version{v});
+    }
 }
 
 } // namespace features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -443,9 +443,7 @@ private:
 
     // The controller log offset of last batch applied to this state machine
     void set_applied_offset(model::offset o) { _applied_offset = o; }
-    void set_original_version(cluster::cluster_version v) {
-        _original_version = v;
-    }
+    void set_original_version(cluster::cluster_version v);
 
     void on_update();
 

--- a/tests/rptest/tests/resource_limits_test.py
+++ b/tests/rptest/tests/resource_limits_test.py
@@ -88,16 +88,18 @@ class ResourceLimitsTest(RedpandaTest):
 
         rpk = RpkTool(self.redpanda)
 
-        # Three nodes, each with 1 core, 7000 partition-replicas
-        # per core, so with replicas=3, 7000 partitions should be the limit
+        # Three nodes, each with 1 core, 1000 partition-replicas
+        # per core, so with replicas=3, 1000 partitions should be the limit
         try:
-            rpk.create_topic("toobig", partitions=8000, replicas=3)
+            rpk.create_topic("toobig", partitions=1500, replicas=3)
         except RpkException as e:
             assert 'INVALID_PARTITIONS' in e.msg
         else:
             assert False
 
-        rpk.create_topic("okay", partitions=6000, replicas=3)
+        # This is not exactly 1000 because of system partitions consuming
+        # some of hte allowance.
+        rpk.create_topic("okay", partitions=900, replicas=3)
 
     @cluster(num_nodes=3)
     def test_fd_limited(self):


### PR DESCRIPTION
Historically it has been tough to change certain config defaults because it may be unsafe to e.g. decrease a limit if there are systems in the wild that are already beyond the new limit.

This PR adds a new mechanism where early in startup, the feature table notifies the configuration object of the original logical version, and the configuration properties may override their `_default` based on that version.

That mechanism is then used to reduce the partitions per shard default to 1000.  This change is important because the current limits are unsafe, both for raw partition count issues, and also for the default limits on tiered storage reader limits, which are driven by the max partition count.

The main limitation to the mechanism used here is that it will only help with configs that are read _after_ cluster bootstrap happens, or in the case of a node joining a cluster, after the new node sees initial controller log messages.  This is suitable for the particular config being handled in this PR, but it is important that any future uses of the mechanism bear this in mind (there is a boldface comment by the definition of `legacy_version` struct)

Fixes https://github.com/redpanda-data/redpanda/issues/9179

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Newly created Redpanda clusters will apply a limit of 1000 partitions per shard (cluster configuration property `topic_partitions_per_shard`) by default.  Legacy clusters will continue to use the legacy limit (7000), although it is recommended to modify configuration on legacy clusters to use a lower limit, to avoid risk of instability if excessive partitions are created.