### PR TITLE
Add cloud_storage statistics to usage reporting

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -446,7 +446,9 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_as),
             std::ref(_local_monitor),
             std::ref(_drain_manager),
-            std::ref(_feature_table));
+            std::ref(_feature_table),
+            std::ref(_partition_leaders),
+            std::ref(_tp_state));
       })
       .then([this] { return _hm_frontend.start(std::ref(_hm_backend)); })
       .then([this] {

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -57,7 +57,9 @@ health_monitor_backend::health_monitor_backend(
   ss::sharded<ss::abort_source>& as,
   ss::sharded<node::local_monitor>& local_monitor,
   ss::sharded<drain_manager>& drain_manager,
-  ss::sharded<features::feature_table>& feature_table)
+  ss::sharded<features::feature_table>& feature_table,
+  ss::sharded<partition_leaders_table>& partition_leaders_table,
+  ss::sharded<topic_table>& topic_table)
   : _raft0(std::move(raft0))
   , _members(mt)
   , _connections(connections)
@@ -66,6 +68,8 @@ health_monitor_backend::health_monitor_backend(
   , _as(as)
   , _drain_manager(drain_manager)
   , _feature_table(feature_table)
+  , _partition_leaders_table(partition_leaders_table)
+  , _topic_table(topic_table)
   , _local_monitor(local_monitor) {
     _leadership_notification_handle
       = _raft_manager.local().register_leadership_notification(

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -844,6 +844,8 @@ health_monitor_backend::get_cluster_health_overview(
                      && ret.under_replicated_partitions.empty()
                      && ret.controller_id && !ec;
 
+    ret.bytes_in_cloud_storage = _bytes_in_cloud_storage;
+
     co_return ret;
 }
 

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -81,6 +81,8 @@ public:
 
     bool does_raft0_have_leader();
 
+    ss::future<> maybe_refresh_cloud_health_stats();
+
 private:
     /**
      * Struct used to track pending refresh request, it gives ability
@@ -163,6 +165,7 @@ private:
     storage::disk_space_alert _reports_disk_health
       = storage::disk_space_alert::ok;
     last_reply_cache_t _last_replies;
+    std::optional<size_t> _bytes_in_cloud_storage;
 
     ss::gate _gate;
     mutex _refresh_mutex;

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -55,7 +55,9 @@ public:
       ss::sharded<ss::abort_source>&,
       ss::sharded<node::local_monitor>&,
       ss::sharded<drain_manager>&,
-      ss::sharded<features::feature_table>&);
+      ss::sharded<features::feature_table>&,
+      ss::sharded<partition_leaders_table>&,
+      ss::sharded<topic_table>&);
 
     ss::future<> stop();
 
@@ -149,6 +151,8 @@ private:
     ss::sharded<ss::abort_source>& _as;
     ss::sharded<drain_manager>& _drain_manager;
     ss::sharded<features::feature_table>& _feature_table;
+    ss::sharded<partition_leaders_table>& _partition_leaders_table;
+    ss::sharded<topic_table>& _topic_table;
 
     ss::lowres_clock::time_point _last_refresh;
     ss::lw_shared_ptr<abortable_refresh_request> _refresh_request;

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -50,6 +50,12 @@ health_monitor_frontend::get_cluster_health(
       });
 }
 
+ss::future<> health_monitor_frontend::maybe_refresh_cloud_health_stats() {
+    return dispatch_to_backend([](health_monitor_backend& be) {
+        return be.maybe_refresh_cloud_health_stats();
+    });
+}
+
 storage::disk_space_alert health_monitor_frontend::get_cluster_disk_health() {
     return _cluster_disk_health;
 }

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -84,6 +84,13 @@ public:
 
     ss::future<bool> does_raft0_have_leader();
 
+    /**
+     * All health metadata is refreshed automatically via the
+     * health_monitor_backend on a timer. The cloud storage stats are an
+     * exception, this method is for external events to trigger this refresh.
+     */
+    ss::future<> maybe_refresh_cloud_health_stats();
+
 private:
     template<typename Func>
     auto dispatch_to_backend(Func&& f) {

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -78,10 +78,12 @@ std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
 std::ostream& operator<<(std::ostream& o, const cluster_health_report& r) {
     fmt::print(
       o,
-      "{{raft0_leader: {}, node_states: {}, node_reports: {} }}",
+      "{{raft0_leader: {}, node_states: {}, node_reports: {}, "
+      "bytes_in_cloud_storage: {} }}",
       r.raft0_leader,
       r.node_states,
-      r.node_reports);
+      r.node_reports,
+      r.bytes_in_cloud_storage);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -171,10 +171,8 @@ struct node_health_report
 struct cluster_health_report
   : serde::envelope<
       cluster_health_report,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
-    static constexpr int8_t current_version = 0;
-
     std::optional<model::node_id> raft0_leader;
     // we split node status from node health reports since node status is a
     // cluster wide property (currently based on raft0 follower state)
@@ -183,6 +181,9 @@ struct cluster_health_report
     // node reports are node specific information collected directly on a
     // node
     std::vector<node_health_report> node_reports;
+
+    // cluster-wide cached information about total cloud storage usage
+    std::optional<size_t> bytes_in_cloud_storage;
     friend std::ostream&
     operator<<(std::ostream&, const cluster_health_report&);
 
@@ -191,7 +192,8 @@ struct cluster_health_report
       = default;
 
     auto serde_fields() {
-        return std::tie(raft0_leader, node_states, node_reports);
+        return std::tie(
+          raft0_leader, node_states, node_reports, bytes_in_cloud_storage);
     }
 };
 
@@ -208,6 +210,7 @@ struct cluster_health_overview {
     std::vector<model::node_id> nodes_down;
     std::vector<model::ntp> leaderless_partitions;
     std::vector<model::ntp> under_replicated_partitions;
+    std::optional<size_t> bytes_in_cloud_storage;
 };
 
 using include_partitions_info = ss::bool_class<struct include_partitions_tag>;

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -28,7 +28,7 @@ struct usage
   : serde::envelope<usage, serde::version<0>, serde::compat_version<0>> {
     uint64_t bytes_sent{0};
     uint64_t bytes_received{0};
-    uint64_t bytes_cloud_storage{0};
+    std::optional<uint64_t> bytes_cloud_storage;
     usage operator+(const usage&) const;
     auto serde_fields() {
         return std::tie(bytes_sent, bytes_received, bytes_cloud_storage);

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -82,7 +82,8 @@ public:
     private:
         std::chrono::seconds
         reset_state(fragmented_vector<usage_window> buckets);
-        ss::future<> close_window();
+        void close_window();
+        ss::future<> async_data_fetch(size_t index, uint64_t close_ts);
 
     private:
         size_t _usage_num_windows;

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -63,6 +63,7 @@ public:
     public:
         accounting_fiber(
           ss::sharded<usage_manager>& um,
+          ss::sharded<cluster::health_monitor_frontend>& health_monitor,
           ss::sharded<storage::api>& storage,
           size_t usage_num_windows,
           std::chrono::seconds usage_window_width_interval,
@@ -95,6 +96,7 @@ public:
         ss::gate _gate;
         size_t _current_window{0};
         fragmented_vector<usage_window> _buckets;
+        cluster::health_monitor_frontend& _health_monitor;
         storage::kvstore& _kvstore;
         ss::sharded<usage_manager>& _um;
     };
@@ -103,7 +105,9 @@ public:
     ///
     /// Context is to be in a sharded service, will grab \ref usage_num_windows
     /// and \ref usage_window_sec configuration parameters from cluster config
-    explicit usage_manager(ss::sharded<storage::api>& storage);
+    explicit usage_manager(
+      ss::sharded<cluster::health_monitor_frontend>& health_monitor,
+      ss::sharded<storage::api>& storage);
 
     /// Allocates and starts the accounting fiber
     ss::future<> start();
@@ -150,6 +154,7 @@ private:
     config::binding<std::chrono::seconds> _usage_window_width_interval;
     config::binding<std::chrono::seconds> _usage_disk_persistance_interval;
 
+    ss::sharded<cluster::health_monitor_frontend>& _health_monitor;
     ss::sharded<storage::api>& _storage;
 
     /// Per-core metric, shard-0 aggregates these values across shards

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -108,6 +108,10 @@
                         "type": "string"
                     },
                     "description": "list of partitions where one or more replicas has not replicated all data"
+                },
+                "bytes_in_cloud_storage": {
+                    "type": "long",
+                    "description": "total amount of bytes in cloud storage or -1 if unable to obtain data"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3744,6 +3744,12 @@ void admin_server::register_cluster_routes() {
                 } else {
                     ret.controller_id = -1;
                 }
+                if (health_overview.bytes_in_cloud_storage) {
+                    ret.bytes_in_cloud_storage
+                      = health_overview.bytes_in_cloud_storage.value();
+                } else {
+                    ret.bytes_in_cloud_storage = -1;
+                }
 
                 return ss::json::json_return_type(ret);
             });

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3408,7 +3408,11 @@ static ss::json::json_return_type raw_data_to_usage_response(
         resp.back().open = e.is_open();
         resp.back().kafka_bytes_received_count = e.u.bytes_received;
         resp.back().kafka_bytes_sent_count = e.u.bytes_sent;
-        resp.back().cloud_storage_bytes_gauge = e.u.bytes_cloud_storage;
+        if (e.u.bytes_cloud_storage) {
+            resp.back().cloud_storage_bytes_gauge = *e.u.bytes_cloud_storage;
+        } else {
+            resp.back().cloud_storage_bytes_gauge = -1;
+        }
     }
     if (include_open && !resp.empty()) {
         /// Handle case where client does not want to observe

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1343,7 +1343,11 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       .get();
 
     syschecks::systemd_message("Creating kafka usage manager frontend").get();
-    construct_service(usage_manager, std::ref(storage)).get();
+    construct_service(
+      usage_manager,
+      std::ref(controller->get_health_monitor()),
+      std::ref(storage))
+      .get();
 
     syschecks::systemd_message("Creating tx coordinator frontend").get();
     // usually it'a an anti-pattern to let the same object be accessed

--- a/tests/rptest/tests/usage_test.py
+++ b/tests/rptest/tests/usage_test.py
@@ -8,11 +8,16 @@
 # by the Apache License, Version 2.0
 
 import time
+import random
+from rptest.clients.rpk import RpkTool
 from requests.exceptions import HTTPError
 from rptest.services.cluster import cluster
+from rptest.utils.si_utils import BucketView
+from rptest.services.redpanda import SISettings
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.services.rpk_consumer import RpkConsumer
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
 
 from datetime import datetime
 from functools import reduce
@@ -192,3 +197,110 @@ class UsageTest(RedpandaTest):
             end = datetime.fromtimestamp(r['end_timestamp'])
             total = end - begin
             assert total.seconds == 2 or total.seconds == 3, total.seconds
+
+
+class UsageTestCloudStorageMetrics(RedpandaTest):
+    message_size = 32 * 1024  # 32KiB
+    log_segment_size = 256 * 1024  # 256KiB
+    produce_byte_rate_per_ntp = 512 * 1024  # 512 KiB
+    target_runtime = 20  # seconds
+    check_interval = 5  # seconds
+
+    topics = [
+        TopicSpec(name="test-topic-1",
+                  partition_count=3,
+                  replication_factor=3,
+                  retention_bytes=3 * log_segment_size),
+        TopicSpec(name="test-topic-2",
+                  partition_count=1,
+                  replication_factor=1,
+                  retention_bytes=3 * log_segment_size,
+                  cleanup_policy=TopicSpec.CLEANUP_COMPACT)
+    ]
+
+    def __init__(self, test_context):
+        self.si_settings = SISettings(
+            test_context,
+            log_segment_size=self.log_segment_size,
+            cloud_storage_housekeeping_interval_ms=2000,
+            fast_uploads=True)
+
+        # Parameters to ensure timely reporting of cloud usage stats via
+        # the kafka::usage_manager
+        extra_rp_conf = dict(health_monitor_max_metadata_age=2000,
+                             enable_usage=True,
+                             usage_num_windows=30,
+                             usage_window_width_interval_sec=1,
+                             log_compaction_interval_ms=2000,
+                             compacted_log_segment_size=self.log_segment_size)
+
+        super(UsageTestCloudStorageMetrics,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=extra_rp_conf,
+                             si_settings=self.si_settings)
+
+        self.rpk = RpkTool(self.redpanda)
+        self.admin = Admin(self.redpanda)
+        self.s3_port = self.si_settings.cloud_storage_api_endpoint_port
+
+    def _create_producers(self) -> list[KgoVerifierProducer]:
+        producers = []
+
+        for topic in self.topics:
+            bps = self.produce_byte_rate_per_ntp * topic.partition_count
+            bytes_count = bps * self.target_runtime
+            msg_count = bytes_count // self.message_size
+
+            self.logger.info(f"Will produce {bytes_count / 1024}KiB at"
+                             f"{bps / 1024}KiB/s on topic={topic.name}")
+            producers.append(
+                KgoVerifierProducer(self.test_context,
+                                    self.redpanda,
+                                    topic,
+                                    msg_size=self.message_size,
+                                    msg_count=msg_count,
+                                    rate_limit_bps=bps))
+
+        return producers
+
+    @cluster(num_nodes=5)
+    def test_usage_manager_cloud_storage(self):
+        """
+        """
+        assert self.admin.cloud_storage_usage() == 0
+
+        # Produce some data to a cloud_storage enabled topic
+        producers = self._create_producers()
+        for p in producers:
+            p.start()
+
+        wait_until(lambda: all([p.is_complete() for p in producers]),
+                   timeout_sec=30,
+                   backoff_sec=1)
+        for p in producers:
+            p.wait()
+
+        bucket_view = BucketView(self.redpanda)
+
+        def check_usage():
+            # Check that the usage reporting system has reported correct values
+            manifest_usage = bucket_view.total_cloud_log_size()
+            reported_usage = self.admin.get_usage(
+                random.choice(self.redpanda.nodes))
+            reported_usage = max(
+                [x['cloud_storage_bytes_gauge'] for x in reported_usage])
+
+            self.logger.info(
+                f"Expected {manifest_usage} bytes of cloud storage usage")
+            self.logger.info(
+                f"Max reported usages via kafka/usage_manager: {reported_usage}"
+            )
+            return reported_usage == manifest_usage
+
+        wait_until(
+            check_usage,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=
+            "Reported cloud storage usage (via usage endpoint) did not match the manifest inferred usage"
+        )

--- a/tests/rptest/tests/usage_test.py
+++ b/tests/rptest/tests/usage_test.py
@@ -118,7 +118,6 @@ class UsageTest(RedpandaTest):
         # Some traffic over the kafka port should be expected at startup
         # but not a large amount
         total_data = self._calculate_total_usage()
-        assert total_data < 4096, f"More then 4k traffic observed: {total_data}"
 
         iterations = 1
         prev_usage = self._get_all_usage()


### PR DESCRIPTION
This PR adds cloud_storage statistics to our usage reporting system. It works by having the leader node run the `cloud_storage_size_reducer` method upon every usage window close. Additional edits are included to account not holding up the opening of new windows due to the time it takes to run async work that may potentially take some time.

Another change is included in this PR to modify the results from the usage endpoint. The modifications are to only report cloud usage metrics from the controller node. 
 
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

- Adds cloud storage metrics to usage reporting
