### PR TITLE
cloud_storage: Improve column-store

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -398,15 +398,18 @@ public:
             return;
         }
         auto ix = lb.index();
-        std::apply(
-          [ix](auto&&... col) { (col.prefix_truncate_ix(ix), ...); },
-          columns());
         // We need to remove hints that belong to the first frame.
         // This frame was truncated and therefore the hints that
         // belong to it are no longer valid.
         const auto& frame = _base_offset.get_frame_by_element_index(ix).get();
         auto frame_max_offset = frame.last_value();
         auto it = _hints.upper_bound(frame_max_offset.value_or(bo));
+
+        // Truncate columns
+        std::apply(
+          [ix](auto&&... col) { (col.prefix_truncate_ix(ix), ...); },
+          columns());
+
         // The elements are ordered by base offset from large to small
         // so the hints that belong to removed and truncated frames are
         // at the end.

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
 
 using namespace cloud_storage;
@@ -39,6 +40,20 @@ using delta_delta_column = segment_meta_column<int64_t, delta_delta_alg>;
 
 static const delta_xor_alg initial_xor{};
 static const delta_delta_alg initial_delta{0};
+
+// The performance of these tests depend on compiler optimizations a lot.
+// The read codepath only works well when the compiler is able to vectorize
+// it. Because of that the runtime of the debug version is very high if the
+// parameters are the same. To reduce the runtime of the debug version we
+// have to use smaller dataset. It's important to actually run the tests in
+// debug to detect potential memory bugs using ASan.
+#ifdef NDEBUG
+static constexpr size_t short_test_size = 10000;
+static constexpr size_t long_test_size = 100000;
+#else
+static constexpr size_t short_test_size = 1500;
+static constexpr size_t long_test_size = 3000;
+#endif
 
 template<class column_t>
 void append_test_case(const int64_t num_elements, column_t& column) {
@@ -55,22 +70,22 @@ void append_test_case(const int64_t num_elements, column_t& column) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_xor) {
     delta_xor_frame frame(initial_xor);
-    append_test_case(100000, frame);
+    append_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_delta) {
     delta_delta_frame frame(initial_delta);
-    append_test_case(100000, frame);
+    append_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_xor) {
     delta_xor_column col(initial_xor);
-    append_test_case(100000, col);
+    append_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_delta) {
     delta_delta_column col(initial_delta);
-    append_test_case(100000, col);
+    append_test_case(short_test_size, col);
 }
 
 template<class column_t>
@@ -91,22 +106,22 @@ void append_tx_test_case(const int64_t num_elements, column_t& column) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_tx_xor) {
     delta_xor_frame frame(initial_xor);
-    append_tx_test_case(100000, frame);
+    append_tx_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_append_tx_delta) {
     delta_delta_frame frame(initial_delta);
-    append_tx_test_case(100000, frame);
+    append_tx_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_tx_xor) {
     delta_xor_column col(initial_xor);
-    append_tx_test_case(100000, col);
+    append_tx_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_append_tx_delta) {
     delta_delta_column col(initial_delta);
-    append_tx_test_case(100000, col);
+    append_tx_test_case(short_test_size, col);
 }
 
 template<class column_t>
@@ -131,22 +146,22 @@ void iter_test_case(const int64_t num_elements, column_t& column) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_iter_xor) {
     delta_xor_frame frame(initial_xor);
-    iter_test_case(100000, frame);
+    iter_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_iter_delta) {
     delta_delta_frame frame(initial_delta);
-    iter_test_case(100000, frame);
+    iter_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_iter_xor) {
     delta_xor_column col(initial_xor);
-    iter_test_case(100000, col);
+    iter_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_iter_delta) {
     delta_delta_column col(initial_delta);
-    iter_test_case(100000, col);
+    iter_test_case(short_test_size, col);
 }
 
 template<class column_t>
@@ -177,7 +192,7 @@ void find_test_case(const int64_t num_elements, column_t& column) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_xor) {
     delta_xor_frame frame(initial_xor);
-    find_test_case(100000, frame);
+    find_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_xor_small) {
@@ -187,7 +202,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_xor_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_delta) {
     delta_delta_frame frame(initial_delta);
-    find_test_case(100000, frame);
+    find_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_delta_small) {
@@ -197,7 +212,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_find_delta_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor) {
     delta_xor_column col(initial_xor);
-    find_test_case(100000, col);
+    find_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor_small) {
@@ -207,7 +222,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_xor_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_delta) {
     delta_delta_column col(initial_delta);
-    find_test_case(100000, col);
+    find_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_find_delta_small) {
@@ -252,7 +267,7 @@ void lower_bound_test_case(const int64_t num_elements, column_t& column) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_xor) {
     delta_xor_frame frame(initial_xor);
-    lower_bound_test_case(100000, frame);
+    lower_bound_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_xor_small) {
@@ -262,7 +277,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_xor_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_delta) {
     delta_delta_frame frame(initial_delta);
-    lower_bound_test_case(100000, frame);
+    lower_bound_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_delta_small) {
@@ -272,7 +287,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_lower_bound_delta_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_xor) {
     delta_xor_column col(initial_xor);
-    lower_bound_test_case(100000, col);
+    lower_bound_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_xor_small) {
@@ -282,7 +297,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_xor_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_delta) {
     delta_delta_column col(initial_delta);
-    lower_bound_test_case(100000, col);
+    lower_bound_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_lower_bound_delta_small) {
@@ -325,7 +340,7 @@ void upper_bound_test_case(const int64_t num_elements, column_t& column) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_xor) {
     delta_xor_frame frame(initial_xor);
-    upper_bound_test_case(100000, frame);
+    upper_bound_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_xor_small) {
@@ -335,7 +350,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_xor_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_delta) {
     delta_delta_frame frame(initial_delta);
-    upper_bound_test_case(100000, frame);
+    upper_bound_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_delta_small) {
@@ -345,7 +360,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_upper_bound_delta_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_xor) {
     delta_xor_column col(initial_xor);
-    upper_bound_test_case(100000, col);
+    upper_bound_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_xor_small) {
@@ -355,7 +370,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_xor_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_delta) {
     delta_delta_column col(initial_delta);
-    upper_bound_test_case(100000, col);
+    upper_bound_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_upper_bound_delta_small) {
@@ -392,7 +407,7 @@ void at_test_case(const int64_t num_elements, column_t& column) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_xor) {
     delta_xor_frame frame(initial_xor);
-    at_test_case(100000, frame);
+    at_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_xor_small) {
@@ -402,7 +417,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_xor_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_delta) {
     delta_delta_frame frame(initial_delta);
-    at_test_case(100000, frame);
+    at_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_delta_small) {
@@ -412,7 +427,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_delta_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_xor) {
     delta_xor_column col(initial_xor);
-    at_test_case(100000, col);
+    at_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_xor_small) {
@@ -422,7 +437,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_xor_small) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_delta) {
     delta_delta_column col(initial_delta);
-    at_test_case(100000, col);
+    at_test_case(short_test_size, col);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_delta_small) {
@@ -549,22 +564,22 @@ void at_with_hint_test_case(const int64_t num_elements, column_t& column) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_with_hint_xor) {
     delta_xor_frame frame(initial_xor);
-    at_with_hint_test_case(0x1000, frame);
+    at_with_hint_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_frame_at_with_hint_delta) {
     delta_delta_frame frame(initial_delta);
-    at_with_hint_test_case(0x1000, frame);
+    at_with_hint_test_case(short_test_size, frame);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_with_hint_xor) {
     delta_xor_column column(initial_xor);
-    at_with_hint_test_case(0x1000, column);
+    at_with_hint_test_case(short_test_size, column);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_col_at_with_hint_delta) {
     delta_delta_column column(initial_delta);
-    at_with_hint_test_case(0x1000, column);
+    at_with_hint_test_case(short_test_size, column);
 }
 
 std::vector<segment_meta> generate_metadata(size_t sz) {
@@ -613,7 +628,8 @@ std::vector<segment_meta> generate_metadata(size_t sz) {
             curr.size_bytes = rg::get_int(1, 200000);
             curr.base_timestamp = curr.max_timestamp;
             curr.max_timestamp = model::timestamp(
-              curr.max_timestamp.value() + rg::get_int(0, 100000));
+              curr.max_timestamp.value()
+              + rg::get_int(0, (int)short_test_size));
             curr.delta_offset = curr.delta_offset_end;
             curr.delta_offset_end = curr.delta_offset_end
                                     + model::offset_delta(rg::get_int(15));
@@ -633,7 +649,7 @@ std::vector<segment_meta> generate_metadata(size_t sz) {
 
 void test_compression_ratio() {
     segment_meta_cstore store;
-    auto manifest = generate_metadata(1000000);
+    auto manifest = generate_metadata(long_test_size);
     for (const auto& sm : manifest) {
         store.insert(sm);
     }
@@ -658,7 +674,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_compression_ratio) {
 
 void test_cstore_iter() {
     segment_meta_cstore store;
-    auto manifest = generate_metadata(100000);
+    auto manifest = generate_metadata(short_test_size);
     for (const auto& sm : manifest) {
         store.insert(sm);
     }
@@ -675,7 +691,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_iter) { test_cstore_iter(); }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_find) {
     segment_meta_cstore store;
-    auto manifest = generate_metadata(10000);
+    auto manifest = generate_metadata(short_test_size);
     for (const auto& sm : manifest) {
         store.insert(sm);
     }
@@ -690,7 +706,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_find) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_lower_bound) {
     segment_meta_cstore store;
-    auto manifest = generate_metadata(10000);
+    auto manifest = generate_metadata(short_test_size);
     for (const auto& sm : manifest) {
         store.insert(sm);
     }
@@ -705,7 +721,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_lower_bound) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_upper_bound) {
     segment_meta_cstore store;
-    auto manifest = generate_metadata(10000);
+    auto manifest = generate_metadata(short_test_size);
     for (const auto& sm : manifest) {
         store.insert(sm);
     }
@@ -720,7 +736,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_upper_bound) {
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_full_contains) {
     segment_meta_cstore store;
-    auto manifest = generate_metadata(10000);
+    auto manifest = generate_metadata(short_test_size);
     for (const auto& sm : manifest) {
         store.insert(sm);
     }
@@ -744,6 +760,15 @@ void test_cstore_prefix_truncate(size_t test_size, size_t max_truncate_ix) {
     auto iter = manifest.begin();
     std::advance(iter, ix);
     auto start_offset = iter->base_offset;
+
+    vlog(
+      test.info,
+      "going to truncate cstore, test_size={}, max_truncate_ix={}, "
+      "start_offset={}, num remaining={}",
+      test_size,
+      max_truncate_ix,
+      start_offset,
+      std::distance(iter, manifest.end()));
     manifest.erase(manifest.begin(), iter);
     store.prefix_truncate(start_offset);
 
@@ -759,9 +784,9 @@ void test_cstore_prefix_truncate(size_t test_size, size_t max_truncate_ix) {
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_small) {
-    test_cstore_prefix_truncate(10000, 100);
+    test_cstore_prefix_truncate(short_test_size, 100);
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_full) {
-    test_cstore_prefix_truncate(10000, 2000);
+    test_cstore_prefix_truncate(short_test_size, short_test_size);
 }


### PR DESCRIPTION
This PR fixes prefix truncation code. The method first truncated the columns and then it attempted to use the same index to find the frame. The operation has failed if the truncation affected more than one frame.

Also, this PR fixes runtime of column-store tests.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none