### PR TITLE
cloud_storage: conditional multi object delete

### DIFF
--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -128,12 +128,20 @@ void s3_imposter_fixture::set_routes(
                   .url = request._url, .body = request.content};
                 return "";
             } else if (request._method == "DELETE") {
+                // TODO (abhijat) - enable conditionally failing requests
+                // instead of this hardcoding
+                if (request._url == "/failme") {
+                    repl.set_status(reply::status_type::internal_server_error);
+                    return "";
+                }
+
                 auto it = expectations.find(request._url);
                 if (it == expectations.end() || !it->second.body.has_value()) {
                     vlog(fixt_log.trace, "Reply DELETE request with error");
                     repl.set_status(reply::status_type::not_found);
                     return error_payload;
                 }
+
                 repl.set_status(reply::status_type::no_content);
                 it->second.body = std::nullopt;
                 return "";

--- a/src/v/cloud_storage/topic_recovery_service.cc
+++ b/src/v/cloud_storage/topic_recovery_service.cc
@@ -643,7 +643,7 @@ ss::future<> topic_recovery_service::do_check_for_downloads() {
     // As deleting keys in azure is a linear operation, timeout should be
     // adjusted to take this into account.
     size_t timeout_multiplier = 1;
-    if (config::shard_local_cfg().cloud_storage_azure_storage_account()) {
+    if (!_remote.local().is_batch_delete_supported()) {
         timeout_multiplier = results.size();
     }
     auto clear_fib = make_rtc(_as, _config, timeout_multiplier);

--- a/src/v/cloud_storage_clients/logger.h
+++ b/src/v/cloud_storage_clients/logger.h
@@ -17,4 +17,5 @@
 namespace cloud_storage_clients {
 inline ss::logger s3_log("s3");
 inline ss::logger abs_log("abs");
+inline ss::logger client_config_log("client_config");
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -773,8 +773,8 @@ s3_client::delete_object(
                 s3_log.debug,
                 "Object to be deleted was not found in cloud storage: "
                 "object={}, bucket={}. Ignoring ...",
-                bucket,
-                key);
+                key,
+                bucket);
               return ss::make_ready_future<ret_t>(no_response{});
           } else {
               return ss::make_ready_future<ret_t>(result);

--- a/src/v/utils/string_switch.h
+++ b/src/v/utils/string_switch.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <optional>
+#include <regex>
 #include <stdexcept>
 #include <string>
 
@@ -171,6 +172,17 @@ public:
       T value) {
         return match(S0, value).match_all(
           S1, S2, S3, S4, S5, S6, S7, S8, S9, value);
+    }
+
+    constexpr string_switch& match_expr(std::string_view expr, T value) {
+        if (
+          !result
+          && std::regex_search(
+            std::string{view.data(), view.size()},
+            std::regex{expr.data(), expr.size()})) {
+            result = std::move(value);
+        }
+        return *this;
     }
 
     constexpr R default_match(T value) {


### PR DESCRIPTION
Remote has a field denoting which backend it is working against, we use that information to decide whether to delete objects in batch or one at a time.

Fixes https://github.com/redpanda-data/redpanda/issues/9169

Caveats:

1. The caller to `delete_objects` must supply a deadline/timeout sufficient to accommodate sequential deletes if the backend requires this. Currently the only caller is topic recovery which does this. A method `is_batch_delete_supported` is added to remote to query this.
2. Sequential deletes are done concurrently on a single shard, up to `remote::concurrency()` calls at a time.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
