### PR TITLE
[v23.1.x] cluster: increment redpanda_cluster_partitions per partition on topic creation

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -64,8 +64,8 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
     md.replica_revisions.reserve(cmd.value.assignments.size());
     for (auto& pas : md.get_assignments()) {
         auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, pas.id);
+        _partition_count++;
         for (auto& r : pas.replicas) {
-            _partition_count++;
             md.replica_revisions[pas.id][r.node_id] = model::revision_id(
               offset);
         }

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -255,8 +255,12 @@ class ClusterMetricsTest(RedpandaTest):
                                               "cluster_partitions",
                                               value=0)
 
-            RpkTool(self.redpanda).create_topic("topic-a", partitions=20)
-            RpkTool(self.redpanda).create_topic("topic-b", partitions=10)
+            RpkTool(self.redpanda).create_topic("topic-a",
+                                                partitions=20,
+                                                replicas=3)
+            RpkTool(self.redpanda).create_topic("topic-b",
+                                                partitions=10,
+                                                replicas=3)
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
                                                 value=30)
@@ -266,7 +270,9 @@ class ClusterMetricsTest(RedpandaTest):
                                                 "cluster_partitions",
                                                 value=10)
 
-            RpkTool(self.redpanda).create_topic("topic-a", partitions=30)
+            RpkTool(self.redpanda).create_topic("topic-a",
+                                                partitions=30,
+                                                replicas=3)
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
                                                 value=40)


### PR DESCRIPTION
This is a backport request of https://github.com/redpanda-data/redpanda/pull/9393 to 23.1.x. 9393 was merged to dev but not backportable to the released versions due to missing the controller snapshot feature (298f9b437b982798e88311bc69724766cdd04874 specifically).

Increment `redpanda_cluster_partitions` count per `partition` when creating a topic. It was incremented per `replica` but it was against the metric's spec.

```
# HELP redpanda_cluster_partitions Number of partitions in the cluster (replicas not included)
```

It's decremented per `partition` on a topic deletion and incremented per `partition` on adding partitions as well, which align with the spec. Hence, this eventually causes a wrong total partition count being reported via the metric.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* redpanda_cluster_partitions should be incremented per partition, not per replica, on a topic creation
