### PR TITLE
archival: remove timeouts from archival_metadata_stm

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -193,6 +193,7 @@ ss::future<> ntp_archiver::upload_until_abort() {
           .handle_exception_type([](const ss::sleep_aborted&) {})
           .handle_exception_type([](const ss::gate_closed_exception&) {})
           .handle_exception_type([](const ss::broken_semaphore&) {})
+          .handle_exception_type([](const ss::broken_named_semaphore&) {})
           .handle_exception_type([this](const ss::semaphore_timed_out& e) {
               vlog(
                 _rtclog.warn,
@@ -246,6 +247,8 @@ ss::future<> ntp_archiver::sync_manifest_until_abort() {
             co_await sync_manifest_until_term_change()
               .handle_exception_type(
                 [](const ss::abort_requested_exception&) {})
+              .handle_exception_type([](const ss::broken_semaphore&) {})
+              .handle_exception_type([](const ss::broken_named_semaphore&) {})
               .handle_exception_type([](const ss::sleep_aborted&) {})
               .handle_exception_type([](const ss::gate_closed_exception&) {});
         } catch (const ss::semaphore_timed_out& e) {

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -346,8 +346,7 @@ ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
         if (now >= deadline) {
             co_return errc::replication_error;
         }
-        auto timeout = deadline - now;
-        applied = co_await wait_no_throw(result.value().last_offset, timeout);
+        applied = co_await wait_no_throw(result.value().last_offset, deadline);
     }
 
     if (!applied) {

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -193,8 +193,7 @@ ss::future<std::error_code> command_batch_builder::replicate() {
                 return ss::make_ready_future<std::error_code>(errc::timeout);
             }
             auto batch = std::move(_builder).build();
-            return _stm.get().do_replicate_commands(
-              std::move(batch), _deadline, _as);
+            return _stm.get().do_replicate_commands(std::move(batch), _as);
         });
     });
 }
@@ -312,44 +311,46 @@ ss::future<std::error_code> archival_metadata_stm::cleanup_metadata(
 
 ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
   model::record_batch batch,
-  ss::lowres_clock::time_point deadline,
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    auto current_term = _insync_term;
     auto fut = _raft->replicate(
-      _insync_term,
+      current_term,
       model::make_memory_record_batch_reader(std::move(batch)),
       raft::replicate_options{raft::consistency_level::quorum_ack});
 
+    // Run with an abort source so shutdown doesn't have to wait a full
+    // replication timeout to proceed.
     if (as) {
-        fut = ssx::with_timeout_abortable(std::move(fut), deadline, *as);
-    } else {
-        fut = ss::with_timeout(deadline, std::move(fut));
+        fut = ssx::with_timeout_abortable(
+          std::move(fut), model::no_timeout, *as);
     }
 
-    result<raft::replicate_result> result{{}};
-    try {
-        result = co_await std::move(fut);
-    } catch (const ss::timed_out_error&) {
-        result = errc::timeout;
-    }
-
+    auto result = co_await std::move(fut);
     if (!result) {
         vlog(
           _logger.warn,
           "error on replicating remote segment metadata: {}",
           result.error());
+        // If there was an error for whatever reason, it is unsafe to make any
+        // assumptions about whether batches were replicated or not. Explicitly
+        // step down if we're still leader and force callers to re-sync in a
+        // new term with a new leader.
+        if (_c->is_leader() && _c->term() == current_term) {
+            co_await _c->step_down(ssx::sformat(
+              "failed to replicate archival batch in term {}", current_term));
+        }
         co_return result.error();
     }
 
-    bool applied = false;
-    {
-        auto now = ss::lowres_clock::now();
-        if (now >= deadline) {
-            co_return errc::replication_error;
-        }
-        applied = co_await wait_no_throw(result.value().last_offset, deadline);
-    }
-
+    auto applied = co_await wait_no_throw(
+      result.value().last_offset, model::no_timeout, as);
     if (!applied) {
+        if (
+          as.has_value() && !as.value().get().abort_requested()
+          && _c->is_leader() && _c->term() == current_term) {
+            co_await _c->step_down(ssx::sformat(
+              "failed to replicate archival batch in term {}", current_term));
+        }
         co_return errc::replication_error;
     }
 
@@ -391,7 +392,7 @@ ss::future<std::error_code> archival_metadata_stm::do_truncate(
 
     auto batch = std::move(b).build();
 
-    auto ec = co_await do_replicate_commands(std::move(batch), deadline, as);
+    auto ec = co_await do_replicate_commands(std::move(batch), as);
     if (ec) {
         co_return ec;
     }
@@ -456,7 +457,7 @@ ss::future<std::error_code> archival_metadata_stm::do_cleanup_metadata(
 
     auto batch = std::move(b).build();
 
-    auto ec = co_await do_replicate_commands(std::move(batch), deadline, as);
+    auto ec = co_await do_replicate_commands(std::move(batch), as);
     if (ec) {
         co_return ec;
     }
@@ -521,7 +522,7 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
     }
 
     auto batch = std::move(b).build();
-    auto ec = co_await do_replicate_commands(std::move(batch), deadline, as);
+    auto ec = co_await do_replicate_commands(std::move(batch), as);
     if (ec) {
         co_return ec;
     }

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -180,9 +180,10 @@ private:
       ss::lowres_clock::time_point,
       std::optional<std::reference_wrapper<ss::abort_source>>);
 
+    /// NOTE: no deadline provided, as it is expected further updates to the
+    /// archiver will depend on all record batches having been applied.
     ss::future<std::error_code> do_replicate_commands(
       model::record_batch,
-      ss::lowres_clock::time_point,
       std::optional<std::reference_wrapper<ss::abort_source>>);
 
     ss::future<> apply(model::record_batch batch) override;

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -80,7 +80,8 @@ ss::future<bool> id_allocator_stm::set_state(
         co_return false;
     }
     if (!co_await wait_no_throw(
-          model::offset(r.value().last_offset()), timeout)) {
+          model::offset(r.value().last_offset()),
+          model::timeout_clock::now() + timeout)) {
         co_return false;
     }
     co_return true;

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -19,6 +19,7 @@
 #include "storage/record_batch_builder.h"
 #include "storage/snapshot.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 
@@ -324,9 +325,10 @@ ss::future<bool> persisted_stm::sync(model::timeout_clock::duration timeout) {
 }
 
 ss::future<bool> persisted_stm::wait_no_throw(
-  model::offset offset, model::timeout_clock::duration timeout) {
-    auto deadline = model::timeout_clock::now() + timeout;
-    return wait(offset, deadline)
+  model::offset offset,
+  model::timeout_clock::time_point deadline,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    return wait(offset, deadline, as)
       .then([] { return true; })
       .handle_exception_type([](const ss::abort_requested_exception&) {
           // Shutting down

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -123,8 +123,10 @@ public:
      */
     ss::future<> start() override;
 
-    ss::future<bool>
-    wait_no_throw(model::offset offset, model::timeout_clock::duration);
+    ss::future<bool> wait_no_throw(
+      model::offset offset,
+      model::timeout_clock::time_point,
+      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
 
 private:
     ss::future<> wait_offset_committed(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -464,7 +464,8 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
     }
 
     if (!co_await wait_no_throw(
-          model::offset(r.value().last_offset()), _sync_timeout)) {
+          model::offset(r.value().last_offset()),
+          model::timeout_clock::now() + _sync_timeout)) {
         vlog(
           _ctx_log.trace,
           "timeout on waiting until {} is applied (begin_tx pid:{} tx_seq:{})",
@@ -656,7 +657,8 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
     }
 
     if (!co_await wait_no_throw(
-          model::offset(r.value().last_offset()), timeout)) {
+          model::offset(r.value().last_offset()),
+          model::timeout_clock::now() + timeout)) {
         co_return tx_errc::unknown_server_error;
     }
 
@@ -695,7 +697,8 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
     // catching up with all previous end_tx operations (commit | abort)
     // to avoid writing the same commit | abort marker twice
     if (_mem_state.last_end_tx >= model::offset{0}) {
-        if (!co_await wait_no_throw(_mem_state.last_end_tx, timeout)) {
+        if (!co_await wait_no_throw(
+              _mem_state.last_end_tx, model::timeout_clock::now() + timeout)) {
             co_return tx_errc::stale;
         }
     }
@@ -821,7 +824,8 @@ ss::future<tx_errc> rm_stm::do_commit_tx(
         }
         co_return tx_errc::timeout;
     }
-    if (!co_await wait_no_throw(r.value().last_offset, timeout)) {
+    if (!co_await wait_no_throw(
+          r.value().last_offset, model::timeout_clock::now() + timeout)) {
         if (_c->is_leader() && _c->term() == synced_term) {
             co_await _c->step_down("do_commit_tx wait error");
         }
@@ -944,7 +948,8 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
     // catching up with all previous end_tx operations (commit | abort)
     // to avoid writing the same commit | abort marker twice
     if (_mem_state.last_end_tx >= model::offset{0}) {
-        if (!co_await wait_no_throw(_mem_state.last_end_tx, timeout)) {
+        if (!co_await wait_no_throw(
+              _mem_state.last_end_tx, model::timeout_clock::now() + timeout)) {
             vlog(
               _ctx_log.trace,
               "Can't catch up to abort pid:{} tx_seq:{}",
@@ -1045,7 +1050,8 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
         _mem_state.last_end_tx = r.value().last_offset;
     }
 
-    if (!co_await wait_no_throw(r.value().last_offset, timeout)) {
+    if (!co_await wait_no_throw(
+          r.value().last_offset, model::timeout_clock::now() + timeout)) {
         vlog(
           _ctx_log.trace,
           "timeout on waiting until {} is applied (abort_tx pid:{} tx_seq:{})",
@@ -1476,7 +1482,8 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
         co_return r.error();
     }
     if (!co_await wait_no_throw(
-          model::offset(r.value().last_offset()), _sync_timeout)) {
+          model::offset(r.value().last_offset()),
+          model::timeout_clock::now() + _sync_timeout)) {
         vlog(
           _ctx_log.warn,
           "application of the replicated tx batch has timed out pid:{}",
@@ -2098,7 +2105,9 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
     // catching up with all previous end_tx operations (commit | abort)
     // to avoid writing the same commit | abort marker twice
     if (_mem_state.last_end_tx >= model::offset{0}) {
-        if (!co_await wait_no_throw(_mem_state.last_end_tx, _sync_timeout)) {
+        if (!co_await wait_no_throw(
+              _mem_state.last_end_tx,
+              model::timeout_clock::now() + _sync_timeout)) {
             co_return tx_errc::timeout;
         }
     }
@@ -2176,7 +2185,8 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                     _mem_state.last_end_tx = cr.value().last_offset;
                 }
                 if (!co_await wait_no_throw(
-                      cr.value().last_offset, _sync_timeout)) {
+                      cr.value().last_offset,
+                      model::timeout_clock::now() + _sync_timeout)) {
                     vlog(
                       _ctx_log.warn,
                       "Timed out on waiting for the commit marker to be "
@@ -2212,7 +2222,8 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                     _mem_state.last_end_tx = cr.value().last_offset;
                 }
                 if (!co_await wait_no_throw(
-                      cr.value().last_offset, _sync_timeout)) {
+                      cr.value().last_offset,
+                      model::timeout_clock::now() + _sync_timeout)) {
                     vlog(
                       _ctx_log.warn,
                       "Timed out on waiting for the abort marker to be applied "

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -268,8 +268,11 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
 
     auto op = stm.abort_tx(pid2, tx_seq, 2'000ms).get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
-    BOOST_REQUIRE(
-      stm.wait_no_throw(_raft.get()->committed_offset(), 2'000ms).get0());
+    BOOST_REQUIRE(stm
+                    .wait_no_throw(
+                      _raft.get()->committed_offset(),
+                      model::timeout_clock::now() + 2'000ms)
+                    .get0());
     aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
 
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 1);
@@ -365,8 +368,11 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
 
     op = stm.abort_tx(pid2, tx_seq, 2'000ms).get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
-    BOOST_REQUIRE(
-      stm.wait_no_throw(_raft.get()->committed_offset(), 2'000ms).get0());
+    BOOST_REQUIRE(stm
+                    .wait_no_throw(
+                      _raft.get()->committed_offset(),
+                      model::timeout_clock::now() + 2'000ms)
+                    .get0());
     aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
 
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 1);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -276,7 +276,8 @@ tm_stm::do_update_tx(tm_transaction tx, model::term_id term) {
     }
 
     auto offset = model::offset(r.value().last_offset());
-    if (!co_await wait_no_throw(offset, _sync_timeout)) {
+    if (!co_await wait_no_throw(
+          offset, model::timeout_clock::now() + _sync_timeout)) {
         vlog(
           txlog.info,
           "timeout on waiting until {} is applied on updating tx:{} pid:{} "
@@ -544,7 +545,8 @@ ss::future<tm_stm::op_status> tm_stm::do_register_new_producer(
     }
 
     if (!co_await wait_no_throw(
-          model::offset(r.value().last_offset()), _sync_timeout)) {
+          model::offset(r.value().last_offset()),
+          model::timeout_clock::now() + _sync_timeout)) {
         co_return tm_stm::op_status::unknown;
     }
     if (_c->term() != expected_term) {

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -235,7 +235,6 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             cloud_storage_segment_size_target=4 * self.log_segment_size,
             cloud_storage_segment_size_min=2 * self.log_segment_size,
             retention_local_target_bytes_default=10 * self.log_segment_size,
-            cloud_storage_manifest_upload_timeout_ms=60 * 1000,
             cloud_storage_enable_segment_merging=True)
 
         super(CloudStorageTimingStressTest,


### PR DESCRIPTION
At a high level, the archival loop is implemented with the following steps:

```
while not aborted:
  wait until node is leader
  sync that offsets from previous terms are applied
  while node is leader:
    upload segments based on what is in the manifest
    replicate changes to manifest via archival stm
    wait for archival stm update to be applied (updates manifest)
```

The archival loop currently expects that updates to the manifest are either driven by it (or the housekeeping service, though ignoring this for the sake of example). One case where this invariant is broken is the case where the replication/apply of archival batches times out -- the actual apply of the op may proceed as a part of the raft::state_machine background fiber, and the archival loop itself may proceed without waiting, meaning the updates to the manifest may race with a subsequent iteration of the archival loop.

This commit remediates this by removing the timeout from the archival_metadata_stm::do_replicate_commands() call, forcing the caller to wait indefinitely for the op to complete. In the event of an unsuccessful wait, if the persisted_stm is still leader, it will explicitly step down to force the archival loop to re-sync in a new term.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes
* Fixes an issue with the archival upload path that could contribute to data loss when archival metadata updates took a long time to be replicated and applied.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
