### PR TITLE
Apply both size and time retention

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -782,7 +782,7 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
           gclog.trace,
           "[{}] skipped log deletion, exempt topic",
           config().ntp());
-        return ss::make_ready_future<>();
+        co_return;
     }
     if (cfg.max_bytes) {
         size_t max = cfg.max_bytes.value();
@@ -793,10 +793,10 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
           max,
           _probe.partition_size());
         if (!_segs.empty() && _probe.partition_size() > max) {
-            return garbage_collect_max_partition_size(cfg);
+            co_return co_await garbage_collect_max_partition_size(cfg);
         }
     }
-    return garbage_collect_oldest_segments(cfg);
+    co_await garbage_collect_oldest_segments(cfg);
 }
 
 ss::future<> disk_log_impl::remove_empty_segments() {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -777,9 +777,6 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
       "[{}] applying 'deletion' log cleanup policy with config: {}",
       config().ntp(),
       cfg);
-    if (unlikely(cfg.asrc->abort_requested())) {
-        return ss::make_ready_future<>();
-    }
     if (deletion_exempt(config().ntp())) {
         vlog(
           gclog.trace,

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -51,6 +51,25 @@
 
 using namespace std::literals::chrono_literals;
 
+namespace {
+/*
+ * Some logs must be exempt from the cleanup=delete policy such that their full
+ * history is retained. This function explicitly protects against any accidental
+ * configuration changes that might violate that constraint. Examples include
+ * the controller and internal kafka topics, with the exception of the
+ * transaction manager topic.
+ *
+ * Once controller snapshots are enabled this rule will relaxed accordingly.
+ */
+bool deletion_exempt(const model::ntp& ntp) {
+    bool is_internal_namespace = ntp.ns() == model::redpanda_ns
+                                 || ntp.ns() == model::kafka_internal_namespace;
+    bool is_tx_manager_ntp = ntp.ns == model::kafka_internal_namespace
+                             && ntp.tp.topic == model::tx_manager_topic;
+    return !is_tx_manager_ntp && is_internal_namespace;
+}
+} // namespace
+
 namespace storage {
 
 disk_log_impl::disk_log_impl(
@@ -761,20 +780,10 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
     if (unlikely(cfg.asrc->abort_requested())) {
         return ss::make_ready_future<>();
     }
-    // TODO: this a workaround until we have raft-snapshotting in the the
-    // controller so that we can still evict older data. At the moment we keep
-    // the full history.
-    bool is_internal_namespace = config().ntp().ns() == model::redpanda_ns
-                                 || config().ntp().ns()
-                                      == model::kafka_internal_namespace;
-    bool is_tx_manager_ntp = config().ntp().ns
-                               == model::kafka_internal_namespace
-                             && config().ntp().tp.topic
-                                  == model::tx_manager_topic;
-    if (!is_tx_manager_ntp && is_internal_namespace) {
+    if (deletion_exempt(config().ntp())) {
         vlog(
           gclog.trace,
-          "[{}] skipped log deletion, internal topic",
+          "[{}] skipped log deletion, exempt topic",
           config().ntp());
         return ss::make_ready_future<>();
     }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -219,6 +219,10 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     }
 
     while ((_logs_list.front().flags & bflags::compacted) == bflags::none) {
+        if (_abort_source.abort_requested()) {
+            co_return;
+        }
+
         auto& current_log = _logs_list.front();
 
         _logs_list.pop_front();


### PR DESCRIPTION
Apply both size and time based retention simultaneously. This means that size-based retention may override time-based retention, and vice versa. This is inline with the semantics of upstream Kakfa. See reference here:

https://github.com/apache/kafka/blob/44e613c4cd1a2b7303da7dd30d47bbe87090131f/core/src/main/scala/kafka/log/UnifiedLog.scala#L1364-L1372

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.
-->

### Improvements

* Both size and time based retention apply equally when cleaning a partition.


