### PR TITLE
cloud_storage: move eviction under remote_partition

### DIFF
--- a/src/v/cloud_storage/materialized_segments.cc
+++ b/src/v/cloud_storage/materialized_segments.cc
@@ -62,30 +62,11 @@ materialized_segments::materialized_segments()
 ss::future<> materialized_segments::stop() {
     cst_log.debug("Stopping materialized_segments...");
     _stm_timer.cancel();
-    _cvar.broken();
 
     co_await _gate.close();
-
-    // Do the last pass over the eviction list to stop remaining items returned
-    // from readers after the eviction loop stopped.
-    for (auto& rs : _eviction_pending) {
-        co_await std::visit(
-          [](auto&& rs) {
-              if (!rs->is_stopped()) {
-                  return rs->stop();
-              } else {
-                  return ss::make_ready_future<>();
-              }
-          },
-          rs);
-    }
     cst_log.debug("Stopped materialized_segments...");
 }
 ss::future<> materialized_segments::start() {
-    // Fiber that consumes from _eviction_list and calls stop
-    // on items before destroying them
-    ssx::spawn_with_gate(_gate, [this] { return run_eviction_loop(); });
-
     // Timer to invoke TTL eviction of segments
     _stm_timer.set_callback([this] {
         trim_segments(std::nullopt);
@@ -112,47 +93,6 @@ size_t materialized_segments::current_readers() const {
 
 size_t materialized_segments::current_segments() const {
     return _segment_units.outstanding();
-}
-
-void materialized_segments::evict_reader(
-  std::unique_ptr<remote_segment_batch_reader> reader) {
-    _eviction_pending.push_back(std::move(reader));
-    _cvar.signal();
-}
-void materialized_segments::evict_segment(
-  ss::lw_shared_ptr<remote_segment> segment) {
-    _eviction_pending.push_back(std::move(segment));
-    _cvar.signal();
-}
-
-ss::future<> materialized_segments::flush_evicted() {
-    if (_eviction_pending.empty() && _eviction_in_flight.empty()) {
-        // Fast path, avoid waking up the eviction loop if there is no work.
-        co_return;
-    }
-
-    auto barrier = ss::make_lw_shared<eviction_barrier>();
-
-    // Write a barrier to the list and wait for the eviction consumer
-    // to reach it: this
-    _eviction_pending.push_back(barrier);
-    _cvar.signal();
-
-    co_await barrier->promise.get_future();
-}
-
-ss::future<> materialized_segments::run_eviction_loop() {
-    // Evict readers asynchronously
-    while (true) {
-        co_await _cvar.wait([this] { return !_eviction_pending.empty(); });
-        _eviction_in_flight = std::exchange(_eviction_pending, {});
-        co_await ss::max_concurrent_for_each(
-          _eviction_in_flight, 1024, [](auto&& rs_variant) {
-              return std::visit(
-                [](auto&& rs) { return rs->stop(); }, rs_variant);
-          });
-        _eviction_in_flight.clear();
-    }
 }
 
 void materialized_segments::register_segment(materialized_segment_state& s) {
@@ -238,7 +178,13 @@ void materialized_segments::trim_readers(size_t target_free) {
         // Readers hold a reference to the segment, so for the
         // segment.owned() check to pass, we need to clear them out.
         while (!st.readers.empty() && _reader_units.current() < target_free) {
-            evict_reader(std::move(st.readers.front()));
+            auto partition = st.parent;
+            // TODO: consider asserting here instead: it's a bug for
+            // 'partition' to be null, since readers outlive the partition, and
+            // we can't create new readers if the partition has been shut down.
+            if (likely(partition)) {
+                partition->evict_reader(std::move(st.readers.front()));
+            }
             st.readers.pop_front();
         }
     }
@@ -356,7 +302,13 @@ void materialized_segments::maybe_trim_segment(
         // Readers hold a reference to the segment, so for the
         // segment.owned() check to pass, we need to clear them out.
         while (!st.readers.empty()) {
-            evict_reader(std::move(st.readers.front()));
+            // TODO: consider asserting here instead: it's a bug for
+            // 'partition' to be null, since readers outlive the partition, and
+            // we can't create new readers if the partition has been shut down.
+            auto partition = st.parent;
+            if (likely(partition)) {
+                partition->evict_reader(std::move(st.readers.front()));
+            }
             st.readers.pop_front();
         }
     }

--- a/src/v/cloud_storage/segment_state.cc
+++ b/src/v/cloud_storage/segment_state.cc
@@ -20,9 +20,9 @@ namespace cloud_storage {
 void materialized_segment_state::offload(remote_partition* partition) {
     _hook.unlink();
     for (auto&& rs : readers) {
-        partition->materialized().evict_reader(std::move(rs));
+        partition->evict_reader(std::move(rs));
     }
-    partition->materialized().evict_segment(std::move(segment));
+    partition->evict_segment(std::move(segment));
     partition->_probe.segment_offloaded();
 }
 


### PR DESCRIPTION
Previously each remote_partition would wait for an eviction barrier to pass through the eviction loop, ensuring all segments are destructed before stopping the partition. Each segment references members of the remote_partition, so it's important the shutdown sequence stops the segments before destructing the remote_partition. At the same time, having each partition wait for another set of partitions to finish flushing can result in a slow shutdown.

This commit moves the eviction loop into the remote_partition, allowing partition shutdown to entirely avoid waiting for any other partition to shut down, while still ensuring that each underlying segment is destructed after the remote_partition.

Without this commit, I witnessed the period of partition shutdown in a heavily loaded server take 30 minutes. With this commit I see a similarly shaped shutdown taking 10 seconds.

Related #9569

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* The shutdown sequence for partitions that use tiered storage is now faster in clusters with heavy read traffic that hydrates readers from object storage.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.



### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
