### PR TITLE
serde: add checksum_envelope support to async read/write

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -905,7 +905,8 @@ read_async_nested(iobuf_parser& in, size_t const bytes_left_limit) {
               [&t]() { return std::move(t); });
         });
     } else {
-        return ss::make_ready_future<std::decay_t<T>>(read<T>(in));
+        return ss::make_ready_future<std::decay_t<T>>(
+          read_nested<T>(in, bytes_left_limit));
     }
 }
 

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -416,13 +416,15 @@ static_assert(serde::has_serde_async_write<test_snapshot_header>);
 
 ss::future<> test_snapshot_header::serde_async_read(
   iobuf_parser& in, serde::header const h) {
-    ns_ = serde::read_nested<decltype(ns_)>(in, h._bytes_left_limit);
-    header_crc = serde::read_nested<decltype(header_crc)>(
+    ns_ = co_await serde::read_async_nested<decltype(ns_)>(
       in, h._bytes_left_limit);
-    metadata_crc = serde::read_nested<decltype(metadata_crc)>(
+    header_crc = co_await serde::read_async_nested<decltype(header_crc)>(
       in, h._bytes_left_limit);
-    version = serde::read_nested<decltype(version)>(in, h._bytes_left_limit);
-    metadata_size = serde::read_nested<decltype(metadata_size)>(
+    metadata_crc = co_await serde::read_async_nested<decltype(metadata_crc)>(
+      in, h._bytes_left_limit);
+    version = co_await serde::read_async_nested<decltype(version)>(
+      in, h._bytes_left_limit);
+    metadata_size = co_await serde::read_async_nested<decltype(metadata_size)>(
       in, h._bytes_left_limit);
 
     vassert(metadata_size >= 0, "Invalid metadata size {}", metadata_size);
@@ -433,41 +435,53 @@ ss::future<> test_snapshot_header::serde_async_read(
     crc.extend(ss::cpu_to_le(metadata_size));
 
     if (header_crc != crc.value()) {
-        return ss::make_exception_future<>(std::runtime_error(fmt::format(
+        throw std::runtime_error(fmt::format(
           "Corrupt snapshot. Failed to verify header crc: {} != "
           "{}: path?",
           crc.value(),
-          header_crc)));
+          header_crc));
     }
-
-    return ss::make_ready_future<>();
 }
 
 ss::future<> test_snapshot_header::serde_async_write(iobuf& out) const {
-    serde::write(out, ns_);
-    serde::write(out, header_crc);
-    serde::write(out, metadata_crc);
-    serde::write(out, version);
-    serde::write(out, metadata_size);
-    return ss::make_ready_future<>();
+    co_await serde::write_async(out, ns_);
+    co_await serde::write_async(out, header_crc);
+    co_await serde::write_async(out, metadata_crc);
+    co_await serde::write_async(out, version);
+    co_await serde::write_async(out, metadata_size);
 }
 
 SEASTAR_THREAD_TEST_CASE(snapshot_test) {
-    auto b = iobuf();
-    auto write_future = serde::write_async(
-      b,
-      test_snapshot_header{
-        .header_crc = 1, .metadata_crc = 2, .version = 3, .metadata_size = 4});
-    write_future.wait();
-    auto parser = iobuf_parser{std::move(b)};
-    auto read_future = serde::read_async<test_snapshot_header>(parser);
-    read_future.wait();
-    BOOST_CHECK(read_future.failed());
-    try {
-        std::rethrow_exception(read_future.get_exception());
-    } catch (std::exception const& e) {
+    {
+        auto obj = test_snapshot_header{
+          .metadata_crc = 2, .version = 3, .metadata_size = 4};
+        crc::crc32c header_crc;
+        header_crc.extend(ss::cpu_to_le(obj.metadata_crc));
+        header_crc.extend(ss::cpu_to_le(obj.version));
+        header_crc.extend(ss::cpu_to_le(obj.metadata_size));
+        obj.header_crc = header_crc.value();
+
+        auto b = iobuf();
+        serde::write_async(b, obj).get();
+
+        auto parser = iobuf_parser{std::move(b)};
         BOOST_CHECK(
-          std::string_view{e.what()}.starts_with("Corrupt snapshot."));
+          obj == serde::read_async<test_snapshot_header>(parser).get());
+    }
+
+    {
+        auto obj_with_bad_crc = test_snapshot_header{
+          .header_crc = 1, .metadata_crc = 2, .version = 3, .metadata_size = 4};
+        auto b = iobuf();
+        serde::write_async(b, obj_with_bad_crc).get();
+
+        auto parser = iobuf_parser{std::move(b)};
+        try {
+            serde::read_async<test_snapshot_header>(parser).get();
+        } catch (std::exception const& e) {
+            BOOST_CHECK(
+              std::string_view{e.what()}.starts_with("Corrupt snapshot."));
+        }
     }
 }
 


### PR DESCRIPTION
Previously when you tried to async serialize-deserialize a checksum_envelope, it resulted in a size mismatch (because `write_async` didn't write the checksum, but `read_async` expected it when parsing the header). Added async checksum computation/writing and validation.

Also fixed a small bug in `read_async_nested` (`read` -> `read_nested` in the fallback case).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none