### PR TITLE
tests: use homogeneous configs by default

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1051,8 +1051,8 @@ class RedpandaService(Service):
               start_si=True,
               parallel: bool = True,
               expect_fail: bool = False,
-              auto_assign_node_id: bool = False,
-              omit_seeds_on_idx_one: bool = True):
+              auto_assign_node_id: bool = True,
+              omit_seeds_on_idx_one: bool = False):
         """
         Start the service on all nodes.
 
@@ -1380,8 +1380,8 @@ class RedpandaService(Service):
                    write_config=True,
                    first_start=False,
                    expect_fail: bool = False,
-                   auto_assign_node_id: bool = False,
-                   omit_seeds_on_idx_one: bool = True,
+                   auto_assign_node_id: bool = True,
+                   omit_seeds_on_idx_one: bool = False,
                    skip_readiness_check: bool = False):
         """
         Start a single instance of redpanda. This function will not return until
@@ -2138,8 +2138,8 @@ class RedpandaService(Service):
     def write_node_conf_file(self,
                              node,
                              override_cfg_params=None,
-                             auto_assign_node_id=False,
-                             omit_seeds_on_idx_one=True):
+                             auto_assign_node_id=True,
+                             omit_seeds_on_idx_one=False):
         """
         Write the node config file for a redpanda node: this is the YAML representation
         of Redpanda's `node_config` class.  Distinct from Redpanda's _cluster_ configuration


### PR DESCRIPTION
They've had a bit over a quarter to bake, let's use them by default in tests.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
