### PR TITLE
cloud_storage: manifest upload efficiency and observability improvements

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1586,6 +1586,11 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::garbage_collect() {
     const auto to_remove
       = _parent.archival_meta_stm()->get_segments_to_cleanup();
 
+    // Avoid replicating 'cleanup_metadata_cmd' if there's nothing to remove.
+    if (to_remove.size() == 0) {
+        co_return updated;
+    }
+
     size_t successful_deletes{0};
     co_await ss::max_concurrent_for_each(
       to_remove,

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -338,7 +338,7 @@ ss::future<> ntp_archiver::upload_until_term_change() {
     // uploads).
     {
         auto units = co_await ss::get_units(_uploads_active, 1);
-        co_await maybe_upload_manifest();
+        co_await maybe_upload_manifest(upload_loop_prologue_ctx_label);
         co_await maybe_flush_manifest_clean_offset();
     }
 
@@ -419,7 +419,7 @@ ss::future<> ntp_archiver::upload_until_term_change() {
         // This is the fallback path for uploading manifest if it didn't happen
         // inline with segment uploads: this path will be taken on e.g. restarts
         // or unclean leadership changes.
-        if (co_await maybe_upload_manifest()) {
+        if (co_await maybe_upload_manifest(upload_loop_epilogue_ctx_label)) {
             co_await maybe_flush_manifest_clean_offset();
         }
 
@@ -708,13 +708,14 @@ ntp_archiver::download_manifest() {
  * then we will do an upload + mark_clean in the main upload loop, even
  * if we did not upload any segments.
  */
-ss::future<bool> ntp_archiver::maybe_upload_manifest() {
+ss::future<bool> ntp_archiver::maybe_upload_manifest(const char* upload_ctx) {
     if (
       _parent.archival_meta_stm()->get_dirty(_projected_manifest_clean_at)
       == cluster::archival_metadata_stm::state_dirty::clean) {
         vlog(
           _rtclog.debug,
-          "Manifest is clean{}, skipping upload",
+          "[{}] Manifest is clean{}, skipping upload",
+          upload_ctx,
           _projected_manifest_clean_at.has_value() ? " (projected)" : "");
         co_return false;
     }
@@ -729,14 +730,7 @@ ss::future<bool> ntp_archiver::maybe_upload_manifest() {
         co_return false;
     }
 
-    auto upload_insync_offset
-      = _parent.archival_meta_stm()->get_insync_offset();
-    vlog(
-      _rtclog.debug,
-      "Uploading partition manifest, insync_offset={}",
-      upload_insync_offset);
-
-    auto result = co_await upload_manifest();
+    auto result = co_await upload_manifest(upload_ctx);
     co_return result == cloud_storage::upload_result::success;
 }
 
@@ -769,13 +763,16 @@ ss::future<> ntp_archiver::maybe_flush_manifest_clean_offset() {
 }
 
 ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
+  const char* upload_ctx,
   std::optional<std::reference_wrapper<retry_chain_node>> source_rtc) {
     if (!_feature_table.local().is_active(
           features::feature::cloud_storage_manifest_format_v2)) {
         vlog(
           archival_log.info,
-          "Skipping manifest upload until all nodes in the cluster have been "
-          "upgraded.");
+          "[{}] Skipping manifest upload until all nodes in the cluster have "
+          "been "
+          "upgraded.",
+          upload_ctx);
 
         co_return cloud_storage::upload_result::cancelled;
     }
@@ -787,18 +784,17 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
       _conf->cloud_storage_initial_backoff,
       &rtc.get());
     retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
-    vlog(
-      ctxlog.debug,
-      "Uploading manifest, path: {}",
-      manifest().get_manifest_path());
     auto units = co_await _parent.archival_meta_stm()->acquire_manifest_lock();
 
     auto upload_insync_offset
       = _parent.archival_meta_stm()->get_insync_offset();
+
     vlog(
       _rtclog.debug,
-      "Uploading partition manifest, insync_offset={}",
-      upload_insync_offset);
+      "[{}] Uploading partition manifest, insync_offset={}, path={}",
+      upload_ctx,
+      upload_insync_offset,
+      manifest().get_manifest_path());
 
     auto result = co_await _remote.upload_manifest(
       get_bucket_name(), manifest(), fib, _manifest_tags);
@@ -810,7 +806,12 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
         // It is not necessary to retry: we are called from within the main
         // upload_until_term_change loop, and will get another chance to
         // upload the manifest eventually from there.
-        vlog(_rtclog.warn, "Failed to upload partition manifest: {}", result);
+        vlog(
+          _rtclog.warn,
+          "[{}] Failed to upload partition manifest at insync_offset={}: {}",
+          upload_ctx,
+          result,
+          upload_insync_offset);
     }
 
     co_return result;
@@ -1195,8 +1196,10 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
         // so that we can conveniently await it along with our segment
         // uploads.  The actual result is reflected in
         // _projected_manifest_clean_at if something was uploaded.
-        flist.push_back(maybe_upload_manifest().then(
-          [](bool) { return cloud_storage::upload_result::success; }));
+        flist.push_back(
+          maybe_upload_manifest(concurrent_with_segs_ctx_label).then([](bool) {
+              return cloud_storage::upload_result::success;
+          }));
     }
 
     auto segment_results = co_await ss::when_all_succeed(
@@ -1303,7 +1306,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
             // * infrequent means we're uploading a segment less often than the
             //   manifest upload interval, so can afford to upload manifest
             //   immediately after each segment upload.
-            co_await maybe_upload_manifest();
+            co_await maybe_upload_manifest(post_add_segs_ctx_label);
         }
     }
 
@@ -1468,7 +1471,7 @@ ntp_archiver::maybe_truncate_manifest() {
             vlog(
               ctxlog.debug,
               "archival metadata STM update passed, re-uploading manifest");
-            co_await upload_manifest();
+            co_await upload_manifest(sync_local_state_ctx_label);
         }
         vlog(
           ctxlog.info,
@@ -1529,7 +1532,7 @@ ss::future<> ntp_archiver::housekeeping() {
             const auto retention_updated_manifest = co_await apply_retention();
             const auto gc_updated_manifest = co_await garbage_collect();
             if (retention_updated_manifest || gc_updated_manifest) {
-                co_await upload_manifest();
+                co_await upload_manifest(housekeeping_ctx_label);
             }
         }
     } catch (std::exception& e) {
@@ -1846,7 +1849,7 @@ ss::future<bool> ntp_archiver::do_upload_local(
         co_return false;
     }
     if (
-      co_await upload_manifest(source_rtc)
+      co_await upload_manifest(segment_merger_ctx_label, source_rtc)
       != cloud_storage::upload_result::success) {
         vlog(
           _rtclog.info,

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -248,6 +248,21 @@ public:
     void complete_transfer_leadership();
 
 private:
+    // Labels for contexts in which manifest uploads occur. Used for logging.
+    static constexpr const char* housekeeping_ctx_label = "housekeeping";
+    static constexpr const char* sync_local_state_ctx_label
+      = "sync_local_state";
+    static constexpr const char* post_add_segs_ctx_label
+      = "made_dirty_post_add_segments";
+    static constexpr const char* concurrent_with_segs_ctx_label
+      = "was_dirty_concurrent_with_segments";
+    static constexpr const char* upload_loop_epilogue_ctx_label
+      = "upload_loop_epilogue";
+    static constexpr const char* upload_loop_prologue_ctx_label
+      = "upload_loop_prologue";
+    static constexpr const char* segment_merger_ctx_label
+      = "adjacent_segment_merger";
+
     ss::future<bool> do_upload_local(
       upload_candidate_with_locks candidate,
       std::optional<std::reference_wrapper<retry_chain_node>> source_rtc);
@@ -359,7 +374,7 @@ private:
     /// in the expectation that we will be called again in the main upload loop.
     /// Returns true if something was uploaded (_projected_manifest_clean_at
     /// will have been updated if so)
-    ss::future<bool> maybe_upload_manifest();
+    ss::future<bool> maybe_upload_manifest(const char* upload_ctx);
 
     /// If we have a projected manifest clean offset, then flush it to
     /// the persistent stm clean offset.
@@ -367,6 +382,7 @@ private:
 
     /// Upload manifest to the pre-defined S3 location
     ss::future<cloud_storage::upload_result> upload_manifest(
+      const char* upload_ctx,
       std::optional<std::reference_wrapper<retry_chain_node>> source_rtc
       = std::nullopt);
 

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -68,7 +68,8 @@ class CloudRetentionTest(PreallocNodesTest):
             max_read_msgs = 2000
 
         si_settings = SISettings(self.test_context,
-                                 log_segment_size=segment_size)
+                                 log_segment_size=segment_size,
+                                 fast_uploads=True)
         self.redpanda.set_si_settings(si_settings)
 
         extra_rp_conf = dict(retention_local_target_bytes_default=self.
@@ -165,7 +166,8 @@ class CloudRetentionTest(PreallocNodesTest):
         small_segment_size = 1024 * 1024
         num_partitions = 16
         si_settings = SISettings(self.test_context,
-                                 log_segment_size=small_segment_size)
+                                 log_segment_size=small_segment_size,
+                                 fast_uploads=True)
         self.redpanda.set_si_settings(si_settings)
         extra_rp_conf = dict(retention_local_target_bytes_default=self.
                              default_retention_segments * small_segment_size,
@@ -270,7 +272,8 @@ class CloudRetentionTimelyGCTest(RedpandaTest):
 
     def __init__(self, test_context):
         si_settings = SISettings(test_context,
-                                 log_segment_size=self.segment_size)
+                                 log_segment_size=self.segment_size,
+                                 fast_uploads=True)
         self.s3_bucket_name = si_settings.cloud_storage_bucket
         super().__init__(
             test_context,

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -298,7 +298,8 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
         extra_rp_conf = dict(log_compaction_interval_ms=1000)
 
         si_settings = SISettings(test_context,
-                                 log_segment_size=self.segment_size)
+                                 log_segment_size=self.segment_size,
+                                 fast_uploads=True)
         super(ShadowIndexingCloudRetentionTest,
               self).__init__(test_context=test_context,
                              si_settings=si_settings,


### PR DESCRIPTION
This PR fixes a couple of issues related to manifest uploads and improves the log
reading experience by adding a context to manifest upload related logs.

1. Avoid manifest uploads from the ntp_archiver housekeeping if no segments
were removed. There was a previous attempt at this, but it was not complete or
degraded due to some other change.
2. Treat all manifest uploads the same. Previously, only some manifest upload
paths updated the in-memory state of `ntp_archiver` (i.e. timer and projected clean
offset).

## Backports Required

Only the [archival: avoid replicating cmd if cleanup is noop](https://github.com/redpanda-data/redpanda/commit/c9f3d9cb3618c704fc0716c79ad8cfecd91c9e5d) commit should be backported.

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
