### PR TITLE
[v22.3.x] cluster: increment redpanda_cluster_partitions per partition on topic creation

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -64,8 +64,8 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
     md.replica_revisions.reserve(cmd.value.assignments.size());
     for (auto& pas : md.get_assignments()) {
         auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, pas.id);
+        _partition_count++;
         for (auto& r : pas.replicas) {
-            _partition_count++;
             md.replica_revisions[pas.id][r.node_id] = model::revision_id(
               offset);
         }

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -255,8 +255,12 @@ class ClusterMetricsTest(RedpandaTest):
                                               "cluster_partitions",
                                               value=0)
 
-            RpkTool(self.redpanda).create_topic("topic-a", partitions=20)
-            RpkTool(self.redpanda).create_topic("topic-b", partitions=10)
+            RpkTool(self.redpanda).create_topic("topic-a",
+                                                partitions=20,
+                                                replicas=3)
+            RpkTool(self.redpanda).create_topic("topic-b",
+                                                partitions=10,
+                                                replicas=3)
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
                                                 value=30)
@@ -266,7 +270,9 @@ class ClusterMetricsTest(RedpandaTest):
                                                 "cluster_partitions",
                                                 value=10)
 
-            RpkTool(self.redpanda).create_topic("topic-a", partitions=30)
+            RpkTool(self.redpanda).create_topic("topic-a",
+                                                partitions=30,
+                                                replicas=3)
             self._wait_until_metric_holds_value(controller,
                                                 "cluster_partitions",
                                                 value=40)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9393 to v22.3.x.