### PR TITLE
Another piece of improvement in constraints solver interface

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -215,29 +215,23 @@ partition_constraints partition_balancer_planner::get_partition_constraints(
     allocation_constraints allocation_constraints;
 
     // Add constraint on least disk usage
-    allocation_constraints.soft_constraints.push_back(
-      ss::make_lw_shared<soft_constraint>(
-        least_disk_filled(max_disk_usage_ratio, rrs.node_disk_reports)));
+    allocation_constraints.add(
+      least_disk_filled(max_disk_usage_ratio, rrs.node_disk_reports));
 
     // Add constraint on partition max_disk_usage_ratio overfill
     size_t upper_bound_for_partition_size = partition_size
                                             + _config.segment_fallocation_step;
-    allocation_constraints.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint>(disk_not_overflowed_by_partition(
-        max_disk_usage_ratio,
-        upper_bound_for_partition_size,
-        rrs.node_disk_reports)));
+    allocation_constraints.add(disk_not_overflowed_by_partition(
+      max_disk_usage_ratio,
+      upper_bound_for_partition_size,
+      rrs.node_disk_reports));
 
     // Add constraint on unavailable nodes
-    allocation_constraints.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint>(
-        distinct_from(rrs.timed_out_unavailable_nodes)));
+    allocation_constraints.add(distinct_from(rrs.timed_out_unavailable_nodes));
 
     // Add constraint on decommissioning nodes
     if (!rrs.decommissioning_nodes.empty()) {
-        allocation_constraints.hard_constraints.push_back(
-          ss::make_lw_shared<hard_constraint>(
-            distinct_from(rrs.decommissioning_nodes)));
+        allocation_constraints.add(distinct_from(rrs.decommissioning_nodes));
     }
 
     return partition_constraints(

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -55,25 +55,17 @@ allocation_constraints partition_allocator::default_constraints(
   const partition_allocation_domain domain) {
     allocation_constraints req;
 
-    req.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint>(distinct_nodes()));
-
-    req.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint>(not_fully_allocated()));
-
-    req.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint>(is_active()));
+    req.add(distinct_nodes());
+    req.add(not_fully_allocated());
+    req.add(is_active());
 
     if (domain == partition_allocation_domains::common) {
-        req.soft_constraints.push_back(
-          ss::make_lw_shared<soft_constraint>(least_allocated()));
+        req.add(least_allocated());
     } else {
-        req.soft_constraints.push_back(ss::make_lw_shared<soft_constraint>(
-          least_allocated_in_domain(domain)));
+        req.add(least_allocated_in_domain(domain));
     }
     if (_enable_rack_awareness()) {
-        req.soft_constraints.push_back(ss::make_lw_shared<soft_constraint>(
-          distinct_rack_preferred(*_state)));
+        req.add(distinct_rack_preferred(*_state));
     }
     return req;
 }
@@ -366,8 +358,7 @@ result<allocation_units> partition_allocator::reassign_decommissioned_replicas(
     });
 
     auto req = default_constraints(domain);
-    req.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint>(distinct_from(current_replicas)));
+    req.add(distinct_from(current_replicas));
 
     auto replicas = do_reallocate_partition(
       partition_constraints(current_assignment.id, replication_factor),

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -57,7 +57,7 @@ public:
      * Return an allocation_units object wrapping the result of the allocating
      * the given allocation request, or an error if it was not possible.
      */
-    result<allocation_units::pointer> allocate(allocation_request);
+    ss::future<result<allocation_units::pointer>> allocate(allocation_request);
 
     /// Reallocates partition replicas, moving them away from decommissioned
     /// nodes. Replicas on nodes that were left untouched are not changed.

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -11,11 +11,33 @@
 
 #include "cluster/scheduling/types.h"
 
+#include "cluster/logger.h"
 #include "cluster/scheduling/allocation_state.h"
 
 #include <fmt/ostream.h>
 
 namespace cluster {
+
+hard_constraint_evaluator
+hard_constraint::make_evaluator(const replicas_t& current_replicas) const {
+    auto ev = _impl->make_evaluator(current_replicas);
+    return [this, ev = std::move(ev)](const allocation_node& node) {
+        auto res = ev(node);
+        vlog(clusterlog.trace, "{}({}) = {}", name(), node.id(), res);
+        return res;
+    };
+}
+
+soft_constraint_evaluator
+soft_constraint::make_evaluator(const replicas_t& current_replicas) const {
+    auto ev = _impl->make_evaluator(current_replicas);
+    return [this, ev = std::move(ev)](const allocation_node& node) {
+        auto res = ev(node);
+        vlog(clusterlog.trace, "{}({}) = {}", name(), node.id(), res);
+        return res;
+    };
+};
+
 std::ostream& operator<<(std::ostream& o, const allocation_constraints& a) {
     fmt::print(
       o,

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -60,9 +60,7 @@ public:
     ~hard_constraint() noexcept = default;
 
     hard_constraint_evaluator
-    make_evaluator(const replicas_t& current_replicas) const {
-        return _impl->make_evaluator(current_replicas);
-    }
+    make_evaluator(const replicas_t& current_replicas) const;
 
     ss::sstring name() const { return _impl->name(); }
 
@@ -96,9 +94,7 @@ public:
     ~soft_constraint() noexcept = default;
 
     soft_constraint_evaluator
-    make_evaluator(const replicas_t& current_replicas) const {
-        return _impl->make_evaluator(current_replicas);
-    };
+    make_evaluator(const replicas_t& current_replicas) const;
 
     ss::sstring name() const { return _impl->name(); }
 

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -120,6 +120,16 @@ struct allocation_constraints {
     std::vector<soft_constraint_ptr> soft_constraints;
     std::vector<hard_constraint_ptr> hard_constraints;
 
+    void add(soft_constraint c) {
+        return soft_constraints.push_back(
+          ss::make_lw_shared<soft_constraint>(std::move(c)));
+    }
+
+    void add(hard_constraint c) {
+        return hard_constraints.push_back(
+          ss::make_lw_shared<hard_constraint>(std::move(c)));
+    }
+
     void add(allocation_constraints);
     friend std::ostream&
     operator<<(std::ostream&, const allocation_constraints&);

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -68,7 +68,7 @@ public:
 
 private:
     friend std::ostream& operator<<(std::ostream& o, const hard_constraint& c) {
-        fmt::print("hard constraint: [{}]", c.name());
+        fmt::print(o, "hard constraint: [{}]", c.name());
         return o;
     }
     std::unique_ptr<impl> _impl;
@@ -104,7 +104,7 @@ public:
 
 private:
     friend std::ostream& operator<<(std::ostream& o, const soft_constraint& c) {
-        fmt::print("soft constraint: [{}]", c.name());
+        fmt::print(o, "soft constraint: [{}]", c.name());
         return o;
     }
 

--- a/src/v/cluster/tests/allocation_bench.cc
+++ b/src/v/cluster/tests/allocation_bench.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/tests/partition_allocator_fixture.h"
 #include "cluster/types.h"
+#include "outcome.h"
 #include "raft/types.h"
 
 #include <seastar/core/reactor.hh>
@@ -24,9 +25,10 @@ PERF_TEST_F(partition_allocator_fixture, allocation_3) {
     auto req = make_allocation_request(1, 3);
 
     perf_tests::start_measuring_time();
-    auto vals = allocator.allocate(std::move(req));
-    perf_tests::do_not_optimize(vals);
-    perf_tests::stop_measuring_time();
+    return allocator.allocate(std::move(req)).then([](auto vals) {
+        perf_tests::do_not_optimize(vals);
+        perf_tests::stop_measuring_time();
+    });
 }
 PERF_TEST_F(partition_allocator_fixture, deallocation_3) {
     register_node(0, 24);
@@ -35,19 +37,23 @@ PERF_TEST_F(partition_allocator_fixture, deallocation_3) {
     auto req = make_allocation_request(1, 3);
 
     std::vector<model::broker_shard> replicas;
-    {
-        auto vals = std::move(allocator.allocate(std::move(req)).value());
-        replicas = vals->get_assignments().front().replicas;
-        allocator.update_allocation_state(
-          vals->get_assignments().front().replicas,
-          vals->get_assignments().front().group,
-          cluster::partition_allocation_domains::common);
-    }
-    perf_tests::do_not_optimize(replicas);
-    perf_tests::start_measuring_time();
-    allocator.deallocate(
-      replicas, cluster::partition_allocation_domains::common);
-    perf_tests::stop_measuring_time();
+
+    return allocator.allocate(std::move(req)).then([this](auto r) {
+        std::vector<model::broker_shard> replicas;
+        {
+            auto units = std::move(r.value());
+            replicas = units->get_assignments().front().replicas;
+            allocator.update_allocation_state(
+              units->get_assignments().front().replicas,
+              units->get_assignments().front().group,
+              cluster::partition_allocation_domains::common);
+        }
+        perf_tests::do_not_optimize(replicas);
+        perf_tests::start_measuring_time();
+        allocator.deallocate(
+          replicas, cluster::partition_allocation_domains::common);
+        perf_tests::stop_measuring_time();
+    });
 }
 PERF_TEST_F(partition_allocator_fixture, recovery) {
     register_node(0, 24);

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -62,8 +62,9 @@ struct partition_allocator_fixture {
     }
 
     void saturate_all_machines() {
-        auto units = allocator.allocate(
-          make_allocation_request(max_capacity(), 1));
+        auto units = allocator
+                       .allocate(make_allocation_request(max_capacity(), 1))
+                       .get();
 
         for (auto& pas : units.value()->get_assignments()) {
             allocator.state().apply_update(

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -111,6 +111,7 @@ struct partition_balancer_planner_fixture {
 
         auto pas = workers.allocator.local()
                      .allocate(std::move(req))
+                     .get()
                      .value()
                      ->get_assignments();
 

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -97,6 +97,7 @@ struct topic_table_fixture {
 
         auto pas = allocator.local()
                      .allocate(std::move(req))
+                     .get()
                      .value()
                      ->get_assignments();
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -414,8 +414,7 @@ make_allocation_request(const custom_assignable_topic_configuration& ca_cfg) {
         req.partitions.reserve(ca_cfg.custom_assignments.size());
         for (auto& cas : ca_cfg.custom_assignments) {
             allocation_constraints constraints;
-            constraints.hard_constraints.push_back(
-              ss::make_lw_shared<hard_constraint>(on_nodes(cas.replicas)));
+            constraints.add(on_nodes(cas.replicas));
 
             req.partitions.emplace_back(
               cas.id, cas.replicas.size(), std::move(constraints));
@@ -1137,9 +1136,8 @@ partition_constraints topics_frontend::get_partition_constraints(
     allocation_constraints allocation_constraints;
 
     // Add constraint on least disk usage
-    allocation_constraints.soft_constraints.push_back(
-      ss::make_lw_shared<soft_constraint>(
-        least_disk_filled(max_disk_usage_ratio, info.node_disk_reports)));
+    allocation_constraints.add(
+      least_disk_filled(max_disk_usage_ratio, info.node_disk_reports));
 
     auto partition_size_it = info.ntp_sizes.find(id);
     if (partition_size_it == info.ntp_sizes.end()) {
@@ -1147,11 +1145,8 @@ partition_constraints topics_frontend::get_partition_constraints(
     }
 
     // Add constraint on partition max_disk_usage_ratio overfill
-    allocation_constraints.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint>(disk_not_overflowed_by_partition(
-        max_disk_usage_ratio,
-        partition_size_it->second,
-        info.node_disk_reports)));
+    allocation_constraints.add(disk_not_overflowed_by_partition(
+      max_disk_usage_ratio, partition_size_it->second, info.node_disk_reports));
 
     return {id, new_replication_factor, std::move(allocation_constraints)};
 }
@@ -1331,8 +1326,7 @@ allocation_request make_allocation_request(
       get_allocation_domain(model::topic_namespace{ntp.ns, ntp.tp.topic}));
     req.partitions.reserve(1);
     allocation_constraints constraints;
-    constraints.hard_constraints.push_back(
-      ss::make_lw_shared<hard_constraint>(on_nodes(new_replicas)));
+    constraints.add(on_nodes(new_replicas));
     req.partitions.emplace_back(
       ntp.tp.partition, tp_replication_factor, std::move(constraints));
     return req;


### PR DESCRIPTION
Made it easier to express chained constraints. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none