### PR TITLE
tests: explicitly stop asserted node in FeaturesUpgradeAssertionTest

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -527,6 +527,9 @@ class FeaturesUpgradeAssertionTest(FeaturesTestBase):
         with expect_exception(DucktapeTimeoutError, lambda _: True):
             self.redpanda.start_node(upgrade_node)
 
+        # Don't assume that the asserted node will have exited promptly: explicitly kill it.
+        self.redpanda.stop_node(upgrade_node)
+
         # With the config set to override checks, start should succeed
         self.redpanda.start_node(
             upgrade_node,


### PR DESCRIPTION
This has been seen to fail occasionally with
"failed to lock pidfile" on the subsequent startup: this could be explained by the node asserting but the process not being promptly cleaned up.

Add an explicit stop to ensure the process is gone before trying to start it again.

Fixes https://github.com/redpanda-data/redpanda/issues/9373

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
