### PR TITLE
Reassign topics uniformly after partition is added

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -27,6 +27,7 @@
 #include <seastar/util/later.hh>
 #include <seastar/util/optimized_optional.hh>
 
+#include <absl/container/node_hash_map.h>
 #include <absl/container/node_hash_set.h>
 #include <fmt/ostream.h>
 
@@ -49,10 +50,7 @@ struct node_replicas {
     size_t allocated_replicas;
     size_t max_capacity;
 };
-struct unevenness_error_info {
-    double e;
-    double e_step;
-};
+
 using node_replicas_map_t = absl::node_hash_map<model::node_id, node_replicas>;
 static absl::node_hash_map<model::node_id, node_replicas>
 calculate_replicas_per_node(
@@ -88,14 +86,8 @@ calculate_total_replicas(const node_replicas_map_t& node_replicas) {
 
 void reassign_replicas(
   partition_allocator& allocator,
-  partition_assignment& current_assignment,
+  partition_assignment current_assignment,
   members_backend::partition_reallocation& reallocation) {
-    vlog(
-      clusterlog.debug,
-      "[ntp: {}, {} -> -]  trying to reassign partition replicas",
-      reallocation.ntp,
-      current_assignment.replicas);
-
     // remove nodes that are going to be reassigned from current assignment.
     std::erase_if(
       current_assignment.replicas,
@@ -161,23 +153,8 @@ void reassign_replicas(
  *                               e
  *                                max
  *
- *
- * Since the improvement depends on the number of replicas moved in a single
- * batch we need to calculate the improvement that would moving a single
- * partition replica introduce. Since single move requested by a balancer moves
- * partition from node A->B (where A has more than requested number of replicas
- * per nd B should have less than requested number of replicas) we can calculate
- * the error improvement introduced by single move as:
- *
- *                                     2
- *                           e     = ─────
- *                            step   N ⋅ T
- *
- * Single step error must be normalized as well. We stop if the improvement is
- * less than the equivalent of the improvement made by 1/10th of the number of
- * moves in a batch (or 1 move if that is bigger)
  **/
-unevenness_error_info calculate_unevenness_error(
+double calculate_unevenness_error(
   const partition_allocator& allocator,
   const members_backend::update_meta& update,
   partition_allocation_domain domain) {
@@ -205,7 +182,7 @@ unevenness_error_info calculate_unevenness_error(
     const auto total_replicas = calculate_total_replicas(node_replicas);
 
     if (total_replicas == 0) {
-        return {.e = 0.0, .e_step = 0.0};
+        return 0.0;
     }
 
     const auto target_replicas_per_node = total_replicas
@@ -226,22 +203,19 @@ unevenness_error_info calculate_unevenness_error(
 
         vlog(
           clusterlog.trace,
-          "node {} has {} replicas allocated, requested replicas per node "
-          "{}, difference: {}",
+          "node {} has {} replicas allocated in domain {}, requested replicas "
+          "per node {}, difference: {}",
           id,
           allocation_info.allocated_replicas,
+          domain,
           target_replicas_per_node,
           diff);
         err += std::abs(diff);
     }
     err /= (static_cast<double>(total_replicas) * node_cnt);
 
-    double e_step
-      = 2.0
-        / (static_cast<double>(total_replicas) * static_cast<double>(node_cnt) * max_err);
-
     // normalize error to stay in range (0,1)
-    return {.e = err / max_err, .e_step = e_step};
+    return err / max_err;
 }
 
 } // namespace
@@ -482,27 +456,20 @@ void members_backend::default_reallocation_strategy::
       max_batch_size, allocator, topics, meta, domain);
     auto current_error = calculate_unevenness_error(allocator, meta, domain);
     auto [it, _] = meta.last_unevenness_error.try_emplace(domain, 1.0);
-    const auto min_improvement
-      = std::max<size_t>(
-          (meta.partition_reallocations.size() - prev_reallocations_count) / 10,
-          1)
-        * current_error.e_step;
 
-    auto improvement = it->second - current_error.e;
+    auto improvement = it->second - current_error;
     vlog(
       clusterlog.info,
-      "[update: {}] unevenness error: {}, previous error: {}, "
-      "improvement: {}, min improvement: {}",
+      "[update: {}] unevenness error: {}, previous error: {}, improvement: {}",
       meta.update,
-      current_error.e,
+      current_error,
       it->second,
-      improvement,
-      min_improvement);
+      improvement);
 
-    it->second = current_error.e;
+    it->second = current_error;
 
     // drop all reallocations if there is no improvement
-    if (improvement < min_improvement) {
+    if (improvement <= 0) {
         meta.partition_reallocations.erase(
           std::next(
             meta.partition_reallocations.begin(),
@@ -611,26 +578,16 @@ void members_backend::default_reallocation_strategy::
       domain,
       target_replicas_per_node);
     // 3. calculate how many replicas have to be moved from each node
-    std::vector<replicas_to_move> to_move_from_node;
+    absl::flat_hash_map<model::node_id, size_t> to_move_from_node;
+
     for (auto& [id, info] : node_replicas) {
         auto to_move = info.allocated_replicas
                        - std::min(
                          target_replicas_per_node, info.allocated_replicas);
-        to_move_from_node.emplace_back(id, to_move);
+        if (to_move > 0) {
+            to_move_from_node.emplace(id, to_move);
+        }
     }
-
-    auto all_empty = std::all_of(
-      to_move_from_node.begin(),
-      to_move_from_node.end(),
-      [](const replicas_to_move& m) { return m.left_to_move == 0; });
-    // nothing to do, exit early
-    if (all_empty) {
-        return;
-    }
-
-    auto cmp = [](const replicas_to_move& lhs, const replicas_to_move& rhs) {
-        return lhs.left_to_move < rhs.left_to_move;
-    };
 
     if (clusterlog.is_enabled(ss::log_level::info)) {
         for (const auto& [id, cnt] : to_move_from_node) {
@@ -645,105 +602,153 @@ void members_backend::default_reallocation_strategy::
               node_replicas[id].allocated_replicas);
         }
     }
-    auto [idx_it, _] = meta.last_ntp_index.try_emplace(domain, 0);
-    size_t current_idx = 0;
-    // 4. Pass over all partition metadata
-    for (auto& [tp_ns, metadata] : topics.topics_map()) {
-        // skip partitions outside of current domain
-        if (get_allocation_domain(tp_ns) != domain) {
-            continue;
+
+    if (to_move_from_node.empty()) {
+        return;
+    }
+
+    auto to_move_it = to_move_from_node.begin();
+    absl::node_hash_set<model::ntp> scheduled_moves;
+    while (to_move_it != to_move_from_node.end()) {
+        std::vector<partition_reallocation> reallocations;
+        auto& [id, to_move] = *to_move_it;
+
+        size_t effective_batch_size = std::min<size_t>(
+          to_move, max_batch_size - meta.partition_reallocations.size());
+
+        if (effective_batch_size <= 0) {
+            return;
         }
-        // do not try to move internal partitions
-        if (
-          tp_ns.ns == model::kafka_internal_namespace
-          || tp_ns.ns == model::redpanda_ns) {
-            continue;
-        }
-        if (!metadata.is_topic_replicable()) {
-            continue;
-        }
-        // do not move topics that were created after node was added, they are
-        // allocated with new cluster capacity
-        if (meta.update) {
-            if (metadata.get_revision() > meta.update->offset()) {
-                vlog(
-                  clusterlog.debug,
-                  "skipping reallocating topic {}, its revision {} is greater "
-                  "than "
-                  "node update {}",
-                  tp_ns,
-                  metadata.get_revision(),
-                  meta.update->offset);
+        reallocations.reserve(effective_batch_size);
+
+        size_t idx = 0;
+        for (auto& [tp_ns, metadata] : topics.topics_map()) {
+            // skip partitions outside of current domain
+            if (get_allocation_domain(tp_ns) != domain) {
                 continue;
             }
-        }
-        size_t rand_idx = 0;
-        /**
-         * We use 64 bit field initialized with random number to sample topic
-         * partitions to move, every time the bitfield is exhausted we
-         * reinitialize it and reset counter. This way we chose random
-         * partitions to move without iterating multiple times over the topic
-         * set
-         */
-        std::bitset<sizeof(uint64_t)> sampling_bytes;
-        for (const auto& p : metadata.get_assignments()) {
-            if (idx_it->second > current_idx++) {
+            // do not try to move internal partitions
+            if (
+              tp_ns.ns == model::kafka_internal_namespace
+              || tp_ns.ns == model::redpanda_ns) {
                 continue;
             }
-
-            if (rand_idx % sizeof(uint64_t) == 0) {
-                sampling_bytes = random_generators::get_int(
-                  std::numeric_limits<uint64_t>::max());
-                rand_idx = 0;
-            }
-
-            idx_it->second++;
-
-            if (sampling_bytes.test(rand_idx++)) {
+            if (!metadata.is_topic_replicable()) {
                 continue;
             }
+            // do not move topics that were created after node was added, they
+            // are allocated with new cluster capacity
+            if (meta.update) {
+                if (metadata.get_revision() > meta.update->offset()) {
+                    vlog(
+                      clusterlog.debug,
+                      "skipping reallocating topic {}, its revision {} is "
+                      "greater than node update {}",
+                      tp_ns,
+                      metadata.get_revision(),
+                      meta.update->offset);
+                    continue;
+                }
+            }
 
-            std::erase_if(to_move_from_node, [](const replicas_to_move& v) {
-                return v.left_to_move == 0;
-            });
-
-            std::sort(to_move_from_node.begin(), to_move_from_node.end(), cmp);
-            for (auto& to_move : to_move_from_node) {
-                if (
-                  is_in_replica_set(p.replicas, to_move.id)
-                  && to_move.left_to_move > 0) {
+            for (const auto& p : metadata.get_assignments()) {
+                if (is_in_replica_set(p.replicas, id)) {
                     partition_reallocation reallocation(
                       model::ntp(tp_ns.ns, tp_ns.tp, p.id), p.replicas.size());
-                    reallocation.replicas_to_remove.emplace(to_move.id);
-                    auto current_assignment = p;
-                    reassign_replicas(
-                      allocator, current_assignment, reallocation);
-                    // skip if partition was reassigned to the same node
-                    if (is_reassigned_to_node(reallocation, to_move.id)) {
+                    if (scheduled_moves.contains(reallocation.ntp)) {
                         continue;
                     }
+                    reallocation.replicas_to_remove.emplace(id);
+                    reassign_replicas(allocator, p, reallocation);
+
+                    if (!reallocation.allocation_units.has_value()) {
+                        continue;
+                    }
+                    const auto& new_assignment = reallocation.allocation_units
+                                                   .value()
+                                                   .get_assignments()
+                                                   .begin()
+                                                   ->replicas;
+                    // skip if partition was reassigned to the same node
+                    if (is_reassigned_to_node(reallocation, id)) {
+                        continue;
+                    }
+                    const auto added_replicas = subtract_replica_sets(
+                      new_assignment, p.replicas);
+                    const auto not_improving_move = std::any_of(
+                      added_replicas.begin(),
+                      added_replicas.end(),
+                      [&to_move_from_node](const model::broker_shard& bs) {
+                          auto it = to_move_from_node.find(bs.node_id);
+                          return it != to_move_from_node.end()
+                                 && it->second > 0;
+                      });
+                    vlog(
+                      clusterlog.trace,
+                      "ntp {} move from {} -> {} skipping: {}",
+                      reallocation.ntp,
+                      p.replicas,
+                      new_assignment,
+                      not_improving_move);
+
+                    /**
+                     * If there is no error improvement, skip this reallocation
+                     */
+                    if (not_improving_move) {
+                        continue;
+                    }
+
+                    idx++;
                     reallocation.current_replica_set = p.replicas;
                     reallocation.state = reallocation_state::reassigned;
-                    meta.partition_reallocations.push_back(
-                      std::move(reallocation));
-                    to_move.left_to_move--;
-                    // reached max concurrent reallocations, yield
-                    if (meta.partition_reallocations.size() >= max_batch_size) {
-                        vlog(
-                          clusterlog.info,
-                          "reached limit of max concurrent reallocations: {}",
-                          meta.partition_reallocations.size());
-                        return;
+                    /**
+                     * Reservoir sampling part, after we have at least required
+                     * number of moves replace one of the reallocations with
+                     * decreasing probability.
+                     */
+
+                    if (reallocations.size() < effective_batch_size) {
+                        to_move--;
+                        reallocations.push_back(std::move(reallocation));
+                    } else {
+                        auto r_idx = random_generators::get_int<size_t>(
+                          0, idx - 1);
+                        if (r_idx < reallocations.size()) {
+                            to_move--;
+                            std::swap(reallocations[r_idx], reallocation);
+                            // update to move as we replaced one of the entries
+                            for (const auto node_id :
+                                 reallocation.replicas_to_remove) {
+                                auto [it, _] = to_move_from_node.try_emplace(
+                                  node_id, 0);
+                                it->second++;
+                            }
+                        }
                     }
-                    break;
                 }
             }
         }
+        ++to_move_it;
+
+        for (auto& r : reallocations) {
+            scheduled_moves.emplace(r.ntp);
+        }
+
+        std::move(
+          reallocations.begin(),
+          reallocations.end(),
+          std::back_inserter(meta.partition_reallocations));
     }
-    // reset after moving over all the partitions, the only case if the idx
-    // iterator is not reset is the case when we reached max concurrent
-    // reallocations.
-    idx_it->second = 0;
+    if (clusterlog.is_enabled(ss::log_level::debug)) {
+        for (auto& r : meta.partition_reallocations) {
+            vlog(
+              clusterlog.debug,
+              "{} moving {} -> {}",
+              r.ntp,
+              *r.replicas_to_remove.begin(),
+              subtract_replica_sets(r.new_replica_set, r.current_replica_set));
+        }
+    }
 }
 
 std::vector<model::ntp> members_backend::ntps_moving_from_node_older_than(
@@ -777,7 +782,8 @@ ss::future<> members_backend::calculate_reallocations_after_recommissioned(
       "recommissioning rebalance must be related with node update");
     vassert(
       meta.update->decommission_update_revision,
-      "Decommission update revision must be present for recommission update "
+      "Decommission update revision must be present for recommission "
+      "update "
       "metadata");
 
     auto ntps = ntps_moving_from_node_older_than(
@@ -837,7 +843,8 @@ ss::future<std::error_code> members_backend::reconcile() {
         } else {
             vlog(
               clusterlog.trace,
-              "waiting for all raft0 updates to be applied - barrier offset: "
+              "waiting for all raft0 updates to be applied - barrier "
+              "offset: "
               "{}, raft_0 dirty offset: {}",
               barrier_result.value(),
               _raft0->dirty_offset());
@@ -995,8 +1002,8 @@ ss::future<std::error_code> members_backend::do_remove_node(model::node_id id) {
 
 bool members_backend::should_stop_rebalancing_update(
   const members_backend::update_meta& meta) const {
-    // do not finish decommissioning and recommissioning updates as they have
-    // strict stop conditions
+    // do not finish decommissioning and recommissioning updates as they
+    // have strict stop conditions
     using update_t = node_update_type;
     if (
       meta.update
@@ -1022,14 +1029,14 @@ members_backend::try_to_finish_update(members_backend::update_meta& meta) {
             reallocation.state = reallocation_state::finished;
         }
     }
-    // we do not have to check if all reallocations are finished, we will finish
-    // the update when node will be removed
+    // we do not have to check if all reallocations are finished, we will
+    // finish the update when node will be removed
     if (meta.update && meta.update->type == node_update_type::decommissioned) {
         co_return;
     }
 
-    // if all reallocations are propagate reallocation finished event and mark
-    // update as finished
+    // if all reallocations are propagate reallocation finished event and
+    // mark update as finished
     const auto all_reallocations_finished = std::all_of(
       meta.partition_reallocations.begin(),
       meta.partition_reallocations.end(),
@@ -1067,7 +1074,8 @@ ss::future<> members_backend::reallocate_replica_set(
         meta.current_replica_set = current_assignment->replicas;
         // initial state, try to reassign partition replicas
 
-        reassign_replicas(_allocator.local(), *current_assignment, meta);
+        reassign_replicas(
+          _allocator.local(), std::move(*current_assignment), meta);
         if (meta.new_replica_set.empty()) {
             // if partition allocator failed to reassign partitions return
             // and wait for next retry
@@ -1125,7 +1133,8 @@ ss::future<> members_backend::reallocate_replica_set(
           = co_await _api.local().get_reconciliation_state(meta.ntp);
         vlog(
           clusterlog.info,
-          "[ntp: {}, {} -> {}] reconciliation state: {}, pending operations: "
+          "[ntp: {}, {} -> {}] reconciliation state: {}, pending "
+          "operations: "
           "{}",
           meta.ntp,
           meta.current_replica_set,
@@ -1169,7 +1178,8 @@ ss::future<> members_backend::reallocate_replica_set(
           = co_await _api.local().get_reconciliation_state(meta.ntp);
         vlog(
           clusterlog.info,
-          "[ntp: {}, {} -> {}] reconciliation state: {}, pending operations: "
+          "[ntp: {}, {} -> {}] reconciliation state: {}, pending "
+          "operations: "
           "{}",
           meta.ntp,
           meta.current_replica_set,
@@ -1210,12 +1220,12 @@ void members_backend::stop_node_addition_and_ondemand_rebalance(
         if (!current.update || current.update->type == update_t::added) {
             /**
              * Clear current reallocations related with node addition or on
-             * demand rebalancing, scheduled reallocations may never finish as
-             * the target node may be the one that is decommissioned.
+             * demand rebalancing, scheduled reallocations may never finish
+             * as the target node may be the one that is decommissioned.
              *
-             * Clearing reallocations will force recalculation of reallocations
-             * when the update will be processed again, after finishing
-             * decommission.
+             * Clearing reallocations will force recalculation of
+             * reallocations when the update will be processed again, after
+             * finishing decommission.
              */
 
             _updates.front().partition_reallocations.clear();

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -43,6 +43,207 @@
 #include <vector>
 
 namespace cluster {
+namespace {
+struct node_replicas {
+    size_t allocated_replicas;
+    size_t max_capacity;
+};
+struct unevenness_error_info {
+    double e;
+    double e_step;
+};
+using node_replicas_map_t = absl::node_hash_map<model::node_id, node_replicas>;
+static absl::node_hash_map<model::node_id, node_replicas>
+calculate_replicas_per_node(
+  const partition_allocator& allocator, partition_allocation_domain domain) {
+    node_replicas_map_t ret;
+    ret.reserve(allocator.state().allocation_nodes().size());
+
+    for (const auto& [id, n] : allocator.state().allocation_nodes()) {
+        if (!n->is_active()) {
+            continue;
+        }
+        auto [it, _] = ret.try_emplace(
+          id,
+          node_replicas{
+            .allocated_replicas = 0,
+            .max_capacity = n->domain_partition_capacity(domain),
+          });
+
+        const auto domain_allocated = n->domain_allocated_partitions(domain);
+        it->second.allocated_replicas += domain_allocated;
+    }
+    return ret;
+}
+
+static size_t
+calculate_total_replicas(const node_replicas_map_t& node_replicas) {
+    size_t total_replicas = 0;
+    for (auto& [_, replicas] : node_replicas) {
+        total_replicas += replicas.allocated_replicas;
+    }
+    return total_replicas;
+}
+
+void reassign_replicas(
+  partition_allocator& allocator,
+  partition_assignment& current_assignment,
+  members_backend::partition_reallocation& reallocation) {
+    vlog(
+      clusterlog.debug,
+      "[ntp: {}, {} -> -]  trying to reassign partition replicas",
+      reallocation.ntp,
+      current_assignment.replicas);
+
+    // remove nodes that are going to be reassigned from current assignment.
+    std::erase_if(
+      current_assignment.replicas,
+      [&reallocation](const model::broker_shard& bs) {
+          return reallocation.replicas_to_remove.contains(bs.node_id);
+      });
+
+    auto res = allocator.reallocate_partition(
+      reallocation.constraints.value(),
+      current_assignment,
+      get_allocation_domain(reallocation.ntp));
+    if (res.has_value()) {
+        reallocation.set_new_replicas(std::move(res.value()));
+    }
+}
+
+/**
+ * The new replicas placement optimization stop condition is based on evenness
+ * error.
+ *
+ * When there is no improvement of unevenness error after requesting partition
+ * rebalancing the rebalancing stops.
+ *
+ * Error is calculated as:
+ *
+ *                                    N
+ *                                   ___
+ *                                   ╲    |R - r |
+ *                                   ╱    |     n|
+ *                                   ‾‾‾
+ *                                  n = 0
+ *                           e    = ──────────────
+ *                            raw        T ⋅ N
+ *
+ *
+ *                               T
+ *                           R = ─
+ *                               N
+ *
+ * Where:
+ *
+ * T - total number or replicas in cluster
+ * R - requested replicas per node
+ * N - number of nodes in the cluster
+ * r_n - number of replicas on the node n
+ *
+ *
+ * then the error is normalized to be in range [0,1].
+ * To do this we calculate the maximum error:
+ *                                              N
+ *                                             ___
+ *                                             ╲
+ *                                  (T - R) +  ╱    R
+ *                                             ‾‾‾
+ *                                            n = 1
+ *                           e    = ─────────────────
+ *                            max         T ⋅ N
+ *
+ * normalized error is equal to:
+ *
+ *                                 e
+ *                           e = ────
+ *                               e
+ *                                max
+ *
+ *
+ * Since the improvement depends on the number of replicas moved in a single
+ * batch we need to calculate the improvement that would moving a single
+ * partition replica introduce. Since single move requested by a balancer moves
+ * partition from node A->B (where A has more than requested number of replicas
+ * per nd B should have less than requested number of replicas) we can calculate
+ * the error improvement introduced by single move as:
+ *
+ *                                     2
+ *                           e     = ─────
+ *                            step   N ⋅ T
+ *
+ * Single step error must be normalized as well. We stop if the improvement is
+ * less than the equivalent of the improvement made by 1/10th of the number of
+ * moves in a batch (or 1 move if that is bigger)
+ **/
+unevenness_error_info calculate_unevenness_error(
+  const partition_allocator& allocator,
+  const members_backend::update_meta& update,
+  partition_allocation_domain domain) {
+    static const std::vector<partition_allocation_domain> domains{
+      partition_allocation_domains::consumer_offsets,
+      partition_allocation_domains::common};
+
+    const auto node_cnt = allocator.state().available_nodes();
+
+    auto node_replicas = calculate_replicas_per_node(allocator, domain);
+    /**
+     * adjust per node replicas with the replicas that are going to be removed
+     * from the node after successful reallocation
+     */
+    for (const auto& r : update.partition_reallocations) {
+        if (r.allocation_units) {
+            for (const auto& to_remove : r.replicas_to_remove) {
+                auto it = node_replicas.find(to_remove);
+                if (it != node_replicas.end()) {
+                    it->second.allocated_replicas--;
+                }
+            }
+        }
+    }
+    const auto total_replicas = calculate_total_replicas(node_replicas);
+
+    if (total_replicas == 0) {
+        return {.e = 0.0, .e_step = 0.0};
+    }
+
+    const auto target_replicas_per_node = total_replicas
+                                          / allocator.state().available_nodes();
+    // max error is an error calculated when all replicas are allocated on
+    // the same node
+    double max_err = (total_replicas - target_replicas_per_node)
+                     + target_replicas_per_node * (node_cnt - 1);
+    // divide by total replicas and node count to make the error independent
+    // from number of nodes and number of replicas.
+    max_err /= static_cast<double>(total_replicas);
+    max_err /= static_cast<double>(node_cnt);
+
+    double err = 0;
+    for (auto& [id, allocation_info] : node_replicas) {
+        double diff = static_cast<double>(target_replicas_per_node)
+                      - static_cast<double>(allocation_info.allocated_replicas);
+
+        vlog(
+          clusterlog.trace,
+          "node {} has {} replicas allocated, requested replicas per node "
+          "{}, difference: {}",
+          id,
+          allocation_info.allocated_replicas,
+          target_replicas_per_node,
+          diff);
+        err += std::abs(diff);
+    }
+    err /= (static_cast<double>(total_replicas) * node_cnt);
+
+    double e_step
+      = 2.0
+        / (static_cast<double>(total_replicas) * static_cast<double>(node_cnt) * max_err);
+
+    // normalize error to stay in range (0,1)
+    return {.e = err / max_err, .e_step = e_step};
+}
+
+} // namespace
 
 members_backend::members_backend(
   ss::sharded<cluster::topics_frontend>& topics_frontend,
@@ -261,7 +462,8 @@ void members_backend::reallocations_for_even_partition_count(
   members_backend::update_meta& meta, partition_allocation_domain domain) {
     size_t prev_reallocations_count = meta.partition_reallocations.size();
     calculate_reallocations_batch(meta, domain);
-    auto current_error = calculate_unevenness_error(meta, domain);
+    auto current_error = calculate_unevenness_error(
+      _allocator.local(), meta, domain);
     auto [it, _] = meta.last_unevenness_error.try_emplace(domain, 1.0);
     const auto min_improvement
       = std::max<size_t>(
@@ -368,173 +570,12 @@ bool is_reassigned_to_node(
       reallocation.allocation_units->get_assignments().front().replicas,
       node_id);
 }
-absl::node_hash_map<model::node_id, members_backend::node_replicas>
-members_backend::calculate_replicas_per_node(
-  partition_allocation_domain domain) const {
-    absl::node_hash_map<model::node_id, members_backend::node_replicas> ret;
-    ret.reserve(_allocator.local().state().allocation_nodes().size());
-
-    for (const auto& [id, n] : _allocator.local().state().allocation_nodes()) {
-        if (!n->is_active()) {
-            continue;
-        }
-        auto [it, _] = ret.try_emplace(
-          id,
-          node_replicas{
-            .allocated_replicas = 0,
-            .max_capacity = n->domain_partition_capacity(domain),
-          });
-
-        const auto domain_allocated = n->domain_allocated_partitions(domain);
-        it->second.allocated_replicas += domain_allocated;
-    }
-    return ret;
-}
-
-size_t members_backend::calculate_total_replicas(
-  const node_replicas_map_t& node_replicas) {
-    size_t total_replicas = 0;
-    for (auto& [_, replicas] : node_replicas) {
-        total_replicas += replicas.allocated_replicas;
-    }
-    return total_replicas;
-}
-
-/**
- * The new replicas placement optimization stop condition is based on evenness
- * error.
- *
- * When there is no improvement of unevenness error after requesting partition
- * rebalancing the rebalancing stops.
- *
- * Error is calculated as:
- *
- *                                    N
- *                                   ___
- *                                   ╲    |R - r |
- *                                   ╱    |     n|
- *                                   ‾‾‾
- *                                  n = 0
- *                           e    = ──────────────
- *                            raw        T ⋅ N
- *
- *
- *                               T
- *                           R = ─
- *                               N
- *
- * Where:
- *
- * T - total number or replicas in cluster
- * R - requested replicas per node
- * N - number of nodes in the cluster
- * r_n - number of replicas on the node n
- *
- *
- * then the error is normalized to be in range [0,1].
- * To do this we calculate the maximum error:
- *                                              N
- *                                             ___
- *                                             ╲
- *                                  (T - R) +  ╱    R
- *                                             ‾‾‾
- *                                            n = 1
- *                           e    = ─────────────────
- *                            max         T ⋅ N
- *
- * normalized error is equal to:
- *
- *                                 e
- *                           e = ────
- *                               e
- *                                max
- *
- *
- * Since the improvement depends on the number of replicas moved in a single
- * batch we need to calculate the improvement that would moving a single
- * partition replica introduce. Since single move requested by a balancer moves
- * partition from node A->B (where A has more than requested number of replicas
- * per nd B should have less than requested number of replicas) we can calculate
- * the error improvement introduced by single move as:
- *
- *                                     2
- *                           e     = ─────
- *                            step   N ⋅ T
- *
- * Single step error must be normalized as well. We stop if the improvement is
- * less than the equivalent of the improvement made by 1/10th of the number of
- * moves in a batch (or 1 move if that is bigger)
- **/
-members_backend::unevenness_error_info
-members_backend::calculate_unevenness_error(
-  const update_meta& update, partition_allocation_domain domain) const {
-    static const std::vector<partition_allocation_domain> domains{
-      partition_allocation_domains::consumer_offsets,
-      partition_allocation_domains::common};
-
-    const auto node_cnt = _allocator.local().state().available_nodes();
-
-    auto node_replicas = calculate_replicas_per_node(domain);
-    /**
-     * adjust per node replicas with the replicas that are going to be removed
-     * from the node after successful reallocation
-     */
-    for (const auto& r : update.partition_reallocations) {
-        if (r.allocation_units) {
-            for (const auto& to_remove : r.replicas_to_remove) {
-                auto it = node_replicas.find(to_remove);
-                if (it != node_replicas.end()) {
-                    it->second.allocated_replicas--;
-                }
-            }
-        }
-    }
-    const auto total_replicas = calculate_total_replicas(node_replicas);
-
-    if (total_replicas == 0) {
-        return {.e = 0.0, .e_step = 0.0};
-    }
-
-    const auto target_replicas_per_node
-      = total_replicas / _allocator.local().state().available_nodes();
-    // max error is an error calculated when all replicas are allocated on
-    // the same node
-    double max_err = (total_replicas - target_replicas_per_node)
-                     + target_replicas_per_node * (node_cnt - 1);
-    // divide by total replicas and node count to make the error independent
-    // from number of nodes and number of replicas.
-    max_err /= static_cast<double>(total_replicas);
-    max_err /= static_cast<double>(node_cnt);
-
-    double err = 0;
-    for (auto& [id, allocation_info] : node_replicas) {
-        double diff = static_cast<double>(target_replicas_per_node)
-                      - static_cast<double>(allocation_info.allocated_replicas);
-
-        vlog(
-          clusterlog.trace,
-          "node {} has {} replicas allocated, requested replicas per node "
-          "{}, difference: {}",
-          id,
-          allocation_info.allocated_replicas,
-          target_replicas_per_node,
-          diff);
-        err += std::abs(diff);
-    }
-    err /= (static_cast<double>(total_replicas) * node_cnt);
-
-    double e_step
-      = 2.0
-        / (static_cast<double>(total_replicas) * static_cast<double>(node_cnt) * max_err);
-
-    // normalize error to stay in range (0,1)
-    return {.e = err / max_err, .e_step = e_step};
-}
 
 void members_backend::calculate_reallocations_batch(
   members_backend::update_meta& meta, partition_allocation_domain domain) {
     // 1. count current node allocations
-    auto node_replicas = calculate_replicas_per_node(domain);
+    auto node_replicas = calculate_replicas_per_node(
+      _allocator.local(), domain);
     auto total_replicas = calculate_total_replicas(node_replicas);
     // 2. calculate number of replicas per node leading to even replica per
     // node distribution
@@ -655,7 +696,8 @@ void members_backend::calculate_reallocations_batch(
                       model::ntp(tp_ns.ns, tp_ns.tp, p.id), p.replicas.size());
                     reallocation.replicas_to_remove.emplace(to_move.id);
                     auto current_assignment = p;
-                    reassign_replicas(current_assignment, reallocation);
+                    reassign_replicas(
+                      _allocator.local(), current_assignment, reallocation);
                     // skip if partition was reassigned to the same node
                     if (is_reassigned_to_node(reallocation, to_move.id)) {
                         continue;
@@ -992,31 +1034,6 @@ members_backend::try_to_finish_update(members_backend::update_meta& meta) {
     }
 }
 
-void members_backend::reassign_replicas(
-  partition_assignment& current_assignment,
-  partition_reallocation& reallocation) {
-    vlog(
-      clusterlog.debug,
-      "[ntp: {}, {} -> -]  trying to reassign partition replicas",
-      reallocation.ntp,
-      current_assignment.replicas);
-
-    // remove nodes that are going to be reassigned from current assignment.
-    std::erase_if(
-      current_assignment.replicas,
-      [&reallocation](const model::broker_shard& bs) {
-          return reallocation.replicas_to_remove.contains(bs.node_id);
-      });
-
-    auto res = _allocator.local().reallocate_partition(
-      reallocation.constraints.value(),
-      current_assignment,
-      get_allocation_domain(reallocation.ntp));
-    if (res.has_value()) {
-        reallocation.set_new_replicas(std::move(res.value()));
-    }
-}
-
 ss::future<> members_backend::reallocate_replica_set(
   members_backend::partition_reallocation& meta) {
     auto current_assignment = _topics.local().get_partition_assignment(
@@ -1032,7 +1049,7 @@ ss::future<> members_backend::reallocate_replica_set(
         meta.current_replica_set = current_assignment->replicas;
         // initial state, try to reassign partition replicas
 
-        reassign_replicas(*current_assignment, meta);
+        reassign_replicas(_allocator.local(), *current_assignment, meta);
         if (meta.new_replica_set.empty()) {
             // if partition allocator failed to reassign partitions return
             // and wait for next retry

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -79,6 +79,40 @@ public:
         absl::flat_hash_map<partition_allocation_domain, size_t> last_ntp_index;
     };
 
+    struct reallocation_strategy {
+        reallocation_strategy() = default;
+        reallocation_strategy(const reallocation_strategy&) = default;
+        reallocation_strategy(reallocation_strategy&&) = default;
+        reallocation_strategy& operator=(const reallocation_strategy&)
+          = default;
+        reallocation_strategy& operator=(reallocation_strategy&&) = default;
+        virtual ~reallocation_strategy() = default;
+        virtual void reallocations_for_even_partition_count(
+          size_t batch_size,
+          partition_allocator&,
+          topic_table&,
+          update_meta&,
+          partition_allocation_domain)
+          = 0;
+    };
+
+    class default_reallocation_strategy : public reallocation_strategy {
+        void reallocations_for_even_partition_count(
+          size_t batch_size,
+          partition_allocator&,
+          topic_table&,
+          update_meta&,
+          partition_allocation_domain) final;
+
+    private:
+        void calculate_reallocations_batch(
+          size_t batch_size,
+          partition_allocator&,
+          topic_table&,
+          update_meta&,
+          partition_allocation_domain);
+    };
+
     members_backend(
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::topic_table>&,
@@ -112,10 +146,9 @@ private:
     void stop_node_decommissioning(model::node_id);
     void stop_node_addition_and_ondemand_rebalance(model::node_id id);
     void handle_reallocation_finished(model::node_id);
-    void
-    calculate_reallocations_batch(update_meta&, partition_allocation_domain);
     void reallocations_for_even_partition_count(
       update_meta&, partition_allocation_domain);
+
     ss::future<> calculate_reallocations_after_decommissioned(update_meta&);
     ss::future<> calculate_reallocations_after_recommissioned(update_meta&);
     std::vector<model::ntp> ntps_moving_from_node_older_than(
@@ -143,6 +176,7 @@ private:
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<members_frontend>& _members_frontend;
     ss::sharded<features::feature_table>& _features;
+    std::unique_ptr<reallocation_strategy> _reallocation_strategy;
     consensus_ptr _raft0;
     ss::sharded<ss::abort_source>& _as;
     ss::gate _bg;

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -98,16 +98,7 @@ public:
 
 private:
     static constexpr model::revision_id raft0_revision{0};
-    struct node_replicas {
-        size_t allocated_replicas;
-        size_t max_capacity;
-    };
-    struct unevenness_error_info {
-        double e;
-        double e_step;
-    };
-    using node_replicas_map_t
-      = absl::node_hash_map<model::node_id, members_backend::node_replicas>;
+
     void start_reconciliation_loop();
     ss::future<> reconciliation_loop();
     ss::future<std::error_code> reconcile();
@@ -121,7 +112,6 @@ private:
     void stop_node_decommissioning(model::node_id);
     void stop_node_addition_and_ondemand_rebalance(model::node_id id);
     void handle_reallocation_finished(model::node_id);
-    void reassign_replicas(partition_assignment&, partition_reallocation&);
     void
     calculate_reallocations_batch(update_meta&, partition_allocation_domain);
     void reallocations_for_even_partition_count(
@@ -131,14 +121,9 @@ private:
     std::vector<model::ntp> ntps_moving_from_node_older_than(
       model::node_id, model::revision_id) const;
     void setup_metrics();
-    absl::node_hash_map<model::node_id, node_replicas>
-      calculate_replicas_per_node(partition_allocation_domain) const;
 
-    unevenness_error_info calculate_unevenness_error(
-      const update_meta&, partition_allocation_domain) const;
     bool should_stop_rebalancing_update(const update_meta&) const;
 
-    static size_t calculate_total_replicas(const node_replicas_map_t&);
     ss::future<std::error_code>
     update_raft0_configuration(const members_manager::node_update&);
 

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -93,6 +93,7 @@ public:
     bool is_rack_awareness_enabled() const { return _enable_rack_awareness(); }
 
     allocation_state& state() { return *_state; }
+    const allocation_state& state() const { return *_state; }
 
 private:
     template<typename T>

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(srcs
     topic_configuration_compat_test.cc
     local_monitor_test.cc
     tx_compaction_tests.cc
+
     )
 
 foreach(cluster_test_src ${srcs})
@@ -50,6 +51,7 @@ set(srcs
         ephemeral_credential_test.cc
         health_monitor_test.cc
         metadata_dissemination_test.cc
+        backend_reallocation_strategy_test.cc
         replicas_rebalancing_tests.cc)
 
 foreach(cluster_test_src ${srcs})

--- a/src/v/cluster/tests/backend_reallocation_strategy_test.cc
+++ b/src/v/cluster/tests/backend_reallocation_strategy_test.cc
@@ -1,0 +1,320 @@
+
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "cluster/cluster_utils.h"
+#include "cluster/commands.h"
+#include "cluster/members_backend.h"
+#include "cluster/members_table.h"
+#include "cluster/scheduling/allocation_node.h"
+#include "cluster/scheduling/partition_allocator.h"
+#include "cluster/scheduling/types.h"
+#include "cluster/topic_table.h"
+#include "cluster/types.h"
+#include "config/property.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "net/unresolved_address.h"
+#include "random/generators.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/util/log.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/container/node_hash_map.h>
+#include <boost/test/tools/old/interface.hpp>
+#include <fmt/core.h>
+
+#include <math.h>
+#include <tuple>
+
+static ss::logger tlog("test-logger");
+
+struct strategy_test_fixture {
+    strategy_test_fixture()
+      : topics()
+      , members()
+      , allocator(
+          members,
+          config::mock_binding<std::optional<size_t>>(std::nullopt),
+          config::mock_binding<std::optional<int32_t>>(std::nullopt),
+          config::mock_binding<uint32_t>(1000),
+          config::mock_binding<uint32_t>(10),
+          config::mock_binding<bool>(true)) {}
+
+    cluster::topic_table topics;
+    ss::sharded<cluster::members_table> members;
+    cluster::partition_allocator allocator;
+    model::offset rev_offset{0};
+
+    model::broker make_broker(
+      model::node_id id, uint32_t cores, std::optional<model::rack_id> rack) {
+        return model::broker(
+          id,
+          net::unresolved_address("localhost", 9092),
+          net::unresolved_address("localhost", 33145),
+          std::move(rack),
+          model::broker_properties{.cores = cores});
+    }
+
+    void add_node(
+      int id,
+      uint32_t cores,
+      std::optional<model::rack_id> rack = std::nullopt) {
+        model::node_id n_id(id);
+        auto broker = make_broker(n_id, cores, std::move(rack));
+        members.local().apply(rev_offset++, cluster::add_node_cmd(0, broker));
+        allocator.upsert_allocation_node(broker);
+    }
+
+    ss::future<> add_topic(int partition_count, int rf) {
+        cluster::allocation_request request(
+          cluster::partition_allocation_domains::common);
+        for (int i = 0; i < partition_count; ++i) {
+            request.partitions.emplace_back(model::partition_id(i), rf);
+        }
+
+        auto res = co_await allocator.allocate(std::move(request));
+        BOOST_REQUIRE(res.has_value());
+
+        auto units = std::move(res.value());
+
+        for (auto& p_as : units->get_assignments()) {
+            allocator.update_allocation_state(
+              p_as.replicas,
+              p_as.group,
+              cluster::partition_allocation_domains::common);
+        }
+
+        cluster::topic_configuration_assignment t_cfg;
+
+        t_cfg.assignments = units->get_assignments();
+        t_cfg.cfg.tp_ns = model::topic_namespace(
+          model::kafka_namespace,
+          model::topic(fmt::format("test-topic-{}", rev_offset())));
+        t_cfg.cfg.partition_count = partition_count;
+        t_cfg.cfg.replication_factor = rf;
+
+        co_await topics.apply(
+          cluster::create_topic_cmd(t_cfg.cfg.tp_ns, t_cfg), rev_offset++);
+    }
+
+    absl::flat_hash_map<model::node_id, size_t> replicas_per_node() {
+        absl::flat_hash_map<model::node_id, size_t> ret;
+        for (auto& n : allocator.state().allocation_nodes()) {
+            ret[n.first] = n.second->allocated_partitions();
+        }
+        return ret;
+    }
+
+    void print_replicas_per_node() {
+        auto per_node = replicas_per_node();
+        for (auto& [id, cnt] : per_node) {
+            fmt::print("node {} = {} replicas\n", id, cnt);
+        }
+    }
+
+    size_t total_replicas() {
+        auto per_node = replicas_per_node();
+        size_t ret = 0;
+        for (auto [_, cnt] : per_node) {
+            ret += cnt;
+        }
+        return ret;
+    }
+
+    void validate_even_replica_distribution() {
+        static constexpr double max_skew = 0.01;
+        auto per_node = replicas_per_node();
+        auto total = total_replicas();
+        auto expected_per_node = floor(
+          static_cast<double>(total) / per_node.size());
+
+        for (auto& [id, replicas] : per_node) {
+            tlog.info(
+              "node {} has {} replicas, expected: {}",
+              id,
+              replicas,
+              expected_per_node);
+            BOOST_REQUIRE_GE(
+              replicas, expected_per_node - ceil(max_skew * expected_per_node));
+            BOOST_REQUIRE_LE(
+              replicas, expected_per_node + ceil(max_skew * expected_per_node));
+        }
+    }
+
+    void validate_even_topic_distribution() {
+        absl::node_hash_map<
+          model::topic_namespace,
+          absl::flat_hash_map<model::node_id, size_t>>
+          topic_replica_distribution;
+
+        absl::node_hash_map<model::topic_namespace, size_t>
+          total_topic_replicas;
+
+        for (auto& [tp_ns, topic_md] : topics.all_topics_metadata()) {
+            for (auto& p_as : topic_md.get_assignments()) {
+                total_topic_replicas[tp_ns] += p_as.replicas.size();
+                for (auto& r : p_as.replicas) {
+                    topic_replica_distribution[tp_ns][r.node_id]++;
+                }
+            }
+        }
+
+        for (auto& [tp, node_replicas] : topic_replica_distribution) {
+            auto expected_replicas_per_node = ceil(
+              static_cast<double>(total_topic_replicas[tp])
+              / allocator.state().available_nodes());
+
+            if (
+              total_topic_replicas[tp] < allocator.state().available_nodes()) {
+                continue;
+            }
+            for (auto& [id, _] : allocator.state().allocation_nodes()) {
+                auto it = node_replicas.find(id);
+                const auto replicas_on_node = it == node_replicas.end()
+                                                ? 0
+                                                : it->second;
+                tlog.info(
+                  "topic {} has {} replicas on {}, expected: {} total "
+                  "replicas: {}",
+                  tp,
+                  replicas_on_node,
+                  id,
+                  expected_replicas_per_node,
+                  total_topic_replicas[tp]);
+                auto err = std::abs(
+                             expected_replicas_per_node - replicas_on_node)
+                           / (double)total_topic_replicas[tp];
+                // assert that the skew is smaller than 30%
+                BOOST_REQUIRE_LE(err, 0.3);
+            }
+        }
+    }
+
+    std::unique_ptr<cluster::members_backend::reallocation_strategy>
+    make_strategy() {
+        return std::make_unique<
+          cluster::members_backend::default_reallocation_strategy>();
+    }
+
+    ss::future<>
+    apply_reallocations(cluster::members_backend::update_meta& meta) {
+        for (auto& pr : meta.partition_reallocations) {
+            auto added = cluster::subtract_replica_sets(
+              pr.new_replica_set, pr.current_replica_set);
+            auto removed = cluster::subtract_replica_sets(
+              pr.current_replica_set, pr.new_replica_set);
+            // update allocator
+            allocator.add_allocations(
+              added, cluster::partition_allocation_domains::common);
+            allocator.remove_allocations(
+              removed, cluster::partition_allocation_domains::common);
+
+            auto ec = co_await topics.apply(
+              cluster::move_partition_replicas_cmd(pr.ntp, pr.new_replica_set),
+              ++rev_offset);
+            BOOST_REQUIRE(!ec);
+
+            ec = co_await topics.apply(
+              cluster::finish_moving_partition_replicas_cmd(
+                pr.ntp, pr.new_replica_set),
+              ++rev_offset);
+            BOOST_REQUIRE(!ec);
+        }
+        meta.partition_reallocations.clear();
+    }
+
+    ss::future<>
+    rebalance(cluster::members_backend::reallocation_strategy& strategy) {
+        cluster::members_backend::update_meta meta;
+        while (true) {
+            strategy.reallocations_for_even_partition_count(
+              50,
+              allocator,
+              topics,
+              meta,
+              cluster::partition_allocation_domains::common);
+            if (meta.partition_reallocations.empty()) {
+                break;
+            }
+
+            co_await apply_reallocations(meta);
+        }
+    }
+
+    ss::future<> start() { return members.start_single(); }
+
+    ~strategy_test_fixture() { members.stop().get(); }
+};
+
+FIXTURE_TEST(rebalance_with_two_nodes_added, strategy_test_fixture) {
+    start().get();
+
+    add_node(0, 8);
+    add_node(1, 8);
+    add_node(2, 8);
+
+    for (int i = 0; i < 100; ++i) {
+        add_topic(random_generators::get_int(5, 100), 3).get();
+    }
+
+    // add two more nodes
+    add_node(3, 8);
+    add_node(4, 8);
+
+    auto strategy = make_strategy();
+    rebalance(*strategy).get();
+
+    validate_even_replica_distribution();
+    validate_even_topic_distribution();
+}
+
+FIXTURE_TEST(rebalance_with_one_node_added, strategy_test_fixture) {
+    start().get();
+
+    add_node(0, 8);
+    add_node(1, 8);
+    add_node(2, 8);
+
+    for (int i = 0; i < 100; ++i) {
+        add_topic(random_generators::get_int(5, 100), 3).get();
+    }
+
+    // add one node
+    add_node(3, 8);
+
+    auto strategy = make_strategy();
+    rebalance(*strategy).get();
+
+    validate_even_replica_distribution();
+    validate_even_topic_distribution();
+}
+
+FIXTURE_TEST(rebalance_single_topic, strategy_test_fixture) {
+    start().get();
+
+    add_node(0, 8);
+    add_node(1, 8);
+    add_node(2, 8);
+
+    add_topic(3, 3).get();
+
+    // add one node
+    add_node(3, 8);
+
+    auto strategy = make_strategy();
+    rebalance(*strategy).get();
+
+    validate_even_replica_distribution();
+    validate_even_topic_distribution();
+}


### PR DESCRIPTION
Using reservoir sampling to chose the replicas that are going to be
reallocated to the new node provides better uniformity of topic replicas
distribution across the cluster. Additionally reservoir sampling
algorithm isn't prone to not selecting enough reallocations.

Fixes #7756
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- Topics are more uniformly distributed across the cluster after new nodes are added 
