### PR TITLE
Support disk space reclaim estimation

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1697,4 +1697,74 @@ log make_disk_backed_log(
     return log(ptr);
 }
 
+ss::future<reclaim_size_limits>
+disk_log_impl::estimate_reclaim_size(compaction_config cfg) {
+    if (!config().is_collectable()) {
+        co_return reclaim_size_limits();
+    }
+
+    cfg = apply_overrides(cfg);
+
+    auto max_offset = retention_offset(cfg);
+    if (!max_offset.has_value()) {
+        co_return reclaim_size_limits();
+    }
+
+    /*
+     * evicting data based on the retention policy is a coordinated effort
+     * between disk_log_impl housekeeping and the raft/eviction_stm. it works
+     * roughly as follows:
+     *
+     * 1. log computes ideal target offset for reclaim: max_offset computed by
+     *    the call to retention_offset(cfg).
+     *
+     * 2. log notifies the eviction stm which computes: min(max_offset, clamp)
+     *    where clamp is any additional restrictions, such as what has been
+     *    uploaded to cloud storage.
+     *
+     * 3. raft attempts to prefix truncate the log at the clamped offset after
+     *    it has prepared and taken any necessary snapshots.
+     *
+     * Because this effort is split between the log, raft, and eviction_stm we
+     * end up having to duplicate some of the logic here, such as handling the
+     * max collectible offset from stm. A future refactoring may consider moving
+     * more of the retention controls into a higher level location.
+     */
+    const auto max_collectible = stm_manager()->max_collectible_offset();
+    const auto retention_offset = std::min(max_offset.value(), max_collectible);
+
+    /*
+     * truncate_prefix() dry run
+     */
+    fragmented_vector<segment_set::type> retention_segments;
+    fragmented_vector<segment_set::type> available_segments;
+    for (auto& seg : _segs) {
+        if (seg->offsets().dirty_offset <= retention_offset) {
+            retention_segments.push_back(seg);
+        } else if (seg->offsets().dirty_offset <= max_collectible) {
+            available_segments.push_back(seg);
+        } else {
+            break;
+        }
+    }
+
+    auto ret = co_await ss::when_all_succeed(
+      // reduce segment subject to retention policy
+      ss::map_reduce(
+        retention_segments,
+        [](const segment_set::type& seg) { return seg->persistent_size(); },
+        size_t(0),
+        std::plus<>()),
+
+      // reduce segments available for reclaim
+      ss::map_reduce(
+        available_segments,
+        [](const segment_set::type& seg) { return seg->persistent_size(); },
+        size_t(0),
+        std::plus<>()));
+
+    co_return reclaim_size_limits{
+      .retention = std::get<0>(ret), .available = std::get<1>(ret)};
+}
+
 } // namespace storage

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -415,6 +415,7 @@ ss::future<> disk_log_impl::do_compact(
           segment->reader().filename(),
           result);
         if (result.did_compact()) {
+            segment->invalidate_compaction_index_size();
             _compaction_ratio.update(result.compaction_ratio());
             co_return;
         }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -34,6 +34,22 @@
 
 namespace storage {
 
+/*
+ * Report number of bytes available for reclaim under different scenarios.
+ *
+ * retention: number of bytes that would be reclaimed by applying
+ *            the log's retention policy.
+ *
+ * available: number of bytes that could be safely reclaimed if the
+ *            retention policy was ignored. for example reclaiming
+ *            past the retention limits if the data being reclaimed
+ *            has been uploaded to cloud storage.
+ */
+struct reclaim_size_limits {
+    size_t retention{0};
+    size_t available{0};
+};
+
 class disk_log_impl final : public log::impl {
 public:
     using failure_probes = storage::log_failure_probes;
@@ -181,6 +197,8 @@ private:
     bool is_cloud_retention_active() const;
 
     std::optional<model::offset> retention_offset(compaction_config);
+
+    ss::future<reclaim_size_limits> estimate_reclaim_size(compaction_config);
 
 private:
     size_t max_segment_size() const;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -180,6 +180,8 @@ private:
 
     bool is_cloud_retention_active() const;
 
+    std::optional<model::offset> retention_offset(compaction_config);
+
 private:
     size_t max_segment_size() const;
     // Computes the segment size based on the latest max_segment_size

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -160,8 +160,7 @@ public:
     ss::future<ss::rwlock::holder> write_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
 
-    ss::future<> remove_persistent_state(std::filesystem::path);
-    ss::future<> remove_persistent_state();
+    ss::future<size_t> remove_persistent_state();
 
     generation_id get_generation_id() const { return _generation_id; }
     void advance_generation() { _generation_id++; }
@@ -193,10 +192,11 @@ private:
       segment_appender_ptr,
       std::optional<batch_cache_index>,
       std::optional<compacted_index_writer>);
-    ss::future<> remove_tombstones();
     ss::future<> compaction_index_batch(const model::record_batch&);
     ss::future<> do_compaction_index_batch(const model::record_batch&);
     void release_appender_in_background(readers_cache* readers_cache);
+
+    ss::future<size_t> remove_persistent_state(std::filesystem::path);
 
     struct appender_callbacks : segment_appender::callbacks {
         explicit appender_callbacks(segment* segment)

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -160,6 +160,17 @@ public:
     ss::future<ss::rwlock::holder> write_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
 
+    /*
+     * return an estimate of how much data on disk is associated with this
+     * segment (e.g. the data file, indices, etc...). if the segment has been
+     * removed already (i.e. marked as a tombstone and closed) then the total
+     * amount of bytes actually removed from disk is reported.
+     */
+    ss::future<size_t> persistent_size();
+
+    /*
+     * return the number of bytes removed from disk.
+     */
     ss::future<size_t> remove_persistent_state();
 
     generation_id get_generation_id() const { return _generation_id; }
@@ -176,6 +187,10 @@ public:
     constexpr std::optional<ss::lowres_clock::time_point>
     first_write_ts() const {
         return _first_write;
+    }
+
+    void invalidate_compaction_index_size() {
+        _compaction_index_size = std::nullopt;
     }
 
 private:
@@ -196,6 +211,12 @@ private:
     ss::future<> do_compaction_index_batch(const model::record_batch&);
     void release_appender_in_background(readers_cache* readers_cache);
 
+    /*
+     * _removed_persistent_size is the total number of bytes removed when this
+     * segment is deleted. it is set once, after the segment is marked as a
+     * tombstone and closed.
+     */
+    std::optional<size_t> _removed_persistent_size;
     ss::future<size_t> remove_persistent_state(std::filesystem::path);
 
     struct appender_callbacks : segment_appender::callbacks {
@@ -232,7 +253,13 @@ private:
     segment_index _idx;
     bitflags _flags{bitflags::none};
     segment_appender_ptr _appender;
+
+    // compaction index size should be cleared whenever the size might change
+    // (e.g. after compaction). when cleared it will reset the next time the
+    // size of the compaction index is needed (e.g. estimating total seg size).
+    std::optional<size_t> _compaction_index_size;
     std::optional<compacted_index_writer> _compaction_index;
+
     std::optional<batch_cache_index> _cache;
     ss::rwlock _destructive_ops;
     ss::gate _gate;

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -160,6 +160,7 @@ public:
     ss::future<ss::rwlock::holder> write_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
 
+    ss::future<> remove_persistent_state(std::filesystem::path);
     ss::future<> remove_persistent_state();
 
     generation_id get_generation_id() const { return _generation_id; }

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -853,6 +853,7 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
     from_path = from_path.to_compacted_index();
     auto to_path = to->reader().path().to_compacted_index();
     co_await ss::rename_file(from_path.string(), to_path.string());
+    to->invalidate_compaction_index_size();
 
     // clean up replacement segment
     co_await from->remove_persistent_state();

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -25,6 +25,8 @@
 #include <seastar/core/future-util.hh>
 
 #include <fmt/ostream.h>
+
+#include <exception>
 using namespace std::chrono_literals;
 
 namespace storage::internal {
@@ -339,7 +341,7 @@ ss::future<> spill_key_index::close() {
         // index can detect invalid content and regenerate.
         _midx.clear();
 
-        throw ex;
+        std::rethrow_exception(ex);
     }
 }
 

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -137,6 +137,17 @@ ss::future<> disk_log_builder::gc(
     return ss::make_ready_future<>();
 }
 
+ss::future<reclaim_size_limits> disk_log_builder::gc_estimate(
+  model::timestamp collection_upper_bound,
+  std::optional<size_t> max_partition_retention_size) {
+    return get_disk_log_impl().estimate_reclaim_size(compaction_config(
+      collection_upper_bound,
+      max_partition_retention_size,
+      model::offset::max(),
+      ss::default_priority_class(),
+      _abort_source));
+}
+
 ss::future<std::optional<model::offset>>
 disk_log_builder::apply_retention(compaction_config cfg) {
     return get_disk_log_impl().gc(cfg);

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -303,6 +303,9 @@ public:
     ss::future<> gc(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);
+    ss::future<reclaim_size_limits> gc_estimate(
+      model::timestamp collection_upper_bound,
+      std::optional<size_t> max_partition_retention_size);
     ss::future<std::optional<model::offset>>
     apply_retention(compaction_config cfg);
     ss::future<> apply_compaction(

--- a/src/v/vlog.h
+++ b/src/v/vlog.h
@@ -22,3 +22,17 @@
 
 // NOLINTNEXTLINE
 #define vlog(method, fmt, args...) fmt_with_ctx(method, fmt, ##args)
+
+// NOLINTNEXTLINE
+#define fmt_with_ctx_level(logger, level, fmt, args...)                        \
+    logger.log(                                                                \
+      level,                                                                   \
+      "{}:{} - " fmt,                                                          \
+      (const char*)&__FILE__[vlog_internal::log_basename_start<                \
+        vlog_internal::basename_index(__FILE__)>::value],                      \
+      __LINE__,                                                                \
+      ##args)
+
+// NOLINTNEXTLINE
+#define vlogl(logger, level, fmt, args...)                                     \
+    fmt_with_ctx_level(logger, level, fmt, ##args)


### PR DESCRIPTION
The primary changes in this pull request are:

* Parallel removal of persistent segment files
* Reporting of data removed from disk on segment removal
* Estimation of data available for reclaim by GC under 2 scenarios:
  * Normal retention policy
  * Safe, but violating retention policy (e.g. uploaded to cloud)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

