### PR TITLE
cloud_storage: Add sname format to lw segment meta

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -321,6 +321,93 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
     archival_stm.stop().get();
 }
 
+FIXTURE_TEST(test_sname_derivation, archival_metadata_stm_base_fixture) {
+    start_raft();
+    auto& ntp_cfg = _raft->log_config();
+    partition_manifest m(ntp_cfg.ntp(), ntp_cfg.get_initial_revision());
+
+    // original segments
+    m.add(
+      segment_name("0-1-v1.log"),
+      segment_meta{
+        .base_offset = model::offset(0),
+        .committed_offset = model::offset(99),
+        .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
+        .sname_format = cloud_storage::segment_name_format::v1,
+      });
+
+    m.add(
+      segment_name("100-1-v1.log"),
+      segment_meta{
+        .base_offset = model::offset(100),
+        .committed_offset = model::offset(199),
+        .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
+        .sname_format = cloud_storage::segment_name_format::v2,
+      });
+
+    m.add(
+      segment_name("200-1-v1.log"),
+      segment_meta{
+        .base_offset = model::offset(200),
+        .committed_offset = model::offset(299),
+        .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
+        .sname_format = cloud_storage::segment_name_format::v3,
+      });
+
+    // replaced segments
+    m.add(
+      segment_name("0-1-v1.log"),
+      segment_meta{
+        .base_offset = model::offset(0),
+        .committed_offset = model::offset(99),
+        .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
+        .sname_format = cloud_storage::segment_name_format::v1,
+      });
+
+    m.add(
+      segment_name("100-1-v1.log"),
+      segment_meta{
+        .base_offset = model::offset(100),
+        .committed_offset = model::offset(199),
+        .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
+        .sname_format = cloud_storage::segment_name_format::v2,
+      });
+
+    m.add(
+      segment_name("200-1-v1.log"),
+      segment_meta{
+        .base_offset = model::offset(200),
+        .committed_offset = model::offset(299),
+        .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1),
+        .sname_format = cloud_storage::segment_name_format::v3,
+      });
+
+    m.advance_insync_offset(model::offset{42});
+    cluster::archival_metadata_stm::make_snapshot(ntp_cfg, m, model::offset{42})
+      .get();
+
+    cluster::archival_metadata_stm archival_stm(
+      _raft.get(), cloud_api.local(), feature_table.local(), logger);
+
+    archival_stm.start().get();
+    auto action = ss::defer([&archival_stm] { archival_stm.stop().get(); });
+    wait_for_confirmed_leader();
+
+    auto replaced = archival_stm.manifest().replaced_segments();
+    BOOST_REQUIRE_EQUAL(
+      replaced[0].sname_format, cloud_storage::segment_name_format::v1);
+    BOOST_REQUIRE_EQUAL(
+      replaced[1].sname_format, cloud_storage::segment_name_format::v2);
+    BOOST_REQUIRE_EQUAL(
+      replaced[2].sname_format, cloud_storage::segment_name_format::v3);
+}
+
 FIXTURE_TEST(
   test_archival_stm_segment_truncate, archival_metadata_stm_fixture) {
     using lw_segment_meta = cloud_storage::partition_manifest::lw_segment_meta;

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -373,6 +373,8 @@ segment_name partition_manifest::generate_remote_segment_name(
         return segment_name(
           ssx::sformat("{}-{}-v1.log", val.base_offset(), val.segment_term()));
     case segment_name_format::v2:
+        [[fallthrough]];
+    case segment_name_format::v3:
         // Use new stlyle format ".../base-committed-term-size-v1.log"
         return segment_name(ssx::sformat(
           "{}-{}-{}-{}-v1.log",

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -189,13 +189,24 @@ partition_manifest::lw_segment_meta::convert(const segment_meta& m) {
       .committed_offset = m.committed_offset,
       .archiver_term = m.archiver_term,
       .segment_term = m.segment_term,
-      .size_bytes = m.sname_format == segment_name_format::v2 ? m.size_bytes
-                                                              : 0,
+      .size_bytes = m.sname_format == segment_name_format::v1 ? 0
+                                                              : m.size_bytes,
+      .sname_format = m.sname_format,
     };
 }
 
 segment_meta partition_manifest::lw_segment_meta::convert(
   const partition_manifest::lw_segment_meta& lw) {
+    // default the name format to v1
+    auto sname_format = segment_name_format::v1;
+
+    // if we have an explicit format other than the default then use it,
+    // otherwise derive from size_bytes
+    if (lw.sname_format != segment_name_format::v1) {
+        sname_format = lw.sname_format;
+    } else if (lw.size_bytes != 0) {
+        sname_format = segment_name_format::v2;
+    }
     return segment_meta{
       .size_bytes = lw.size_bytes,
       .base_offset = lw.base_offset,
@@ -203,8 +214,7 @@ segment_meta partition_manifest::lw_segment_meta::convert(
       .ntp_revision = lw.ntp_revision,
       .archiver_term = lw.archiver_term,
       .segment_term = lw.segment_term,
-      .sname_format = lw.size_bytes == 0 ? segment_name_format::v1
-                                         : segment_name_format::v2,
+      .sname_format = sname_format,
     };
 }
 
@@ -888,16 +898,15 @@ struct partition_manifest_handler
                 if (!_replaced) {
                     _replaced = std::make_unique<replaced_segments_list>();
                 }
-                // In lw_segment_meta the sname_format field is encoded using
-                // the size_bytes field. For v1 name format we don't need
-                // size_bytes so we can set it to 0 to represent the
-                // sname_format field. For v2 we actually need to use both
-                // size_bytes and committed_offset. This code uses segment_meta
-                // to represent decoded elements from both 'segments' and
-                // 'replaced' fields. Because of that we need to do this trick.
-                _meta.sname_format = _meta.size_bytes != 0
-                                       ? segment_name_format::v2
-                                       : segment_name_format::v1;
+
+                // Set version to v2 if not set explicitly and size_bytes is non
+                // zero.
+                if (
+                  _meta.sname_format == segment_name_format::v1
+                  && _meta.size_bytes != 0) {
+                    _meta.sname_format = segment_name_format::v2;
+                }
+
                 _replaced->push_back(
                   partition_manifest::lw_segment_meta::convert(_meta));
                 _state = state::expect_replaced_path;
@@ -1366,6 +1375,11 @@ void partition_manifest::serialize_removed_segment_meta(
     }
     w.Key("segment_term");
     w.Int64(meta.segment_term());
+
+    w.Key("sname_format");
+    using name_format_type = std::underlying_type<segment_name_format>::type;
+    w.Int64(static_cast<name_format_type>(meta.sname_format));
+
     w.EndObject();
 }
 

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -89,10 +89,11 @@ public:
         model::term_id archiver_term;
         /// Term of the segment itself
         model::term_id segment_term;
-        /// Size of the segment if segment_name_format::v2 is used,
-        /// or 0 otherwise. The sname_format field is not added explicitly
-        /// but its value is encoded using size-bytes field.
+        /// Size of the segment if segment_name_format::v2 or later is used,
+        /// or 0 otherwise.
         size_t size_bytes;
+
+        segment_name_format sname_format{segment_name_format::v1};
 
         auto operator<=>(const lw_segment_meta&) const = default;
 

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -69,6 +69,8 @@ std::ostream& operator<<(std::ostream& o, const segment_name_format& r) {
     case segment_name_format::v2:
         o << "{v2}";
         break;
+    case segment_name_format::v3:
+        o << "{v3}";
     }
     return o;
 }

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -48,7 +48,7 @@ using local_segment_path
 using connection_limit = named_type<size_t, struct archival_connection_limit_t>;
 
 /// Version of the segment name format
-enum class segment_name_format : int16_t { v1 = 1, v2 = 2 };
+enum class segment_name_format : int16_t { v1 = 1, v2 = 2, v3 = 3 };
 
 std::ostream& operator<<(std::ostream& o, const segment_name_format& r);
 


### PR DESCRIPTION
The lw segment meta object can be used to create a full segment meta. It uses the size_bytes field to derive the sname format version, where if the size_bytes is non zero the version is 2. As we add higher versions this derivation is not possible, so an explicit sname format field is added to the lw segment meta.

When a redpanda broker is updated from a version which does not contain the version in lw meta to a version which does contain this field, the version will be derived from size_bytes as before. Once we start setting higher versions explicitly in code, this field will reflect the actual version.

FIXES https://github.com/redpanda-data/redpanda/issues/9457

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
