### PR TITLE
controller snapshots: bootstrap + members + features +config

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -101,6 +101,7 @@ v_cc_library(
     controller_probe.cc
     controller_log_limiter.cc
     controller_stm.cc
+    controller_snapshot.cc
     controller.cc
     partition.cc
     partition_probe.cc

--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -179,8 +179,8 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd) {
         // If we didn't already save a snapshot, create it so that subsequent
         // startups see their feature table version immediately, without
         // waiting to replay the bootstrap message.
-        if (!_feature_backend.local().has_snapshot()) {
-            co_await _feature_backend.local().save_snapshot();
+        if (!_feature_backend.local().has_local_snapshot()) {
+            co_await _feature_backend.local().save_local_snapshot();
         }
     }
 

--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -199,4 +199,13 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd) {
     co_return errc::success;
 }
 
+ss::future<> bootstrap_backend::fill_snapshot(controller_snapshot&) const {
+    return ss::now();
+}
+
+ss::future<>
+bootstrap_backend::apply_snapshot(model::offset, const controller_snapshot&) {
+    return ss::now();
+}
+
 } // namespace cluster

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -53,6 +53,9 @@ public:
                == model::record_batch_type::cluster_bootstrap_cmd;
     }
 
+    ss::future<> fill_snapshot(controller_snapshot&) const;
+    ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
+
 private:
     ss::future<std::error_code> apply(bootstrap_cluster_cmd);
 

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -58,6 +58,7 @@ public:
 
 private:
     ss::future<std::error_code> apply(bootstrap_cluster_cmd);
+    ss::future<> apply_cluster_uuid(model::cluster_uuid);
 
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<storage::api>& _storage;

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -904,4 +904,13 @@ config_manager::status_map config_manager::get_projected_status() const {
     return r;
 }
 
+ss::future<> config_manager::fill_snapshot(controller_snapshot&) const {
+    return ss::now();
+}
+
+ss::future<>
+config_manager::apply_snapshot(model::offset, const controller_snapshot&) {
+    return ss::now();
+}
+
 } // namespace cluster

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -63,6 +63,8 @@ public:
     // mux_state_machine interface
     bool is_batch_applicable(const model::record_batch& b);
     ss::future<std::error_code> apply_update(model::record_batch);
+    ss::future<> fill_snapshot(controller_snapshot&) const;
+    ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
 
     // Result of trying to apply a delta to a configuration
     struct apply_result {

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -463,6 +463,7 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
       .then([this] {
           return _metrics_reporter.start_single(
             _raft0,
+            std::ref(_stm),
             std::ref(_members_table),
             std::ref(_tp_state),
             std::ref(_hm_frontend),

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -15,11 +15,14 @@ namespace cluster {
 
 ss::future<> controller_snapshot::serde_async_write(iobuf& out) {
     co_await serde::write_async(out, std::move(bootstrap));
+    co_await serde::write_async(out, std::move(features));
 }
 
 ss::future<>
 controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
     bootstrap = co_await serde::read_async_nested<decltype(bootstrap)>(
+      in, h._bytes_left_limit);
+    features = co_await serde::read_async_nested<decltype(features)>(
       in, h._bytes_left_limit);
 
     if (in.bytes_left() > h._bytes_left_limit) {

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -16,6 +16,7 @@ namespace cluster {
 ss::future<> controller_snapshot::serde_async_write(iobuf& out) {
     co_await serde::write_async(out, std::move(bootstrap));
     co_await serde::write_async(out, std::move(features));
+    co_await serde::write_async(out, std::move(members));
 }
 
 ss::future<>
@@ -23,6 +24,8 @@ controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
     bootstrap = co_await serde::read_async_nested<decltype(bootstrap)>(
       in, h._bytes_left_limit);
     features = co_await serde::read_async_nested<decltype(features)>(
+      in, h._bytes_left_limit);
+    members = co_await serde::read_async_nested<decltype(members)>(
       in, h._bytes_left_limit);
 
     if (in.bytes_left() > h._bytes_left_limit) {

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -17,6 +17,7 @@ ss::future<> controller_snapshot::serde_async_write(iobuf& out) {
     co_await serde::write_async(out, std::move(bootstrap));
     co_await serde::write_async(out, std::move(features));
     co_await serde::write_async(out, std::move(members));
+    co_await serde::write_async(out, std::move(config));
 }
 
 ss::future<>
@@ -26,6 +27,8 @@ controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
     features = co_await serde::read_async_nested<decltype(features)>(
       in, h._bytes_left_limit);
     members = co_await serde::read_async_nested<decltype(members)>(
+      in, h._bytes_left_limit);
+    config = co_await serde::read_async_nested<decltype(config)>(
       in, h._bytes_left_limit);
 
     if (in.bytes_left() > h._bytes_left_limit) {

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/controller_snapshot.h"
+
+namespace cluster {
+
+ss::future<> controller_snapshot::serde_async_write(iobuf&) { co_return; }
+
+ss::future<>
+controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
+    if (in.bytes_left() > h._bytes_left_limit) {
+        in.skip(in.bytes_left() - h._bytes_left_limit);
+    }
+    co_return;
+}
+
+} // namespace cluster

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -13,14 +13,18 @@
 
 namespace cluster {
 
-ss::future<> controller_snapshot::serde_async_write(iobuf&) { co_return; }
+ss::future<> controller_snapshot::serde_async_write(iobuf& out) {
+    co_await serde::write_async(out, std::move(bootstrap));
+}
 
 ss::future<>
 controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
+    bootstrap = co_await serde::read_async_nested<decltype(bootstrap)>(
+      in, h._bytes_left_limit);
+
     if (in.bytes_left() > h._bytes_left_limit) {
         in.skip(in.bytes_left() - h._bytes_left_limit);
     }
-    co_return;
 }
 
 } // namespace cluster

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -18,6 +18,7 @@ ss::future<> controller_snapshot::serde_async_write(iobuf& out) {
     co_await serde::write_async(out, std::move(features));
     co_await serde::write_async(out, std::move(members));
     co_await serde::write_async(out, std::move(config));
+    co_await serde::write_async(out, std::move(metrics_reporter));
 }
 
 ss::future<>
@@ -30,6 +31,9 @@ controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
       in, h._bytes_left_limit);
     config = co_await serde::read_async_nested<decltype(config)>(
       in, h._bytes_left_limit);
+    metrics_reporter
+      = co_await serde::read_async_nested<decltype(metrics_reporter)>(
+        in, h._bytes_left_limit);
 
     if (in.bytes_left() > h._bytes_left_limit) {
         in.skip(in.bytes_left() - h._bytes_left_limit);

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -109,6 +109,19 @@ struct config_t
     auto serde_fields() { return std::tie(version, values, nodes_status); }
 };
 
+struct metrics_reporter_t
+  : public serde::envelope<
+      metrics_reporter_t,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    metrics_reporter_cluster_info cluster_info;
+
+    friend bool operator==(const metrics_reporter_t&, const metrics_reporter_t&)
+      = default;
+
+    auto serde_fields() { return std::tie(cluster_info); }
+};
+
 } // namespace controller_snapshot_parts
 
 struct controller_snapshot
@@ -120,6 +133,7 @@ struct controller_snapshot
     controller_snapshot_parts::features_t features;
     controller_snapshot_parts::members_t members;
     controller_snapshot_parts::config_t config;
+    controller_snapshot_parts::metrics_reporter_t metrics_reporter;
 
     friend bool
     operator==(const controller_snapshot&, const controller_snapshot&)

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -16,6 +16,10 @@
 #include "serde/envelope.h"
 #include "serde/serde.h"
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/container/node_hash_map.h>
+
 namespace cluster {
 
 namespace controller_snapshot_parts {
@@ -40,6 +44,56 @@ struct features_t
     auto serde_fields() { return std::tie(snap); }
 };
 
+struct members_t
+  : public serde::
+      envelope<members_t, serde::version<0>, serde::compat_version<0>> {
+    struct node_t
+      : serde::envelope<node_t, serde::version<0>, serde::compat_version<0>> {
+        model::broker broker;
+        broker_state state;
+
+        friend bool operator==(const node_t&, const node_t&) = default;
+
+        auto serde_fields() { return std::tie(broker, state); }
+    };
+
+    struct update_t
+      : serde::envelope<update_t, serde::version<0>, serde::compat_version<0>> {
+        node_update_type type;
+        model::offset offset;
+        std::optional<model::revision_id> decommission_update_revision;
+
+        friend bool operator==(const update_t&, const update_t&) = default;
+
+        auto serde_fields() {
+            return std::tie(type, offset, decommission_update_revision);
+        }
+    };
+
+    absl::flat_hash_map<model::node_uuid, model::node_id> node_ids_by_uuid;
+    model::node_id next_assigned_id;
+
+    absl::node_hash_map<model::node_id, node_t> nodes;
+    absl::node_hash_map<model::node_id, node_t> removed_nodes;
+    absl::flat_hash_set<model::node_id> removed_nodes_still_in_raft0;
+    absl::node_hash_map<model::node_id, update_t> in_progress_updates;
+
+    model::offset first_node_operation_command_offset;
+
+    friend bool operator==(const members_t&, const members_t&) = default;
+
+    auto serde_fields() {
+        return std::tie(
+          node_ids_by_uuid,
+          next_assigned_id,
+          nodes,
+          removed_nodes,
+          removed_nodes_still_in_raft0,
+          in_progress_updates,
+          first_node_operation_command_offset);
+    }
+};
+
 } // namespace controller_snapshot_parts
 
 struct controller_snapshot
@@ -49,6 +103,7 @@ struct controller_snapshot
       serde::compat_version<0>> {
     controller_snapshot_parts::bootstrap_t bootstrap;
     controller_snapshot_parts::features_t features;
+    controller_snapshot_parts::members_t members;
 
     friend bool
     operator==(const controller_snapshot&, const controller_snapshot&)

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/types.h"
+#include "features/feature_table_snapshot.h"
 #include "serde/envelope.h"
 #include "serde/serde.h"
 
@@ -29,6 +30,16 @@ struct bootstrap_t
     auto serde_fields() { return std::tie(cluster_uuid); }
 };
 
+struct features_t
+  : public serde::
+      envelope<features_t, serde::version<0>, serde::compat_version<0>> {
+    features::feature_table_snapshot snap;
+
+    friend bool operator==(const features_t&, const features_t&) = default;
+
+    auto serde_fields() { return std::tie(snap); }
+};
+
 } // namespace controller_snapshot_parts
 
 struct controller_snapshot
@@ -37,6 +48,7 @@ struct controller_snapshot
       serde::version<0>,
       serde::compat_version<0>> {
     controller_snapshot_parts::bootstrap_t bootstrap;
+    controller_snapshot_parts::features_t features;
 
     friend bool
     operator==(const controller_snapshot&, const controller_snapshot&)

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -26,7 +26,8 @@ struct controller_snapshot
     operator==(const controller_snapshot&, const controller_snapshot&)
       = default;
 
-    auto serde_fields() { return std::tie(); }
+    ss::future<> serde_async_write(iobuf&);
+    ss::future<> serde_async_read(iobuf_parser&, serde::header const);
 };
 
 } // namespace cluster

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -17,11 +17,27 @@
 
 namespace cluster {
 
+namespace controller_snapshot_parts {
+
+struct bootstrap_t
+  : public serde::
+      envelope<bootstrap_t, serde::version<0>, serde::compat_version<0>> {
+    std::optional<model::cluster_uuid> cluster_uuid;
+
+    friend bool operator==(const bootstrap_t&, const bootstrap_t&) = default;
+
+    auto serde_fields() { return std::tie(cluster_uuid); }
+};
+
+} // namespace controller_snapshot_parts
+
 struct controller_snapshot
   : public serde::checksum_envelope<
       controller_snapshot,
       serde::version<0>,
       serde::compat_version<0>> {
+    controller_snapshot_parts::bootstrap_t bootstrap;
+
     friend bool
     operator==(const controller_snapshot&, const controller_snapshot&)
       = default;

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -53,6 +53,10 @@ public:
     controller_stm& operator=(const controller_stm&) = delete;
     ~controller_stm() = default;
 
+    metrics_reporter_cluster_info& get_metrics_reporter_cluster_info() {
+        return _metrics_reporter_cluster_info;
+    }
+
     template<typename Cmd>
     requires ControllerCommand<Cmd>
     bool throttle() { return _limiter.throttle<Cmd>(); }
@@ -71,6 +75,8 @@ private:
     controller_log_limiter _limiter;
     const features::feature_table& _feature_table;
     config::binding<std::chrono::seconds> _snapshot_max_age;
+
+    metrics_reporter_cluster_info _metrics_reporter_cluster_info;
 
     ss::timer<ss::lowres_clock> _snapshot_debounce_timer;
 };

--- a/src/v/cluster/feature_backend.cc
+++ b/src/v/cluster/feature_backend.cc
@@ -88,6 +88,15 @@ feature_backend::apply_feature_update_command(feature_update_cmd update) {
     }
 }
 
+ss::future<> feature_backend::fill_snapshot(controller_snapshot&) const {
+    return ss::now();
+}
+
+ss::future<>
+feature_backend::apply_snapshot(model::offset, const controller_snapshot&) {
+    return ss::now();
+}
+
 bool feature_backend::has_snapshot() {
     return _storage.local()
       .kvs()

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -41,8 +41,11 @@ public:
     ss::future<> fill_snapshot(controller_snapshot&) const;
     ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
 
-    bool has_snapshot();
-    ss::future<> save_snapshot();
+    /// this functions deal with the snapshot stored in local kvstore (in
+    /// contrast to fill/apply_snapshot which deal with the feature table data
+    /// in the replicated controller snapshot).
+    bool has_local_snapshot();
+    ss::future<> save_local_snapshot();
 
     bool is_batch_applicable(const model::record_batch& b) {
         return b.header().type == model::record_batch_type::feature_update;

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -38,6 +38,8 @@ public:
       , _storage(storage) {}
 
     ss::future<std::error_code> apply_update(model::record_batch);
+    ss::future<> fill_snapshot(controller_snapshot&) const;
+    ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
 
     bool has_snapshot();
     ss::future<> save_snapshot();

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -15,6 +15,7 @@ namespace cluster {
 
 class controller;
 class controller_backend;
+class controller_stm;
 class controller_stm_shard;
 class id_allocator_frontend;
 class rm_partition_frontend;

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -12,6 +12,7 @@
 #include "cluster/cluster_utils.h"
 #include "cluster/commands.h"
 #include "cluster/controller_service.h"
+#include "cluster/controller_snapshot.h"
 #include "cluster/controller_stm.h"
 #include "cluster/drain_manager.h"
 #include "cluster/errc.h"
@@ -605,13 +606,206 @@ members_manager::apply_raft_configuration_batch(model::record_batch b) {
     co_return make_error_code(errc::success);
 }
 
-ss::future<> members_manager::fill_snapshot(controller_snapshot&) const {
-    return ss::now();
+ss::future<>
+members_manager::fill_snapshot(controller_snapshot& controller_snap) const {
+    auto& snap = controller_snap.members;
+    snap.node_ids_by_uuid = _id_by_uuid;
+    snap.next_assigned_id = _next_assigned_id;
+
+    _members_table.local().fill_snapshot(controller_snap);
+
+    snap.removed_nodes_still_in_raft0 = _removed_nodes_still_in_raft0;
+
+    for (const auto& [id, update] : _in_progress_updates) {
+        snap.in_progress_updates.emplace(
+          id,
+          controller_snapshot_parts::members_t::update_t{
+            .type = update.type,
+            .offset = update.offset,
+            .decommission_update_revision
+            = update.decommission_update_revision});
+    }
+
+    snap.first_node_operation_command_offset
+      = _first_node_operation_command_offset;
+
+    co_return;
 }
 
-ss::future<>
-members_manager::apply_snapshot(model::offset, const controller_snapshot&) {
-    return ss::now();
+ss::future<> members_manager::apply_snapshot(
+  model::offset snap_offset, const controller_snapshot& controller_snap) {
+    const auto& snap = controller_snap.members;
+
+    // 1. update uuid map
+
+    _id_by_uuid = snap.node_ids_by_uuid;
+    _next_assigned_id = snap.next_assigned_id;
+
+    // 2. calculate brokers diff to update inter-node connections
+
+    changed_nodes diff;
+    for (const auto& [id, new_node] : snap.nodes) {
+        auto old_node = _members_table.local().get_node_metadata_ref(id);
+        if (!old_node) {
+            diff.added.push_back(new_node.broker);
+        } else if (old_node->get().broker != new_node.broker) {
+            diff.updated.push_back(new_node.broker);
+        }
+    }
+    for (const auto& [id, old_node] : _members_table.local().nodes()) {
+        if (!snap.nodes.contains(id)) {
+            if (!snap.removed_nodes_still_in_raft0.contains(id)) {
+                diff.removed.push_back(id);
+            } else {
+                auto new_node = snap.removed_nodes.find(id);
+                vassert(
+                  new_node != snap.removed_nodes.end(),
+                  "info about removed node {} must be present in the snapshot",
+                  id);
+                if (new_node->second.broker != old_node.broker) {
+                    diff.updated.push_back(new_node->second.broker);
+                }
+            }
+        }
+    }
+    for (auto id : _removed_nodes_still_in_raft0) {
+        if (!snap.removed_nodes_still_in_raft0.contains(id)) {
+            diff.removed.push_back(id);
+        }
+    }
+
+    // 3. calculate self maintenance state diff
+
+    std::optional<model::maintenance_state> old_self_maintenance_state;
+    std::optional<model::maintenance_state> new_self_maintenance_state;
+    if (auto it = _members_table.local().nodes().find(_self.id());
+        it != _members_table.local().nodes().end()) {
+        old_self_maintenance_state = it->second.state.get_maintenance_state();
+    }
+    if (auto it = snap.nodes.find(_self.id()); it != snap.nodes.end()) {
+        new_self_maintenance_state = it->second.state.get_maintenance_state();
+    }
+
+    // 4. update members table
+
+    _first_node_operation_command_offset
+      = snap.first_node_operation_command_offset;
+
+    co_await _members_table.invoke_on_all(
+      [snap_offset, &controller_snap](members_table& mt) {
+          return mt.apply_snapshot(snap_offset, controller_snap);
+      });
+
+    _removed_nodes_still_in_raft0 = snap.removed_nodes_still_in_raft0;
+
+    co_await persist_members_in_kvstore(snap_offset);
+
+    // partition allocator will be updated by topic_updates_dispatcher
+
+    // 5. reconcile _in_progress_updates and generate corresponding
+    // members_backend updates
+
+    std::vector<node_update> updates;
+
+    auto interrupt_previous_update = [&](model::node_id id) {
+        updates.push_back(node_update{
+          .id = id,
+          .type = node_update_type::interrupted,
+          .offset = snap_offset,
+        });
+    };
+
+    for (const auto& [id, update] : snap.in_progress_updates) {
+        bool need_raft0_update
+          = (update.type == node_update_type::added
+             || update.type == node_update_type::removed)
+            && update.offset >= snap.first_node_operation_command_offset;
+
+        auto new_update = node_update{
+          .id = id,
+          .type = update.type,
+          .offset = update.offset,
+          .need_raft0_update = need_raft0_update,
+          .decommission_update_revision = update.decommission_update_revision};
+
+        auto old_it = _in_progress_updates.find(id);
+        if (old_it == _in_progress_updates.end()) {
+            _in_progress_updates[id] = new_update;
+            updates.push_back(new_update);
+        } else {
+            auto& old_update = old_it->second;
+            if (old_update.offset != new_update.offset) {
+                interrupt_previous_update(id);
+                old_update = new_update;
+                updates.push_back(new_update);
+            }
+        }
+    }
+
+    for (auto old_it = _in_progress_updates.begin();
+         old_it != _in_progress_updates.end();) {
+        auto it_copy = old_it++;
+        if (!snap.in_progress_updates.contains(it_copy->first)) {
+            interrupt_previous_update(it_copy->first);
+            _in_progress_updates.erase(it_copy);
+        }
+    }
+
+    for (auto& update : updates) {
+        co_await _update_queue.push_eventually(std::move(update));
+    }
+
+    // 6. update drain_mamager
+
+    if (old_self_maintenance_state != new_self_maintenance_state) {
+        bool should_drain = new_self_maintenance_state
+                            == model::maintenance_state::active;
+        bool should_restore = old_self_maintenance_state
+                              == model::maintenance_state::active;
+        if (should_drain || should_restore) {
+            co_await _drain_manager.invoke_on_all(
+              [should_drain](cluster::drain_manager& dm) {
+                  if (should_drain) {
+                      return dm.drain();
+                  } else {
+                      return dm.restore();
+                  }
+              });
+        }
+    }
+
+    // 7. update connections
+
+    if (snap_offset >= _last_connection_update_offset) {
+        for (auto& broker : diff.added) {
+            if (broker.id() != _self.id()) {
+                co_await update_broker_client(
+                  _self.id(),
+                  _connection_cache,
+                  broker.id(),
+                  broker.rpc_address(),
+                  _rpc_tls_config);
+            }
+        }
+        for (auto& broker : diff.updated) {
+            if (broker.id() != _self.id()) {
+                co_await update_broker_client(
+                  _self.id(),
+                  _connection_cache,
+                  broker.id(),
+                  broker.rpc_address(),
+                  _rpc_tls_config);
+            }
+        }
+        for (model::node_id id : diff.removed) {
+            if (id != _self.id()) {
+                co_await remove_broker_client(
+                  _self.id(), _connection_cache, id);
+            }
+        }
+
+        _last_connection_update_offset = snap_offset;
+    }
 }
 
 ss::future<std::vector<members_manager::node_update>>
@@ -642,7 +836,7 @@ ss::future<> members_manager::set_initial_state(
   std::vector<model::broker> initial_brokers, uuid_map_t id_by_uuid) {
     vassert(_id_by_uuid.empty(), "will not overwrite existing data");
     if (!id_by_uuid.empty()) {
-        vlog(clusterlog.debug, "Initial node UUID map: {}", id_by_uuid);
+        vlog(clusterlog.info, "Initial node UUID map: {}", id_by_uuid);
     }
     // Start the node ID assignment counter just past the highest node ID. This
     // helps ensure removed seed servers are accounted for when auto-assigning

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -605,6 +605,15 @@ members_manager::apply_raft_configuration_batch(model::record_batch b) {
     co_return make_error_code(errc::success);
 }
 
+ss::future<> members_manager::fill_snapshot(controller_snapshot&) const {
+    return ss::now();
+}
+
+ss::future<>
+members_manager::apply_snapshot(model::offset, const controller_snapshot&) {
+    return ss::now();
+}
+
 ss::future<std::vector<members_manager::node_update>>
 members_manager::get_node_updates() {
     if (_update_queue.empty()) {

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -162,6 +162,9 @@ public:
     // Whether the given batch applies to this raft::mux_state_machine.
     bool is_batch_applicable(const model::record_batch& b) const;
 
+    ss::future<> fill_snapshot(controller_snapshot&) const;
+    ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
+
     // This API is backed by the seastar::queue. It can not be called
     // concurrently from multiple fibers.
     ss::future<std::vector<node_update>> get_node_updates();

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -55,6 +55,9 @@ public:
 
     void set_initial_brokers(std::vector<model::broker>);
 
+    void fill_snapshot(controller_snapshot&);
+    void apply_snapshot(model::offset, const controller_snapshot&);
+
     model::revision_id version() const { return _version; }
 
     ss::future<> await_membership(model::node_id id, ss::abort_source& as) {

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -83,6 +83,7 @@ public:
 
     metrics_reporter(
       consensus_ptr,
+      ss::sharded<controller_stm>&,
       ss::sharded<members_table>&,
       ss::sharded<topic_table>&,
       ss::sharded<health_monitor_frontend>&,
@@ -103,15 +104,14 @@ private:
     ss::future<> try_initialize_cluster_info();
     ss::future<> propagate_cluster_id();
 
-    ss::sstring _cluster_uuid;
     consensus_ptr _raft0;
+    metrics_reporter_cluster_info& _cluster_info; // owned by controller_stm
     ss::sharded<members_table>& _members_table;
     ss::sharded<topic_table>& _topics;
     ss::sharded<health_monitor_frontend>& _health_monitor;
     ss::sharded<config_frontend>& _config_frontend;
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<ss::abort_source>& _as;
-    model::timestamp _creation_timestamp;
     prefix_logger _logger;
     ss::timer<> _tick_timer;
     details::address _address;

--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -11,6 +11,7 @@
 #include "cluster/security_manager.h"
 
 #include "cluster/commands.h"
+#include "cluster/controller_snapshot.h"
 #include "model/metadata.h"
 #include "raft/types.h"
 #include "security/authorizer.h"
@@ -142,6 +143,15 @@ ss::future<std::error_code> security_manager::dispatch_updates_to_cores(
                 return ret;
             });
       });
+}
+
+ss::future<> security_manager::fill_snapshot(controller_snapshot&) const {
+    return ss::now();
+}
+
+ss::future<>
+security_manager::apply_snapshot(model::offset, const controller_snapshot&) {
+    return ss::now();
 }
 
 } // namespace cluster

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "cluster/commands.h"
+#include "cluster/fwd.h"
 #include "model/record.h"
 #include "security/fwd.h"
 
@@ -39,6 +40,9 @@ public:
                || batch.header().type
                     == model::record_batch_type::acl_management_cmd;
     }
+
+    ss::future<> fill_snapshot(controller_snapshot&) const;
+    ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
 
 private:
     template<typename Cmd, typename Service>

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -543,4 +543,14 @@ void topic_updates_dispatcher::update_allocations(
       shards, max_group_id, domain);
 }
 
+ss::future<>
+topic_updates_dispatcher::fill_snapshot(controller_snapshot&) const {
+    return ss::now();
+}
+
+ss::future<> topic_updates_dispatcher::apply_snapshot(
+  model::offset, const controller_snapshot&) {
+    return ss::now();
+}
+
 } // namespace cluster

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -58,6 +58,8 @@ public:
       ss::sharded<partition_balancer_state>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
+    ss::future<> fill_snapshot(controller_snapshot&) const;
+    ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
 
     static constexpr auto commands = make_commands_list<
       create_topic_cmd,

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1003,6 +1003,8 @@ std::ostream& operator<<(std::ostream& o, const node_update_type& tp) {
         return o << "reallocation_finished";
     case node_update_type::removed:
         return o << "removed";
+    case node_update_type::interrupted:
+        return o << "interrupted";
     }
     return o << "unknown";
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3244,6 +3244,24 @@ struct partition_cloud_storage_status {
     std::optional<kafka::offset> local_log_start_offset;
 };
 
+struct metrics_reporter_cluster_info
+  : serde::envelope<
+      metrics_reporter_cluster_info,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    ss::sstring uuid;
+    model::timestamp creation_timestamp;
+
+    bool is_initialized() const { return !uuid.empty(); }
+
+    friend bool operator==(
+      const metrics_reporter_cluster_info&,
+      const metrics_reporter_cluster_info&)
+      = default;
+
+    auto serde_fields() { return std::tie(uuid, creation_timestamp); }
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3153,6 +3153,9 @@ enum class node_update_type : int8_t {
 
     // node has been removed from the cluster
     removed,
+
+    // previous updates must be interrupted
+    interrupted,
 };
 
 std::ostream& operator<<(std::ostream&, const node_update_type&);

--- a/src/v/features/feature_table_snapshot.cc
+++ b/src/v/features/feature_table_snapshot.cc
@@ -36,6 +36,11 @@ feature_table_snapshot feature_table_snapshot::from(const feature_table& ft) {
 }
 
 void feature_table_snapshot::apply(feature_table& ft) const {
+    vlog(
+      featureslog.debug,
+      "applying snapshot with applied offset {}",
+      applied_offset);
+
     ft.set_active_version(version);
     ft._license = license;
     for (auto& cur_state : ft._feature_state) {

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2797,3 +2797,36 @@ class RedpandaService(Service):
 
         # Fall through, match on all nodes
         return True
+
+    def controller_start_offset(self, node):
+        metrics = list(self.metrics(node))
+        for family in metrics:
+            if family.name == 'vectorized_cluster_partition_start_offset':
+                for s in family.samples:
+                    if s.labels['namespace'] == 'redpanda' and s.labels[
+                            'topic'] == 'controller':
+                        return int(s.value)
+        return 0
+
+    def wait_for_controller_snapshot(self,
+                                     node,
+                                     prev_mtime=0,
+                                     prev_start_offset=0):
+        def check():
+            storage = self.node_storage(node)
+            controller = storage.partitions('redpanda', 'controller')
+            assert len(controller) == 1
+            controller = controller[0]
+
+            mtime = 0
+            if 'snapshot' in controller.files:
+                mtime = controller.get_mtime('snapshot')
+
+            so = self.controller_start_offset(node)
+            self.logger.info(
+                f"node {node.account.hostname}: "
+                f"controller start offset: {so}, snapshot mtime: {mtime}")
+
+            return (mtime > prev_mtime and so > prev_start_offset, (mtime, so))
+
+        return wait_until_result(check, timeout_sec=30, backoff_sec=1)

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -14,6 +14,7 @@ from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool
 from rptest.util import wait_until_result
 
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
 
@@ -55,3 +56,97 @@ class ControllerSnapshotPolicyTest(RedpandaTest):
             mtime, start_offset = node_idx2snapshot_info[self.redpanda.idx(n)]
             self.redpanda.wait_for_controller_snapshot(
                 n, prev_mtime=mtime, prev_start_offset=start_offset)
+
+
+class ControllerSnapshotTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        # TODO: remove partition_autobalancing_mode after applying controller snapshots
+        # to partition_allocator gets implemented (rebalance on node addition doesn't
+        # like empty partition allocator)
+        super().__init__(*args,
+                         num_brokers=4,
+                         extra_rp_conf={
+                             'controller_snapshot_max_age_sec': 5,
+                             'partition_autobalancing_mode': 'off',
+                         },
+                         **kwargs)
+
+    def setUp(self):
+        # start the nodes manually
+        pass
+
+    @cluster(num_nodes=4)
+    @matrix(auto_assign_node_ids=[False, True])
+    def test_bootstrap(self, auto_assign_node_ids):
+        """
+        Test that Redpanda nodes can assemble into a cluster when controller snapshots are enabled. In particular, test that:
+        1. Nodes can join
+        2. Nodes can restart and the cluster remains healthy
+        3. Node ids and cluster uuid remain stable
+        """
+
+        seed_nodes = self.redpanda.nodes[0:3]
+        joiner_node = self.redpanda.nodes[3]
+        self.redpanda.set_seed_servers(seed_nodes)
+
+        self.redpanda.start(nodes=seed_nodes,
+                            auto_assign_node_id=auto_assign_node_ids,
+                            omit_seeds_on_idx_one=False)
+        admin = Admin(self.redpanda, default_node=seed_nodes[0])
+        admin.put_feature("controller_snapshots", {"state": "active"})
+
+        for n in seed_nodes:
+            self.redpanda.wait_for_controller_snapshot(n)
+
+        cluster_uuid = admin.get_cluster_uuid(node=seed_nodes[0])
+        assert cluster_uuid is not None
+
+        node_ids_per_idx = {}
+
+        def check_and_save_node_ids(started):
+            for n in started:
+                uuid = admin.get_cluster_uuid(node=n)
+                assert cluster_uuid == uuid, f"unexpected cluster uuid {uuid}"
+
+                brokers = admin.get_brokers(node=n)
+                assert len(brokers) == len(started)
+
+                node_id = self.redpanda.node_id(n, force_refresh=True)
+                idx = self.redpanda.idx(n)
+                if idx in node_ids_per_idx:
+                    expected_node_id = node_ids_per_idx[idx]
+                    assert expected_node_id == node_id,\
+                        f"Expected {expected_node_id} but got {node_id}"
+                else:
+                    node_ids_per_idx[idx] = node_id
+
+        check_and_save_node_ids(seed_nodes)
+
+        self.logger.info(f"seed nodes formed cluster, uuid: {cluster_uuid}")
+
+        self.redpanda.restart_nodes(seed_nodes,
+                                    auto_assign_node_id=auto_assign_node_ids,
+                                    omit_seeds_on_idx_one=False)
+        self.redpanda.wait_for_membership(first_start=False)
+
+        check_and_save_node_ids(seed_nodes)
+
+        self.logger.info(f"seed nodes restarted successfully")
+
+        self.redpanda.start(nodes=[joiner_node],
+                            auto_assign_node_id=auto_assign_node_ids,
+                            omit_seeds_on_idx_one=False)
+        self.redpanda.wait_for_membership(first_start=True)
+
+        check_and_save_node_ids(self.redpanda.nodes)
+
+        self.logger.info("cluster fully bootstrapped, restarting...")
+
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=auto_assign_node_ids,
+                                    omit_seeds_on_idx_one=False)
+        self.redpanda.wait_for_membership(first_start=False)
+
+        check_and_save_node_ids(self.redpanda.nodes)
+
+        self.logger.info("cluster restarted successfully")


### PR DESCRIPTION
This is part 2 of the implementation of controller snapshots. It contains support for
* bootstrap_backend
* members_manager
* features_backend
* config_manager
as well as some simple tests

## Backports Required
- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none