### PR TITLE
[v23.1.x] Do not update follower received sequence if not leader

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -329,6 +329,12 @@ consensus::success_reply consensus::update_follower_index(
           _group));
     }
 
+    // check preconditions for processing the reply
+    if (unlikely(!is_elected_leader())) {
+        vlog(_ctxlog.debug, "ignoring append entries reply, not leader");
+        return success_reply::no;
+    }
+
     update_node_reply_timestamp(node);
 
     if (
@@ -367,11 +373,6 @@ consensus::success_reply consensus::update_follower_index(
     auto broadcast_state_change = ss::defer(
       [&idx] { idx.follower_state_change.broadcast(); });
 
-    // check preconditions for processing the reply
-    if (!is_elected_leader()) {
-        vlog(_ctxlog.debug, "ignoring append entries reply, not leader");
-        return success_reply::no;
-    }
     // If RPC request or response contains term T > currentTerm:
     // set currentTerm = T, convert to follower (Raft paper: §5.1)
     if (reply.term > _term) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -369,7 +369,8 @@ consensus::success_reply consensus::update_follower_index(
      * seq 98, updating the last_received_seq unconditionally would cause
      * accepting request with seq 98, which should be rejected
      */
-    idx.last_received_seq = std::max(seq, idx.last_received_seq);
+    idx.last_received_seq = std::min(
+      std::max(seq, idx.last_received_seq), idx.last_sent_seq);
     auto broadcast_state_change = ss::defer(
       [&idx] { idx.follower_state_change.broadcast(); });
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9384
Fixes https://github.com/redpanda-data/redpanda/issues/9388,