### PR TITLE
admin: Add blocked_reactor_notify_ms command

### DIFF
--- a/src/v/redpanda/admin/api-doc/config.json
+++ b/src/v/redpanda/admin/api-doc/config.json
@@ -79,4 +79,30 @@
       }
     }
   }
+},
+"/v1/config/blocked_reactor_notify_ms/{timeout}": {
+  "put": {
+    "summary": "Temporarily reduce the threshold over which the reactor is considered blocked if no progress is made. The original threshold value will be restored after 'expire' seconds (default: 5 min)",
+    "operationId": "blocked_reactor_notify_ms",
+    "parameters": [
+        {
+            "name": "timeout",
+            "in": "path",
+            "required": true,
+            "type": "long"
+        },
+        {
+            "name": "expires",
+            "in": "query",
+            "required": false,
+            "allowMultiple": false,
+            "type": "long"
+        }
+    ],
+    "responses": {
+      "200": {
+        "description": "Blocked reactor notify threshold updated"
+      }
+    }
+  }
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -427,4 +427,7 @@ private:
     ss::sharded<cloud_storage::topic_recovery_service>& _topic_recovery_service;
     ss::sharded<cluster::topic_recovery_status_frontend>&
       _topic_recovery_status_frontend;
+    // Value before the temporary override
+    std::chrono::milliseconds _default_blocked_reactor_notify;
+    ss::timer<> _blocked_reactor_notify_reset_timer;
 };


### PR DESCRIPTION
The command changes the timeout of stall detector (`blocked-reactor-notify-ms` command line parameter) for brief period of time.

Example:
`curl -XPUT  "127.0.0.1:9644/v1/config/blocked_reactor_notify_ms/1?expires=15"`

This command will change the value to 1ms and it will be reset back after 15 seconds. If 'expires' parameter is not set the default expire value will be used. The default is 5 minutes and the largest expire time is 30 minutes.

The command doesn't allow you to set timeout value which is large than the one provided in the command line via `blocked-reactor-notify-ms` command. It can only be decreased for brief period of time.

The command is needed for performance testing. When the cpu is high on the node it's usually difficult to diagnose without using `perf`. The workaround is to use this command to change the reactor stall detector timeout to smaller value. 

This is not a bug fix but it's supposed to be back ported.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* Add admin API command that changes `--blocked-reactor-notify-ms` parameter on the fly.