### PR TITLE
service_fixture: replace std::reduce with std::accumulate to fix build with GCC.

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -385,7 +385,7 @@ void segment_matcher<Fixture>::verify_segments(
     storage::concat_segment_reader_view v{
       segments, 0, segments.back()->size_bytes(), ss::default_priority_class()};
 
-    auto expected_size = std::reduce(
+    auto expected_size = std::accumulate(
       segments.begin(),
       segments.end(),
       size_t{0},


### PR DESCRIPTION
* std::reduce expects a binary op, which will be applied to the
result of dereferencing the input iterators, the results of other
binary op and init.
* std::accumulate expects a binary op, which will be applied to
init and the result of deferencing the input iterators.

The implementation of std::reduce in libstdc++[^1] requires that
the type of element, init value and return value should be the
same(or convertible, roughly speaking), which differs from that
of libc++[^2] and apparently cannot be satisfied in our case.

Here we simply replace std::reduce with std::accumulate.

[^1]: https://github.com/gcc-mirror/gcc/blob/releases/gcc-12/libstdc%2B%2B-v3/include/std/numeric#L284
[^2]: https://github.com/llvm/llvm-project/blob/release/16.x/libcxx/include/__numeric/reduce.h#L24

Signed-off-by: Jianyong Chen <baluschch@gmail.com>

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
