### PR TITLE
[v22.3.x] storage: do not compact below log start offset

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1949,8 +1949,7 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
               return _offset_translator.prefix_truncate_reset(
                 _last_snapshot_index, delta);
           })
-          .then([this] { return truncate_to_latest_snapshot(); })
-          .then([this] { _log.set_collectible_offset(_last_snapshot_index); });
+          .then([this] { return truncate_to_latest_snapshot(); });
     });
 }
 
@@ -2104,8 +2103,6 @@ ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
               _flushed_offset = std::max(last_included_index, _flushed_offset);
           });
     });
-
-    _log.set_collectible_offset(last_included_index);
 }
 
 ss::future<>

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -294,7 +294,7 @@ bool disk_log_impl::is_front_segment(const segment_set::type& ptr) const {
            && ptr->reader().filename() == (*_segs.begin())->reader().filename();
 }
 
-ss::future<> disk_log_impl::garbage_collect_segments(
+ss::future<model::offset> disk_log_impl::garbage_collect_segments(
   compaction_config cfg, model::offset max_offset, std::string_view ctx) {
     vlog(
       gclog.debug,
@@ -310,7 +310,11 @@ ss::future<> disk_log_impl::garbage_collect_segments(
     if (_eviction_monitor && have_segments_to_evict) {
         _eviction_monitor->promise.set_value(max_offset);
         _eviction_monitor.reset();
+
+        co_return max_offset;
     }
+
+    // This is dead code. A subsequent commit removes it.
 
     // Max collectible offset can be overriden from multiple places
     // (unfortunately). We take the min.
@@ -318,7 +322,7 @@ ss::future<> disk_log_impl::garbage_collect_segments(
       cfg.max_collectible_offset,
       std::min(max_offset, _max_collectible_offset));
     auto* as = cfg.asrc;
-    return ss::do_until(
+    co_await ss::do_until(
       [this, as, max_offset] {
           return _segs.size() <= 1 || as->abort_requested()
                  || _segs.front()->offsets().committed_offset > max_offset;
@@ -335,16 +339,18 @@ ss::future<> disk_log_impl::garbage_collect_segments(
                 return remove_segment_permanently(ptr, ctx);
             });
       });
+
+    co_return _start_offset;
 }
 
-ss::future<>
+ss::future<model::offset>
 disk_log_impl::garbage_collect_max_partition_size(compaction_config cfg) {
     model::offset max_offset = size_based_gc_max_offset(cfg.max_bytes.value());
     return garbage_collect_segments(
       cfg, max_offset, "gc[size_based_retention]");
 }
 
-ss::future<>
+ss::future<model::offset>
 disk_log_impl::garbage_collect_oldest_segments(compaction_config cfg) {
     vlog(
       gclog.debug,
@@ -358,7 +364,8 @@ disk_log_impl::garbage_collect_oldest_segments(compaction_config cfg) {
       cfg, max_offset, "gc[time_based_retention]");
 }
 
-ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
+ss::future<> disk_log_impl::do_compact(
+  compaction_config cfg, std::optional<model::offset> new_start_offset) {
     vlog(
       gclog.trace,
       "[{}] applying 'compaction' log cleanup policy with config: {}",
@@ -366,11 +373,24 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
       cfg);
 
     // create a logging predicate for offsets..
-    auto offsets_compactible = [&cfg, this](segment& s) {
+    auto offsets_compactible = [&cfg, &new_start_offset, this](segment& s) {
+        if (new_start_offset && s.offsets().base_offset < *new_start_offset) {
+            vlog(
+              gclog.debug,
+              "[{}] segment {} base offs {}, new start offset {}, "
+              "skipping self compaction.",
+              config().ntp(),
+              s.reader().filename(),
+              s.offsets().base_offset,
+              *new_start_offset);
+            return false;
+        }
+
         if (s.has_compactible_offsets(cfg)) {
             vlog(
               gclog.debug,
-              "[{}] segment {} stable offs {}, max compactible {}, compacting.",
+              "[{}] segment {} stable offs {}, max compactible {}, "
+              "compacting.",
               config().ntp(),
               s.reader().filename(),
               s.offsets().stable_offset,
@@ -380,7 +400,7 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
             vlog(
               gclog.trace,
               "[{}] segment {} stable offs {} > max compactible offs {}, "
-              "skipping.",
+              "skipping self compaction.",
               config().ntp(),
               s.reader().filename(),
               s.offsets().stable_offset,
@@ -751,26 +771,28 @@ disk_log_impl::apply_overrides(compaction_config defaults) const {
 }
 
 ss::future<> disk_log_impl::compact(compaction_config cfg) {
-    return ss::try_with_gate(_compaction_gate, [this, cfg]() mutable {
-        vlog(
-          gclog.trace,
-          "[{}] house keeping with configuration from manager: {}",
-          config().ntp(),
-          cfg);
-        cfg = apply_overrides(cfg);
-        ss::future<> f = ss::now();
-        if (config().is_collectable()) {
-            f = gc(cfg);
-        }
-        if (config().is_compacted() && !_segs.empty()) {
-            f = f.then([this, cfg] { return do_compact(cfg); });
-        }
-        return f.then(
-          [this] { _probe.set_compaction_ratio(_compaction_ratio.get()); });
-    });
+    ss::gate::holder holder{_compaction_gate};
+    vlog(
+      gclog.trace,
+      "[{}] house keeping with configuration from manager: {}",
+      config().ntp(),
+      cfg);
+    cfg = apply_overrides(cfg);
+
+    std::optional<model::offset> new_start_offset;
+    if (config().is_collectable()) {
+        new_start_offset = co_await gc(cfg);
+    }
+
+    if (config().is_compacted() && !_segs.empty()) {
+        co_await do_compact(cfg, new_start_offset);
+    }
+
+    _probe.set_compaction_ratio(_compaction_ratio.get());
 }
 
-ss::future<> disk_log_impl::gc(compaction_config cfg) {
+ss::future<std::optional<model::offset>>
+disk_log_impl::gc(compaction_config cfg) {
     vassert(!_closed, "gc on closed log - {}", *this);
     vlog(
       gclog.trace,
@@ -782,7 +804,7 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
           gclog.trace,
           "[{}] skipped log deletion, exempt topic",
           config().ntp());
-        co_return;
+        co_return std::nullopt;
     }
     if (cfg.max_bytes) {
         size_t max = cfg.max_bytes.value();
@@ -796,7 +818,7 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
             co_return co_await garbage_collect_max_partition_size(cfg);
         }
     }
-    co_await garbage_collect_oldest_segments(cfg);
+    co_return co_await garbage_collect_oldest_segments(cfg);
 }
 
 ss::future<> disk_log_impl::remove_empty_segments() {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -279,14 +279,9 @@ disk_log_impl::monitor_eviction(ss::abort_source& as) {
       .promise.get_future();
 }
 
-void disk_log_impl::set_collectible_offset(model::offset o) {
-    vlog(
-      gclog.debug,
-      "[{}] setting max collectible offset {}, prev offset {}",
-      config().ntp(),
-      o,
-      _max_collectible_offset);
-    _max_collectible_offset = std::max(_max_collectible_offset, o);
+// TODO: Remove this function once mem_log_impl is gone
+void disk_log_impl::set_collectible_offset(model::offset) {
+    vassert(false, "set_collectible_offset called on disk_log_impl");
 }
 
 bool disk_log_impl::is_front_segment(const segment_set::type& ptr) const {
@@ -311,34 +306,8 @@ ss::future<model::offset> disk_log_impl::garbage_collect_segments(
         _eviction_monitor->promise.set_value(max_offset);
         _eviction_monitor.reset();
 
-        co_return max_offset;
+        co_return model::next_offset(max_offset);
     }
-
-    // This is dead code. A subsequent commit removes it.
-
-    // Max collectible offset can be overriden from multiple places
-    // (unfortunately). We take the min.
-    max_offset = std::min(
-      cfg.max_collectible_offset,
-      std::min(max_offset, _max_collectible_offset));
-    auto* as = cfg.asrc;
-    co_await ss::do_until(
-      [this, as, max_offset] {
-          return _segs.size() <= 1 || as->abort_requested()
-                 || _segs.front()->offsets().committed_offset > max_offset;
-      },
-      [this, ctx] {
-          auto ptr = _segs.front();
-          return update_start_offset(
-                   ptr->offsets().dirty_offset + model::offset(1))
-            .then([this, ptr, ctx](bool /*updated*/) {
-                if (!is_front_segment(ptr)) {
-                    return ss::now();
-                }
-                _segs.pop_front();
-                return remove_segment_permanently(ptr, ctx);
-            });
-      });
 
     co_return _start_offset;
 }
@@ -1610,10 +1579,9 @@ storage_resources& disk_log_impl::resources() { return _manager.resources(); }
 std::ostream& disk_log_impl::print(std::ostream& o) const {
     fmt::print(
       o,
-      "{{offsets: {}, max_collectible_offset: {}, is_closed: {}, segments: "
+      "{{offsets: {}, is_closed: {}, segments: "
       "[{}], config: {}}}",
       offsets(),
-      _max_collectible_offset,
       _closed,
       _segs,
       config());

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -782,7 +782,7 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
           gclog.trace,
           "[{}] skipped log deletion, exempt topic",
           config().ntp());
-        return ss::make_ready_future<>();
+        co_return;
     }
     if (cfg.max_bytes) {
         size_t max = cfg.max_bytes.value();
@@ -793,10 +793,10 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
           max,
           _probe.partition_size());
         if (!_segs.empty() && _probe.partition_size() > max) {
-            return garbage_collect_max_partition_size(cfg);
+            co_return co_await garbage_collect_max_partition_size(cfg);
         }
     }
-    return garbage_collect_oldest_segments(cfg);
+    co_await garbage_collect_oldest_segments(cfg);
 }
 
 ss::future<> disk_log_impl::remove_empty_segments() {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -743,15 +743,6 @@ ss::future<> disk_log_impl::compact(compaction_config cfg) {
         if (config().is_collectable()) {
             f = gc(cfg);
         }
-        if (unlikely(
-              config().has_overrides()
-              && config().get_overrides().cleanup_policy_bitflags
-                   == model::cleanup_policy_bitflags::none)) {
-            // prevent *any* collection - used for snapshots
-            // all the internal redpanda logs - i.e.: controller, etc should
-            // have this set
-            f = ss::now();
-        }
         if (config().is_compacted() && !_segs.empty()) {
             f = f.then([this, cfg] { return do_compact(cfg); });
         }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -777,9 +777,6 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
       "[{}] applying 'deletion' log cleanup policy with config: {}",
       config().ntp(),
       cfg);
-    if (unlikely(cfg.asrc->abort_requested())) {
-        return ss::make_ready_future<>();
-    }
     if (deletion_exempt(config().ntp())) {
         vlog(
           gclog.trace,

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -192,7 +192,6 @@ private:
     storage::probe _probe;
     failure_probes _failure_probes;
     std::optional<eviction_monitor> _eviction_monitor;
-    model::offset _max_collectible_offset;
     size_t _max_segment_size;
     std::unique_ptr<readers_cache> _readers_cache;
     // average ratio of segment sizes after segment size before compaction

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -120,13 +120,14 @@ private:
     // Returns if the update actually took place.
     ss::future<bool> update_start_offset(model::offset o);
 
-    ss::future<> do_compact(compaction_config);
+    ss::future<> do_compact(
+      compaction_config, std::optional<model::offset> = std::nullopt);
     ss::future<compaction_result> compact_adjacent_segments(
       std::pair<segment_set::iterator, segment_set::iterator>,
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_compaction_range(const compaction_config&);
-    ss::future<> gc(compaction_config);
+    ss::future<std::optional<model::offset>> gc(compaction_config);
 
     ss::future<> remove_empty_segments();
 
@@ -146,9 +147,11 @@ private:
     ss::future<> do_truncate_prefix(truncate_prefix_config);
     ss::future<> remove_prefix_full_segments(truncate_prefix_config);
 
-    ss::future<> garbage_collect_max_partition_size(compaction_config cfg);
-    ss::future<> garbage_collect_oldest_segments(compaction_config cfg);
-    ss::future<> garbage_collect_segments(
+    ss::future<model::offset>
+    garbage_collect_max_partition_size(compaction_config cfg);
+    ss::future<model::offset>
+    garbage_collect_oldest_segments(compaction_config cfg);
+    ss::future<model::offset> garbage_collect_segments(
       compaction_config cfg, model::offset, std::string_view);
     model::offset size_based_gc_max_offset(size_t);
     model::offset time_based_gc_max_offset(model::timestamp);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -208,6 +208,10 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     }
 
     while ((_logs_list.front().flags & bflags::compacted) == bflags::none) {
+        if (_abort_source.abort_requested()) {
+            co_return;
+        }
+
         auto& current_log = _logs_list.front();
 
         _logs_list.pop_front();

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -33,8 +33,6 @@ FIXTURE_TEST(retention_test_time, gc_fixture) {
       | storage::add_segment(102)
       | storage::add_random_batch(102, 2, storage::maybe_compress_batches::yes)
       | storage::add_segment(104) | storage::add_random_batches(104, 3);
-    builder.get_log().set_collectible_offset(
-      builder.get_log().offsets().dirty_offset);
     BOOST_TEST_MESSAGE(
       "Should not collect segments with timestamp older than 1");
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
@@ -64,8 +62,6 @@ FIXTURE_TEST(retention_test_size, gc_fixture) {
       | storage::add_segment(102)
       | storage::add_random_batch(102, 2, storage::maybe_compress_batches::yes)
       | storage::add_segment(104) | storage::add_random_batches(104, 3);
-    builder.get_log().set_collectible_offset(
-      builder.get_log().offsets().dirty_offset);
     BOOST_TEST_MESSAGE("Should not collect segments because size equal to "
                        "current partition size");
     builder
@@ -75,13 +71,12 @@ FIXTURE_TEST(retention_test_size, gc_fixture) {
           builder.get_disk_log_impl().get_probe().partition_size()));
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
 
-    BOOST_TEST_MESSAGE(
-      "Should collect all inactive segments, leaving an active one");
+    BOOST_TEST_MESSAGE("Should collect all segments");
     builder
       | storage::garbage_collect(model::timestamp(1), std::optional<size_t>(0))
       | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 1);
+    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
 }
 
 FIXTURE_TEST(retention_test_after_truncation, gc_fixture) {
@@ -91,8 +86,6 @@ FIXTURE_TEST(retention_test_after_truncation, gc_fixture) {
       | storage::truncate_log(model::offset(0))
       | storage::garbage_collect(model::timestamp::now(), std::nullopt)
       | storage::stop();
-    builder.get_log().set_collectible_offset(
-      builder.get_log().offsets().dirty_offset);
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
     BOOST_CHECK_EQUAL(
       builder.get_disk_log_impl().get_probe().partition_size(), 0);
@@ -140,9 +133,6 @@ FIXTURE_TEST(retention_by_size_with_remote_write, gc_fixture) {
         ++dirty_offset;
         partition_size
           = builder.get_disk_log_impl().get_probe().partition_size();
-
-        builder.get_log().set_collectible_offset(
-          builder.get_log().offsets().dirty_offset);
 
         auto segment_count_before_gc = builder.get_log().segment_count();
         builder
@@ -207,9 +197,6 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
         storage::disk_log_builder::should_flush_after::yes,
         log_creation_time);
 
-    builder.get_log().set_collectible_offset(
-      builder.get_log().offsets().dirty_offset);
-
     // Try to garbage collet the segments. None should get collected
     // because we are currently using the default local target retention.
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt);
@@ -222,8 +209,8 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
       = tristate<std::chrono::milliseconds>{0ms};
     builder.update_configuration(time_override).get();
 
-    // Collect again. One segment should be removed this time.
+    // Collect again. All segments should be removed this time.
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt)
       | storage::stop();
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 1);
+    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
 }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -66,6 +66,26 @@ void validate_offsets(
         it++;
     }
 }
+
+void compact_and_prefix_truncate(
+  storage::disk_log_impl& log, storage::compaction_config cfg) {
+    ss::abort_source as;
+    auto eviction_future = log.monitor_eviction(as);
+
+    log.compact(cfg).get();
+
+    if (eviction_future.available()) {
+        auto evict_until = eviction_future.get();
+        log
+          .truncate_prefix(storage::truncate_prefix_config{
+            model::next_offset(evict_until), ss::default_priority_class()})
+          .get();
+    } else {
+        as.request_abort();
+        eviction_future.ignore_ready_future();
+    }
+}
+
 FIXTURE_TEST(
   test_assinging_offsets_in_single_segment_log, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
@@ -507,14 +527,12 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
      * [100..110][200..230][231..261]
      */
 
-    // Set max_collectible_offset to min should not gc any segments.
     storage::compaction_config ccfg_no_compact(
       model::timestamp(200),
       std::nullopt,
       model::offset::min(), // should prevent compaction
       ss::default_priority_class(),
       as);
-    log.set_collectible_offset(log.offsets().dirty_offset);
     auto before = log.offsets();
     log.compact(ccfg_no_compact).get0();
     auto after = log.offsets();
@@ -528,10 +546,9 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
           ss::default_priority_class(),
           as);
     };
-    log.set_collectible_offset(log.offsets().dirty_offset);
 
     // gc with timestamp 50, no segments should be evicted
-    log.compact(make_compaction_cfg(50)).get0();
+    compact_and_prefix_truncate(*disk_log, make_compaction_cfg(50));
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 3);
     BOOST_REQUIRE_EQUAL(
       disk_log->segments().front()->offsets().base_offset, model::offset(0));
@@ -539,21 +556,21 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
       disk_log->segments().back()->offsets().dirty_offset, model::offset(59));
 
     // gc with timestamp 102, no segments should be evicted
-    log.compact(make_compaction_cfg(102)).get0();
+    compact_and_prefix_truncate(*disk_log, make_compaction_cfg(102));
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 3);
     BOOST_REQUIRE_EQUAL(
       disk_log->segments().front()->offsets().base_offset, model::offset(0));
     BOOST_REQUIRE_EQUAL(
       disk_log->segments().back()->offsets().dirty_offset, model::offset(59));
     // gc with timestamp 201, should evict first segment
-    log.compact(make_compaction_cfg(201)).get0();
+    compact_and_prefix_truncate(*disk_log, make_compaction_cfg(201));
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 2);
     BOOST_REQUIRE_EQUAL(
       disk_log->segments().front()->offsets().base_offset, model::offset(10));
     BOOST_REQUIRE_EQUAL(
       disk_log->segments().back()->offsets().dirty_offset, model::offset(59));
     // gc with timestamp 240, should evict first segment
-    log.compact(make_compaction_cfg(240)).get0();
+    compact_and_prefix_truncate(*disk_log, make_compaction_cfg(240));
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 1);
     BOOST_REQUIRE_EQUAL(
       disk_log->segments().front()->offsets().base_offset, model::offset(40));
@@ -573,6 +590,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto disk_log = get_disk_log(log);
     auto headers = append_random_batches(log, 10);
     log.flush().get0();
     auto all_batches = read_and_validate_all_batches(log);
@@ -592,15 +610,15 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       size_t(0),
       [](size_t acc, model::record_batch& b) { return acc + b.size_bytes(); });
 
-    // Set max_collectible_offset to min should not gc any segments.
+    // Set the max number of bytes to the total size of the log.
+    // This will prevent compaction.
     storage::compaction_config ccfg_no_compact(
       model::timestamp::min(),
-      (total_size - first_size) + 1,
-      model::offset::min(), // should prevent compaction
+      total_size + first_size,
+      model::offset::max(),
       ss::default_priority_class(),
       as);
-    log.set_collectible_offset(log.offsets().dirty_offset);
-    log.compact(ccfg_no_compact).get0();
+    compact_and_prefix_truncate(*disk_log, ccfg_no_compact);
 
     auto new_lstats = log.offsets();
     BOOST_REQUIRE_EQUAL(new_lstats.start_offset, lstats.start_offset);
@@ -611,8 +629,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       model::offset::max(),
       ss::default_priority_class(),
       as);
-    log.set_collectible_offset(log.offsets().dirty_offset);
-    log.compact(ccfg).get0();
+    compact_and_prefix_truncate(*disk_log, ccfg);
 
     new_lstats = log.offsets();
     info("Final offsets {}", new_lstats);
@@ -666,10 +683,12 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
     auto lstats_after = log.offsets();
 
     BOOST_REQUIRE_EQUAL(lstats_before.start_offset, lstats_after.start_offset);
-    // set max evictable offset
-    log.set_collectible_offset(offset);
     // wait for compaction
     log.compact(ccfg).get0();
+    log
+      .truncate_prefix(storage::truncate_prefix_config{
+        model::next_offset(offset), ss::default_priority_class()})
+      .get();
     auto compacted_lstats = log.offsets();
     info("Compacted offsets {}", compacted_lstats);
     // check if compaction happend
@@ -759,7 +778,6 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
     ss::semaphore _sem{1};
     int appends = 100;
     int batches_per_append = 5;
-    log.set_collectible_offset(model::offset(10000000));
     auto compact = [log, &as]() mutable {
         storage::compaction_config ccfg(
           model::timestamp::min(),
@@ -1363,7 +1381,6 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
       lstats_before.committed_offset, model::offset{input_batch_count - 1});
     BOOST_REQUIRE_EQUAL(lstats_before.start_offset, model::offset{0});
 
-    log.set_collectible_offset(log.offsets().dirty_offset);
     storage::compaction_config ccfg(
       model::timestamp::min(),
       50_KiB,
@@ -1374,7 +1391,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     // Compact 10 times, with a configuration calling for 60kiB max log size.
     // This results in prefix truncating at offset 50.
     for (int i = 0; i < 10; ++i) {
-        log.compact(ccfg).get0();
+        compact_and_prefix_truncate(*get_disk_log(log), ccfg);
     }
     get_disk_log(log)->get_probe().partition_size();
 
@@ -3282,16 +3299,15 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
         auto disk_log = get_disk_log(log);
 
         BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 11);
-        log.set_collectible_offset(model::offset::max());
 
-        log
-          .compact(storage::compaction_config(
+        compact_and_prefix_truncate(
+          *disk_log,
+          storage::compaction_config(
             model::timestamp::min(),
             cfg.retention_bytes(),
             model::offset::max(),
             ss::default_priority_class(),
-            as))
-          .get();
+            as));
         // make sure we retain less than expected bytes
         BOOST_REQUIRE_LE(disk_log->size_bytes(), tc.expected_bytes_left);
         BOOST_REQUIRE_GT(
@@ -3302,7 +3318,7 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
     using namespace storage;
 
     ss::abort_source abs;
-    temporary_dir tmp_dir("concat_segment_read");
+    temporary_dir tmp_dir("storage_e2e");
     auto data_path = tmp_dir.get_path();
 
     storage::ntp_config config{{"test_ns", "test_tpc", 0}, {data_path}};
@@ -3347,17 +3363,16 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
 
     // Grab the new start offset from the notification and
     // update the collectible offset and start offsets.
-    auto start_offset = eviction_future.get();
-    BOOST_REQUIRE_EQUAL(*new_start_offset, start_offset);
-    BOOST_REQUIRE(b.update_start_offset(start_offset).get());
-    log.set_collectible_offset(start_offset);
+    auto evict_at_offset = eviction_future.get();
+    BOOST_REQUIRE_EQUAL(*new_start_offset, model::next_offset(evict_at_offset));
+    BOOST_REQUIRE(b.update_start_offset(*new_start_offset).get());
 
     // Call into `disk_log_impl::compact`. The only segment eligible for
     // compaction is the below the start offset and it should be ignored.
     auto& first_seg = log.segments().front();
     BOOST_REQUIRE_EQUAL(first_seg->finished_self_compaction(), false);
 
-    b.apply_compaction(cfg, start_offset).get();
+    b.apply_compaction(cfg, *new_start_offset).get();
 
     BOOST_REQUIRE_EQUAL(first_seg->finished_self_compaction(), false);
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -22,11 +22,13 @@
 #include "storage/ntp_config.h"
 #include "storage/record_batch_builder.h"
 #include "storage/segment_utils.h"
+#include "storage/tests/disk_log_builder_fixture.h"
 #include "storage/tests/storage_test_fixture.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "storage/tests/utils/log_gap_analysis.h"
 #include "storage/types.h"
 #include "test_utils/async.h"
+#include "test_utils/tmp_dir.h"
 #include "units.h"
 #include "utils/directory_walker.h"
 #include "utils/to_string.h"
@@ -3295,4 +3297,69 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
         BOOST_REQUIRE_GT(
           disk_log->size_bytes(), tc.expected_bytes_left - segment_size);
     }
+}
+FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
+    using namespace storage;
+
+    ss::abort_source abs;
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+
+    storage::ntp_config config{{"test_ns", "test_tpc", 0}, {data_path}};
+
+    storage::ntp_config::default_overrides overrides;
+    overrides.retention_bytes = tristate<size_t>{1};
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction
+        | model::cleanup_policy_bitflags::deletion;
+
+    config.set_overrides(overrides);
+
+    // Create a log and populate it with two segments,
+    // while making sure to close the first segment before
+    // opening the second.
+    b | start(std::move(config));
+
+    auto& log = b.get_disk_log_impl();
+
+    b | add_segment(0) | add_random_batch(0, 100);
+
+    log.force_roll(ss::default_priority_class()).get();
+
+    b | add_segment(100) | add_random_batch(100, 100);
+
+    BOOST_REQUIRE_EQUAL(log.segment_count(), 2);
+
+    compaction_config cfg{
+      model::timestamp::max(),
+      1,
+      model::offset::max(),
+      ss::default_priority_class(),
+      abs};
+
+    // Call into `disk_log_impl::gc` and listen for the eviction
+    // notification being created.
+    auto eviction_future = log.monitor_eviction(abs);
+    auto new_start_offset = b.apply_retention(cfg).get();
+    BOOST_REQUIRE(new_start_offset);
+
+    BOOST_REQUIRE_EQUAL(log.segment_count(), 2);
+
+    // Grab the new start offset from the notification and
+    // update the collectible offset and start offsets.
+    auto start_offset = eviction_future.get();
+    BOOST_REQUIRE_EQUAL(*new_start_offset, start_offset);
+    BOOST_REQUIRE(b.update_start_offset(start_offset).get());
+    log.set_collectible_offset(start_offset);
+
+    // Call into `disk_log_impl::compact`. The only segment eligible for
+    // compaction is the below the start offset and it should be ignored.
+    auto& first_seg = log.segments().front();
+    BOOST_REQUIRE_EQUAL(first_seg->finished_self_compaction(), false);
+
+    b.apply_compaction(cfg, start_offset).get();
+
+    BOOST_REQUIRE_EQUAL(first_seg->finished_self_compaction(), false);
+
+    b.stop().get();
 }

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -115,6 +115,21 @@ ss::future<> disk_log_builder::gc(
       _abort_source));
 }
 
+ss::future<std::optional<model::offset>>
+disk_log_builder::apply_retention(compaction_config cfg) {
+    return get_disk_log_impl().gc(cfg);
+}
+
+ss::future<> disk_log_builder::apply_compaction(
+  compaction_config cfg, std::optional<model::offset> new_start_offset) {
+    return get_disk_log_impl().do_compact(cfg, new_start_offset);
+}
+
+ss::future<bool>
+disk_log_builder::update_start_offset(model::offset start_offset) {
+    return get_disk_log_impl().update_start_offset(start_offset);
+}
+
 ss::future<> disk_log_builder::stop() { return _storage.stop(); }
 
 // Low lever interface access

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -107,12 +107,28 @@ ss::future<> disk_log_builder::truncate(model::offset o) {
 ss::future<> disk_log_builder::gc(
   model::timestamp collection_upper_bound,
   std::optional<size_t> max_partition_retention_size) {
-    return get_log().compact(compaction_config(
-      collection_upper_bound,
-      max_partition_retention_size,
-      model::offset::max(),
-      ss::default_priority_class(),
-      _abort_source));
+    ss::abort_source as;
+    auto eviction_future = get_log().monitor_eviction(as);
+
+    get_log()
+      .compact(compaction_config(
+        collection_upper_bound,
+        max_partition_retention_size,
+        model::offset::max(),
+        ss::default_priority_class(),
+        _abort_source))
+      .get();
+
+    if (eviction_future.available()) {
+        auto evict_until = eviction_future.get();
+        return get_log().truncate_prefix(storage::truncate_prefix_config{
+          model::next_offset(evict_until), ss::default_priority_class()});
+    } else {
+        as.request_abort();
+        eviction_future.ignore_ready_future();
+    }
+
+    return ss::make_ready_future<>();
 }
 
 ss::future<std::optional<model::offset>>

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -302,6 +302,12 @@ public:
     ss::future<> gc(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);
+    ss::future<std::optional<model::offset>>
+    apply_retention(compaction_config cfg);
+    ss::future<> apply_compaction(
+      compaction_config cfg,
+      std::optional<model::offset> new_start_offset = std::nullopt);
+    ss::future<bool> update_start_offset(model::offset start_offset);
     ss::future<> add_batch(
       model::record_batch batch,
       log_append_config config = append_config(),


### PR DESCRIPTION
Backport of PRs https://github.com/redpanda-data/redpanda/pull/9483 and https://github.com/redpanda-data/redpanda/pull/9487 (and https://github.com/redpanda-data/redpanda/commit/e7ee3c63ae6484afa8ed8ee028fec9a9bf7d6842) to v22.3.x.

In v22.3.x time based retention runs only when size based retention does not run. https://github.com/redpanda-data/redpanda/pull/9487 changes this to apply both retention policies on each housekeeping run, however this is too
big of a behavioural change to backport. Hence, this backport preserves the v22.3.x behaviour of exclusive application for retention policies, while still including the bug fix from https://github.com/redpanda-data/redpanda/pull/9483.

## Release Notes
### Bug Fixes
* Fix race between compaction and application of retention to the local log. This occurred when compaction
happened below the start offset of the log. It did not have a noticeable impact upon user workloads.
