### PR TITLE
[v22.2.x] Trigger leadership notification after current term is confirmed + fix over-optimistic timeout waiting for leadership

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -245,7 +245,7 @@ void archiver_fixture::wait_for_partition_leadership(const model::ntp& ntp) {
         model::node_id node(0);
         int cnt = 0;
         auto self = app.controller->self();
-        ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 100ms;
+        ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 500ms;
         return table.wait_for_leader(ntp, deadline, {}).get0() == self
                && app.partition_manager.local().get(ntp)->is_elected_leader();
     }).get();

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2179,6 +2179,15 @@ ss::future<std::error_code> consensus::replicate_configuration(
       });
 }
 
+void consensus::update_confirmed_term() {
+    auto prev_confirmed = _confirmed_term;
+    _confirmed_term = _term;
+
+    if (prev_confirmed != _term && is_elected_leader()) {
+        trigger_leadership_notification();
+    }
+}
+
 ss::future<result<replicate_result>> consensus::dispatch_replicate(
   append_entries_request req,
   std::vector<ssx::semaphore_units> u,
@@ -2538,7 +2547,7 @@ consensus::do_maybe_update_leader_commit_idx(ssx::semaphore_units u) {
         return model::offset{};
     });
     if (get_term(majority_match) == _term) {
-        _confirmed_term = _term;
+        update_confirmed_term();
     }
     /**
      * we have to make sure that we do not advance committed_index beyond the
@@ -2554,7 +2563,7 @@ consensus::do_maybe_update_leader_commit_idx(ssx::semaphore_units u) {
     majority_match = std::min(majority_match, _flushed_offset);
 
     if (majority_match > _commit_index && get_term(majority_match) == _term) {
-        _confirmed_term = _term;
+        update_confirmed_term();
         _commit_index = majority_match;
         vlog(_ctxlog.trace, "Leader commit index updated {}", _commit_index);
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -580,6 +580,9 @@ private:
         }
         return false;
     }
+
+    void update_confirmed_term();
+
     // args
     vnode _self;
     raft::group_id _group;

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -262,7 +262,6 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
     _ptr->_hbeat = clock_type::time_point::max();
     vlog(_ctxlog.info, "becoming the leader term:{}", term);
     _ptr->_last_quorum_replicated_index = _ptr->_flushed_offset;
-    _ptr->trigger_leadership_notification();
 
     auto ec = co_await replicate_config_as_new_leader(std::move(u));
 

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -14,6 +14,7 @@ from math import ceil
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from rptest.util import wait_until, wait_until_result
+from rptest.utils.mode_checks import skip_debug_mode
 from rptest.clients.default import DefaultClient
 from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
 from rptest.services.failure_injector import FailureInjector, FailureSpec
@@ -285,7 +286,8 @@ class PartitionBalancerTest(EndToEndTest):
 
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
-    @cluster(num_nodes=8, log_allow_list=LOG_ALLOW_LIST)
+    @skip_debug_mode
+    @cluster(num_nodes=8, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_rack_awareness(self):
         extra_rp_conf = self._extra_rp_conf | {"enable_rack_awareness": True}
         self.redpanda = RedpandaService(self.test_context,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8744
Backport of PR https://github.com/redpanda-data/redpanda/pull/8540