### PR TITLE
cloud_storage: Fix fuzz test failures

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -27,6 +27,7 @@ scan_remote_partition_incrementally_with_reuploads(
   std::vector<in_memory_segment> segments,
   size_t maybe_max_segments = 0,
   size_t maybe_max_readers = 0) {
+    ss::lowres_clock::update();
     auto conf = imposter.get_configuration();
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {

--- a/src/v/cloud_storage/tests/util.h
+++ b/src/v/cloud_storage/tests/util.h
@@ -559,6 +559,7 @@ std::vector<model::record_batch_header> scan_remote_partition_incrementally(
   size_t maybe_max_bytes = 0,
   size_t maybe_max_segments = 0,
   size_t maybe_max_readers = 0) {
+    ss::lowres_clock::update();
     auto conf = imposter.get_configuration();
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {
@@ -632,6 +633,7 @@ std::vector<model::record_batch_header> scan_remote_partition(
   model::offset max = model::offset::max(),
   size_t maybe_max_segments = 0,
   size_t maybe_max_readers = 0) {
+    ss::lowres_clock::update();
     auto conf = imposter.get_configuration();
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {
@@ -674,6 +676,7 @@ void reupload_compacted_segments(
   const std::vector<in_memory_segment>& segments,
   cloud_storage::remote& api,
   bool truncate_segments = false) {
+    ss::lowres_clock::update();
     static ss::abort_source never_abort;
 
     model::offset delta{0};


### PR DESCRIPTION
The fuzz tests are failing because when the data is generated the reactor gets stalled. When this happens the lowres_clock counter is not updated and becomes stale (the time delta dpeneds on the duration of the reactor stall). When the test code tries to fetch the manifest from S3 as a next step it uses cloud_storage::remote::download_manifest. This method accepts a timestamp which is used as a deadline for the operation. In case of failure the deadline is computed incorrectly and operation fails by timeout.

This PR fixes the problem by invoking lowres_clock::update before the test starts doing anything.

Fixes #7548

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none