### PR TITLE
Validate raft response node

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1507,6 +1507,7 @@ ss::future<vote_reply> consensus::do_vote(vote_request&& r) {
     vote_reply reply;
     reply.term = _term;
     reply.target_node_id = r.node_id;
+    reply.node_id = _self;
     auto lstats = _log.offsets();
     auto last_log_index = lstats.dirty_offset;
     _probe.vote_request();
@@ -1991,6 +1992,7 @@ consensus::do_install_snapshot(install_snapshot_request&& r) {
     install_snapshot_reply reply{
       .term = _term, .bytes_stored = r.chunk.size_bytes(), .success = false};
     reply.target_node_id = r.node_id;
+    reply.node_id = _self;
 
     if (unlikely(is_request_target_node_invalid("install_snapshot", r))) {
         return ss::make_ready_future<install_snapshot_reply>(reply);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -309,6 +309,21 @@ consensus::success_reply consensus::update_follower_index(
     follower_index_metadata& idx = it->second;
     const append_entries_reply& reply = r.value();
     vlog(_ctxlog.trace, "Append entries response: {}", reply);
+
+    /**
+     * Do not update any of the follower state if a node that replied to
+     * append_entries_request is not the one that the request was addressed to.
+     */
+    if (unlikely(reply.node_id.id() != physical_node)) {
+        vlog(
+          _ctxlog.warn,
+          "Received append entries response node_id doesn't match expected "
+          "node_id (received: {}, expected: {})",
+          reply.node_id.id(),
+          node);
+        return success_reply::no;
+    }
+
     if (unlikely(reply.result == append_entries_reply::status::timeout)) {
         // ignore this response, timed out on the receiver node
         vlog(_ctxlog.trace, "Append entries request timedout at node {}", node);

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -52,8 +52,9 @@ ss::future<result<vote_reply>> prevote_stm::do_dispatch_prevote(vnode n) {
     r.target_node_id = n;
     return _ptr->_client_protocol
       .vote(n.id(), std::move(r), rpc::client_opts(_prevote_timeout))
-      .then([this](result<vote_reply> reply) {
-          return _ptr->validate_reply_target_node("prevote", std::move(reply));
+      .then([this, target_node_id = n.id()](result<vote_reply> reply) {
+          return _ptr->validate_reply_target_node(
+            "prevote", reply, target_node_id);
       });
 }
 

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -315,7 +315,7 @@ ss::future<> recovery_stm::send_install_snapshot_request() {
             .then([this](result<install_snapshot_reply> reply) {
                 return handle_install_snapshot_reply(
                   _ptr->validate_reply_target_node(
-                    "install_snapshot", std::move(reply)));
+                    "install_snapshot", reply, _node_id.id()));
             })
             .finally([this, seq] {
                 _ptr->update_suppress_heartbeats(
@@ -504,7 +504,7 @@ ss::future<result<append_entries_reply>> recovery_stm::dispatch_append_entries(
       .append_entries(_node_id.id(), std::move(r), std::move(opts))
       .then([this](result<append_entries_reply> reply) {
           return _ptr->validate_reply_target_node(
-            "append_entries_recovery", std::move(reply));
+            "append_entries_recovery", reply, _node_id.id());
       });
 }
 

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -118,9 +118,10 @@ replicate_entries_stm::send_append_entries_request(
 
           return _ptr->_client_protocol
             .append_entries(n.id(), std::move(req), std::move(opts))
-            .then([this](result<append_entries_reply> reply) {
+            .then([this, target_node_id = n.id()](
+                    result<append_entries_reply> reply) {
                 return _ptr->validate_reply_target_node(
-                  "append_entries_replicate", std::move(reply));
+                  "append_entries_replicate", reply, target_node_id);
             })
             .finally([this, n, u = std::move(u)] {
                 _ptr->_fstats.return_append_entries_units(n);

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -430,7 +430,7 @@ struct vote_request
 };
 
 struct vote_reply
-  : serde::envelope<vote_reply, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<vote_reply, serde::version<1>, serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
     /// \brief callee's term, for the caller to upate itself
@@ -444,12 +444,15 @@ struct vote_reply
     /// - "Preventing disruptions when a server rejoins the cluster"
     bool log_ok = false;
 
+    // replying node
+    vnode node_id;
+
     friend std::ostream& operator<<(std::ostream& o, const vote_reply& r);
 
     friend bool operator==(const vote_reply&, const vote_reply&) = default;
 
     auto serde_fields() {
-        return std::tie(target_node_id, term, granted, log_ok);
+        return std::tie(target_node_id, term, granted, log_ok, node_id);
     }
 };
 
@@ -595,7 +598,7 @@ private:
 struct install_snapshot_reply
   : serde::envelope<
       install_snapshot_reply,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     // node id to validate on receiver
     vnode target_node_id;
@@ -613,6 +616,9 @@ struct install_snapshot_reply
     // indicates if the request was successfull
     bool success = false;
 
+    // replying node
+    vnode node_id;
+
     friend std::ostream&
     operator<<(std::ostream&, const install_snapshot_reply&);
 
@@ -621,7 +627,7 @@ struct install_snapshot_reply
       = default;
 
     auto serde_fields() {
-        return std::tie(target_node_id, term, bytes_stored, success);
+        return std::tie(target_node_id, term, bytes_stored, success, node_id);
     }
 };
 

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -56,9 +56,9 @@ ss::future<result<vote_reply>> vote_stm::do_dispatch_one(vnode n) {
     r.target_node_id = n;
     return _ptr->_client_protocol
       .vote(n.id(), std::move(r), rpc::client_opts(tout))
-      .then([this](result<vote_reply> reply) {
+      .then([this, target_node_id = n.id()](result<vote_reply> reply) {
           return _ptr->validate_reply_target_node(
-            "vote_request", std::move(reply));
+            "vote_request", reply, target_node_id);
       });
 }
 


### PR DESCRIPTION
When receiving a reply from a follower leader should always validate if
a follower responding the request is the one that was targeted.
Otherwise a reply should be discarded. Added that missing validation to
all critical raft replies i.e. vote and install_snapshot.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes rare issue that may arise when new node id is assigned to a node with the same set of ip addresses 