### PR TITLE
Support disk space reclaim estimation for applying retention policy

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -450,6 +450,7 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
           segment->reader().filename(),
           result);
         if (result.did_compact()) {
+            segment->invalidate_compaction_index_size();
             _compaction_ratio.update(result.compaction_ratio());
             co_return;
         }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -316,8 +316,12 @@ ss::future<> disk_log_impl::garbage_collect_segments(
         _eviction_monitor.reset();
     }
 
-    // Max collectible offset can be overriden from multiple places
-    // (unfortunately). We take the min.
+    /*
+     * adjust downward the max offset to comply with restrictions other than
+     * basic retention policy. cfg.max_collectible_offset is sourced from
+     * installed stms (e.g. archival) and _max_collecitble_offset member is set
+     * by raft is used to protect an offset range not included in snapshots.
+     */
     max_offset = std::min(
       cfg.max_collectible_offset,
       std::min(max_offset, _max_collectible_offset));

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -115,6 +115,8 @@ private:
     friend class disk_log_builder;  // for tests
     friend std::ostream& operator<<(std::ostream& o, const disk_log_impl& d);
 
+    using dry_run = ss::bool_class<struct dry_run>;
+
     ss::future<model::record_batch_reader>
       make_unchecked_reader(log_reader_config);
 
@@ -157,8 +159,14 @@ private:
 
     ss::future<> garbage_collect_max_partition_size(compaction_config cfg);
     ss::future<> garbage_collect_oldest_segments(compaction_config cfg);
-    ss::future<> garbage_collect_segments(
-      compaction_config cfg, model::offset, std::string_view);
+
+    /*
+     * when dry_run is requested then an estimate of the number of bytes that
+     * would be removed from a non-dry run is returned.
+     */
+    ss::future<size_t> garbage_collect_segments(
+      compaction_config cfg, model::offset, std::string_view, dry_run);
+
     model::offset size_based_gc_max_offset(size_t);
     model::offset time_based_gc_max_offset(model::timestamp);
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -138,6 +138,19 @@ private:
 
     ss::future<size_t> gc(compaction_config, dry_run dry_run = dry_run::no);
 
+    /*
+     * a private, temporary, testing only interface called from the friendly
+     * disk log builder to interact with retention gc dry run mode. this will be
+     * removed as we surface more of the api for disk space management.
+     */
+    ss::future<size_t> testing_only_gc(compaction_config cfg, dry_run dry_run) {
+        cfg = apply_overrides(cfg);
+        if (config().is_collectable()) {
+            co_return co_await gc(cfg, dry_run);
+        }
+        co_return 0;
+    }
+
     ss::future<> remove_empty_segments();
 
     ss::future<> remove_segment_permanently(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -135,7 +135,8 @@ private:
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_compaction_range(const compaction_config&);
-    ss::future<> gc(compaction_config);
+
+    ss::future<size_t> gc(compaction_config, dry_run dry_run = dry_run::no);
 
     ss::future<> remove_empty_segments();
 
@@ -157,8 +158,8 @@ private:
     ss::future<> do_truncate_prefix(truncate_prefix_config);
     ss::future<> remove_prefix_full_segments(truncate_prefix_config);
 
-    ss::future<> garbage_collect_max_partition_size(compaction_config cfg);
-    ss::future<> garbage_collect_oldest_segments(compaction_config cfg);
+    std::optional<model::offset> size_retention_offset(compaction_config cfg);
+    std::optional<model::offset> time_retention_offset(compaction_config cfg);
 
     /*
      * when dry_run is requested then an estimate of the number of bytes that

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -160,8 +160,7 @@ public:
     ss::future<ss::rwlock::holder> write_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
 
-    ss::future<> remove_persistent_state(std::filesystem::path);
-    ss::future<> remove_persistent_state();
+    ss::future<size_t> remove_persistent_state();
 
     generation_id get_generation_id() const { return _generation_id; }
     void advance_generation() { _generation_id++; }
@@ -193,10 +192,11 @@ private:
       segment_appender_ptr,
       std::optional<batch_cache_index>,
       std::optional<compacted_index_writer>);
-    ss::future<> remove_tombstones();
     ss::future<> compaction_index_batch(const model::record_batch&);
     ss::future<> do_compaction_index_batch(const model::record_batch&);
     void release_appender_in_background(readers_cache* readers_cache);
+
+    ss::future<size_t> remove_persistent_state(std::filesystem::path);
 
     struct appender_callbacks : segment_appender::callbacks {
         explicit appender_callbacks(segment* segment)

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -160,6 +160,17 @@ public:
     ss::future<ss::rwlock::holder> write_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
 
+    /*
+     * return an estimate of how much data on disk is associated with this
+     * segment (e.g. the data file, indices, etc...). if the segment has been
+     * removed already (i.e. marked as a tombstone and closed) then the total
+     * amount of bytes actually removed from disk is reported.
+     */
+    ss::future<size_t> persistent_size();
+
+    /*
+     * return the number of bytes removed from disk.
+     */
     ss::future<size_t> remove_persistent_state();
 
     generation_id get_generation_id() const { return _generation_id; }
@@ -176,6 +187,10 @@ public:
     constexpr std::optional<ss::lowres_clock::time_point>
     first_write_ts() const {
         return _first_write;
+    }
+
+    void invalidate_compaction_index_size() {
+        _compaction_index_size = std::nullopt;
     }
 
 private:
@@ -196,6 +211,12 @@ private:
     ss::future<> do_compaction_index_batch(const model::record_batch&);
     void release_appender_in_background(readers_cache* readers_cache);
 
+    /*
+     * _removed_persistent_size is the total number of bytes removed when this
+     * segment is deleted. it is set once, after the segment is marked as a
+     * tombstone and closed.
+     */
+    std::optional<size_t> _removed_persistent_size;
     ss::future<size_t> remove_persistent_state(std::filesystem::path);
 
     struct appender_callbacks : segment_appender::callbacks {
@@ -232,7 +253,13 @@ private:
     segment_index _idx;
     bitflags _flags{bitflags::none};
     segment_appender_ptr _appender;
+
+    // compaction index size should be cleared whenever the size might change
+    // (e.g. after compaction). when cleared it will reset the next time the
+    // size of the compaction index is needed (e.g. estimating total seg size).
+    std::optional<size_t> _compaction_index_size;
     std::optional<compacted_index_writer> _compaction_index;
+
     std::optional<batch_cache_index> _cache;
     ss::rwlock _destructive_ops;
     ss::gate _gate;

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -160,6 +160,7 @@ public:
     ss::future<ss::rwlock::holder> write_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
 
+    ss::future<> remove_persistent_state(std::filesystem::path);
     ss::future<> remove_persistent_state();
 
     generation_id get_generation_id() const { return _generation_id; }

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -853,6 +853,7 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
     from_path = from_path.to_compacted_index();
     auto to_path = to->reader().path().to_compacted_index();
     co_await ss::rename_file(from_path.string(), to_path.string());
+    to->invalidate_compaction_index_size();
 
     // clean up replacement segment
     co_await from->remove_persistent_state();

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -25,6 +25,8 @@
 #include <seastar/core/future-util.hh>
 
 #include <fmt/ostream.h>
+
+#include <exception>
 using namespace std::chrono_literals;
 
 namespace storage::internal {
@@ -339,7 +341,7 @@ ss::future<> spill_key_index::close() {
         // index can detect invalid content and regenerate.
         _midx.clear();
 
-        throw ex;
+        std::rethrow_exception(ex);
     }
 }
 

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -121,6 +121,20 @@ ss::future<> disk_log_builder::gc(
       _abort_source));
 }
 
+ss::future<size_t> disk_log_builder::gc_retention(
+  model::timestamp collection_upper_bound,
+  std::optional<size_t> max_partition_retention_size,
+  bool dry_run) {
+    return get_disk_log_impl().testing_only_gc(
+      compaction_config(
+        collection_upper_bound,
+        max_partition_retention_size,
+        model::offset::max(),
+        ss::default_priority_class(),
+        _abort_source),
+      disk_log_impl::dry_run(dry_run));
+}
+
 ss::future<> disk_log_builder::stop() {
     return _storage.stop().then([this]() { return _feature_table.stop(); });
 }

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -303,6 +303,10 @@ public:
     ss::future<> gc(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);
+    ss::future<size_t> gc_retention(
+      model::timestamp collection_upper_bound,
+      std::optional<size_t> max_partition_retention_size,
+      bool dry_run);
     ss::future<> add_batch(
       model::record_batch batch,
       log_append_config config = append_config(),

--- a/src/v/vlog.h
+++ b/src/v/vlog.h
@@ -22,3 +22,17 @@
 
 // NOLINTNEXTLINE
 #define vlog(method, fmt, args...) fmt_with_ctx(method, fmt, ##args)
+
+// NOLINTNEXTLINE
+#define fmt_with_ctx_level(logger, level, fmt, args...)                        \
+    logger.log(                                                                \
+      level,                                                                   \
+      "{}:{} - " fmt,                                                          \
+      (const char*)&__FILE__[vlog_internal::log_basename_start<                \
+        vlog_internal::basename_index(__FILE__)>::value],                      \
+      __LINE__,                                                                \
+      ##args)
+
+// NOLINTNEXTLINE
+#define vlogl(logger, level, fmt, args...)                                     \
+    fmt_with_ctx_level(logger, level, fmt, ##args)


### PR DESCRIPTION
The primary changes in this pull request are:

* Parallel removal of persistent segment files
* Reporting of data removed from disk on segment removal
* Garbage collection dry-run mode for to calculate how much data is subject to reclaim by the current retention policy

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

