### PR TITLE
cloud_storage: refinements to topic deletion

### DIFF
--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -117,6 +117,11 @@ public:
       const cloud_storage_clients::object_key& path,
       retry_chain_node& parent);
 
+    ss::future<bool> tolerant_delete_objects(
+      const cloud_storage_clients::bucket_name& bucket,
+      std::vector<cloud_storage_clients::object_key>&& keys,
+      retry_chain_node& parent);
+
     struct finalize_result {
         // If this is set, use this manifest for deletion instead of the usual
         // local state (the remote content was newer than our local content)

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -116,6 +116,17 @@ public:
       const cloud_storage_clients::object_key& path,
       retry_chain_node& parent);
 
+    struct finalize_result {
+        // If this is set, use this manifest for deletion instead of the usual
+        // local state (the remote content was newer than our local content)
+        std::optional<partition_manifest> manifest;
+        download_result get_status{download_result::failed};
+    };
+
+    /// Flush metadata to object storage, prior to a topic deletion with
+    /// remote deletion disabled.
+    ss::future<finalize_result> finalize(ss::abort_source&);
+
     /// Remove objects from S3
     ss::future<> erase(ss::abort_source&);
 

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -20,6 +20,7 @@
 #include "cloud_storage_clients/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "raft/types.h"
 #include "storage/ntp_config.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
@@ -125,10 +126,12 @@ public:
 
     /// Flush metadata to object storage, prior to a topic deletion with
     /// remote deletion disabled.
-    ss::future<finalize_result> finalize(ss::abort_source&);
+    ss::future<finalize_result>
+    finalize(ss::abort_source&, raft::vnode, raft::group_configuration);
 
     /// Remove objects from S3
-    ss::future<> erase(ss::abort_source&);
+    ss::future<>
+    erase(ss::abort_source&, raft::vnode, raft::group_configuration);
 
     /// Hook for materialized_segment to notify us when a segment is evicted
     void offload_segment(model::offset);

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -631,6 +631,10 @@ ss::future<> partition::remove_remote_persistent_state(ss::abort_source& as) {
           get_ntp_config().is_archival_enabled(),
           get_ntp_config().is_read_replica_mode_enabled());
         co_await _cloud_storage_partition->erase(as);
+    } else if (_cloud_storage_partition && tiered_storage) {
+        // Tiered storage is enabled, but deletion is disabled: ensure the
+        // remote metadata is up to date before we drop the local partition.
+        co_await _cloud_storage_partition->finalize(as);
     } else {
         vlog(
           clusterlog.info, "Leaving S3 objects behind for partition {}", ntp());

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -630,11 +630,13 @@ ss::future<> partition::remove_remote_persistent_state(ss::abort_source& as) {
           get_ntp_config(),
           get_ntp_config().is_archival_enabled(),
           get_ntp_config().is_read_replica_mode_enabled());
-        co_await _cloud_storage_partition->erase(as);
+        co_await _cloud_storage_partition->erase(
+          as, _raft->self(), group_configuration());
     } else if (_cloud_storage_partition && tiered_storage) {
         // Tiered storage is enabled, but deletion is disabled: ensure the
         // remote metadata is up to date before we drop the local partition.
-        co_await _cloud_storage_partition->finalize(as);
+        co_await _cloud_storage_partition->finalize(
+          as, _raft->self(), group_configuration());
     } else {
         vlog(
           clusterlog.info, "Leaving S3 objects behind for partition {}", ntp());


### PR DESCRIPTION
These are lightweight changes that don't go as far as adding tombstones etc, but should help significantly with deletion the way it works today:
- Ensure manifests are flushed to cloud storage first, if it is stale -- this is especially important for topics where `redpanda.remote.delete` is false, if one later wants to use topic recovery on the topic.
- Use whichever is more up to date of the remote or local manifest state (previously always used remote state)
- Delay starting deletion process on nodes which are not the first replica, to reduce redundant operations.
- Use `DeleteObjects` to avoid issuing individual deletes for all objects.  This currently only helps on AWS, but should make a big difference there.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Deletion of tiered storage topics on AWS now uses fewer S3 requests, and is less likely to encounter S3 throttling.
