### PR TITLE
Fix race in transactions take_snapshot

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2750,68 +2750,69 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
         });
     }
 
-    iobuf tx_ss_buf;
-    auto version = active_snapshot_version();
-    if (version == tx_snapshot::version) {
-        tx_snapshot tx_ss;
-        fill_snapshot_wo_seqs(tx_ss);
-        for (const auto& entry : _log_state.seq_table) {
-            tx_ss.seqs.push_back(entry.second.entry.copy());
-        }
-        tx_ss.offset = _insync_offset;
-
-        for (const auto& entry : _log_state.tx_seqs) {
-            tx_ss.tx_seqs.push_back(tx_snapshot::tx_seqs_snapshot{
-              .pid = entry.first, .tx_seq = entry.second});
-        }
-
-        for (const auto& entry : _log_state.expiration) {
-            tx_ss.expiration.push_back(tx_snapshot::expiration_snapshot{
-              .pid = entry.first, .timeout = entry.second.timeout});
-        }
-
-        reflection::adl<tx_snapshot>{}.to(tx_ss_buf, std::move(tx_ss));
-    } else if (version == tx_snapshot_v2::version) {
-        tx_snapshot_v2 tx_ss;
-        fill_snapshot_wo_seqs(tx_ss);
-        for (const auto& entry : _log_state.seq_table) {
-            tx_ss.seqs.push_back(entry.second.entry.copy());
-        }
-        tx_ss.offset = _insync_offset;
-        reflection::adl<tx_snapshot_v2>{}.to(tx_ss_buf, std::move(tx_ss));
-    } else if (version == tx_snapshot_v1::version) {
-        tx_snapshot_v1 tx_ss;
-        fill_snapshot_wo_seqs(tx_ss);
-        for (const auto& it : _log_state.seq_table) {
-            auto& entry = it.second.entry;
-            seq_entry_v1 seqs;
-            seqs.pid = entry.pid;
-            seqs.seq = entry.seq;
-            try {
-                seqs.last_offset = to_log_offset(entry.last_offset);
-            } catch (...) {
-                // ignoring outside the translation range errors
-                continue;
+    return f.then([this]() mutable {
+        iobuf tx_ss_buf;
+        auto version = active_snapshot_version();
+        if (version == tx_snapshot::version) {
+            tx_snapshot tx_ss;
+            fill_snapshot_wo_seqs(tx_ss);
+            for (const auto& entry : _log_state.seq_table) {
+                tx_ss.seqs.push_back(entry.second.entry.copy());
             }
-            seqs.last_write_timestamp = entry.last_write_timestamp;
-            seqs.seq_cache.reserve(seqs.seq_cache.size());
-            for (auto& item : entry.seq_cache) {
+            tx_ss.offset = _insync_offset;
+
+            for (const auto& entry : _log_state.tx_seqs) {
+                tx_ss.tx_seqs.push_back(tx_snapshot::tx_seqs_snapshot{
+                  .pid = entry.first, .tx_seq = entry.second});
+            }
+
+            for (const auto& entry : _log_state.expiration) {
+                tx_ss.expiration.push_back(tx_snapshot::expiration_snapshot{
+                  .pid = entry.first, .timeout = entry.second.timeout});
+            }
+
+            reflection::adl<tx_snapshot>{}.to(tx_ss_buf, std::move(tx_ss));
+        } else if (version == tx_snapshot_v2::version) {
+            tx_snapshot_v2 tx_ss;
+            fill_snapshot_wo_seqs(tx_ss);
+            for (const auto& entry : _log_state.seq_table) {
+                tx_ss.seqs.push_back(entry.second.entry.copy());
+            }
+            tx_ss.offset = _insync_offset;
+            reflection::adl<tx_snapshot_v2>{}.to(tx_ss_buf, std::move(tx_ss));
+        } else if (version == tx_snapshot_v1::version) {
+            tx_snapshot_v1 tx_ss;
+            fill_snapshot_wo_seqs(tx_ss);
+            for (const auto& it : _log_state.seq_table) {
+                auto& entry = it.second.entry;
+                seq_entry_v1 seqs;
+                seqs.pid = entry.pid;
+                seqs.seq = entry.seq;
                 try {
-                    seqs.seq_cache.push_back(seq_cache_entry_v1{
-                      .seq = item.seq, .offset = to_log_offset(item.offset)});
+                    seqs.last_offset = to_log_offset(entry.last_offset);
                 } catch (...) {
                     // ignoring outside the translation range errors
                     continue;
                 }
+                seqs.last_write_timestamp = entry.last_write_timestamp;
+                seqs.seq_cache.reserve(seqs.seq_cache.size());
+                for (auto& item : entry.seq_cache) {
+                    try {
+                        seqs.seq_cache.push_back(seq_cache_entry_v1{
+                          .seq = item.seq,
+                          .offset = to_log_offset(item.offset)});
+                    } catch (...) {
+                        // ignoring outside the translation range errors
+                        continue;
+                    }
+                }
+                tx_ss.seqs.push_back(std::move(seqs));
             }
-            tx_ss.seqs.push_back(std::move(seqs));
+            tx_ss.offset = _insync_offset;
+            reflection::adl<tx_snapshot_v1>{}.to(tx_ss_buf, std::move(tx_ss));
+        } else {
+            vassert(false, "unsupported tx_snapshot version {}", version);
         }
-        tx_ss.offset = _insync_offset;
-        reflection::adl<tx_snapshot_v1>{}.to(tx_ss_buf, std::move(tx_ss));
-    } else {
-        vassert(false, "unsupported tx_snapshot version {}", version);
-    }
-    return f.then([this, version, tx_ss_buf = std::move(tx_ss_buf)]() mutable {
         return stm_snapshot::create(
           version, _insync_offset, std::move(tx_ss_buf));
     });

--- a/tests/rptest/tests/tx_abort_index_test.py
+++ b/tests/rptest/tests/tx_abort_index_test.py
@@ -106,11 +106,7 @@ class TxAbortSnapshotTest(RedpandaTest):
                     segments[node.account.hostname].append(m.group(1))
         return segments
 
-    # FIXME: once issue https://github.com/redpanda-data/redpanda/issues/9091 is resolved, remove
-    # the log_allow_list entry for snapshot removal race.
-    @cluster(num_nodes=3,
-             log_allow_list=RESTART_LOG_ALLOW_LIST +
-             ["Raced removing snapshot abort.idx"])
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_index_removal(self) -> None:
         self.fill_idx(self.topics[0].name)
         segments = self.find_segments(self.topics[0].name)


### PR DESCRIPTION
Fix race condition in `tm_stm` `take_snapshot`. 
offload_aborted_txns changes _log_state.aborted
fill_snapshot_wo_seqs uses _log_state.aborted
they shouldn't work in parallel

Fixes #9091
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Fix race condition in `tm_stm` `take_snapshot`. 

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
