### PR TITLE
storage: do not compact below log start offset

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2061,9 +2061,7 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
                     // prefix-truncating.
                     return ss::now();
                 }
-                return truncate_to_latest_snapshot().then([this] {
-                    _log.set_collectible_offset(_last_snapshot_index);
-                });
+                return truncate_to_latest_snapshot();
             });
       })
       .then([this] { return _snapshot_mgr.get_snapshot_size(); })
@@ -2230,8 +2228,6 @@ ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
               _flushed_offset = std::max(last_included_index, _flushed_offset);
           });
     });
-
-    _log.set_collectible_offset(last_included_index);
 }
 
 ss::future<>

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -202,7 +202,6 @@ private:
     storage::probe _probe;
     failure_probes _failure_probes;
     std::optional<eviction_monitor> _eviction_monitor;
-    model::offset _max_collectible_offset;
     size_t _max_segment_size;
     std::unique_ptr<readers_cache> _readers_cache;
     // average ratio of segment sizes after segment size before compaction

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -156,14 +156,17 @@ private:
     ss::future<> do_truncate_prefix(truncate_prefix_config);
     ss::future<> remove_prefix_full_segments(truncate_prefix_config);
 
-    ss::future<model::offset>
-    garbage_collect_max_partition_size(compaction_config cfg);
-    ss::future<model::offset>
-    garbage_collect_oldest_segments(compaction_config cfg);
-    ss::future<model::offset> garbage_collect_segments(
-      compaction_config cfg, model::offset, std::string_view);
-    model::offset size_based_gc_max_offset(size_t);
-    model::offset time_based_gc_max_offset(model::timestamp);
+    // Propagate a request to the Raft layer to evict segments up until the
+    // specified offest.
+    //
+    // Returns the new start offset of the log.
+    ss::future<model::offset> request_eviction_until_offset(model::offset);
+
+    // These methods search the log for the offset to evict at such that
+    // the retention policy is satisfied. If no such offset is found
+    // std::nullopt is returned.
+    std::optional<model::offset> size_based_gc_max_offset(compaction_config);
+    std::optional<model::offset> time_based_gc_max_offset(compaction_config);
 
     bool is_front_segment(const segment_set::type&) const;
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -127,13 +127,14 @@ private:
     // Returns if the update actually took place.
     ss::future<bool> update_start_offset(model::offset o);
 
-    ss::future<> do_compact(compaction_config);
+    ss::future<> do_compact(
+      compaction_config, std::optional<model::offset> = std::nullopt);
     ss::future<compaction_result> compact_adjacent_segments(
       std::pair<segment_set::iterator, segment_set::iterator>,
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_compaction_range(const compaction_config&);
-    ss::future<> gc(compaction_config);
+    ss::future<std::optional<model::offset>> gc(compaction_config);
 
     ss::future<> remove_empty_segments();
 
@@ -155,9 +156,11 @@ private:
     ss::future<> do_truncate_prefix(truncate_prefix_config);
     ss::future<> remove_prefix_full_segments(truncate_prefix_config);
 
-    ss::future<> garbage_collect_max_partition_size(compaction_config cfg);
-    ss::future<> garbage_collect_oldest_segments(compaction_config cfg);
-    ss::future<> garbage_collect_segments(
+    ss::future<model::offset>
+    garbage_collect_max_partition_size(compaction_config cfg);
+    ss::future<model::offset>
+    garbage_collect_oldest_segments(compaction_config cfg);
+    ss::future<model::offset> garbage_collect_segments(
       compaction_config cfg, model::offset, std::string_view);
     model::offset size_based_gc_max_offset(size_t);
     model::offset time_based_gc_max_offset(model::timestamp);

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -121,6 +121,21 @@ ss::future<> disk_log_builder::gc(
       _abort_source));
 }
 
+ss::future<std::optional<model::offset>>
+disk_log_builder::apply_retention(compaction_config cfg) {
+    return get_disk_log_impl().gc(cfg);
+}
+
+ss::future<> disk_log_builder::apply_compaction(
+  compaction_config cfg, std::optional<model::offset> new_start_offset) {
+    return get_disk_log_impl().do_compact(cfg, new_start_offset);
+}
+
+ss::future<bool>
+disk_log_builder::update_start_offset(model::offset start_offset) {
+    return get_disk_log_impl().update_start_offset(start_offset);
+}
+
 ss::future<> disk_log_builder::stop() {
     return _storage.stop().then([this]() { return _feature_table.stop(); });
 }

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -113,12 +113,28 @@ ss::future<> disk_log_builder::truncate(model::offset o) {
 ss::future<> disk_log_builder::gc(
   model::timestamp collection_upper_bound,
   std::optional<size_t> max_partition_retention_size) {
-    return get_log().compact(compaction_config(
-      collection_upper_bound,
-      max_partition_retention_size,
-      model::offset::max(),
-      ss::default_priority_class(),
-      _abort_source));
+    ss::abort_source as;
+    auto eviction_future = get_log().monitor_eviction(as);
+
+    get_log()
+      .compact(compaction_config(
+        collection_upper_bound,
+        max_partition_retention_size,
+        model::offset::max(),
+        ss::default_priority_class(),
+        _abort_source))
+      .get();
+
+    if (eviction_future.available()) {
+        auto evict_until = eviction_future.get();
+        return get_log().truncate_prefix(storage::truncate_prefix_config{
+          model::next_offset(evict_until), ss::default_priority_class()});
+    } else {
+        as.request_abort();
+        eviction_future.ignore_ready_future();
+    }
+
+    return ss::make_ready_future<>();
 }
 
 ss::future<std::optional<model::offset>>

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -303,6 +303,12 @@ public:
     ss::future<> gc(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);
+    ss::future<std::optional<model::offset>>
+    apply_retention(compaction_config cfg);
+    ss::future<> apply_compaction(
+      compaction_config cfg,
+      std::optional<model::offset> new_start_offset = std::nullopt);
+    ss::future<bool> update_start_offset(model::offset start_offset);
     ss::future<> add_batch(
       model::record_batch batch,
       log_append_config config = append_config(),


### PR DESCRIPTION
This PR does two things (listed in the order of importance):

**1. Fix races between the application of compaction and retention**

Compaction and prefix truncation (retention) of the local log are async
operations that can race, despite the fact that their futures are
ordered in `disk_log_impl::compact`. This is because `disk_log_impl::gc`
does not remove any segments inline, but simply notifies the log
eviction STM of the offset recommended by the retention policy. Segments
are removed when Raft calls into `disk_log_impl::prefix_truncate`.

Hence, compaction may be operating on segments that are being removed,
which leads to strange races.

The fix is to skip compaction of segments that are below the new start
offset which the retention policy determined.

**2. Only notify the Raft layer once and dead-code removal**

Previously `disk_log_impl::garbage_collect_segments` had a code path
that actually removed segments from disk. Turns out that this code path
was only used by our unit tests because because the normal path for
retention is via the Raft layer calling into `disk_log_impl::prefix_truncate`.

That code path was removed, and I also took the liberty to refactor the
local retention code a bit. We now query both retention policies for the eviction
offset and notify the Raft layer with the maximum. Previously, if both retention
policies requested eviction, that would result in two separate truncations. I also
got rid of the `_max_collectible_offset` as that was only used on the dead code path.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Bug Fixes
* Fix race between compaction and application of retention to the local log. This occurred when compaction
happened below the start offset of the log. It did not have a noticeable impact upon user workloads.