### PR TITLE
kafka: expose hwm for max offset in public metrics

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -200,7 +200,7 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
         sm::make_gauge(
           "max_offset",
           [this] {
-              auto log_offset = _partition.committed_offset();
+              auto log_offset = _partition.high_watermark();
               auto translator = _partition.get_offset_translator_state();
 
               try {
@@ -213,8 +213,7 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
               }
           },
           sm::description(
-            "Latest committed offset for the partition (i.e. the offset of the "
-            "last message safely persisted on most replicas)"),
+            "Latest readable offset of the partition (i.e. high watermark)"),
           labels)
           .aggregate({sm::shard_label}),
         sm::make_gauge(


### PR DESCRIPTION
The recommended way to calculate consumer lag with prometheus is

```
max by(redpanda_namespace, redpanda_topic,
redpanda_partition)(redpanda_kafka_max_offset{redpanda_namespace="kafka"}) - on(redpanda_topic, redpanda_partition) group_right max by(redpanda_group, redpanda_topic,
redpanda_partition)(redpanda_kafka_consumer_group_committed_offset)
```

which uses `max_offset` which in turn maps to the kafka translated offset of the last raft committed offset. however, kafka clients that read offset X commit offset X+1 (sort of like they commit the next thing that should be read).

So when computing the lag it will look like the consumer is always at least one offset away from the end despite having read naything.

HWM contains that +1 factor. This is also what seems to be done in franz-go and upstream kafka for computing lag.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - breaking change
- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* The public metrics "kafka_max_offset" now returns the high watermark suitable for calculating consumer lag. Prior to this change it returned the commit offset, which presented an off-by-one situation when calculating lag.
