### PR TITLE
archival: improve cloud retention logging

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1533,7 +1533,7 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::apply_retention() {
     auto next_start_offset = retention_calculator->next_start_offset();
     if (next_start_offset) {
         vlog(
-          _rtclog.debug,
+          _rtclog.info,
           "{} Advancing start offset to {} satisfy retention policy",
           retention_calculator->strategy_name(),
           *next_start_offset);

--- a/src/v/archival/retention_calculator.cc
+++ b/src/v/archival/retention_calculator.cc
@@ -20,7 +20,7 @@ namespace archival {
  */
 class time_based_strategy final : public retention_strategy {
 public:
-    static constexpr auto strat_name = "size_based_retention";
+    static constexpr auto strat_name = "time_based_retention";
 
     explicit time_based_strategy(model::timestamp);
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3427,11 +3427,6 @@ admin_server::cloud_storage_usage_handler(
         }
     }
 
-    vlog(
-      logger.info,
-      "Members table at: {}",
-      static_cast<void*>(&(_controller->get_members_table())));
-
     cluster::cloud_storage_size_reducer reducer(
       _controller->get_topics_state(),
       _controller->get_members_table(),


### PR DESCRIPTION
During incidents, one often wishes to validate that cloud retention is
operating correctly. That's tricky to do without this INFO level log.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none