### PR TITLE
Evenly distributing topic partitions when adding node to cluster

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -16,6 +16,7 @@
 #include "model/namespace.h"
 #include "model/timeout_clock.h"
 #include "prometheus/prometheus_sanitize.h"
+#include "random/generators.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/loop.hh>
@@ -29,9 +30,13 @@
 #include <fmt/ostream.h>
 
 #include <algorithm>
+#include <bitset>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <iterator>
+#include <limits>
 #include <optional>
 #include <ostream>
 #include <system_error>
@@ -593,11 +598,31 @@ void members_backend::calculate_reallocations_batch(
                 continue;
             }
         }
+        size_t rand_idx = 0;
+        /**
+         * We use 64 bit field initialized with random number to sample topic
+         * partitions to move, every time the bitfield is exhausted we
+         * reinitialize it and reset counter. This way we chose random
+         * partitions to move without iterating multiple times over the topic
+         * set
+         */
+        std::bitset<sizeof(uint64_t)> sampling_bytes;
         for (const auto& p : metadata.get_assignments()) {
             if (idx_it->second > current_idx++) {
                 continue;
             }
+
+            if (rand_idx % sizeof(uint64_t) == 0) {
+                sampling_bytes = random_generators::get_int(
+                  std::numeric_limits<uint64_t>::max());
+                rand_idx = 0;
+            }
+
             idx_it->second++;
+
+            if (sampling_bytes.test(rand_idx++)) {
+                continue;
+            }
 
             std::erase_if(to_move_from_node, [](const replicas_to_move& v) {
                 return v.left_to_move == 0;


### PR DESCRIPTION
Using bitfield to randomly sample topic partitions to move when handing
node addition and on demand rebalancing. Randomly choosing partitions
from a topic prevents Redpanda from moving all partitions from the same
topic to newly added node.

Fixes: #9261


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- all topics are evenly distributed after nodes are added to the cluster 