### PR TITLE
[v22.3.x] cloud_storage: fix "Leaving S3 objects behind" message

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -508,9 +508,11 @@ ss::future<> partition::remove_remote_persistent_state() {
           get_ntp_config().is_archival_enabled(),
           get_ntp_config().is_read_replica_mode_enabled());
         co_await _cloud_storage_partition->erase();
-    } else {
+    } else if (_cloud_storage_partition && tiered_storage) {
         vlog(
-          clusterlog.info, "Leaving S3 objects behind for partition {}", ntp());
+          clusterlog.info,
+          "Leaving tiered storage objects behind for partition {}",
+          ntp());
     }
 }
 


### PR DESCRIPTION
If tiered storage is disabled, we shouldn't print
this misleading message when not deleting objects.

Backport of https://github.com/redpanda-data/redpanda/pull/9405

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* A spurious "Leaving S3 objects behind" log message is no longer printed when deleting non-tiered-storage partitions.
