### PR TITLE
ducktape: fix last_replicas_left/bytes_left tracking

### DIFF
--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -192,13 +192,14 @@ class NodeDecommissionWaiter():
             )
             # check if node bytes left changed
             if self.last_replicas_left is None or replicas_left < self.last_replicas_left:
-                self.last_replicas_left = replicas_left
                 self.last_update = time.time()
             if partitions_bytes_left is not None and partitions_bytes_left > 0:
                 # check if currently moving partitions bytes left changed
                 if self.last_partitions_bytes_left is None or partitions_bytes_left < self.last_partitions_bytes_left:
-                    self.last_partitions_bytes_left = partitions_bytes_left
                     self.last_update = time.time()
+
+            self.last_replicas_left = replicas_left
+            self.last_partitions_bytes_left = partitions_bytes_left
 
             if decommission_status["finished"] == True:
                 break


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
