### PR TITLE
admin: add the metadata dissemination service to the restart endpoint

### DIFF
--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -502,4 +502,10 @@ ss::future<> metadata_dissemination_service::stop() {
     return _bg.close();
 }
 
+ss::future<> metadata_dissemination_service::restart() {
+    vlog(clusterlog.info, "Restarting the metadata dissemination service");
+    co_await stop();
+    co_await start();
+}
+
 } // namespace cluster

--- a/src/v/cluster/metadata_dissemination_service.h
+++ b/src/v/cluster/metadata_dissemination_service.h
@@ -93,6 +93,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    ss::future<> restart();
 
 private:
     // Used to store pending updates

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -40,6 +40,7 @@ struct admin_server_cfg {
 
 enum class service_kind {
     schema_registry,
+    metadata_dissemination_service,
 };
 
 namespace detail {
@@ -66,7 +67,8 @@ public:
       ss::sharded<cluster::self_test_frontend>&,
       pandaproxy::schema_registry::api*,
       ss::sharded<cloud_storage::topic_recovery_service>&,
-      ss::sharded<cluster::topic_recovery_status_frontend>&);
+      ss::sharded<cluster::topic_recovery_status_frontend>&,
+      ss::sharded<cluster::metadata_dissemination_service>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -427,4 +429,6 @@ private:
     ss::sharded<cloud_storage::topic_recovery_service>& _topic_recovery_service;
     ss::sharded<cluster::topic_recovery_status_frontend>&
       _topic_recovery_status_frontend;
+    ss::sharded<cluster::metadata_dissemination_service>&
+      _md_dissemination_service;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -827,7 +827,8 @@ void application::configure_admin_server() {
       std::ref(self_test_frontend),
       _schema_registry.get(),
       std::ref(topic_recovery_service),
-      std::ref(topic_recovery_status_frontend))
+      std::ref(topic_recovery_status_frontend),
+      std::ref(md_dissemination_service))
       .get();
 }
 

--- a/tests/rptest/tests/restart_services_test.py
+++ b/tests/rptest/tests/restart_services_test.py
@@ -61,9 +61,17 @@ class RestartServicesTest(RedpandaTest):
             self.logger.debug(ex)
             assert ex.response.status_code == requests.codes.not_found
 
+        # Success checks
         self.logger.debug("Check schema registry restart")
         result_raw = admin.redpanda_services_restart(
             rp_service='schema-registry')
         check_service_restart(self.redpanda, "Restarting the schema registry")
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug("Check metadata dissemination service restart")
+        result_raw = admin.redpanda_services_restart(
+            rp_service='metadata-dissemination-service')
+        check_service_restart(self.redpanda, "Restarting the metadata dissemination service")
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.ok


### PR DESCRIPTION
## Cover Letter

A class of bugs related to cached data (e.g. stale data, or bugs preventing/delaying cache eviction/refresh) are often solved by restarting a node or waiting. However, as more and more services and sub-systems are added to Redpanda the impact of a restart becomes higher. For example, Redpanda can't cycle the dissemination service without cycling all services.

This PR therefore adds the dissemination service to the restart services endpoint on the Admin API.

Fixes #9108

## Backports Required

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* Users can now restart the dissemination service by issuing a PUT request to admin/redpanda-services/restart?service=metadata-dissemination-service. This request will wipe http proxy state.

## Release Notes

### Improvements

* Adds a method to the metadata dissemination service that clears state.
