### PR TITLE
tests: integration testing for compaction with compression

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -111,7 +111,7 @@ function install_rust_tools() {
 
   git clone https://github.com/redpanda-data/client-swarm.git
   pushd client-swarm
-  git reset --hard 63b4cd558203cdd79a69a0893c7435104c10f428
+  git reset --hard 5610f614545ee34f593e1279b30ee9986959d9b0
   cargo build --release
   cp target/release/client-swarm /usr/local/bin
   popd

--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -6,6 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import enum
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
@@ -17,10 +18,20 @@ from rptest.services.producer_swarm import ProducerSwarm
 from ducktape.mark import matrix
 
 
+class CompactionMode(str, enum.Enum):
+    NONE = "none"
+    REALISTIC = "realistic"
+    PATHOLOGICAL = "pathological"
+
+
 class ManyClientsTest(RedpandaTest):
     PRODUCER_COUNT = 4000
 
-    TARGET_THROUGHPUT_MB_S_PER_NODE = 104857600
+    # Our workload generates tiny I/Os, so we anticipate being IOP-bound.
+    # For an i3en.xlarge that can do about 65,000 IOPs, and considering 3x
+    # replication, our per-node throughput would be be about 1/3 of that, if
+    # we were perfectly IOP-bound.
+    TARGET_THROUGHPUT_MB_S_PER_NODE = 40
 
     def __init__(self, *args, **kwargs):
         # We will send huge numbers of messages, so tune down the log verbosity
@@ -30,23 +41,25 @@ class ManyClientsTest(RedpandaTest):
         kwargs['extra_rp_conf'] = {
             # Enable segment size jitter as this is a stress test and does not
             # rely on exact segment counts.
-            'log_segment_size_jitter_percent': 5,
+            'log_segment_size_jitter_percent':
+            5,
+
             # This limit caps the produce throughput to a sustainable rate for a RP
             # cluster that has 384MB of memory per shard. It is set here to
             # since our current backpressure mechanisms will allow producers to
             # produce at a much higher rate and cause RP to run out of memory.
-            'target_quota_byte_rate':
-            31460000,  # 30MiB/s of throughput per shard
-            # Same intention as above but utilizing node-wide throughput limit
             'kafka_throughput_limit_node_in_bps':
-            self.TARGET_THROUGHPUT_MB_S_PER_NODE,  # 100MiB/s per node
+            self.TARGET_THROUGHPUT_MB_S_PER_NODE * 1024 *
+            1024,  # 100MiB/s per node
 
             # Set higher connection count limits than the redpanda default.
             # Factor of 4: allow each client 3 connections (producer,consumer,admin), plus
             # 1 connection to accomodate reconnects while a previous connection is
             # still live.
-            'kafka_connections_max': self.PRODUCER_COUNT * 4,
-            'kafka_connections_max_per_ip': self.PRODUCER_COUNT * 4,
+            'kafka_connections_max':
+            self.PRODUCER_COUNT * 4,
+            'kafka_connections_max_per_ip':
+            self.PRODUCER_COUNT * 4,
         }
         super().__init__(*args, **kwargs)
 
@@ -55,8 +68,11 @@ class ManyClientsTest(RedpandaTest):
         pass
 
     @cluster(num_nodes=7)
-    @matrix(compacted=[True, False])
-    def test_many_clients(self, compacted):
+    @matrix(compaction_mode=[
+        CompactionMode.NONE, CompactionMode.REALISTIC,
+        CompactionMode.PATHOLOGICAL
+    ])
+    def test_many_clients(self, compaction_mode):
         """
         Check that redpanda remains stable under higher numbers of clients
         than usual.
@@ -66,13 +82,22 @@ class ManyClientsTest(RedpandaTest):
         # a workstation.
         assert not self.debug_mode
 
+        # 20MiB is the largest vector of zeros we can use while keeping
+        # the compressed size <1MiB.  snappy is the worst algo for simple arrays
+        # of zeros.
+        pathological_record_size_mb = 20
+        if compaction_mode == CompactionMode.PATHOLOGICAL:
+            compacted_record_size_max_mb = pathological_record_size_mb
+        else:
+            compacted_record_size_max_mb = 1
+
+        num_cpus = 2
+
         # Compacted topics using compression have a higher
         # memory footprint: they may decompress/compress up to two batches
         # per shard concurrently (one for index updates on the produce path,
         # one for housekeeping)
-        compacted_record_size_max_mb = 32
-        num_cpus = 2
-        memory_mb = 768 if not compacted else 768 + compacted_record_size_max_mb * 2 * num_cpus
+        memory_mb = 768 if compaction_mode == CompactionMode.NONE else 768 + compacted_record_size_max_mb * 2 * num_cpus
 
         resource_settings = ResourceSettings(
             num_cpus=num_cpus,
@@ -87,14 +112,6 @@ class ManyClientsTest(RedpandaTest):
         partition_count = 100
         producer_count = self.PRODUCER_COUNT
 
-        if not self.redpanda.dedicated_nodes:
-            # This mode is handy for developers on their workstations
-            producer_count //= 10
-            self.logger.info(
-                f"Running at reduced scale ({producer_count} producers)")
-
-            partition_count = 16
-
         PRODUCER_TIMEOUT_MS = 5000
         TOPIC_NAME = "manyclients"
 
@@ -102,10 +119,7 @@ class ManyClientsTest(RedpandaTest):
         segment_size = 128 * 1024 * 1024
         retention_size = 8 * segment_size
 
-        cleanup_policy = "compact" if compacted else "delete"
-
-        target_throughput_mb_s = self.TARGET_THROUGHPUT_MB_S_PER_NODE * len(
-            self.redpanda.nodes)
+        cleanup_policy = "compact" if compaction_mode != CompactionMode.NONE else "delete"
 
         self.client().create_topic(
             TopicSpec(name=TOPIC_NAME,
@@ -135,40 +149,70 @@ class ManyClientsTest(RedpandaTest):
                                  save_msgs=False)
 
         key_space = 10
-        records_per_producer = 1000
+
+        target_throughput_mb_s = self.TARGET_THROUGHPUT_MB_S_PER_NODE * len(
+            self.redpanda.nodes)
 
         producer_kwargs = {}
-        if compacted:
+        if compaction_mode == CompactionMode.NONE:
+            producer_kwargs['min_record_size'] = 0
+            producer_kwargs['max_record_size'] = 16384
+
+            effective_msg_size = producer_kwargs['min_record_size'] + (
+                producer_kwargs['max_record_size'] -
+                producer_kwargs['min_record_size']) // 2
+        else:
             # Compaction is much more stressful when the clients sends compacted
             # data, because the server must decompress it to index it.
             producer_kwargs['compression_type'] = 'mixed'
 
-            # Use large compressible payloads, to stress memory consumption: a
-            # compressed batch will be accepted by the Kafka API, but
-            producer_kwargs['compressible_payload'] = True,
-            producer_kwargs['min_record_size'] = 16 * 1024 * 1024
-            producer_kwargs[
-                'max_record_size'] = compacted_record_size_max_mb * 1024 * 1024
+            if compaction_mode == CompactionMode.PATHOLOGICAL:
+                # Use large compressible payloads, to stress memory consumption: a
+                # compressed batch will be accepted by the Kafka API, but
+                producer_kwargs['compressible_payload'] = True
+                producer_kwargs['min_record_size'] = 16 * 1024 * 1024
+                producer_kwargs[
+                    'max_record_size'] = pathological_record_size_mb * 1024 * 1024
+
+                # Actual messages are tiny.  Use a heuristic to approximate what kind
+                # of throughput one of these "big batch of zeros" messages would
+                # correspond to if it was a regular batch.
+                effective_msg_size = 256000
+            else:
+                # Regular data that just happens to be compressed: we take the CPU
+                # hit but do not have batches that blow up into huge memory.
+                producer_kwargs['min_record_size'] = 0
+                producer_kwargs['max_record_size'] = 16384
+
+                effective_msg_size = producer_kwargs['min_record_size'] + (
+                    producer_kwargs['max_record_size'] -
+                    producer_kwargs['min_record_size']) // 2
+
             producer_kwargs['keys'] = key_space
 
             # Clients have to do the compression work on these larger messages,
             # so curb our expectations about how many we may run concurrently.
             producer_count = producer_count // 10
-        else:
-            producer_kwargs['min_record_size'] = 0
-            producer_kwargs['max_record_size'] = 16384
 
-        mean_msg_size = producer_kwargs['min_record_size'] + (
-            producer_kwargs['max_record_size'] -
-            producer_kwargs['min_record_size']) // 2
-        msg_rate = (target_throughput_mb_s * 1024 * 1024) // mean_msg_size
-        messages_per_sec_per_producer = msg_rate // self.PRODUCER_COUNT
+        self.logger.info(
+            f"Using mean message size {effective_msg_size} ({producer_kwargs['min_record_size']}-{producer_kwargs['max_record_size']})"
+        )
+
+        msg_rate = (target_throughput_mb_s * 1024 * 1024) // effective_msg_size
+        messages_per_sec_per_producer = msg_rate // producer_count
         producer_kwargs[
             'messages_per_second_per_producer'] = messages_per_sec_per_producer
 
         # If this fails, the test was altered to have an impractical ratio of
         # producers to traffic rate.
         assert messages_per_sec_per_producer > 0, "Bad sizing params, need at least 1 MPS"
+
+        target_runtime_s = 30
+        records_per_producer = messages_per_sec_per_producer * target_runtime_s
+
+        self.logger.info(
+            f"compaction={compaction_mode} mode, {producer_count} producers writing {messages_per_sec_per_producer} msg/s each, {records_per_producer} records each"
+        )
 
         producer = ProducerSwarm(self.test_context,
                                  self.redpanda,
@@ -185,7 +229,7 @@ class ManyClientsTest(RedpandaTest):
         producer.wait()
 
         expect = producer_count * records_per_producer
-        if compacted:
+        if compaction_mode != CompactionMode.NONE:
             # When using compaction, we may well not see all the original messages, as
             # they could have been compacted away before we read them.
             expect = min(partition_count * key_space, expect)

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -44,7 +44,9 @@ class KgoRepeaterService(Service):
                  use_transactions: bool = False,
                  transaction_abort_rate: Optional[float] = None,
                  rate_limit_bps: Optional[int] = None,
-                 msgs_per_transaction: Optional[int] = None):
+                 msgs_per_transaction: Optional[int] = None,
+                 compression_type: Optional[str] = None,
+                 compressible_payload: Optional[bool] = None):
         """
         :param rate_limit_bps: Total rate for all nodes: each node will get an equal share.
         """
@@ -84,6 +86,9 @@ class KgoRepeaterService(Service):
         self.transaction_abort_rate = transaction_abort_rate
         self.msgs_per_transaction = msgs_per_transaction
 
+        self.compression_type = compression_type
+        self.compressible_payload = compressible_payload
+
         self._stopped = False
 
     def clean_node(self, node):
@@ -122,6 +127,12 @@ class KgoRepeaterService(Service):
 
             if self.msgs_per_transaction is not None:
                 cmd += f" -msgs-per-transaction={self.msgs_per_transaction}"
+
+        if self.compression_type is not None:
+            cmd += f" -compression-type={self.compression_type}"
+
+        if self.compressible_payload is not None:
+            cmd += f" -compressible-payload={'true' if self.compressible_payload else 'false'}"
 
         cmd = f"nohup {cmd} >> {self.LOG_PATH} 2>&1 &"
 

--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -30,12 +30,14 @@ class ProducerSwarm(Service):
                  compressible_payload: Optional[bool] = None,
                  min_record_size: Optional[int] = None,
                  max_record_size: Optional[int] = None,
-                 keys: Optional[int] = None):
+                 keys: Optional[int] = None,
+                 messages_per_second_per_producer: Optional[int] = None):
         super(ProducerSwarm, self).__init__(context, num_nodes=1)
         self._redpanda = redpanda
         self._topic = topic
         self._producers = producers
         self._records_per_producer = records_per_producer
+        self._messages_per_second_per_producer = messages_per_second_per_producer
         self._log_level = log_level
         self._properties = properties
         self._timeout_ms = timeout_ms
@@ -75,6 +77,9 @@ class ProducerSwarm(Service):
 
         if self._keys is not None:
             cmd += f" --keys={self._keys}"
+
+        if self._messages_per_second_per_producer is not None:
+            cmd += f" --messages-per-second {self._messages_per_second_per_producer}"
 
         cmd = f"RUST_LOG={self._log_level} bash /opt/remote/control/start.sh {self.EXE} \"{cmd}\""
         node.account.ssh(cmd)

--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.services.service import Service
+from typing import Optional
 
 
 class ProducerSwarm(Service):
@@ -24,7 +25,12 @@ class ProducerSwarm(Service):
                  records_per_producer: int,
                  log_level="DEBUG",
                  properties={},
-                 timeout_ms: int = 1000):
+                 timeout_ms: int = 1000,
+                 compression_type: Optional[str] = None,
+                 compressible_payload: Optional[bool] = None,
+                 min_record_size: Optional[int] = None,
+                 max_record_size: Optional[int] = None,
+                 keys: Optional[int] = None):
         super(ProducerSwarm, self).__init__(context, num_nodes=1)
         self._redpanda = redpanda
         self._topic = topic
@@ -33,9 +39,14 @@ class ProducerSwarm(Service):
         self._log_level = log_level
         self._properties = properties
         self._timeout_ms = timeout_ms
+        self._compression_type = compression_type
+        self._compressible_payload = compressible_payload
+        self._min_record_size = min_record_size
+        self._max_record_size = max_record_size
+        self._keys = keys
 
     def clean_node(self, node):
-        self.redpanda.logger.debug(f"{self.__class__.__name__}.clean_node")
+        self._redpanda.logger.debug(f"{self.__class__.__name__}.clean_node")
         node.account.kill_process(self.EXE, clean_shutdown=False)
         if node.account.exists(self.LOG_PATH):
             node.account.remove(self.LOG_PATH)
@@ -49,6 +60,22 @@ class ProducerSwarm(Service):
         cmd += f" --timeout-ms {self._timeout_ms}"
         for k, v in self._properties.items():
             cmd += f" --properties {k}={v}"
+
+        if self._compressible_payload:
+            cmd += f" --compressible-payload"
+
+        if self._compression_type is not None:
+            cmd += f" --compression-type={self._compression_type}"
+
+        if self._min_record_size is not None:
+            cmd += f" --min-record-size={self._min_record_size}"
+
+        if self._max_record_size is not None:
+            cmd += f" --max-record-size={self._max_record_size}"
+
+        if self._keys is not None:
+            cmd += f" --keys={self._keys}"
+
         cmd = f"RUST_LOG={self._log_level} bash /opt/remote/control/start.sh {self.EXE} \"{cmd}\""
         node.account.ssh(cmd)
         self._redpanda.wait_until(


### PR DESCRIPTION
Issue https://github.com/redpanda-data/redpanda/issues/9521 exposed a lack  of coverage in this area.

The tests are separate to the fixes, because the fixes will be backportable and the tests won't.

In this PR:
- Update kgo-verifier, kgo-repeater and client-swarm to versions that include compression options, including a `mixed` mode that exercises several different codecs at the same time, and an optional highly-compressible payload that can enable huge records (100MB+) to sneak into the cluster under test by compressing below the batch size limit.
- Add a variant of `ManyClientsTest` that uses compaction: this works well as a reproducer for issues like #9521, where many concurrent produce requests can try and get memory for their uncompressed batches at the same time.
- Modify ManyPartitionsTest to use compaction + compression, since this is a stress test to validate scale, and we should use the most stressful type of traffic.
- Revamp ManyClientsTest message counts etc to adapt its runtime to the different variants (compaction, non-compacted), and use rate limiting to make the runtime more consistent by avoiding clients stalling on long backoffs.

Fixes: https://github.com/redpanda-data/redpanda/issues/10092

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
