### PR TITLE
dt: add suite for azure tests

### DIFF
--- a/tests/rptest/test_suite_azure.yml
+++ b/tests/rptest/test_suite_azure.yml
@@ -1,0 +1,14 @@
+azure:
+  included:
+    - tests
+
+  excluded:
+    - tests/librdkafka_test.py # normally disabled
+    - tests/wasm_filter_test.py # no wasm
+    - tests/wasm_failure_recovery_test.py # no wasm
+    - tests/wasm_identity_test.py # no wasm
+    - tests/wasm_topics_test.py # no wasm
+    - tests/wasm_redpanda_failure_recovery_test.py # no wasm
+    - tests/wasm_partition_movement_test.py # no wasm
+    - tests/e2e_iam_role_test.py # use static credentials
+    - tests/consumer_group_recovery_tool_test.py # use script available in dockerfile


### PR DESCRIPTION
adds a suite for azure, similar to aws' but skipping scale tests. this is similar to the GCP one recently added.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none