### PR TITLE
archival: demote failure to upload to warn

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1783,7 +1783,7 @@ ss::future<bool> ntp_archiver::do_upload_local(
 
     if (upl_res != cloud_storage::upload_result::success) {
         vlog(
-          _rtclog.error,
+          _rtclog.warn,
           "Failed to upload segment: {}, error: {}",
           upload.exposed_name,
           upl_res);


### PR DESCRIPTION
When uploading as a part of segment merging, we may fail to upload because of a leadership change. The top-level operation error is logged at the error level, though when the child calls abort because of a leadership change, it is logged at the warn level\[1].

This reduces the log severity of the top-level operation to warn.

\[1]:
```
WARN  2023-03-11 15:42:58,563 [shard 0] cloud_storage - [fiber1~0~0|1|30000ms] - remote.cc:403 - lost leadership or term changed during upload, current leadership status: false, current term: 2, original term: 2: cancelled uploading {"f9b3e14a/kafka/topic-hbfundbxga/90_16/0-0-683-1-v1.log.2"} to {panda-bucket-38458bd8-c023-11ed-81dd-d9e51621f77b}
ERROR 2023-03-11 15:42:58,563 [shard 0] archival - [fiber120 kafka/topic-hbfundbxga/90] - ntp_archiver_service.cc:1568 - Failed to upload segment: {0-1-v1.log}, error: {cancelled}
```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
