### PR TITLE
[v22.2.x] r/consensus: do not report learners as under replicated followers

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3248,7 +3248,8 @@ follower_metrics build_follower_metrics(
       .last_heartbeat = meta.last_received_append_entries_reply_timestamp,
       .is_live = is_live,
       .under_replicated = (meta.is_recovering || !is_live)
-                          && meta.match_index < lstats.dirty_offset};
+                          && meta.match_index < lstats.dirty_offset
+                          && !meta.is_learner};
 }
 
 std::vector<follower_metrics> consensus::get_follower_metrics() const {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9503
