### PR TITLE
[v23.1.x] cluster: expose cloud storage usage accross the entire cluster

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -518,6 +518,10 @@ bool remote_partition::is_data_available() const {
                 != _manifest.end();
 }
 
+uint64_t remote_partition::cloud_log_size() const {
+    return _manifest.cloud_log_size();
+}
+
 // returns term last kafka offset
 std::optional<kafka::offset>
 remote_partition::get_term_last_offset(model::term_id term) const {

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -103,6 +103,8 @@ public:
     /// Returns true if at least one segment is uploaded to the bucket
     bool is_data_available() const;
 
+    uint64_t cloud_log_size() const;
+
     // returns term last kafka offset
     std::optional<kafka::offset> get_term_last_offset(model::term_id) const;
 

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -156,6 +156,7 @@ v_cc_library(
     node_isolation_watcher.cc
     topic_recovery_status_types.cc
     topic_table_partition_generator.cc
+    cloud_storage_size_reducer.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -155,6 +155,7 @@ v_cc_library(
     topic_recovery_status_frontend.cc
     node_isolation_watcher.cc
     topic_recovery_status_types.cc
+    topic_table_partition_generator.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/cloud_storage_size_reducer.cc
+++ b/src/v/cluster/cloud_storage_size_reducer.cc
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster/cloud_storage_size_reducer.h"
+
+#include "cluster/controller_service.h"
+#include "cluster/members_table.h"
+#include "cluster/partition_leaders_table.h"
+
+namespace cluster {
+cloud_storage_size_reducer_exception::cloud_storage_size_reducer_exception(
+  const std::string& m)
+  : std::runtime_error(m) {}
+
+cloud_storage_size_reducer::cloud_storage_size_reducer(
+  ss::sharded<topic_table>& topic_table,
+  ss::sharded<members_table>& members_table,
+  ss::sharded<partition_leaders_table>& leaders_table,
+  ss::sharded<rpc::connection_cache>& conn_cache,
+  size_t batch_size,
+  uint8_t retries_allowed)
+  : _topic_table(std::ref(topic_table))
+  , _members_table(std::ref(members_table))
+  , _leaders_table(std::ref(leaders_table))
+  , _conn_cache{conn_cache}
+  , _batch_size{batch_size}
+  , _retries_allowed{retries_allowed} {}
+
+ss::future<std::optional<uint64_t>> cloud_storage_size_reducer::reduce() {
+    try {
+        co_return co_await do_reduce();
+    } catch (const topic_table_partition_generator_exception& e) {
+        vlog(
+          clusterlog.debug,
+          "Failed to generate total cloud storage usage across the cluster "
+          "(retries left: {}): {}",
+          _retries_allowed - _retries_attempted,
+          e.what());
+    } catch (const cloud_storage_size_reducer_exception& e) {
+        vlog(
+          clusterlog.debug,
+          "Failed to generate total cloud storage usage across the cluster "
+          "(retries left: {}): {}",
+          _retries_allowed - _retries_attempted,
+          e.what());
+    } catch (const std::exception& e) {
+        vlog(clusterlog.warn, "Unexpected exception thrown: {}", e.what());
+        throw;
+    }
+
+    if (++_retries_attempted <= _retries_allowed) {
+        co_return co_await reduce();
+    } else {
+        vlog(
+          clusterlog.warn,
+          "Failed to generate cloud storage usage for cluster after {} retries",
+          _retries_allowed);
+        co_return std::nullopt;
+    }
+}
+
+ss::future<uint64_t> cloud_storage_size_reducer::do_reduce() {
+    topic_table_partition_generator partition_gen{_topic_table, _batch_size};
+
+    uint64_t total_cloud_storage_bytes{0};
+    auto batch = co_await partition_gen.next_batch();
+    while (batch) {
+        requests_t request_futures = map_batch(*batch);
+        auto results = co_await ss::when_all_succeed(
+          request_futures.begin(), request_futures.end());
+
+        for (auto& res : results) {
+            if (res.has_error()) {
+                throw cloud_storage_size_reducer_exception(
+                  "RPC for cloud storage usage failed");
+            }
+
+            if (res.value().missing_partitions.size() > 0) {
+                throw cloud_storage_size_reducer_exception(fmt::format(
+                  "Cloud storage usage for {} partitions was not found",
+                  res.value().missing_partitions.size()));
+            }
+
+            total_cloud_storage_bytes += res.value().total_size_bytes;
+        }
+
+        batch = co_await partition_gen.next_batch();
+    }
+
+    co_return total_cloud_storage_bytes;
+}
+
+ss::future<result<cloud_storage_usage_reply>>
+cloud_storage_size_reducer::send_query(
+  const model::broker& destination, cloud_storage_usage_request req) {
+    return with_client<controller_client_protocol>(
+      _self.id(),
+      _conn_cache,
+      destination.id(),
+      destination.rpc_address(),
+      _rpc_tls_config,
+      _timeout,
+      [this, req = std::move(req)](controller_client_protocol c) mutable {
+          return c
+            .cloud_storage_usage(std::move(req), rpc::client_opts(_timeout))
+            .then(&rpc::get_ctx_data<cloud_storage_usage_reply>);
+      });
+}
+
+cloud_storage_size_reducer::requests_t cloud_storage_size_reducer::map_batch(
+  const topic_table_partition_generator::generator_type_t& batch) {
+    absl::flat_hash_map<model::broker, std::vector<model::ntp>> ntps_per_node;
+
+    for (const auto& [ntp, replicas] : batch) {
+        auto broker = select_replica(ntp, replicas);
+        ntps_per_node[broker].push_back(ntp);
+    }
+
+    requests_t futs;
+    futs.reserve(ntps_per_node.size());
+
+    for (auto& [broker, ntps] : ntps_per_node) {
+        futs.emplace_back(send_query(broker, {.partitions = std::move(ntps)}));
+    }
+
+    return futs;
+}
+
+// This function picks a replica of a given partition to serve
+// the cloud_storage_usage request. If we think the leader is alive,
+// pick it, otherwise select the first live replica.
+model::broker cloud_storage_size_reducer::select_replica(
+  const model::ntp& ntp,
+  const std::vector<model::broker_shard>& replicas) const {
+    const auto leader = _leaders_table.local().get_leader(ntp);
+
+    std::optional<model::broker> first_live_replica;
+    for (const auto& replica : replicas) {
+        if (
+          auto md = _members_table.local().get_node_metadata_ref(
+            replica.node_id)) {
+            if (leader && *leader == replica.node_id) {
+                return md.value().get().broker;
+            }
+
+            if (!first_live_replica) {
+                first_live_replica = md.value().get().broker;
+            }
+        }
+    }
+
+    if (first_live_replica) {
+        return *first_live_replica;
+    }
+
+    throw cloud_storage_size_reducer_exception(
+      fmt::format("No live replicas for {}", ntp));
+}
+
+} // namespace cluster

--- a/src/v/cluster/cloud_storage_size_reducer.h
+++ b/src/v/cluster/cloud_storage_size_reducer.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cluster/cluster_utils.h"
+#include "cluster/fwd.h"
+#include "cluster/topic_table_partition_generator.h"
+#include "cluster/types.h"
+#include "config/node_config.h"
+#include "rpc/connection_cache.h"
+
+namespace cluster {
+
+class cloud_storage_size_reducer_exception : public std::runtime_error {
+public:
+    explicit cloud_storage_size_reducer_exception(const std::string& m);
+};
+
+/*
+ * This utility class performs a map-reduce operation accross the cluster
+ * in order to determine the total number of cloud storage bytes used by
+ * all partitions.
+ *
+ * It iterates across the current topic table in batche. For each batch,
+ * the following sequence of operations is performed:
+ * 1. Find the first live replica of each partition in the batch
+ * 2. Prepare `cloud_storage_usage` RPC requests for each node in the cluster.
+ * The request will contain the partitions being queried by shard.
+ * 3. Reduce the reponses and update the accumulator.
+ *
+ * One important thing to note is that this operation requires topic table
+ * stability (i.e. the topic table does not change in the meantime). This
+ * property is enfored by the `topic_table_partition_generator`, which will
+ * throw if the topic table has been updated during the iteration. If such
+ * a change does happen, it's treated as a retryable error.
+ *
+ * Usage: `reduce` should only be called once per object instance.
+ */
+class cloud_storage_size_reducer {
+public:
+    static constexpr uint8_t default_retries_allowed = 3;
+
+    cloud_storage_size_reducer(
+      ss::sharded<topic_table>& topic_table,
+      ss::sharded<members_table>& members_table,
+      ss::sharded<partition_leaders_table>& leaders_table,
+      ss::sharded<rpc::connection_cache>& conn_cache,
+      size_t batch_size = topic_table_partition_generator::default_batch_size,
+      uint8_t retries_allowed = 3);
+
+    ss::future<std::optional<uint64_t>> reduce();
+
+private:
+    ss::future<uint64_t> do_reduce();
+
+    ss::future<result<cloud_storage_usage_reply>> send_query(
+      const model::broker& destination, cloud_storage_usage_request req);
+
+    using requests_t
+      = std::vector<ss::future<result<cloud_storage_usage_reply>>>;
+
+    requests_t
+    map_batch(const topic_table_partition_generator::generator_type_t& batch);
+
+    model::broker select_replica(
+      const model::ntp& ntp,
+      const std::vector<model::broker_shard>& replicas) const;
+
+    const model::broker _self{make_self_broker(config::node())};
+    const config::tls_config _rpc_tls_config{config::node().rpc_server_tls()};
+    const std::chrono::seconds _timeout{2};
+
+    ss::sharded<topic_table>& _topic_table;
+    ss::sharded<members_table>& _members_table;
+    ss::sharded<partition_leaders_table>& _leaders_table;
+    ss::sharded<rpc::connection_cache>& _conn_cache;
+
+    size_t _batch_size;
+
+    uint8_t _retries_allowed;
+    uint8_t _retries_attempted{0};
+};
+
+} // namespace cluster

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -130,6 +130,11 @@
             "name": "transfer_leadership",
             "input_type": "transfer_leadership_request",
             "output_type": "transfer_leadership_reply"
+        },
+        {
+            "name": "cloud_storage_usage",
+            "input_type": "cloud_storage_usage_request",
+            "output_type": "cloud_storage_usage_reply"
         }
     ]
 }

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -447,4 +447,9 @@ controller_api::shard_for(const raft::group_id& group) const {
     }
 }
 
+std::optional<ss::shard_id>
+controller_api::shard_for(const model::ntp& ntp) const {
+    return _shard_table.local().shard_for(ntp);
+}
+
 } // namespace cluster

--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -77,6 +77,7 @@ public:
         model::node_id, model::timeout_clock::time_point);
 
     std::optional<ss::shard_id> shard_for(const raft::group_id& group) const;
+    std::optional<ss::shard_id> shard_for(const model::ntp& ntp) const;
 
 private:
     ss::future<result<bool>> are_ntps_ready(

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -27,6 +27,7 @@ class shard_table;
 class topics_frontend;
 class topic_table;
 struct topic_table_delta;
+class topic_table_partition_generator;
 class members_manager;
 class members_table;
 class metadata_cache;

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -28,6 +28,7 @@ class topics_frontend;
 class topic_table;
 struct topic_table_delta;
 class topic_table_partition_generator;
+class cloud_storage_size_reducer;
 class members_manager;
 class members_table;
 class metadata_cache;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -171,6 +171,14 @@ bool partition::cloud_data_available() const {
            && _cloud_storage_partition->is_data_available();
 }
 
+uint64_t partition::cloud_log_size() const {
+    if (!cloud_data_available() || is_read_replica_mode_enabled()) {
+        return 0;
+    }
+
+    return _cloud_storage_partition->cloud_log_size();
+}
+
 model::offset partition::start_cloud_offset() const {
     vassert(
       cloud_data_available(),

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -242,6 +242,8 @@ public:
     /// method returned 'true'.
     bool cloud_data_available() const;
 
+    uint64_t cloud_log_size() const;
+
     /// Starting offset in the object store
     model::offset start_cloud_offset() const;
 

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -675,4 +675,70 @@ ss::future<transfer_leadership_reply> service::transfer_leadership(
     }
 }
 
+ss::future<cloud_storage_usage_reply> service::cloud_storage_usage(
+  cloud_storage_usage_request&& req, rpc::streaming_context&) {
+    return ss::with_scheduling_group(get_scheduling_group(), [this, req]() {
+        return do_cloud_storage_usage(req);
+    });
+}
+
+ss::future<cloud_storage_usage_reply>
+service::do_cloud_storage_usage(cloud_storage_usage_request req) {
+    struct res_type {
+        uint64_t total_size{0};
+        std::vector<model::ntp> missing_partitions;
+    };
+
+    std::vector<model::ntp> missing_ntps;
+
+    absl::flat_hash_map<ss::shard_id, std::vector<model::ntp>> ntps_by_shard;
+    for (const auto& ntp : req.partitions) {
+        auto shard = _api.local().shard_for(ntp);
+        if (!shard) {
+            missing_ntps.push_back(ntp);
+        } else {
+            ntps_by_shard[*shard].push_back(ntp);
+        }
+    }
+
+    res_type result = co_await _partition_manager.map_reduce0(
+      [&partitions = ntps_by_shard](const partition_manager& pm) {
+          auto iter = partitions.find(ss::this_shard_id());
+          if (iter == partitions.end()) {
+              return res_type{};
+          }
+
+          const auto& ntps_for_shard = iter->second;
+
+          std::vector<model::ntp> missing_partitions_on_shard;
+          uint64_t size_on_shard = 0;
+          for (const auto& ntp : ntps_for_shard) {
+              auto partition = pm.get(ntp);
+
+              if (!partition) {
+                  missing_partitions_on_shard.push_back(ntp);
+              } else {
+                  size_on_shard += partition->cloud_log_size();
+              }
+          }
+          return res_type{
+            .total_size = size_on_shard,
+            .missing_partitions = std::move(missing_partitions_on_shard)};
+      },
+      res_type{.missing_partitions = std::move(missing_ntps)},
+      [](res_type acc, res_type map_result) {
+          acc.total_size += map_result.total_size;
+          acc.missing_partitions.insert(
+            acc.missing_partitions.end(),
+            std::make_move_iterator(map_result.missing_partitions.begin()),
+            std::make_move_iterator(map_result.missing_partitions.end()));
+
+          return acc;
+      });
+
+    co_return cloud_storage_usage_reply{
+      .total_size_bytes = result.total_size,
+      .missing_partitions = std::move(result.missing_partitions)};
+}
+
 } // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -115,6 +115,9 @@ public:
     ss::future<transfer_leadership_reply> transfer_leadership(
       transfer_leadership_request&& r, rpc::streaming_context&) final;
 
+    ss::future<cloud_storage_usage_reply> cloud_storage_usage(
+      cloud_storage_usage_request&& r, rpc::streaming_context&) final;
+
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
     std::
@@ -148,6 +151,9 @@ private:
     ss::future<cancel_partition_movements_reply>
       do_cancel_node_partition_movements(
         cancel_node_partition_movements_request);
+
+    ss::future<cloud_storage_usage_reply>
+      do_cloud_storage_usage(cloud_storage_usage_request);
 
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(srcs
     commands_serialization_test.cc
     topic_table_test.cc
     topic_updates_dispatcher_test.cc
+    topic_table_partition_generator_test.cc
     controller_backend_test.cc
     idempotency_tests.cc
     feature_barrier_test.cc

--- a/src/v/cluster/tests/topic_table_partition_generator_test.cc
+++ b/src/v/cluster/tests/topic_table_partition_generator_test.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster/tests/topic_table_fixture.h"
+#include "cluster/topic_table_partition_generator.h"
+
+inline ss::logger test_log("test");
+
+FIXTURE_TEST(test_successful_generation, topic_table_fixture) {
+    auto cmd_1 = make_create_topic_cmd("test_tp_1", 10, 3);
+    auto cmd_2 = make_create_topic_cmd("test_tp_2", 10, 3);
+    auto cmd_3 = make_create_topic_cmd("test_tp_3", 10, 1);
+
+    auto res_1 = table.local().apply(std::move(cmd_1), model::offset(1)).get();
+    auto res_2 = table.local().apply(std::move(cmd_2), model::offset(2)).get();
+    auto res_3 = table.local().apply(std::move(cmd_3), model::offset(3)).get();
+
+    BOOST_REQUIRE_EQUAL(res_1, cluster::errc::success);
+    BOOST_REQUIRE_EQUAL(res_2, cluster::errc::success);
+    BOOST_REQUIRE_EQUAL(res_3, cluster::errc::success);
+
+    cluster::topic_table_partition_generator gen(table, 5);
+
+    std::unordered_map<model::ntp, std::vector<model::broker_shard>> result;
+
+    std::optional<cluster::topic_table_partition_generator::generator_type_t>
+      next_batch = std::nullopt;
+    do {
+        next_batch = gen.next_batch().get();
+        if (next_batch) {
+            BOOST_REQUIRE(next_batch->size() <= 5);
+            for (auto& p_replicas : *next_batch) {
+                vlog(test_log.debug, "{}", p_replicas.partition);
+                result[p_replicas.partition] = std::move(p_replicas.replicas);
+            }
+        }
+    } while (next_batch.has_value());
+
+    BOOST_REQUIRE(result.size() == 30);
+
+    auto node_ids = members.local().node_ids();
+    for (const auto& [ntp, replicas] : result) {
+        if (ntp.tp.topic() == "test_tp_3") {
+            BOOST_REQUIRE_EQUAL(replicas.size(), 1);
+        } else {
+            BOOST_REQUIRE_EQUAL(replicas.size(), 3);
+
+            // Check that all nodes are present for
+            // ntps with replication factor equal to 3.
+            for (const auto& node_id : node_ids) {
+                auto iter = std::find_if(
+                  replicas.begin(),
+                  replicas.end(),
+                  [&node_id](model::broker_shard bs) {
+                      return bs.node_id == node_id;
+                  });
+
+                BOOST_REQUIRE(iter != replicas.end());
+            }
+        }
+    }
+}
+
+FIXTURE_TEST(test_topic_table_mutated, topic_table_fixture) {
+    auto cmd_1 = make_create_topic_cmd("test_tp_1", 10, 3);
+    auto cmd_3 = make_create_topic_cmd("test_tp_3", 10, 1);
+
+    auto res_1 = table.local().apply(std::move(cmd_1), model::offset(1)).get();
+
+    BOOST_REQUIRE_EQUAL(res_1, cluster::errc::success);
+
+    cluster::topic_table_partition_generator gen(table, 3);
+
+    auto res = gen.next_batch().get();
+    BOOST_REQUIRE(res.has_value());
+    BOOST_REQUIRE(res->size() == 3);
+
+    auto cmd_2 = make_create_topic_cmd("test_tp_2", 10, 3);
+    auto res_2 = table.local().apply(std::move(cmd_2), model::offset(2)).get();
+    BOOST_REQUIRE_EQUAL(res_2, cluster::errc::success);
+
+    // The topic table mutated, so we expected the generator to detect
+    // this and throw.
+    BOOST_REQUIRE_THROW(
+      gen.next_batch().get(),
+      cluster::topic_table_partition_generator_exception);
+}

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -469,6 +469,8 @@ private:
       model::model_limits<model::offset>::min()};
     std::vector<delta>::difference_type _last_consumed_by_notifier_offset{0};
     topic_table_probe _probe;
+
+    friend class topic_table_partition_generator;
 };
 
 } // namespace cluster

--- a/src/v/cluster/topic_table_partition_generator.cc
+++ b/src/v/cluster/topic_table_partition_generator.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster/topic_table_partition_generator.h"
+
+namespace cluster {
+
+topic_table_partition_generator_exception::
+  topic_table_partition_generator_exception(const std::string& m)
+  : std::runtime_error(m) {}
+
+topic_table_partition_generator::topic_table_partition_generator(
+  ss::sharded<topic_table>& topic_table, size_t batch_size)
+  : _topic_table(topic_table)
+  , _stable_revision_id(_topic_table.local().last_applied_revision())
+  , _batch_size(batch_size) {
+    if (_topic_table.local()._topics.empty()) {
+        _topic_iterator = _topic_table.local()._topics.end();
+        _exhausted = true;
+    } else {
+        _topic_iterator = _topic_table.local()._topics.begin();
+        _partition_iterator = current_assignment_set().begin();
+    }
+}
+
+ss::future<std::optional<topic_table_partition_generator::generator_type_t>>
+topic_table_partition_generator::next_batch() {
+    const auto current_revision_id
+      = _topic_table.local().last_applied_revision();
+    if (current_revision_id != _stable_revision_id) {
+        throw topic_table_partition_generator_exception(fmt::format(
+          "Last applied revision id moved from {} to {} whilst "
+          "the generator was active",
+          _stable_revision_id,
+          current_revision_id));
+    }
+
+    if (_exhausted) {
+        co_return std::nullopt;
+    }
+
+    generator_type_t batch;
+    batch.reserve(_batch_size);
+
+    while (!_exhausted && batch.size() < _batch_size) {
+        model::topic_namespace tn = _topic_iterator->first;
+        model::partition_id pid = _partition_iterator->id;
+        std::vector<model::broker_shard> replicas
+          = _partition_iterator->replicas;
+        partition_replicas entry{
+          .partition = model::ntp{tn.ns, tn.tp, pid},
+          .replicas = std::move(replicas)};
+
+        batch.push_back(std::move(entry));
+
+        next();
+    }
+
+    co_return batch;
+}
+
+void topic_table_partition_generator::next() {
+    if (++_partition_iterator == current_assignment_set().end()) {
+        if (++_topic_iterator == _topic_table.local()._topics.end()) {
+            _exhausted = true;
+            return;
+        }
+
+        _partition_iterator = current_assignment_set().begin();
+    }
+}
+
+const assignments_set&
+topic_table_partition_generator::current_assignment_set() const {
+    return _topic_iterator->second.get_assignments();
+}
+
+} // namespace cluster

--- a/src/v/cluster/topic_table_partition_generator.h
+++ b/src/v/cluster/topic_table_partition_generator.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cluster/topic_table.h"
+
+namespace cluster {
+struct partition_replicas {
+    model::ntp partition;
+    std::vector<model::broker_shard> replicas;
+};
+
+class topic_table_partition_generator_exception : public std::runtime_error {
+public:
+    explicit topic_table_partition_generator_exception(const std::string& m);
+};
+
+/*
+ * This is a utility class that walks the topic table and returns batches
+ * of partitions and their replicas. For this operation to make sense,
+ * topic table stability is required. The generator will throw if the topic
+ * table has been updated between batches.
+ */
+class topic_table_partition_generator {
+public:
+    using generator_type_t = std::vector<partition_replicas>;
+
+    static constexpr size_t default_batch_size = 256;
+
+    explicit topic_table_partition_generator(
+      ss::sharded<topic_table>& topic_table,
+      size_t batch_size = default_batch_size);
+
+    ss::future<std::optional<generator_type_t>> next_batch();
+
+private:
+    void next();
+
+    const assignments_set& current_assignment_set() const;
+
+    ss::sharded<topic_table>& _topic_table;
+    model::revision_id _stable_revision_id;
+    size_t _batch_size;
+    bool _exhausted{false};
+
+    topic_table::underlying_t::const_iterator _topic_iterator;
+    assignments_set::const_iterator _partition_iterator;
+};
+} // namespace cluster

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2978,6 +2978,46 @@ struct cancel_partition_movements_reply
     std::vector<move_cancellation_result> partition_results;
 };
 
+struct cloud_storage_usage_request
+  : serde::envelope<
+      cloud_storage_usage_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    std::vector<model::ntp> partitions;
+
+    friend bool operator==(
+      const cloud_storage_usage_request&, const cloud_storage_usage_request&)
+      = default;
+
+    auto serde_fields() { return std::tie(partitions); }
+};
+
+struct cloud_storage_usage_reply
+  : serde::envelope<
+      cloud_storage_usage_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    uint64_t total_size_bytes{0};
+
+    // When replies are handled in 'cloud_storage_size_reducer'
+    // only the size of this list is currently used. However,
+    // having the actual missing ntps allws for future optimisations:
+    // the request can be retried only for the 'missing_partitions'.
+    std::vector<model::ntp> missing_partitions;
+
+    friend bool operator==(
+      const cloud_storage_usage_reply&, const cloud_storage_usage_reply&)
+      = default;
+
+    auto serde_fields() {
+        return std::tie(total_size_bytes, missing_partitions);
+    }
+};
+
 struct revert_cancel_partition_move_cmd_data
   : serde::envelope<
       revert_cancel_partition_move_cmd_data,

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -147,6 +147,34 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/cloud_storage_usage",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get the sum of the cloud storage log for all partitions in the cluster",
+                    "type": "long",
+                    "nickname": "get_cloud_storage_usage",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "retries_allowed",
+                            "in": "query",
+                            "required": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "batch_size",
+                            "in": "query",
+                            "required": false,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -381,6 +381,10 @@ private:
     ss::future<ss::json::json_return_type>
       redpanda_services_restart_handler(std::unique_ptr<ss::httpd::request>);
 
+    // Debug routes
+    ss::future<ss::json::json_return_type>
+      cloud_storage_usage_handler(std::unique_ptr<ss::httpd::request>);
+
     ss::future<> throw_on_error(
       ss::httpd::request& req,
       std::error_code ec,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -859,3 +859,8 @@ class Admin:
 
     def is_node_isolated(self, node):
         return self._request("GET", "debug/is_node_isolated", node=node).json()
+
+    def cloud_storage_usage(self) -> int:
+        return int(
+            self._request(
+                "GET", "debug/cloud_storage_usage?retries_allowed=10").json())

--- a/tests/rptest/tests/cloud_storage_usage_test.py
+++ b/tests/rptest/tests/cloud_storage_usage_test.py
@@ -16,6 +16,7 @@ from rptest.util import firewall_blocked
 from rptest.utils.si_utils import S3Snapshot
 from rptest.clients.types import TopicSpec
 from rptest.tests.partition_movement import PartitionMovementMixin
+from rptest.utils.mode_checks import skip_debug_mode
 from ducktape.utils.util import wait_until
 
 import random
@@ -45,7 +46,6 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
         self.si_settings = SISettings(
             test_context,
             log_segment_size=self.log_segment_size,
-            cloud_storage_segment_max_upload_interval_sec=5,
             cloud_storage_housekeeping_interval_ms=2000)
 
         extra_rp_conf = dict(log_compaction_interval_ms=2000,
@@ -103,24 +103,16 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
         # what's in the uploaded manifest. For this reason, we wait until the two match.
         wait_until(
             check,
-            timeout_sec=5,
+            timeout_sec=timeout_sec,
             backoff_sec=0.2,
             err_msg=
             "Reported cloud storage usage did not match the actual usage")
 
     def _test_epilogue(self):
-        bucket_view = S3Snapshot(self.topics,
-                                 self.redpanda.cloud_storage_client,
-                                 self.s3_bucket_name, self.logger)
-
-        # Assert that housekeeping operated during the test
-        topic_1_manifests = [
-            bucket_view.manifest_for_ntp(self.topics[0].name, p)
-            for p in range(self.topics[0].partition_count)
-            if bucket_view.is_ntp_in_manifest(self.topics[0].name, p)
-        ]
-        assert any(
-            p_man.get("start_offset", 0) > 0 for p_man in topic_1_manifests)
+        # Assert tht retention was active
+        self.redpanda.metric_sum(
+            "redpanda_cloud_storage_deleted_segments",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS) > 0
 
         # Assert that compacted segment re-upload operated during the test
         bucket_view = S3Snapshot(self.topics,
@@ -145,7 +137,7 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
 
         producers_done = lambda: all([p.is_complete() for p in producers])
         while not producers_done():
-            self._check_usage()
+            self._check_usage(timeout_sec=5)
 
             time.sleep(self.check_interval)
 
@@ -155,6 +147,7 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
         self._test_epilogue()
 
     @cluster(num_nodes=5)
+    @skip_debug_mode
     def test_cloud_storage_usage_reporting_with_partition_moves(self):
         """
         This test has the same workload as test_cloud_storage_usage_reporting,
@@ -178,7 +171,7 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
             self._dispatch_random_partition_move(ntp_to_move[0],
                                                  ntp_to_move[1])
 
-            self._check_usage()
+            self._check_usage(timeout_sec=10)
 
             time.sleep(self.check_interval)
 

--- a/tests/rptest/tests/cloud_storage_usage_test.py
+++ b/tests/rptest/tests/cloud_storage_usage_test.py
@@ -1,0 +1,186 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import MetricsEndpoint, SISettings
+from rptest.util import firewall_blocked
+from rptest.utils.si_utils import S3Snapshot
+from rptest.clients.types import TopicSpec
+from rptest.tests.partition_movement import PartitionMovementMixin
+from ducktape.utils.util import wait_until
+
+import random
+import time
+
+
+class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
+    message_size = 32 * 1024  # 32KiB
+    log_segment_size = 256 * 1024  # 256KiB
+    produce_byte_rate_per_ntp = 512 * 1024  # 512 KiB
+    target_runtime = 60  # seconds
+    check_interval = 5  # seconds
+
+    topics = [
+        TopicSpec(name="test-topic-1",
+                  partition_count=3,
+                  replication_factor=3,
+                  retention_bytes=3 * log_segment_size),
+        TopicSpec(name="test-topic-2",
+                  partition_count=1,
+                  replication_factor=1,
+                  retention_bytes=3 * log_segment_size,
+                  cleanup_policy=TopicSpec.CLEANUP_COMPACT)
+    ]
+
+    def __init__(self, test_context):
+        self.si_settings = SISettings(
+            test_context,
+            log_segment_size=self.log_segment_size,
+            cloud_storage_segment_max_upload_interval_sec=5,
+            cloud_storage_housekeeping_interval_ms=2000)
+
+        extra_rp_conf = dict(log_compaction_interval_ms=2000,
+                             compacted_log_segment_size=self.log_segment_size)
+
+        super(CloudStorageUsageTest,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=extra_rp_conf,
+                             si_settings=self.si_settings)
+
+        self.rpk = RpkTool(self.redpanda)
+        self.admin = Admin(self.redpanda)
+        self.s3_bucket_name = self.si_settings.cloud_storage_bucket
+        self.s3_port = self.si_settings.cloud_storage_api_endpoint_port
+
+    def _create_producers(self) -> list[KgoVerifierProducer]:
+        producers = []
+
+        for topic in self.topics:
+            bps = self.produce_byte_rate_per_ntp * topic.partition_count
+            bytes_count = bps * self.target_runtime
+            msg_count = bytes_count // self.message_size
+
+            self.logger.info(f"Will produce {bytes_count / 1024}KiB at"
+                             f"{bps / 1024}KiB/s on topic={topic.name}")
+            producers.append(
+                KgoVerifierProducer(self.test_context,
+                                    self.redpanda,
+                                    topic,
+                                    msg_size=self.message_size,
+                                    msg_count=msg_count,
+                                    rate_limit_bps=bps))
+
+        return producers
+
+    def _check_usage(self, timeout_sec):
+        def check():
+            bucket_view = S3Snapshot(self.topics,
+                                     self.redpanda.cloud_storage_client,
+                                     self.s3_bucket_name, self.logger)
+
+            actual_usage = bucket_view.total_cloud_log_size()
+            reported_usage = self.admin.cloud_storage_usage()
+
+            self.logger.info(
+                f"Expected {actual_usage} bytes of cloud storage usage")
+            self.logger.info(
+                f"Reported {reported_usage} bytes of cloud storage usage")
+            return actual_usage == reported_usage
+
+        # Manifests are not immediately uploaded after they are mutated locally.
+        # For example, during cloud storage housekeeping, the manifest is not uploaded
+        # after the 'start_offset' advances, but after the segments are deleted as well.
+        # If a request lands mid-housekeeping, the results will not be consistent with
+        # what's in the uploaded manifest. For this reason, we wait until the two match.
+        wait_until(
+            check,
+            timeout_sec=5,
+            backoff_sec=0.2,
+            err_msg=
+            "Reported cloud storage usage did not match the actual usage")
+
+    def _test_epilogue(self):
+        bucket_view = S3Snapshot(self.topics,
+                                 self.redpanda.cloud_storage_client,
+                                 self.s3_bucket_name, self.logger)
+
+        # Assert that housekeeping operated during the test
+        topic_1_manifests = [
+            bucket_view.manifest_for_ntp(self.topics[0].name, p)
+            for p in range(self.topics[0].partition_count)
+            if bucket_view.is_ntp_in_manifest(self.topics[0].name, p)
+        ]
+        assert any(
+            p_man.get("start_offset", 0) > 0 for p_man in topic_1_manifests)
+
+        # Assert that compacted segment re-upload operated during the test
+        bucket_view = S3Snapshot(self.topics,
+                                 self.redpanda.cloud_storage_client,
+                                 self.s3_bucket_name, self.logger)
+        bucket_view.assert_at_least_n_uploaded_segments_compacted(
+            self.topics[1].name, partition=0, n=1)
+
+    @cluster(num_nodes=5)
+    def test_cloud_storage_usage_reporting(self):
+        """
+        This test uses a diverse cloud storage write-only workload
+        (includes retention and compacted re-uploads). It periodically,
+        checks that the cloud storage usage reported by `/v1/debug/cloud_storage_usage`
+        is in line with the contents of the uploaded manifest.
+        """
+        assert self.admin.cloud_storage_usage() == 0
+
+        producers = self._create_producers()
+        for p in producers:
+            p.start()
+
+        producers_done = lambda: all([p.is_complete() for p in producers])
+        while not producers_done():
+            self._check_usage()
+
+            time.sleep(self.check_interval)
+
+        for p in producers:
+            p.wait()
+
+        self._test_epilogue()
+
+    @cluster(num_nodes=5)
+    def test_cloud_storage_usage_reporting_with_partition_moves(self):
+        """
+        This test has the same workload as test_cloud_storage_usage_reporting,
+        but also includes random partition movements.
+        """
+        assert self.admin.cloud_storage_usage() == 0
+
+        producers = self._create_producers()
+        for p in producers:
+            p.start()
+
+        partitions = []
+        for topic in self.topics:
+            partitions.extend([(topic.name, pid)
+                               for pid in range(topic.partition_count)])
+
+        producers_done = lambda: all([p.is_complete() for p in producers])
+
+        while not producers_done():
+            ntp_to_move = random.choice(partitions)
+            self._dispatch_random_partition_move(ntp_to_move[0],
+                                                 ntp_to_move[1])
+
+            self._check_usage()
+
+            time.sleep(self.check_interval)
+
+        for p in producers:
+            p.wait()

--- a/tests/rptest/tests/cloud_storage_usage_test.py
+++ b/tests/rptest/tests/cloud_storage_usage_test.py
@@ -21,6 +21,7 @@ from ducktape.utils.util import wait_until
 
 import random
 import time
+from collections import deque
 
 
 class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
@@ -82,31 +83,36 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
         return producers
 
     def _check_usage(self, timeout_sec):
+
+        # The usage inferred from the uploaded manifest
+        # lags behind the actual reported usage. For this reason,
+        # we maintain a sliding window of reported usages and check whether
+        # the manifest inferred usage can be found in it.
+        reported_usage_sliding_window = deque(maxlen=10)
+
         def check():
             bucket_view = S3Snapshot(self.topics,
                                      self.redpanda.cloud_storage_client,
                                      self.s3_bucket_name, self.logger)
+            manifest_usage = bucket_view.total_cloud_log_size()
 
-            actual_usage = bucket_view.total_cloud_log_size()
             reported_usage = self.admin.cloud_storage_usage()
+            reported_usage_sliding_window.append(reported_usage)
 
             self.logger.info(
-                f"Expected {actual_usage} bytes of cloud storage usage")
+                f"Expected {manifest_usage} bytes of cloud storage usage")
             self.logger.info(
-                f"Reported {reported_usage} bytes of cloud storage usage")
-            return actual_usage == reported_usage
+                f"Reported usages in sliding window: {reported_usage_sliding_window}"
+            )
+            return manifest_usage in reported_usage_sliding_window
 
-        # Manifests are not immediately uploaded after they are mutated locally.
-        # For example, during cloud storage housekeeping, the manifest is not uploaded
-        # after the 'start_offset' advances, but after the segments are deleted as well.
-        # If a request lands mid-housekeeping, the results will not be consistent with
-        # what's in the uploaded manifest. For this reason, we wait until the two match.
         wait_until(
             check,
             timeout_sec=timeout_sec,
             backoff_sec=0.2,
             err_msg=
-            "Reported cloud storage usage did not match the actual usage")
+            "Reported cloud storage usage did not match the manifest inferred usage"
+        )
 
     def _test_epilogue(self):
         # Assert tht retention was active


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9305, https://github.com/redpanda-data/redpanda/pull/9386 and https://github.com/redpanda-data/redpanda/pull/9463

All of the logic backported cleanly, but the tests needed a little adjusting. On `dev`, the python `S3Snapshot` util class
was reworked into `BucketView`. The new tests work fine with `S3Snapshot`, so I just extended its interface a bit to
match the requirements of the new tests.