### PR TITLE
[v22.3.x] archival: fix re-upload of nop compacted segments

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -428,7 +428,7 @@ archival_policy::get_next_compacted_segment(
         * compacted_segment_size_multiplier};
 
     compacted_segment_collector.collect_segments();
-    if (!compacted_segment_collector.can_replace_manifest_segment()) {
+    if (!compacted_segment_collector.should_replace_manifest_segment()) {
         co_return upload_candidate_with_locks{upload_candidate{}, {}};
     }
 

--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -230,8 +230,41 @@ const storage::ntp_config* segment_collector::ntp_cfg() const {
     return _ntp_cfg;
 }
 
-bool segment_collector::can_replace_manifest_segment() const {
-    return _can_replace_manifest_segment && _begin_inclusive < _end_inclusive;
+bool segment_collector::should_replace_manifest_segment() const {
+    const bool valid_collection = _can_replace_manifest_segment
+                                  && _begin_inclusive < _end_inclusive;
+
+    // If we have selected only one segment for collection, ensure
+    // that its compacted size is smaller than the size associated
+    // with the selected segment in the manifest. This guards against,
+    // name clashing between the existing segment and the re-uploaded segment.
+    if (valid_collection && _segments.size() == 1) {
+        auto segment_to_replace = _manifest.segment_containing(
+          _begin_inclusive);
+
+        // This branch is *not* taken if the begin and/or end offsets of the
+        // collected range are in a manifest gap. In that scenario, a name
+        // clash is not possible.
+        if (
+          segment_to_replace != _manifest.end()
+          && _begin_inclusive == segment_to_replace->second.base_offset
+          && _end_inclusive == segment_to_replace->second.committed_offset) {
+            const bool should = _collected_size
+                                < segment_to_replace->second.size_bytes;
+
+            if (!should) {
+                vlog(
+                  archival_log.debug,
+                  "Skipping re-upload of compacted segment as its size has "
+                  "not decreased as a result of self-compaction: {}",
+                  *(_segments.front()));
+            }
+
+            return should;
+        }
+    }
+
+    return valid_collection;
 }
 
 cloud_storage::segment_name segment_collector::adjust_segment_name() const {

--- a/src/v/archival/segment_reupload.h
+++ b/src/v/archival/segment_reupload.h
@@ -43,8 +43,8 @@ public:
     segment_seq segments();
 
     /// Once segments are collected, this query determines if the collected
-    /// segments will be able to replace at least one segment in manifest.
-    bool can_replace_manifest_segment() const;
+    /// segments should replace at least one segment in manifest.
+    bool should_replace_manifest_segment() const;
 
     /// The starting point for the collection, this may not coincide with the
     /// start of the first collected compacted segment. It should be aligned

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -11,6 +11,7 @@
 #include "archival/segment_reupload.h"
 #include "archival/tests/service_fixture.h"
 #include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/types.h"
 #include "storage/log_manager.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/archival.h"
@@ -113,7 +114,7 @@ SEASTAR_THREAD_TEST_CASE(test_segment_collection) {
 
     // The three compacted segments are collected, with the begin and end
     // markers set to align with manifest segment.
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
     BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
     BOOST_REQUIRE_EQUAL(3, collector.segments().size());
@@ -138,7 +139,7 @@ SEASTAR_THREAD_TEST_CASE(test_start_ahead_of_manifest) {
 
         collector.collect_segments();
 
-        BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+        BOOST_REQUIRE_EQUAL(false, collector.should_replace_manifest_segment());
         auto segments = collector.segments();
         BOOST_REQUIRE(segments.empty());
     }
@@ -151,7 +152,7 @@ SEASTAR_THREAD_TEST_CASE(test_start_ahead_of_manifest) {
 
         collector.collect_segments();
 
-        BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+        BOOST_REQUIRE_EQUAL(false, collector.should_replace_manifest_segment());
         auto segments = collector.segments();
         BOOST_REQUIRE(segments.empty());
     }
@@ -174,7 +175,7 @@ SEASTAR_THREAD_TEST_CASE(test_empty_manifest) {
 
     collector.collect_segments();
 
-    BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+    BOOST_REQUIRE_EQUAL(false, collector.should_replace_manifest_segment());
     BOOST_REQUIRE(collector.segments().empty());
 }
 
@@ -206,7 +207,7 @@ SEASTAR_THREAD_TEST_CASE(test_short_compacted_segment_inside_manifest_segment) {
 
     collector.collect_segments();
 
-    BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+    BOOST_REQUIRE_EQUAL(false, collector.should_replace_manifest_segment());
     BOOST_REQUIRE_EQUAL(collector.segments().size(), 1);
 }
 
@@ -234,7 +235,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_aligned_with_manifest_segment) {
 
     collector.collect_segments();
 
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(!collector.should_replace_manifest_segment());
     auto segments = collector.segments();
     BOOST_REQUIRE_EQUAL(1, segments.size());
 
@@ -270,7 +271,7 @@ SEASTAR_THREAD_TEST_CASE(
 
     collector.collect_segments();
 
-    BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+    BOOST_REQUIRE_EQUAL(false, collector.should_replace_manifest_segment());
     auto segments = collector.segments();
     BOOST_REQUIRE_EQUAL(1, segments.size());
 
@@ -306,7 +307,7 @@ SEASTAR_THREAD_TEST_CASE(
 
     collector.collect_segments();
 
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
     auto segments = collector.segments();
     BOOST_REQUIRE_EQUAL(5, segments.size());
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
@@ -339,7 +340,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_larger_than_manifest_segment) {
 
     collector.collect_segments();
 
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(!collector.should_replace_manifest_segment());
     auto segments = collector.segments();
 
     BOOST_REQUIRE_EQUAL(1, segments.size());
@@ -378,7 +379,7 @@ SEASTAR_THREAD_TEST_CASE(test_collect_capped_by_size) {
 
     collector.collect_segments();
 
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
     auto segments = collector.segments();
 
     BOOST_REQUIRE_EQUAL(3, segments.size());
@@ -420,7 +421,7 @@ SEASTAR_THREAD_TEST_CASE(test_no_compacted_segments) {
 
     collector.collect_segments();
 
-    BOOST_REQUIRE_EQUAL(false, collector.can_replace_manifest_segment());
+    BOOST_REQUIRE_EQUAL(false, collector.should_replace_manifest_segment());
     BOOST_REQUIRE(collector.segments().empty());
 }
 
@@ -510,7 +511,7 @@ SEASTAR_THREAD_TEST_CASE(test_collected_segments_completely_cover_gap) {
 
         collector.collect_segments();
 
-        BOOST_REQUIRE(collector.can_replace_manifest_segment());
+        BOOST_REQUIRE(collector.should_replace_manifest_segment());
         auto segments = collector.segments();
 
         BOOST_REQUIRE_EQUAL(3, segments.size());
@@ -554,7 +555,7 @@ SEASTAR_THREAD_TEST_CASE(test_collected_segments_completely_cover_gap) {
 
         collector.collect_segments();
 
-        BOOST_REQUIRE(collector.can_replace_manifest_segment());
+        BOOST_REQUIRE(collector.should_replace_manifest_segment());
         auto segments = collector.segments();
 
         BOOST_REQUIRE_EQUAL(3, segments.size());
@@ -601,7 +602,7 @@ SEASTAR_THREAD_TEST_CASE(test_collection_starts_in_gap) {
       model::offset{2}, m, b.get_disk_log_impl(), max_upload_size};
 
     collector.collect_segments();
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
     BOOST_REQUIRE_EQUAL(1, collector.segments().size());
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{25});
     BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
@@ -633,7 +634,7 @@ SEASTAR_THREAD_TEST_CASE(test_collection_ends_in_gap) {
       model::offset{1}, m, b.get_disk_log_impl(), max_upload_size};
 
     collector.collect_segments();
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
     BOOST_REQUIRE_EQUAL(1, collector.segments().size());
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{20});
     BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{44});
@@ -665,7 +666,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_after_manifest_start) {
       model::offset{0}, m, b.get_disk_log_impl(), max_upload_size};
 
     collector.collect_segments();
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
     BOOST_REQUIRE_EQUAL(1, collector.segments().size());
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{20});
     BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
@@ -715,7 +716,7 @@ SEASTAR_THREAD_TEST_CASE(test_upload_candidate_generation) {
       model::offset{5}, m, b.get_disk_log_impl(), max_size};
 
     collector.collect_segments();
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
 
     auto upload_with_locks = collector
                                .make_upload_candidate(
@@ -797,7 +798,7 @@ SEASTAR_THREAD_TEST_CASE(test_upload_aligned_to_non_existent_offset) {
       model::offset{5}, m, b.get_disk_log_impl(), max_size};
 
     collector.collect_segments();
-    BOOST_REQUIRE(collector.can_replace_manifest_segment());
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
 
     auto upload_with_locks = collector
                                .make_upload_candidate(
@@ -823,4 +824,90 @@ SEASTAR_THREAD_TEST_CASE(test_upload_aligned_to_non_existent_offset) {
       expected_content_length, upload_candidate.content_length);
 
     BOOST_REQUIRE_EQUAL(upload_with_locks.read_locks.size(), 3);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_same_size_reupload_skipped) {
+    // 'segment_collector' should not propose the re-upload
+    // of a single segment if the compacted size is equal to
+    // the size of the segment in the manifest. In that case,
+    // the resulting addresable name in cloud storage would be the
+    // same for the segment before and after compaction. This would
+    // result in the deletion of the segment.
+    //
+    // This test checks the invariant above.
+
+    auto ntp = model::ntp{"test_ns", "test_tpc", 0};
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    auto o = std::make_unique<ntp_config::default_overrides>();
+    o->cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    b | start(ntp_config{ntp, {data_path}, std::move(o)});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // Create a segment containing two records with unique keys and
+    // add it to the partition manifest.
+    b | storage::add_segment(0) | storage::add_random_batch(0, 2);
+    auto first_seg_size = b.get_segment(0).size_bytes();
+    cloud_storage::partition_manifest m(ntp, model::initial_revision_id{1});
+    m.add(
+      cloud_storage::segment_name("0-1-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = first_seg_size,
+        .base_offset = model::offset(0),
+        .committed_offset = model::offset(1),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+
+    // Mark self compaction as complete on the segment and collect
+    // segments for re-upload. 'should_replace_manifest_segment'
+    // must return 'false' as the 'mock' self-compaction did not reduce
+    // the size.
+    b.get_segment(0).mark_as_finished_self_compaction();
+
+    {
+        archival::segment_collector collector{
+          model::offset{0}, m, b.get_disk_log_impl(), first_seg_size};
+
+        collector.collect_segments();
+        BOOST_REQUIRE_EQUAL(collector.collected_size(), first_seg_size);
+        BOOST_REQUIRE(!collector.should_replace_manifest_segment());
+    }
+
+    // Add another segment to the log and partition manifest.
+    b | storage::add_segment(2) | storage::add_random_batch(2, 2);
+    auto second_seg_size = b.get_segment(1).size_bytes();
+    m.add(
+      cloud_storage::segment_name("2-1-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = second_seg_size,
+        .base_offset = model::offset(2),
+        .committed_offset = model::offset(3),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+
+    // Mark the second segment as having completed self compaction
+    // and collect segments for re-upload again. This time,
+    // 'should_replace_manifest_segment' must return 'true',
+    // as we are not replacing a signle segment and there's no
+    // posibility for a clash (two segments get replaced with one).
+    b.get_segment(1).mark_as_finished_self_compaction();
+
+    {
+        archival::segment_collector collector{
+          model::offset{0},
+          m,
+          b.get_disk_log_impl(),
+          first_seg_size + second_seg_size};
+
+        collector.collect_segments();
+        BOOST_REQUIRE_EQUAL(
+          collector.collected_size(), first_seg_size + second_seg_size);
+        BOOST_REQUIRE(collector.should_replace_manifest_segment());
+    }
 }

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -71,60 +71,59 @@ static void write_batches(
     seg->flush().get();
 }
 
-static segment_layout write_random_batches(
+segment_layout write_random_batches(
   ss::lw_shared_ptr<storage::segment> seg,
-  size_t num_batches = 1,
-  std::optional<model::timestamp> timestamp = std::nullopt) { // NOLINT
+  size_t records,
+  size_t records_per_batch,
+  std::optional<model::timestamp> timestamp) { // NOLINT
     segment_layout layout{
       .base_offset = seg->offsets().base_offset,
     };
-    auto batches = model::test::make_random_batches(
-      seg->offsets().base_offset,
-      num_batches,
-      true /* allow_compression */,
-      timestamp);
 
-    vlog(fixt_log.debug, "Generated {} random batches", batches.size());
-    for (const auto& batch : batches) {
+    auto leftover_records = records % records_per_batch;
+    int full_batches_count = records / records_per_batch;
+    auto full_batches = model::test::make_random_batches(
+      model::test::record_batch_spec{
+        .offset = seg->offsets().base_offset,
+        .allow_compression = true,
+        .count = full_batches_count,
+        .records = records_per_batch,
+        .max_key_cardinality = 1,
+        .timestamp = timestamp});
+
+    vlog(
+      fixt_log.debug,
+      "Generated {} random batches",
+      leftover_records ? full_batches.size() + 1 : full_batches.size());
+    for (const auto& batch : full_batches) {
         vlog(fixt_log.debug, "Generated random batch {}", batch);
         layout.ranges.push_back({
           .base_offset = batch.base_offset(),
           .last_offset = batch.last_offset(),
         });
     }
-    write_batches(seg, std::move(batches));
-    return layout;
-}
+    write_batches(seg, std::move(full_batches));
 
-segment_layout write_random_batches_with_single_record(
-  ss::lw_shared_ptr<storage::segment> seg, size_t num_batches) {
-    segment_layout layout{
-      .base_offset = seg->offsets().base_offset,
-    };
+    if (leftover_records != 0) {
+        auto leftover_batches = model::test::make_random_batches(
+          model::test::record_batch_spec{
+            .offset = seg->offsets().committed_offset + model::offset(1),
+            .allow_compression = true,
+            .count = 1,
+            .records = leftover_records,
+            .max_key_cardinality = 1,
+            .timestamp = timestamp});
 
-    ss::circular_buffer<model::record_batch> batches;
-    batches.reserve(num_batches);
-
-    auto ts = model::timestamp::now();
-    auto o = seg->offsets().base_offset;
-
-    for (int i = 0; i < num_batches; i++) {
-        auto b = model::test::make_random_batch(
-          o, 1, true, model::record_batch_type::raft_data, std::nullopt, ts);
-        o = b.last_offset() + model::offset(1);
-        b.set_term(model::term_id(0));
-        batches.push_back(std::move(b));
+        for (const auto& batch : leftover_batches) {
+            vlog(fixt_log.debug, "Generated random batch {}", batch);
+            layout.ranges.push_back({
+              .base_offset = batch.base_offset(),
+              .last_offset = batch.last_offset(),
+            });
+        }
+        write_batches(seg, std::move(leftover_batches));
     }
 
-    vlog(fixt_log.debug, "Generated {} random batches", batches.size());
-    for (const auto& batch : batches) {
-        vlog(fixt_log.debug, "Generated random batch {}", batch);
-        layout.ranges.push_back({
-          .base_offset = batch.base_offset(),
-          .last_offset = batch.last_offset(),
-        });
-    }
-    write_batches(seg, std::move(batches));
     return layout;
 }
 
@@ -279,13 +278,12 @@ void archiver_fixture::initialize_shard(
         vlog(fixt_log.trace, "write random batches to segment");
 
         segment_layout layout;
-        if (fit_segments) {
-            layout = write_random_batches_with_single_record(
-              seg, d.num_batches.value());
-        } else {
-            layout = write_random_batches(
-              seg, d.num_batches.value_or(1), d.timestamp);
-        }
+
+        layout = write_random_batches(
+          seg,
+          d.num_records.value_or(1),
+          d.records_per_batch.value_or(1),
+          d.timestamp);
 
         layouts[d.ntp].push_back(std::move(layout));
         vlog(fixt_log.trace, "segment close");
@@ -390,8 +388,7 @@ template<class Fixture>
 void segment_matcher<Fixture>::verify_segments(
   const model::ntp& ntp,
   const std::vector<archival::segment_name>& names,
-  const seastar::sstring& expected,
-  size_t expected_size) {
+  const seastar::sstring& expected) {
     std::vector<ss::lw_shared_ptr<storage::segment>> segments;
     segments.reserve(names.size());
     std::transform(
@@ -402,6 +399,12 @@ void segment_matcher<Fixture>::verify_segments(
 
     storage::concat_segment_reader_view v{
       segments, 0, segments.back()->size_bytes(), ss::default_priority_class()};
+
+    auto expected_size = std::reduce(
+      segments.begin(),
+      segments.end(),
+      size_t{0},
+      [](auto acc, const auto& seg) { return acc + seg->size_bytes(); });
 
     auto stream = v.take_stream();
     auto data = stream.read_exactly(expected_size).get0();
@@ -548,7 +551,6 @@ void upload_and_verify(
       [&archiver, expected, lso]() {
           return archiver.upload_next_candidates(lso).then(
             [expected](auto result) { return result == expected; });
-          ;
       })
       .get0();
 }

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -37,7 +37,8 @@ struct segment_desc {
     model::ntp ntp;
     model::offset base_offset;
     model::term_id term;
-    std::optional<size_t> num_batches;
+    std::optional<size_t> num_records;
+    std::optional<size_t> records_per_batch;
     std::optional<model::timestamp> timestamp;
 };
 
@@ -112,8 +113,7 @@ public:
     void verify_segments(
       const model::ntp& ntp,
       const std::vector<archival::segment_name>& names,
-      const ss::sstring& expected,
-      size_t expected_size);
+      const ss::sstring& expected);
 
     /// Verify manifest using log_manager's state,
     /// find matching segments and check the fields.
@@ -236,7 +236,8 @@ void upload_and_verify(
   archival::ntp_archiver::batch_result,
   std::optional<model::offset> lso = std::nullopt);
 
-/// Creates num_batches with a single record each, used to fit segments close to
-/// each other without gaps.
-segment_layout write_random_batches_with_single_record(
-  ss::lw_shared_ptr<storage::segment> seg, size_t num_batches);
+segment_layout write_random_batches(
+  ss::lw_shared_ptr<storage::segment> seg,
+  size_t records = 1,
+  size_t records_per_batch = 1,
+  std::optional<model::timestamp> timestamp = std::nullopt);

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -242,7 +242,7 @@ make_random_batches(record_batch_spec spec) {
             base_sequence += num_records;
         }
         auto b = make_random_batch(batch_spec);
-        o = b.last_offset() + model::offset(num_records);
+        o = b.last_offset() + model::offset(1);
         b.set_term(model::term_id(0));
         ret.push_back(std::move(b));
     }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9404 to v22.3.x