### PR TITLE
rpk: small bug fixes (Typo, help text and unused property)

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -59,9 +59,6 @@ rpk:
     # The path to the client certificate key (PEM)
     #key_file: ""
 
-  # Enables sending environment and resource usage data to Vectorized.
-  enable_usage_stats: true
-
   # Available tuners
   tune_network: false
   tune_disk_scheduler: false

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -52,7 +52,7 @@ func AddKafkaFlags(
 		"config",
 		"",
 		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations",
+			" in $PWD or /etc/redpanda/redpanda.yaml",
 	)
 	command.PersistentFlags().StringVar(
 		user,

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -31,7 +31,7 @@ func NewInfoCommand() *cobra.Command {
 			// no-op: keeping the command for backompat.
 		},
 	}
-	cmd.Flags().StringVar(&configFile, "config", "", "Redpanda config file, if not set the file will be searched for in the default locations")
+	cmd.Flags().StringVar(&configFile, "config", "", "Redpanda config file, if not set the file will be searched for in $PWD or /etc/redpanda/redpanda.yaml")
 	cmd.Flags().BoolVar(&send, "send", false, "If true, send resource usage data to Redpanda")
 	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Second, "How long to wait to calculate the Redpanda CPU % utilization")
 	cmd.Flags().MarkHidden("config")

--- a/src/go/rpk/pkg/cli/cmd/iotune/iotune.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune/iotune.go
@@ -76,7 +76,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		"config",
 		"",
 		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations",
+			" in $PWD or /etc/redpanda/redpanda.yaml",
 	)
 	command.Flags().StringVar(
 		&outputFile,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
@@ -42,7 +42,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		"config",
 		"",
 		"rpk config file, if not set the file will be searched for"+
-			" in the default locations",
+			" in $PWD or /etc/redpanda/redpanda.yaml",
 	)
 
 	cmd.PersistentFlags().StringSliceVar(

--- a/src/go/rpk/pkg/cli/cmd/redpanda/check.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/check.go
@@ -48,7 +48,7 @@ func NewCheckCommand(fs afero.Fs) *cobra.Command {
 		"config",
 		"",
 		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations.",
+			" in $PWD or /etc/redpanda/redpanda.yaml.",
 	)
 	command.Flags().DurationVar(
 		&timeout,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -342,11 +342,11 @@ rpk:
           port: 9644
     developer_mode: true
 rpk:
-    enable_usage_stats: true
     tune_network: true
     tune_disk_scheduler: true
+    tune_cpu: true
 `,
-			args: []string{"rpk.enable_usage_stats", "true"},
+			args: []string{"rpk.tune_cpu", "true"},
 		},
 	} {
 		fs := afero.NewMemMapFs()

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
@@ -45,7 +45,7 @@ func NewModeCommand(fs afero.Fs) *cobra.Command {
 		"config",
 		"",
 		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations.",
+			" in $PWD or /etc/redpanda/redpanda.yaml.",
 	)
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -103,7 +103,7 @@ func TestModeCommand(t *testing.T) {
 			exp: fillRpkConfig(configPath, config.ModeProd),
 		},
 		{
-			name: "mode should work if --config isn't passed, but the file is in /etc/redpanda/redpanda.yaml",
+			name: "mode should work if --config isn't passed, but the file is in $PWD or /etc/redpanda/redpanda.yaml",
 			args: []string{"prod"},
 			before: func(fs afero.Fs) (string, error) {
 				bs, err := yaml.Marshal(fillRpkConfig(configPath, config.ModeDev))

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -374,7 +374,7 @@ func NewStartCommand(fs afero.Fs, launcher rp.Launcher) *cobra.Command {
 		configFlag,
 		"",
 		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations.",
+			" in $PWD or /etc/redpanda/redpanda.yaml.",
 	)
 	command.Flags().IntVar(
 		&nodeID,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -339,7 +339,7 @@ func TestStartCommand(t *testing.T) {
 				// A single int value
 				"--set", "redpanda.node_id=39",
 				// A single bool value
-				"--set", "rpk.enable_usage_stats=true",
+				"--set", "rpk.tune_network=true",
 				// A single string value
 				"--set", "node_uuid=helloimauuid1337",
 				// A JSON object
@@ -383,6 +383,7 @@ func TestStartCommand(t *testing.T) {
 			require.Exactly(st, 39, *conf.Redpanda.ID)
 			require.Exactly(st, expectedAdmin, conf.Redpanda.AdminAPI)
 			require.Exactly(st, expectedKafkaAPI, conf.Redpanda.KafkaAPI)
+			require.Exactly(st, true, conf.Rpk.TuneNetwork)
 		},
 	}, {
 		name: "it should still save values passed through field-specific flags, and prioritize them if they overlap with values set with --set",
@@ -404,7 +405,7 @@ func TestStartCommand(t *testing.T) {
 				// A single int value
 				"--set", "redpanda.node_id=39",
 				// A single bool value
-				"--set", "rpk.enable_usage_stats=true",
+				"--set", "rpk.tune_cpu=true",
 				// A single string value
 				"--set", "node_uuid=helloimauuid1337",
 				// A JSON object

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
@@ -53,7 +53,7 @@ running.`,
 		"config",
 		"",
 		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations.",
+			" in $PWD or /etc/redpanda/redpanda.yaml.",
 	)
 	command.Flags().DurationVar(
 		&timeout,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/list.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/list.go
@@ -79,7 +79,7 @@ You may use 'rpk redpanda config set' to enable or disable a tuner.
 		config.FlagConfig,
 		"",
 		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations.",
+			" in $PWD or /etc/redpanda/redpanda.yaml.",
 	)
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/tune.go
@@ -119,7 +119,7 @@ To learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.
 		&configFile,
 		config.FlagConfig,
 		"",
-		"Redpanda config file, if not set the file will be searched for in the default locations.",
+		"Redpanda config file, if not set the file will be searched for in $PWD or /etc/redpanda/redpanda.yaml.",
 	)
 	command.Flags().StringVar(&outTuneScriptFile,
 		"output-script",

--- a/src/go/rpk/pkg/cli/cmd/topic/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/produce.go
@@ -167,7 +167,7 @@ func newProduceCommand(fs afero.Fs) *cobra.Command {
 	}
 
 	// The following flags require parsing before we initialize our client.
-	cmd.Flags().StringVarP(&compression, "compression", "z", "snappy", "Compression to use for producing batches (none, gzip, snapy, lz4, zstd)")
+	cmd.Flags().StringVarP(&compression, "compression", "z", "snappy", "Compression to use for producing batches (none, gzip, snappy, lz4, zstd)")
 	cmd.Flags().IntVar(&acks, "acks", -1, "Number of acks required for producing (-1=all, 0=none, 1=leader)")
 	cmd.Flags().DurationVar(&timeout, "delivery-timeout", 0, "Per-record delivery timeout, if non-zero, min 1s")
 	cmd.Flags().Int32VarP(&partition, "partition", "p", -1, "Partition to directly produce to, if non-negative (also allows %p parsing to set partitions)")

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -95,7 +95,6 @@ func setDevelopment(conf *Config) *Config {
 		KafkaAPI:             conf.Rpk.KafkaAPI,
 		AdminAPI:             conf.Rpk.AdminAPI,
 		AdditionalStartFlags: conf.Rpk.AdditionalStartFlags,
-		EnableUsageStats:     conf.Rpk.EnableUsageStats,
 		CoredumpDir:          conf.Rpk.CoredumpDir,
 		SMP:                  DevDefault().Rpk.SMP,
 		BallastFilePath:      conf.Rpk.BallastFilePath,

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -25,7 +25,6 @@ func getValidConfig() *Config {
 	}
 	conf.Redpanda.DeveloperMode = false
 	conf.Rpk = RpkConfig{
-		EnableUsageStats:         true,
 		TuneNetwork:              true,
 		TuneDiskScheduler:        true,
 		TuneDiskWriteCache:       true,
@@ -115,10 +114,10 @@ func TestSet(t *testing.T) {
 		},
 		{
 			name:  "set single bool fields",
-			key:   "rpk.enable_usage_stats",
+			key:   "rpk.tune_network",
 			value: "true",
 			check: func(st *testing.T, c *Config) {
-				require.Exactly(st, true, c.Rpk.EnableUsageStats)
+				require.Exactly(st, true, c.Rpk.TuneNetwork)
 			},
 		},
 		{
@@ -164,10 +163,10 @@ func TestSet(t *testing.T) {
 		},
 		{
 			name:  "detect single bool fields if format isn't passed",
-			key:   "rpk.enable_usage_stats",
+			key:   "rpk.tune_cpu",
 			value: "true",
 			check: func(st *testing.T, c *Config) {
-				require.Exactly(st, true, c.Rpk.EnableUsageStats)
+				require.Exactly(st, true, c.Rpk.TuneCPU)
 			},
 		},
 		{
@@ -178,7 +177,6 @@ tune_cpu: true`,
 			format: "yaml",
 			check: func(st *testing.T, c *Config) {
 				expected := RpkConfig{
-					EnableUsageStats:         false,
 					Overprovisioned:          false,
 					TuneNetwork:              false,
 					TuneDiskScheduler:        false,
@@ -540,7 +538,6 @@ func TestWrite(t *testing.T) {
         - address: 0.0.0.0
           port: 9644
 rpk:
-    enable_usage_stats: true
     tune_network: true
     tune_disk_scheduler: true
     tune_disk_nomerges: true
@@ -593,7 +590,6 @@ schema_registry: {}
         address: 174.32.64.2
         port: 33145
 rpk:
-    enable_usage_stats: true
     tune_network: true
     tune_disk_scheduler: true
     tune_disk_nomerges: true
@@ -676,7 +672,6 @@ schema_registry: {}
           port: 9644
     log_segment_size: 536870912
 rpk:
-    enable_usage_stats: true
     tune_network: true
     tune_disk_scheduler: true
     tune_disk_nomerges: true

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -256,8 +256,7 @@ func TestRedpandaSampleFile(t *testing.T) {
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{
-			CoredumpDir:      "/var/lib/redpanda/coredump",
-			EnableUsageStats: true,
+			CoredumpDir: "/var/lib/redpanda/coredump",
 		},
 		Pandaproxy:     &Pandaproxy{},
 		SchemaRegistry: &SchemaRegistry{},
@@ -297,7 +296,6 @@ func TestRedpandaSampleFile(t *testing.T) {
           port: 9644
     developer_mode: true
 rpk:
-    enable_usage_stats: true
     coredump_dir: /var/lib/redpanda/coredump
 pandaproxy: {}
 schema_registry: {}

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -193,7 +193,6 @@ type RpkConfig struct {
 	KafkaAPI                 RpkKafkaAPI `yaml:"kafka_api,omitempty" json:"kafka_api"`
 	AdminAPI                 RpkAdminAPI `yaml:"admin_api,omitempty" json:"admin_api"`
 	AdditionalStartFlags     []string    `yaml:"additional_start_flags,omitempty"  json:"additional_start_flags"`
-	EnableUsageStats         bool        `yaml:"enable_usage_stats,omitempty" json:"enable_usage_stats"`
 	TuneNetwork              bool        `yaml:"tune_network,omitempty" json:"tune_network"`
 	TuneDiskScheduler        bool        `yaml:"tune_disk_scheduler,omitempty" json:"tune_disk_scheduler"`
 	TuneNomerges             bool        `yaml:"tune_disk_nomerges,omitempty" json:"tune_disk_nomerges"`

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -385,7 +385,6 @@ func (rpkc *RpkConfig) UnmarshalYAML(n *yaml.Node) error {
 		KafkaAPI                 RpkKafkaAPI     `yaml:"kafka_api"`
 		AdminAPI                 RpkAdminAPI     `yaml:"admin_api"`
 		AdditionalStartFlags     weakStringArray `yaml:"additional_start_flags"`
-		EnableUsageStats         weakBool        `yaml:"enable_usage_stats"`
 		TuneNetwork              weakBool        `yaml:"tune_network"`
 		TuneDiskScheduler        weakBool        `yaml:"tune_disk_scheduler"`
 		TuneNomerges             weakBool        `yaml:"tune_disk_nomerges"`
@@ -416,7 +415,6 @@ func (rpkc *RpkConfig) UnmarshalYAML(n *yaml.Node) error {
 	rpkc.KafkaAPI = internal.KafkaAPI
 	rpkc.AdminAPI = internal.AdminAPI
 	rpkc.AdditionalStartFlags = internal.AdditionalStartFlags
-	rpkc.EnableUsageStats = bool(internal.EnableUsageStats)
 	rpkc.TuneNetwork = bool(internal.TuneNetwork)
 	rpkc.TuneDiskScheduler = bool(internal.TuneDiskScheduler)
 	rpkc.TuneNomerges = bool(internal.TuneNomerges)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -154,7 +154,6 @@ schema_registry_client:
 {% endif %}
 
 rpk:
-  enable_usage_stats: false
   tune_network: false
   tune_disk_scheduler: false
   tune_disk_nomerges: false


### PR DESCRIPTION
3 small fixes:

- Remove `enable_usage_stats` from redpanda.yaml since it's no longer used.
- Fixes a typo: snapy -> snappy
- Specify the default location in the help text.

Fixes #7871,  Fixes #8532, Fixes #9141
## Backports Required


## Release Notes
### Improvements
* Remove unused propoerty `rpk.enable_usage_stat` from redpanda.yaml.
