### PR TITLE
[v22.3.x] cloud_storage: bump timeouts in remote_partiton_test

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -455,7 +455,7 @@ static void reupload_compacted_segments(
             m.add(s.sname, meta);
             auto url = m.generate_segment_path(*m.get(meta.base_offset));
             vlog(test_log.debug, "reuploading segment {}", url);
-            retry_chain_node rtc(10s, 1s);
+            retry_chain_node rtc(60s, 1s);
             bytes bb;
             bb.resize(body.size());
             std::memcpy(bb.data(), body.data(), body.size());
@@ -1592,7 +1592,7 @@ static void remove_segment_from_s3(
     auto meta = m.get(o);
     BOOST_REQUIRE(meta != nullptr);
     auto path = m.generate_segment_path(*meta);
-    retry_chain_node fib(10s, 1s);
+    retry_chain_node fib(60s, 1s);
     auto res = api.delete_object(bucket, s3::object_key(path()), fib).get();
     BOOST_REQUIRE(res == cloud_storage::upload_result::success);
 }


### PR DESCRIPTION
This is a mitigation for a failure where the test occasionally hits a connection error and exhausts is retry time allowance.

Related: https://github.com/redpanda-data/redpanda/issues/7548 (cherry picked from commit 53f9e01508ee7d914d740a8cba4d1c09a88ab8bd)

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none