### PR TITLE
tests: update partition limits

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -94,7 +94,7 @@ class ScaleParameters:
         # Reserve a few slots for internal partitions, do not be
         # super specific about how many because we may add some in
         # future for e.g. audit logging.
-        internal_partition_slack = 10
+        internal_partition_slack = 32
 
         # Calculate how many partitions we will aim to create, based
         # on the size & count of nodes.  This enables running the

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -182,7 +182,10 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             message_size = 256 * (2**10)
             message_cnt = 819200
             consumers = 8
-            partitions_count = 18000
+            # Multiply default partition per shard limit by cores in system, subtract
+            # a few to leave room for the consumer offsets etc partitions.
+            partitions_count = 1000 * self.redpanda.get_node_cpu_count() * len(
+                self.redpanda.nodes) - 32
             max_concurrent_moves = 400
             timeout = 500
         else:
@@ -192,6 +195,8 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             partitions_count = 200
             max_concurrent_moves = 200
             timeout = 500
+
+        self.logger.info(f"Running with {partitions_count} partitions")
 
         # set max number of concurrent moves
         self.redpanda.set_cluster_config(


### PR DESCRIPTION
Change 3e3975bd70f3e67d3f76a1b42b21c9386bc49ecb caused some scale tests to fail https://ci-artifacts.dev.vectorized.cloud/vtools/0186a681-02da-49ac-8a24-e33caa78970f/vbuild/ducktape/results/2023-03-03--001/report.html

These limits need updating so that the tests operate within the supported range.  ManyPartitionsTest was only out by a few, partition balancer test was further out.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none