### PR TITLE
rptest: tweak allow list of ABS key change test

### DIFF
--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1451,7 +1451,8 @@ class ClusterConfigAzureSharedKey(RedpandaTest):
 
     @cluster(num_nodes=3,
              log_allow_list=[
-                 r"abs - .* Received .* AuthorizationFailure error response"
+                 r"abs - .* Received .* AuthorizationFailure error response",
+                 r"abs - .* Received .* AuthenticationFailed error response"
              ])
     @parametrize(cloud_storage_type=CloudStorageType.ABS)
     def test_live_shared_key_change(self, cloud_storage_type):


### PR DESCRIPTION
This test is failing when running against real Azure (not Azurite), due to an inconsitency in the errors returned.
This commit updates the log allow list to account for the different error returned by Azure.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

