### PR TITLE
[admin_api] Expose local node info about ntp to admin_api

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -159,6 +159,8 @@ public:
         return _raft0->committed_offset();
     }
 
+    consensus_ptr get_raft0() { return _raft0; }
+
 private:
     friend controller_probe;
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -256,6 +256,16 @@ public:
 
     model::offset get_latest_configuration_offset() const;
     model::offset committed_offset() const { return _commit_index; }
+    model::offset flushed_offset() const { return _flushed_offset; }
+    model::offset last_quorum_replicated_index() const {
+        return _last_quorum_replicated_index;
+    }
+    model::offset majority_replicated_index() const {
+        return _majority_replicated_index;
+    }
+    model::offset visibility_upper_bound_index() const {
+        return _visibility_upper_bound_index;
+    }
 
     /**
      * Last visible index is an offset that is safe to be fetched by the
@@ -409,6 +419,8 @@ public:
      * Allow the current node to become a leader for this group.
      */
     void unblock_new_leadership() { _node_priority_override.reset(); }
+
+    const follower_stats& get_follower_stats() const { return _fstats; }
 
 private:
     friend replicate_entries_stm;

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -209,6 +209,40 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/partition/{namespace}/{topic}/{partition}",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get partition state for current node",
+                    "type": "partition_state",
+                    "nickname": "get_partition_state",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -451,6 +485,76 @@
                 "ms_since_last_heartbeat": {
                     "type": "long",
                     "description": "Ms since last heartbeat"
+                }
+            }
+        },
+        "partition_state": {
+            "id": "partition_state",
+            "description": "Partition state",
+            "properties": {
+                "start_offset": {
+                    "type": "long",
+                    "description": "Start offset"
+                },
+                "committed_offset": {
+                    "type": "long",
+                    "description": "Commmited offset"
+                },
+                "last_stable_offset": {
+                    "type": "long",
+                    "description": "Last stable offset"
+                },
+                "high_watermark": {
+                    "type": "long",
+                    "description": "High watermark"
+                },
+                "dirty_offset": {
+                    "type": "long",
+                    "description": "Dirty offset"
+                },
+                "latest_configuration_offset": {
+                    "type": "long",
+                    "description": "Get latest configuration offset"
+                },
+                "term": {
+                    "type": "long",
+                    "description": "Raft term"
+                },
+                "revision_id": {
+                    "type": "long",
+                    "description": "Revision id"
+                },
+                "log_size_bytes": {
+                    "type": "long",
+                    "description": "Log size bytes"
+                },
+                "non_log_disk_size_bytes": {
+                    "type": "long",
+                    "description": "Non log disk size bytes"
+                },
+                "is_read_replica_mode_enabled": {
+                    "type": "boolean",
+                    "description": "Is read replica mode enabled"
+                },
+                "read_replica_bucket": {
+                    "type": "string",
+                    "description": "Read replica bucket"
+                },
+                "is_remote_fetch_enabled": {
+                    "type": "boolean",
+                    "description": "Is remote fetch enabled"
+                },
+                "is_cloud_data_available": {
+                    "type": "boolean",
+                    "description": "Is cloud data available"
+                },
+                "start_cloud_offset": {
+                    "type": "long",
+                    "description": "Start cloud offset"
+                },
+                "last_cloud_offset": {
+                    "type": "long",
+                    "description": "Last cloud offset"
                 }
             }
         }

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -175,6 +175,40 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/raft/{namespace}/{topic}/{partition}",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get raft states for leader and followers. This request can be executed only on leader for partition . If follower get this request it will be redirected to leader",
+                    "type": "raft_state",
+                    "nickname": "get_raft_state",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -324,6 +358,99 @@
                         "type": "self_test_result"
                     },
                     "description": "Recordings of test runs from a single node"
+                }
+            }
+        },
+        "raft_state": {
+            "id": "raft_state",
+            "description": "Raft state",
+            "properties": {
+                "leader_info": {
+                    "type": "raft_leader_state",
+                    "description": "Raft metrics for ntp raft leader"
+                },
+                "followers": {
+                    "type": "array",
+                    "items": {
+                        "type": "raft_follower_state"
+                    },
+                    "description": "Raft metrics for ntp followers"
+                }
+            }
+        },
+        "raft_leader_state": {
+            "id": "raft_leader_state",
+            "description": "Information about raft state for ntp for leader",
+            "properties": {
+                "id": {
+                    "type": "int",
+                    "description": "Node id"
+                },
+                "term": {
+                    "type": "long",
+                    "description": "Current term"
+                },
+                "flushed_offset": {
+                    "type": "long",
+                    "description": "Flushed offset"
+                },
+                "commit_index": {
+                    "type": "long",
+                    "description": "Commit index"
+                },
+                "majority_replicated_index": {
+                    "type": "long",
+                    "description": "Majority replicated index"
+                },
+                "visibility_upper_bound_index": {
+                    "type": "long",
+                    "description": "Visibility upper bound index"
+                },
+                "last_quorum_replicated_index": {
+                    "type": "long",
+                    "description": "Last quorum replicated index"
+                }
+            }
+        },
+        "raft_follower_state": {
+            "id": "raft_follower_state",
+            "description": "Information about raft state for ntp for follower",
+            "properties": {
+                "id": {
+                    "type": "int",
+                    "description": "Node id"
+                },
+                "last_flushed_log_index": {
+                    "type": "long",
+                    "description": "Last flushed log index"
+                },
+                "last_dirty_log_index": {
+                    "type": "long",
+                    "description": "Last dirty log index"
+                },
+                "match_index": {
+                    "type": "long",
+                    "description": "Match index"
+                },
+                "next_index": {
+                    "type": "long",
+                    "description": "Next index"
+                },
+                "last_sent_offset": {
+                    "type": "long",
+                    "description": "Last sent offset"
+                },
+                "heartbeats_failed": {
+                    "type": "long",
+                    "description": "Heartbeats failed"
+                },
+                "is_learner": {
+                    "type": "boolean",
+                    "description": "Is node learner"
+                },
+                "ms_since_last_heartbeat": {
+                    "type": "long",
+                    "description": "Ms since last heartbeat"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -83,9 +83,11 @@
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
 #include <seastar/core/prometheus.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/with_scheduling_group.hh>
@@ -3452,6 +3454,89 @@ admin_server::cloud_storage_usage_handler(
     }
 }
 
+namespace {
+
+ss::json::json_return_type
+fill_status(cluster::consensus_ptr raft, model::ntp ntp) {
+    if (!raft->is_leader()) {
+        throw ss::httpd::server_error_exception(
+          fmt_with_ctx(fmt::format, "Can not find leader for ntp {}", ntp));
+    }
+
+    seastar::httpd::debug_json::raft_state ans;
+
+    seastar::httpd::debug_json::raft_leader_state leader_metrics;
+    leader_metrics.id = raft->get_leader_id().value();
+    leader_metrics.term = raft->term();
+    leader_metrics.commit_index = raft->committed_offset();
+    leader_metrics.flushed_offset = raft->flushed_offset();
+    leader_metrics.last_quorum_replicated_index
+      = raft->last_quorum_replicated_index();
+    leader_metrics.majority_replicated_index
+      = raft->majority_replicated_index();
+    leader_metrics.visibility_upper_bound_index
+      = raft->visibility_upper_bound_index();
+
+    ans.leader_info = leader_metrics;
+
+    auto followers_info = raft->get_follower_metrics();
+    for (const auto& [_, follower_stat] : raft->get_follower_stats()) {
+        seastar::httpd::debug_json::raft_follower_state metrics;
+        metrics.id = follower_stat.node_id.id();
+        metrics.last_flushed_log_index = follower_stat.last_flushed_log_index;
+        metrics.last_dirty_log_index = follower_stat.last_dirty_log_index;
+        metrics.match_index = follower_stat.match_index;
+        metrics.next_index = follower_stat.next_index;
+        metrics.last_sent_offset = follower_stat.last_sent_offset;
+        metrics.heartbeats_failed = follower_stat.heartbeats_failed;
+        metrics.is_learner = follower_stat.is_learner;
+        metrics.ms_since_last_heartbeat
+          = std::chrono::duration_cast<std::chrono::milliseconds>(
+              raft::clock_type::now()
+              - follower_stat.last_received_reply_timestamp)
+              .count();
+        ans.followers.push(metrics);
+    }
+
+    return ans;
+}
+
+} // namespace
+
+ss::future<ss::json::json_return_type>
+admin_server::get_raft_state_handler(std::unique_ptr<ss::httpd::request> req) {
+    const model::ntp ntp = parse_ntp_from_request(req->param);
+
+    if (need_redirect_to_leader(ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, ntp);
+    }
+
+    const bool is_controller = ntp == model::controller_ntp;
+    cluster::consensus_ptr raft;
+
+    if (is_controller) {
+        co_return co_await ss::smp::submit_to(
+          ss::shard_id(0),
+          [ntp, this]() -> ss::future<ss::json::json_return_type> {
+              return ss::make_ready_future<ss::json::json_return_type>(
+                fill_status(_controller->get_raft0(), ntp));
+          });
+    } else {
+        auto shard = _shard_table.local().shard_for(ntp);
+        if (!shard) {
+            throw ss::httpd::not_found_exception(
+              fmt::format("Could not find shard for ntp: {}", ntp));
+        }
+        co_return co_await _partition_manager.invoke_on(
+          shard.value(),
+          [ntp](auto& pm) -> ss::future<ss::json::json_return_type> {
+              auto partition = pm.get(ntp);
+              return ss::make_ready_future<ss::json::json_return_type>(
+                fill_status(partition->raft(), ntp));
+          });
+    }
+}
+
 void admin_server::register_debug_routes() {
     register_route<user>(
       ss::httpd::debug_json::reset_leaders_info,
@@ -3540,6 +3625,13 @@ void admin_server::register_debug_routes() {
       [this](std::unique_ptr<ss::httpd::request> req)
         -> ss::future<ss::json::json_return_type> {
           return cloud_storage_usage_handler(std::move(req));
+      });
+
+    register_route<user>(
+      seastar::httpd::debug_json::get_raft_state,
+      [this](std::unique_ptr<ss::httpd::request> req)
+        -> ss::future<ss::json::json_return_type> {
+          return get_raft_state_handler(std::move(req));
       });
 }
 ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -378,6 +378,10 @@ private:
     ss::future<ss::json::json_return_type>
       self_test_get_results_handler(std::unique_ptr<ss::httpd::request>);
 
+    /// Debug routes
+    ss::future<ss::json::json_return_type>
+      get_raft_state_handler(std::unique_ptr<ss::httpd::request>);
+
     ss::future<ss::json::json_return_type>
       redpanda_services_restart_handler(std::unique_ptr<ss::httpd::request>);
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -381,6 +381,8 @@ private:
     /// Debug routes
     ss::future<ss::json::json_return_type>
       get_raft_state_handler(std::unique_ptr<ss::httpd::request>);
+    ss::future<ss::json::json_return_type>
+      get_partition_state_handler(std::unique_ptr<ss::httpd::request>);
 
     ss::future<ss::json::json_return_type>
       redpanda_services_restart_handler(std::unique_ptr<ss::httpd::request>);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -872,3 +872,7 @@ class Admin:
     def get_raft_state(self, namespace, topic, partition):
         path = f"debug/raft/{namespace}/{topic}/{partition}"
         return self._request("GET", path).json()
+
+    def get_local_partition_state(self, namespace, topic, partition, node):
+        path = f"debug/partition/{namespace}/{topic}/{partition}"
+        return self._request("GET", path, node=node).json()

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -868,3 +868,7 @@ class Admin:
         return int(
             self._request(
                 "GET", "debug/cloud_storage_usage?retries_allowed=10").json())
+
+    def get_raft_state(self, namespace, topic, partition):
+        path = f"debug/raft/{namespace}/{topic}/{partition}"
+        return self._request("GET", path).json()

--- a/tests/rptest/tests/admin_api_raft_metrics_test.py
+++ b/tests/rptest/tests/admin_api_raft_metrics_test.py
@@ -1,0 +1,108 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.admin import Admin
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.util import wait_until_result
+from rptest.util import wait_until
+import requests
+
+# Errors we should tolerate right after start Redpanda
+NOT_LEADER_LOG_ERRORS = [
+    # e.g.  admin_api_server - admin_server.cc:409 - [_anonymous] exception intercepted - url: [http://docker-rp-6:9644/v1/debug/raft/kafka/topic-sppnwqzxzz/0] http_return_status[500] reason - seastar::httpd::server_error_exception (admin_server.cc:3347 - Can not find leader for ntp {kafka/topic-sppnwqzxzz/0})">
+    "admin_api_server - .*http_return_status[500]"
+]
+
+
+class AdminApiRaftStateTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1, replication_factor=3), )
+
+    def __init__(self, test_context):
+        super(AdminApiRaftStateTest, self).__init__(test_context=test_context,
+                                                    num_brokers=3)
+
+        self.admin = Admin(self.redpanda)
+
+    @cluster(num_nodes=3, log_allow_list=NOT_LEADER_LOG_ERRORS)
+    def simple_test(self):
+        self.topic_name = self.topics[0].name
+
+        def leader_is_elected():
+            try:
+                info = self.admin.get_raft_state("kafka", self.topic_name, 0)
+                return True, info
+            except requests.exceptions.HTTPError as e:
+                # Leader is not elected yet. We should retry
+                assert e.response.status_code == 500
+                return False
+
+        raft_info = wait_until_result(
+            leader_is_elected,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Can not elect leader for topic: {self.topic_name}")
+
+        leader_id = self.admin.get_partition_leader(namespace="kafka",
+                                                    topic=self.topic_name,
+                                                    partition=0)
+
+        assert raft_info["leader_info"]["id"] == leader_id
+        assert raft_info["leader_info"]["commit_index"] == 0
+        assert raft_info["leader_info"]["majority_replicated_index"] == 0
+
+        assert len(raft_info["followers"]) == 2
+
+        for follower in raft_info["followers"]:
+            assert follower["id"] != leader_id
+
+    @cluster(num_nodes=3, log_allow_list=NOT_LEADER_LOG_ERRORS)
+    def controller_test(self):
+        self.topic_name = "controller"
+
+        def leader_is_elected():
+            try:
+                info = self.admin.get_raft_state("redpanda", self.topic_name,
+                                                 0)
+                return True, info
+            except requests.exceptions.HTTPError as e:
+                # Leader is not elected yet. We should retry
+                assert e.response.status_code == 500
+                return False
+
+        raft_info = wait_until_result(
+            leader_is_elected,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Can not elect leader for topic: {self.topic_name}")
+
+        leader_id = self.admin.get_partition_leader(namespace="redpanda",
+                                                    topic=self.topic_name,
+                                                    partition=0)
+
+        assert raft_info["leader_info"]["id"] == leader_id
+
+        for follower in raft_info["followers"]:
+            assert follower["id"] != leader_id
+
+        def wait_all_followers_sync():
+            info = self.admin.get_raft_state("redpanda", self.topic_name, 0)
+            leader_ci = info["leader_info"]["commit_index"]
+            for follower in info["followers"]:
+                if leader_ci != follower["last_flushed_log_index"]:
+                    return False
+            return True
+
+        wait_until(
+            wait_all_followers_sync,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Followers can not sync with leader for controller")


### PR DESCRIPTION
This pr contains new admin_api request:

```
"path": "/v1/debug/partition/{namespace}/{topic}/{partition}",
"operations": [
    {
        "method": "GET",
        "summary": "Get partition state for current node",
```

`get_partition_state` request return partition state for chosen ntp. This request is executed locally on node

It contains:
* start_offset
* committed_offset
* last_stable_offset
* high_watermark
* dirty_offset
* latest_configuration_offset
* term
* revision_id
* log_size_bytes
* non_log_disk_size_bytes
* is_read_replica_mode_enabled
* read_replica_bucket
* is_remote_fetch_enabled
* is_cloud_data_available
* start_cloud_offset
* last_cloud_offset

Fixes #9097 

[small rfc](https://docs.google.com/document/d/11q2ok7ZUQeLLXVE_O4mDq06k3GjTjbWoXJj7_eP4Kss/edit?usp=sharing)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features


* New admin_api request `/v1/debug/partition/{namespace}/{topic}/{partition}` to get raft internal state for ntp
