### PR TITLE
tests: use a new tool for validating object storage state at end of tests

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -211,6 +211,9 @@ partition_cloud_storage_status partition::get_cloud_storage_status() const {
 
     if (status.mode != cloud_storage_mode::disabled) {
         const auto& manifest = _archival_meta_stm->manifest();
+        status.cloud_metadata_update_pending
+          = _archival_meta_stm->get_dirty()
+            == archival_metadata_stm::state_dirty::dirty;
         status.cloud_log_size_bytes = manifest.cloud_log_size();
         status.cloud_log_segment_count = manifest.size();
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3268,6 +3268,9 @@ struct partition_cloud_storage_status {
     size_t cloud_log_segment_count{0};
     size_t local_log_segment_count{0};
 
+    // Friendlier name for archival_metadata_stm::get_dirty
+    bool cloud_metadata_update_pending{false};
+
     std::optional<kafka::offset> cloud_log_start_offset;
     std::optional<kafka::offset> local_log_last_offset;
 

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -175,6 +175,11 @@
             "nullable": true,
             "description": "Delta in milliseconds since the last manifest sync (only present for read replicas)"
         },
+        "metadata_update_pending": {
+          "type": "boolean",
+          "description": "If true, the remote metadata may not yet include all segments that have been uploaded."
+
+        },
         "total_log_size_bytes": {
             "type": "long",
             "description": "Total size of the log for the partition (overlap between local and cloud log is excluded)"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4097,6 +4097,8 @@ map_status_to_json(cluster::partition_cloud_storage_status status) {
           = status.since_last_manifest_sync->count();
     }
 
+    json.metadata_update_pending = status.cloud_metadata_update_pending;
+
     json.total_log_size_bytes = status.total_log_size_bytes;
     json.cloud_log_size_bytes = status.cloud_log_size_bytes;
     json.local_log_size_bytes = status.local_log_size_bytes;

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -66,7 +66,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 # Compile and install rust-based workload generator.
 # Install & remove compiler in the same step, to avoid bulking
 # out the resulting container image.
-RUN /opt/ducktape-deps.sh install_client_swarm /root
+RUN /opt/ducktape-deps.sh install_rust_tools /root
 
 # Install golang dependencies for kafka clients such as sarama
 RUN /opt/ducktape-deps.sh install_sarama_examples

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -94,11 +94,17 @@ function install_kaf() {
   mv /root/go/bin/kaf /usr/local/bin/
 }
 
+# Alias so that vtools can be updated asynchronously.
 function install_client_swarm() {
+  install_rust_tools "$1"
+}
+
+function install_rust_tools() {
   dir="$1"
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
   export PATH="$dir/.cargo/bin:${PATH}"
   pushd /tmp
+
   git clone https://github.com/redpanda-data/client-swarm.git
   pushd client-swarm
   git reset --hard 9ef8e93
@@ -106,8 +112,18 @@ function install_client_swarm() {
   cp target/release/client-swarm /usr/local/bin
   popd
   rm -rf client-swarm
+
+  git clone https://github.com/jcsp/segment_toy.git
+  pushd segment_toy
+  git reset --hard 899c1310b0a55e1ade66237054faba81bb4223a4
+  cargo build --release
+  cp target/release/segments /usr/local/bin
+  popd
+  rm -rf segment_toy
+
   popd
   rm -rf $dir/.cargo
+  rm -rf $dir/.rustup
 }
 
 function install_sarama_examples() {

--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -2,13 +2,12 @@ from rptest.archival.s3_client import ObjectMetadata
 from rptest.archival.shared_client_utils import key_to_topic
 
 from azure.storage.blob import BlobClient, BlobServiceClient, BlobType, ContainerClient
-from itertools import chain, islice
+from itertools import islice
 
 import time
 import datetime
 from logging import Logger
-from typing import Iterator, NamedTuple, Optional
-from base64 import standard_b64decode
+from typing import Iterator, Optional
 
 
 def build_connection_string(proto: str, endpoint: Optional[str],

--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -94,6 +94,23 @@ class ABSClient:
 
         return []
 
+    def move_object(self,
+                    bucket: str,
+                    src: str,
+                    dst: str,
+                    validate: bool = False,
+                    validation_timeout_sec=30):
+        # `validate` and `validation_timeout_sec` are unused, only present
+        # for compatibility with S3Client
+        container_client = ContainerClient.from_connection_string(
+            self.conn_str, container_name=bucket)
+
+        # There is no server-side "move" in ABS: this is a crude implementation,
+        # but good enough for tiny objects
+        content = container_client.download_blob(src).readall()
+        container_client.upload_blob(dst, content)
+        container_client.delete_blob(src)
+
     def delete_object(self, bucket: str, key: str, verify=False):
         blob_client = BlobClient.from_connection_string(self.conn_str,
                                                         container_name=bucket,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -889,6 +889,7 @@ class Admin:
                              "debug/refresh_disk_health_info",
                              node=node)
 
-    def get_partition_cloud_storage_status(self, topic, partition):
-        return self._request(
-            "GET", f"cloud_storage/status/{topic}/{partition}").json()
+    def get_partition_cloud_storage_status(self, topic, partition, node=None):
+        return self._request("GET",
+                             f"cloud_storage/status/{topic}/{partition}",
+                             node=node).json()

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -90,6 +90,17 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                             redpanda.cloud_storage_diagnostics()
                             raise
 
+                if self.redpanda.si_settings is not None:
+                    try:
+                        self.redpanda.stop_and_scrub_object_storage()
+                    except:
+                        self.redpanda.cloud_storage_diagnostics()
+                        raise
+
+                # Finally, if the test passed and all post-test checks
+                # also passed, we may trim the logs to INFO level to
+                # save space.
+                for redpanda in all_redpandas(self):
                     redpanda.trim_logs()
 
                 return r

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -16,6 +16,7 @@ import signal
 import tempfile
 import shutil
 import requests
+import json
 import random
 import threading
 import collections
@@ -38,6 +39,7 @@ from prometheus_client.parser import text_string_to_metric_families
 from ducktape.errors import TimeoutError
 from ducktape.tests.test import TestContext
 
+from rptest.archival.abs_client import build_connection_string
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.rpk import RpkTool
 from rptest.clients.rpk_remote import RpkRemoteTool
@@ -60,6 +62,11 @@ SaslCredentials = collections.namedtuple("SaslCredentials",
                                          ["username", "password", "algorithm"])
 # Map of path -> (checksum, size)
 FileToChecksumSize = dict[str, Tuple[str, int]]
+
+# The endpoint info for the azurite (Azure ABS emulator )container that
+# is used when running tests in a docker environment.
+AZURITE_HOSTNAME = 'azurite'
+AZURITE_PORT = 10000
 
 DEFAULT_LOG_ALLOW_LIST = [
     # Tests currently don't run on XFS, although in future they should.
@@ -377,7 +384,7 @@ class SISettings:
 
             self._cloud_storage_azure_container = f'panda-container-{uuid.uuid1()}'
             self.cloud_storage_api_endpoint = f'{self.cloud_storage_azure_storage_account}.blob.localhost'
-            self.cloud_storage_api_endpoint_port = 10000
+            self.cloud_storage_api_endpoint_port = AZURITE_PORT
         else:
             assert False, f"Unexpected value provided for 'cloud_storage_type' injected arg: {self.cloud_storage_type}"
 
@@ -1023,7 +1030,7 @@ class RedpandaService(Service):
         with docker/podman is unstable, as it isn't consistent across operating
         systems.  Instead do it more crudely but robustly, but editing /etc/hosts.
         """
-        azurite_ip = socket.gethostbyname("azurite")
+        azurite_ip = socket.gethostbyname(AZURITE_HOSTNAME)
         azurite_dns = f"{self._si_settings.cloud_storage_azure_storage_account}.blob.localhost"
 
         def update_hosts_file(node_name, path):
@@ -2828,3 +2835,100 @@ class RedpandaService(Service):
             return (mtime > prev_mtime and so > prev_start_offset, (mtime, so))
 
         return wait_until_result(check, timeout_sec=30, backoff_sec=1)
+
+    def stop_and_scrub_object_storage(self):
+        # We stop because the scrubbing routine would otherwise interpret
+        # ongoing uploads as inconsistency.  In future, we may replace this
+        # stop with a flush, when Redpanda gets an admin API for explicitly
+        # flushing data to remote storage.
+        self.stop()
+
+        vars = {}
+        backend = ""
+        if self.si_settings.cloud_storage_type == CloudStorageType.S3:
+            backend = "aws"
+            vars["AWS_REGION"] = self.si_settings.cloud_storage_region
+            if self.si_settings.endpoint_url:
+                vars["AWS_ENDPOINT"] = self.si_settings.endpoint_url
+                if self.si_settings.endpoint_url.startswith("http://"):
+                    vars["AWS_ALLOW_HTTP"] = "true"
+
+            if self.si_settings.cloud_storage_access_key is not None:
+                vars[
+                    "AWS_ACCESS_KEY_ID"] = self.si_settings.cloud_storage_access_key
+                vars[
+                    "AWS_SECRET_ACCESS_KEY"] = self.si_settings.cloud_storage_secret_key
+        elif self.si_settings.cloud_storage_type == CloudStorageType.ABS:
+            backend = "azure"
+            if self.si_settings.cloud_storage_azure_storage_account == SISettings.ABS_AZURITE_ACCOUNT:
+                vars["AZURE_STORAGE_USE_EMULATOR"] = "true"
+                # We do not use the SISettings.endpoint_url, because that includes the account
+                # name in the URL, and the `object_store` crate used in the scanning tool
+                # assumes that when the emulator is used, the account name should always
+                # appear in the path.
+                vars[
+                    "AZURITE_BLOB_STORAGE_URL"] = f"http://{AZURITE_HOSTNAME}:{AZURITE_PORT}"
+            else:
+                vars[
+                    "AZURE_STORAGE_CONNECTION_STRING"] = self.cloud_storage_client.conn_str
+                vars[
+                    "AZURE_STORAGE_ACCOUNT_KEY"] = self.si_settings.cloud_storage_azure_shared_key
+                vars[
+                    "AZURE_STORAGE_ACCOUNT_NAME"] = self.si_settings.cloud_storage_azure_storage_account
+
+        # Pick an arbitrary node to run the scrub from
+        node = self.nodes[0]
+
+        bucket = self.si_settings.cloud_storage_bucket
+        environment = ' '.join(f'{k}=\"{v}\"' for k, v in vars.items())
+        output = node.account.ssh_output(
+            f"{environment} segments --backend {backend} scan --source {bucket}",
+            combine_stderr=False,
+            allow_fail=True)
+
+        try:
+            report = json.loads(output)
+        except:
+            self.logger.error(f"Error running bucket scrub: {output}")
+            raise
+
+        # Example of a report:
+        # {"malformed_manifests":[],
+        #  "malformed_topic_manifests":[]
+        #  "missing_segments":[
+        #    "db0df8df/kafka/test/58_57/0-6-895-1-v1.log.2",
+        #    "5c34266a/kafka/test/52_57/0-6-895-1-v1.log.2"
+        #  ],
+        #  "ntpr_no_manifest":[],
+        #  "ntr_no_topic_manifest":[],
+        #  "segments_outside_manifest":[],
+        #  "unknown_keys":[]}
+
+        # It is legal for tiered storage to leak objects under
+        # certain circumstances: this will remain the case until
+        # we implement background scrub + modify test code to
+        # insist on Redpanda completing its own scrub before
+        # we externally validate
+        # (https://github.com/redpanda-data/redpanda/issues/9072)
+        permitted_anomalies = {"segments_outside_manifest"}
+
+        # Whether any anomalies were found
+        any_anomalies = any(len(v) for v in report.values())
+
+        # List of fatal anomalies found
+        fatal_anomalies = set(k for k, v in report.items()
+                              if len(v) and k not in permitted_anomalies)
+
+        if not any_anomalies:
+            self.logger.info(f"No anomalies in object storage scrub")
+        elif not fatal_anomalies:
+            self.logger.warn(
+                f"Non-fatal anomalies in remote storage: {json.dumps(report, indent=2)}"
+            )
+        else:
+            self.logger.error(
+                f"Fatal anomalies in remote storage: {json.dumps(report, indent=2)}"
+            )
+            raise RuntimeError(
+                f"Object storage scrub detected fatal anomalies of type {fatal_anomalies}"
+            )

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -894,10 +894,6 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                                             stop_timeout=90)
 
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
-    # Redpandas before v23.1 did not have support for ABS.
-    # TODO(vlad): This @ignore can be removed once v23.1 becomes
-    # the "previous version".
-    @ignore(num_to_upgrade=2, cloud_storage_type=CloudStorageType.ABS)
     @matrix(num_to_upgrade=[0, 2], cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     def test_shadow_indexing(self, num_to_upgrade, cloud_storage_type):
@@ -913,7 +909,6 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         install_opts = InstallOptions(
             install_previous_version=test_mixed_versions)
         self.start_redpanda(num_nodes=3, install_opts=install_opts)
-        installer = self.redpanda._installer
 
         spec = TopicSpec(name="topic",
                          partition_count=partitions,
@@ -942,9 +937,6 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     # Redpandas before v23.1 did not have support for ABS.
-    # TODO(vlad): This @ignore can be removed once v23.1 becomes
-    # the "previous version".
-    @ignore(num_to_upgrade=2, cloud_storage_type=CloudStorageType.ABS)
     @matrix(num_to_upgrade=[0, 2], cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     def test_cross_shard(self, num_to_upgrade, cloud_storage_type):
@@ -952,12 +944,6 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         Test interaction between the shadow indexing and the partition movement.
         Move partitions with SI enabled between shards.
         """
-
-        # Redpandas before v23.1 did not have support for ABS.
-        # TODO(vlad): This check can be removed once v23.1 becomes
-        # the "previous version".
-        if num_to_upgrade > 0 and cloud_storage_type == CloudStorageType.ABS:
-            return
 
         throughput, records, moves, partitions = self._get_scale_params()
 

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -303,8 +303,6 @@ class TestReadReplicaService(EndToEndTest):
         # Consume from read replica topic and validate
         self.start_consumer()
         self.run_validation()  # calls self.consumer.stop()
-        assert self.redpanda
-        self.redpanda.stop()
 
         # Run consumer again, this time with source cluster stopped.
         # Now we can test that replicas do not write to s3.

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -114,6 +114,7 @@ class SIAdminApiTest(RedpandaTest):
             self.logger.info(f"describe topic result {partition}")
             assert partition.start_offset == 0, f"start-offset of the partition is supposed to be 0 instead of {partition.start_offset}"
 
+        self.redpanda.si_settings.set_expected_damage({"missing_segments"})
         segment_to_remove = self.find_deletion_candidate()
         self.logger.info(f"trying to remove segment {segment_to_remove}")
         self.cloud_storage_client.delete_object(self.s3_bucket_name,

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1392,6 +1392,8 @@ class TopicRecoveryTest(RedpandaTest):
         """Test the handling of the missing segment. The segment is
         missing if it's present in the manifest but deleted from the
         bucket."""
+        self.redpanda.si_settings.set_expected_damage({"missing_segments"})
+
         test_case = MissingSegment(self.cloud_storage_client, self.kafka_tools,
                                    self.rpk, self.s3_bucket, self.logger,
                                    self.rpk_producer_maker)


### PR DESCRIPTION
Tests are generally responsible for verifying that they can e.g. read data that they wrote.  However, there can also be data integrity issues that aren't obvious:
- Issues in housekeeping that might happen after a test has already successfully read something
- Issues where remote storage is damaged, but client reads are being served successfully from local storage.

This PR inlines (https://github.com/redpanda-data/redpanda/pull/9920), without which CloudStorageUsageTest will fail with a 500 error on the cloud storage status API.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none