### PR TITLE
[v22.3.x] tests: reinstate exact consumer count checks in KgoRepeaterService

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -447,6 +447,10 @@ class RpkTool:
                     # Transient, return None to retry
                     # e.g. broker replied that group repeat01 has broker coordinator 8, but did not reply with that broker in the broker list
                     return None
+                elif "connection refused" in e.msg:
+                    # Metadata directed us to a broker that is uncontactable, perhaps
+                    # it was just stopped.  Retry should succeed once metadata updates.
+                    return None
                 else:
                     raise
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/6285
Fixes https://github.com/redpanda-data/redpanda/issues/9496,