### PR TITLE
[v23.1.x] cloud_storage: Protect segments from accidental removal

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -495,7 +495,8 @@ FIXTURE_TEST(test_archival_stm_batching, archival_metadata_stm_fixture) {
       .base_offset = model::offset(0),
       .committed_offset = model::offset(999),
       .archiver_term = model::term_id(2),
-      .segment_term = model::term_id(1)});
+      .segment_term = model::term_id(1),
+      .sname_format = cloud_storage::segment_name_format::v2});
     // Replicate add_segment_cmd command that adds segment with offset 0
     auto batcher = archival_stm->batch_start(ss::lowres_clock::now() + 10s);
     batcher.add_segments(m);

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -11,6 +11,7 @@
 
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote.h"
+#include "cloud_storage/types.h"
 #include "cluster/errc.h"
 #include "cluster/persisted_stm.h"
 #include "config/configuration.h"
@@ -783,6 +784,47 @@ archival_metadata_stm::get_segments_to_cleanup() const {
     // Include replaced segments to the backlog
     using lw_segment_meta = cloud_storage::partition_manifest::lw_segment_meta;
     std::vector<lw_segment_meta> backlog = _manifest->lw_replaced_segments();
+
+    // Make sure that 'replaced' list doesn't have any references to active
+    // segments. This is a protection from the data loss. This should not
+    // happen, but protects us from data loss in cases where bugs elsewhere.
+    auto backlog_size = backlog.size();
+    backlog.erase(
+      std::remove_if(
+        backlog.begin(),
+        backlog.end(),
+        [this](const lw_segment_meta& m) {
+            auto it = _manifest->find(m.base_offset);
+            if (it == _manifest->end()) {
+                return false;
+            }
+            const auto& s = it->second;
+            auto m_name = _manifest->generate_remote_segment_name(
+              cloud_storage::partition_manifest::lw_segment_meta::convert(m));
+            auto s_name = _manifest->generate_remote_segment_name(s);
+            // The segment will have the same path as the one we have in
+            // manifest in S3 so if we will delete it the data will be lost.
+            if (m_name == s_name) {
+                vlog(
+                  _logger.warn,
+                  "The replaced segment name {} collides with the segment {} "
+                  "in the manifest. It will be removed to prevent the data "
+                  "loss.",
+                  m_name,
+                  s_name);
+                return true;
+            }
+            return false;
+        }),
+      backlog.end());
+
+    if (backlog.size() < backlog_size) {
+        vlog(
+          _logger.warn,
+          "{} segments will not be removed from the bucket because they're "
+          "available in the manifest",
+          backlog_size - backlog.size());
+    }
 
     auto so = _manifest->get_start_offset().value_or(model::offset(0));
     for (const auto& m : *_manifest) {


### PR DESCRIPTION
This PR adds a safety net for upload housekeeping. If the segment queued for removal is present in the manifest we shouldn't remove it. This PR adds a check to the code that creates a list. It filters out every segment which can still be found in the manifest.

Backports #9600 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Backport of the #9600

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Add extra check to prevent accidental removal of data uploaded to the cloud