### PR TITLE
tests: update test_si_cache_space_leak & kgo-verifier

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -142,7 +142,7 @@ function install_kcl() {
 function install_kgo_verifier() {
   git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
   cd /opt/kgo-verifier
-  git reset --hard 53d4c21aa86e179aa4b79aeee592e4687d08b569
+  git reset --hard 9f1c7d0a0d9a2137e4c729c40d9477c5d77b1704
   go mod tidy
   make
 }


### PR DESCRIPTION

### test_si_cache_space_leak

    Since strict cache size enforcement was added, this test
    tends to bump against the cache size limit and end up
    waiting for the 5s cache trim throttle interval.
    
    Because it used a consumer message count of 1000, that
    could result in a health consumer still failing to complete
    wait() in the default timeout.
    
    We may simply use a smaller message count: this does the same
    amount of I/O because the consumer loops until asked to stop,
    irrespective of the message count.


### kgo-verifier

This pulls in commit:

commit 9f1c7d0a0d9a2137e4c729c40d9477c5d77b1704
Author: John Spray <jcs@redpanda.com>
Date:   Tue Mar 14 10:46:23 2023 +0000

    kgo-verifier: handle out of range offsets in random consumer

    Related: https://github.com/redpanda-data/redpanda/issues/9423

Fixes: https://github.com/redpanda-data/redpanda/issues/9423

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
