### PR TITLE
[v23.1.x] cloud_storage: only consider truncations past start_offset

### DIFF
--- a/src/v/archival/retention_calculator.cc
+++ b/src/v/archival/retention_calculator.cc
@@ -101,14 +101,17 @@ retention_calculator::retention_calculator(
   , _strategies(std::move(strategies)) {}
 
 std::optional<model::offset> retention_calculator::next_start_offset() {
+    auto begin = _manifest.first_addressable_segment();
     auto it = std::find_if(
-      _manifest.begin(), _manifest.end(), [this](const auto& entry) -> bool {
+      begin, _manifest.end(), [this](const auto& entry) -> bool {
           return std::all_of(
             _strategies.begin(), _strategies.end(), [&](auto& strat) {
                 return strat->done(entry.second);
             });
       });
 
+    // We made it to the end of our strategies and our policies are still not
+    // satisfied. Return just past the end -- we will truncate all segments.
     if (it == _manifest.end()) {
         return model::next_offset(std::prev(it)->second.committed_offset);
     }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9494
Fixes https://github.com/redpanda-data/redpanda/issues/9538,