### PR TITLE
override goreleaser tag

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -75,6 +75,7 @@ jobs:
           QUILL_NOTARY_KEY: ${{ secrets.QUILL_NOTARY_KEY_BASE64 }}
           QUILL_NOTARY_ISSUER: ${{ secrets.QUILL_NOTARY_ISSUER }}
           GITHUB_TOKEN: ${{ secrets.VBOT_GITHUB_API_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
         with:
           distribution: goreleaser
           version: ${{ env.GITHUB_REF_NAME }}

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -80,7 +80,7 @@ jobs:
           distribution: goreleaser
           version: ${{ env.GITHUB_REF_NAME }}
           workdir: src/go/rpk/
-          args: release --rm-dist --release-notes /tmp/empty_notes
+          args: release --clean --release-notes /tmp/empty_notes
 
       - name: Archive quill output
         if: failure()


### PR DESCRIPTION
Forcing goreleaser to [set a custome git tag](https://goreleaser.com/cookbooks/set-a-custom-git-tag/) because for git commit 63fea9a it choses tag v22.3.14-rc4 instead of v22.3.14.

Populating with github [context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) variable for the tag name.

Related to issue https://github.com/redpanda-data/devprod/issues/638

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none