### PR TITLE
tests: disable many_partitions_tiered_storage

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -876,12 +876,14 @@ class ManyPartitionsTest(PreallocNodesTest):
     def test_many_partitions(self):
         self._test_many_partitions(compacted=False)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8777
-    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    @matrix(compacted=[False])  # FIXME: run with compaction
-    def test_many_partitions_tiered_storage(self, compacted):
-        self._test_many_partitions(compacted=compacted,
-                                   tiered_storage_enabled=True)
+    # TODO: re-enable once infra has stabilitized
+    # https://github.com/redpanda-data/redpanda/issues/9569
+    # @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8777
+    # @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    # @matrix(compacted=[False])  # FIXME: run with compaction
+    # def test_many_partitions_tiered_storage(self, compacted):
+    #     self._test_many_partitions(compacted=compacted,
+    #                                tiered_storage_enabled=True)
 
     @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_omb(self):


### PR DESCRIPTION
The test is unstable in a way that prevents the ducktape driver from running other tests.

Related #9569

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
