### PR TITLE
node_folder_deletion_test: use homogeneous configs in restarted node

### DIFF
--- a/tests/rptest/tests/node_folder_deletion_test.py
+++ b/tests/rptest/tests/node_folder_deletion_test.py
@@ -85,7 +85,9 @@ class NodeFolderDeletionTest(PreallocNodesTest):
         self.redpanda.stop_node(to_stop)
         self.redpanda.clean_node(to_stop)
         # start node back up
-        self.redpanda.start_node(to_stop, auto_assign_node_id=True)
+        self.redpanda.start_node(to_stop,
+                                 auto_assign_node_id=True,
+                                 omit_seeds_on_idx_one=False)
         # assert that node id has changed
         assert id != self.redpanda.node_id(to_stop, force_refresh=True)
         wait_until(lambda: producer.produce_status.acked > 200000,


### PR DESCRIPTION
We previously would omit seed servers on the first node, resulting in a size-1 cluster being formed with node_id 0.

Fixes #9326

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
