### PR TITLE
[backport] [22.3.x] rm_stm: replace std::vector usage with fragmented_vector

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -565,7 +565,7 @@ ntp_archiver::upload_tx(upload_candidate candidate) {
 
     auto path = segment_path_for_candidate(candidate);
 
-    cloud_storage::tx_range_manifest manifest(path, tx_range);
+    cloud_storage::tx_range_manifest manifest(path, std::move(tx_range));
 
     co_return co_await _remote.upload_manifest(
       _bucket, manifest, fib, _tx_tags);

--- a/src/v/cloud_storage/tests/tx_range_manifest_test.cc
+++ b/src/v/cloud_storage/tests/tx_range_manifest_test.cc
@@ -78,7 +78,9 @@ SEASTAR_THREAD_TEST_CASE(empty_serialization_roundtrip_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(serialization_roundtrip_test) {
-    tx_range_manifest m(segment_path, ranges);
+    fragmented_vector<tx_range_t> tx_ranges;
+    tx_ranges = ranges;
+    tx_range_manifest m(segment_path, std::move(tx_ranges));
     auto [is, size] = m.serialize();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -32,13 +32,9 @@ remote_manifest_path generate_remote_tx_path(const remote_segment_path& path) {
 }
 
 tx_range_manifest::tx_range_manifest(
-  remote_segment_path spath, const std::vector<model::tx_range>& range)
-  : _path(std::move(spath)) {
-    for (const auto& tx : range) {
-        _ranges.push_back(tx);
-    }
-    _ranges.shrink_to_fit();
-}
+  remote_segment_path spath, fragmented_vector<model::tx_range> ranges)
+  : _path(std::move(spath))
+  , _ranges(std::move(ranges)) {}
 
 tx_range_manifest::tx_range_manifest(remote_segment_path spath)
   : _path(std::move(spath)) {}

--- a/src/v/cloud_storage/tx_range_manifest.h
+++ b/src/v/cloud_storage/tx_range_manifest.h
@@ -29,7 +29,7 @@ class tx_range_manifest final : public base_manifest {
 public:
     /// Create manifest for specific ntp
     explicit tx_range_manifest(
-      remote_segment_path spath, const std::vector<model::tx_range>& range);
+      remote_segment_path spath, fragmented_vector<model::tx_range> range);
 
     /// Create empty manifest that supposed to be updated later
     explicit tx_range_manifest(remote_segment_path spath);

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -203,11 +203,11 @@ public:
 
     ss::shared_ptr<cluster::tm_stm> tm_stm() { return _tm_stm; }
 
-    ss::future<std::vector<rm_stm::tx_range>>
+    ss::future<fragmented_vector<rm_stm::tx_range>>
     aborted_transactions(model::offset from, model::offset to) {
         if (!_rm_stm) {
-            return ss::make_ready_future<std::vector<rm_stm::tx_range>>(
-              std::vector<rm_stm::tx_range>());
+            return ss::make_ready_future<fragmented_vector<rm_stm::tx_range>>(
+              fragmented_vector<rm_stm::tx_range>());
         }
         return _rm_stm->aborted_transactions(from, to);
     }

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -175,9 +175,9 @@ model::offset persisted_stm::max_collectible_offset() {
     return model::offset::max();
 }
 
-ss::future<std::vector<model::tx_range>>
+ss::future<fragmented_vector<model::tx_range>>
 persisted_stm::aborted_tx_ranges(model::offset, model::offset) {
-    return ss::make_ready_future<std::vector<model::tx_range>>();
+    return ss::make_ready_future<fragmented_vector<model::tx_range>>();
 }
 
 ss::future<> persisted_stm::wait_offset_committed(

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -88,7 +88,7 @@ public:
     void make_snapshot_in_background() final;
     ss::future<> ensure_snapshot_exists(model::offset) final;
     model::offset max_collectible_offset() override;
-    ss::future<std::vector<model::tx_range>>
+    ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
 
     virtual ss::future<> remove_persistent_state();

--- a/src/v/reflection/adl.h
+++ b/src/v/reflection/adl.h
@@ -33,6 +33,8 @@ struct adl {
     static constexpr bool is_optional = is_std_optional<type>;
     static constexpr bool is_sstring = std::is_same_v<type, ss::sstring>;
     static constexpr bool is_vector = is_std_vector<type>;
+    static constexpr bool is_fragmented_vector
+      = reflection::is_fragmented_vector<type>;
     static constexpr bool is_named_type = is_rp_named_type<type>;
     static constexpr bool is_iobuf = std::is_same_v<type, iobuf>;
     static constexpr bool is_standard_layout = std::is_standard_layout_v<type>;
@@ -83,6 +85,14 @@ struct adl {
             int32_t n = in.template consume_type<int32_t>();
             std::vector<value_type> ret;
             ret.reserve(n);
+            while (n-- > 0) {
+                ret.push_back(adl<value_type>{}.from(in));
+            }
+            return ret;
+        } else if constexpr (is_fragmented_vector) {
+            using value_type = typename type::value_type;
+            int32_t n = in.template consume_type<int32_t>();
+            fragmented_vector<value_type> ret;
             while (n-- > 0) {
                 ret.push_back(adl<value_type>{}.from(in));
             }
@@ -146,8 +156,14 @@ struct adl {
             adl<int32_t>{}.to(out, int32_t(t.size()));
             out.append(t.data(), t.size());
             return;
-        } else if constexpr (is_vector) {
+        } else if constexpr (is_vector || is_fragmented_vector) {
             using value_type = typename type::value_type;
+            if (unlikely(t.size() > std::numeric_limits<int32_t>::max())) {
+                throw std::invalid_argument(fmt::format(
+                  "Vector size {} exceeded int32_max: {}",
+                  t.size(),
+                  std::numeric_limits<int32_t>::max()));
+            }
             adl<int32_t>{}.to(out, t.size());
             for (value_type& i : t) {
                 adl<value_type>{}.to(out, std::move(i));

--- a/src/v/reflection/type_traits.h
+++ b/src/v/reflection/type_traits.h
@@ -13,6 +13,7 @@
 
 #include "seastarx.h"
 #include "tristate.h"
+#include "utils/fragmented_vector.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/circular_buffer.hh>
@@ -32,12 +33,24 @@ template<typename T, template<typename...> class C>
 inline constexpr bool is_specialization_of_v
   = is_specialization_of<T, C>::value;
 
+template<class T, template<class, size_t> class C>
+struct is_specialization_of_sized : std::false_type {};
+template<template<class, size_t> class C, class T, size_t N>
+struct is_specialization_of_sized<C<T, N>, C> : std::true_type {};
+template<typename T, template<class, size_t> class C>
+inline constexpr bool is_specialization_of_sized_v
+  = is_specialization_of_sized<T, C>::value;
+
 } // namespace detail
 
 namespace reflection {
 
 template<typename T>
 concept is_std_vector = ::detail::is_specialization_of_v<T, std::vector>;
+
+template<typename T>
+concept is_fragmented_vector
+  = ::detail::is_specialization_of_sized_v<T, fragmented_vector>;
 
 template<typename T>
 concept is_ss_circular_buffer

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -180,7 +180,7 @@ class tx_reducer : public compaction_reducer {
 public:
     explicit tx_reducer(
       ss::lw_shared_ptr<storage::stm_manager> stm_mgr,
-      std::vector<model::tx_range>&& txs,
+      fragmented_vector<model::tx_range>&& txs,
       compacted_index_writer* w) noexcept
       : _delegate(index_rebuilder_reducer(w))
       , _aborted_txs(model::tx_range_cmp(), std::move(txs))
@@ -227,7 +227,7 @@ private:
     // A min heap of aborted transactions based on begin offset.
     using underlying_t = std::priority_queue<
       model::tx_range,
-      std::vector<model::tx_range>,
+      fragmented_vector<model::tx_range>,
       model::tx_range_cmp>;
     underlying_t _aborted_txs;
     // Current list of aborted transactions maintained up to the

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -505,7 +505,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
 ss::future<> rebuild_compaction_index(
   model::record_batch_reader rdr,
   ss::lw_shared_ptr<storage::stm_manager> stm_manager,
-  std::vector<model::tx_range>&& aborted_txs,
+  fragmented_vector<model::tx_range>&& aborted_txs,
   std::filesystem::path p,
   compaction_config cfg,
   storage_resources& resources) {

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -74,7 +74,7 @@ public:
 
     // Only valid for state machines maintaining transactional state.
     // Returns aborted transactions in range [from, to] offsets.
-    virtual ss::future<std::vector<model::tx_range>>
+    virtual ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) = 0;
 
     virtual model::control_record_type
@@ -142,9 +142,9 @@ public:
         return result;
     }
 
-    ss::future<std::vector<model::tx_range>>
+    ss::future<fragmented_vector<model::tx_range>>
     aborted_tx_ranges(model::offset to, model::offset from) {
-        std::vector<model::tx_range> r;
+        fragmented_vector<model::tx_range> r;
         if (_tx_stm) {
             r = co_await _tx_stm->aborted_tx_ranges(to, from);
         }

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -66,6 +66,9 @@ class fragmented_vector {
 public:
     using this_type = fragmented_vector<T, max_fragment_size>;
     using value_type = T;
+    using reference = T&;
+    using const_reference = const T&;
+    using size_type = size_t;
 
     /**
      * The maximum number of bytes per fragment as specified in
@@ -78,20 +81,33 @@ public:
 
     fragmented_vector() noexcept = default;
     fragmented_vector& operator=(const fragmented_vector&) noexcept = delete;
-    fragmented_vector(fragmented_vector&&) noexcept = default;
-    fragmented_vector& operator=(fragmented_vector&&) noexcept = default;
+    fragmented_vector(fragmented_vector&& other) noexcept {
+        *this = std::move(other);
+    }
+    fragmented_vector& operator=(fragmented_vector&& other) noexcept {
+        if (this != &other) {
+            this->_size = other._size;
+            this->_capacity = other._capacity;
+            this->_frags = std::move(other._frags);
+            // Move compatibility with std::vector that post move
+            // the vector is empty().
+            other._size = other._capacity = 0;
+        }
+        return *this;
+    }
     ~fragmented_vector() noexcept = default;
 
     fragmented_vector copy() const noexcept { return *this; }
 
-    void push_back(T elem) {
+    template<class E = T>
+    void push_back(E&& elem) {
         if (_size == _capacity) {
             std::vector<T> frag;
             frag.reserve(elems_per_frag);
             _frags.push_back(std::move(frag));
             _capacity += elems_per_frag;
         }
-        _frags.back().push_back(elem);
+        _frags.back().push_back(std::forward<E>(elem));
         ++_size;
     }
 
@@ -115,6 +131,7 @@ public:
         return const_cast<T&>(std::as_const(*this)[index]);
     }
 
+    const T& front() const { return _frags.front().front(); }
     const T& back() const { return _frags.back().back(); }
     bool empty() const noexcept { return _size == 0; }
     size_t size() const noexcept { return _size; }

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -272,6 +272,24 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_comparison) {
     BOOST_CHECK(b1 >= b);
 }
 
+BOOST_AUTO_TEST_CASE(fragmented_vector_empty_after_move) {
+    // Checks that post move, the source vector is empty().
+    // This is inline with std::vector guarantees.
+    fragmented_vector<int> v1;
+    v1.push_back(1);
+    BOOST_CHECK(!v1.empty());
+
+    auto v2 = std::move(v1);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    BOOST_CHECK(v1.empty());
+    BOOST_CHECK(v1.begin() == v1.end());
+
+    auto v3(std::move(v2));
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    BOOST_CHECK(v2.empty());
+    BOOST_CHECK(v2.begin() == v2.end());
+}
+
 BOOST_AUTO_TEST_CASE(fragmented_vector_sort) {
     auto v = make<int64_t, 8>({3, 2, 1});
     auto expected = make<int64_t, 8>({1, 2, 3});


### PR DESCRIPTION
A lot of state in rm_stm is backed by std::vector. With frequent snapshotting + non trivial pid counts large contiguous allocations cannot be satisfied if the memory is fragmented. This patch switches to using fragmented_vector for this usecase.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.
-->

### Improvements

* Improves memory management with transactions and idempotency by avoiding large contiguous allocations.
