### PR TITLE
tests/RedpandaService: rm undefined variable

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2792,7 +2792,7 @@ class RedpandaService(Service):
             # Match not found
             if exit_status != 0:
                 self.logger.debug(
-                    f"Did not find {pattern} on node {node.name}: {line}")
+                    f"Did not find {pattern} on node {node.name}")
                 return False
 
         # Fall through, match on all nodes


### PR DESCRIPTION
## Cover letter

A static code analysis tool revealed an unused variable in `RedpandaService::search_log_all`. This PR removes that variable.
Shoutout to @andijcr for catching this.

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
