### PR TITLE
c/members_manager: track in-progress node ops

### DIFF
--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -77,9 +77,6 @@ public:
         absl::flat_hash_map<partition_allocation_domain, double>
           last_unevenness_error;
         absl::flat_hash_map<partition_allocation_domain, size_t> last_ntp_index;
-        // revision of a related decommission command, present only in
-        // recommission update_meta
-        std::optional<model::revision_id> decommission_update_revision;
     };
 
     members_backend(
@@ -121,8 +118,6 @@ private:
 
     ss::future<> handle_updates();
     void handle_single_update(members_manager::node_update);
-    model::revision_id handle_recommissioned_and_get_decomm_revision(
-      members_manager::node_update&);
     void stop_node_decommissioning(model::node_id);
     void stop_node_addition_and_ondemand_rebalance(model::node_id id);
     void handle_reallocation_finished(model::node_id);

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -101,7 +101,6 @@ public:
 
 private:
     static constexpr model::revision_id raft0_revision{0};
-    using update_t = members_manager::node_update_type;
     struct node_replicas {
         size_t allocated_replicas;
         size_t max_capacity;

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -244,6 +244,10 @@ ss::future<> members_manager::handle_raft0_cfg_update(
         }
     }
 
+    for (auto id : fully_removed_nodes) {
+        _in_progress_updates.erase(id);
+    }
+
     if (update_offset >= _last_connection_update_offset) {
         for (auto id : fully_removed_nodes) {
             if (id != _self.id()) {
@@ -286,10 +290,13 @@ members_manager::apply_update(model::record_batch b) {
                 auto f = ss::now();
                 if (!error) {
                     _allocator.local().decommission_node(id);
-                    f = _update_queue.push_eventually(node_update{
+                    auto update = node_update{
                       .id = id,
                       .type = node_update_type::decommissioned,
-                      .offset = update_offset});
+                      .offset = update_offset,
+                    };
+                    _in_progress_updates[id] = update;
+                    f = _update_queue.push_eventually(std::move(update));
                 }
                 return f.then([error] { return error; });
             });
@@ -320,15 +327,31 @@ members_manager::apply_update(model::record_batch b) {
               }
           }
 
+          auto update_it = _in_progress_updates.find(id);
+          if (update_it == _in_progress_updates.end()) {
+              return ss::make_ready_future<std::error_code>(
+                errc::invalid_node_operation);
+          }
+          if (update_it->second.type != node_update_type::decommissioned) {
+              return ss::make_ready_future<std::error_code>(
+                errc::invalid_node_operation);
+          }
+          auto corresponding_decom_rev = model::revision_id{
+            update_it->second.offset};
+
           return dispatch_updates_to_cores(update_offset, cmd)
-            .then([this, id, update_offset](std::error_code error) {
+            .then([this, id, update_offset, corresponding_decom_rev](
+                    std::error_code error) {
                 auto f = ss::now();
                 if (!error) {
                     _allocator.local().recommission_node(id);
-                    f = _update_queue.push_eventually(node_update{
+                    auto update = node_update{
                       .id = id,
                       .type = node_update_type::recommissioned,
-                      .offset = update_offset});
+                      .offset = update_offset,
+                      .decommission_update_revision = corresponding_decom_rev};
+                    _in_progress_updates[id] = update;
+                    f = _update_queue.push_eventually(std::move(update));
                 }
                 return f.then([error] { return error; });
             });
@@ -345,9 +368,26 @@ members_manager::apply_update(model::record_batch b) {
             id,
             update_offset);
 
+          if (auto it = _in_progress_updates.find(id);
+              it != _in_progress_updates.end()) {
+              auto update_type = it->second.type;
+              // We could have started decommissioning the node while we
+              // were finishing reallocations for node addition or
+              // recommissioning so we need to verify the update type before
+              // deleting. Unfortunately, there is no way to verify that this
+              // command really comes from processing the it->second update and
+              // not from some earlier one, but it will be stopped anyway so we
+              // can safely delete it.
+
+              if (
+                update_type == node_update_type::added
+                || update_type == node_update_type::recommissioned) {
+                  _in_progress_updates.erase(it);
+              }
+          }
           return _update_queue
             .push_eventually(node_update{
-              .id = cmd.key,
+              .id = id,
               .type = node_update_type::reallocation_finished,
               .offset = update_offset})
             .then([] { return make_error_code(errc::success); });
@@ -471,13 +511,16 @@ ss::future<std::error_code> members_manager::do_apply_add_node(
         _last_connection_update_offset = update_offset;
     }
 
-    co_await _update_queue.push_eventually(node_update{
+    auto update = node_update{
       .id = cmd.value.id(),
       .type = node_update_type::added,
       .offset = update_offset,
       .need_raft0_update = update_offset
                            >= _first_node_operation_command_offset,
-    });
+    };
+    _in_progress_updates[update.id] = update;
+    co_await _update_queue.push_eventually(std::move(update));
+
     co_return errc::success;
 }
 
@@ -534,13 +577,15 @@ ss::future<std::error_code> members_manager::do_apply_remove_node(
           allocator.remove_allocation_node(cmd.key);
       });
 
-    co_await _update_queue.push_eventually(node_update{
+    auto update = node_update{
       .id = cmd.key,
       .type = node_update_type::removed,
       .offset = update_offset,
       .need_raft0_update = update_offset
                            >= _first_node_operation_command_offset,
-    });
+    };
+    _in_progress_updates[update.id] = update;
+    co_await _update_queue.push_eventually(std::move(update));
 
     co_return errc::success;
 }
@@ -635,12 +680,14 @@ ss::future<> members_manager::set_initial_state(
         _last_connection_update_offset = model::offset{0};
     }
     for (auto& b : initial_brokers) {
-        co_await _update_queue.push_eventually(node_update{
+        auto update = node_update{
           .id = b.id(),
           .type = node_update_type::added,
           .offset = model::offset{0},
           .need_raft0_update = false,
-        });
+        };
+        _in_progress_updates[b.id()] = update;
+        co_await _update_queue.push_eventually(std::move(update));
     }
 }
 
@@ -1337,11 +1384,13 @@ std::ostream&
 operator<<(std::ostream& o, const members_manager::node_update& u) {
     fmt::print(
       o,
-      "{{node_id: {}, type: {}, offset: {}, update_raft0: {}}}",
+      "{{node_id: {}, type: {}, offset: {}, update_raft0: {}, "
+      "decom_upd_revision: {}}}",
       u.id,
       u.type,
       u.offset,
-      u.need_raft0_update);
+      u.need_raft0_update,
+      u.decommission_update_revision);
     return o;
 }
 

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1304,22 +1304,6 @@ members_manager::handle_configuration_update_request(
             errc::join_request_dispatch_error);
       });
 }
-std::ostream&
-operator<<(std::ostream& o, const members_manager::node_update_type& tp) {
-    switch (tp) {
-    case members_manager::node_update_type::added:
-        return o << "added";
-    case members_manager::node_update_type::decommissioned:
-        return o << "decommissioned";
-    case members_manager::node_update_type::recommissioned:
-        return o << "recommissioned";
-    case members_manager::node_update_type::reallocation_finished:
-        return o << "reallocation_finished";
-    case members_manager::node_update_type::removed:
-        return o << "removed";
-    }
-    return o << "unknown";
-}
 
 std::ostream&
 operator<<(std::ostream& o, const members_manager::node_update& u) {

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -93,8 +93,13 @@ public:
         model::offset offset;
         // indicates if command needs a raft 0 configuration update
         bool need_raft0_update = false;
+        // revision of a related decommission command, present only in
+        // recommission node_update
+        std::optional<model::revision_id> decommission_update_revision;
+
         friend bool operator==(const node_update&, const node_update&)
           = default;
+
         friend std::ostream& operator<<(std::ostream&, const node_update&);
     };
 
@@ -296,6 +301,9 @@ private:
 
     // Gate with which to guard new work (e.g. if stop() has been called).
     ss::gate _gate;
+
+    // Node membership updates that are currently processed by members_backend
+    absl::flat_hash_map<model::node_id, node_update> _in_progress_updates;
 
     // Cluster membership updates that have yet to be released via the call to
     // get_node_updates().

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -86,29 +86,6 @@ public:
     static constexpr ss::shard_id shard = 0;
     static constexpr size_t max_updates_queue_size = 100;
 
-    // Update types, used for communication between the manager and backend.
-    //
-    // NOTE: maintenance mode doesn't interact with the members_backend,
-    // instead interacting with each core via their respective drain_manager.
-    enum class node_update_type : int8_t {
-        // A node has been added to the cluster.
-        added,
-
-        // A node has been decommissioned from the cluster.
-        decommissioned,
-
-        // A node has been recommissioned after an incomplete decommission.
-        recommissioned,
-
-        // All reallocations associated with a given node update have completed
-        // (e.g. it's been fully decommissioned, indicating it can no longer be
-        // recommissioned).
-        reallocation_finished,
-
-        // node has been removed from the cluster
-        removed,
-    };
-
     // Node update information to be processed by the members_backend.
     struct node_update {
         model::node_id id;
@@ -343,6 +320,4 @@ private:
     model::offset _first_node_operation_command_offset = model::offset::max();
 };
 
-std::ostream&
-operator<<(std::ostream&, const members_manager::node_update_type&);
 } // namespace cluster

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -978,6 +978,22 @@ std::ostream& operator<<(std::ostream& o, const node_metadata& nm) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const node_update_type& tp) {
+    switch (tp) {
+    case node_update_type::added:
+        return o << "added";
+    case node_update_type::decommissioned:
+        return o << "decommissioned";
+    case node_update_type::recommissioned:
+        return o << "recommissioned";
+    case node_update_type::reallocation_finished:
+        return o << "reallocation_finished";
+    case node_update_type::removed:
+        return o << "removed";
+    }
+    return o << "unknown";
+}
+
 std::ostream& operator<<(std::ostream& o, reconfiguration_state update) {
     switch (update) {
     case reconfiguration_state::in_progress:

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3131,6 +3131,33 @@ struct node_metadata {
       = default;
     friend std::ostream& operator<<(std::ostream&, const node_metadata&);
 };
+
+// Node update types, used for communication between members_manager and
+// members_backend.
+//
+// NOTE: maintenance mode doesn't interact with the members_backend,
+// instead interacting with each core via their respective drain_manager.
+enum class node_update_type : int8_t {
+    // A node has been added to the cluster.
+    added,
+
+    // A node has been decommissioned from the cluster.
+    decommissioned,
+
+    // A node has been recommissioned after an incomplete decommission.
+    recommissioned,
+
+    // All reallocations associated with a given node update have completed
+    // (e.g. it's been fully decommissioned, indicating it can no longer be
+    // recommissioned).
+    reallocation_finished,
+
+    // node has been removed from the cluster
+    removed,
+};
+
+std::ostream& operator<<(std::ostream&, const node_update_type&);
+
 /**
  * Reconfiguration state indicates if ongoing reconfiguration is a result of
  * partition movement, cancellation or forced cancellation


### PR DESCRIPTION
Tracking currently executing node ops in members_manager is needed for snapshotting them.

Executing the recommission update requires knowing the revision of the corresponding decommission command. Previously, we got it from the updates queue, but now we can get it from the current in-progress operation for the node.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
