### PR TITLE
tests: improvements to SI utils

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -751,7 +751,7 @@ class Admin:
         """
         Start maintenanceing on 'node', sending the request to 'dst_node'.
         """
-        id = self.redpanda.idx(node)
+        id = self.redpanda.node_id(node)
         url = f"brokers/{id}/maintenance"
         self.redpanda.logger.info(
             f"Starting maintenance on node {node.name}/{id}")
@@ -761,7 +761,7 @@ class Admin:
         """
         Stop maintenanceing on 'node', sending the request to 'dst_node'.
         """
-        id = self.redpanda.idx(node)
+        id = self.redpanda.node_id(node)
         url = f"brokers/{id}/maintenance"
         self.redpanda.logger.info(
             f"Stopping maintenance on node {node.name}/{id}")
@@ -771,7 +771,7 @@ class Admin:
         """
         Get maintenance status of a node.
         """
-        id = self.redpanda.idx(node)
+        id = self.redpanda.node_id(node)
         self.redpanda.logger.info(
             f"Getting maintenance status on node {node.name}/{id}")
         return self._request("get", "maintenance", node=node).json()
@@ -780,7 +780,7 @@ class Admin:
         """
         Reset info for leaders on node
         """
-        id = self.redpanda.idx(node)
+        id = self.redpanda.node_id(node)
         self.redpanda.logger.info(f"Reset leaders info on {node.name}/{id}")
         url = "debug/reset_leaders"
         return self._request("post", url, node=node)
@@ -789,7 +789,7 @@ class Admin:
         """
         Get info for leaders on node
         """
-        id = self.redpanda.idx(node)
+        id = self.redpanda.node_id(node)
         self.redpanda.logger.info(f"Get leaders info on {node.name}/{id}")
         url = "debug/partition_leaders_table"
         return self._request("get", url, node=node).json()

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -785,12 +785,16 @@ class Admin:
         url = "debug/reset_leaders"
         return self._request("post", url, node=node)
 
-    def get_leaders_info(self, node):
+    def get_leaders_info(self, node=None):
         """
         Get info for leaders on node
         """
-        id = self.redpanda.node_id(node)
-        self.redpanda.logger.info(f"Get leaders info on {node.name}/{id}")
+        if node:
+            id = self.redpanda.node_id(node)
+            self.redpanda.logger.info(f"Get leaders info on {node.name}/{id}")
+        else:
+            self.redpanda.logger.info(f"Get leaders info on any node")
+
         url = "debug/partition_leaders_table"
         return self._request("get", url, node=node).json()
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -841,6 +841,10 @@ class RedpandaService(Service):
         self._extra_rp_conf = self._si_settings.update_rp_conf(
             self._extra_rp_conf)
 
+    @property
+    def si_settings(self):
+        return self._si_settings
+
     def add_extra_rp_conf(self, conf):
         self._extra_rp_conf = {**self._extra_rp_conf, **conf}
 

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -14,6 +14,7 @@ from rptest.services.redpanda import CloudStorageType, RedpandaService, SISettin
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.utils.si_utils import S3Snapshot
 from rptest.util import (
     segments_count,
     produce_until_segments,
@@ -145,25 +146,25 @@ class ArchivalTest(RedpandaTest):
                         replication_factor=3), )
 
     def __init__(self, test_context):
-        si_settings = SISettings(test_context,
-                                 cloud_storage_max_connections=5,
-                                 log_segment_size=self.log_segment_size)
-        self.s3_bucket_name = si_settings.cloud_storage_bucket
+        self.si_settings = SISettings(test_context,
+                                      cloud_storage_max_connections=5,
+                                      log_segment_size=self.log_segment_size)
+        self.s3_bucket_name = self.si_settings.cloud_storage_bucket
 
         extra_rp_conf = dict(
             log_compaction_interval_ms=self.log_compaction_interval_ms,
             log_segment_size=self.log_segment_size)
 
         if test_context.function_name == "test_timeboxed_uploads":
-            si_settings.log_segment_size = 1024 * 1024 * 1024
+            self.si_settings.log_segment_size = 1024 * 1024 * 1024
             extra_rp_conf.update(
                 cloud_storage_segment_max_upload_interval_sec=1)
 
         super(ArchivalTest, self).__init__(test_context=test_context,
                                            extra_rp_conf=extra_rp_conf,
-                                           si_settings=si_settings)
+                                           si_settings=self.si_settings)
 
-        self._s3_port = si_settings.cloud_storage_api_endpoint_port
+        self._s3_port = self.si_settings.cloud_storage_api_endpoint_port
 
         self.kafka_tools = KafkaCliTools(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
@@ -194,6 +195,7 @@ class ArchivalTest(RedpandaTest):
     @parametrize(cloud_storage_type=CloudStorageType.S3)
     def test_isolate(self, cloud_storage_type):
         """Verify that our isolate/rejoin facilities actually work"""
+
         with firewall_blocked(self.redpanda.nodes, self._s3_port):
             self.kafka_tools.produce(self.topic, 10000, 1024)
             time.sleep(10)  # can't busy wait here
@@ -201,16 +203,55 @@ class ArchivalTest(RedpandaTest):
             # Topic manifest can be present in the bucket because topic is created before
             # firewall is blocked. No segments or partition manifest should be present.
             topic_manifest_id = "d0000000/meta/kafka/panda-topic/topic_manifest.json"
-            objects = self.cloud_storage_client.list_objects(
-                self.s3_bucket_name)
-            keys = [x.key for x in objects]
 
-            assert len(keys) < 2, \
-                f"Bucket should be empty or contain only {topic_manifest_id}, but contains {keys}"
+            bucket_content = S3Snapshot(self.topics,
+                                        self.redpanda.cloud_storage_client,
+                                        self.s3_bucket_name,
+                                        self.redpanda.logger)
 
-            if len(keys) == 1:
-                assert topic_manifest_id == keys[0], \
-                    f"Bucket should be empty or contain only {topic_manifest_id}, but contains {keys[0]}"
+            # Any partition manifests must contain no segments
+            for ntp, manifest in bucket_content.partition_manifests.items():
+                assert not manifest.get(
+                    'segment', []), f"Segments found in a manifest {ntp}"
+
+            # No segments must have been uploaded
+            assert bucket_content.segment_objects == 0, "Data segments found"
+
+            # All objects must belong to the topic we created (make sure we aren't searching on the wrong topic)
+            if bucket_content.ignored_objects > 0:
+                raise RuntimeError(f"Unexpected objects in bucket")
+
+        # Firewall is unblocked, segment uploads should proceed
+        def data_uploaded():
+            bucket_content = S3Snapshot(self.topics,
+                                        self.redpanda.cloud_storage_client,
+                                        self.s3_bucket_name,
+                                        self.redpanda.logger)
+            has_segments = bucket_content.segment_objects > 0
+
+            if not has_segments:
+                self.logger.info(
+                    f"No segments yet, objects are: {bucket_content.objects}")
+                return False
+
+            has_segments_in_manifest = any(
+                len(m.get('segments', [])) > 0
+                for m in bucket_content.partition_manifests.values())
+            if not has_segments_in_manifest:
+                self.logger.info("No segments in any manifests yet")
+
+            if bucket_content.ignored_objects > 0:
+                # Our topic filter should have matched everything in the bucket.
+                self.logger.info(
+                    f"Ignored {bucket_content.ignored_objects} objects")
+
+            return has_segments and has_segments_in_manifest and not bucket_content.ignored_objects
+
+        self.redpanda.wait_until(
+            data_uploaded,
+            timeout_sec=90,
+            backoff_sec=5,
+            err_msg="Data not uploaded after firewall unblocked")
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
     @parametrize(cloud_storage_type=CloudStorageType.ABS)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -28,7 +28,7 @@ from rptest.services.redpanda import CloudStorageType, SISettings, RESTART_LOG_A
 from rptest.services.metrics_check import MetricCheck
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_http_error, expect_exception, produce_until_segments
-from rptest.utils.si_utils import S3Snapshot
+from rptest.utils.si_utils import BucketView
 
 BOOTSTRAP_CONFIG = {
     # A non-default value for checking bootstrap import works
@@ -1435,15 +1435,8 @@ class ClusterConfigAzureSharedKey(RedpandaTest):
         self.kafka_cli = KafkaCliTools(self.redpanda)
 
     def get_cloud_log_size(self):
-        s3_snapshot = S3Snapshot(self.topics,
-                                 self.redpanda.cloud_storage_client,
-                                 self.si_settings.cloud_storage_bucket,
-                                 self.logger)
-
-        if not s3_snapshot.is_ntp_in_manifest(self.topic, 0):
-            return 0
-        else:
-            return s3_snapshot.cloud_log_size_for_ntp(self.topic, 0)
+        s3_snapshot = BucketView(self.redpanda, topics=self.topics)
+        return s3_snapshot.cloud_log_size_for_ntp(self.topic, 0)
 
     def wait_for_cloud_uploads(self, initial_count: int, delta: int):
         def segment_uploaded():

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -29,7 +29,7 @@ from rptest.util import (
     produce_until_segments,
     wait_for_removal_of_n_segments,
 )
-from rptest.utils.si_utils import nodes_report_cloud_segments, S3Snapshot
+from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView
 from rptest.utils.mode_checks import skip_debug_mode
 
 
@@ -211,9 +211,7 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         self.start_consumer(verify_offsets=False)
         self.run_consumer_validation(enable_compaction=True)
 
-        s3_snapshot = S3Snapshot(self.topics,
-                                 self.redpanda.cloud_storage_client,
-                                 self.s3_bucket_name, self.logger)
+        s3_snapshot = BucketView(self.redpanda, topics=self.topics)
         s3_snapshot.assert_at_least_n_uploaded_segments_compacted(self.topic,
                                                                   partition=0,
                                                                   n=1)
@@ -247,9 +245,7 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         self.start_consumer(verify_offsets=False)
         self.run_consumer_validation(enable_compaction=True)
 
-        s3_snapshot = S3Snapshot(self.topics,
-                                 self.redpanda.cloud_storage_client,
-                                 self.s3_bucket_name, self.logger)
+        s3_snapshot = BucketView(self.redpanda, topics=self.topics)
         s3_snapshot.assert_at_least_n_uploaded_segments_compacted(self.topic,
                                                                   partition=0,
                                                                   n=1)
@@ -350,9 +346,7 @@ class ShadowIndexingInfiniteRetentionTest(EndToEndShadowIndexingBase):
 
         # Wait for there to be some segments.
         def manifest_has_segments():
-            s3_snapshot = S3Snapshot(self.topics,
-                                     self.redpanda.cloud_storage_client,
-                                     self.s3_bucket_name, self.logger)
+            s3_snapshot = BucketView(self.redpanda, topics=self.topics)
             manifest = s3_snapshot.manifest_for_ntp(self.infinite_topic_name,
                                                     0)
             return "segments" in manifest
@@ -361,9 +355,7 @@ class ShadowIndexingInfiniteRetentionTest(EndToEndShadowIndexingBase):
 
         # Give ample time for would-be segment deletions to occur.
         time.sleep(5)
-        s3_snapshot = S3Snapshot(self.topics,
-                                 self.redpanda.cloud_storage_client,
-                                 self.s3_bucket_name, self.logger)
+        s3_snapshot = BucketView(self.redpanda, topics=self.topics)
         manifest = s3_snapshot.manifest_for_ntp(self.infinite_topic_name, 0)
         assert "0-1-v1.log" in manifest["segments"], manifest
 

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -22,7 +22,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (produce_until_segments, produce_total_bytes,
                          wait_for_local_storage_truncate, segments_count,
                          expect_exception)
-from rptest.utils.si_utils import S3Snapshot
+from rptest.utils.si_utils import BucketView
 
 
 def bytes_for_segments(want_segments, segment_size):
@@ -396,9 +396,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                             bytes_to_produce=total_bytes)
 
         def cloud_log_size() -> int:
-            s3_snapshot = S3Snapshot([topic],
-                                     self.redpanda.cloud_storage_client,
-                                     self.s3_bucket_name, self.logger)
+            s3_snapshot = BucketView(self.redpanda, topics=[topic])
             cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(topic.name, 0)
             self.logger.debug(f"Current cloud log size is: {cloud_log_size}")
             return cloud_log_size
@@ -461,9 +459,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                             bytes_to_produce=total_bytes)
 
         def cloud_log_segment_count() -> int:
-            s3_snapshot = S3Snapshot([topic],
-                                     self.redpanda.cloud_storage_client,
-                                     self.s3_bucket_name, self.logger)
+            s3_snapshot = BucketView(self.redpanda, topics=[topic])
             count = s3_snapshot.cloud_log_segment_count_for_ntp(topic.name, 0)
             self.logger.debug(
                 f"Current count of segments in manifest is: {count}")
@@ -542,9 +538,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                             bytes_to_produce=total_bytes)
 
         def ntp_in_manifest() -> int:
-            s3_snapshot = S3Snapshot([topic],
-                                     self.redpanda.cloud_storage_client,
-                                     self.s3_bucket_name, self.logger)
+            s3_snapshot = BucketView(self.redpanda, topics=[topic])
             return s3_snapshot.is_ntp_in_manifest(topic.name, 0)
 
         # Sleep for 4 cloud_storage_housekeeping_interval_ms, then assert ntp does
@@ -565,9 +559,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
         wait_until(lambda: ntp_in_manifest(), timeout_sec=10)
 
         def cloud_log_size() -> int:
-            s3_snapshot = S3Snapshot([topic],
-                                     self.redpanda.cloud_storage_client,
-                                     self.s3_bucket_name, self.logger)
+            s3_snapshot = BucketView(self.redpanda, topics=[topic])
             cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(topic.name, 0)
             self.logger.debug(f"Current cloud log size is: {cloud_log_size}")
             return cloud_log_size

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -998,25 +998,6 @@ class AdminApiBasedRestore(FastCheck):
             assert not item.key.startswith('recovery_state/kafka')
 
 
-def get_node_partition_sizes(redpanda):
-    """
-    Fetch the on-disk size of all partitions on all nodes
-
-    :return: map of topic->partition->node->size
-    """
-    storage = redpanda.storage(sizes=True)
-
-    result = {}
-    for topic in storage.ns["kafka"].topics.keys():
-        for node_partition in storage.partitions("kafka", topic):
-            partition_size = sum(s.size if s.size else 0
-                                 for s in node_partition.segments.values())
-            result[topic][node_partition.num][
-                node_partition.node.name] = partition_size
-
-    return result
-
-
 class TopicRecoveryTest(RedpandaTest):
     def __init__(self,
                  test_context: TestContext,

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -33,8 +33,8 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_result
 from rptest.utils.si_utils import (
-    EMPTY_SEGMENT_SIZE, MISSING_DATA_ERRORS, NTPR, TRANSIENT_ERRORS,
-    PathMatcher, S3Snapshot, SegmentReader, default_log_segment_size,
+    EMPTY_SEGMENT_SIZE, MISSING_DATA_ERRORS, NTP, TRANSIENT_ERRORS,
+    PathMatcher, BucketView, SegmentReader, default_log_segment_size,
     gen_manifest_path, get_expected_ntp_restored_size,
     get_on_disk_size_per_ntp, is_close_size, parse_s3_manifest_path,
     parse_s3_segment_path, verify_file_layout)
@@ -146,23 +146,20 @@ class BaseCase:
         revisions = {}
         for key in self._list_objects():
             if key.endswith("/manifest.json"):
-                res = parse_s3_manifest_path(key)
-                rev = res.revision
-                ntp = res.ntp
-                revisions[ntp] = rev
+                ntpr = parse_s3_manifest_path(key)
+                revisions[ntpr.to_ntp()] = ntpr.revision
+
         for topic in self.topics:
             for partition in self._rpk.describe_topic(topic.name):
                 hw = partition.high_watermark
-                ntp = NTPR(ns='kafka',
-                           topic=topic.name,
-                           partition=partition.id,
-                           revision=revisions[ntp])
-                partition_uri = gen_manifest_path(ntp, rev)
+                ntp = NTP(ns='kafka', topic=topic.name, partition=partition.id)
+                ntpr = ntp.to_ntpr(revisions[ntp])
+                partition_uri = gen_manifest_path(ntpr)
                 data = self._s3.get_object_data(self._bucket, partition_uri)
                 obj = json.loads(data)
                 last_offset = obj['last_offset']
                 self.logger.info(
-                    f"validating partition: {ntp}, rev: {rev}, last offset: {last_offset}"
+                    f"validating partition: {ntp}, rev: {ntpr.revision}, last offset: {last_offset}"
                 )
                 # Explanation: high watermark is a kafka offset equal to the last offset in the log + 1.
                 # last_offset in the manifest is the last uploaded redpanda offset. Difference between
@@ -471,12 +468,12 @@ class MissingPartition(BaseCase):
         manifest = None
         for key in self._list_objects():
             if key.endswith("/manifest.json") and self.topic_name in key:
-                attr = parse_s3_manifest_path(key)
-                assert attr.ntp.topic == self.topic_name
-                if attr.ntp.partition == 0:
+                ntpr = parse_s3_manifest_path(key)
+                assert ntpr.topic == self.topic_name
+                if ntpr.partition == 0:
                     manifest = key
                 else:
-                    assert attr.ntp.partition == 1
+                    assert ntpr.partition == 1
                     data = self._s3.get_object_data(self._bucket, key)
                     obj = json.loads(data)
                     self._part1_offset = obj['last_offset']
@@ -573,7 +570,7 @@ class MissingSegment(BaseCase):
                 attr = parse_s3_segment_path(key)
                 if attr.name.startswith('0'):
                     self._delete(key)
-                    self._smaller_ntp = attr.ntp
+                    self._smaller_ntp = attr.ntpr.to_ntp()
                     break
         else:
             assert False, "No segments found in the bucket"
@@ -618,9 +615,10 @@ class MissingSegment(BaseCase):
 class FastCheck(BaseCase):
     """This test case covers normal recovery process. It creates configured
     set of topics and runs recovery and validations."""
-    def __init__(self, s3_client, kafka_tools, rpk_client, s3_bucket, logger,
-                 rpk_producer_maker, topics):
+    def __init__(self, redpanda, s3_client, kafka_tools, rpk_client, s3_bucket,
+                 logger, rpk_producer_maker, topics):
         self.topics = topics
+        self.redpanda = redpanda
         super(FastCheck, self).__init__(s3_client, kafka_tools, rpk_client,
                                         s3_bucket, logger, rpk_producer_maker)
 
@@ -641,15 +639,14 @@ class FastCheck(BaseCase):
         for differences caused because configuration batches are not written to restored data.
         """
         non_data_batches_per_ntp = defaultdict(lambda: 0)
-        s3_snapshot = S3Snapshot(expected_topics, self._s3, self._bucket,
-                                 self.logger)
+        s3_snapshot = BucketView(self.redpanda, topics=expected_topics)
         segments = [
             item for item in self._s3.list_objects(self._bucket)
             if s3_snapshot.is_segment_part_of_a_manifest(item)
         ]
         for seg in segments:
             components = parse_s3_segment_path(seg.key)
-            ntp = components.ntp
+            ntp = components.ntpr.to_ntp()
             segment_data = self._s3.get_object_data(self._bucket, seg.key)
             segment_size = len(segment_data)
             segment = SegmentReader(io.BytesIO(segment_data))
@@ -933,10 +930,10 @@ class TimeBasedRetention(BaseCase):
 
 
 class AdminApiBasedRestore(FastCheck):
-    def __init__(self, s3_client, kafka_tools, rpk_client: RpkTool, s3_bucket,
-                 logger, rpk_producer_maker, topics, admin: Admin):
-        super().__init__(s3_client, kafka_tools, rpk_client, s3_bucket, logger,
-                         rpk_producer_maker, topics)
+    def __init__(self, redpanda, s3_client, kafka_tools, rpk_client: RpkTool,
+                 s3_bucket, logger, rpk_producer_maker, topics, admin: Admin):
+        super().__init__(redpanda, s3_client, kafka_tools, rpk_client,
+                         s3_bucket, logger, rpk_producer_maker, topics)
         self.admin = admin
 
     def _assert_duplicate_request_is_rejected(self):
@@ -945,7 +942,7 @@ class AdminApiBasedRestore(FastCheck):
             response = self.admin.initiate_topic_scan_and_recovery()
         except requests.exceptions.HTTPError as e:
             assert e.response.status_code == requests.status_codes.codes[
-                'conflict'], f'request status code: {response.status_code}'
+                'conflict'], f'request status code: {e.response.status_code}'
 
     def _assert_retention(self, value):
         def wait_for_topic():
@@ -966,7 +963,7 @@ class AdminApiBasedRestore(FastCheck):
         def wait_for_status():
             r = self.admin.get_topic_recovery_status()
             assert r.status_code == requests.status_codes.codes[
-                'ok'], f'request status code: {response.status_code}'
+                'ok'], f'request status code: {r.status_code}'
             response = r.json()
             self.logger.debug(f'response {response}')
             if isinstance(response, dict):
@@ -1414,9 +1411,9 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=1,
                       replication_factor=3)
         ]
-        test_case = FastCheck(self.cloud_storage_client, self.kafka_tools,
-                              self.rpk, self.s3_bucket, self.logger,
-                              self.rpk_producer_maker, topics)
+        test_case = FastCheck(self.redpanda, self.cloud_storage_client,
+                              self.kafka_tools, self.rpk, self.s3_bucket,
+                              self.logger, self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
@@ -1433,9 +1430,9 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=3,
                       replication_factor=3),
         ]
-        test_case = FastCheck(self.cloud_storage_client, self.kafka_tools,
-                              self.rpk, self.s3_bucket, self.logger,
-                              self.rpk_producer_maker, topics)
+        test_case = FastCheck(self.redpanda, self.cloud_storage_client,
+                              self.kafka_tools, self.rpk, self.s3_bucket,
+                              self.logger, self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
@@ -1455,9 +1452,9 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=2,
                       replication_factor=3),
         ]
-        test_case = FastCheck(self.cloud_storage_client, self.kafka_tools,
-                              self.rpk, self.s3_bucket, self.logger,
-                              self.rpk_producer_maker, topics)
+        test_case = FastCheck(self.redpanda, self.cloud_storage_client,
+                              self.kafka_tools, self.rpk, self.s3_bucket,
+                              self.logger, self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
     @cluster(num_nodes=3, log_allow_list=TRANSIENT_ERRORS)
@@ -1526,7 +1523,8 @@ class TopicRecoveryTest(RedpandaTest):
                       partition_count=1,
                       replication_factor=3)
         ]
-        test_case = AdminApiBasedRestore(self.cloud_storage_client,
+        test_case = AdminApiBasedRestore(self.redpanda,
+                                         self.cloud_storage_client,
                                          self.kafka_tools, self.rpk,
                                          self.s3_bucket, self.logger,
                                          self.rpk_producer_maker, topics,

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -707,11 +707,11 @@ class FastCheck(BaseCase):
 class SizeBasedRetention(BaseCase):
     """
     Restore the topic using the size base retention policy.
-        The initial topic is created with default retention policy (which is time based).
-        The recovered topic is created with size based retention policy.
-        The test generates 20MB of data per ntp, than after the restart it recovers
-        the topic with size limit set to 10MB per ntp.
-        The verification takes into account individual segment size. The recovery process
+    The initial topic is created with default retention policy (which is time based).
+    The recovered topic is created with size based retention policy.
+    The test generates 20MB of data per ntp, than after the restart it recovers
+    the topic with size limit set to 10MB per ntp.
+    The verification takes into account individual segment size. The recovery process
     should restore at not more than 10MB but not less than 10MB - oldest segment size."""
     def __init__(self, s3_client, kafka_tools, rpk_client, s3_bucket, logger,
                  rpk_producer_maker, topics):

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -33,7 +33,7 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_result
 from rptest.utils.si_utils import (
-    EMPTY_SEGMENT_SIZE, MISSING_DATA_ERRORS, NTP, TRANSIENT_ERRORS,
+    EMPTY_SEGMENT_SIZE, MISSING_DATA_ERRORS, NTPR, TRANSIENT_ERRORS,
     PathMatcher, S3Snapshot, SegmentReader, default_log_segment_size,
     gen_manifest_path, get_expected_ntp_restored_size,
     get_on_disk_size_per_ntp, is_close_size, parse_s3_manifest_path,
@@ -153,8 +153,10 @@ class BaseCase:
         for topic in self.topics:
             for partition in self._rpk.describe_topic(topic.name):
                 hw = partition.high_watermark
-                ntp = NTP(ns='kafka', topic=topic.name, partition=partition.id)
-                rev = revisions[ntp]
+                ntp = NTPR(ns='kafka',
+                           topic=topic.name,
+                           partition=partition.id,
+                           revision=revisions[ntp])
                 partition_uri = gen_manifest_path(ntp, rev)
                 data = self._s3.get_object_data(self._bucket, partition_uri)
                 obj = json.loads(data)

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -27,7 +27,7 @@ from rptest.util import (
     produce_until_segments,
     wait_until_segments,
 )
-from rptest.utils.si_utils import S3Snapshot
+from rptest.utils.si_utils import BucketView
 from rptest.utils.mode_checks import skip_azure_blob_storage
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SISettings
@@ -610,9 +610,7 @@ class UpgradeFrom22_2_7VerifyMigratedRetentionSettings(RedpandaTest):
         produce_until_segments(self.redpanda, topic.name, 0, total_segments)
 
         def cloud_log_size() -> int:
-            s3_snapshot = S3Snapshot([topic],
-                                     self.redpanda.cloud_storage_client,
-                                     self.s3_bucket_name, self.logger)
+            s3_snapshot = BucketView(self.redpanda, topics=[topic])
             cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(topic.name, 0)
             self.logger.debug(f"Current cloud log size is: {cloud_log_size}")
             return cloud_log_size

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -16,6 +16,7 @@ import xxhash
 
 from rptest.archival.s3_client import ObjectMetadata, S3Client
 from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
 from rptest.services.redpanda import MetricsEndpoint, RESTART_LOG_ALLOW_LIST
 
 EMPTY_SEGMENT_SIZE = 4096
@@ -24,7 +25,19 @@ BLOCK_SIZE = 4096
 
 default_log_segment_size = 1048576  # 1MB
 
-NTP = namedtuple("NTP", ['ns', 'topic', 'partition'])
+NTPBase = namedtuple("NTP", ['ns', 'topic', 'partition'])
+NTPRBase = namedtuple("NTP", ['ns', 'topic', 'partition', 'revision'])
+
+
+class NTP(NTPBase):
+    def to_ntpr(self, revision: int) -> 'NTPR':
+        return NTPR(self.ns, self.topic, self.partition, revision)
+
+
+class NTPR(NTPRBase):
+    def to_ntp(self) -> NTP:
+        return NTP(self.ns, self.topic, self.partition)
+
 
 TopicManifestMetadata = namedtuple('TopicManifestMetadata',
                                    ['ntp', 'revision'])
@@ -32,11 +45,7 @@ SegmentMetadata = namedtuple(
     'SegmentMetadata',
     ['ntp', 'revision', 'base_offset', 'term', 'md5', 'size'])
 
-SegmentPathComponents = namedtuple('SegmentPathComponents',
-                                   ['ntp', 'revision', 'name'])
-
-ManifestPathComponents = namedtuple('ManifestPathComponents',
-                                    ['ntp', 'revision'])
+SegmentPathComponents = namedtuple('SegmentPathComponents', ['ntpr', 'name'])
 
 MISSING_DATA_ERRORS = [
     "No segments found. Empty partition manifest generated",
@@ -83,7 +92,7 @@ class SegmentReader:
             yield it
 
 
-def parse_s3_manifest_path(path):
+def parse_s3_manifest_path(path: str) -> NTPR:
     """Parse S3 manifest path. Return ntp and revision.
     Sample name: 50000000/meta/kafka/panda-topic/0_19/manifest.json
     """
@@ -93,11 +102,10 @@ def parse_s3_manifest_path(path):
     part_rev = items[4].split('_')
     partition = int(part_rev[0])
     revision = int(part_rev[1])
-    ntp = NTP(ns=ns, topic=topic, partition=partition)
-    return ManifestPathComponents(ntp=ntp, revision=revision)
+    return NTPR(ns=ns, topic=topic, partition=partition, revision=revision)
 
 
-def parse_s3_segment_path(path):
+def parse_s3_segment_path(path) -> SegmentPathComponents:
     """Parse S3 segment path. Return ntp, revision and name.
     Sample name: b525cddd/kafka/panda-topic/0_9/4109-1-v1.log
     """
@@ -211,9 +219,9 @@ def verify_file_layout(baseline_per_host,
             f" The original is {orig_ntp_size} bytes which {delta} bytes larger."
 
 
-def gen_manifest_path(ntp, rev):
+def gen_manifest_path(ntpr: NTPR):
     x = xxhash.xxh32()
-    path = f"{ntp.ns}/{ntp.topic}/{ntp.partition}_{rev}"
+    path = f"{ntpr.ns}/{ntpr.topic}/{ntpr.partition}_{ntpr.revision}"
     x.update(path.encode('ascii'))
     hash = x.hexdigest()[0] + '0000000'
     return f"{hash}/meta/{path}/manifest.json"
@@ -333,59 +341,178 @@ def is_close_size(actual_size, expected_size):
 
 
 class PathMatcher:
-    def __init__(self, expected_topics: Sequence[TopicSpec]):
+    def __init__(self, expected_topics: Optional[Sequence[TopicSpec]] = None):
         self.expected_topics = expected_topics
-        self.topic_names = {t.name for t in self.expected_topics}
-        self.topic_manifest_paths = {
-            f'/{t}/topic_manifest.json'
-            for t in self.topic_names
-        }
+        if expected_topics is not None:
+            self.topic_names = {t.name for t in self.expected_topics}
+            self.topic_manifest_paths = {
+                f'/{t}/topic_manifest.json'
+                for t in self.topic_names
+            }
+        else:
+            self.topic_names = None
+            self.topic_manifest_paths = None
+
+    def _match_partition_manifest(self, key):
+        if self.topic_names is None:
+            return True
+        else:
+            return any(tn in key for tn in self.topic_names)
+
+    def _match_topic_manifest(self, key):
+        if self.topic_manifest_paths is None:
+            return True
+        else:
+            return any(key.endswith(t) for t in self.topic_manifest_paths)
 
     def is_partition_manifest(self, o: ObjectMetadata) -> bool:
-        return o.key.endswith('/manifest.json') and any(
-            tn in o.key for tn in self.topic_names)
+        return o.key.endswith(
+            '/manifest.json') and self._match_partition_manifest(o.key)
 
     def is_topic_manifest(self, o: ObjectMetadata) -> bool:
-        return any(o.key.endswith(t) for t in self.topic_manifest_paths)
+        return self._match_topic_manifest(o.key)
 
     def is_segment(self, o: ObjectMetadata) -> bool:
         try:
-            return parse_s3_segment_path(o.key).ntp.topic in self.topic_names
+            parsed = parse_s3_segment_path(o.key)
         except Exception:
             return False
+        else:
+            if self.topic_names is not None:
+                return parsed.ntp.topic in self.topic_names
+            else:
+                return True
 
     def path_matches_any_topic(self, path: str) -> bool:
-        return any(t in path for t in self.topic_names)
+        return self._match_partition_manifest(path)
 
 
-class S3Snapshot:
-    def __init__(self, expected_topics: Sequence[TopicSpec], client: S3Client,
-                 bucket: str, logger):
-        self.logger = logger
-        self.bucket = bucket
-        self.client = client
-        self.expected_topics = expected_topics
-        self.path_matcher = PathMatcher(self.expected_topics)
-        self.objects = self.client.list_objects(self.bucket)
+class BucketViewState:
+    """
+    Results of a full listing of the bucket, if listed is True, or
+    partial results if listed is False
+    """
+    def __init__(self):
+        self.listed = False
         self.segment_objects = 0
         self.ignored_objects = 0
-
         self.partition_manifests = {}
+
+
+class BucketView:
+    """
+    A caching view onto an object storage bucket, that knows how to construct paths
+    for manifests, and can also scan the bucket for aggregate segment info.
+
+    For directly fetching a manifest or manifest-derived info for a partition,
+    this will avoid doing object listings.  Access to properties that require
+    object listings (like the object counts) will list the bucket and then cache
+    the result.
+    """
+    def __init__(self, redpanda, topics: Optional[Sequence[TopicSpec]] = None):
+        """
+
+        :param redpanda: a RedpandaService, whose SISettings we will use
+        :param topics: optional list of topics to filter result to
+        """
+        self.redpanda = redpanda
+        self.logger = redpanda.logger
+        self.bucket = redpanda.si_settings.cloud_storage_bucket
+        self.client = redpanda.cloud_storage_client
+        self.path_matcher = PathMatcher(topics)
+
+        # Cache built on demand from admin API
+        self._ntp_to_revision = None
+
+        self._state = BucketViewState()
+
+    def reset(self):
+        """
+        Drop all cached state, so that subsequent calls will use fresh data
+        """
+        self._state = BucketViewState()
+
+    def ntp_to_ntpr(self, ntp: NTP) -> NTPR:
+        """
+        Raises KeyError if the NTP is not found
+        """
+        if self._ntp_to_revision is None:
+            self._ntp_to_revision = {}
+            admin = Admin(self.redpanda)
+            for p in admin.get_leaders_info():
+                self._ntp_to_revision[NTP(
+                    ns=p['ns'], topic=p['topic'],
+                    partition=p['partition_id'])] = p['partition_revision']
+
+        revision = self._ntp_to_revision[ntp]
+        return ntp.to_ntpr(revision)
+
+    @property
+    def segment_objects(self) -> int:
+        self._ensure_listing()
+        return self._state.segment_objects
+
+    @property
+    def ignored_objects(self) -> int:
+        self._ensure_listing()
+        return self._state.ignored_objects
+
+    @property
+    def partition_manifests(self) -> int:
+        self._ensure_listing()
+        return self._state.partition_manifests
+
+    def _ensure_listing(self):
+        if not self._state.listed is True:
+            self._do_listing()
+            self._state.listed = True
+
+    def _do_listing(self):
         for o in self.client.list_objects(self.bucket):
             if self.path_matcher.is_partition_manifest(o):
-                manifest_path = parse_s3_manifest_path(o.key)
-                data = self.client.get_object_data(self.bucket, o.key)
-                self.partition_manifests[manifest_path.ntp] = json.loads(data)
-                self.logger.debug(
-                    f'registered partition manifest for {manifest_path.ntp}: '
-                    f'{pprint.pformat(self.partition_manifests[manifest_path.ntp], indent=2)}'
-                )
+                ntpr = parse_s3_manifest_path(o.key)
+                ntp = ntpr.to_ntp()
+                manifest = self._load_manifest(ntp, o.key)
+                self.logger.debug(f'registered partition manifest for {ntp}: '
+                                  f'{pprint.pformat(manifest, indent=2)}')
             elif self.path_matcher.is_segment(o):
-                self.segment_objects += 1
+                self._state.segment_objects += 1
             elif self.path_matcher.is_topic_manifest(o):
                 pass
             else:
-                self.ignored_objects += 1
+                self._state.ignored_objects += 1
+
+    def _load_manifest(self, ntp, path):
+        """
+        Having composed the path for a manifest, download it cache the result, and return the manifest dict
+
+        Raises KeyError if the object is not found.
+        """
+        try:
+            data = self.client.get_object_data(self.bucket, path)
+        except Exception as e:
+            # Very generic exception handling because the storage client
+            # may be one of several classes with their own exceptions
+            self.logger.debug(f"Exception loading {path}: {e}")
+            raise KeyError(f"Manifest for ntp {ntp} not found")
+
+        manifest = json.loads(data)
+
+        self.logger.debug(f"Loaded manifest {ntp}: {pprint.pformat(manifest)}")
+
+        self._state.partition_manifests[ntp] = manifest
+        return manifest
+
+    def get_partition_manifest(self, ntp):
+        """
+        Fetch a manifest, looking up revision as needed.
+        """
+        if ntp in self._state.partition_manifests:
+            return self._state.partition_manifests[ntp]
+
+        ntpr = self.ntp_to_ntpr(ntp)
+        manifest_path = gen_manifest_path(ntpr)
+        return self._load_manifest(ntp, manifest_path)
 
     def is_segment_part_of_a_manifest(self, o: ObjectMetadata) -> bool:
         """
@@ -397,10 +524,11 @@ class S3Snapshot:
                 return False
 
             segment_path = parse_s3_segment_path(o.key)
-            partition_manifest = self.partition_manifests.get(segment_path.ntp)
+            partition_manifest = self.get_partition_manifest(segment_path.ntpr)
             if not partition_manifest:
-                self.logger.warn(f'no manifest found for {segment_path.ntp}')
+                self.logger.warn(f'no manifest found for {segment_path.ntpr}')
                 return False
+
             segments_in_manifest = partition_manifest['segments']
 
             # Filename for segment contains the archiver term, eg:
@@ -436,19 +564,23 @@ class S3Snapshot:
                            topic: str,
                            partition: int,
                            ns: str = "kafka") -> bool:
+        """
+        Whether a manifest is present for this NTP
+        """
         ntp = NTP(ns, topic, partition)
-        return ntp in self.partition_manifests
+        try:
+            self.get_partition_manifest(ntp)
+        except KeyError:
+            return False
+        else:
+            return True
 
     def manifest_for_ntp(self,
                          topic: str,
                          partition: int,
                          ns: str = 'kafka') -> dict:
         ntp = NTP(ns, topic, partition)
-        assert ntp in self.partition_manifests, f'NTP {ntp} not in manifests in S3: ' \
-                                                f'{pprint.pformat(self.partition_manifests)}'
-        manifest_data = self.partition_manifests[ntp]
-        self.logger.debug(f'manifest: {pprint.pformat(manifest_data)}')
-        return manifest_data
+        return self.get_partition_manifest(ntp)
 
     def cloud_log_segment_count_for_ntp(self,
                                         topic: str,
@@ -464,13 +596,16 @@ class S3Snapshot:
                                topic: str,
                                partition: int,
                                ns: str = 'kafka') -> int:
-        manifest = self.manifest_for_ntp(topic, partition, ns)
-
-        if 'segments' not in manifest:
+        try:
+            manifest = self.manifest_for_ntp(topic, partition, ns)
+        except KeyError:
             return 0
+        else:
+            if 'segments' not in manifest:
+                return 0
 
-        return sum(seg_meta['size_bytes']
-                   for seg_meta in manifest['segments'].values())
+            return sum(seg_meta['size_bytes']
+                       for seg_meta in manifest['segments'].values())
 
     def assert_at_least_n_uploaded_segments_compacted(self,
                                                       topic: str,
@@ -486,6 +621,6 @@ class S3Snapshot:
 
     def assert_segments_replaced(self, topic: str, partition: int):
         manifest_data = self.manifest_for_ntp(topic, partition)
-        assert len(
-            manifest_data['replaced']
-        ) > 0, f"No replaced segments after compacted segments uploaded"
+        assert len(manifest_data.get(
+            'replaced',
+            [])) > 0, f"No replaced segments after compacted segments uploaded"

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -116,8 +116,8 @@ def parse_s3_segment_path(path) -> SegmentPathComponents:
     partition = int(part_rev[0])
     revision = int(part_rev[1])
     fname = items[4]
-    ntp = NTP(ns=ns, topic=topic, partition=partition)
-    return SegmentPathComponents(ntp=ntp, revision=revision, name=fname)
+    ntpr = NTPR(ns=ns, topic=topic, partition=partition, revision=revision)
+    return SegmentPathComponents(ntpr=ntpr, name=fname)
 
 
 def _parse_checksum_entry(path, value, ignore_rev):
@@ -343,7 +343,7 @@ def is_close_size(actual_size, expected_size):
 class PathMatcher:
     def __init__(self, expected_topics: Optional[Sequence[TopicSpec]] = None):
         self.expected_topics = expected_topics
-        if expected_topics is not None:
+        if self.expected_topics is not None:
             self.topic_names = {t.name for t in self.expected_topics}
             self.topic_manifest_paths = {
                 f'/{t}/topic_manifest.json'
@@ -379,7 +379,7 @@ class PathMatcher:
             return False
         else:
             if self.topic_names is not None:
-                return parsed.ntp.topic in self.topic_names
+                return parsed.ntpr.topic in self.topic_names
             else:
                 return True
 
@@ -458,7 +458,7 @@ class BucketView:
         return self._state.ignored_objects
 
     @property
-    def partition_manifests(self) -> int:
+    def partition_manifests(self) -> dict[NTP, dict]:
         self._ensure_listing()
         return self._state.partition_manifests
 


### PR DESCRIPTION
These changes were motivated by working on the test in https://github.com/redpanda-data/redpanda/pull/9154 -- I didn't want to hand-write different code for manifest helpers, but the existing S3Snapshot relies on exhaustive bucket listing, which is not a good fit for tests that will write significant amounts of data.

- Make constructing the object terser by taking a `RedpandaService` and picking off the needed attributes, rather than passing in individually
- Do partition manifest fetches by composing the path, rather than relying on doing a full bucket listing to find the manifests
- The `self.objects` was broken, it was a generator object that had already been drained by the time the constructor finishes.  Replace this with a couple of counters.
- Make passing in a list of topics optional, this is more efficient if you don't want to do filtering on topic, and makes the constructor terser if you didn't need this filtering. 

There are also a couple cleanup commits tucked in here as followup from https://github.com/redpanda-data/redpanda/pull/8256, to avoid a whole separate PR just for that.


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
