### PR TITLE
c/members_backend: fixed calculation of unevenness error

### DIFF
--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -134,8 +134,8 @@ private:
     absl::node_hash_map<model::node_id, node_replicas>
       calculate_replicas_per_node(partition_allocation_domain) const;
 
-    unevenness_error_info
-      calculate_unevenness_error(partition_allocation_domain) const;
+    unevenness_error_info calculate_unevenness_error(
+      const update_meta&, partition_allocation_domain) const;
     bool should_stop_rebalancing_update(const update_meta&) const;
 
     static size_t calculate_total_replicas(const node_replicas_map_t&);


### PR DESCRIPTION
When calculating an unevennes error we must include planned moves. When move is planned in redpanda the allocation is only added to the replicas that are about to be added to the replica set but not removed from the one that are removed during partition reallocation. Fixed calculation of unevenness error by subtracting removed replicas on the nodes they are moved from.

Fixes: #9507

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fixed automatic rebalancing of replicas stopping to early before achieving even distribution of replicas.