### PR TITLE
app: avoid masking failure on sharded service startup

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1563,6 +1563,7 @@ void application::wire_up_bootstrap_services() {
     // Wire up the internal RPC server.
     ss::sharded<net::server_configuration> rpc_cfg;
     rpc_cfg.start(ss::sstring("internal_rpc")).get();
+    auto stop_cfg = ss::defer([&rpc_cfg] { rpc_cfg.stop().get(); });
     rpc_cfg
       .invoke_on_all([this](net::server_configuration& c) {
           return ss::async([this, &c] {
@@ -1608,7 +1609,6 @@ void application::wire_up_bootstrap_services() {
       "Constructing internal RPC services {}", rpc_cfg.local())
       .get();
     _rpc.start(&rpc_cfg).get();
-    rpc_cfg.stop().get();
 }
 
 void application::start_bootstrap_services() {


### PR DESCRIPTION
If an exception is thrown before the sharded service is stopped then we'll trigger an assertion rather than exposing the underlying problem. Use raii object to solve.

1701580: redpanda: /home/nwatkins/src/redpanda/vbuild/debug/clang/rp_deps_install/include/seastar/core/sharded.hh:560: seastar::sharded<net::server_configuration>::~sharded() [Service = net::server_configuration]: Assertion `_instances.empty()' failed.
1701580: Aborting on shard 0.
1701580: Backtrace:
1701580:   0x3b18f39a
1701580:   0x4ded5f34

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

-->

* none
