### PR TITLE
archival: lock segments before opening readers

### DIFF
--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -327,6 +327,19 @@ segment_collector::make_upload_candidate(
         co_return upload_candidate_with_locks{upload_candidate{}, {}};
     }
 
+    // Take the locks before opening any readers on the segments.
+    auto deadline = std::chrono::steady_clock::now() + segment_lock_duration;
+    std::vector<ss::future<ss::rwlock::holder>> locks;
+    locks.reserve(_segments.size());
+    std::transform(
+      _segments.begin(),
+      _segments.end(),
+      std::back_inserter(locks),
+      [&deadline](auto& seg) { return seg->read_lock(deadline); });
+
+    auto locks_resolved = co_await ss::when_all_succeed(
+      locks.begin(), locks.end());
+
     auto first = _segments.front();
     auto head_seek_result = co_await storage::convert_begin_offset_to_file_pos(
       _begin_inclusive,
@@ -352,18 +365,6 @@ segment_collector::make_upload_candidate(
     size_t content_length = _collected_size
                             - (head_seek.bytes + last->size_bytes());
     content_length += tail_seek.bytes;
-
-    auto deadline = std::chrono::steady_clock::now() + segment_lock_duration;
-    std::vector<ss::future<ss::rwlock::holder>> locks;
-    locks.reserve(_segments.size());
-    std::transform(
-      _segments.begin(),
-      _segments.end(),
-      std::back_inserter(locks),
-      [&deadline](auto& seg) { return seg->read_lock(deadline); });
-
-    auto locks_resolved = co_await ss::when_all_succeed(
-      locks.begin(), locks.end());
 
     auto starting_offset = head_seek.offset;
     if (starting_offset != _begin_inclusive) {


### PR DESCRIPTION
A read lock is placed on any segment that the cloud storage upload loop selects: compacted or not. The upload loop needs to convert the begin and end offsets into the segments to file offsets for partial uploads.

Previously, in the case of compacted segment reuploads, the locks were taken after the conversion to file offsets. When we couple this with the fact that compacted re-uploads can occur below the latest disk log start offset, it meant that the segment could be removed with an outstanding reader before the locks were acquired. This bubbled up and stopped the upload loop with "Bad file descriptor" errors.

This commit fixes the issue by taking the locks before any readers are created. Note that the non-compacted upload path does the same thing.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [X] v22.3.x
- [ ] v22.2.x

## Release Notes
### Bug Fixes
* Fix race between re-uploaded segment compaction and local truncation that prevented the re-upload
from succeeding.
