### PR TITLE
cloud_storage: only consider truncations past start_offset

### DIFF
--- a/src/v/archival/retention_calculator.cc
+++ b/src/v/archival/retention_calculator.cc
@@ -101,14 +101,17 @@ retention_calculator::retention_calculator(
   , _strategies(std::move(strategies)) {}
 
 std::optional<model::offset> retention_calculator::next_start_offset() {
+    auto begin = _manifest.first_addressable_segment();
     auto it = std::find_if(
-      _manifest.begin(), _manifest.end(), [this](const auto& entry) -> bool {
+      begin, _manifest.end(), [this](const auto& entry) -> bool {
           return std::all_of(
             _strategies.begin(), _strategies.end(), [&](auto& strat) {
                 return strat->done(entry.second);
             });
       });
 
+    // We made it to the end of our strategies and our policies are still not
+    // satisfied. Return just past the end -- we will truncate all segments.
     if (it == _manifest.end()) {
         return model::next_offset(std::prev(it)->second.committed_offset);
     }


### PR DESCRIPTION
The following sequence of events was possible:
1. Upload segments [1, 10].
2. Cloud retention dictates we truncate, and we end up truncating the entire log: our manifest still contains [1, 10] but our new start_offset is 11.
3. A leadership transfer occurs, and garbage collection doesn't happen immediately, meaning the manifest still contains [1, 10] for the time being.
4. In the new term, a new segment is added, [10, 20].
5. When truncating again, we iterate through all segments rather than starting from the start_offset, so we end up trying to truncate the first segment again, and setting the start_offset to 10.
6. The following message is logged:

ERROR 2023-03-15 05:04:57,848 [shard 1] cluster - ntp: {kafka/test-topic-1/0} - archival_metadata_stm.cc:842 - Can't truncate manifest up to offset 393, offset out of range

The retention calculator factory begins its search for truncatable segments at the start_offset -- the calculator itself should follow suit.

Fixes #9286

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes
* Fixed an issue that could prevent cloud storage truncation following leadership changes.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
