### PR TITLE
rpk: disable uploads to homebrew repo

### DIFF
--- a/src/go/rpk/.goreleaser.yaml
+++ b/src/go/rpk/.goreleaser.yaml
@@ -53,35 +53,3 @@ release:
     name: redpanda
   draft: true
   discussion_category_name: Releases
-brews:
-  - name: redpanda
-    homepage: "https://redpanda.com"
-    description: "Redpanda CLI & toolbox"
-    tap:
-      owner: redpanda-data
-      name: homebrew-tap
-    folder: Formula
-    skip_upload: auto
-    caveats: |
-        Redpanda Keeper (rpk) is Redpanda's command line interface (CLI)
-        utility. The rpk commands let you configure, manage, and tune
-        Redpanda clusters. They also let you manage topics, groups,
-        and access control lists (ACLs).
-        Start a three-node docker cluster locally:
-
-            rpk container start -n 3
-
-        Interact with the cluster using commands like:
-
-            rpk topic list
-
-        When done, stop and delete the docker cluster:
-
-            rpk container purge
-
-        For more examples and guides, visit: https://docs.redpanda.com
-    commit_author:
-      name: vbotbuildovich
-      email: vbot@redpanda.com
-announce:
-  skip: "true"


### PR DESCRIPTION
Removes publishing step for the rpk github action workflow

related to https://github.com/redpanda-data/devprod/issues/508

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
