### PR TITLE
storage: remove dubious-looking dead code

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -743,15 +743,6 @@ ss::future<> disk_log_impl::compact(compaction_config cfg) {
           if (config().is_collectable()) {
               f = gc(cfg);
           }
-          if (unlikely(
-                config().has_overrides()
-                && config().get_overrides().cleanup_policy_bitflags
-                     == model::cleanup_policy_bitflags::none)) {
-              // prevent *any* collection - used for snapshots
-              // all the internal redpanda logs - i.e.: controller, etc should
-              // have this set
-              f = ss::now();
-          }
           if (config().is_compacted() && !_segs.empty()) {
               f = f.then([this, cfg] { return do_compact(cfg); });
           }


### PR DESCRIPTION
Without knowing the `is_collectible()` condition and the "unlikely" condition are mutually exclusive, it looks as though we're abandoning a futurized `gc()`, which is quite alarming.

From John:
"Then 95320bc6087 fixed the bug by adding the is_collectable check, and the unlikely block has been dead code ever since."

See Slack thread: https://redpandadata.slack.com/archives/C04ASNM2ZLK/p1677794802065029
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
