### PR TITLE
cloud_storage_clients: fix typo in metric name

### DIFF
--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -214,7 +214,7 @@ void client_probe::setup_public_metrics(
           labels)
           .aggregate({sm::shard_label}),
         sm::make_counter(
-          "dowload_backoff",
+          "download_backoff",
           [this] { return _total_download_slowdowns; },
           sm::description("Total number of download requests that backed off"),
           labels)


### PR DESCRIPTION
Fix a typo in the `redpanda_cloud_clients_download_backoff` name.
                                                                         
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
