### PR TITLE
cluster: increment redpanda_cluster_partitions per partition on topic creation

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -66,8 +66,8 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
     for (auto& pas : md.get_assignments()) {
         auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, pas.id);
         replicas_revision_map replica_revisions;
+        _partition_count++;
         for (auto& r : pas.replicas) {
-            _partition_count++;
             replica_revisions[r.node_id] = rev_id;
         }
         md.partitions.emplace(

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -255,8 +255,12 @@ class ClusterMetricsTest(RedpandaTest):
                                               "cluster_partitions",
                                               value=0)
 
-            RpkTool(self.redpanda).create_topic("topic-a", partitions=20)
-            RpkTool(self.redpanda).create_topic("topic-b", partitions=10)
+            RpkTool(self.redpanda).create_topic("topic-a",
+                                                partitions=20,
+                                                replicas=3)
+            RpkTool(self.redpanda).create_topic("topic-b",
+                                                partitions=10,
+                                                replicas=3)
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
                                                 value=30)
@@ -266,7 +270,9 @@ class ClusterMetricsTest(RedpandaTest):
                                                 "cluster_partitions",
                                                 value=10)
 
-            RpkTool(self.redpanda).create_topic("topic-a", partitions=30)
+            RpkTool(self.redpanda).create_topic("topic-a",
+                                                partitions=30,
+                                                replicas=3)
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
                                                 value=40)


### PR DESCRIPTION
`redpanda_cluster_partitions` being exposed via `/public_metrics` is incremented per **replica** on a topic creation but this is against the spec. 

```
# HELP redpanda_cluster_partitions Number of partitions in the cluster (replicas not included)
```

It's decremented per partition on a topic deletion and incremented per partition on adding partitions as well, which align with the spec. Hence, this eventually causes a wrong total partition count via the metric being reported.

With this commit, the metric value is incremented per partition on a topic creation to align with the spec.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* `redpanda_cluster_partitions` is incremented per partition, not per replica, on a topic creation

