### PR TITLE
cloud_storage: fix "Leaving S3 objects behind" message

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -643,11 +643,12 @@ ss::future<> partition::remove_remote_persistent_state(ss::abort_source& as) {
     } else if (_cloud_storage_partition && tiered_storage) {
         // Tiered storage is enabled, but deletion is disabled: ensure the
         // remote metadata is up to date before we drop the local partition.
+        vlog(
+          clusterlog.info,
+          "Leaving tiered storage objects behind for partition {}",
+          ntp());
         co_await _cloud_storage_partition->finalize(
           as, _raft->self(), group_configuration());
-    } else {
-        vlog(
-          clusterlog.info, "Leaving S3 objects behind for partition {}", ntp());
     }
 }
 


### PR DESCRIPTION
If tiered storage is disabled, we shouldn't print
this misleading message when not deleting objects.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* A spurious "Leaving S3 objects behind" log message is no longer printed when deleting non-tiered-storage partitions.