### PR TITLE
Fix for CI failure `ERROR` log in `UsageTest.test_usage_settings_changed`

### DIFF
--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -92,6 +92,7 @@ public:
         ss::timer<ss::lowres_clock> _timer;
         ss::timer<ss::lowres_clock> _persist_disk_timer;
 
+        ss::gate _bg_write_gate;
         ss::gate _gate;
         size_t _current_window{0};
         fragmented_vector<usage_window> _buckets;


### PR DESCRIPTION
- This situtation may naturally occur, logging at error will raise an exception in DT tests

- Fixes: #9647

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none