### PR TITLE
Added missing set for _in_sync offset in stms

### DIFF
--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -203,6 +203,7 @@ ss::future<> id_allocator_stm::handle_eviction() {
     _next_snapshot = _c->start_offset();
     _processed = 0;
     set_next(_next_snapshot);
+    _insync_offset = model::prev_offset(_next_snapshot);
     return ss::now();
 }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2913,6 +2913,7 @@ ss::future<> rm_stm::handle_eviction() {
           _log_state.reset();
           _mem_state = mem_state{_tx_root_tracker};
           set_next(_c->start_offset());
+          _insync_offset = model::prev_offset(_raft->start_offset());
           return ss::now();
       });
 }

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -952,6 +952,7 @@ ss::future<> tm_stm::handle_eviction() {
           _cache.local().clear_mem();
           _pid_tx_id.clear();
           set_next(_c->start_offset());
+          _insync_offset = model::prev_offset(_raft->start_offset());
           return ss::now();
       });
 }


### PR DESCRIPTION
Missing setting `_in_sync` offset in some of the STMs made it to trigger an assertion as the `_next` offset was updated but not the `_in_sync` offset.

Fixes: #9459

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

Fixes issue that may
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes
- fixes an assertion that may happen when Raft snapshot is delivered to recover follower having any of `rm` `tx` or `id_allocator` stms