### PR TITLE
Improved logging in `persisted_stm` 

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -60,7 +60,7 @@ ss::future<std::optional<stm_snapshot>> persisted_stm::load_snapshot() {
 
     if (version == snapshot_version_v0) {
         vlog(
-          clusterlog.warn,
+          _log.warn,
           "Skipping snapshot {} due to old format",
           _snapshot_mgr.snapshot_path());
 
@@ -222,7 +222,7 @@ ss::future<bool> persisted_stm::do_sync(
             co_return false;
         } catch (...) {
             vlog(
-              clusterlog.error,
+              _log.error,
               "sync error: wait_offset_committed on {} failed with {}; "
               "offsets: "
               "dirty={}, committed={}; ntp={}",
@@ -250,7 +250,7 @@ ss::future<bool> persisted_stm::do_sync(
             co_return false;
         } catch (const ss::timed_out_error&) {
             vlog(
-              clusterlog.warn,
+              _log.warn,
               "sync timeout: waiting for {} offset={}; committed "
               "offset={}; ntp={}",
               name(),
@@ -260,7 +260,7 @@ ss::future<bool> persisted_stm::do_sync(
             co_return false;
         } catch (...) {
             vlog(
-              clusterlog.error,
+              _log.error,
               "sync error: waiting for {} offset={} failed with {}; committed "
               "offset={}; ntp={}",
               name(),
@@ -338,7 +338,7 @@ ss::future<bool> persisted_stm::wait_no_throw(
       .handle_exception_type(
         [this, offset, ntp = _c->ntp()](const ss::timed_out_error&) {
             vlog(
-              clusterlog.warn,
+              _log.warn,
               "timed out while waiting for {} offset: {}, ntp: {}",
               name(),
               offset,
@@ -347,7 +347,7 @@ ss::future<bool> persisted_stm::wait_no_throw(
         })
       .handle_exception([this, offset, ntp = _c->ntp()](std::exception_ptr e) {
           vlog(
-            clusterlog.error,
+            _log.error,
             "An error {} happened during waiting for {} offset: {}, ntp: {}",
             e,
             name(),
@@ -375,7 +375,7 @@ ss::future<> persisted_stm::start() {
         auto next_offset = model::next_offset(snapshot.header.offset);
         if (next_offset >= _c->start_offset()) {
             vlog(
-              clusterlog.debug,
+              _log.debug,
               "{} start with applied snapshot, set_next {}",
               name(),
               next_offset);
@@ -388,11 +388,11 @@ ss::future<> persisted_stm::start() {
             // continue. The stm will later detect this situation and deal with
             // it in the apply fiber by calling handle_eviction.
             vlog(
-              clusterlog.warn,
+              _log.warn,
               "Skipping snapshot {} since it's out of sync with the log",
               _snapshot_mgr.snapshot_path());
             vlog(
-              clusterlog.debug,
+              _log.debug,
               "{} start with non-applied snapshot, set_next {}",
               name(),
               next_offset);
@@ -404,7 +404,7 @@ ss::future<> persisted_stm::start() {
     } else {
         auto offset = _c->start_offset();
         vlog(
-          clusterlog.debug,
+          _log.debug,
           "{} start without snapshot, maybe set_next {}",
           name(),
           offset);

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -24,6 +24,7 @@
 #include "utils/expiring_promise.h"
 #include "utils/fragmented_vector.h"
 #include "utils/mutex.h"
+#include "utils/prefix_logger.h"
 
 #include <absl/container/flat_hash_map.h>
 
@@ -158,7 +159,7 @@ protected:
     uint64_t _snapshot_size{0};
     raft::consensus* _c;
     storage::simple_snapshot_manager _snapshot_mgr;
-    ss::logger& _log;
+    prefix_logger _log;
 };
 
 } // namespace cluster


### PR DESCRIPTION
Added more context to `cluster::persisted_stm` log and assertion messages.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none