### PR TITLE
cloud_storage: Prevent segment from being added to the manifest twice

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -222,7 +222,8 @@ FIXTURE_TEST(test_archival_stm_segment_replace, archival_metadata_stm_fixture) {
       .base_offset = model::offset(0),
       .committed_offset = model::offset(999),
       .archiver_term = model::term_id(1),
-      .segment_term = model::term_id(1)});
+      .segment_term = model::term_id(1),
+      .sname_format = cloud_storage::segment_name_format::v2});
     archival_stm->add_segments(m2, std::nullopt, ss::lowres_clock::now() + 10s)
       .get();
     archival_stm->sync(10s).get();
@@ -519,6 +520,7 @@ FIXTURE_TEST(test_archival_stm_batching, archival_metadata_stm_fixture) {
     wait_for_confirmed_leader();
     std::vector<cloud_storage::segment_meta> m;
     m.push_back(segment_meta{
+      .size_bytes = 200,
       .base_offset = model::offset(0),
       .committed_offset = model::offset(999),
       .archiver_term = model::term_id(1),
@@ -529,10 +531,12 @@ FIXTURE_TEST(test_archival_stm_batching, archival_metadata_stm_fixture) {
       .archiver_term = model::term_id(1),
       .segment_term = model::term_id(1)});
     m.push_back(segment_meta{
+      .size_bytes = 100,
       .base_offset = model::offset(0),
       .committed_offset = model::offset(999),
       .archiver_term = model::term_id(2),
-      .segment_term = model::term_id(1)});
+      .segment_term = model::term_id(1),
+      .sname_format = cloud_storage::segment_name_format::v2});
     // Replicate add_segment_cmd command that adds segment with offset 0
     auto batcher = archival_stm->batch_start(ss::lowres_clock::now() + 10s);
     batcher.add_segments(m);

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -327,7 +327,9 @@ private:
     /// Move segments from _segments to _replaced
     /// Returns the total size in bytes of the replaced segments
     size_t move_aligned_offset_range(
-      model::offset begin_inclusive, model::offset end_inclusive);
+      model::offset begin_inclusive,
+      model::offset end_inclusive,
+      const segment_meta& replacing_segment);
 
     friend class serialization_cursor_data_source;
 


### PR DESCRIPTION
Throw exception if the segment with the same parameters is added to the manifest second time. In this case the 'replaced' and 'segments' lists will have the same segment. The name of the segment is the same so when the housekeeping will remove it we will lose the data completely.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Prevent possible data loss in situation when the same segment is added twice to the manifest