### PR TITLE
rpk: redact SCRAM credentials in debug bundle

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_linux.go
@@ -474,9 +474,13 @@ func saveConfig(ps *stepParams, conf *config.Config) step {
 		}
 		if conf.PandaproxyClient != nil {
 			redactOtherMap(conf.PandaproxyClient.Other)
+			conf.PandaproxyClient.SCRAMPassword = &redacted
+			conf.PandaproxyClient.SCRAMUsername = &redacted
 		}
 		if conf.SchemaRegistryClient != nil {
 			redactOtherMap(conf.SchemaRegistryClient.Other)
+			conf.SchemaRegistryClient.SCRAMPassword = &redacted
+			conf.SchemaRegistryClient.SCRAMUsername = &redacted
 		}
 
 		bs, err := yaml.Marshal(conf)


### PR DESCRIPTION
Redact SCRAM username and password for pandaproxy and schema registry clients in the bundle generated by `rpk debug bundle`

## Backports Required

- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Improvements
* Redact SCRAM username and password for pandaproxy and schema registry clients in the bundle generated by  `rpk debug bundle`

