### PR TITLE
admin: add a reset endpoint for the cluster health monitor

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -67,6 +67,7 @@ enum class errc : int16_t {
     cluster_already_exists,
     no_partition_assignments,
     failed_to_create_partition,
+    reset_in_progress,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -191,6 +192,8 @@ struct errc_category final : public std::error_category {
             return "No replica assignments for the requested partition";
         case errc::failed_to_create_partition:
             return "Failed to create partition replica instance";
+        case errc::reset_in_progress:
+            return "Service reset is in progress";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -10,6 +10,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "cluster/errc.h"
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/node/local_monitor.h"
@@ -58,6 +59,7 @@ public:
       ss::sharded<features::feature_table>&);
 
     ss::future<> stop();
+    void reset();
 
     ss::future<result<cluster_health_report>> get_cluster_health(
       cluster_report_filter, force_refresh, model::timeout_clock::time_point);
@@ -90,7 +92,7 @@ private:
 
         ss::future<std::error_code>
           abortable_await(ss::future<std::error_code>);
-        void abort();
+        void abort(errc ec = errc::leadership_changed);
 
         bool finished = false;
         model::node_id leader_id;
@@ -136,7 +138,7 @@ private:
       process_node_reply(model::node_id, result<get_node_health_reply>);
 
     std::chrono::milliseconds max_metadata_age();
-    void abort_current_refresh();
+    void abort_current_refresh(errc ec = errc::leadership_changed);
 
     void on_leadership_changed(
       raft::group_id, model::term_id, std::optional<model::node_id>);

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -147,4 +147,14 @@ ss::future<bool> health_monitor_frontend::does_raft0_have_leader() {
       [](health_monitor_backend& be) { return be.does_raft0_have_leader(); });
 }
 
+ss::future<> health_monitor_frontend::reset() {
+    vlog(clusterlog.info, "Resetting Health Monitor Frontend");
+    co_await dispatch_to_backend(
+      [](health_monitor_backend& be) { be.reset(); });
+
+    _cluster_disk_health = storage::disk_space_alert::ok;
+    // Resetting _refresh_timer is not needed as it is simply a mechnism to
+    // trigger disk health tick
+}
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -44,6 +44,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    ss::future<> reset();
 
     // Reports cluster health. Cluster health is based on the cluster health
     // state that is cached on current node. If force_refresh flag is set. It

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -217,6 +217,10 @@ std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
 
 void metadata_cache::reset_leaders() { _leaders.local().reset(); }
 
+ss::future<> metadata_cache::reset_health_monitor() {
+    co_await _health_monitor.local().reset();
+}
+
 cluster::partition_leaders_table::leaders_info_t
 metadata_cache::get_leaders() const {
     return _leaders.local().get_leaders();

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -163,6 +163,7 @@ public:
     std::optional<model::node_id> get_controller_leader_id();
 
     void reset_leaders();
+    ss::future<> reset_health_monitor();
     cluster::partition_leaders_table::leaders_info_t get_leaders() const;
 
     void set_is_node_isolated_status(bool is_node_isolated);

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -84,6 +84,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::cluster_already_exists:
     case cluster::errc::no_partition_assignments:
     case cluster::errc::failed_to_create_partition:
+    case cluster::errc::reset_in_progress:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -175,6 +175,21 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/reset_health_info",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Reset information about cluster health for node",
+                    "type": "void",
+                    "nickname": "reset_health_info",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3464,6 +3464,16 @@ void admin_server::register_debug_routes() {
       });
 
     register_route<user>(
+      ss::httpd::debug_json::reset_health_info,
+      [this](std::unique_ptr<ss::httpd::request>) {
+          vlog(logger.info, "Request to reset cluster health info");
+          return _metadata_cache
+            .invoke_on_all([](auto& mc) { return mc.reset_health_monitor(); })
+            .then(
+              [] { return ss::json::json_return_type(ss::json::json_void()); });
+      });
+
+    register_route<user>(
       ss::httpd::debug_json::get_leaders_info,
       [this](std::unique_ptr<ss::httpd::request>) {
           vlog(logger.info, "Request to get leaders info");

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -868,3 +868,9 @@ class Admin:
         return int(
             self._request(
                 "GET", "debug/cloud_storage_usage?retries_allowed=10").json())
+
+    def reset_health_info(self, node: Optional[ClusterNode] = None):
+        """
+        Reset info for cluster health on node
+        """
+        return self._request("post", "debug/reset_health_info", node=node)

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 import random
+import requests
 from pickletools import long1
 from time import sleep, time, time_ns
 
@@ -20,9 +21,11 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import LoggingConfig
 from rptest.services.storage import Topic
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.restart_services_test import check_service_restart
 from rptest.utils.full_disk import FullDiskHelper
 from rptest.utils.partition_metrics import PartitionMetrics
 from rptest.utils.expect_rate import ExpectRate, RateTarget
@@ -46,7 +49,9 @@ class WriteRejectTest(RedpandaTest):
     topic_names = [spec.name for spec in topics]
 
     def __init__(self, test_context: TestContext):
-        super().__init__(test_context)
+        super().__init__(test_context,
+                         log_config=LoggingConfig(
+                             'info', logger_levels={'cluster': 'trace'}))
         self.producers = None
         self.full_disk = FullDiskHelper(self.logger, self.redpanda)
 
@@ -69,18 +74,21 @@ class WriteRejectTest(RedpandaTest):
         # around this.
         sleep(5)
 
+        self.NUM_MESSAGES = MAX_MSG // len(self.topics)
+        self.PAUSE_S = len(self.topics) * 1.0 / MAX_MSG_PER_SEC
+
     def _send_all_topics(self, msg: str, expect_blocked=False):
         """ Send `msg` to all topics, retrying a fixed number of times for
         expected success or failure. """
         futures = []
-        num_topics = len(self.topics)
-        pause: float = num_topics * 1.0 / MAX_MSG_PER_SEC
+        num_topics = self.NUM_MESSAGES
+        pause: float = self.PAUSE_S
         was_blocked = False
         success = False
         t0 = time()
         i = 0
         producers = self._get_producers(refresh=True)
-        for _ in range(MAX_MSG // num_topics):
+        for _ in range(self.NUM_MESSAGES):
             sleep(pause)
             try:
                 for j, topic in enumerate(self.topic_names):
@@ -129,6 +137,68 @@ class WriteRejectTest(RedpandaTest):
                 "A: I don't know, but they can do a lot of bites per second.",
                 expect_blocked=True)
             self.full_disk.clear_low_space()
+
+    @cluster(num_nodes=3, log_allow_list=FDT_LOG_ALLOW_LIST)
+    def test_reset_health_monitor(self):
+        """ Verify that health monitor frontend and backend have valid state after
+        they are reset by writing enough data that the disk health check triggers.
+        """
+        def check_health_monitor_frontend(disk_space_change: str):
+            # Looking for a log statement about a change in disk space.
+            # This is a check for the health monitor frontend because
+            # that structure logs disk space alerts.
+            pattern = f"Update disk health cache {disk_space_change}"
+            wait_until(
+                lambda: self.redpanda.search_log_any(pattern),
+                timeout_sec=5,
+                err_msg=f"Failed to find disk space change: {disk_space_change}"
+            )
+
+        def check_health_monitor_backend(fail_msg: str):
+            # This is an indirect check for the health monitor backend because
+            # RedpandaService.healthy() uses the prometheus metric, vectorized_cluster_partition_under_replicated_replicas,
+            # which is measured in the health monitor backend.
+            wait_until(lambda: self.redpanda.healthy(),
+                       timeout_sec=20,
+                       backoff_sec=1,
+                       err_msg=fail_msg)
+
+        self._setup()
+
+        self._send_all_topics("Q: Why should you be scared of computers?")
+        self.full_disk.trigger_low_space()
+        self._send_all_topics("A: They byte!", expect_blocked=True)
+
+        # Disk health should show degraded state
+        check_health_monitor_frontend(disk_space_change="ok -> degraded")
+
+        check_health_monitor_backend(
+            fail_msg="Cluster is not healthy before health monitor reset")
+
+        self.logger.debug("Check health monitor reset")
+        for node in self.redpanda.nodes:
+            result_raw = self.admin.reset_health_info(node=node)
+            self.logger.debug(result_raw)
+            check_service_restart(self.redpanda,
+                                  "Resetting Health Monitor Frontend")
+            check_service_restart(self.redpanda,
+                                  "Resetting Health Monitor Backend")
+            assert result_raw.status_code == requests.codes.ok
+
+        check_health_monitor_backend(
+            fail_msg="Cluster is not healthy after health monitor reset")
+
+        # RP should still reject writes before clearing space
+        self._send_all_topics("Q: What animal does a computer like to watch?",
+                              expect_blocked=True)
+
+        self.full_disk.clear_low_space()
+
+        # RP should now accept writes after clearing space
+        self._send_all_topics("A: A RAM!")
+
+        # Expect the disk health check to tranistion from degraded to ok
+        check_health_monitor_frontend(disk_space_change="degraded -> ok")
 
 
 class FullDiskTest(EndToEndTest):


### PR DESCRIPTION
## Cover Letter

A class of bugs related to cached data (e.g. stale data, or bugs preventing/delaying cache eviction/refresh) are often solved by restarting a node or waiting. However, as more and more services and sub-systems are added to Redpanda the impact of a restart becomes higher. For example, Redpanda can't cycle the dissemination service without cycling all services.

This PR therefore adds the dissemination service to the restart services endpoint on the Admin API.

Fixes #9107

Changes from force-push `f77a534`:
- Refactor the reset method in the health monitor frontend so the gate and mutex are not changed
- Add a reset method to the health monitor backend
- Edit restart tests to check for the health monitor backend
- Add a test into `full_disk_test.py` that checks for `_cluster_disk_health` from the frontend and uses metrics to check the backend

Changes from force-push `f06b0f3`:
- Remove re-registering leadership notification callbacks
- Clear local caches in the reset method
- Reset `_refresh_request` by setting the `finished` field
- Reset `_last_refresh` by assigning an empty `time_point`

Changes from force-push `f62bbf3`:
- Fix typos
- Do nothing with `_refresh_request` in the `reset` method

Changes from force-push `f8fae52` and `b33ffab`:
- Rebase dev to resolve conflicts
- Do not cancel or rearm timers in the reset methods
- Do reset the disk health alerts
- Overload `abortable_refresh_request::abort` and `abort_current_refresh` to take a default `std::error_code`

Changes from force-push `fe65e70`:
- Remove health monitor reset from restart_services_test.py
- Clean up commits, they got messy after bad cherry-picks

Changes from force-push ``:
- Remove dead code
- Use `cluster::errc` instead of `std::error_code` as the parameter type for`abortable_refresh_request::abort`

## Backports Required

- [x] none - not a bug fix
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* Users can now reset the cluster health monitor by issuing a POST request to <uri>:9644/v1/debug/reset_health_info. This request will wipe health monitor state.

## Release Notes

### Improvements

* Adds a method to the cluster health monitor that clears state.
