### PR TITLE
[admin_api] Expose raft internal state in admin API

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -159,6 +159,8 @@ public:
         return _raft0->committed_offset();
     }
 
+    consensus_ptr get_raft0() { return _raft0; }
+
 private:
     friend controller_probe;
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -256,6 +256,16 @@ public:
 
     model::offset get_latest_configuration_offset() const;
     model::offset committed_offset() const { return _commit_index; }
+    model::offset flushed_offset() const { return _flushed_offset; }
+    model::offset last_quorum_replicated_index() const {
+        return _last_quorum_replicated_index;
+    }
+    model::offset majority_replicated_index() const {
+        return _majority_replicated_index;
+    }
+    model::offset visibility_upper_bound_index() const {
+        return _visibility_upper_bound_index;
+    }
 
     /**
      * Last visible index is an offset that is safe to be fetched by the
@@ -409,6 +419,8 @@ public:
      * Allow the current node to become a leader for this group.
      */
     void unblock_new_leadership() { _node_priority_override.reset(); }
+
+    const follower_stats& get_follower_stats() const { return _fstats; }
 
 private:
     friend replicate_entries_stm;

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -219,6 +219,40 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/raft/{namespace}/{topic}/{partition}",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get raft states for leader and followers. This request can be executed only on leader for partition . If follower get this request it will be redirected to leader",
+                    "type": "raft_state",
+                    "nickname": "get_raft_state",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -368,6 +402,119 @@
                         "type": "self_test_result"
                     },
                     "description": "Recordings of test runs from a single node"
+                }
+            }
+        },
+        "raft_state": {
+            "id": "raft_state",
+            "description": "Raft state",
+            "properties": {
+                "leader_info": {
+                    "type": "raft_leader_state",
+                    "description": "Raft metrics for ntp raft leader"
+                },
+                "followers": {
+                    "type": "array",
+                    "items": {
+                        "type": "raft_follower_state"
+                    },
+                    "description": "Raft metrics for ntp followers"
+                }
+            }
+        },
+        "raft_leader_state": {
+            "id": "raft_leader_state",
+            "description": "Information about raft state for ntp for leader",
+            "properties": {
+                "id": {
+                    "type": "int",
+                    "description": "Node id"
+                },
+                "term": {
+                    "type": "long",
+                    "description": "Current term"
+                },
+                "flushed_offset": {
+                    "type": "long",
+                    "description": "Flushed offset"
+                },
+                "commit_index": {
+                    "type": "long",
+                    "description": "Commit index"
+                },
+                "majority_replicated_index": {
+                    "type": "long",
+                    "description": "Majority replicated index"
+                },
+                "visibility_upper_bound_index": {
+                    "type": "long",
+                    "description": "Visibility upper bound index"
+                },
+                "last_quorum_replicated_index": {
+                    "type": "long",
+                    "description": "Last quorum replicated index"
+                }
+            }
+        },
+        "raft_follower_state": {
+            "id": "raft_follower_state",
+            "description": "Information about raft state for ntp for follower",
+            "properties": {
+                "id": {
+                    "type": "int",
+                    "description": "Node id"
+                },
+                "last_flushed_log_index": {
+                    "type": "long",
+                    "description": "Last flushed log index"
+                },
+                "last_dirty_log_index": {
+                    "type": "long",
+                    "description": "Last dirty log index"
+                },
+                "match_index": {
+                    "type": "long",
+                    "description": "Match index"
+                },
+                "next_index": {
+                    "type": "long",
+                    "description": "Next index"
+                },
+                "last_sent_offset": {
+                    "type": "long",
+                    "description": "Last sent offset"
+                },
+                "heartbeats_failed": {
+                    "type": "long",
+                    "description": "Heartbeats failed"
+                },
+                "is_learner": {
+                    "type": "boolean",
+                    "description": "Is node learner"
+                },
+                "ms_since_last_heartbeat": {
+                    "type": "long",
+                    "description": "Ms since last heartbeat"
+                },
+                "last_sent_seq": {
+                    "type": "long",
+                    "description": "Last sent seq"
+                },
+                "last_received_seq": {
+                    "type": "long",
+                    "description": "Last received seq"
+                },
+                "last_successful_received_seq": {
+                    "type": "long",
+                    "description": "Last successful received seq"
+                },
+                "suppress_heartbeats": {
+                    "type": "boolean",
+                    "description": "Suppress heartbeats"
+                },
+                "is_recovering": {
+                    "type": "boolean",
+                    "description": "Is node recovering"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -384,6 +384,10 @@ private:
     ss::future<ss::json::json_return_type>
       self_test_get_results_handler(std::unique_ptr<ss::httpd::request>);
 
+    /// Debug routes
+    ss::future<ss::json::json_return_type>
+      get_raft_state_handler(std::unique_ptr<ss::httpd::request>);
+
     ss::future<ss::json::json_return_type>
       redpanda_services_restart_handler(std::unique_ptr<ss::httpd::request>);
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -884,3 +884,7 @@ class Admin:
         return self._request("post",
                              "debug/refresh_disk_health_info",
                              node=node)
+
+    def get_raft_state(self, namespace, topic, partition):
+        path = f"debug/raft/{namespace}/{topic}/{partition}"
+        return self._request("GET", path).json()

--- a/tests/rptest/tests/admin_api_raft_metrics_test.py
+++ b/tests/rptest/tests/admin_api_raft_metrics_test.py
@@ -1,0 +1,100 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.admin import Admin
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.util import wait_until_result
+from rptest.util import wait_until
+import requests
+
+
+class AdminApiRaftStateTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1, replication_factor=3), )
+
+    def __init__(self, test_context):
+        super(AdminApiRaftStateTest, self).__init__(test_context=test_context,
+                                                    num_brokers=3)
+
+        self.admin = Admin(self.redpanda)
+
+    @cluster(num_nodes=3)
+    def getting_info_from_regular_ntp_test(self):
+        self.topic_name = self.topics[0].name
+
+        def leader_is_elected():
+            try:
+                info = self.admin.get_raft_state("kafka", self.topic_name, 0)
+                return True, info
+            except requests.exceptions.HTTPError as e:
+                # Leader is not elected yet. We should retry
+                assert e.response.status_code == 500
+                return False
+
+        raft_info = wait_until_result(
+            leader_is_elected,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Can not elect leader for topic: {self.topic_name}")
+
+        leader_id = self.admin.get_partition_leader(namespace="kafka",
+                                                    topic=self.topic_name,
+                                                    partition=0)
+
+        assert raft_info["leader_info"]["id"] == leader_id
+
+        assert len(raft_info["followers"]) == 2
+
+        for follower in raft_info["followers"]:
+            assert follower["id"] != leader_id
+
+    @cluster(num_nodes=3)
+    def getting_info_from_controller_test(self):
+        self.topic_name = "controller"
+
+        def leader_is_elected():
+            try:
+                info = self.admin.get_raft_state("redpanda", self.topic_name,
+                                                 0)
+                return True, info
+            except requests.exceptions.HTTPError as e:
+                # Leader is not elected yet. We should retry
+                assert e.response.status_code == 500
+                return False
+
+        raft_info = wait_until_result(
+            leader_is_elected,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Can not elect leader for topic: {self.topic_name}")
+
+        leader_id = self.admin.get_partition_leader(namespace="redpanda",
+                                                    topic=self.topic_name,
+                                                    partition=0)
+
+        assert raft_info["leader_info"]["id"] == leader_id
+
+        for follower in raft_info["followers"]:
+            assert follower["id"] != leader_id
+
+        def wait_all_followers_sync():
+            info = self.admin.get_raft_state("redpanda", self.topic_name, 0)
+            leader_ci = info["leader_info"]["commit_index"]
+            for follower in info["followers"]:
+                if leader_ci != follower["last_flushed_log_index"]:
+                    return False
+            return True
+
+        wait_until(
+            wait_all_followers_sync,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Followers can not sync with leader for controller")


### PR DESCRIPTION
This pr contains new admin_api request:

```
"path": "/v1/debug/raft/{namespace}/{topic}/{partition}",
"operations": [
    {
        "method": "GET",
        "summary": "Get raft metrics for leader and followers",
```

`get_raft_metrics` request return raft state for chosen ntp. This request should be dispatched to ntp leader.

It contains leader_info:
* id
* committed_log_index
* dirty_log_index

Follower_info:
* id
* is_learner
* committed_log_index
* dirty_log_index
* match_index
* ms_since_last_heartbeat
* is_live
* under_replicated

Fixes #9097 

[small rfc](https://docs.google.com/document/d/11q2ok7ZUQeLLXVE_O4mDq06k3GjTjbWoXJj7_eP4Kss/edit?usp=sharing)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features


* New admin_api request `/v1/debug/raft/{namespace}/{topic}/{partition}` to get raft internal state for ntp
