### PR TITLE
Controller snapshots: topic_table preparations

### DIFF
--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -321,7 +321,7 @@ ss::future<result<std::vector<partition_reconfiguration_state>>>
 controller_api::get_partitions_reconfiguration_state(
   std::vector<model::ntp> partitions,
   model::timeout_clock::time_point timeout) {
-    auto& updates_in_progress = _topics.local().in_progress_updates();
+    auto& updates_in_progress = _topics.local().updates_in_progress();
 
     partitions_filter partitions_filter;
     absl::node_hash_map<model::ntp, partition_reconfiguration_state> states;

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -410,7 +410,7 @@ find_interrupting_operation(deltas_t::iterator current_it, deltas_t& deltas) {
 ss::future<std::error_code> do_update_replica_set(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replicas,
-  const topic_table_delta::revision_map_t& replica_revisions,
+  const replicas_revision_map& replica_revisions,
   model::revision_id rev,
   ss::lw_shared_ptr<partition> p,
   members_table& members,
@@ -437,7 +437,7 @@ ss::future<std::error_code> do_update_replica_set(
 ss::future<std::error_code> revert_configuration_update(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replicas,
-  const topic_table_delta::revision_map_t& replica_revisions,
+  const replicas_revision_map& replica_revisions,
   model::revision_id rev,
   ss::lw_shared_ptr<partition> p,
   members_table& members,
@@ -998,7 +998,7 @@ controller_backend::process_partition_reconfiguration(
   model::ntp ntp,
   const partition_assignment& target_assignment,
   const std::vector<model::broker_shard>& previous_replicas,
-  const topic_table_delta::revision_map_t& replica_revisions,
+  const replicas_revision_map& replica_revisions,
   model::revision_id command_rev) {
     vlog(
       clusterlog.trace,
@@ -1313,7 +1313,7 @@ ss::future<std::error_code> controller_backend::execute_reconfiguration(
   topic_table_delta::op_type type,
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replica_set,
-  const topic_table_delta::revision_map_t& replica_revisions,
+  const replicas_revision_map& replica_revisions,
   const std::vector<model::broker_shard>& previous_replica_set,
   model::revision_id revision) {
     switch (type) {
@@ -1461,7 +1461,7 @@ controller_backend::apply_configuration_change_on_leader(
 ss::future<std::error_code> controller_backend::cancel_replica_set_update(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replicas,
-  const topic_table_delta::revision_map_t& replica_revisions,
+  const replicas_revision_map& replica_revisions,
   const std::vector<model::broker_shard>& previous_replicas,
   model::revision_id rev) {
     /**
@@ -1558,7 +1558,7 @@ controller_backend::dispatch_revert_cancel_move(model::ntp ntp) {
 ss::future<std::error_code> controller_backend::force_abort_replica_set_update(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replicas,
-  const topic_table_delta::revision_map_t& replica_revisions,
+  const replicas_revision_map& replica_revisions,
   const std::vector<model::broker_shard>& previous_replicas,
   model::revision_id rev) {
     /**
@@ -1641,7 +1641,7 @@ ss::future<std::error_code> controller_backend::force_abort_replica_set_update(
 ss::future<std::error_code> controller_backend::update_partition_replica_set(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& replicas,
-  const topic_table_delta::revision_map_t& replica_revisions,
+  const replicas_revision_map& replica_revisions,
   model::revision_id rev) {
     /**
      * Following scenarios can happen in here:

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -280,18 +280,18 @@ private:
     ss::future<std::error_code> execute_partition_op(const delta_metadata&);
     ss::future<std::error_code> process_partition_reconfiguration(
       uint64_t current_retry,
-      topic_table_delta::op_type operation_type,
-      model::ntp ntp,
+      topic_table_delta::op_type,
+      model::ntp,
       const partition_assignment& requested_assignment,
       const std::vector<model::broker_shard>& previous_replica_set,
-      const topic_table_delta::revision_map_t& revisions_map,
-      model::revision_id rev);
+      const replicas_revision_map&,
+      model::revision_id);
 
     ss::future<std::error_code> execute_reconfiguration(
       topic_table_delta::op_type,
       const model::ntp&,
       const std::vector<model::broker_shard>&,
-      const topic_table_delta::revision_map_t&,
+      const replicas_revision_map&,
       const std::vector<model::broker_shard>&,
       model::revision_id);
 
@@ -328,19 +328,19 @@ private:
     ss::future<std::error_code> update_partition_replica_set(
       const model::ntp&,
       const std::vector<model::broker_shard>&,
-      const topic_table_delta::revision_map_t&,
+      const replicas_revision_map&,
       model::revision_id);
     ss::future<std::error_code> cancel_replica_set_update(
       const model::ntp&,
       const std::vector<model::broker_shard>&,
-      const topic_table_delta::revision_map_t&,
+      const replicas_revision_map&,
       const std::vector<model::broker_shard>&,
       model::revision_id);
 
     ss::future<std::error_code> force_abort_replica_set_update(
       const model::ntp&,
       const std::vector<model::broker_shard>&,
-      const topic_table_delta::revision_map_t&,
+      const replicas_revision_map&,
       const std::vector<model::broker_shard>&,
       model::revision_id);
 

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -647,7 +647,7 @@ std::vector<model::ntp> members_backend::ntps_moving_from_node_older_than(
   model::node_id node, model::revision_id revision) const {
     std::vector<model::ntp> ret;
 
-    for (const auto& [ntp, state] : _topics.local().in_progress_updates()) {
+    for (const auto& [ntp, state] : _topics.local().updates_in_progress()) {
         if (state.get_update_revision() < revision) {
             continue;
         }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -803,8 +803,6 @@ void topic_table::notify_waiters() {
         for (auto& cb : _notifications) {
             cb.second(changes);
         }
-
-        _last_consumed_by_notifier = changes.back().offset;
     }
 
     _last_consumed_by_notifier_offset = _pending_deltas.end()
@@ -933,7 +931,7 @@ bool topic_table::contains(
 
 topic_table::topic_state topic_table::get_topic_state(
   model::topic_namespace_view tp, model::revision_id id) const {
-    if (id > _last_consumed_by_notifier) {
+    if (id > _last_applied_revision_id) {
         // Cache is not sufficiently up to date to give a
         // reliable result.
         return topic_state::indeterminate;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -374,7 +374,8 @@ topic_table::apply(cancel_moving_partition_replicas_cmd cmd, model::offset o) {
 
     in_progress_it->second.set_state(
       cmd.value.force ? reconfiguration_state::force_cancelled
-                      : reconfiguration_state::cancelled);
+                      : reconfiguration_state::cancelled,
+      model::revision_id{o});
 
     auto replicas = current_assignment_it->replicas;
     // replace replica set with set from in progress operation

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -396,6 +396,11 @@ topic_table::apply(cancel_moving_partition_replicas_cmd cmd, model::offset o) {
               cs,
               cmd.key);
 
+            child_it->second.set_state(
+              cmd.value.force ? reconfiguration_state::force_cancelled
+                              : reconfiguration_state::cancelled,
+              model::revision_id{o});
+
             auto sfound = _topics.find(cs);
             vassert(
               sfound != _topics.end(),

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -71,7 +71,10 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
             replica_revisions[r.node_id] = rev_id;
         }
         md.partitions.emplace(
-          pas.id, partition_meta{.replicas_revisions = replica_revisions});
+          pas.id,
+          partition_meta{
+            .replicas_revisions = replica_revisions,
+            .last_update_finished_revision = rev_id});
         _pending_deltas.emplace_back(
           std::move(ntp),
           pas,
@@ -170,7 +173,8 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
             replicas_revisions[bs.node_id] = rev_id;
         }
         tp->second.partitions[p_as.id] = partition_meta{
-          .replicas_revisions = replicas_revisions};
+          .replicas_revisions = replicas_revisions,
+          .last_update_finished_revision = rev_id};
         _pending_deltas.emplace_back(
           std::move(ntp),
           std::move(p_as),
@@ -282,6 +286,7 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
           cmd.value,
           it->second.get_update_revision());
     }
+    p_meta_it->second.last_update_finished_revision = model::revision_id{o};
 
     _updates_in_progress.erase(it);
 

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -91,6 +91,7 @@ public:
           , _target_replicas(std::move(target_replicas))
           , _state(state)
           , _update_revision(update_revision)
+          , _last_cmd_revision(update_revision)
           , _probe(probe) {
             _probe.handle_update(_previous_replicas, _target_replicas);
         }
@@ -113,7 +114,7 @@ public:
 
         const reconfiguration_state& get_state() const { return _state; }
 
-        void set_state(reconfiguration_state state) {
+        void set_state(reconfiguration_state state, model::revision_id rev) {
             if (
               _state == reconfiguration_state::in_progress
               && (state == reconfiguration_state::cancelled || state == reconfiguration_state::force_cancelled)) {
@@ -121,6 +122,7 @@ public:
                   _previous_replicas, _target_replicas);
             }
             _state = state;
+            _last_cmd_revision = rev;
         }
 
         const std::vector<model::broker_shard>& get_previous_replicas() const {
@@ -134,8 +136,8 @@ public:
             return _update_revision;
         }
 
-        void swap_replica_revisions(replicas_revision_map& revisions) {
-            std::swap(_replicas_revisions, revisions);
+        const model::revision_id& get_last_cmd_revision() const {
+            return _last_cmd_revision;
         }
 
     private:
@@ -143,6 +145,7 @@ public:
         std::vector<model::broker_shard> _target_replicas;
         reconfiguration_state _state;
         model::revision_id _update_revision;
+        model::revision_id _last_cmd_revision;
         topic_table_probe& _probe;
     };
 

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -388,11 +388,6 @@ public:
     std::optional<std::vector<model::broker_shard>>
     get_target_replica_set(const model::ntp&) const;
 
-    const absl::node_hash_map<model::ntp, in_progress_update>&
-    in_progress_updates() const {
-        return _updates_in_progress;
-    }
-
     /**
      * Lists all NTPs that replicas are being move to a node
      */
@@ -431,7 +426,6 @@ private:
         ss::abort_source::subscription sub;
         uint64_t id;
     };
-    void deallocate_topic_partitions(const std::vector<partition_assignment>&);
 
     void notify_waiters();
 

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -79,6 +79,23 @@ class topic_table {
 public:
     enum class topic_state { exists, not_exists, indeterminate };
 
+    // Guide to various partition revisions (i.e. offsets of the corresponding
+    // commands in the controller log), presented in the chronological order:
+    // * topic creation revision
+    // * revision of the command (topic creation or partition movement) that
+    //   caused a partition replica to appear on a given node (note that the
+    //   partition can move away from a node and come back again and each time
+    //   revision will be different). This revision appears in:
+    //   * replicas_revision_map
+    //   * partition::get_ntp_config().get_revision()
+    //   * the partition directory name
+    // * revision of the last applied command that caused raft reconfiguration
+    //   (can be reconfiguration itself or cancellation). This revision appears
+    //   in:
+    //   * in_progress_update::get_last_cmd_revision()
+    //   * partition::get_revision_id()
+    //   * raft::group_configuration::revision_id()
+
     class in_progress_update {
     public:
         explicit in_progress_update(

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -151,6 +151,9 @@ public:
         /// updates* (i.e. it only gets updated when the update_finished command
         /// is processed).
         replicas_revision_map replicas_revisions;
+        /// Revision id of the last applied update_finished controller command
+        /// (or of addition command if none)
+        model::revision_id last_update_finished_revision;
     };
 
     struct topic_metadata_item {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -78,12 +78,6 @@ namespace cluster {
 class topic_table {
 public:
     enum class topic_state { exists, not_exists, indeterminate };
-    /**
-     * Replicas revision map is used to track revision of brokers in a replica
-     * set. When a node is added into replica set its gets the revision assigned
-     */
-    using replicas_revision_map
-      = absl::flat_hash_map<model::node_id, model::revision_id>;
 
     class in_progress_update {
     public:

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -457,8 +457,6 @@ private:
     std::vector<std::pair<cluster::notification_id_type, delta_cb_t>>
       _notifications;
     uint64_t _waiter_id{0};
-    model::offset _last_consumed_by_notifier{
-      model::model_limits<model::offset>::min()};
     std::vector<delta>::difference_type _last_consumed_by_notifier_offset{0};
     topic_table_probe _probe;
 };

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -217,7 +217,7 @@ topic_table_delta::topic_table_delta(
   model::offset o,
   op_type tp,
   std::optional<std::vector<model::broker_shard>> previous,
-  std::optional<revision_map_t> replica_revisions)
+  std::optional<replicas_revision_map> replica_revisions)
   : ntp(std::move(ntp))
   , new_assignment(std::move(new_assignment))
   , offset(o)
@@ -384,12 +384,13 @@ std::ostream& operator<<(std::ostream& o, const topic_table_delta& d) {
     fmt::print(
       o,
       "{{type: {}, ntp: {}, offset: {}, new_assignment: {}, "
-      "previous_replica_set: {}}}",
+      "previous_replica_set: {}, replica_revisions: {}}}",
       d.type,
       d.ntp,
       d.offset,
       d.new_assignment,
-      d.previous_replica_set);
+      d.previous_replica_set,
+      d.replica_revisions);
 
     return o;
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1874,10 +1874,16 @@ public:
 private:
     ss::sstring _msg;
 };
+
+/**
+ * Replicas revision map is used to track revision of brokers in a replica
+ * set. When a node is added into replica set its gets the revision assigned
+ */
+using replicas_revision_map
+  = absl::flat_hash_map<model::node_id, model::revision_id>;
+
 // delta propagated to backend
 struct topic_table_delta {
-    using revision_map_t
-      = absl::flat_hash_map<model::node_id, model::revision_id>;
     enum class op_type {
         add,
         del,
@@ -1896,14 +1902,14 @@ struct topic_table_delta {
       model::offset,
       op_type,
       std::optional<std::vector<model::broker_shard>> = std::nullopt,
-      std::optional<revision_map_t> = std::nullopt);
+      std::optional<replicas_revision_map> = std::nullopt);
 
     model::ntp ntp;
     cluster::partition_assignment new_assignment;
     model::offset offset;
     op_type type;
     std::optional<std::vector<model::broker_shard>> previous_replica_set;
-    std::optional<revision_map_t> replica_revisions;
+    std::optional<replicas_revision_map> replica_revisions;
 
     model::topic_namespace_view tp_ns() const {
         return model::topic_namespace_view(ntp);
@@ -4052,3 +4058,22 @@ struct adl<cluster::cancel_partition_movements_reply> {
 };
 
 } // namespace reflection
+
+namespace absl {
+
+template<typename K, typename V>
+std::ostream& operator<<(std::ostream& o, const absl::flat_hash_map<K, V>& r) {
+    o << "{";
+    bool first = true;
+    for (const auto& [k, v] : r) {
+        if (!first) {
+            o << ", ";
+        }
+        o << "{" << k << " -> " << v << "}";
+        first = false;
+    }
+    o << "}";
+    return o;
+}
+
+} // namespace absl


### PR DESCRIPTION
This PR contains some changes to how topic_table handles revisions that are needed for controller snapshots. They should not result in any changes to observable behavior.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none