### PR TITLE
archival: hanlde leader swings in housekeeping

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1531,7 +1531,8 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::apply_retention() {
     }
 
     auto next_start_offset = retention_calculator->next_start_offset();
-    if (next_start_offset) {
+    auto current_start_offset = manifest().get_start_offset();
+    if (next_start_offset && next_start_offset > current_start_offset) {
         vlog(
           _rtclog.debug,
           "{} Advancing start offset to {} satisfy retention policy",

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -451,6 +451,17 @@ bool partition_manifest::contains(const segment_name& name) const {
 void partition_manifest::delete_replaced_segments() { _replaced.clear(); }
 
 bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
+    if (new_start_offset <= _start_offset) {
+        vlog(
+          cst_log.error,
+          "[{}] New start offest is not greater than current start offset: {} "
+          "<= {}. Skipping truncation.",
+          _ntp,
+          new_start_offset,
+          _start_offset);
+        return false;
+    }
+
     if (new_start_offset > _start_offset && !_segments.empty()) {
         auto it = _segments.upper_bound(new_start_offset);
         if (it == _segments.begin()) {


### PR DESCRIPTION
Truncaction of the cloud log is a two step process. First, the new start offset is determined and an STM command is replicated in order to update the manifest start offsets. Then, async, the segments below the start offset in the manifest are deleted.

Leadership changes can occur between these two steps. When that happens, the first step will be repeated once a new leader is established. If the start offset we choose to truncate at is the same, then the command to update the start offset is replicated again. It succeeds, but produces an error log which trips up the tests.

This commit fixes this scenario by only replicating the command to advance the start offset if the new offset is greater than the current one.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none