### PR TITLE
[v22.2.x] metrics: ensure consistent histogram upper bounds

### DIFF
--- a/src/v/utils/hdr_hist.h
+++ b/src/v/utils/hdr_hist.h
@@ -111,7 +111,8 @@ public:
       int64_t min = 1,
       int32_t significant_figures = 1)
       : _hist(hist_internal::make_unique_hdr_histogram(
-        max_value, min, significant_figures)) {}
+        max_value, min, significant_figures))
+      , _first_discernible_value(min) {}
     hdr_hist(
       std::chrono::microseconds max_value, std::chrono::microseconds min_value)
       : hdr_hist(max_value.count(), min_value.count()) {}
@@ -161,6 +162,7 @@ private:
     hist_internal::hdr_histogram_ptr _hist;
     uint64_t _sample_count{0};
     uint64_t _sample_sum{0};
+    int64_t _first_discernible_value{1};
 
     friend std::ostream& operator<<(std::ostream& o, const hdr_hist& h);
 };

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ rp_test(
     input_stream_fanout_test.cc
     waiter_queue_test.cc
     delta_for_test.cc
+    seastar_histogram_test.cc
   LIBRARIES v::seastar_testing_main v::utils v::bytes
   ARGS "-- -c 1"
   LABELS utils

--- a/src/v/utils/tests/seastar_histogram_test.cc
+++ b/src/v/utils/tests/seastar_histogram_test.cc
@@ -1,0 +1,22 @@
+#include "utils/hdr_hist.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+SEASTAR_THREAD_TEST_CASE(test_seastar_histograms_match) {
+    using namespace std::chrono_literals;
+
+    hdr_hist a{120s, 1ms};
+    hdr_hist b{120s, 1ms};
+
+    std::chrono::microseconds one_hundred_secs = 100s;
+    a.record(one_hundred_secs.count());
+
+    const auto logform_a = a.seastar_histogram_logform();
+    const auto logform_b = b.seastar_histogram_logform();
+
+    for (size_t idx = 0; idx < logform_a.buckets.size(); ++idx) {
+        BOOST_CHECK_EQUAL(
+          logform_a.buckets[idx].upper_bound,
+          logform_b.buckets[idx].upper_bound);
+    }
+}


### PR DESCRIPTION
Backport of PR #9192

Mostly clean backport. There was a conflict in `CMakeLists.txt`, but the logic was clean.


