### PR TITLE
cloud_storage: fix usage accounting bug

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -562,11 +562,11 @@ bool partition_manifest::add(
           meta.committed_offset, _last_uploaded_compacted_offset);
     }
 
-    subtract_from_cloud_log_size(total_replaced_size);
     if (ok) {
         // If the segment does not replace the one that we have we will
         // fail to insert it into the map. In this case we shouldn't
         // modify the total cloud size.
+        subtract_from_cloud_log_size(total_replaced_size);
         _cloud_log_size_bytes += meta.size_bytes;
     }
 


### PR DESCRIPTION
d4bc671 updated `partition_manifest_move_alligned_offset_range` to skip the update to the total cloud log size if the segment was not actually being added to the manifest. However, the substraction was not included in the if branch. This commit fixes the issue.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none