### PR TITLE
[v22.3.x] Add config properties to metrics report

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -452,6 +452,9 @@ void rjson_serialize(
         rjson_serialize(w, m);
     }
     w.EndArray();
+
+    w.Key("config");
+    config::shard_local_cfg().to_json_for_metrics(w);
     w.EndObject();
 }
 

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -136,6 +136,36 @@ public:
         w.EndObject();
     }
 
+    void to_json_for_metrics(json::Writer<json::StringBuffer>& w) {
+        w.StartObject();
+
+        for (const auto& [name, property] : _properties) {
+            if (property->get_visibility() == visibility::deprecated) {
+                continue;
+            }
+
+            if (property->type_name() == "boolean") {
+                w.Key(name.data(), name.size());
+                property->to_json(w, redact_secrets::yes);
+                continue;
+            }
+
+            if (property->is_nullable()) {
+                w.Key(name.data(), name.size());
+                w.String(property->is_default() ? "default" : "[value]");
+                continue;
+            }
+
+            if (!property->enum_values().empty()) {
+                w.Key(name.data(), name.size());
+                property->to_json(w, redact_secrets::yes);
+                continue;
+            }
+        }
+
+        w.EndObject();
+    }
+
     std::set<std::string_view> property_names() const {
         std::set<std::string_view> result;
         for (const auto& i : _properties) {

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -33,6 +33,7 @@ class MetricsReporterTest(RedpandaTest):
                 "metrics_reporter_report_interval": 1000,
                 "enable_metrics_reporter": True,
                 "metrics_reporter_url": f"{self.http.url}/metrics",
+                "retention_bytes": 20000,
             })
 
     def setUp(self):
@@ -80,6 +81,10 @@ class MetricsReporterTest(RedpandaTest):
         # cluster uuid and create timestamp should stay the same across requests
         assert_fields_are_the_same(metadata, 'cluster_uuid')
         assert_fields_are_the_same(metadata, 'cluster_created_ts')
+
+        # cluster config should be the same
+        assert_fields_are_the_same(metadata, 'config')
+
         # get the last report
         last = metadata.pop()
         assert last['topic_count'] == total_topics
@@ -110,6 +115,13 @@ class MetricsReporterTest(RedpandaTest):
                    backoff_sec=1)
         assert_fields_are_the_same(metadata, 'cluster_uuid')
         assert_fields_are_the_same(metadata, 'cluster_created_ts')
+
+        # Check config values
+        assert last["config"]["retention_bytes"] == "[value]"
+        assert last["config"]["enable_metrics_reporter"] == True
+        assert last["config"]["auto_create_topics_enabled"] == False
+        assert "metrics_reporter_tick_interval" not in last["config"]
+        assert last["config"]["log_message_timestamp_type"] == "CreateTime"
 
 
 class MultiNodeMetricsReporterTest(MetricsReporterTest):


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/8846

CONFLICTS:
* `rjson_serialize` for metrics_reporter.cc because of `has_kafka_gssapi`
* metrics_reporter_test.py because of `assert_fields_are_the_same(metadata, 'has_kafka_gssapi')`