### PR TITLE
exclude test dirs from kics to reduce noise

### DIFF
--- a/.github/workflows/kics-iac.yml
+++ b/.github/workflows/kics-iac.yml
@@ -18,6 +18,7 @@ jobs:
           path: .
           ignore_on_exit: results
           output_path: res/
+          exclude_paths: tests/,src/go/k8s/tests/,src/go/rpk/pkg/testfs/
       - name: display kics results
         run: |
           cat res/results.json


### PR DESCRIPTION
KICS should not scan test dirs as it just makes noise. 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
