### PR TITLE
[v23.1.x] storage: do not compact below log start offset

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1978,9 +1978,7 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
                 return _offset_translator.prefix_truncate_reset(
                   _last_snapshot_index, delta);
             })
-            .then([this] { return truncate_to_latest_snapshot(); })
-            .then(
-              [this] { _log.set_collectible_offset(_last_snapshot_index); });
+            .then([this] { return truncate_to_latest_snapshot(); });
       })
       .then([this] { return _snapshot_mgr.get_snapshot_size(); })
       .then([this](uint64_t size) { _snapshot_size = size; });
@@ -2136,8 +2134,6 @@ ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
               _flushed_offset = std::max(last_included_index, _flushed_offset);
           });
     });
-
-    _log.set_collectible_offset(last_included_index);
 }
 
 ss::future<>

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -743,15 +743,6 @@ ss::future<> disk_log_impl::compact(compaction_config cfg) {
           if (config().is_collectable()) {
               f = gc(cfg);
           }
-          if (unlikely(
-                config().has_overrides()
-                && config().get_overrides().cleanup_policy_bitflags
-                     == model::cleanup_policy_bitflags::none)) {
-              // prevent *any* collection - used for snapshots
-              // all the internal redpanda logs - i.e.: controller, etc should
-              // have this set
-              f = ss::now();
-          }
           if (config().is_compacted() && !_segs.empty()) {
               f = f.then([this, cfg] { return do_compact(cfg); });
           }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -298,7 +298,7 @@ bool disk_log_impl::is_front_segment(const segment_set::type& ptr) const {
            && ptr->reader().filename() == (*_segs.begin())->reader().filename();
 }
 
-ss::future<> disk_log_impl::garbage_collect_segments(
+ss::future<model::offset> disk_log_impl::garbage_collect_segments(
   compaction_config cfg, model::offset max_offset, std::string_view ctx) {
     vlog(
       gclog.debug,
@@ -314,7 +314,11 @@ ss::future<> disk_log_impl::garbage_collect_segments(
     if (_eviction_monitor && have_segments_to_evict) {
         _eviction_monitor->promise.set_value(max_offset);
         _eviction_monitor.reset();
+
+        co_return max_offset;
     }
+
+    // This is dead code. A subsequent commit removes it.
 
     // Max collectible offset can be overriden from multiple places
     // (unfortunately). We take the min.
@@ -322,7 +326,7 @@ ss::future<> disk_log_impl::garbage_collect_segments(
       cfg.max_collectible_offset,
       std::min(max_offset, _max_collectible_offset));
     auto* as = cfg.asrc;
-    return ss::do_until(
+    co_await ss::do_until(
       [this, as, max_offset] {
           return _segs.size() <= 1 || as->abort_requested()
                  || _segs.front()->offsets().committed_offset > max_offset;
@@ -339,16 +343,18 @@ ss::future<> disk_log_impl::garbage_collect_segments(
                 return remove_segment_permanently(ptr, ctx);
             });
       });
+
+    co_return _start_offset;
 }
 
-ss::future<>
+ss::future<model::offset>
 disk_log_impl::garbage_collect_max_partition_size(compaction_config cfg) {
     model::offset max_offset = size_based_gc_max_offset(cfg.max_bytes.value());
     return garbage_collect_segments(
       cfg, max_offset, "gc[size_based_retention]");
 }
 
-ss::future<>
+ss::future<model::offset>
 disk_log_impl::garbage_collect_oldest_segments(compaction_config cfg) {
     vlog(
       gclog.debug,
@@ -362,7 +368,8 @@ disk_log_impl::garbage_collect_oldest_segments(compaction_config cfg) {
       cfg, max_offset, "gc[time_based_retention]");
 }
 
-ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
+ss::future<> disk_log_impl::do_compact(
+  compaction_config cfg, std::optional<model::offset> new_start_offset) {
     vlog(
       gclog.trace,
       "[{}] applying 'compaction' log cleanup policy with config: {}",
@@ -370,11 +377,24 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
       cfg);
 
     // create a logging predicate for offsets..
-    auto offsets_compactible = [&cfg, this](segment& s) {
+    auto offsets_compactible = [&cfg, &new_start_offset, this](segment& s) {
+        if (new_start_offset && s.offsets().base_offset < *new_start_offset) {
+            vlog(
+              gclog.debug,
+              "[{}] segment {} base offs {}, new start offset {}, "
+              "skipping self compaction.",
+              config().ntp(),
+              s.reader().filename(),
+              s.offsets().base_offset,
+              *new_start_offset);
+            return false;
+        }
+
         if (s.has_compactible_offsets(cfg)) {
             vlog(
               gclog.debug,
-              "[{}] segment {} stable offs {}, max compactible {}, compacting.",
+              "[{}] segment {} stable offs {}, max compactible {}, "
+              "compacting.",
               config().ntp(),
               s.reader().filename(),
               s.offsets().stable_offset,
@@ -384,7 +404,7 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
             vlog(
               gclog.trace,
               "[{}] segment {} stable offs {} > max compactible offs {}, "
-              "skipping.",
+              "skipping self compaction.",
               config().ntp(),
               s.reader().filename(),
               s.offsets().stable_offset,
@@ -750,27 +770,28 @@ disk_log_impl::apply_overrides(compaction_config defaults) const {
 }
 
 ss::future<> disk_log_impl::compact(compaction_config cfg) {
-    return ss::try_with_gate(
-      _compaction_housekeeping_gate, [this, cfg]() mutable {
-          vlog(
-            gclog.trace,
-            "[{}] house keeping with configuration from manager: {}",
-            config().ntp(),
-            cfg);
-          cfg = apply_overrides(cfg);
-          ss::future<> f = ss::now();
-          if (config().is_collectable()) {
-              f = gc(cfg);
-          }
-          if (config().is_compacted() && !_segs.empty()) {
-              f = f.then([this, cfg] { return do_compact(cfg); });
-          }
-          return f.then(
-            [this] { _probe.set_compaction_ratio(_compaction_ratio.get()); });
-      });
+    ss::gate::holder holder{_compaction_housekeeping_gate};
+    vlog(
+      gclog.trace,
+      "[{}] house keeping with configuration from manager: {}",
+      config().ntp(),
+      cfg);
+    cfg = apply_overrides(cfg);
+
+    std::optional<model::offset> new_start_offset;
+    if (config().is_collectable()) {
+        new_start_offset = co_await gc(cfg);
+    }
+
+    if (config().is_compacted() && !_segs.empty()) {
+        co_await do_compact(cfg, new_start_offset);
+    }
+
+    _probe.set_compaction_ratio(_compaction_ratio.get());
 }
 
-ss::future<> disk_log_impl::gc(compaction_config cfg) {
+ss::future<std::optional<model::offset>>
+disk_log_impl::gc(compaction_config cfg) {
     vassert(!_closed, "gc on closed log - {}", *this);
     vlog(
       gclog.trace,
@@ -782,7 +803,7 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
           gclog.trace,
           "[{}] skipped log deletion, exempt topic",
           config().ntp());
-        co_return;
+        co_return std::nullopt;
     }
     if (cfg.max_bytes) {
         size_t max = cfg.max_bytes.value();
@@ -796,7 +817,7 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
             co_return co_await garbage_collect_max_partition_size(cfg);
         }
     }
-    co_await garbage_collect_oldest_segments(cfg);
+    co_return co_await garbage_collect_oldest_segments(cfg);
 }
 
 ss::future<> disk_log_impl::remove_empty_segments() {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -782,7 +782,7 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
           gclog.trace,
           "[{}] skipped log deletion, exempt topic",
           config().ntp());
-        return ss::make_ready_future<>();
+        co_return;
     }
     if (cfg.max_bytes) {
         size_t max = cfg.max_bytes.value();
@@ -793,10 +793,10 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
           max,
           _probe.partition_size());
         if (!_segs.empty() && _probe.partition_size() > max) {
-            return garbage_collect_max_partition_size(cfg);
+            co_return co_await garbage_collect_max_partition_size(cfg);
         }
     }
-    return garbage_collect_oldest_segments(cfg);
+    co_await garbage_collect_oldest_segments(cfg);
 }
 
 ss::future<> disk_log_impl::remove_empty_segments() {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -283,14 +283,9 @@ disk_log_impl::monitor_eviction(ss::abort_source& as) {
       .promise.get_future();
 }
 
-void disk_log_impl::set_collectible_offset(model::offset o) {
-    vlog(
-      gclog.debug,
-      "[{}] setting max collectible offset {}, prev offset {}",
-      config().ntp(),
-      o,
-      _max_collectible_offset);
-    _max_collectible_offset = std::max(_max_collectible_offset, o);
+// TODO: Remove this function once mem_log_impl is gone
+void disk_log_impl::set_collectible_offset(model::offset) {
+    vassert(false, "set_collectible_offset called on disk_log_impl");
 }
 
 bool disk_log_impl::is_front_segment(const segment_set::type& ptr) const {
@@ -315,34 +310,8 @@ ss::future<model::offset> disk_log_impl::garbage_collect_segments(
         _eviction_monitor->promise.set_value(max_offset);
         _eviction_monitor.reset();
 
-        co_return max_offset;
+        co_return model::next_offset(max_offset);
     }
-
-    // This is dead code. A subsequent commit removes it.
-
-    // Max collectible offset can be overriden from multiple places
-    // (unfortunately). We take the min.
-    max_offset = std::min(
-      cfg.max_collectible_offset,
-      std::min(max_offset, _max_collectible_offset));
-    auto* as = cfg.asrc;
-    co_await ss::do_until(
-      [this, as, max_offset] {
-          return _segs.size() <= 1 || as->abort_requested()
-                 || _segs.front()->offsets().committed_offset > max_offset;
-      },
-      [this, ctx] {
-          auto ptr = _segs.front();
-          return update_start_offset(
-                   ptr->offsets().dirty_offset + model::offset(1))
-            .then([this, ptr, ctx](bool /*updated*/) {
-                if (!is_front_segment(ptr)) {
-                    return ss::now();
-                }
-                _segs.pop_front();
-                return remove_segment_permanently(ptr, ctx);
-            });
-      });
 
     co_return _start_offset;
 }
@@ -1699,10 +1668,9 @@ storage_resources& disk_log_impl::resources() { return _manager.resources(); }
 std::ostream& disk_log_impl::print(std::ostream& o) const {
     fmt::print(
       o,
-      "{{offsets: {}, max_collectible_offset: {}, is_closed: {}, segments: "
+      "{{offsets: {}, is_closed: {}, segments: "
       "[{}], config: {}}}",
       offsets(),
-      _max_collectible_offset,
       _closed,
       _segs,
       config());

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -777,9 +777,6 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
       "[{}] applying 'deletion' log cleanup policy with config: {}",
       config().ntp(),
       cfg);
-    if (unlikely(cfg.asrc->abort_requested())) {
-        return ss::make_ready_future<>();
-    }
     if (deletion_exempt(config().ntp())) {
         vlog(
           gclog.trace,

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -51,6 +51,25 @@
 
 using namespace std::literals::chrono_literals;
 
+namespace {
+/*
+ * Some logs must be exempt from the cleanup=delete policy such that their full
+ * history is retained. This function explicitly protects against any accidental
+ * configuration changes that might violate that constraint. Examples include
+ * the controller and internal kafka topics, with the exception of the
+ * transaction manager topic.
+ *
+ * Once controller snapshots are enabled this rule will relaxed accordingly.
+ */
+bool deletion_exempt(const model::ntp& ntp) {
+    bool is_internal_namespace = ntp.ns() == model::redpanda_ns
+                                 || ntp.ns() == model::kafka_internal_namespace;
+    bool is_tx_manager_ntp = ntp.ns == model::kafka_internal_namespace
+                             && ntp.tp.topic == model::tx_manager_topic;
+    return !is_tx_manager_ntp && is_internal_namespace;
+}
+} // namespace
+
 namespace storage {
 
 disk_log_impl::disk_log_impl(
@@ -761,20 +780,10 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
     if (unlikely(cfg.asrc->abort_requested())) {
         return ss::make_ready_future<>();
     }
-    // TODO: this a workaround until we have raft-snapshotting in the the
-    // controller so that we can still evict older data. At the moment we keep
-    // the full history.
-    bool is_internal_namespace = config().ntp().ns() == model::redpanda_ns
-                                 || config().ntp().ns()
-                                      == model::kafka_internal_namespace;
-    bool is_tx_manager_ntp = config().ntp().ns
-                               == model::kafka_internal_namespace
-                             && config().ntp().tp.topic
-                                  == model::tx_manager_topic;
-    if (!is_tx_manager_ntp && is_internal_namespace) {
+    if (deletion_exempt(config().ntp())) {
         vlog(
           gclog.trace,
-          "[{}] skipped log deletion, internal topic",
+          "[{}] skipped log deletion, exempt topic",
           config().ntp());
         return ss::make_ready_future<>();
     }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -202,7 +202,6 @@ private:
     storage::probe _probe;
     failure_probes _failure_probes;
     std::optional<eviction_monitor> _eviction_monitor;
-    model::offset _max_collectible_offset;
     size_t _max_segment_size;
     std::unique_ptr<readers_cache> _readers_cache;
     // average ratio of segment sizes after segment size before compaction

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -127,13 +127,14 @@ private:
     // Returns if the update actually took place.
     ss::future<bool> update_start_offset(model::offset o);
 
-    ss::future<> do_compact(compaction_config);
+    ss::future<> do_compact(
+      compaction_config, std::optional<model::offset> = std::nullopt);
     ss::future<compaction_result> compact_adjacent_segments(
       std::pair<segment_set::iterator, segment_set::iterator>,
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_compaction_range(const compaction_config&);
-    ss::future<> gc(compaction_config);
+    ss::future<std::optional<model::offset>> gc(compaction_config);
 
     ss::future<> remove_empty_segments();
 
@@ -155,9 +156,11 @@ private:
     ss::future<> do_truncate_prefix(truncate_prefix_config);
     ss::future<> remove_prefix_full_segments(truncate_prefix_config);
 
-    ss::future<> garbage_collect_max_partition_size(compaction_config cfg);
-    ss::future<> garbage_collect_oldest_segments(compaction_config cfg);
-    ss::future<> garbage_collect_segments(
+    ss::future<model::offset>
+    garbage_collect_max_partition_size(compaction_config cfg);
+    ss::future<model::offset>
+    garbage_collect_oldest_segments(compaction_config cfg);
+    ss::future<model::offset> garbage_collect_segments(
       compaction_config cfg, model::offset, std::string_view);
     model::offset size_based_gc_max_offset(size_t);
     model::offset time_based_gc_max_offset(model::timestamp);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -219,6 +219,10 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     }
 
     while ((_logs_list.front().flags & bflags::compacted) == bflags::none) {
+        if (_abort_source.abort_requested()) {
+            co_return;
+        }
+
         auto& current_log = _logs_list.front();
 
         _logs_list.pop_front();

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -33,8 +33,6 @@ FIXTURE_TEST(retention_test_time, gc_fixture) {
       | storage::add_segment(102)
       | storage::add_random_batch(102, 2, storage::maybe_compress_batches::yes)
       | storage::add_segment(104) | storage::add_random_batches(104, 3);
-    builder.get_log().set_collectible_offset(
-      builder.get_log().offsets().dirty_offset);
     BOOST_TEST_MESSAGE(
       "Should not collect segments with timestamp older than 1");
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
@@ -64,8 +62,6 @@ FIXTURE_TEST(retention_test_size, gc_fixture) {
       | storage::add_segment(102)
       | storage::add_random_batch(102, 2, storage::maybe_compress_batches::yes)
       | storage::add_segment(104) | storage::add_random_batches(104, 3);
-    builder.get_log().set_collectible_offset(
-      builder.get_log().offsets().dirty_offset);
     BOOST_TEST_MESSAGE("Should not collect segments because size equal to "
                        "current partition size");
     builder
@@ -75,13 +71,12 @@ FIXTURE_TEST(retention_test_size, gc_fixture) {
           builder.get_disk_log_impl().get_probe().partition_size()));
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
 
-    BOOST_TEST_MESSAGE(
-      "Should collect all inactive segments, leaving an active one");
+    BOOST_TEST_MESSAGE("Should collect all segments");
     builder
       | storage::garbage_collect(model::timestamp(1), std::optional<size_t>(0))
       | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 1);
+    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
 }
 
 FIXTURE_TEST(retention_test_after_truncation, gc_fixture) {
@@ -91,8 +86,6 @@ FIXTURE_TEST(retention_test_after_truncation, gc_fixture) {
       | storage::truncate_log(model::offset(0))
       | storage::garbage_collect(model::timestamp::now(), std::nullopt)
       | storage::stop();
-    builder.get_log().set_collectible_offset(
-      builder.get_log().offsets().dirty_offset);
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
     BOOST_CHECK_EQUAL(
       builder.get_disk_log_impl().get_probe().partition_size(), 0);
@@ -140,9 +133,6 @@ FIXTURE_TEST(retention_by_size_with_remote_write, gc_fixture) {
         ++dirty_offset;
         partition_size
           = builder.get_disk_log_impl().get_probe().partition_size();
-
-        builder.get_log().set_collectible_offset(
-          builder.get_log().offsets().dirty_offset);
 
         auto segment_count_before_gc = builder.get_log().segment_count();
         builder
@@ -207,9 +197,6 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
         storage::disk_log_builder::should_flush_after::yes,
         log_creation_time);
 
-    builder.get_log().set_collectible_offset(
-      builder.get_log().offsets().dirty_offset);
-
     // Try to garbage collet the segments. None should get collected
     // because we are currently using the default local target retention.
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt);
@@ -222,8 +209,8 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
       = tristate<std::chrono::milliseconds>{0ms};
     builder.update_configuration(time_override).get();
 
-    // Collect again. One segment should be removed this time.
+    // Collect again. All segments should be removed this time.
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt)
       | storage::stop();
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 1);
+    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
 }

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -121,6 +121,21 @@ ss::future<> disk_log_builder::gc(
       _abort_source));
 }
 
+ss::future<std::optional<model::offset>>
+disk_log_builder::apply_retention(compaction_config cfg) {
+    return get_disk_log_impl().gc(cfg);
+}
+
+ss::future<> disk_log_builder::apply_compaction(
+  compaction_config cfg, std::optional<model::offset> new_start_offset) {
+    return get_disk_log_impl().do_compact(cfg, new_start_offset);
+}
+
+ss::future<bool>
+disk_log_builder::update_start_offset(model::offset start_offset) {
+    return get_disk_log_impl().update_start_offset(start_offset);
+}
+
 ss::future<> disk_log_builder::stop() {
     return _storage.stop().then([this]() { return _feature_table.stop(); });
 }

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -113,12 +113,28 @@ ss::future<> disk_log_builder::truncate(model::offset o) {
 ss::future<> disk_log_builder::gc(
   model::timestamp collection_upper_bound,
   std::optional<size_t> max_partition_retention_size) {
-    return get_log().compact(compaction_config(
-      collection_upper_bound,
-      max_partition_retention_size,
-      model::offset::max(),
-      ss::default_priority_class(),
-      _abort_source));
+    ss::abort_source as;
+    auto eviction_future = get_log().monitor_eviction(as);
+
+    get_log()
+      .compact(compaction_config(
+        collection_upper_bound,
+        max_partition_retention_size,
+        model::offset::max(),
+        ss::default_priority_class(),
+        _abort_source))
+      .get();
+
+    if (eviction_future.available()) {
+        auto evict_until = eviction_future.get();
+        return get_log().truncate_prefix(storage::truncate_prefix_config{
+          model::next_offset(evict_until), ss::default_priority_class()});
+    } else {
+        as.request_abort();
+        eviction_future.ignore_ready_future();
+    }
+
+    return ss::make_ready_future<>();
 }
 
 ss::future<std::optional<model::offset>>

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -303,6 +303,12 @@ public:
     ss::future<> gc(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);
+    ss::future<std::optional<model::offset>>
+    apply_retention(compaction_config cfg);
+    ss::future<> apply_compaction(
+      compaction_config cfg,
+      std::optional<model::offset> new_start_offset = std::nullopt);
+    ss::future<bool> update_start_offset(model::offset start_offset);
     ss::future<> add_batch(
       model::record_batch batch,
       log_append_config config = append_config(),


### PR DESCRIPTION
Backport of PRs https://github.com/redpanda-data/redpanda/pull/9483 and https://github.com/redpanda-data/redpanda/pull/9487 (and e7ee3c63ae6484afa8ed8ee028fec9a9bf7d6842) to v23.1.x.

In v23.1.x time based retention runs only when size based retention does not run. https://github.com/redpanda-data/redpanda/pull/9487 changes this to apply both retention policies on each housekeeping run, however this is too
big of a behavioural change to backport. Hence, this backport preserves the v23.1.x behaviour of exclusive application for retention policies, while still including the bug fix from https://github.com/redpanda-data/redpanda/pull/9483.