### PR TITLE
[v22.3.x] tests/storage: Relaxed deleted segments count

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -382,7 +382,8 @@ class ShadowIndexingRetentionTest(RedpandaTest):
             self.logger.debug(f"Deleted {deleted} segments from the cloud")
             return deleted
 
-        wait_until(lambda: deleted_segments_count() == 10,
+        # https://github.com/redpanda-data/redpanda/issues/8658#issuecomment-1420905967
+        wait_until(lambda: 9 <= deleted_segments_count() <= 10,
                    timeout_sec=10,
                    backoff_sec=1,
                    err_msg=f"Segments were not removed from the cloud")


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8967
Fixes https://github.com/redpanda-data/redpanda/issues/9468,