### PR TITLE
cloud_storage: fix trying to trim accesstime.tmp

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -282,7 +282,10 @@ ss::future<> cache::trim() {
             // Skip the accesstime file, we should never delete this.
             if (
               file_stat.path
-              == (_cache_dir / access_time_tracker_file_name).string()) {
+                == (_cache_dir / access_time_tracker_file_name).string()
+              || file_stat.path
+                   == (_cache_dir / access_time_tracker_file_name_tmp)
+                        .string()) {
                 candidate_i++;
                 continue;
             }


### PR DESCRIPTION
This causes a spurious log error if cache trim runs at the same time as access time tracker writes out.

Fixes https://github.com/redpanda-data/redpanda/issues/9442

## Backports Required

This issue might technically exist in previous branches, but I think the reason we're really seeing it is because of stricter cache enforcement on the tip of dev.  Since it's just log hygiene, not worth backporting.

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none