### PR TITLE
Added retries on timeout in Admin API usage in nodes decommissioning and admin fuzzer

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0
 
 import random
+
+import requests
 from rptest.clients.kafka_cat import KafkaCat
 from time import sleep
 from rptest.clients.default import DefaultClient
@@ -158,6 +160,47 @@ class NodesDecommissioningTest(EndToEndTest):
 
         self._check_state_consistent(decommissioned_id)
 
+    def _decommission(self, node_id, node=None):
+        def decommissioned():
+            try:
+                brokers = self.admin.get_brokers()
+                for b in brokers:
+                    if b['node_id'] == node_id and b[
+                            'membership_status'] == 'draining':
+                        return True
+
+                r = self.admin.decommission_broker(node_id, node=node)
+                return r.status_code == 200
+            except requests.exceptions.RetryError:
+                return False
+            except requests.exceptions.ConnectionError:
+                return False
+            except requests.exceptions.HTTPError:
+                return False
+
+        wait_until(decommissioned, 30, 1)
+
+    def _recommission(self, node_id, node=None):
+        def recommissioned():
+            try:
+
+                brokers = self.admin.get_brokers()
+                for b in brokers:
+                    if b['node_id'] == node_id and b[
+                            'membership_status'] == 'active':
+                        return True
+
+                r = self.admin.recommission_broker(node_id, node=node)
+                return r.status_code == 200
+            except requests.exceptions.RetryError:
+                return False
+            except requests.exceptions.ConnectionError:
+                return False
+            except requests.exceptions.HTTPError:
+                return False
+
+        wait_until(recommissioned, 30, 1)
+
     @cluster(
         num_nodes=6,
         # A decom can look like a restart in terms of logs from peers dropping
@@ -175,7 +218,7 @@ class NodesDecommissioningTest(EndToEndTest):
         to_decommission = random.choice(self.redpanda.nodes)
         to_decommission_id = self.redpanda.idx(to_decommission)
         self.logger.info(f"decommissioning node: {to_decommission_id}", )
-        self.admin.decommission_broker(to_decommission_id)
+        self._decommission(to_decommission_id)
         if delete_topic:
             self.client().delete_topic(self.topic)
         self._wait_for_node_removed(to_decommission_id)
@@ -205,7 +248,7 @@ class NodesDecommissioningTest(EndToEndTest):
         node_id = self.redpanda.idx(to_decommission)
         self.redpanda.stop_node(node=to_decommission)
         self.logger.info(f"decommissioning node: {node_id}", )
-        self.admin.decommission_broker(id=node_id)
+        self._decommission(node_id)
 
         self._wait_for_node_removed(node_id)
 
@@ -255,7 +298,7 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=1)
 
         self.logger.info(f"decommissioning node: {to_decommission}", )
-        self.admin.decommission_broker(to_decommission)
+        self._decommission(to_decommission)
 
         # adjust recovery throttle to make sure moves will finish
         self._set_recovery_rate(2 << 30)
@@ -282,7 +325,7 @@ class NodesDecommissioningTest(EndToEndTest):
         self._set_recovery_rate(1)
 
         self.logger.info(f"decommissioning node: {to_decommission}", )
-        self.admin.decommission_broker(to_decommission)
+        self._decommission(to_decommission)
 
         self._wait_until_status(to_decommission, 'draining')
 
@@ -291,7 +334,7 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=1)
 
         # recommission broker
-        self.admin.recommission_broker(to_decommission)
+        self._recommission(to_decommission)
         self._wait_until_status(to_decommission, 'active')
 
         wait_until(lambda: self._partitions_not_moving(),
@@ -314,7 +357,7 @@ class NodesDecommissioningTest(EndToEndTest):
         self._set_recovery_rate(1)
 
         self.logger.info(f"decommissioning node: {to_decommission}", )
-        self.admin.decommission_broker(to_decommission)
+        self._decommission(to_decommission)
 
         self._wait_until_status(to_decommission, 'draining')
 
@@ -323,14 +366,14 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=1)
 
         # recommission broker
-        self.admin.recommission_broker(to_decommission)
+        self._recommission(to_decommission)
         self._wait_until_status(to_decommission, 'active')
 
         wait_until(lambda: self._partitions_not_moving(),
                    timeout_sec=15,
                    backoff_sec=1)
 
-        self.admin.decommission_broker(to_decommission)
+        self._decommission(to_decommission)
 
         self._wait_until_status(to_decommission, 'draining')
         self._set_recovery_rate(1024 * 1024 * 1024)
@@ -373,7 +416,7 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=1)
 
         self.logger.info(f"decommissioning node: {to_decommission}", )
-        self.admin.decommission_broker(to_decommission)
+        self._decommission(to_decommission)
 
         self._wait_until_status(to_decommission, 'draining')
 
@@ -382,7 +425,7 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=1)
 
         # recommission broker
-        self.admin.recommission_broker(to_decommission)
+        self._recommission(to_decommission)
         self._wait_until_status(to_decommission, 'active')
 
         def one_left_moving():
@@ -416,9 +459,9 @@ class NodesDecommissioningTest(EndToEndTest):
         self._set_recovery_rate(1)
 
         self.logger.info(f"decommissioning node: {to_decommission_1}", )
-        self.admin.decommission_broker(to_decommission_1, node=survivor_node)
+        self._decommission(to_decommission_1, node=survivor_node)
         self.logger.info(f"decommissioning node: {to_decommission_2}", )
-        self.admin.decommission_broker(to_decommission_2, node=survivor_node)
+        self._decommission(to_decommission_2, node=survivor_node)
 
         self._wait_until_status(to_decommission_1,
                                 'draining',
@@ -432,7 +475,7 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=1)
 
         # recommission broker that was decommissioned first
-        self.admin.recommission_broker(to_decommission_1, node=survivor_node)
+        self._recommission(to_decommission_1, node=survivor_node)
         self._wait_until_status(to_decommission_1,
                                 'active',
                                 api_node=survivor_node)
@@ -483,7 +526,7 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=1)
 
         # request decommission of newly added broker
-        self.admin.decommission_broker(to_decommission_id, node=first_node)
+        self._decommission(to_decommission_id, node=first_node)
 
         # stop the node that is being decommissioned
         if shutdown_decommissioned:
@@ -513,7 +556,7 @@ class NodesDecommissioningTest(EndToEndTest):
 
         survivor_node = self._not_decommissioned_node(node_id)
         self.logger.info(f"decommissioning node: {node_id}", )
-        self.admin.decommission_broker(id=node_id)
+        self._decommission(node_id)
 
         self._set_recovery_rate(100)
         # wait for some partitions to start moving
@@ -558,7 +601,7 @@ class NodesDecommissioningTest(EndToEndTest):
             # set recovery rate to small value to prevent node
             # from finishing decommission operation
             self._set_recovery_rate(1)
-            self.admin.decommission_broker(id=node_id)
+            self._decommission(node_id)
             wait_until(lambda: self._partitions_moving(node=survivor_node) or
                        self._node_removed(node_id, survivor_node),
                        timeout_sec=60,
@@ -566,13 +609,13 @@ class NodesDecommissioningTest(EndToEndTest):
             if self._node_removed(node_id, survivor_node):
                 break
             self.logger.info(f"recommissioning node: {node_id}", )
-            self.admin.recommission_broker(id=node_id)
+            self._recommission(node_id)
             self._set_recovery_rate(100 * 1024 * 1024)
 
         if not self._node_removed(node_id, survivor_node):
             # finally decommission node
             self.logger.info(f"decommissioning node: {node_id}", )
-            self.admin.decommission_broker(id=node_id)
+            self._decommission(node_id)
 
             self._wait_for_node_removed(node_id)
 
@@ -616,7 +659,7 @@ class NodesDecommissioningTest(EndToEndTest):
                 self.logger.info(f"decommissioning node: {id}, iteration: {i}")
 
                 decom_node = node_by_id(id)
-                self.admin.decommission_broker(id)
+                self._decommission(id)
                 self._wait_for_node_removed(id)
 
                 def has_partitions():
@@ -650,7 +693,7 @@ class NodesDecommissioningTest(EndToEndTest):
         to_decommission = self.redpanda.nodes[-1]
         to_decommission_id = self.redpanda.node_id(to_decommission)
         self.logger.info(f"decommissioning node: {to_decommission_id}")
-        self.admin.decommission_broker(to_decommission_id)
+        self._decommission(to_decommission_id)
         self._wait_for_node_removed(to_decommission_id)
 
         # restart decommissioned node without cleaning up the data directory,

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -596,11 +596,11 @@ class NodesDecommissioningTest(EndToEndTest):
         if not node_is_alive:
             self.redpanda.stop_node(to_decommission)
 
+        self._set_recovery_rate(1)
         for i in range(1, 10):
-            self.logger.info(f"decommissioning node: {node_id}")
             # set recovery rate to small value to prevent node
             # from finishing decommission operation
-            self._set_recovery_rate(1)
+            self.logger.info(f"decommissioning node: {node_id}")
             self._decommission(node_id)
             wait_until(lambda: self._partitions_moving(node=survivor_node) or
                        self._node_removed(node_id, survivor_node),
@@ -610,8 +610,8 @@ class NodesDecommissioningTest(EndToEndTest):
                 break
             self.logger.info(f"recommissioning node: {node_id}", )
             self._recommission(node_id)
-            self._set_recovery_rate(100 * 1024 * 1024)
 
+        self._set_recovery_rate(100 * 1024 * 1024)
         if not self._node_removed(node_id, survivor_node):
             # finally decommission node
             self.logger.info(f"decommissioning node: {node_id}", )


### PR DESCRIPTION
Since admin operations fuzzer and node decommissioning test are executed in environment where Redpanda nodes are restarted or even crashed we must retry on timeouts in Admin API. This way we are making sure that the test is able to make progress.

Fixes: #9289
Fixes: #8673
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none