### PR TITLE
rpk: Correctly handle node_id and version when decommissioning

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/decommission.go
@@ -47,7 +47,7 @@ cluster is unreachable), use the hidden --force flag.
 
 			if !force {
 				brokers, err := cl.Brokers(cmd.Context())
-				out.MaybeDie(err, "unable to get broker list: %v; to bypass the node version check re-run this with --force; see this command's help text for for more details", err)
+				out.MaybeDie(err, "unable to get broker list: %v; to bypass the node version check re-run this with --force; see this command's help text for more details", err)
 
 				var (
 					b             admin.Broker
@@ -55,8 +55,11 @@ cluster is unreachable), use the hidden --force flag.
 				)
 				for _, br := range brokers {
 					if br.NodeID == broker {
+						if br.Version == "" {
+							out.Exit("version for broker %d is unknown, is the node offline?\nto bypass the node version check re-run this with --force; see this command's help text for more details", br.NodeID)
+						}
 						version, err := redpanda.VersionFromString(br.Version)
-						out.MaybeDie(err, "unable to get broker %q version: %v; to bypass the node version check re-run this with --force; see this command's help text for for more details", br.NodeID, err)
+						out.MaybeDie(err, "unable to get broker %q version: %v; to bypass the node version check re-run this with --force; see this command's help text for more details", br.NodeID, err)
 						isOld := version.Less(redpanda.Version{Year: 23, Feature: 1, Patch: 1})
 
 						anyOld = anyOld || isOld
@@ -65,7 +68,7 @@ cluster is unreachable), use the hidden --force flag.
 					}
 				}
 				if !found {
-					out.Die("unable to find broker %v in the cluster; to bypass the node version check re-run this with --force; see this command's help text for for more details", broker)
+					out.Die("unable to find broker %v in the cluster; to bypass the node version check re-run this with --force; see this command's help text for more details", broker)
 				}
 
 				// If any of the brokers is older than v23.1.1 we need to check

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/decommission.go
@@ -59,7 +59,7 @@ cluster is unreachable), use the hidden --force flag.
 							out.Exit("version for broker %d is unknown, is the node offline?\nto bypass the node version check re-run this with --force; see this command's help text for more details", br.NodeID)
 						}
 						version, err := redpanda.VersionFromString(br.Version)
-						out.MaybeDie(err, "unable to get broker %q version: %v; to bypass the node version check re-run this with --force; see this command's help text for more details", br.NodeID, err)
+						out.MaybeDie(err, "unable to get broker %d version: %v; to bypass the node version check re-run this with --force; see this command's help text for more details", br.NodeID, err)
 						isOld := version.Less(redpanda.Version{Year: 23, Feature: 1, Patch: 1})
 
 						anyOld = anyOld || isOld


### PR DESCRIPTION
When a node `789128` is dead, the decommission command fails like below:

```
$ rpk redpanda admin brokers decommission 789128
unable to get broker '\U000c0a88' version: unable to get the redpanda version from ""; to bypass the node version check re-run this with --force; see this command's help text for for more details
```

There are two problems here

* the node_id isn't handled properly
* version check runs whereas the version field is empty

With this commit, the command fails like below.

```
$ rpk redpanda admin brokers decommission 789128
version for broker 789128 is unknown. The node is likely dead?
to bypass the node version check re-run this with --force; see this command's help text for for more details
```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* rpk: decommission command fails with a friendly message when a node is dead
