### PR TITLE
storage: increase retention estimate error

### DIFF
--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -126,7 +126,7 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
 
     BOOST_CHECK_LT(
       (builder.gc_estimate(model::timestamp::now(), 0).get().retention - 2_MiB),
-      10_KiB);
+      20_KiB);
 
     // second segment
     builder | storage::add_segment(offset);
@@ -147,7 +147,7 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     // the first segment is now eligible for reclaim
     BOOST_CHECK_LT(
       (builder.gc_estimate(model::timestamp::now(), 0).get().retention - 3_MiB),
-      10_KiB);
+      20_KiB);
 
     // third segment
     builder | storage::add_segment(offset);
@@ -168,7 +168,7 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     // the first,second segment is now eligible for reclaim
     BOOST_CHECK_LT(
       (builder.gc_estimate(model::timestamp::now(), 0).get().retention - 4_MiB),
-      10_KiB);
+      20_KiB);
 
     // active segment
     builder | storage::add_segment(offset);
@@ -189,7 +189,7 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     // the first,second segment is now eligible for reclaim
     BOOST_CHECK_LT(
       (builder.gc_estimate(model::timestamp::now(), 0).get().retention - 5_MiB),
-      10_KiB);
+      20_KiB);
 
     builder | storage::garbage_collect(yesterday, 4_MiB);
 


### PR DESCRIPTION
Building the batches uses random sizes. Increasing the theshold here to avoid that noise causing a failure.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

