### PR TITLE
mergify: prefix backport PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,6 +8,12 @@ pull_request_rules:
         name: dev
         merge_bot_account: vbotbuildovich
         update_bot_account: vbotbuildovich
+  - name: backport to supported branch
+    conditions:
+      - base~=^v\d+\.\d+\.x$
+    actions:
+      backport:
+        title: "[{{ destination_branch }}] {{ title }}"
 queue_rules:
   - name: dev
     speculative_checks: 2


### PR DESCRIPTION
this PR prefixes mergify backport PR titles with the branch name. ref: https://docs.mergify.com/actions/backport/#options

this is one of the changes desired before `@mergify backport` can be used in redpanda repo: https://github.com/redpanda-data/devprod/issues/641

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none