### PR TITLE
archival: Avoid reuploading if log is truncated

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1736,7 +1736,12 @@ ss::future<bool> ntp_archiver::upload(
     if (upload_locks.candidate.sources.size() > 0) {
         return do_upload_local(std::move(upload_locks), source_rtc);
     }
-    return do_upload_remote(std::move(upload_locks), source_rtc);
+    // Currently, the uploading of remote segments is disabled and
+    // the only reason why the list of locks is empty is truncation.
+    // The log could be truncated right after we scanned the manifest to
+    // find upload candidate. In this case we will get an empty candidate
+    // which is not a failure so we shuld return 'true'.
+    return ss::make_ready_future<bool>(true);
 }
 
 ss::future<bool> ntp_archiver::do_upload_local(


### PR DESCRIPTION
The housekeeping may try to reupload the beginning of the local log. When this happens it's possible that the log will be truncated between the manifest scanning and creation of the upload candidate (which is an object that holds segment locks). When this happens the upload housekeeping may interpret the upload candidate as a remote reupload (the one which requires fetching segments from S3). This PR fixes this by not calling a remote reuplaod method of the ntp archiver (which is not implemented yet).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix upload housekeeping errors on log truncation