### PR TITLE
c/topic_table: Fix topic de-allocations with canceled updates 

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -289,6 +289,28 @@ inline std::vector<model::broker_shard> subtract_replica_sets(
     return ret;
 }
 
+inline std::vector<model::broker_shard> union_replica_sets(
+  const std::vector<model::broker_shard>& lhs,
+  const std::vector<model::broker_shard>& rhs) {
+    std::vector<model::broker_shard> ret;
+    // Inefficient but constant time for small replica sets.
+    std::copy_if(
+      lhs.begin(),
+      lhs.end(),
+      std::back_inserter(ret),
+      [&ret](const model::broker_shard& bs) {
+          return std::find(ret.begin(), ret.end(), bs) == ret.end();
+      });
+    std::copy_if(
+      rhs.begin(),
+      rhs.end(),
+      std::back_inserter(ret),
+      [&ret](const model::broker_shard& bs) {
+          return std::find(ret.begin(), ret.end(), bs) == ret.end();
+      });
+    return ret;
+}
+
 /**
  * Subtracts second replica set from the first one. Result contains only brokers
  * that node_ids are present in the first list but not the other one

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -89,6 +89,7 @@ private:
       std::vector<partition_assignment>, partition_allocation_domain);
 
     void deallocate_topic(
+      const model::topic_namespace&,
       const assignments_set&,
       const in_progress_map&,
       partition_allocation_domain);

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -158,7 +158,9 @@ class NodesDecommissioningTest(EndToEndTest):
         # A decom can look like a restart in terms of logs from peers dropping
         # connections with it
         log_allow_list=RESTART_LOG_ALLOW_LIST)
-    def test_decommissioning_working_node(self):
+    @parametrize(delete_topic=True)
+    @parametrize(delete_topic=False)
+    def test_decommissioning_working_node(self, delete_topic):
         self.start_redpanda(num_nodes=4)
         self._create_topics()
 
@@ -170,6 +172,8 @@ class NodesDecommissioningTest(EndToEndTest):
         to_decommission_id = self.redpanda.idx(to_decommission)
         self.logger.info(f"decommissioning node: {to_decommission_id}", )
         admin.decommission_broker(to_decommission_id)
+        if delete_topic:
+            self.client().delete_topic(self.topic)
         self._wait_for_node_removed(to_decommission_id)
 
         # Stop the decommissioned node, because redpanda internally does not
@@ -179,7 +183,9 @@ class NodesDecommissioningTest(EndToEndTest):
         # from responding to client Kafka requests.
         self.redpanda.stop_node(to_decommission)
 
-        self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+        if not delete_topic:
+            self.run_validation(enable_idempotence=False,
+                                consumer_timeout_sec=45)
 
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_decommissioning_crashed_node(self):
@@ -327,7 +333,6 @@ class NodesDecommissioningTest(EndToEndTest):
 
         self._wait_until_status(to_decommission, 'draining')
         self._set_recovery_rate(1024 * 1024 * 1024)
-
         self._wait_for_node_removed(to_decommission)
 
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -492,7 +497,10 @@ class NodesDecommissioningTest(EndToEndTest):
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=240)
 
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    def test_decommissioning_finishes_after_manual_cancellation(self):
+    @parametrize(delete_topic=True)
+    @parametrize(delete_topic=False)
+    def test_decommissioning_finishes_after_manual_cancellation(
+            self, delete_topic):
 
         self.start_redpanda(num_nodes=4)
         self._create_topics(replication_factors=[3])
@@ -516,10 +524,16 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=1)
         # cancel all reconfigurations
         admin.cancel_all_reconfigurations()
+
+        if delete_topic:
+            self.client().delete_topic(self.topic)
+
         self._set_recovery_rate(2 << 30)
         self._wait_for_node_removed(node_id)
 
-        self.run_validation(enable_idempotence=False, consumer_timeout_sec=240)
+        if not delete_topic:
+            self.run_validation(enable_idempotence=False,
+                                consumer_timeout_sec=240)
 
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(node_is_alive=True)

--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -102,6 +102,28 @@ class NodeDecommissionWaiter():
             if has_decommission_progress_api(n)
         ]
 
+    def _dump_partition_move_available_bandwidth(self):
+        def get_metric(self, node):
+            try:
+                metrics = list(self.redpanda.metrics(node))
+                family = filter(
+                    lambda fam: fam.name ==
+                    "vectorized_raft_recovery_partition_movement_available_bandwidth",
+                    metrics)
+                shard_to_bandwidth = [{
+                    m.labels['shard']: m.value
+                } for m in next(family).samples]
+                return shard_to_bandwidth
+            except:
+                self.logger.debug(f"error querying metrics for {node}",
+                                  exc_info=True)
+                return None
+
+        for n in self.redpanda.started_nodes():
+            self.logger.debug(
+                f"partition move available bandwidth: node_id: {self.redpanda.node_id(n)} ==> {get_metric(self, n)}"
+            )
+
     def _not_decommissioned_node(self):
         return random.choice([
             n for n in self._nodes_with_decommission_progress_api()
@@ -180,6 +202,7 @@ class NodeDecommissionWaiter():
 
             if decommission_status["finished"] == True:
                 break
+            self._dump_partition_move_available_bandwidth()
             time.sleep(1)
 
         assert self._made_progress(


### PR DESCRIPTION
The sequence of actions in the failing node_ops_fuzz with a blocked allocation is as follows.

1. add node 0 - computes re-allocations to move replicas to 0
2. decommission node 0 - cancels the moves scheduled in step (1)
3. delete topic foo - deletes the topic foo that is a part of (1) and (2)

(3) was essentially racing with (2) when certain `cancel_update` moves are in-flight. 

During a `cancel_update` we flip the current assignment for the ntp in topic_table to `previous assignment` of step (1) signaling a reversal of move. However (3) when computing the `in progress` assignments to de-allocate was not factoring this in, so the deletion doesn't result in a complete deallocation of the topic/ntp. This blocks decommission because one of the exit conditions for it finish is that there are no (pending) allocations. In this case the assignment is already gone (due to delete) but because of the incorrect accounting, the decommission waits forever.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes #9052

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
