### PR TITLE
tests: ability to dynamically parametrize cloud_storage_type

### DIFF
--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -13,9 +13,10 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, RedpandaService, MetricsEndpoint, SISettings
+from rptest.services.redpanda import CloudStorageType, RedpandaService, MetricsEndpoint, SISettings, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import wait_until
+from ducktape.mark import matrix
 
 LOCAL_CONFIGURATION = {
     "partition_amount": 3,
@@ -170,7 +171,7 @@ class CloudStorageCompactionTest(EndToEndTest):
                  "Cannot validate Kafka record batch. Missmatching CRC",
                  "batch has invalid CRC"
              ])
-    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_read_from_replica(self, cloud_storage_type):
         self.start_workload()
         self.start_consumer(num_nodes=2,

--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -171,7 +171,8 @@ class CloudStorageCompactionTest(EndToEndTest):
                  "Cannot validate Kafka record batch. Missmatching CRC",
                  "batch has invalid CRC"
              ])
-    @matrix(cloud_storage_type=get_cloud_storage_type())
+    @matrix(
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True))
     def test_read_from_replica(self, cloud_storage_type):
         self.start_workload()
         self.start_consumer(num_nodes=2,

--- a/tests/rptest/scale_tests/extreme_recovery_test.py
+++ b/tests/rptest/scale_tests/extreme_recovery_test.py
@@ -171,7 +171,8 @@ class ExtremeRecoveryTest(TopicRecoveryTest):
         super(ExtremeRecoveryTest, self).tearDown()
 
     @cluster(num_nodes=8, log_allow_list=TRANSIENT_ERRORS)
-    @matrix(cloud_storage_type=get_cloud_storage_type())
+    @matrix(
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True))
     def test_recovery_scale(self, cloud_storage_type):
         # This test requires dedicated system resources
         assert self.redpanda.dedicated_nodes

--- a/tests/rptest/scale_tests/extreme_recovery_test.py
+++ b/tests/rptest/scale_tests/extreme_recovery_test.py
@@ -2,13 +2,13 @@ from logging import Logger
 from time import time
 from typing import Callable, Sequence
 
-from ducktape.mark import ignore, parametrize
+from ducktape.mark import ignore, matrix
 from ducktape.tests.test import TestContext
 from rptest.archival.s3_client import S3Client
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
-from rptest.services.redpanda import CloudStorageType
+from rptest.services.redpanda import CloudStorageType, get_cloud_storage_type
 from rptest.services.cluster import cluster
 from rptest.services.franz_go_verifiable_services import \
     FranzGoVerifiableProducer, \
@@ -171,7 +171,7 @@ class ExtremeRecoveryTest(TopicRecoveryTest):
         super(ExtremeRecoveryTest, self).tearDown()
 
     @cluster(num_nodes=8, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_recovery_scale(self, cloud_storage_type):
         # This test requires dedicated system resources
         assert self.redpanda.dedicated_nodes

--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -10,7 +10,7 @@
 import os
 
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
@@ -21,7 +21,7 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierRandomConsumer,
     KgoVerifierConsumerGroupConsumer,
 )
-from rptest.services.redpanda import CloudStorageType, SISettings, RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda import CloudStorageType, SISettings, RESTART_LOG_ALLOW_LIST, get_cloud_storage_type
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.utils.mode_checks import skip_debug_mode
 
@@ -226,12 +226,12 @@ class KgoVerifierWithSiTest(KgoVerifierBase):
 
 class KgoVerifierWithSiTestLargeSegments(KgoVerifierWithSiTest):
     @cluster(num_nodes=4, log_allow_list=KGO_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_si_without_timeboxed(self, cloud_storage_type):
         self.without_timeboxed()
 
     @cluster(num_nodes=4, log_allow_list=KGO_RESTART_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_si_with_timeboxed(self, cloud_storage_type):
         self.with_timeboxed()
 
@@ -240,11 +240,11 @@ class KgoVerifierWithSiTestSmallSegments(KgoVerifierWithSiTest):
     segment_size = 20 * 2**20
 
     @cluster(num_nodes=4, log_allow_list=KGO_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_si_without_timeboxed(self, cloud_storage_type):
         self.without_timeboxed()
 
     @cluster(num_nodes=4, log_allow_list=KGO_RESTART_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.AUTO)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_si_with_timeboxed(self, cloud_storage_type):
         self.with_timeboxed()

--- a/tests/rptest/scale_tests/franz_go_verifiable_test.py
+++ b/tests/rptest/scale_tests/franz_go_verifiable_test.py
@@ -226,12 +226,14 @@ class KgoVerifierWithSiTest(KgoVerifierBase):
 
 class KgoVerifierWithSiTestLargeSegments(KgoVerifierWithSiTest):
     @cluster(num_nodes=4, log_allow_list=KGO_LOG_ALLOW_LIST)
-    @matrix(cloud_storage_type=get_cloud_storage_type())
+    @matrix(
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True))
     def test_si_without_timeboxed(self, cloud_storage_type):
         self.without_timeboxed()
 
     @cluster(num_nodes=4, log_allow_list=KGO_RESTART_LOG_ALLOW_LIST)
-    @matrix(cloud_storage_type=get_cloud_storage_type())
+    @matrix(
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True))
     def test_si_with_timeboxed(self, cloud_storage_type):
         self.with_timeboxed()
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -169,6 +169,40 @@ def one_or_many(value):
         return value
 
 
+def get_cloud_storage_type(applies_only_on: list(CloudStorageType) = None):
+    """
+    Returns a list(CloudStorageType) based on the "CLOUD_PROVIDER"
+    environment variable. For example:
+    CLOUD_PROVIDER=docker => returns: [CloudStorageType.S3, CloudStorageType.ABS]
+    CLOUD_PROVIDER=aws => returns: [CloudStorageType.S3]
+
+    :env "CLOUD_PROVIDER": one of "aws", "gcp", "azure" or "docker"
+    :param applies_only_on: optional list(CloudStorageType)
+    that is the allow-list of the cloud storage type for a
+    test.
+    If it's set the function will return the inresection
+    of:
+    * <cloud_storage_type>: discovered based on the CLOUD_PROVIDER env
+    * <applies_only_on>: param provided
+    """
+
+    if applies_only_on is None:
+        applies_only_on = []
+
+    cloud_provider = os.getenv("CLOUD_PROVIDER", "docker")
+    if cloud_provider == "docker":
+        cloud_storage_type = [CloudStorageType.S3, CloudStorageType.ABS]
+    elif cloud_provider in ("aws", "gcp"):
+        cloud_storage_type = [CloudStorageType.S3]
+    elif cloud_provider == "azure":
+        cloud_storage_type = [CloudStorageType.ABS]
+
+    if applies_only_on:
+        cloud_storage_type = list(
+            set(applies_only_on).intersection(cloud_storage_type))
+    return cloud_storage_type
+
+
 class ResourceSettings:
     """
     Control CPU+memory footprint of Redpanda instances.  Pass one

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -169,7 +169,8 @@ def one_or_many(value):
         return value
 
 
-def get_cloud_storage_type(applies_only_on: list(CloudStorageType) = None):
+def get_cloud_storage_type(applies_only_on: list(CloudStorageType) = None,
+                           docker_use_arbitrary=False):
     """
     Returns a list(CloudStorageType) based on the "CLOUD_PROVIDER"
     environment variable. For example:
@@ -182,8 +183,10 @@ def get_cloud_storage_type(applies_only_on: list(CloudStorageType) = None):
     test.
     If it's set the function will return the inresection
     of:
-    * <cloud_storage_type>: discovered based on the CLOUD_PROVIDER env
-    * <applies_only_on>: param provided
+        * <cloud_storage_type>: discovered based on the CLOUD_PROVIDER env
+        * <applies_only_on>: param provided
+    :param docker_use_arbitrary: optional bool to use arbitrary backend when
+    the cloud provider is docker.
     """
 
     if applies_only_on is None:
@@ -191,7 +194,10 @@ def get_cloud_storage_type(applies_only_on: list(CloudStorageType) = None):
 
     cloud_provider = os.getenv("CLOUD_PROVIDER", "docker")
     if cloud_provider == "docker":
-        cloud_storage_type = [CloudStorageType.S3, CloudStorageType.ABS]
+        if docker_use_arbitrary:
+            cloud_storage_type = [CloudStorageType.S3]
+        else:
+            cloud_storage_type = [CloudStorageType.S3, CloudStorageType.ABS]
     elif cloud_provider in ("aws", "gcp"):
         cloud_storage_type = [CloudStorageType.S3]
     elif cloud_provider == "azure":

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -417,14 +417,6 @@ class SISettings:
             self.endpoint_url = None
             self.cloud_storage_disable_tls = False
             self.cloud_storage_api_endpoint_port = 443
-        if test_context.globals.get(self.GLOBAL_S3_SECRET_KEY, None):
-            test_context.ok_to_fail = True
-
-            msg = (
-                "Test requested ABS cloud storage, but provided globals for Azure."
-                " Stopping and marking as OFAIL.")
-            logger.info(msg)
-            raise Exception(msg)
         else:
             logger.debug("Running in Dockerised env against Azurite. "
                          "Using Azurite defualt credentials.")
@@ -464,17 +456,7 @@ class SISettings:
             self.cloud_storage_region = cloud_storage_region
             self.cloud_storage_api_endpoint_port = 443
         else:
-            if test_context.globals.get(self.GLOBAL_ABS_SHARED_KEY, None):
-                test_context.ok_to_fail = True
-
-                msg = (
-                    "Test requested S3 cloud storage, but provided globals for Azure."
-                    " Stopping and marking as OFAIL.")
-                logger.info(msg)
-                raise Exception(msg)
-            else:
-                logger.info(
-                    'No AWS credentials supplied, assuming minio defaults')
+            logger.info('No AWS credentials supplied, assuming minio defaults')
 
     @property
     def cloud_storage_bucket(self):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -154,8 +154,6 @@ class CloudStorageType(IntEnum):
     S3 = 1
     # Use Azure ABS on dedicated nodes, or azurite in docker
     ABS = 2
-    # Auto-select the cloud's storage service on dedicated nodes, or use minio+S3 on docker
-    AUTO = 3
 
 
 def one_or_many(value):
@@ -319,8 +317,6 @@ class SISettings:
     GLOBAL_ABS_SHARED_KEY = "abs_shared_key"
     GLOBAL_CLOUD_PROVIDER = "cloud_provider"
 
-    DEDICATED_NODE_KEY = "dedicated_nodes"
-
     # The account and key to use with local Azurite testing.
     # These are the default Azurite (Azure emulator) storage account and shared key.
     # Both are readily available in the docs.
@@ -356,29 +352,12 @@ class SISettings:
                              quickly when they wait for uploads to complete.
         """
 
-        self.cloud_storage_type = CloudStorageType.AUTO
+        self.cloud_storage_type = get_cloud_storage_type()[0]
         if hasattr(test_context, 'injected_args') \
         and test_context.injected_args is not None \
         and 'cloud_storage_type' in test_context.injected_args:
             self.cloud_storage_type = test_context.injected_args[
                 'cloud_storage_type']
-
-        if self.cloud_storage_type == CloudStorageType.AUTO:
-            dedicated_nodes = test_context.globals.get(self.DEDICATED_NODE_KEY,
-                                                       False)
-            if dedicated_nodes:
-                abs_shared_key = test_context.globals.get(
-                    self.GLOBAL_ABS_SHARED_KEY, None)
-                s3_region = test_context.globals.get(self.GLOBAL_S3_REGION_KEY,
-                                                     None)
-                if abs_shared_key is not None:
-                    self.cloud_storage_type = CloudStorageType.ABS
-                elif s3_region is not None:
-                    self.cloud_storage_type = CloudStorageType.S3
-                else:
-                    raise RuntimeError("Cannot autodetect cloud storage")
-            else:
-                self.cloud_storage_type = CloudStorageType.S3
 
         if self.cloud_storage_type == CloudStorageType.S3:
             self.cloud_storage_credentials_source = cloud_storage_credentials_source

--- a/tests/rptest/tests/adjacent_segment_merging_test.py
+++ b/tests/rptest/tests/adjacent_segment_merging_test.py
@@ -8,7 +8,7 @@
 
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import CloudStorageType, SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
@@ -70,8 +70,7 @@ class AdjacentSegmentMergingTest(RedpandaTest):
         super().tearDown()
 
     @cluster(num_nodes=3)
-    @matrix(acks=[-1, 0, 1],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    @matrix(acks=[-1, 0, 1], cloud_storage_type=get_cloud_storage_type())
     def test_reupload_of_local_segments(self, acks, cloud_storage_type):
         """Test adjacent segment merging using using local data.
         The test starts by uploading large number of very small segments.

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -9,7 +9,7 @@
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import CloudStorageType, RedpandaService, SISettings
+from rptest.services.redpanda import CloudStorageType, RedpandaService, SISettings, get_cloud_storage_type
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
@@ -182,8 +182,7 @@ class ArchivalTest(RedpandaTest):
         super().tearDown()
 
     @cluster(num_nodes=3)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_write(self, cloud_storage_type):
         """Simpe smoke test, write data to redpanda and check if the
         data hit the S3 storage bucket"""
@@ -191,8 +190,7 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_isolate(self, cloud_storage_type):
         """Verify that our isolate/rejoin facilities actually work"""
 
@@ -245,8 +243,7 @@ class ArchivalTest(RedpandaTest):
             err_msg="Data not uploaded after firewall unblocked")
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_reconnect(self, cloud_storage_type):
         """Disconnect redpanda from S3, write data, connect redpanda to S3
         and check that the data is uploaded"""
@@ -259,8 +256,7 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_one_node_reconnect(self, cloud_storage_type):
         """Disconnect one redpanda node from S3, write data, connect redpanda to S3
         and check that the data is uploaded"""
@@ -275,8 +271,7 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_connection_drop(self, cloud_storage_type):
         """Disconnect redpanda from S3 during the active upload, restore connection
         and check that everything is uploaded"""
@@ -289,8 +284,7 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_connection_flicker(self, cloud_storage_type):
         """Disconnect redpanda from S3 during the active upload for short period of time
         during upload and check that everything is uploaded"""
@@ -308,8 +302,7 @@ class ArchivalTest(RedpandaTest):
         validate(self._quick_verify, self.logger, 90)
 
     @cluster(num_nodes=3)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_single_partition_leadership_transfer(self, cloud_storage_type):
         """Start uploading data, restart leader node of the partition 0 to trigger the
         leadership transfer, continue upload, verify S3 bucket content"""
@@ -325,8 +318,7 @@ class ArchivalTest(RedpandaTest):
         validate(self._cross_node_verify, self.logger, 90)
 
     @cluster(num_nodes=3)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_all_partitions_leadership_transfer(self, cloud_storage_type):
         """Start uploading data, restart leader nodes of all partitions to trigger the
         leadership transfer, continue upload, verify S3 bucket content"""
@@ -343,8 +335,7 @@ class ArchivalTest(RedpandaTest):
         validate(self._cross_node_verify, self.logger, 90)
 
     @cluster(num_nodes=3)
-    @matrix(acks=[-1, 0, 1],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    @matrix(acks=[-1, 0, 1], cloud_storage_type=get_cloud_storage_type())
     def test_timeboxed_uploads(self, acks, cloud_storage_type):
         """This test checks segment upload time limit. The feature is enabled in the
         configuration. The configuration defines maximum time interval between uploads.
@@ -422,8 +413,7 @@ class ArchivalTest(RedpandaTest):
         validate(check_upload, self.logger, 90)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @matrix(acks=[1, -1],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    @matrix(acks=[1, -1], cloud_storage_type=get_cloud_storage_type())
     def test_retention_archival_coordination(self, acks, cloud_storage_type):
         """
         Test that only archived segments can be evicted and that eviction

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -16,7 +16,7 @@ from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
-from rptest.services.redpanda import CloudStorageType, SISettings, MetricsEndpoint, CloudStorageType, CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import CloudStorageType, SISettings, MetricsEndpoint, CloudStorageType, CHAOS_LOG_ALLOW_LIST, get_cloud_storage_type
 from rptest.services.kgo_verifier_services import (
     KgoVerifierConsumerGroupConsumer, KgoVerifierProducer)
 from rptest.utils.mode_checks import skip_debug_mode
@@ -40,7 +40,7 @@ class CloudRetentionTest(PreallocNodesTest):
 
     @cluster(num_nodes=4)
     @matrix(max_consume_rate_mb=[20, None],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode
     def test_cloud_retention(self, max_consume_rate_mb, cloud_storage_type):
         """
@@ -156,7 +156,7 @@ class CloudRetentionTest(PreallocNodesTest):
 
     @cluster(num_nodes=4)
     @skip_debug_mode
-    @matrix(cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_gc_entire_manifest(self, cloud_storage_type):
         """
         Regression test for #8945, where GCing all cloud segments could prevent
@@ -279,8 +279,7 @@ class CloudRetentionTimelyGCTest(RedpandaTest):
 
     @cluster(num_nodes=4, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @skip_debug_mode
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_retention_with_node_failures(self, cloud_storage_type):
         max_overshoot_percentage = 100
         runtime = 120

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -15,7 +15,7 @@ from typing import Any, NamedTuple
 
 import requests
 import yaml
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize, matrix
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -24,7 +24,7 @@ from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings, RESTART_LOG_ALLOW_LIST, IAM_ROLES_API_CALL_ALLOW_LIST
+from rptest.services.redpanda import CloudStorageType, SISettings, RESTART_LOG_ALLOW_LIST, IAM_ROLES_API_CALL_ALLOW_LIST, get_cloud_storage_type
 from rptest.services.metrics_check import MetricCheck
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_http_error, expect_exception, produce_until_segments
@@ -1453,7 +1453,8 @@ class ClusterConfigAzureSharedKey(RedpandaTest):
              log_allow_list=[
                  r"abs - .* Received .* AuthorizationFailure error response"
              ])
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.ABS]))
     def test_live_shared_key_change(self, cloud_storage_type):
         """
         This test ensures that 'cloud_storage_azure_shared_key' can

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -21,7 +21,7 @@ from rptest.services.action_injector import ActionConfig, random_process_kills
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierRandomConsumer, KgoVerifierSeqConsumer
 from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
-from rptest.services.redpanda import CloudStorageType, SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import Scale, wait_until_segments
@@ -82,8 +82,7 @@ class EndToEndShadowIndexingBase(EndToEndTest):
 
 class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
     @cluster(num_nodes=5)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_write(self, cloud_storage_type):
         """Write at least 10 segments, set retention policy to leave only 5
         segments, wait for segments removal, consume data and run validation,
@@ -190,8 +189,7 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
 
     @skip_debug_mode
     @cluster(num_nodes=5)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_write(self, cloud_storage_type):
         original_snapshot = self._prime_compacted_topic(10)
 
@@ -220,8 +218,7 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
 
     @skip_debug_mode
     @cluster(num_nodes=5)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_compacting_during_leadership_transfer(self, cloud_storage_type):
         original_snapshot = self._prime_compacted_topic(10)
 
@@ -261,8 +258,7 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
                          })
 
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_write_with_node_failures(self, cloud_storage_type):
         self.start_producer()
         produce_until_segments(
@@ -334,8 +330,7 @@ class ShadowIndexingInfiniteRetentionTest(EndToEndShadowIndexingBase):
             })
 
     @cluster(num_nodes=2)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_segments_not_deleted(self, cloud_storage_type):
         self.start_producer()
         produce_until_segments(
@@ -471,7 +466,7 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
 
     @cluster(num_nodes=8)
     @matrix(short_retention=[False, True],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode
     def test_create_or_delete_topics_while_busy(self, short_retention,
                                                 cloud_storage_type):

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -11,7 +11,7 @@ from rptest.services.cluster import cluster
 from ducktape.mark import matrix
 from ducktape.cluster.cluster_spec import ClusterSpec
 from rptest.clients.types import TopicSpec
-from rptest.services.redpanda import CloudStorageType, RedpandaService, SISettings
+from rptest.services.redpanda import CloudStorageType, RedpandaService, SISettings, get_cloud_storage_type
 from rptest.util import Scale, segments_count, wait_for_local_storage_truncate
 from rptest.clients.rpk import RpkTool
 from rptest.tests.redpanda_test import RedpandaTest
@@ -146,8 +146,7 @@ class EndToEndTopicRecovery(RedpandaTest):
         return False
 
     @cluster(num_nodes=4)
-    @matrix(num_messages=[2],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    @matrix(num_messages=[2], cloud_storage_type=get_cloud_storage_type())
     def test_restore_with_config_batches(self, num_messages,
                                          cloud_storage_type):
         """related to issue 6413: force the creation of remote segments containing only configuration batches,
@@ -196,7 +195,7 @@ class EndToEndTopicRecovery(RedpandaTest):
             recovery_overrides=[{}, {
                 'retention.local.target.bytes': 1024
             }],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     def test_restore(self, message_size, num_messages, recovery_overrides,
                      cloud_storage_type):
         """Write some data. Remove local data then restore
@@ -243,7 +242,7 @@ class EndToEndTopicRecovery(RedpandaTest):
         'redpanda.remote.write': True,
         'redpanda.remote.read': True,
     }],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode
     def test_restore_with_aborted_tx(self, recovery_overrides,
                                      cloud_storage_type):

--- a/tests/rptest/tests/multi_restarts_with_archival_test.py
+++ b/tests/rptest/tests/multi_restarts_with_archival_test.py
@@ -11,8 +11,8 @@ import uuid
 
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings
-from ducktape.mark import parametrize
+from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
@@ -33,8 +33,7 @@ class MultiRestartTest(EndToEndTest):
                                                extra_rp_conf=extra_rp_conf)
 
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode
     def test_recovery_after_multiple_restarts(self, cloud_storage_type):
         partition_count = 60

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -28,7 +28,7 @@ from rptest.services.honey_badger import HoneyBadger
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.rpk_consumer import RpkConsumer
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, PREV_VERSION_LOG_ALLOW_LIST, CloudStorageType, SISettings
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, PREV_VERSION_LOG_ALLOW_LIST, CloudStorageType, SISettings, get_cloud_storage_type
 
 # Errors we should tolerate when moving partitions around
 PARTITION_MOVEMENT_LOG_ERRORS = [
@@ -811,8 +811,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     # TODO(vlad): This @ignore can be removed once v23.1 becomes
     # the "previous version".
     @ignore(num_to_upgrade=2, cloud_storage_type=CloudStorageType.ABS)
-    @matrix(num_to_upgrade=[0, 2],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    @matrix(num_to_upgrade=[0, 2], cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     def test_shadow_indexing(self, num_to_upgrade, cloud_storage_type):
         """
@@ -859,8 +858,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     # TODO(vlad): This @ignore can be removed once v23.1 becomes
     # the "previous version".
     @ignore(num_to_upgrade=2, cloud_storage_type=CloudStorageType.ABS)
-    @matrix(num_to_upgrade=[0, 2],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    @matrix(num_to_upgrade=[0, 2], cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     def test_cross_shard(self, num_to_upgrade, cloud_storage_type):
         """

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -18,7 +18,7 @@ from rptest.util import expect_exception
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 
-from rptest.services.redpanda import CloudStorageType, RedpandaService
+from rptest.services.redpanda import CloudStorageType, RedpandaService, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.utils.expect_rate import ExpectRate, RateTarget
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
@@ -194,8 +194,7 @@ class TestReadReplicaService(EndToEndTest):
             return None
 
     @cluster(num_nodes=7, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
-    @matrix(partition_count=[10],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+    @matrix(partition_count=[10], cloud_storage_type=get_cloud_storage_type())
     def test_writes_forbidden(self, partition_count: int,
                               cloud_storage_type: CloudStorageType) -> None:
         """
@@ -233,7 +232,7 @@ class TestReadReplicaService(EndToEndTest):
     @cluster(num_nodes=9, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
     @matrix(partition_count=[10],
             min_records=[10000],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     def test_simple_end_to_end(self, partition_count: int, min_records: int,
                                cloud_storage_type: CloudStorageType) -> None:
 

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -17,7 +17,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings, MetricsEndpoint
+from rptest.services.redpanda import CloudStorageType, SISettings, MetricsEndpoint, get_cloud_storage_type
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (produce_until_segments, produce_total_bytes,
                          wait_for_local_storage_truncate, segments_count,
@@ -54,7 +54,7 @@ class RetentionPolicyTest(RedpandaTest):
         TopicSpec.PROPERTY_RETENTION_TIME, TopicSpec.PROPERTY_RETENTION_BYTES
     ],
             acks=[1, -1],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     def test_changing_topic_retention(self, property, acks,
                                       cloud_storage_type):
         """
@@ -92,8 +92,7 @@ class RetentionPolicyTest(RedpandaTest):
                        timeout_sec=120)
 
     @cluster(num_nodes=3)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_changing_topic_retention_with_restart(self, cloud_storage_type):
         """
         Test changing topic retention duration for topics with data produced
@@ -164,7 +163,7 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
     @cluster(num_nodes=1)
     @matrix(cluster_remote_write=[True, False],
             topic_remote_write=["true", "false", "-1"],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     def test_shadow_indexing_default_local_retention(self,
                                                      cluster_remote_write,
                                                      topic_remote_write,
@@ -220,8 +219,7 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
                            backoff_sec=1)
 
     @cluster(num_nodes=1)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_shadow_indexing_non_default_local_retention(
             self, cloud_storage_type):
         """
@@ -256,7 +254,7 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
 
     @cluster(num_nodes=1)
     @matrix(local_retention_ms=[3600000, -1],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     def test_local_time_based_retention_is_overridden(self, local_retention_ms,
                                                       cloud_storage_type):
         """
@@ -311,8 +309,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
         self.s3_bucket_name = si_settings.cloud_storage_bucket
 
     @cluster(num_nodes=3)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_cloud_retention_deleted_segments_count(self, cloud_storage_type):
         """
         Test that retention deletes the right number of segments. The test sets the
@@ -361,8 +358,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                    err_msg=f"Segments were not removed from the cloud")
 
     @cluster(num_nodes=3)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_cloud_size_based_retention(self, cloud_storage_type):
         """
         Test that retention is enforced in the cloud log by checking
@@ -420,8 +416,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                    err_msg=f"Too many bytes in the cloud")
 
     @cluster(num_nodes=3)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_cloud_time_based_retention(self, cloud_storage_type):
         """
         Test that retention is enforced in the cloud log by checking
@@ -490,8 +485,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                    err_msg=f"Not all segments were removed from the cloud")
 
     @cluster(num_nodes=1)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_cloud_size_based_retention_application(self, cloud_storage_type):
         """
         Test that retention is enforced when applied to topics that initially

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -9,7 +9,7 @@
 import re
 
 import requests
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -17,7 +17,7 @@ from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (
     produce_until_segments,
@@ -78,8 +78,7 @@ class SIAdminApiTest(RedpandaTest):
         super().tearDown()
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_bucket_validation(self, cloud_storage_type):
         """
         The test produces to the partition and waits untils the

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -3,12 +3,12 @@ import pprint
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings, RedpandaService, LoggingConfig
+from rptest.services.redpanda import CloudStorageType, SISettings, RedpandaService, LoggingConfig, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import wait_until_segments, wait_for_removal_of_n_segments
 from rptest.utils.si_utils import BucketView
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 
 
 class ShadowIndexingCompactedTopicTest(EndToEndTest):
@@ -47,8 +47,7 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
                 })
 
     @cluster(num_nodes=4)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_upload(self, cloud_storage_type):
         # Set compaction to happen infrequently initially, so we have several log segments.
         self._rpk_client.cluster_config_set("log_compaction_interval_ms",

--- a/tests/rptest/tests/shadow_indexing_firewall_test.py
+++ b/tests/rptest/tests/shadow_indexing_firewall_test.py
@@ -6,10 +6,10 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import CloudStorageType, SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool, RpkException
@@ -51,8 +51,7 @@ class ShadowIndexingFirewallTest(RedpandaTest):
         self.rpk = RpkTool(self.redpanda)
 
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_consume_from_blocked_s3(self, cloud_storage_type):
         produce_until_segments(redpanda=self.redpanda,
                                topic=self.s3_topic_name,

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -7,9 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
@@ -51,8 +51,7 @@ class ShadowIndexingTxTest(RedpandaTest):
             rpk.alter_topic_config(topic.name, 'redpanda.remote.read', 'true')
 
     @cluster(num_nodes=4)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode
     def test_shadow_indexing_aborted_txs(self, cloud_storage_type):
         """Check that messages belonging to aborted transaction are not seen by clients

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -23,7 +23,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.metrics_check import MetricCheck
-from rptest.services.redpanda import CloudStorageType, SISettings
+from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
 from rptest.util import wait_for_local_storage_truncate, firewall_blocked
 from rptest.services.admin import Admin
 
@@ -279,8 +279,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         log_allow_list=[
             'exception while executing partition operation: {type: deletion'
         ])
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def topic_delete_unavailable_test(self, cloud_storage_type):
         """
         Test deleting while the S3 backend is unavailable: we should see
@@ -361,7 +360,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
     @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=3)
     @matrix(disable_delete=[False, True],
-            cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     def topic_delete_cloud_storage_test(self, disable_delete,
                                         cloud_storage_type):
         if disable_delete:
@@ -413,8 +412,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
     @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=4)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def partition_movement_test(self, cloud_storage_type):
         """
         The unwary programmer might do S3 deletion from the

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -18,7 +18,7 @@ from typing import Callable, NamedTuple, Optional, Sequence
 
 import requests
 from ducktape.cluster.cluster import ClusterNode
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 from rptest.archival.s3_client import S3Client
@@ -28,7 +28,8 @@ from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import (CloudStorageType, FileToChecksumSize,
-                                      RedpandaService, SISettings)
+                                      RedpandaService, SISettings,
+                                      get_cloud_storage_type)
 from rptest.services.rpk_producer import RpkProducer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_result
@@ -1333,8 +1334,7 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=3,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_no_data(self, cloud_storage_type):
         """If we're trying to recovery a topic which didn't have any data
         in old cluster the empty topic should be created. We should be able
@@ -1346,8 +1346,7 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=3,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_empty_segments(self, cloud_storage_type):
         """Test case in which the segments are uploaded but they doesn't
         have any data batches but they do have configuration batches."""
@@ -1359,8 +1358,7 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=3,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_missing_topic_manifest(self, cloud_storage_type):
         """If we're trying to recovery a topic which didn't have any data
         in old cluster the empty topic should be created. We should be able
@@ -1373,8 +1371,7 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=4,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_missing_partition(self, cloud_storage_type):
         """Test situation when one of the partition manifests are missing.
         The partition manifest is missing if it doesn't exist in the bucket
@@ -1390,8 +1387,7 @@ class TopicRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=4,
              log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_missing_segment(self, cloud_storage_type):
         """Test the handling of the missing segment. The segment is
         missing if it's present in the manifest but deleted from the
@@ -1402,8 +1398,7 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_fast1(self, cloud_storage_type):
         """Basic recovery test. This test stresses successful recovery
         of the topic with different set of data."""
@@ -1418,8 +1413,7 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_fast2(self, cloud_storage_type):
         """Basic recovery test. This test stresses successful recovery
         of the topic with different set of data."""
@@ -1437,8 +1431,7 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_fast3(self, cloud_storage_type):
         """Basic recovery test. This test stresses successful recovery
         of the topic with different set of data."""
@@ -1459,8 +1452,7 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=3, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_size_based_retention(self, cloud_storage_type):
         """Test topic recovery with size based retention policy.
         It's tests handling of the situation when only subset of the data needs to
@@ -1477,8 +1469,7 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=3, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_time_based_retention(self, cloud_storage_type):
         """Test topic recovery with time based retention policy.
         It's tests handling of the situation when only subset of the data needs to
@@ -1496,8 +1487,7 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=3, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_time_based_retention_with_legacy_manifest(self,
                                                        cloud_storage_type):
         """Test topic recovery with time based retention policy.
@@ -1516,8 +1506,7 @@ class TopicRecoveryTest(RedpandaTest):
         self.do_run(test_case)
 
     @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
-    @parametrize(cloud_storage_type=CloudStorageType.ABS)
-    @parametrize(cloud_storage_type=CloudStorageType.S3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_admin_api_recovery(self, cloud_storage_type):
         topics = [
             TopicSpec(name='panda-topic',

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@b1d99b539809c04ff5b92ad6535aaa87de15c65a',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@5b4c31648d8f94d3f28113a6fa0377339aa222ed',
         'prometheus-client==0.9.0', 'pyyaml==6.0', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==2.0.2', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==3.19.5', 'fastavro==1.4.9',


### PR DESCRIPTION
Replaced `parametrized` with `matrix` decorator,
and the cloud_storage_type holds the parametrization
needed for each host type. For example for
cdt runs on aws, the matrix will only contain s3
as cloud storage type. same for gcp or azure.
For regular tests (host=docker container), it
parametrizes with both s3 and abs

Additionally, tests that are parametrized to run on a single
cloud storage type, will be explicitly excluded from the test
collection ref: https://github.com/redpanda-data/vtools/pull/1554/commits/131144e09460a07afc690dd4a1ab65a507b41f2d

ref #8704

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

