### PR TITLE
cloud_storage: Add storage backend inference

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -55,7 +55,14 @@ remote::remote(
         [](auto&& cfg) { return cfg.disable_public_metrics; }, conf))),
       *_materialized)
   , _azure_shared_key_binding(
-      config::shard_local_cfg().cloud_storage_azure_shared_key.bind()) {
+      config::shard_local_cfg().cloud_storage_azure_shared_key.bind())
+  , _cloud_storage_backend{
+      cloud_storage_clients::infer_backend_from_configuration(
+        conf, cloud_credentials_source)} {
+    vlog(
+      cst_log.info,
+      "remote initialized with backend {}",
+      _cloud_storage_backend);
     // If the credentials source is from config file, bypass the background
     // op to refresh credentials periodically, and load pool with static
     // credentials right now.

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -411,6 +411,8 @@ private:
     intrusive_list<event_filter, &event_filter::_hook> _filters;
 
     config::binding<std::optional<ss::sstring>> _azure_shared_key_binding;
+
+    model::cloud_storage_backend _cloud_storage_backend;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -192,7 +192,7 @@ model::cloud_storage_backend infer_backend_from_configuration(
         case model::cloud_credentials_source::sts:
             return model::cloud_storage_backend::aws;
         case model::cloud_credentials_source::gcp_instance_metadata:
-            return model::cloud_storage_backend::google;
+            return model::cloud_storage_backend::google_s3_compat;
         case model::cloud_credentials_source::config_file:
             __builtin_unreachable();
             break;
@@ -202,7 +202,7 @@ model::cloud_storage_backend infer_backend_from_configuration(
     auto& s3_config = std::get<s3_configuration>(client_config);
     const auto& uri = s3_config.uri;
     if (uri().find("google") != uri().npos) {
-        return model::cloud_storage_backend::google;
+        return model::cloud_storage_backend::google_s3_compat;
     }
 
     if (uri().find("minio") != uri().npos) {

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -100,4 +100,8 @@ using client_configuration
 template<typename>
 inline constexpr bool always_false_v = false;
 
+model::cloud_storage_backend infer_backend_from_configuration(
+  const client_configuration& client_config,
+  model::cloud_credentials_source cloud_storage_credentials_source);
+
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/tests/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ rp_test(
   UNIT_TEST
   BINARY_NAME s3_single_thread
   SOURCES
+    backend_detection_test.cc
     s3_client_test.cc
     xml_sax_parser_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK

--- a/src/v/cloud_storage_clients/tests/backend_detection_test.cc
+++ b/src/v/cloud_storage_clients/tests/backend_detection_test.cc
@@ -18,7 +18,8 @@ BOOST_AUTO_TEST_CASE(test_backend_from_url) {
     cfg.uri = cloud_storage_clients::access_point_uri{"storage.googleapis.com"};
     auto inferred = cloud_storage_clients::infer_backend_from_configuration(
       cfg, model::cloud_credentials_source::config_file);
-    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::google);
+    BOOST_REQUIRE_EQUAL(
+      inferred, model::cloud_storage_backend::google_s3_compat);
 
     cfg.uri = cloud_storage_clients::access_point_uri{"minio-s3"};
     inferred = cloud_storage_clients::infer_backend_from_configuration(
@@ -38,7 +39,8 @@ BOOST_AUTO_TEST_CASE(test_backend_from_cred_src) {
 
     inferred = cloud_storage_clients::infer_backend_from_configuration(
       cfg, model::cloud_credentials_source::gcp_instance_metadata);
-    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::google);
+    BOOST_REQUIRE_EQUAL(
+      inferred, model::cloud_storage_backend::google_s3_compat);
 
     inferred = cloud_storage_clients::infer_backend_from_configuration(
       cfg, model::cloud_credentials_source::config_file);
@@ -54,9 +56,11 @@ BOOST_AUTO_TEST_CASE(test_backend_when_using_azure) {
 
 BOOST_AUTO_TEST_CASE(test_backend_override) {
     config::shard_local_cfg().cloud_storage_backend.set_value(
-      model::cloud_storage_backend{model::cloud_storage_backend::google});
+      model::cloud_storage_backend{
+        model::cloud_storage_backend::google_s3_compat});
     auto cfg = cloud_storage_clients::abs_configuration{};
     auto inferred = cloud_storage_clients::infer_backend_from_configuration(
       cfg, model::cloud_credentials_source::aws_instance_metadata);
-    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::google);
+    BOOST_REQUIRE_EQUAL(
+      inferred, model::cloud_storage_backend::google_s3_compat);
 }

--- a/src/v/cloud_storage_clients/tests/backend_detection_test.cc
+++ b/src/v/cloud_storage_clients/tests/backend_detection_test.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/configuration.h"
+#include "config/configuration.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(test_backend_from_url) {
+    auto cfg = cloud_storage_clients::s3_configuration{};
+    cfg.uri = cloud_storage_clients::access_point_uri{"storage.googleapis.com"};
+    auto inferred = cloud_storage_clients::infer_backend_from_configuration(
+      cfg, model::cloud_credentials_source::config_file);
+    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::google);
+
+    cfg.uri = cloud_storage_clients::access_point_uri{"minio-s3"};
+    inferred = cloud_storage_clients::infer_backend_from_configuration(
+      cfg, model::cloud_credentials_source::config_file);
+    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::minio);
+}
+
+BOOST_AUTO_TEST_CASE(test_backend_from_cred_src) {
+    auto cfg = cloud_storage_clients::s3_configuration{};
+    auto inferred = cloud_storage_clients::infer_backend_from_configuration(
+      cfg, model::cloud_credentials_source::aws_instance_metadata);
+    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::aws);
+
+    inferred = cloud_storage_clients::infer_backend_from_configuration(
+      cfg, model::cloud_credentials_source::sts);
+    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::aws);
+
+    inferred = cloud_storage_clients::infer_backend_from_configuration(
+      cfg, model::cloud_credentials_source::gcp_instance_metadata);
+    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::google);
+
+    inferred = cloud_storage_clients::infer_backend_from_configuration(
+      cfg, model::cloud_credentials_source::config_file);
+    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::unknown);
+}
+
+BOOST_AUTO_TEST_CASE(test_backend_when_using_azure) {
+    auto cfg = cloud_storage_clients::abs_configuration{};
+    auto inferred = cloud_storage_clients::infer_backend_from_configuration(
+      cfg, model::cloud_credentials_source::aws_instance_metadata);
+    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::azure);
+}
+
+BOOST_AUTO_TEST_CASE(test_backend_override) {
+    config::shard_local_cfg().cloud_storage_backend.set_value(
+      model::cloud_storage_backend{model::cloud_storage_backend::google});
+    auto cfg = cloud_storage_clients::abs_configuration{};
+    auto inferred = cloud_storage_clients::infer_backend_from_configuration(
+      cfg, model::cloud_credentials_source::aws_instance_metadata);
+    BOOST_REQUIRE_EQUAL(inferred, model::cloud_storage_backend::google);
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1320,6 +1320,20 @@ configuration::configuration()
       "waiting.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5s)
+  , cloud_storage_backend(
+      *this,
+      "cloud_storage_backend",
+      "Optional cloud storage backend variant used to select API capabilities. "
+      "If not supplied, will be inferred from other configuration parameters.",
+      {.needs_restart = needs_restart::yes,
+       .example = "aws",
+       .visibility = visibility::user},
+      model::cloud_storage_backend::unknown,
+      {model::cloud_storage_backend::aws,
+       model::cloud_storage_backend::google,
+       model::cloud_storage_backend::azure,
+       model::cloud_storage_backend::minio,
+       model::cloud_storage_backend::unknown})
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1330,7 +1330,7 @@ configuration::configuration()
        .visibility = visibility::user},
       model::cloud_storage_backend::unknown,
       {model::cloud_storage_backend::aws,
-       model::cloud_storage_backend::google,
+       model::cloud_storage_backend::google_s3_compat,
        model::cloud_storage_backend::azure,
        model::cloud_storage_backend::minio,
        model::cloud_storage_backend::unknown})

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -266,6 +266,7 @@ struct configuration final : public config_store {
     property<std::optional<size_t>> cloud_storage_segment_size_min;
     property<std::optional<std::chrono::milliseconds>>
       cloud_storage_graceful_transfer_timeout_ms;
+    enum_property<model::cloud_storage_backend> cloud_storage_backend;
 
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -349,7 +349,9 @@ struct convert<model::cloud_storage_backend> {
 
         rhs = string_switch<type>(std::string_view{value})
                 .match("aws", model::cloud_storage_backend::aws)
-                .match("google", model::cloud_storage_backend::google)
+                .match(
+                  "google_s3_compat",
+                  model::cloud_storage_backend::google_s3_compat)
                 .match("minio", model::cloud_storage_backend::minio)
                 .match("azure", model::cloud_storage_backend::azure)
                 .match("unknown", model::cloud_storage_backend::unknown);

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -329,4 +329,33 @@ struct convert<std::unordered_map<typename T::key_type, T>> {
     }
 };
 
+template<>
+struct convert<model::cloud_storage_backend> {
+    using type = model::cloud_storage_backend;
+
+    static constexpr auto acceptable_values = std::to_array(
+      {"aws", "google", "azure", "minio", "unknown"});
+
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+
+        if (
+          std::find(acceptable_values.begin(), acceptable_values.end(), value)
+          == acceptable_values.end()) {
+            return false;
+        }
+
+        rhs = string_switch<type>(std::string_view{value})
+                .match("aws", model::cloud_storage_backend::aws)
+                .match("google", model::cloud_storage_backend::google)
+                .match("minio", model::cloud_storage_backend::minio)
+                .match("azure", model::cloud_storage_backend::azure)
+                .match("unknown", model::cloud_storage_backend::unknown);
+
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -441,6 +441,8 @@ consteval std::string_view property_type_name() {
     } else if constexpr (std::
                            is_same_v<type, model::cloud_credentials_source>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, model::cloud_storage_backend>) {
+        return "string";
     } else {
         static_assert(dependent_false<T>::value, "Type name not defined");
     }

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -150,4 +150,9 @@ void rjson_serialize(
     stringize(w, v);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::cloud_storage_backend& v) {
+    stringize(w, v);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -68,4 +68,7 @@ void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const model::partition_autobalancing_mode& v);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::cloud_storage_backend& v);
+
 } // namespace json

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -426,7 +426,7 @@ operator<<(std::ostream& o, const partition_autobalancing_mode& m) {
 
 enum class cloud_storage_backend {
     aws = 0,
-    google = 1,
+    google_s3_compat = 1,
     azure = 2,
     minio = 3,
     unknown = 4,
@@ -436,8 +436,8 @@ inline std::ostream& operator<<(std::ostream& os, cloud_storage_backend csb) {
     switch (csb) {
     case cloud_storage_backend::aws:
         return os << "aws";
-    case cloud_storage_backend::google:
-        return os << "google";
+    case cloud_storage_backend::google_s3_compat:
+        return os << "google_s3_compat";
     case cloud_storage_backend::azure:
         return os << "azure";
     case cloud_storage_backend::minio:

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -424,6 +424,29 @@ operator<<(std::ostream& o, const partition_autobalancing_mode& m) {
     }
 }
 
+enum class cloud_storage_backend {
+    aws = 0,
+    google = 1,
+    azure = 2,
+    minio = 3,
+    unknown = 4,
+};
+
+inline std::ostream& operator<<(std::ostream& os, cloud_storage_backend csb) {
+    switch (csb) {
+    case cloud_storage_backend::aws:
+        return os << "aws";
+    case cloud_storage_backend::google:
+        return os << "google";
+    case cloud_storage_backend::azure:
+        return os << "azure";
+    case cloud_storage_backend::minio:
+        return os << "minio";
+    case cloud_storage_backend::unknown:
+        return os << "unknown";
+    }
+}
+
 namespace internal {
 /*
  * Old version for use in backwards compatibility serialization /


### PR DESCRIPTION
The following changes are added in this pr:

1. guess the storage backend from the credentials source (if using IAM roles), configuration type and the api endpoint
2. set the backend in remote for use in api calls
3. allow user to override the backend explicitly as part of cluster config using the property `cloud_storage_backend`

Valid values for backend are:

```
    aws
    google_s3_compat
    azure
    minio
    unknown
```

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* When using tiered storage, Redpanda will now detect the backend in use, to enable certain backend-specific APIs (e.g. DeleteObjects on AWS).  This detection may be overridden with the new cluster configuration property `cloud_storage_backend`, although this should not be necessary when running on supported backends (GCP, AWS, Azure).
