### PR TITLE
c/members_manager: closing connections to removed nodes fixes

### DIFF
--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -307,7 +307,11 @@ private:
 
     ss::sharded<ss::abort_source>& _as;
 
-    absl::flat_hash_set<model::node_id> _connections_to_remove;
+    // A set of node ids for which the removed command has already been
+    // processed, but that are still members of the controller group. We can
+    // close a connection to these nodes only after they leave the controller
+    // group and are fully removed.
+    absl::flat_hash_set<model::node_id> _removed_nodes_still_in_raft0;
 
     const config::tls_config _rpc_tls_config;
 


### PR DESCRIPTION
* Include nodes that are removed but are still in the controller group in the kvstore snapshot (because we still need to open connections to them after a restart)
* Close connections to nodes that were removed before the cluster fully switched to node management commands.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
