### PR TITLE
tests: update client-swarm & pin rust version

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -96,7 +96,7 @@ function install_kaf() {
 
 function install_client_swarm() {
   dir="$1"
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.67.0
   export PATH="$dir/.cargo/bin:${PATH}"
   pushd /tmp
   git clone https://github.com/redpanda-data/client-swarm.git

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -101,7 +101,7 @@ function install_client_swarm() {
   pushd /tmp
   git clone https://github.com/redpanda-data/client-swarm.git
   pushd client-swarm
-  git reset --hard 9ef8e93
+  git reset --hard 1129d51f
   cargo build --release
   cp target/release/client-swarm /usr/local/bin
   popd


### PR DESCRIPTION
This is a defensive change  after seeing a container build issue that might have been related to a compiler warning.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
