### PR TITLE
[v23.1.x] fixed: redpanda_cloud_storage_cache_op_miss metric

### DIFF
--- a/src/v/cloud_storage/cache_probe.cc
+++ b/src/v/cloud_storage/cache_probe.cc
@@ -92,7 +92,7 @@ cache_probe::cache_probe() {
               .aggregate(aggregate_labels),
             sm::make_counter(
               "miss",
-              [this] { return _num_cached_gets; },
+              [this] { return _num_miss_gets; },
               sm::description("Number of get requests that are not satisfied "
                               "from the cache."))
               .aggregate(aggregate_labels),


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9333
