### PR TITLE
Added test verifying behavior when data folder is lost 

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -199,6 +199,7 @@ void consensus::do_step_down(std::string_view ctx) {
           _term,
           _log.offsets().dirty_offset);
     }
+    _fstats.reset();
     _vstate = vote_state::follower;
 }
 

--- a/src/v/raft/follower_stats.h
+++ b/src/v/raft/follower_stats.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/follower_queue.h"
 #include "raft/types.h"
@@ -75,6 +76,12 @@ public:
     void return_append_entries_units(vnode);
 
     void update_with_configuration(const group_configuration&);
+
+    void reset() {
+        for (auto& [_, meta] : _followers) {
+            meta.reset();
+        }
+    }
 
 private:
     friend std::ostream& operator<<(std::ostream&, const follower_stats&);

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -130,6 +130,20 @@ replicate_stages::replicate_stages(raft::errc ec)
   , replicate_finished(
       ss::make_ready_future<result<replicate_result>>(make_error_code(ec))){};
 
+void follower_index_metadata::reset() {
+    last_dirty_log_index = model::offset{};
+    last_flushed_log_index = model::offset{};
+    last_sent_offset = model::offset{};
+    match_index = model::offset{};
+    next_index = model::offset{};
+    heartbeats_failed = 0;
+    last_sent_seq = follower_req_seq{0};
+    last_received_seq = follower_req_seq{0};
+    last_successful_received_seq = follower_req_seq{0};
+    last_suppress_heartbeats_seq = follower_req_seq{0};
+    suppress_heartbeats = heartbeats_suppressed::no;
+}
+
 std::ostream& operator<<(std::ostream& o, const vnode& id) {
     return o << "{id: " << id.id() << ", revision: " << id.revision() << "}";
 }

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -83,6 +83,8 @@ struct follower_index_metadata {
     follower_index_metadata& operator=(const follower_index_metadata&) = delete;
     follower_index_metadata(follower_index_metadata&&) = default;
     follower_index_metadata& operator=(follower_index_metadata&&) = delete;
+    // resets the follower state i.e. all indicies and sequence numbers
+    void reset();
 
     vnode node_id;
     // index of last known log for this follower

--- a/tests/rptest/tests/node_folder_deletion_test.py
+++ b/tests/rptest/tests/node_folder_deletion_test.py
@@ -1,0 +1,106 @@
+# Copyright 2020 Redpanda Data, Inc.
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from rptest.clients.consumer_offsets_recovery import ConsumerOffsetsRecovery
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+
+from rptest.clients.rpk import RpkException, RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.kafka_cli_consumer import KafkaCliConsumer
+from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.rpk_producer import RpkProducer
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.tests.redpanda_test import RedpandaTest
+from ducktape.utils.util import wait_until
+from rptest.utils.mode_checks import skip_debug_mode
+
+from rptest.utils.node_operations import NodeDecommissionWaiter
+
+
+class NodeFolderDeletionTest(PreallocNodesTest):
+    def __init__(self, test_context, *args, **kwargs):
+        super().__init__(test_context=test_context, node_prealloc_count=1)
+
+    def setUp(self):
+        # Defer startup to test body.
+        pass
+
+    @skip_debug_mode
+    @cluster(num_nodes=4)
+    def test_deleting_node_folder(self):
+
+        # new bootstrap
+        self.redpanda.start(auto_assign_node_id=True,
+                            omit_seeds_on_idx_one=False)
+        topics = []
+        for i in range(5):
+            topics.append(TopicSpec(partition_count=16, replication_factor=3))
+
+        self.client().create_topic(topics)
+        topic = topics[0]
+        msg_size = 1024
+        msg_cnt = 400000
+
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       topic.name,
+                                       msg_size,
+                                       msg_cnt,
+                                       custom_node=self.preallocated_nodes,
+                                       rate_limit_bps=msg_size * 1000)
+
+        producer.start(clean=False)
+
+        wait_until(lambda: producer.produce_status.acked > 100,
+                   timeout_sec=60,
+                   backoff_sec=0.5)
+
+        consumer = KgoVerifierConsumerGroupConsumer(
+            self.test_context,
+            self.redpanda,
+            topic.name,
+            msg_size,
+            readers=3,
+            nodes=self.preallocated_nodes)
+
+        consumer.start(clean=False)
+
+        wait_until(lambda: producer.produce_status.acked > 100000,
+                   timeout_sec=120,
+                   backoff_sec=0.5)
+        to_stop = random.choice(self.redpanda.nodes)
+        id = self.redpanda.node_id(to_stop)
+
+        # remove node data folder
+        self.redpanda.stop_node(to_stop)
+        self.redpanda.clean_node(to_stop)
+        # start node back up
+        self.redpanda.start_node(to_stop, auto_assign_node_id=True)
+        # assert that node id has changed
+        assert id != self.redpanda.node_id(to_stop, force_refresh=True)
+        wait_until(lambda: producer.produce_status.acked > 200000,
+                   timeout_sec=120,
+                   backoff_sec=0.5)
+        admin = Admin(self.redpanda)
+        # decommission a node that has been cleared
+        admin.decommission_broker(id)
+        waiter = NodeDecommissionWaiter(self.redpanda,
+                                        id,
+                                        self.logger,
+                                        progress_timeout=60)
+
+        waiter.wait_for_removal()
+
+        wait_until(lambda: producer.produce_status.acked > 300000,
+                   timeout_sec=120,
+                   backoff_sec=0.5)


### PR DESCRIPTION
Added test checking if Redpanda is able to tolerate situation in which a whole data directory on one of the nodes is lost.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none