### PR TITLE
raft: raise shutting_down exception in replicate

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -673,9 +673,10 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
     co_return ret_t(_commit_index);
 }
 
-ss::future<result<replicate_result>> chain_stages(replicate_stages stages) {
+ss::future<result<replicate_result>>
+consensus::chain_stages(replicate_stages stages) {
     return stages.request_enqueued.then_wrapped(
-      [f = std::move(stages.replicate_finished)](
+      [this, f = std::move(stages.replicate_finished)](
         ss::future<> enqueued) mutable {
           if (enqueued.failed()) {
               return enqueued
@@ -683,7 +684,7 @@ ss::future<result<replicate_result>> chain_stages(replicate_stages stages) {
                     vlog(
                       raftlog.debug, "replicate first stage exception - {}", e);
                 })
-                .then([f = std::move(f)]() mutable {
+                .then([this, f = std::move(f)]() mutable {
                     return f.discard_result()
                       .handle_exception([](const std::exception_ptr& e) {
                           vlog(
@@ -691,9 +692,14 @@ ss::future<result<replicate_result>> chain_stages(replicate_stages stages) {
                             "ignoring replicate second stage exception - {}",
                             e);
                       })
-                      .then([] {
-                          return result<replicate_result>(make_error_code(
-                            errc::replicate_first_stage_exception));
+                      .then([this] {
+                          if (_as.abort_requested()) {
+                              return result<replicate_result>(
+                                make_error_code(errc::shutting_down));
+                          } else {
+                              return result<replicate_result>(make_error_code(
+                                errc::replicate_first_stage_exception));
+                          }
                       });
                 });
           }

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -439,6 +439,8 @@ private:
       model::record_batch_reader&&,
       replicate_options);
 
+    ss::future<result<replicate_result>> chain_stages(replicate_stages);
+
     ss::future<storage::append_result>
     disk_append(model::record_batch_reader&&, update_last_quorum_index);
 


### PR DESCRIPTION
...when the abort source has been fired, rather than indiscriminately raising first_stage_exception.

This enables other components to distinguish between a true failure and something that is in the process of shutting down.

Fixes https://github.com/redpanda-data/redpanda/issues/9294

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none