### PR TITLE
tests: add wait_until for cluster start

### DIFF
--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -10,6 +10,7 @@
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool, RpkException
+from ducktape.utils.util import wait_until
 from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.services.redpanda import RedpandaService
 from rptest.services import tls
@@ -292,8 +293,9 @@ class RpkRedpandaStartTest(RedpandaTest):
         # formed a cluster and we can produce and consume from it
         # even after restarting.
         try:
-            nodes = self.rpk.cluster_info()
-            assert len(nodes) == 3
+            wait_until(lambda: len(self.rpk.cluster_info()) == 3,
+                       timeout_sec=120,
+                       backoff_sec=3)
 
             topic = "test-rpc"
             self.rpk.create_topic(topic)
@@ -390,8 +392,9 @@ class RpkRedpandaStartTest(RedpandaTest):
             "redpanda.rpc_server_tls:{ enabled: 0", self.redpanda.nodes)
 
         try:
-            nodes = self.rpk.cluster_info()
-            assert len(nodes) == 3
+            wait_until(lambda: len(self.rpk.cluster_info()) == 3,
+                       timeout_sec=120,
+                       backoff_sec=3)
 
             topic = "test-rpc"
             self.rpk.create_topic(topic)
@@ -418,8 +421,9 @@ class RpkRedpandaStartTest(RedpandaTest):
             "redpanda.rpc_server_tls:{ enabled: 1", self.redpanda.nodes)
 
         try:
-            nodes = self.rpk.cluster_info()
-            assert len(nodes) == 3
+            wait_until(lambda: len(self.rpk.cluster_info()) == 3,
+                       timeout_sec=120,
+                       backoff_sec=3)
 
             for i in range(50, 100):
                 self.rpk.produce(topic, f"k-{i}", f"v-test-{i}", timeout=5)


### PR DESCRIPTION
Fixes #9387

Example of why it's needed: 


At 15:46:30 it started the docker-rp-10 redpanda process:
```
INFO  2023-03-10 15:46:30,930 [shard  0] main - application.cc:1834 - Successfully started Redpanda!
```

But at 15:46:31 it fails to show that broker as part of the cluster:

```
[DEBUG - 2023-03-10 15:46:31,942 - rpk - _execute - lineno:840]: 
CLUSTER
=======
redpanda.adcee426-ac68-4784-b85c-5f1b68cda47c

BROKERS
=======
ID    HOST          PORT
0*    docker-rp-14  9092
1     docker-rp-21  9092


[ERROR - 2023-03-10 15:46:31,943 - cluster - wrapped - lineno:56]: Test failed, doing failure checks on RedpandaService-0-140447805453984...
Traceback (most recent call last):
  File "/root/tests/rptest/services/cluster.py", line 49, in wrapped
    r = f(self, *args, **kwargs)
  File "/root/tests/rptest/tests/rpk_start_test.py", line 296, in test_rpc_tls_start
    assert len(nodes) == 3
AssertionError
```

During this second, the rest of the cluster was trying to add this node repeatedly:
```
INFO  2023-03-10 15:46:30,031 [shard 14] cluster - members_table.cc:77 - adding node {id: 2, kafka_advertised_listeners: {{dnslistener:{host: docker-rp-20, port: 9092}}}, rpc_address: {host: docker-rp-20, port: 33145}, rack: {nullopt}, properties: {cores 48, mem_available 48, disk_available 61}}
INFO  2023-03-10 15:46:30,031 [shard 12] cluster - members_table.cc:77 - adding node {id: 2, kafka_advertised_listeners: {{dnslistener:{host: docker-rp-20, port: 9092}}}, rpc_address: {host: docker-rp-20, port: 33145}, rack: {nullopt}, properties: {cores 48, mem_available 48, disk_available 61}}
INFO  2023-03-10 15:46:30,032 [shard 16] cluster - members_table.cc:77 - adding node {id: 2, kafka_advertised_listeners: {{dnslistener:{host: docker-rp-20, port: 9092}}}, rpc_address: {host: docker-rp-20, port: 33145}, rack: {nullopt}, properties: {cores 48, mem_available 48, disk_available 61}}
INFO  2023-03-10 15:46:30,032 [shard 40] cluster - members_table.cc:77 - adding node {id: 2, kafka_advertised_listeners: {{dnslistener:{host: docker-rp-20, port: 9092}}}, rpc_address: {host: docker-rp-20, port: 33145}, rack: {nullopt}, properties: {cores 48, mem_available 48, disk_available 61}}
INFO  2023-03-10 15:46:30,032 [shard 28] cluster - members_table.cc:77 - adding node {id: 2, kafka_advertised_listeners: {{dnslistener:{host: docker-rp-20, port: 9092}}}, rpc_address: {host: docker-rp-20, port: 33145}, rack: {nullopt}, properties: {cores 48, mem_available 48, disk_available 61}}
```

## Backports Required
- [ ] v23.1.x

## Release Notes
* none

