### PR TITLE
Add REDPANDA_ENVIRONMENT inside metrics reporter

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -255,6 +255,12 @@ metrics_reporter::build_metrics_snapshot() {
       config::shard_local_cfg().sasl_mechanisms(),
       [](auto const& mech) { return mech == "GSSAPI"; });
 
+    auto env_value = std::getenv("REDPANDA_ENVIRONMENT");
+    if (env_value) {
+        snapshot.redpanda_environment = ss::sstring(env_value).substr(
+          0, metrics_snapshot::max_size_for_rp_env);
+    }
+
     co_return snapshot;
 }
 
@@ -477,6 +483,10 @@ void rjson_serialize(
 
     w.Key("config");
     config::shard_local_cfg().to_json_for_metrics(w);
+
+    w.Key("redpanda_environment");
+    w.String(snapshot.redpanda_environment);
+
     w.EndObject();
 }
 

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -75,6 +75,9 @@ public:
 
         std::vector<node_metrics> nodes;
         bool has_kafka_gssapi;
+
+        static constexpr int64_t max_size_for_rp_env = 80;
+        ss::sstring redpanda_environment;
     };
     static constexpr ss::shard_id shard = 0;
 

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -36,6 +36,7 @@ class MetricsReporterTest(RedpandaTest):
                 "metrics_reporter_url": f"{self.http.url}/metrics",
                 "retention_bytes": 20000,
             })
+        self.redpanda.set_environment({"REDPANDA_ENVIRONMENT": "test"})
 
     def setUp(self):
         # Start HTTP server before redpanda
@@ -131,6 +132,7 @@ class MetricsReporterTest(RedpandaTest):
         assert last["config"]["auto_create_topics_enabled"] == False
         assert "metrics_reporter_tick_interval" not in last["config"]
         assert last["config"]["log_message_timestamp_type"] == "CreateTime"
+        assert last["redpanda_environment"] == "test"
 
 
 class MultiNodeMetricsReporterTest(MetricsReporterTest):


### PR DESCRIPTION
Add REDPANDA_ENVIRONMENT option inside metrics reporter.
It just return value for env variable `REDPANDA_ENVIRONMENT`. It can help to understand where redpanda is running (for example in kuber)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Add REDPANDA_ENVIRONMENT inside metrics reporter
