### PR TITLE
fixed: redpanda_cloud_storage_cache_op_miss metric

### DIFF
--- a/src/v/cloud_storage/cache_probe.cc
+++ b/src/v/cloud_storage/cache_probe.cc
@@ -92,7 +92,7 @@ cache_probe::cache_probe() {
               .aggregate(aggregate_labels),
             sm::make_counter(
               "miss",
-              [this] { return _num_cached_gets; },
+              [this] { return _num_miss_gets; },
               sm::description("Number of get requests that are not satisfied "
                               "from the cache."))
               .aggregate(aggregate_labels),


### PR DESCRIPTION
The `redpanda_cloud_storage_cache_op_miss` was not showing the right value.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* The `redpanda_cloud_storage_cache_op_miss` metric was not showing the right value.

