### PR TITLE
[v22.3.x] admin: Add blocked_reactor_notify_ms command

### DIFF
--- a/src/v/redpanda/admin/api-doc/config.json
+++ b/src/v/redpanda/admin/api-doc/config.json
@@ -65,4 +65,30 @@
       }
     }
   }
+},
+"/v1/config/blocked_reactor_notify_ms/{timeout}": {
+  "put": {
+    "summary": "Temporarily reduce the threshold over which the reactor is considered blocked if no progress is made. The original threshold value will be restored after 'expire' seconds (default: 5 min)",
+    "operationId": "blocked_reactor_notify_ms",
+    "parameters": [
+        {
+            "name": "timeout",
+            "in": "path",
+            "required": true,
+            "type": "long"
+        },
+        {
+            "name": "expires",
+            "in": "query",
+            "required": false,
+            "allowMultiple": false,
+            "type": "long"
+        }
+    ],
+    "responses": {
+      "200": {
+        "description": "Blocked reactor notify threshold updated"
+      }
+    }
+  }
 }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -79,8 +79,10 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/prometheus.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/timer.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/http/api_docs.hh>
@@ -95,6 +97,8 @@
 #include <boost/lexical_cast/bad_lexical_cast.hpp>
 #include <fmt/core.h>
 
+#include <charconv>
+#include <chrono>
 #include <limits>
 #include <stdexcept>
 #include <system_error>
@@ -128,9 +132,16 @@ admin_server::admin_server(
   , _auth(config::shard_local_cfg().admin_api_require_auth.bind(), _controller)
   , _archival_service(archival_service)
   , _node_status_table(node_status_table)
-  , _schema_registry(schema_registry) {}
+  , _schema_registry(schema_registry)
+  , _default_blocked_reactor_notify(
+      ss::engine().get_blocked_reactor_notify_ms()) {}
 
 ss::future<> admin_server::start() {
+    _blocked_reactor_notify_reset_timer.set_callback([this] {
+        return ss::smp::invoke_on_all([ms = _default_blocked_reactor_notify] {
+            ss::engine().update_blocked_reactor_notify_ms(ms);
+        });
+    });
     configure_metrics_route();
     configure_admin_routes();
 
@@ -142,7 +153,10 @@ ss::future<> admin_server::start() {
       _cfg.endpoints);
 }
 
-ss::future<> admin_server::stop() { return _server.stop(); }
+ss::future<> admin_server::stop() {
+    _blocked_reactor_notify_reset_timer.cancel();
+    return _server.stop();
+}
 
 void admin_server::configure_admin_routes() {
     auto rb = ss::make_shared<ss::api_registry_builder20>(
@@ -990,6 +1004,70 @@ void admin_server::register_config_routes() {
 
           return ss::make_ready_future<ss::json::json_return_type>(
             ss::json::json_void());
+      });
+
+    register_route<superuser>(
+      ss::httpd::config_json::blocked_reactor_notify_ms,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          ss::sstring timeout_str;
+          if (!ss::httpd::connection::url_decode(
+                req->param["timeout"], timeout_str)) {
+              throw ss::httpd::bad_param_exception(
+                fmt::format("Required parameter 'timeout' is not set"));
+          }
+
+          std::chrono::milliseconds ms;
+          try {
+              ms = std::clamp(
+                std::chrono::milliseconds(
+                  boost::lexical_cast<long long>(timeout_str)),
+                1ms,
+                _default_blocked_reactor_notify);
+          } catch (const boost::bad_lexical_cast&) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Invalid parameter 'timeout' value {{{}}}", timeout_str));
+          }
+
+          std::optional<std::chrono::seconds> expires;
+          static constexpr std::chrono::seconds max_expire_time_sec
+            = std::chrono::minutes(30);
+          if (auto e = req->get_query_param("expires"); !e.empty()) {
+              try {
+                  expires = std::clamp(
+                    std::chrono::seconds(boost::lexical_cast<long long>(e)),
+                    1s,
+                    max_expire_time_sec);
+              } catch (const boost::bad_lexical_cast&) {
+                  throw ss::httpd::bad_param_exception(
+                    fmt::format("Invalid parameter 'expires' value {{{}}}", e));
+              }
+          }
+
+          // This value is used when the expiration time is not set explicitly
+          static constexpr std::chrono::seconds default_expiration_time
+            = std::chrono::minutes(5);
+          auto curr = ss::engine().get_blocked_reactor_notify_ms();
+
+          vlog(
+            logger.info,
+            "Setting blocked_reactor_notify_ms from {} to {} for {} "
+            "(default={})",
+            curr,
+            ms.count(),
+            expires.value_or(default_expiration_time),
+            _default_blocked_reactor_notify);
+
+          return ss::smp::invoke_on_all(
+                   [ms] { ss::engine().update_blocked_reactor_notify_ms(ms); })
+            .then([] {
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::json_void());
+            })
+            .finally([this, expires] {
+                _blocked_reactor_notify_reset_timer.rearm(
+                  ss::steady_clock_type::now()
+                  + expires.value_or(default_expiration_time));
+            });
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -362,4 +362,7 @@ private:
     ss::sharded<archival::scheduler_service>& _archival_service;
     ss::sharded<cluster::node_status_table>& _node_status_table;
     pandaproxy::schema_registry::api* _schema_registry;
+    // Value before the temporary override
+    std::chrono::milliseconds _default_blocked_reactor_notify;
+    ss::timer<> _blocked_reactor_notify_reset_timer;
 };


### PR DESCRIPTION
The command changes the timeout of stall detector for brief period of time.

curl -XPUT  "127.0.0.1:9644/v1/config/blocked_reactor_notify_ms/1?expires=15"

This command will change the value to 1ms and it will be reset back after 15 seconds. If 'expires' parameter is not set the default expire value will be used. The default is 5 minutes.

(cherry picked from commit f09dda91e13ca7242891b94cead34f5991d01446)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features

* Add admin API command that changes --blocked-reactor-notify-ms parameter on the fly.