### PR TITLE
compression: fix bad_allocs in lz4 compression, gzip compression+decompression

### DIFF
--- a/src/v/compression/internal/gzip_compressor.cc
+++ b/src/v/compression/internal/gzip_compressor.cc
@@ -142,7 +142,9 @@ iobuf gzip_compressor::compress(const iobuf& b) {
     iobuf ret;
     auto frag_i = b.begin();
     while (true) {
-        if (strm.avail_in == 0 && frag_i != b.end()) {
+        // If our input fragment is empty and we have more fragments, consume
+        // advance until we find a non-empty fragment.
+        while (strm.avail_in == 0 && frag_i != b.end()) {
             strm.next_in = const_cast<unsigned char*>(
               reinterpret_cast<const unsigned char*>(frag_i->get()));
             strm.avail_in = frag_i->size();
@@ -199,7 +201,7 @@ iobuf gzip_decompression_codec::inflate_to_iobuf() {
         default: /*do nothing*/;
         }
 
-        if (_stream.avail_in == 0) {
+        while (_stream.avail_in == 0 && _input_chunk != _input.end()) {
             _input_chunk++;
             if (_input_chunk != _input.end()) {
                 _stream.next_in = const_cast<unsigned char*>(

--- a/src/v/compression/internal/gzip_compressor.cc
+++ b/src/v/compression/internal/gzip_compressor.cc
@@ -76,9 +76,9 @@ private:
 };
 class gzip_decompression_codec {
 public:
-    gzip_decompression_codec(const char* src, size_t src_size) noexcept
-      : _input(src)
-      , _input_size(src_size) {}
+    gzip_decompression_codec(const iobuf& input) noexcept
+      : _input(input)
+      , _input_chunk(input.begin()) {}
     gzip_decompression_codec(const gzip_decompression_codec&) = delete;
     gzip_decompression_codec& operator=(const gzip_decompression_codec&)
       = delete;
@@ -91,8 +91,8 @@ public:
         _stream = default_zstream();
         // zlib is not const-correct
         // NOLINTNEXTLINE
-        _stream.next_in = (unsigned char*)_input;
-        _stream.avail_in = _input_size;
+        _stream.next_in = (unsigned char*)(_input_chunk->get());
+        _stream.avail_in = _input_chunk->size();
         throw_if_zstream_error(
           "gzip error with inflateInit2:{}", inflateInit2(&_stream, 15 + 32));
         // marking init must happen before gzip header
@@ -103,7 +103,7 @@ public:
           "gzip inflateGetHeader error:{}", inflateGetHeader(&_stream, &_hdr));
     }
 
-    void inflate_to(char* output, size_t out_size);
+    iobuf inflate_to_iobuf();
 
     ~gzip_decompression_codec() {
         if (_init) {
@@ -117,106 +117,113 @@ public:
 
 private:
     bool _init{false};
-    const char* _input;
-    size_t _input_size;
+
+    const iobuf& _input;
+    iobuf::const_iterator _input_chunk;
+
     gz_header _hdr; // needed for gzip
     z_stream _stream;
 };
 
 iobuf gzip_compressor::compress(const iobuf& b) {
-    ss::temporary_buffer<char> obuf;
-    {
-        gzip_compression_codec def;
-        def.reset();
-        z_stream& strm = def.stream();
-        /* Calculate maximum compressed size and
-         * allocate an output buffer accordingly, being
-         * prefixed with the Message header. */
-        const size_t output_size = deflateBound(&strm, b.size_bytes());
-        obuf = ss::temporary_buffer<char>(output_size);
+    const size_t max_chunk_size = details::io_allocation_size::max_chunk_size;
 
-        // NOLINTNEXTLINE
-        strm.next_out = (unsigned char*)obuf.get_write();
-        strm.avail_out = output_size;
+    gzip_compression_codec def;
+    def.reset();
+    z_stream& strm = def.stream();
 
-        /* Iterate through each segment and compress it. */
-        for (auto& io : b) {
-            // zlib is not const correct
-            // NOLINTNEXTLINE
-            strm.next_in = (unsigned char*)io.get();
-            strm.avail_in = io.size();
-            throw_if_zstream_error(
-              "gzip error compressing chunk: {}", deflate(&strm, Z_NO_FLUSH));
-        }
-        /* Finish the compression */
-        if (int ret = deflate(&strm, Z_FINISH); ret != Z_STREAM_END) {
-            throw_if_zstream_error("gzip error finishing compression: {}", ret);
-        }
-        obuf.trim(def.stream().total_out);
-        // trigger deflateEnd
-    }
+    const size_t output_size_estimate = deflateBound(&strm, b.size_bytes());
+    size_t output_chunk_size = std::min(max_chunk_size, output_size_estimate);
+
+    ss::temporary_buffer<char> obuf(output_chunk_size);
+    strm.next_out = reinterpret_cast<unsigned char*>(obuf.get_write());
+    strm.avail_out = obuf.size();
+
     iobuf ret;
+    auto frag_i = b.begin();
+    while (true) {
+        if (strm.avail_in == 0 && frag_i != b.end()) {
+            strm.next_in = const_cast<unsigned char*>(
+              reinterpret_cast<const unsigned char*>(frag_i->get()));
+            strm.avail_in = frag_i->size();
+            frag_i++;
+        }
+
+        if (strm.avail_out == 0) {
+            obuf.trim(output_chunk_size - strm.avail_out);
+            ret.append(std::move(obuf));
+            output_chunk_size = std::min(output_chunk_size * 2, max_chunk_size);
+            obuf = ss::temporary_buffer<char>(output_chunk_size);
+            strm.next_out = reinterpret_cast<unsigned char*>(obuf.get_write());
+            strm.avail_out = obuf.size();
+        }
+
+        int flush = (strm.avail_in == 0) ? Z_FINISH : Z_NO_FLUSH;
+        int deflate_r = deflate(&strm, flush);
+        if (deflate_r == Z_STREAM_END) {
+            break;
+        }
+        throw_if_zstream_error("gzip error compressing chunk: {}", deflate_r);
+    }
+
+    obuf.trim(strm.total_out - ret.size_bytes());
     ret.append(std::move(obuf));
+
     return ret;
 }
 
-void gzip_decompression_codec::inflate_to(char* output, size_t out_size) {
-    size_t consumed_bytes = 0;
+iobuf gzip_decompression_codec::inflate_to_iobuf() {
+    // Max memory allocation
+    const size_t max_chunk_size = details::io_allocation_size::max_chunk_size;
+
+    // Rough guess at compression ratio to guess initial chunk size for
+    // small buffers.
+    size_t chunk_size = std::min(max_chunk_size, _input.size_bytes() * 3);
+
     int code = 0;
-    // NOLINTNEXTLINE
-    auto out = reinterpret_cast<unsigned char*>(output);
+    iobuf output;
     do {
-        // NOLINTNEXTLINE
-        _stream.next_out = out + consumed_bytes;
-        _stream.avail_out = out_size - consumed_bytes;
+        chunk_size = std::min(max_chunk_size, chunk_size * 2);
+
+        ss::temporary_buffer<char> tmp(chunk_size);
+        _stream.next_out = reinterpret_cast<unsigned char*>(tmp.get_write());
+        _stream.avail_out = chunk_size;
+
         code = inflate(&_stream, Z_NO_FLUSH);
         switch (code) {
         case Z_STREAM_ERROR:
         case Z_NEED_DICT:
         case Z_DATA_ERROR:
         case Z_MEM_ERROR:
-            throw_zstream_error("gzip uncmpress error:{}", code);
+            throw_zstream_error("gzip uncompress error:{}", code);
         default: /*do nothing*/;
         }
-        /* Advance output pointer (in pass 2). */
-        consumed_bytes = out_size - _stream.avail_out - consumed_bytes;
-    } while (_stream.avail_out == 0 && code != Z_STREAM_END);
-}
 
-static ss::temporary_buffer<char>
-buffer_for_input(const char* src, size_t src_size) {
-    auto codec = gzip_decompression_codec(src, src_size);
-    codec.reset();
-    std::array<char, 512> dummy_buf{};
-    // find gzip header
-    codec.inflate_to(dummy_buf.data(), dummy_buf.size());
-    return ss::temporary_buffer<char>(codec.stream().total_out);
-}
+        if (_stream.avail_in == 0) {
+            _input_chunk++;
+            if (_input_chunk != _input.end()) {
+                _stream.next_in = const_cast<unsigned char*>(
+                  reinterpret_cast<const unsigned char*>(_input_chunk->get()));
+                _stream.avail_in = _input_chunk->size();
+            }
+        }
 
-static iobuf do_uncompress(const char* src, size_t src_size) {
-    ss::temporary_buffer<char> buf;
-    {
-        auto codec = gzip_decompression_codec(src, src_size);
-        codec.reset();
-        buf = buffer_for_input(src, src_size);
-        // main data decompression
-        codec.inflate_to(buf.get_write(), buf.size());
+        size_t written_out_this_iter = chunk_size - _stream.avail_out;
+        tmp.trim(written_out_this_iter);
+        output.append(std::move(tmp));
+    } while (code == Z_OK && _stream.avail_in > 0);
+
+    if (code != Z_OK && code != Z_STREAM_END) {
+        throw_zstream_error("gzip uncompress error:{}", code);
     }
-    iobuf ret;
-    ret.append(std::move(buf));
-    return ret;
+
+    return output;
 }
 
 iobuf gzip_compressor::uncompress(const iobuf& b) {
-    if (std::distance(b.begin(), b.end()) == 1) {
-        return do_uncompress(b.begin()->get(), b.size_bytes());
-    }
-    // linearize buffer
-    // TODO: use streaming interface instead
-    auto linearized = iobuf_to_bytes(b);
-    return do_uncompress(
-      // NOLINTNEXTLINE
-      reinterpret_cast<const char*>(linearized.data()),
-      linearized.size());
+    auto codec = gzip_decompression_codec(b);
+    codec.reset();
+    return codec.inflate_to_iobuf();
 }
+
 } // namespace compression::internal

--- a/src/v/compression/internal/lz4_frame_compressor.cc
+++ b/src/v/compression/internal/lz4_frame_compressor.cc
@@ -10,11 +10,9 @@
 #include "compression/internal/lz4_frame_compressor.h"
 
 #include "bytes/bytes.h"
-#include "compression/logger.h"
 #include "static_deleter_fn.h"
 #include "units.h"
 #include "vassert.h"
-#include "vlog.h"
 
 #include <seastar/core/temporary_buffer.hh>
 
@@ -76,39 +74,90 @@ iobuf lz4_frame_compressor::compress(const iobuf& b) {
     prefs.compressionLevel = 1; // default
     prefs.frameInfo = {
       .blockMode = LZ4F_blockIndependent, .contentSize = b.size_bytes()};
-    const size_t output_buffer_size = LZ4F_compressBound(b.size_bytes(), &prefs)
-                                      + lz4f_footer_size + lz4f_header_size;
-    check_lz4_error("lz4_compressbound erorr:{}", output_buffer_size);
-    ss::temporary_buffer<char> obuf(output_buffer_size);
-    char* out = obuf.get_write();
-    LZ4F_errorCode_t code = LZ4F_compressBegin(
-      ctx, out, output_buffer_size, &prefs);
-    check_lz4_error("lz4f_compressbegin error:{}", code);
 
-    // start after the bytes from compressBegin
-    size_t consumed_bytes = code;
-    for (auto& frag : b) {
+    const size_t max_chunk_size = details::io_allocation_size::max_chunk_size;
+
+    const size_t compress_bound = LZ4F_compressBound(b.size_bytes(), &prefs);
+    check_lz4_error("lz4_compressbound error:{}", compress_bound);
+
+    const size_t estimated_output_size = compress_bound + lz4f_footer_size
+                                         + lz4f_header_size;
+
+    size_t output_chunk_size = std::min(max_chunk_size, estimated_output_size);
+
+    ss::temporary_buffer<char> obuf(output_chunk_size);
+    char* output = obuf.get_write();
+    size_t output_sz = output_chunk_size;
+    LZ4F_errorCode_t code = LZ4F_compressBegin(
+      ctx, output, obuf.size(), &prefs);
+    check_lz4_error("lz4f_compressbegin error:{}", code);
+    size_t output_cursor = code;
+
+    auto frag_i = b.begin();
+
+    const char* input = nullptr;
+    size_t input_sz = 0;
+    size_t input_cursor = 0;
+    if (frag_i != b.end()) {
+        input = frag_i->get();
+        input_sz = frag_i->size();
+    }
+
+    // We do not consume entire input chunks at once, to avoid
+    // max_chunk_size input chunks resulting in >max_chunk_size output
+    // chunks.  A half-sized input chunk never results in a LZ4F_compressBound
+    // that exceeds a the max output chunk.
+    const size_t max_input_chunk_size = max_chunk_size / 2;
+
+    iobuf ret;
+    while (input_cursor < input_sz || frag_i != b.end()) {
+        if ((input_sz - input_cursor) == 0 && frag_i != b.end()) {
+            frag_i++;
+            if (frag_i != b.end()) {
+                input = frag_i->get();
+                input_sz = frag_i->size();
+                input_cursor = 0;
+            }
+        }
+
+        size_t input_chunk_size = std::min(
+          input_sz - input_cursor, max_input_chunk_size);
+
         code = LZ4F_compressUpdate(
           ctx,
-          // NOLINTNEXTLINE
-          out + consumed_bytes,
-          output_buffer_size - consumed_bytes,
-          frag.get(),
-          frag.size(),
+          output + output_cursor,
+          output_sz - output_cursor,
+          input + input_cursor,
+          input_chunk_size,
           nullptr);
         check_lz4_error("lz4f_compressupdate error:{}", code);
-        consumed_bytes += code;
+
+        // We always consume all input buffer
+        input_cursor += input_chunk_size;
+
+        // Advance by how many bytes we consumed
+        output_cursor += code;
+
+        input_chunk_size = std::min(
+          input_sz - input_cursor, max_input_chunk_size);
+        size_t next_output_size = LZ4F_compressBound(input_chunk_size, &prefs);
+
+        if (output_sz - output_cursor < next_output_size) {
+            obuf.trim(output_cursor);
+            ret.append(std::move(obuf));
+            output_chunk_size = std::min(max_chunk_size, output_chunk_size * 2);
+            obuf = ss::temporary_buffer<char>(output_chunk_size);
+            output = obuf.get_write();
+            output_sz = obuf.size();
+            output_cursor = 0;
+        }
     }
+
     code = LZ4F_compressEnd(
-      ctx,
-      // NOLINTNEXTLINE
-      out + consumed_bytes,
-      output_buffer_size - consumed_bytes,
-      nullptr);
+      ctx, output + output_cursor, output_sz - output_cursor, nullptr);
     check_lz4_error("lz4f_compressend:{}", code);
-    consumed_bytes += code;
-    obuf.trim(consumed_bytes);
-    iobuf ret;
+    output_cursor += code;
+    obuf.trim(output_cursor);
     ret.append(std::move(obuf));
     return ret;
 }
@@ -121,66 +170,78 @@ compute_frame_uncompressed_size(size_t frame_size, size_t original) {
     return frame_size;
 }
 
-static iobuf do_uncompressed(const char* src, const size_t src_size) {
-    auto ctx_ptr = make_decompression_context();
-    LZ4F_decompressionContext_t ctx = ctx_ptr.get();
-    LZ4F_frameInfo_t fi;
-    size_t in_sz = src_size;
-    LZ4F_errorCode_t code = LZ4F_getFrameInfo(ctx, &fi, src, &in_sz);
-    check_lz4_error("lz4f_getframeinfo error: {}", code);
-    size_t this_chunk_size = compute_frame_uncompressed_size(
-      fi.contentSize, src_size);
+iobuf lz4_frame_compressor::uncompress(iobuf const& input) {
+    size_t src_size = input.size_bytes();
 
-    size_t max_chunk = 128_KiB;
-    this_chunk_size = std::min(this_chunk_size, max_chunk);
-
-    // We will decompress into temporary_buffers, and each time
-    // we spill past estimated_output_size, push the
-    ss::temporary_buffer<char> obuf(this_chunk_size);
-    char* out = obuf.get_write();
-
-    // Offset in `src` buffer
-    size_t src_offset = in_sz;
-
-    // Offset in `out` buffer
-    size_t output_this_chunk{0};
+    const size_t max_chunk = details::io_allocation_size::max_chunk_size;
 
     // Compose fragmented result from a series of `obuf` temporary buffers
     iobuf ret;
 
-    while (src_offset < src_size) {
+    // Read interators/offsets
+    auto frag_i = input.begin();
+    size_t read_this_chunk{0};
+    size_t read_total{0};
+
+    auto ctx_ptr = make_decompression_context();
+    LZ4F_decompressionContext_t ctx = ctx_ptr.get();
+
+    // Prior to main loop, optionally consume header to learn total size
+    LZ4F_errorCode_t code = 0;
+    size_t decompressed_size = 0;
+    if (!input.empty() && input.begin()->size() >= lz4f_header_size) {
+        // This is optional, because it is not guaranteed that the caller
+        // passes us an iobuf with the header in a contiguous chunk.
+        auto& first_chunk = *(input.begin());
+        size_t sz_scratch = first_chunk.size();
+        LZ4F_frameInfo_t fi;
+        code = LZ4F_getFrameInfo(ctx, &fi, first_chunk.get(), &sz_scratch);
+        read_this_chunk = sz_scratch;
+        read_total += sz_scratch;
+        check_lz4_error("lz4f_getframeinfo error: {}", code);
+        decompressed_size = fi.contentSize;
+    }
+    size_t write_chunk_size = compute_frame_uncompressed_size(
+      decompressed_size, src_size);
+    write_chunk_size = std::min(write_chunk_size, max_chunk);
+
+    // Write buffer/offsets
+    size_t write_this_chunk{0};
+    ss::temporary_buffer<char> obuf(write_chunk_size);
+    char* out = obuf.get_write();
+
+    while (frag_i != input.end()) {
         // These variables at as an input to LZ4F_decompress to specify
         // buffer size, and then as an output for how many bytes the
         // buffers advanced.
-        size_t consumed_this_iteration = src_size - src_offset;
-        size_t output_this_iteration = this_chunk_size - output_this_chunk;
+        size_t consumed_this_iteration = frag_i->size() - read_this_chunk;
+        size_t output_this_iteration = obuf.size() - write_this_chunk;
 
         code = LZ4F_decompress(
           ctx,
-          // NOLINTNEXTLINE
-          out + output_this_chunk,
+          out + write_this_chunk,
           &output_this_iteration,
-          // NOLINTNEXTLINE
-          src + src_offset,
+          frag_i->get() + read_this_chunk,
           &consumed_this_iteration,
           nullptr);
 
-        output_this_chunk += output_this_iteration;
-        src_offset += consumed_this_iteration;
+        write_this_chunk += output_this_iteration;
+        read_this_chunk += consumed_this_iteration;
+        read_total += consumed_this_iteration;
 
         vassert(
-          output_this_chunk <= this_chunk_size,
+          write_this_chunk <= write_chunk_size,
           "Appended more bytes that allowed. Max:{}, consumed:{} ({} this "
           "iteration)",
-          this_chunk_size,
-          output_this_chunk,
+          write_chunk_size,
+          write_this_chunk,
           output_this_iteration);
 
         vassert(
-          src_offset <= src_size,
+          read_this_chunk <= frag_i->size(),
           "Consumed more bytes than in input buffer (size {}, consumed {})",
-          src_size,
-          src_offset);
+          frag_i->size(),
+          read_this_chunk);
 
         check_lz4_error("lz4f_decompress error: {}", code);
 
@@ -188,45 +249,37 @@ static iobuf do_uncompressed(const char* src, const size_t src_size) {
             break;
         }
 
-        if (output_this_chunk == this_chunk_size && src_offset < src_size) {
+        if (read_this_chunk == frag_i->size()) {
+            read_this_chunk = 0;
+            frag_i++;
+        }
+
+        if (write_this_chunk == write_chunk_size && frag_i != input.end()) {
             ret.append(std::move(obuf));
 
             // If we were using a smaller-than-max chunk, grow it
-            this_chunk_size = std::min(max_chunk, this_chunk_size * 2);
+            write_chunk_size = std::min(max_chunk, write_chunk_size * 2);
 
-            obuf = ss::temporary_buffer<char>(this_chunk_size);
+            obuf = ss::temporary_buffer<char>(write_chunk_size);
             out = obuf.get_write();
-            output_this_chunk = 0;
+            write_this_chunk = 0;
         }
     }
 
-    if (unlikely(src_offset < src_size)) {
+    if (unlikely(read_total < src_size)) {
         throw std::runtime_error(fmt::format(
           "lz4 error. could not consume all input bytes in decompression. "
           "Input:{}, consumed:{}",
           src_size,
-          src_offset));
+          read_total));
     }
 
-    if (output_this_chunk > 0) {
-        obuf.trim(output_this_chunk);
+    if (write_this_chunk > 0) {
+        obuf.trim(write_this_chunk);
         ret.append(std::move(obuf));
     }
 
     return ret;
-}
-
-iobuf lz4_frame_compressor::uncompress(const iobuf& b) {
-    if (std::distance(b.begin(), b.end()) == 1) {
-        return do_uncompressed(b.begin()->get(), b.size_bytes());
-    }
-    // linearize buffer
-    // TODO: optimize iobuf
-    auto linearized = iobuf_to_bytes(b);
-    return do_uncompressed(
-      // NOLINTNEXTLINE
-      reinterpret_cast<const char*>(linearized.data()),
-      linearized.size());
 }
 
 } // namespace compression::internal

--- a/src/v/compression/tests/zstd_stream_bench.cc
+++ b/src/v/compression/tests/zstd_stream_bench.cc
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0
 
 #include "compression/async_stream_zstd.h"
+#include "compression/internal/gzip_compressor.h"
+#include "compression/internal/lz4_frame_compressor.h"
 #include "compression/stream_zstd.h"
 #include "random/generators.h"
 #include "units.h"
@@ -76,6 +78,71 @@ PERF_TEST(streaming_zstd_1mb, compress) { compress_test(1 << 20); }
 PERF_TEST(streaming_zstd_1mb, uncompress) { return uncompress_test(1 << 20); }
 PERF_TEST(streaming_zstd_10mb, compress) { compress_test(10 << 20); }
 PERF_TEST(streaming_zstd_10mb, uncompress) { return uncompress_test(10 << 20); }
+
+template<typename CompressFunc>
+inline void compress_fn_test(CompressFunc&& comp_fn, size_t data_size) {
+    auto o = gen(data_size);
+    perf_tests::start_measuring_time();
+    perf_tests::do_not_optimize(comp_fn(o));
+    perf_tests::stop_measuring_time();
+}
+
+template<typename CompressFunc, typename UncompressFunc>
+inline void uncompress_fn_test(
+  CompressFunc&& comp_fn, UncompressFunc&& uncomp_fn, size_t data_size) {
+    auto o = comp_fn(gen(data_size));
+    perf_tests::start_measuring_time();
+    perf_tests::do_not_optimize(uncomp_fn(o));
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(lz4_1mb, compress) {
+    return compress_fn_test(
+      compression::internal::lz4_frame_compressor::compress, 1 << 20);
+}
+
+PERF_TEST(lz4_10mb, compress) {
+    return compress_fn_test(
+      compression::internal::lz4_frame_compressor::compress, 10 << 20);
+}
+
+PERF_TEST(lz4_1mb, uncompress) {
+    return uncompress_fn_test(
+      compression::internal::lz4_frame_compressor::compress,
+      compression::internal::lz4_frame_compressor::uncompress,
+      1 << 20);
+}
+
+PERF_TEST(lz4_10mb, uncompress) {
+    return uncompress_fn_test(
+      compression::internal::lz4_frame_compressor::compress,
+      compression::internal::lz4_frame_compressor::uncompress,
+      10 << 20);
+}
+
+PERF_TEST(gzip_1mb, compress) {
+    return compress_fn_test(
+      compression::internal::gzip_compressor::compress, 1 << 20);
+}
+
+PERF_TEST(gzip_10mb, compress) {
+    return compress_fn_test(
+      compression::internal::gzip_compressor::compress, 10 << 20);
+}
+
+PERF_TEST(gzip_1mb, uncompress) {
+    return uncompress_fn_test(
+      compression::internal::gzip_compressor::compress,
+      compression::internal::gzip_compressor::uncompress,
+      1 << 20);
+}
+
+PERF_TEST(gzip_10mb, uncompress) {
+    return uncompress_fn_test(
+      compression::internal::gzip_compressor::compress,
+      compression::internal::gzip_compressor::uncompress,
+      10 << 20);
+}
 
 struct async_stream_zstd {};
 PERF_TEST_C(async_stream_zstd, 1mb_compress) {

--- a/src/v/compression/tests/zstd_tests.cc
+++ b/src/v/compression/tests/zstd_tests.cc
@@ -50,7 +50,15 @@ static std::vector<size_t> get_test_sizes() {
         test_sizes.push_back(size);
     }
     test_sizes.push_back(details::io_allocation_size::alloc_table.back() * 2);
+    test_sizes.push_back(
+      details::io_allocation_size::alloc_table.back() * 2 - 1);
+    test_sizes.push_back(
+      details::io_allocation_size::alloc_table.back() * 2 + 1);
     test_sizes.push_back(details::io_allocation_size::alloc_table.back() * 3);
+    test_sizes.push_back(
+      details::io_allocation_size::alloc_table.back() * 3 + 1);
+    test_sizes.push_back(
+      details::io_allocation_size::alloc_table.back() * 3 - 1);
     return test_sizes;
 }
 


### PR DESCRIPTION
Previous PR https://github.com/redpanda-data/redpanda/pull/9563 fixed the most impactful case, but there were several other places in compression code where we could crash on oversized allocations.  This PR revises compression and decompression paths to keep their allocations inside 128KiB.

Performance:
- gzip decompression is >2x better, because the old implementation did two full decompressions (one to learn the size, one to write the data).
- LZ4 is noticeably slower: as a faster algorithm it makes the impact of doing more buffer management most apparent.  I tried turning `max_chunk_size` up to 1MiB and the performance of the 1MiB microbenchmark goes back to exactly what it was pre-fixes, so the performance change appears to be entirely attributable to the (necessary) fragmentation, rather than being anything pathological about the new code.

```

# Before fixes

lz4_1mb.compress                               15024    50.629us     3.845ns    50.625us    50.667us       5.000       0.000   1125423.4
lz4_10mb.compress                               1600   481.005us    36.839ns   480.945us   481.280us       5.000       0.000  11213003.1
lz4_1mb.uncompress                             10626    27.361us    16.434ns    27.342us    27.419us       5.000       0.000    822936.3
lz4_10mb.uncompress                             1123   268.318us    31.929ns   268.163us   268.955us       5.000       0.000   8211884.1
gzip_1mb.compress                                600     1.659ms     1.850us     1.655ms     1.661ms       7.000       0.000  37183003.3
gzip_10mb.compress                                61    16.493ms    18.139us    16.371ms    16.511ms       7.000       0.000 371541188.2
gzip_1mb.uncompress                              389   883.695us     1.419us   882.276us   886.345us       5.000       0.000  15696291.6
gzip_10mb.uncompress                              40     8.708ms     3.876us     8.704ms     8.722ms       5.000       0.000 156360045.5

# After fixes

lz4_1mb.compress                               13712    56.909us    47.060ns    56.862us    57.121us       5.000       0.000   1130008.4
lz4_10mb.compress                               1418   561.559us   239.045ns   559.300us   562.755us       8.000       0.000  11247098.7
lz4_1mb.uncompress                              8892    40.528us    41.428ns    40.479us    40.612us      26.000       0.000    830291.6
lz4_10mb.uncompress                              882   433.802us    49.307ns   433.599us   434.463us     242.000       0.000   8295986.0

gzip_1mb.compress                                595     1.665ms     1.768us     1.663ms     1.667ms       7.000       0.000  37183299.4
gzip_10mb.compress                                61    16.548ms    40.417us    16.467ms    16.630ms       7.000       0.000 371542070.3
gzip_1mb.uncompress                              491   375.450us    84.352ns   375.198us   376.265us      28.000       0.000   7682711.6
gzip_10mb.uncompress                              50     3.773ms    10.248us     3.761ms     3.784ms     241.000       0.000  76618644.5

```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

(And for v22.3.x + v22.2.x, cherry pick in https://github.com/redpanda-data/redpanda/pull/9563 as well)

## Release Notes

### Bug Fixes

* Fix cases where sending very large batches to compacted topics using LZ4 or gzip compression could result in bad_alloc errors.
