### PR TITLE
storage: expose cloud storage status for partitions on the admin API

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -344,7 +344,15 @@ static ss::future<upload_candidate_with_locks> create_upload_candidate(
 
     auto deadline = std::chrono::steady_clock::now() + segment_lock_duration;
     std::vector<ss::rwlock::holder> locks;
+    vlog(
+      archival_log.trace,
+      "Acquiring read lock for segment {}",
+      segment->filename());
     locks.emplace_back(co_await segment->read_lock(deadline));
+    vlog(
+      archival_log.trace,
+      "Read lock acquired for segment {}",
+      segment->filename());
     auto result = ss::make_lw_shared<upload_candidate>(
       {.term = term, .sources = {segment}});
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -850,6 +850,7 @@ ntp_archiver::segment_path_for_candidate(const upload_candidate& candidate) {
 // from offset to offset (by record batch boundary)
 ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
   upload_candidate candidate,
+  std::vector<ss::rwlock::holder> segment_read_locks,
   std::optional<std::reference_wrapper<retry_chain_node>> source_rtc) {
     vassert(
       candidate.remote_sources.empty(),
@@ -888,6 +889,30 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
       fib,
       lazy_abort_source,
       _segment_tags);
+
+    // Note on segment locks:
+    //
+    // We've successfully uploaded the segment. Before we replicate an update
+    // with the archival STM, drop any segment locks that may be held. It's
+    // possible these locks are blocking other fibers from taking write locks,
+    // which in turn, may prevent further read locks from being held.
+    // Replicating and waiting on archival batches to be applied may require
+    // taking read locks on these segments.
+    //
+    // Specifically, we want to avoid a series of events like:
+    // 1. This fiber holds the uploaded segment's read lock
+    // 2. Another fiber attempts to write lock the segment (e.g. during a
+    //    segment roll), but can't. Instead, it prevents other read locks from
+    //    being taken as it waits.
+    // 3. This fiber attempts to replicate an archival batch, which
+    //    subsequently waits for all prior ops to be applied, which may require
+    //    consuming from this segment. In doing so, we attempt to read lock a
+    //    locked segment.
+    //
+    // To avoid this, simply drop the locks here, now that we're done with
+    // them. There's no concern that the underlying offsets will disappear
+    // since the archival STM pins offsets until they are recorded in the
+    // manifest.
 }
 
 std::optional<ss::sstring> ntp_archiver::upload_should_abort() {
@@ -1008,7 +1033,6 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
           .name = std::nullopt,
           .delta = std::nullopt,
           .stop = ss::stop_iteration::yes,
-          .segment_read_locks = {},
         };
     }
 
@@ -1022,7 +1046,7 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
 
     // The upload is successful only if both segment and tx_range are uploaded.
     std::vector<ss::future<cloud_storage::upload_result>> all_uploads;
-    all_uploads.emplace_back(upload_segment(upload));
+    all_uploads.emplace_back(upload_segment(upload, std::move(locks)));
     if (upload_ctx.upload_kind == segment_upload_kind::non_compacted) {
         all_uploads.emplace_back(upload_tx(upload));
     }
@@ -1050,7 +1074,6 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
       },
       .name = upload.exposed_name, .delta = offset - base,
       .stop = ss::stop_iteration::no,
-      .segment_read_locks = std::move(locks),
     };
 }
 
@@ -1815,7 +1838,7 @@ ss::future<bool> ntp_archiver::do_upload_local(
 
     // Upload segments and tx-manifest in parallel
     std::vector<ss::future<cloud_storage::upload_result>> futures;
-    futures.emplace_back(upload_segment(upload, source_rtc));
+    futures.emplace_back(upload_segment(upload, std::move(locks), source_rtc));
     futures.emplace_back(upload_tx(upload, source_rtc));
     auto upl_res = co_await aggregate_upload_results(std::move(futures));
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -590,6 +590,8 @@ ss::future<cloud_storage::download_result> ntp_archiver::sync_manifest() {
             co_return cloud_storage::download_result::failed;
         }
     }
+
+    _last_sync_time = ss::lowres_clock::now();
     co_return cloud_storage::download_result::success;
 }
 
@@ -634,6 +636,11 @@ const model::ntp& ntp_archiver::get_ntp() const { return _ntp; }
 
 model::initial_revision_id ntp_archiver::get_revision_id() const {
     return _rev;
+}
+
+std::optional<ss::lowres_clock::time_point>
+ntp_archiver::get_last_sync_time() const {
+    return _last_sync_time;
 }
 
 ss::future<

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -100,6 +100,10 @@ public:
         return _last_segment_upload_time;
     }
 
+    /// Get the timestamp of the last successful manifest sync.
+    /// Returns nullopt if not in read replica mode
+    std::optional<ss::lowres_clock::time_point> get_last_sync_time() const;
+
     /// Download manifest from pre-defined S3 locatnewion
     ///
     /// \return future that returns true if the manifest was found in S3
@@ -471,6 +475,10 @@ private:
 
     // When we last wrote a segment
     ss::lowres_clock::time_point _last_segment_upload_time;
+    ss::lowres_clock::time_point _last_upload_time;
+
+    // When we last synced the manifest of the read replica
+    std::optional<ss::lowres_clock::time_point> _last_sync_time;
 
     // Used during leadership transfer: instructs the archiver to
     // not proceed with uploads, even if it has leadership.

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -276,7 +276,8 @@ private:
     /// Information about started upload
     struct scheduled_upload {
         /// The future that will be ready when the segment will be fully
-        /// uploaded
+        /// uploaded.
+        /// NOTE: scheduled future may hold segment read locks.
         std::optional<ss::future<cloud_storage::upload_result>> result;
         /// Last offset of the uploaded segment or part
         model::offset inclusive_last_offset;
@@ -292,9 +293,6 @@ private:
         /// case the upload is not started but the method might be called
         /// again anyway.
         ss::stop_iteration stop;
-        /// Protects the underlying segment(s) from being deleted while the
-        /// upload is in flight.
-        std::vector<ss::rwlock::holder> segment_read_locks;
         segment_upload_kind upload_kind;
     };
 
@@ -358,11 +356,14 @@ private:
     /// Upload individual segment to S3.
     ///
     /// \param candidate is an upload candidate
+    /// \param segment_read_locks protects the underlying segment(s) from being
+    ///        deleted while the upload is in flight.
     /// \param source_rtc is a retry_chain_node of the caller, if it's set
     ///        to nullopt own retry chain of the ntp_archiver is used
     /// \return error code
     ss::future<cloud_storage::upload_result> upload_segment(
       upload_candidate candidate,
+      std::vector<ss::rwlock::holder> segment_read_locks,
       std::optional<std::reference_wrapper<retry_chain_node>> source_rtc
       = std::nullopt);
 

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -273,6 +273,16 @@ const model::offset partition_manifest::get_last_offset() const {
 }
 
 const std::optional<kafka::offset>
+partition_manifest::get_last_kafka_offset() const {
+    const auto next_kafka_offset = get_next_kafka_offset();
+    if (!next_kafka_offset || *next_kafka_offset == kafka::offset{0}) {
+        return std::nullopt;
+    }
+
+    return *next_kafka_offset - kafka::offset{1};
+}
+
+const std::optional<kafka::offset>
 partition_manifest::get_next_kafka_offset() const {
     auto last_seg = last_segment();
     if (!last_seg.has_value()) {

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -268,12 +268,11 @@ remote_manifest_path partition_manifest::get_manifest_path() const {
 
 const model::ntp& partition_manifest::get_ntp() const { return _ntp; }
 
-const model::offset partition_manifest::get_last_offset() const {
+model::offset partition_manifest::get_last_offset() const {
     return _last_offset;
 }
 
-const std::optional<kafka::offset>
-partition_manifest::get_last_kafka_offset() const {
+std::optional<kafka::offset> partition_manifest::get_last_kafka_offset() const {
     const auto next_kafka_offset = get_next_kafka_offset();
     if (!next_kafka_offset || *next_kafka_offset == kafka::offset{0}) {
         return std::nullopt;
@@ -282,8 +281,7 @@ partition_manifest::get_last_kafka_offset() const {
     return *next_kafka_offset - kafka::offset{1};
 }
 
-const std::optional<kafka::offset>
-partition_manifest::get_next_kafka_offset() const {
+std::optional<kafka::offset> partition_manifest::get_next_kafka_offset() const {
     auto last_seg = last_segment();
     if (!last_seg.has_value()) {
         return std::nullopt;
@@ -291,7 +289,7 @@ partition_manifest::get_next_kafka_offset() const {
     return last_seg->next_kafka_offset();
 }
 
-const model::offset partition_manifest::get_insync_offset() const {
+model::offset partition_manifest::get_insync_offset() const {
     return _insync_offset;
 }
 

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -489,6 +489,8 @@ bool partition_manifest::contains(const segment_name& name) const {
 void partition_manifest::delete_replaced_segments() { _replaced.clear(); }
 
 bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
+    const auto previous_start_offset = _start_offset;
+
     if (new_start_offset > _start_offset && !_segments.empty()) {
         auto it = _segments.upper_bound(new_start_offset);
         if (it == _segments.begin()) {
@@ -500,14 +502,44 @@ bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
             new_head_segment = std::next(new_head_segment);
         }
 
-        if (new_head_segment == _segments.end()) {
-            _start_offset = new_start_offset;
-        } else {
-            _start_offset = new_head_segment->second.base_offset;
+        model::offset advanced_start_offset
+          = new_head_segment == end() ? new_start_offset
+                                      : new_head_segment->second.base_offset;
+
+        if (previous_start_offset > advanced_start_offset) {
+            vlog(
+              cst_log.error,
+              "Previous start offset is greater than the new one: "
+              "previous_start_offset={}, computed_new_start_offset={}, "
+              "requested_new_start_offset={}",
+              previous_start_offset,
+              advanced_start_offset,
+              new_start_offset);
+            return false;
         }
 
-        for (auto iter = _segments.begin(); iter != new_head_segment; ++iter) {
-            subtract_from_cloud_log_size(iter->second.size_bytes);
+        _start_offset = advanced_start_offset;
+
+        auto previous_head_segment = segment_containing(previous_start_offset);
+        if (previous_head_segment == end()) {
+            // This branch should never be taken. It indicates that the
+            // in-memory manifest may be is in some sort of inconsistent state.
+            vlog(
+              cst_log.warn,
+              "Previous start offset is not within segment in "
+              "manifest for {}: previous_start_offset={}",
+              _ntp,
+              previous_start_offset);
+            previous_head_segment = _segments.begin();
+        }
+
+        // Note that we start subtracting from the cloud log size from the
+        // previous head segments. This is required in order to account for
+        // the case when two `truncate` commands are applied sequentially,
+        // without a `cleanup_metadata` command in between to trim the list of
+        // segments.
+        for (auto it = previous_head_segment; it != new_head_segment; ++it) {
+            subtract_from_cloud_log_size(it->second.size_bytes);
         }
 
         return true;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -165,7 +165,12 @@ public:
               nm.name);
             nm.meta.segment_term = maybe_key->term;
             _segments.insert(std::make_pair(nm.meta.base_offset, nm.meta));
-            _cloud_log_size_bytes += nm.meta.size_bytes;
+
+            if (
+              nm.meta.base_offset >= _start_offset
+              && nm.meta.committed_offset <= _last_offset) {
+                _cloud_log_size_bytes += nm.meta.size_bytes;
+            }
         }
     }
 

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -182,7 +182,11 @@ public:
 
     // Get last offset
     const model::offset get_last_offset() const;
+
+    // Get the last inclusive Kafka offset
     const std::optional<kafka::offset> get_last_kafka_offset() const;
+
+    // Get the last exclusive Kafka offset
     const std::optional<kafka::offset> get_next_kafka_offset() const;
 
     // Get insync offset of the archival_metadata_stm

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -181,19 +181,19 @@ public:
     const model::ntp& get_ntp() const;
 
     // Get last offset
-    const model::offset get_last_offset() const;
+    model::offset get_last_offset() const;
 
     // Get the last inclusive Kafka offset
-    const std::optional<kafka::offset> get_last_kafka_offset() const;
+    std::optional<kafka::offset> get_last_kafka_offset() const;
 
     // Get the last exclusive Kafka offset
-    const std::optional<kafka::offset> get_next_kafka_offset() const;
+    std::optional<kafka::offset> get_next_kafka_offset() const;
 
     // Get insync offset of the archival_metadata_stm
     //
     // The offset is an offset of the last applied record with the
     // archival_metadata_stm command.
-    const model::offset get_insync_offset() const;
+    model::offset get_insync_offset() const;
 
     // Move insync offset forward
     // The method is supposed to be called by the archival_metadata_stm after

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -2036,6 +2036,30 @@ SEASTAR_THREAD_TEST_CASE(test_cloud_log_size_updates) {
     BOOST_REQUIRE_EQUAL(manifest.cloud_log_size(), 100);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_cloud_log_size_truncate_twice) {
+    // This test advances the start offset of the manifest twice
+    // in a row, without cleaning up the metadata in between.
+    //
+    // This scenario can occur when a leadership transfer happens
+    // after houskeeping replicates the truncate command, but before
+    // it gets to replicate the cleanup_metadata command. When the next
+    // leader runs housekeeping, it might choose to advance the start offset
+    // even further.
+
+    partition_manifest manifest;
+    manifest.update(make_manifest_stream(complete_manifest_json)).get();
+
+    BOOST_REQUIRE_EQUAL(manifest.cloud_log_size(), 11264);
+
+    manifest.advance_start_offset(model::offset{30});
+
+    BOOST_REQUIRE_EQUAL(manifest.cloud_log_size(), 8192);
+
+    manifest.advance_start_offset(model::offset{40});
+
+    BOOST_REQUIRE_EQUAL(manifest.cloud_log_size(), 4096);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_deserialize_v1_manifest) {
     // Test the deserialisation of v1 partition manifests (prior to v23.2).
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -152,6 +152,27 @@ ss::future<std::vector<rm_stm::tx_range>> partition::aborted_transactions_cloud(
     return _cloud_storage_partition->aborted_transactions(offsets);
 }
 
+cluster::cloud_storage_mode partition::get_cloud_storage_mode() const {
+    const auto& cfg = _raft->log_config();
+
+    if (cfg.is_read_replica_mode_enabled()) {
+        return cluster::cloud_storage_mode::read_replica;
+    }
+    if (cfg.is_tiered_storage()) {
+        return cluster::cloud_storage_mode::full;
+    }
+    if (cfg.is_tiered_storage()) {
+        return cluster::cloud_storage_mode::full;
+    }
+    if (cfg.is_archival_enabled()) {
+        return cluster::cloud_storage_mode::write_only;
+    }
+    if (cfg.is_remote_fetch_enabled()) {
+        return cluster::cloud_storage_mode::read_only;
+    }
+
+    return cluster::cloud_storage_mode::disabled;
+}
 bool partition::is_remote_fetch_enabled() const {
     const auto& cfg = _raft->log_config();
     if (_feature_table.local().is_active(features::feature::cloud_retention)) {

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -173,6 +173,82 @@ cluster::cloud_storage_mode partition::get_cloud_storage_mode() const {
 
     return cluster::cloud_storage_mode::disabled;
 }
+
+partition_cloud_storage_status partition::get_cloud_storage_status() const {
+    auto wrap_model_offset =
+      [this](model::offset o) -> std::optional<kafka::offset> {
+        if (o == model::offset{}) {
+            return std::nullopt;
+        }
+        return model::offset_cast(
+          get_offset_translator_state()->from_log_offset(o));
+    };
+
+    auto time_point_to_delta = [](ss::lowres_clock::time_point tp)
+      -> std::optional<std::chrono::milliseconds> {
+        if (tp.time_since_epoch().count() == 0) {
+            return std::nullopt;
+        }
+
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+          ss::lowres_clock::now() - tp);
+    };
+
+    partition_cloud_storage_status status;
+
+    status.mode = get_cloud_storage_mode();
+
+    const auto& local_log = _raft->log();
+    status.local_log_size_bytes = local_log.size_bytes();
+    status.total_log_size_bytes = status.local_log_size_bytes;
+    status.local_log_segment_count = local_log.segment_count();
+
+    const auto local_log_offsets = local_log.offsets();
+    status.local_log_start_offset = wrap_model_offset(
+      local_log_offsets.start_offset);
+    status.local_log_last_offset = wrap_model_offset(
+      local_log_offsets.committed_offset);
+
+    if (status.mode != cloud_storage_mode::disabled) {
+        const auto& manifest = _archival_meta_stm->manifest();
+        status.cloud_log_size_bytes = manifest.cloud_log_size();
+        status.cloud_log_segment_count = manifest.size();
+
+        if (manifest.size() > 0) {
+            status.cloud_log_start_offset = manifest.get_start_kafka_offset();
+            status.cloud_log_last_offset = manifest.get_last_kafka_offset();
+        }
+
+        const auto log_overlap = status.cloud_log_last_offset
+                                   ? _raft->log().size_bytes_until_offset(
+                                     manifest.get_last_offset())
+                                   : 0;
+        status.total_log_size_bytes += status.cloud_log_size_bytes
+                                       - log_overlap;
+    }
+
+    if (is_leader() && _archiver) {
+        if (
+          status.mode == cloud_storage_mode::write_only
+          || status.mode == cloud_storage_mode::full) {
+            status.since_last_manifest_upload = time_point_to_delta(
+              _archiver->get_last_manfiest_upload_time());
+            status.since_last_segment_upload = time_point_to_delta(
+              _archiver->get_last_segment_upload_time());
+        } else if (status.mode == cloud_storage_mode::read_replica) {
+            const auto last_sync_at = _archiver->get_last_sync_time();
+            if (last_sync_at) {
+                status.since_last_manifest_sync = time_point_to_delta(
+                  *last_sync_at);
+            } else {
+                status.since_last_manifest_sync = std::nullopt;
+            }
+        }
+    }
+
+    return status;
+}
+
 bool partition::is_remote_fetch_enabled() const {
     const auto& cfg = _raft->log_config();
     if (_feature_table.local().is_active(features::feature::cloud_retention)) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -252,6 +252,8 @@ public:
 
     cloud_storage_mode get_cloud_storage_mode() const;
 
+    partition_cloud_storage_status get_cloud_storage_status() const;
+
     /// Return true if shadow indexing is enabled for the partition
     bool is_remote_fetch_enabled() const;
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -250,6 +250,8 @@ public:
         return _read_replica_bucket.value();
     }
 
+    cloud_storage_mode get_cloud_storage_mode() const;
+
     /// Return true if shadow indexing is enabled for the partition
     bool is_remote_fetch_enabled() const;
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1018,6 +1018,23 @@ std::ostream& operator<<(std::ostream& o, reconfiguration_state update) {
     }
     __builtin_unreachable();
 }
+
+std::ostream& operator<<(std::ostream& o, const cloud_storage_mode& mode) {
+    switch (mode) {
+    case cloud_storage_mode::disabled:
+        return o << "disabled";
+    case cloud_storage_mode::write_only:
+        return o << "write_only";
+    case cloud_storage_mode::read_only:
+        return o << "read_only";
+    case cloud_storage_mode::full:
+        return o << "full";
+    case cloud_storage_mode::read_replica:
+        return o << "read_replica";
+    }
+    __builtin_unreachable();
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3219,6 +3219,28 @@ enum class cloud_storage_mode : uint8_t {
 };
 
 std::ostream& operator<<(std::ostream&, const cloud_storage_mode&);
+
+struct partition_cloud_storage_status {
+    cloud_storage_mode mode;
+
+    std::optional<std::chrono::milliseconds> since_last_manifest_upload;
+    std::optional<std::chrono::milliseconds> since_last_segment_upload;
+    std::optional<std::chrono::milliseconds> since_last_manifest_sync;
+
+    size_t total_log_size_bytes{0};
+    size_t cloud_log_size_bytes{0};
+    size_t local_log_size_bytes{0};
+
+    size_t cloud_log_segment_count{0};
+    size_t local_log_segment_count{0};
+
+    std::optional<kafka::offset> cloud_log_start_offset;
+    std::optional<kafka::offset> local_log_last_offset;
+
+    std::optional<kafka::offset> cloud_log_last_offset;
+    std::optional<kafka::offset> local_log_start_offset;
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3210,6 +3210,15 @@ constexpr auto common = partition_allocation_domain(0);
 constexpr auto consumer_offsets = partition_allocation_domain(-1);
 } // namespace partition_allocation_domains
 
+enum class cloud_storage_mode : uint8_t {
+    disabled = 0,
+    write_only = 1,
+    read_only = 2,
+    full = 3,
+    read_replica = 4
+};
+
+std::ostream& operator<<(std::ostream&, const cloud_storage_mode&);
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -67,6 +67,31 @@
           "nickname": "query_automated_recovery"
         }
       ]
+    },
+    {
+      "path": "/v1/cloud_storage/status/{topic}/{partition}",
+      "operations": [
+        {
+          "method": "GET",
+          "summary": "Get cloud storage status for a partition",
+          "operationId": "get_partition_cloud_storage_status",
+          "nickname": "get_partition_cloud_storage_status",
+          "parameters": [
+            {
+              "name": "topic",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "partition",
+              "in": "path",
+              "required": true,
+              "type": "integer"
+            }
+          ]
+        }
+      ]
     }
   ],
   "models": {
@@ -125,6 +150,70 @@
         },
         "request": {
           "type": "recovery_request_params"
+        }
+      }
+    },
+    "partition_cloud_storage_status": {
+      "id": "partition_cloud_storage_status",
+      "properties": {
+        "cloud_storage_mode": {
+            "type": "string",
+            "description": "The partition's cloud storage mode (one of: disabled, write_only, read_only, full and read_replica)"
+        },
+        "ms_since_last_manifest_upload": {
+            "type": "long",
+            "nullable": true,
+            "description": "Delta in milliseconds since the last upload of the partition's manifest"
+        },
+        "ms_since_last_segment_upload": {
+            "type": "long",
+            "nullable": true,
+            "description": "Delta in milliseconds since the last segment upload for the partition"
+        },
+        "ms_since_last_manifest_sync": {
+            "type": "long",
+            "nullable": true,
+            "description": "Delta in milliseconds since the last manifest sync (only present for read replicas)"
+        },
+        "total_log_size_bytes": {
+            "type": "long",
+            "description": "Total size of the log for the partition (overlap between local and cloud log is excluded)"
+        },
+        "cloud_log_size_bytes": {
+            "type": "long",
+            "description": "Total size of the addressable cloud log for the partition"
+        },
+        "local_log_size_bytes": {
+            "type": "long",
+            "description": "Total size of the addressable local log for the partition"
+        },
+        "cloud_log_segment_count": {
+            "type": "long",
+            "description": "Number of segments in the cloud log (does not include segments queued for removal)"
+        },
+        "local_log_segment_count": {
+            "type": "long",
+            "description": "Number of segments in the local log"
+        },
+        "cloud_log_start_offset": {
+            "type": "long",
+            "nullable": true,
+            "description": "The first Kafka offset accessible from the cloud (inclusive)"
+        },
+        "cloud_log_last_offset": {
+            "type": "long",
+            "nullable": true,
+            "description": "The last Kafka offset accessible from the cloud (inclusive)"
+        },
+        "local_log_start_offset": {
+            "type": "long",
+            "nullable": true,
+            "description": "The first Kafka offset accessible locally (inclusive)"
+        },
+        "local_log_last_offset": {
+            "type": "long",
+            "nullable": true,
+            "description": "The last Kafka offset accessible locally (inclusive)"
         }
       }
     }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -379,6 +379,8 @@ private:
       std::unique_ptr<ss::request>, std::unique_ptr<ss::reply>);
     ss::future<ss::json::json_return_type>
     query_automated_recovery(std::unique_ptr<ss::httpd::request> req);
+    ss::future<ss::json::json_return_type>
+    get_partition_cloud_storage_status(std::unique_ptr<ss::httpd::request> req);
 
     /// Self test routes
     ss::future<ss::json::json_return_type>

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -973,6 +973,19 @@ size_t disk_log_impl::max_segment_size() const {
     return result;
 }
 
+size_t disk_log_impl::size_bytes_until_offset(model::offset o) const {
+    size_t size = 0;
+    for (const auto& seg : _segs) {
+        if (seg->offsets().base_offset >= o) {
+            break;
+        }
+
+        size += seg->size_bytes();
+    }
+
+    return size;
+}
+
 size_t disk_log_impl::bytes_left_before_roll() const {
     if (_segs.empty()) {
         return 0;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -106,6 +106,7 @@ public:
     size_t bytes_left_before_roll() const;
 
     size_t size_bytes() const override { return _probe.partition_size(); }
+    size_t size_bytes_until_offset(model::offset o) const override;
     ss::future<> update_configuration(ntp_config::default_overrides) final;
 
     int64_t compaction_backlog() const final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -89,6 +89,8 @@ public:
         }
 
         virtual size_t size_bytes() const = 0;
+        // Byte size of the log for all segments before offset 'o'
+        virtual size_t size_bytes_until_offset(model::offset o) const = 0;
         virtual ss::future<>
           update_configuration(ntp_config::default_overrides) = 0;
 
@@ -208,6 +210,10 @@ public:
     std::ostream& print(std::ostream& o) const { return _impl->print(o); }
 
     size_t size_bytes() const { return _impl->size_bytes(); }
+
+    size_t size_bytes_until_offset(model::offset o) const {
+        return _impl->size_bytes_until_offset(o);
+    }
 
     impl* get_impl() const { return _impl.get(); }
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -888,3 +888,7 @@ class Admin:
         return self._request("post",
                              "debug/refresh_disk_health_info",
                              node=node)
+
+    def get_partition_cloud_storage_status(self, topic, partition):
+        return self._request(
+            "GET", f"cloud_storage/status/{topic}/{partition}").json()

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -1,0 +1,483 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import MetricsEndpoint, SISettings
+from rptest.util import firewall_blocked, wait_until_result
+from rptest.utils.si_utils import BucketView
+from rptest.clients.types import TopicSpec
+from rptest.tests.partition_movement import PartitionMovementMixin
+from ducktape.utils.util import wait_until
+from rptest.utils.mode_checks import skip_debug_mode
+
+import concurrent.futures
+import random
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+
+
+class CloudStorageCheck:
+    def __init__(self, name, check):
+        self._name = name
+        self._check = check
+
+    @property
+    def check(self):
+        return self._check
+
+    @property
+    def name(self):
+        return self._name
+
+
+def cloud_storage_usage_check(test):
+    bucket_view = BucketView(test.redpanda)
+
+    # The usage inferred from the uploaded manifest
+    # lags behind the actual reported usage. For this reason,
+    # we maintain a sliding window of reported usages and check whether
+    # the manifest inferred usage can be found in it.
+    reported_usage_sliding_window = deque(maxlen=10)
+
+    def check():
+        manifest_usage = bucket_view.total_cloud_log_size()
+
+        reported_usage = test.admin.cloud_storage_usage()
+        reported_usage_sliding_window.append(reported_usage)
+
+        test.logger.info(
+            f"Expected {manifest_usage} bytes of cloud storage usage")
+        test.logger.info(
+            f"Reported usages in sliding window: {reported_usage_sliding_window}"
+        )
+        return manifest_usage in reported_usage_sliding_window
+
+    # Manifests are not immediately uploaded after they are mutated locally.
+    # For example, during cloud storage housekeeping, the manifest is not uploaded
+    # after the 'start_offset' advances, but after the segments are deleted as well.
+    # If a request lands mid-housekeeping, the results will not be consistent with
+    # what's in the uploaded manifest. For this reason, we wait until the two match.
+    wait_until(
+        check,
+        timeout_sec=10,
+        backoff_sec=0.2,
+        err_msg="Reported cloud storage usage did not match the actual usage",
+        retry_on_exc=True)
+
+
+class PartitionStatusValidator:
+    def __init__(self, test):
+        self.test = test
+        self._si_settings = test.si_settings
+        self._logger = test.logger
+        self._validators = [
+            PartitionStatusValidator._validate_mode,
+            PartitionStatusValidator._validate_cloud_log_size_bytes,
+            PartitionStatusValidator._validate_cloud_log_offsets
+        ]
+
+    def is_valid(self, status, manifest) -> bool:
+        return all([v(self, status, manifest) for v in self._validators])
+
+    def _validate_status_shape(self, status, manifest) -> bool:
+        expected_keys = [
+            "cloud_storage_mode", "total_log_size_bytes",
+            "cloud_log_size_bytes", "local_log_size_bytes",
+            "cloud_log_segment_count", "local_log_segment_count"
+        ]
+
+        not_present = []
+        for k in expected_keys:
+            if k not in status:
+                not_present.append(k)
+
+        if len(not_present) > 0:
+            self._logger.info(
+                f"Expected keys missing from status: {not_present}")
+
+        return len(not_present) == 0
+
+    def _validate_mode(self, status, manifest) -> bool:
+        if status["cloud_storage_mode"] != "full":
+            self._logger.info(
+                f"Unexpected for cloud_storage_mode: {status['cloud_storage_mode']}"
+            )
+            return False
+
+        return True
+
+    def _validate_cloud_log_size_bytes(self, status, manifest) -> bool:
+        manifest_cloud_log_size = BucketView.cloud_log_size_from_ntp_manifest(
+            manifest, include_below_start_offset=False)
+
+        reported = status["cloud_log_size_bytes"]
+        if reported != manifest_cloud_log_size:
+            self._logger.info(
+                f"Reported cloud log size does not match manifest: {reported} != {manifest_cloud_log_size}"
+            )
+            return False
+
+        return True
+
+    def _validate_cloud_log_offsets(self, status, manifest) -> bool:
+        if not manifest:
+            return "cloud_log_start_offset" not in status and "cloud_log_last_offset" not in status
+
+        manifest_start = BucketView.kafka_start_offset(manifest)
+        reported_start = status.get("cloud_log_start_offset", None)
+
+        if manifest_start != reported_start:
+            self._logger.info(
+                f"Reported cloud log start does not match manifest: {reported_start} != {manifest_start}"
+            )
+            return False
+
+        manifest_last = BucketView.kafka_last_offset(manifest)
+        reported_last = status.get("cloud_log_last_offset", None)
+
+        if manifest_last != reported_last:
+            self._logger.info(
+                f"Reported cloud log end does not match manifest: {reported_last} != {manifest_last}"
+            )
+            return False
+
+        return True
+
+
+def cloud_storage_status_endpoint_check(test):
+    bucket_view = BucketView(test.redpanda)
+    reported_status_sliding_window = deque(maxlen=10)
+    validator = PartitionStatusValidator(test)
+
+    def check():
+        try:
+            bucket_view.reset()
+
+            status = test.admin.get_partition_cloud_storage_status(
+                test.topic, 0)
+            reported_status_sliding_window.append(status)
+
+            manifest = None
+            try:
+                manifest = bucket_view.manifest_for_ntpr(
+                    test.topic, 0, test._initial_revision)
+            except KeyError:
+                pass
+
+            for status in reported_status_sliding_window:
+                if validator.is_valid(status, manifest):
+                    return True
+
+            return False
+        except Exception as e:
+            test.logger.info(f"status_endpoint_check exception: {e}")
+            raise e
+
+    wait_until(
+        check,
+        timeout_sec=10,
+        backoff_sec=0.2,
+        err_msg="Cloud storage partition status did not match the manifest",
+        retry_on_exc=True)
+
+
+class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
+    """
+    The tests in this class are intended to be generic cloud storage test.
+    They use a workload that enables all operations on the cloud storage log
+    (appends, truncations caused by retention, compacted segment reuploads and
+    adjacent segment merging. A configurable series of checks are performed
+    at every 'check_interval'. If any of the checks result in an exception, or
+    fail to complete the test will fail.
+
+    The tests can be extended by creating a new check function and registering
+    it in the 'prologue' method.
+    """
+
+    mib = 1024 * 1024
+    message_size = 32 * 1024  # 32KiB
+    log_segment_size = 4 * mib  # 4MiB
+    produce_byte_rate_per_ntp = 8 * mib  # 8 MiB
+    target_runtime = 60  # seconds
+    check_interval = 10  # seconds
+    allow_runtime_overshoot_by = 2
+
+    topics = [
+        TopicSpec(name="test-topic",
+                  partition_count=1,
+                  replication_factor=3,
+                  retention_bytes=60 * log_segment_size,
+                  cleanup_policy="compact,delete")
+    ]
+
+    def __init__(self, test_context):
+        self.si_settings = SISettings(
+            test_context,
+            log_segment_size=self.log_segment_size,
+            cloud_storage_housekeeping_interval_ms=1000,
+            fast_uploads=True)
+
+        extra_rp_conf = dict(
+            log_compaction_interval_ms=1000,
+            compacted_log_segment_size=self.log_segment_size,
+            cloud_storage_idle_timeout_ms=100,
+            cloud_storage_segment_size_target=4 * self.log_segment_size,
+            cloud_storage_segment_size_min=2 * self.log_segment_size,
+            retention_local_target_bytes_default=10 * self.log_segment_size,
+            cloud_storage_manifest_upload_timeout_ms=60 * 1000,
+            cloud_storage_enable_segment_merging=True)
+
+        super(CloudStorageTimingStressTest,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=extra_rp_conf,
+                             log_level="trace",
+                             si_settings=self.si_settings)
+
+        self.rpk = RpkTool(self.redpanda)
+        self.admin = Admin(self.redpanda)
+        self.checks = []
+
+    def _create_producer(self) -> KgoVerifierProducer:
+        bps = self.produce_byte_rate_per_ntp * self.topics[0].partition_count
+        bytes_count = bps * self.target_runtime
+        msg_count = bytes_count // self.message_size
+
+        self.logger.info(f"Will produce {bytes_count / self.mib}MiB at"
+                         f"{bps / self.mib}MiB/s on topic={self.topic}")
+
+        return KgoVerifierProducer(self.test_context,
+                                   self.redpanda,
+                                   self.topic,
+                                   msg_size=self.message_size,
+                                   msg_count=msg_count,
+                                   rate_limit_bps=bps,
+                                   debug_logs=True,
+                                   trace_logs=True)
+
+    def _create_consumer(self) -> KgoVerifierSeqConsumer:
+        bps = self.produce_byte_rate_per_ntp * self.topics[0].partition_count
+        bytes_count = bps * self.target_runtime
+        msg_count = bytes_count // self.message_size
+
+        self.logger.info(
+            f"Will consume at {bps / self.mib}MiB/s from topic={self.topic}")
+
+        return KgoVerifierSeqConsumer(self.test_context,
+                                      self.redpanda,
+                                      self.topic,
+                                      msg_size=self.message_size,
+                                      max_throughput_mb=int(bps // self.mib),
+                                      debug_logs=True,
+                                      trace_logs=True)
+
+    def _all_uploads_done(self):
+        topic_description = self.rpk.describe_topic(self.topic)
+        for partition in topic_description:
+            hwm = partition.high_watermark
+
+            manifest = None
+            try:
+                bucket = BucketView(self.redpanda)
+                manifest = bucket.manifest_for_ntpr(self.topic, partition.id,
+                                                    self._initial_revision)
+            except Exception as e:
+                self.logger.info(
+                    f"Exception thrown while retrieving the manifest: {e}")
+                return False
+
+            top_segment = max(manifest['segments'].values(),
+                              key=lambda seg: seg['base_offset'])
+            uploaded_raft_offset = top_segment['committed_offset']
+            uploaded_kafka_offset = uploaded_raft_offset - top_segment[
+                'delta_offset_end']
+            self.logger.info(
+                f"Remote HWM {uploaded_kafka_offset} (raft {uploaded_raft_offset}), local hwm {hwm}"
+            )
+
+            # -1 because uploaded offset is inclusive, hwm is exclusive
+            if uploaded_kafka_offset < (hwm - 1):
+                return False
+
+            return True
+
+    def _check_completion(self):
+        producer_complete = self.producer.is_complete()
+        if not producer_complete:
+            return False, f"Producer did not complete: {self.producer.produce_status}"
+
+        consumed = self.consumer.consumer_status.validator.valid_reads
+        produced = self.producer.produce_status.acked
+        consumer_complete = consumed >= produced
+        if not consumer_complete:
+            return False, f"Consumer consumed only {consumed} out of {produced} messages"
+
+        uploads_done = self._all_uploads_done()
+        if not uploads_done:
+            return False, "There are pending uploads to cloud storage"
+
+        return True, ""
+
+    def is_complete(self):
+        complete, reason = self._check_completion()
+        if complete:
+            return True
+
+        delta = datetime.now() - self.test_start_ts
+        max_runtime = self.target_runtime * self.allow_runtime_overshoot_by
+        if delta.total_seconds() > max_runtime:
+            raise TimeoutError(
+                f"Workload did not complete within {max_runtime}s: {reason}")
+
+        return False
+
+    def _get_initial_revision(self):
+        def get_revision():
+            leaders_info = self.admin.get_leaders_info()
+            for p in leaders_info:
+                if p['topic'] == self.topic:
+                    rev = int(p['partition_revision'])
+                    if rev < 0:
+                        return False
+
+                    self.logger.info(f"Initial revision is {rev}")
+                    return True, rev
+            return False
+
+        return wait_until_result(
+            get_revision,
+            timeout_sec=5,
+            backoff_sec=1,
+            err_msg="Initial revision not found before timeout",
+            retry_on_exc=True)
+
+    def prologue(self):
+        # Preserve the initial revision to be able to fetch the manifest
+        # after the partition moves.
+        self._initial_revision = self._get_initial_revision()
+
+        self.register_check("cloud_storage_usage", cloud_storage_usage_check)
+        self.register_check("cloud_storage_status_endpoint",
+                            cloud_storage_status_endpoint_check)
+
+        self.producer = self._create_producer()
+        self.consumer = self._create_consumer()
+
+        self.producer.start()
+
+        # Sleep for a bit to hit the cloud storage read path when consuming
+        time.sleep(3)
+        self.consumer.start()
+
+        self.test_start_ts = datetime.now()
+
+    def epilogue(self):
+        self.producer.wait()
+        self.consumer.wait()
+
+        self.redpanda.metric_sum(
+            "redpanda_cloud_storage_delete_segments",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS) > 0
+
+        self.redpanda.metric_sum(
+            "redpanda_cloud_storage_local_segment_reuploads",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS) > 0
+
+        self.redpanda.metric_sum(
+            "vectorized_cloud_storage_successful_downloads_total") > 0
+
+        # Assert that compacted segment re-upload operated during the test
+        bucket_view = BucketView(self.redpanda)
+        bucket_view.assert_at_least_n_uploaded_segments_compacted(
+            self.topic, partition=0, revision=self._initial_revision, n=1)
+
+    def register_check(self, name, check_fn):
+        self.checks.append(CloudStorageCheck(name, check_fn))
+
+    def do_checks(self):
+        with ThreadPoolExecutor(max_workers=len(self.checks)) as executor:
+
+            def start_check(check):
+                self.logger.info(f"Check {check.name} starting")
+                return executor.submit(check.check, self)
+
+            futs = {start_check(check): check for check in self.checks}
+
+            done, not_done = concurrent.futures.wait(
+                futs, timeout=self.check_interval)
+
+            failure_count = 0
+            for f in done:
+                check_name = futs[f].name
+                if ex := f.exception():
+                    self.logger.error(
+                        f"Check {check_name} threw an exception: {ex}")
+                    failure_count += 1
+                else:
+                    self.logger.info(
+                        f"Check {check_name} completed successfuly")
+
+            for f in not_done:
+                check_name = futs[f].name
+                self.logger.error(
+                    f"Check {check_name} did not complete within the check interval"
+                )
+
+            if failure_count > 0 or len(not_done) > 0:
+                raise RuntimeError(
+                    f"Failed checks: {failure_count}; Incomplete checks: {len(not_done)}"
+                )
+
+            self.logger.info(f"All checks completed successfuly")
+
+    @cluster(num_nodes=5)
+    def test_cloud_storage(self):
+        """
+        This is the baseline test. It runs the workload and performs the checks
+        periodically, without any external operations being performed.
+        """
+        self.prologue()
+
+        while not self.is_complete():
+            self.do_checks()
+            time.sleep(self.check_interval)
+
+        self.epilogue()
+
+    @cluster(
+        num_nodes=5,
+        log_allow_list=[r"Error in hydraton loop: .*Connection reset by peer"])
+    @skip_debug_mode
+    def test_cloud_storage_with_partition_moves(self):
+        """
+        This test adds partition moves on top of the baseline cloud storage workload.
+        The idea is to evolve this test into a more generic fuzzing test in the future
+        (e.g. isolate/kill nodes, isolate leader from cloud storage, change cloud storage
+        topic/cluster configs on the fly).
+        """
+        self.prologue()
+
+        partitions = []
+        for topic in self.topics:
+            partitions.extend([(topic.name, pid)
+                               for pid in range(topic.partition_count)])
+
+        while not self.is_complete():
+            ntp_to_move = random.choice(partitions)
+            self._dispatch_random_partition_move(ntp_to_move[0],
+                                                 ntp_to_move[1])
+
+            self.do_checks()
+            time.sleep(self.check_interval)
+
+        self.epilogue()

--- a/tests/rptest/tests/cloud_storage_usage_test.py
+++ b/tests/rptest/tests/cloud_storage_usage_test.py
@@ -121,7 +121,7 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
         # Assert that compacted segment re-upload operated during the test
         bucket_view = BucketView(self.redpanda, topics=self.topics)
         bucket_view.assert_at_least_n_uploaded_segments_compacted(
-            self.topics[1].name, partition=0, n=1)
+            self.topics[1].name, partition=0, revision=None, n=1)
 
     @cluster(num_nodes=5)
     def test_cloud_storage_usage_reporting(self):

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -211,9 +211,8 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         self.run_consumer_validation(enable_compaction=True)
 
         s3_snapshot = BucketView(self.redpanda, topics=self.topics)
-        s3_snapshot.assert_at_least_n_uploaded_segments_compacted(self.topic,
-                                                                  partition=0,
-                                                                  n=1)
+        s3_snapshot.assert_at_least_n_uploaded_segments_compacted(
+            self.topic, partition=0, revision=None, n=1)
         s3_snapshot.assert_segments_replaced(self.topic, partition=0)
 
     @skip_debug_mode
@@ -244,9 +243,8 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         self.run_consumer_validation(enable_compaction=True)
 
         s3_snapshot = BucketView(self.redpanda, topics=self.topics)
-        s3_snapshot.assert_at_least_n_uploaded_segments_compacted(self.topic,
-                                                                  partition=0,
-                                                                  n=1)
+        s3_snapshot.assert_at_least_n_uploaded_segments_compacted(
+            self.topic, partition=0, revision=None, n=1)
         s3_snapshot.assert_segments_replaced(self.topic, partition=0)
 
 

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -107,9 +107,8 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
                    err_msg=lambda: f"Compacted segments not uploaded")
 
         s3_snapshot = BucketView(self.redpanda, topics=self.topics)
-        s3_snapshot.assert_at_least_n_uploaded_segments_compacted(self.topic,
-                                                                  partition=0,
-                                                                  n=1)
+        s3_snapshot.assert_at_least_n_uploaded_segments_compacted(
+            self.topic, partition=0, revision=None, n=1)
         s3_snapshot.assert_segments_replaced(self.topic, partition=0)
         self.logger.info(
             f'manifest: {pprint.pformat(s3_snapshot.manifest_for_ntp(self.topic, 0))}'


### PR DESCRIPTION
NB: This PR is rebased on https://github.com/redpanda-data/redpanda/pull/9675.

This PR adds a new route to the admin API: `/v1/cloud_storage/status/{topic}/{partition}`.
It returns various usage stats regarding the partition. We are adding this in order to aid
observability internally, but console is also going to integrate with this in order to enrich
its UX.

Here's an example output from the endpoint:
```
{"cloud_storage_mode": "full", "last_upload_at": 705732663, "total_log_size_bytes": 694,
"cloud_log_size_bytes": 168, "local_log_size_bytes": 526, "cloud_log_segment_count": 1,
"local_log_segment_count": 2, "cloud_log_start_offset": 0, "cloud_log_last_offset": 0,
"local_log_start_offset": 0, "local_log_last_offset": 2}
```

A generic cloud storage test is also added: `CloudStorageTimingStressTest`. It performs a workload
with all cloud log operations enabled and performs periodic checks. The new endpoint
is tested by such a check. This test was designed to be extensible, so it may be good to think
about whether you could add a new check to it (instead of a new test) in the future.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Features
* A new route which returns partition cloud storage information has been added: `/v1/cloud_storage/status/{topic}/{partition}`

