### PR TITLE
storage: remove storage_type enumeration

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -210,7 +210,6 @@ archiver_fixture::get_started_log_builder(
       rev);
 
     auto conf = storage::log_config(
-      storage::log_config::storage_type::disk,
       config::node().data_directory().as_sstring(),
       1_MiB,
       storage::debug_sanitize_files::yes);

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -409,7 +409,6 @@ FIXTURE_TEST(test_concat_segment_upload, s3_imposter_fixture) {
 
     model::ntp test_ntp{"test_ns", "test_tpc", 0};
     disk_log_builder b{log_config{
-      log_config::storage_type::disk,
       data_path.string(),
       1024,
       debug_sanitize_files::yes,

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -44,7 +44,6 @@ local_monitor_fixture::local_monitor_fixture()
     _storage_node_api.start_single().get0();
 
     auto log_conf = storage::log_config{
-      storage::log_config::storage_type::disk,
       "test.dir",
       1024,
       storage::debug_sanitize_files::yes};

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -44,9 +44,7 @@ local_monitor_fixture::local_monitor_fixture()
     _storage_node_api.start_single().get0();
 
     auto log_conf = storage::log_config{
-      "test.dir",
-      1024,
-      storage::debug_sanitize_files::yes};
+      "test.dir", 1024, storage::debug_sanitize_files::yes};
 
     auto kvstore_conf = storage::kvstore_config(
       1_MiB,

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -420,10 +420,7 @@ FIXTURE_TEST(
  */
 FIXTURE_TEST(test_compacted_log_recovery, raft_test_fixture) {
     raft_group gr = raft_group(
-      raft::group_id(0),
-      3,
-      model::cleanup_policy_bitflags::compaction,
-      10_MiB);
+      raft::group_id(0), 3, model::cleanup_policy_bitflags::compaction, 10_MiB);
 
     auto cfg = storage::log_builder_config();
     cfg.base_dir = ssx::sformat("{}/{}", gr.get_data_dir(), 0);
@@ -509,10 +506,7 @@ FIXTURE_TEST(test_compacted_log_recovery, raft_test_fixture) {
  */
 FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
     raft_group gr = raft_group(
-      raft::group_id(0),
-      3,
-      model::cleanup_policy_bitflags::deletion,
-      1_KiB);
+      raft::group_id(0), 3, model::cleanup_policy_bitflags::deletion, 1_KiB);
 
     gr.enable_all();
     auto leader_id = wait_for_group_leader(gr);

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -422,7 +422,6 @@ FIXTURE_TEST(test_compacted_log_recovery, raft_test_fixture) {
     raft_group gr = raft_group(
       raft::group_id(0),
       3,
-      storage::log_config::storage_type::disk,
       model::cleanup_policy_bitflags::compaction,
       10_MiB);
 
@@ -512,7 +511,6 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
     raft_group gr = raft_group(
       raft::group_id(0),
       3,
-      storage::log_config::storage_type::disk,
       model::cleanup_policy_bitflags::deletion,
       1_KiB);
 

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -43,7 +43,6 @@ struct bootstrap_fixture : raft::simple_record_fixture {
         },
         []() {
             return storage::log_config(
-              storage::log_config::storage_type::disk,
               "test.dir",
               1_GiB,
               storage::debug_sanitize_files::yes,

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -46,9 +46,7 @@ struct config_manager_fixture {
         },
         [this]() {
             return storage::log_config(
-              base_dir,
-              100_MiB,
-              storage::debug_sanitize_files::yes);
+              base_dir, 100_MiB, storage::debug_sanitize_files::yes);
         },
         _feature_table))
       , _logger(

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -46,7 +46,6 @@ struct config_manager_fixture {
         },
         [this]() {
             return storage::log_config(
-              storage::log_config::storage_type::disk,
               base_dir,
               100_MiB,
               storage::debug_sanitize_files::yes);

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -56,7 +56,6 @@ struct foreign_entry_fixture {
         },
         [this]() {
             return storage::log_config(
-              storage::log_config::storage_type::disk,
               test_dir,
               1_GiB,
               storage::debug_sanitize_files::yes);

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -56,9 +56,7 @@ struct foreign_entry_fixture {
         },
         [this]() {
             return storage::log_config(
-              test_dir,
-              1_GiB,
-              storage::debug_sanitize_files::yes);
+              test_dir, 1_GiB, storage::debug_sanitize_files::yes);
         },
         _feature_table) {
         _feature_table.start().get();

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -33,7 +33,6 @@ struct manual_deletion_fixture : public raft_test_fixture {
       : gr(
         raft::group_id(0),
         3,
-        storage::log_config::storage_type::disk,
         model::cleanup_policy_bitflags::deletion,
         1_KiB) {
         config::shard_local_cfg().log_segment_size_min.set_value(

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -31,10 +31,7 @@
 struct manual_deletion_fixture : public raft_test_fixture {
     manual_deletion_fixture()
       : gr(
-        raft::group_id(0),
-        3,
-        model::cleanup_policy_bitflags::deletion,
-        1_KiB) {
+        raft::group_id(0), 3, model::cleanup_policy_bitflags::deletion, 1_KiB) {
         config::shard_local_cfg().log_segment_size_min.set_value(
           std::optional<uint64_t>());
         gr.enable_all();

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -141,7 +141,6 @@ struct mux_state_machine_fixture {
 
     storage::log_config default_log_cfg() {
         return storage::log_config(
-          storage::log_config::storage_type::disk,
           _data_dir,
           100_MiB,
           storage::debug_sanitize_files::yes,

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -69,9 +69,7 @@ struct base_fixture {
 
     storage::log_config make_log_cfg() const {
         return storage::log_config(
-          _test_dir,
-          100_MiB,
-          storage::debug_sanitize_files::yes);
+          _test_dir, 100_MiB, storage::debug_sanitize_files::yes);
     }
 
     raft::offset_translator make_offset_translator() {

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -69,7 +69,6 @@ struct base_fixture {
 
     storage::log_config make_log_cfg() const {
         return storage::log_config(
-          storage::log_config::storage_type::disk,
           _test_dir,
           100_MiB,
           storage::debug_sanitize_files::yes);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -857,7 +857,6 @@ static storage::kvstore_config kvstore_config_from_global_config() {
 static storage::log_config
 manager_config_from_global_config(scheduling_groups& sgs) {
     return storage::log_config(
-      storage::log_config::storage_type::disk,
       config::node().data_directory().as_sstring(),
       config::shard_local_cfg().log_segment_size.bind(),
       config::shard_local_cfg().compacted_log_segment_size.bind(),

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -440,7 +440,6 @@ public:
 
     storage::log_config make_default_config() {
         return storage::log_config(
-          storage::log_config::storage_type::disk,
           data_dir.string(),
           1_GiB,
           storage::debug_sanitize_files::yes);

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -440,9 +440,7 @@ public:
 
     storage::log_config make_default_config() {
         return storage::log_config(
-          data_dir.string(),
-          1_GiB,
-          storage::debug_sanitize_files::yes);
+          data_dir.string(), 1_GiB, storage::debug_sanitize_files::yes);
     }
 
     ss::future<> wait_for_topics(std::vector<cluster::topic_result> results) {

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -47,24 +47,19 @@ namespace storage {
 
 // class log_config {
 struct log_config {
-    enum class storage_type { disk };
-
     log_config(
-      storage_type type,
       ss::sstring directory,
       size_t segment_size,
       debug_sanitize_files should,
       ss::io_priority_class compaction_priority
       = ss::default_priority_class()) noexcept;
     log_config(
-      storage_type type,
       ss::sstring directory,
       size_t segment_size,
       debug_sanitize_files should,
       ss::io_priority_class compaction_priority,
       with_cache with) noexcept;
     log_config(
-      storage_type type,
       ss::sstring directory,
       config::binding<size_t> segment_size,
       config::binding<size_t> compacted_segment_size,
@@ -88,7 +83,6 @@ struct log_config {
     log_config(log_config&&) noexcept = default;
     log_config& operator=(log_config&&) noexcept = default;
 
-    storage_type stype;
     ss::sstring base_dir;
     config::binding<size_t> max_segment_size;
 
@@ -244,5 +238,5 @@ private:
 
     friend std::ostream& operator<<(std::ostream&, const log_manager&);
 };
-std::ostream& operator<<(std::ostream& o, log_config::storage_type t);
+
 } // namespace storage

--- a/src/v/storage/opfuzz/opfuzz_test.cc
+++ b/src/v/storage/opfuzz/opfuzz_test.cc
@@ -34,7 +34,6 @@ FIXTURE_TEST(test_random_workload, storage_test_fixture) {
     // BLOCK on logging so that we can make sense of the logs
     std::cout.setf(std::ios::unitbuf);
     storage::log_manager mngr = make_log_manager(storage::log_config(
-      storage::log_config::storage_type::disk,
       std::move(test_dir),
       200_MiB,
       storage::debug_sanitize_files::no,
@@ -83,7 +82,6 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
     // BLOCK on logging so that we can make sense of the logs
     std::cout.setf(std::ios::unitbuf);
     storage::log_manager mngr = make_log_manager(storage::log_config(
-      storage::log_config::storage_type::disk,
       std::move(test_dir),
       200_MiB,
       storage::debug_sanitize_files::no,

--- a/src/v/storage/tests/concat_segment_reader_test.cc
+++ b/src/v/storage/tests/concat_segment_reader_test.cc
@@ -47,7 +47,6 @@ SEASTAR_THREAD_TEST_CASE(
     using namespace storage;
 
     disk_log_builder b{log_config{
-      log_config::storage_type::disk,
       data_path.string(),
       segment_size,
       debug_sanitize_files::yes,
@@ -141,7 +140,6 @@ SEASTAR_THREAD_TEST_CASE(test_single_segment_read_with_bounds) {
     using namespace storage;
 
     disk_log_builder b{log_config{
-      log_config::storage_type::disk,
       data_path.string(),
       segment_size,
       debug_sanitize_files::yes,
@@ -170,7 +168,6 @@ SEASTAR_THREAD_TEST_CASE(test_single_segment_read_full) {
     using namespace storage;
 
     disk_log_builder b{log_config{
-      log_config::storage_type::disk,
       data_path.string(),
       segment_size,
       debug_sanitize_files::yes,
@@ -197,7 +194,6 @@ SEASTAR_THREAD_TEST_CASE(test_multiple_segments_read_full) {
     using namespace storage;
 
     disk_log_builder b{log_config{
-      log_config::storage_type::disk,
       data_path.string(),
       segment_size,
       debug_sanitize_files::yes,

--- a/src/v/storage/tests/half_page_concurrent_dispatch.cc
+++ b/src/v/storage/tests/half_page_concurrent_dispatch.cc
@@ -17,7 +17,6 @@
 
 struct fixture {
     storage::disk_log_builder b{storage::log_config(
-      storage::log_config::storage_type::disk,
       storage::random_dir(),
       1_GiB,
       storage::debug_sanitize_files::yes,

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -44,10 +44,7 @@ void write_batches(ss::lw_shared_ptr<segment> seg) {
 }
 
 log_config make_config() {
-    return log_config{
-      "test.dir",
-      1024,
-      debug_sanitize_files::yes};
+    return log_config{"test.dir", 1024, debug_sanitize_files::yes};
 }
 
 ntp_config config_from_ntp(const model::ntp& ntp) {

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -45,7 +45,6 @@ void write_batches(ss::lw_shared_ptr<segment> seg) {
 
 log_config make_config() {
     return log_config{
-      log_config::storage_type::disk,
       "test.dir",
       1024,
       debug_sanitize_files::yes};

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -332,7 +332,6 @@ FIXTURE_TEST(
   test_truncate_whole_log_when_logs_are_garbadge_collected,
   storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
@@ -426,7 +425,6 @@ FIXTURE_TEST(test_truncate, storage_test_fixture) {
 
 FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     auto ntp = model::ntp("default", "test", 0);
     std::vector<model::offset> truncate_offsets;
 
@@ -506,7 +504,6 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
 
 FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
@@ -642,7 +639,6 @@ FIXTURE_TEST(test_prefix_truncate_then_truncate_all, storage_test_fixture) {
 
 FIXTURE_TEST(test_index_max_timestamp_update, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -465,7 +465,6 @@ FIXTURE_TEST(
       };
 
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
@@ -499,7 +498,6 @@ FIXTURE_TEST(
 
 FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("Configuration: {}", mgr.config());
@@ -584,7 +582,6 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
 FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.max_segment_size = config::mock_binding<size_t>(10);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("Configuration: {}", mgr.config());
@@ -644,7 +641,6 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
     ss::promise<model::offset> last_evicted_offset;
     auto cfg = default_log_config(test_dir);
     cfg.max_segment_size = config::mock_binding<size_t>(10);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("Configuration: {}", mgr.config());
@@ -758,7 +754,6 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     // make sure segments are small
     cfg.max_segment_size = config::mock_binding<size_t>(1000);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     model::offset last_append_offset{};
@@ -826,7 +821,6 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
 
 FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     auto ntp = model::ntp("default", "test", 0);
     using overrides_t = storage::ntp_config::default_overrides;
     overrides_t ov;
@@ -925,7 +919,6 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
 
 FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     auto ntp = model::ntp("default", "test", 0);
     // compacted topic
     using overrides_t = storage::ntp_config::default_overrides;
@@ -1060,7 +1053,6 @@ void append_single_record_batch(
  */
 FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
 
     {
@@ -1106,7 +1098,6 @@ FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
 
 FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -1172,7 +1163,6 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
 FIXTURE_TEST(
   check_segment_roll_after_compacted_log_truncate, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -1228,7 +1218,6 @@ FIXTURE_TEST(check_max_segment_size, storage_test_fixture) {
     auto mock = config::mock_property<size_t>(20_GiB);
     // defaults
     cfg.max_segment_size = mock.bind();
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     using overrides_t = storage::ntp_config::default_overrides;
@@ -1283,7 +1272,6 @@ FIXTURE_TEST(check_max_segment_size_limits, storage_test_fixture) {
         auto mock = config::mock_property<size_t>(100_KiB);
 
         cfg.max_segment_size = mock.bind();
-        cfg.stype = storage::log_config::storage_type::disk;
 
         ss::abort_source as;
         storage::log_manager mgr = make_log_manager(cfg);
@@ -1339,7 +1327,6 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     // make sure segments are small
     cfg.max_segment_size = config::mock_binding<size_t>(10_KiB);
     cfg.compacted_segment_size = config::mock_binding<size_t>(10_KiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     // we want force reading most recent compacted batches, disable the cache
     cfg.cache = storage::with_cache::no;
     ss::abort_source as;
@@ -1434,7 +1421,6 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
 
     // defaults
     cfg.max_segment_size = config::mock_binding<size_t>(100_KiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 
@@ -1462,7 +1448,6 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
 
 FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -1531,7 +1516,6 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
 
 FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -1598,7 +1582,6 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
 FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.max_compacted_segment_size = config::mock_binding<size_t>(6_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -1677,7 +1660,6 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
 
 FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -1742,7 +1724,6 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
 }
 FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
     storage::ntp_config::default_overrides overrides;
@@ -1805,7 +1786,6 @@ FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
 FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -1887,7 +1867,6 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
 FIXTURE_TEST(not_compacted_log_backlog, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -1951,7 +1930,6 @@ ss::future<model::record_batch_reader::data_t> copy_reader_to_memory(
 
 FIXTURE_TEST(disposing_in_use_reader, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     cfg.max_segment_size = config::mock_binding<size_t>(100_MiB);
     storage::ntp_config::default_overrides overrides;
@@ -2018,7 +1996,6 @@ model::record_batch make_batch() {
 
 FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     cfg.max_segment_size = config::mock_binding<size_t>(500_MiB);
     cfg.sanitize_fileops = storage::debug_sanitize_files::no;
@@ -2092,7 +2069,6 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
     // issue: https://github.com/redpanda-data/redpanda/issues/2214
     auto cfg = default_log_config(test_dir);
     cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -2205,7 +2181,6 @@ copy_to_mem(model::record_batch_reader& reader) {
 
 FIXTURE_TEST(reader_prevents_log_shutdown, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
     storage::ntp_config::default_overrides overrides;
@@ -2264,7 +2239,7 @@ FIXTURE_TEST(test_querying_term_last_offset, storage_test_fixture) {
     auto lstats_term_0 = log.offsets();
     // append some batches in term 1
     append_random_batches(log, 10, model::term_id(1));
-    if (cfg.stype == storage::log_config::storage_type::disk) {
+    {
         auto disk_log = get_disk_log(log);
         // force segment roll
         disk_log->force_roll(ss::default_priority_class()).get();
@@ -2347,7 +2322,6 @@ compact_in_memory(storage::log log) {
 FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -2411,7 +2385,6 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
      * Test validating concurrent reads, writes and truncations
      */
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     cfg.max_segment_size = config::mock_binding<size_t>(100_MiB);
     storage::ntp_config::default_overrides overrides;
@@ -2524,7 +2497,6 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
      * Test validating concurrent reads, writes and truncations
      */
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     cfg.max_segment_size = config::mock_binding<size_t>(1_MiB);
     storage::ntp_config::default_overrides overrides;
@@ -2667,7 +2639,6 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
 
 FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
     storage::ntp_config::default_overrides overrides;
@@ -2813,7 +2784,6 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
     // Test setup.
     auto cfg = default_log_config(test_dir);
     cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("Configuration: {}", mgr.config());
@@ -2881,7 +2851,6 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
     // Test setup.
     auto cfg = default_log_config(test_dir);
     cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 
@@ -2933,7 +2902,6 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
     // Test setup.
     auto cfg = default_log_config(test_dir);
     cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 
@@ -2997,7 +2965,6 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     // Test setup.
     auto cfg = f.default_log_config(f.test_dir);
     cfg.max_segment_size = config::mock_binding<size_t>(10_MiB);
-    cfg.stype = storage::log_config::storage_type::disk;
     ss::abort_source as;
     storage::log_manager mgr = f.make_log_manager(cfg);
     tlog.info("Configuration: {}", mgr.config());
@@ -3255,7 +3222,6 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
           .retention_local_target_bytes_default.set_value(
             tc.default_local_bytes);
 
-        cfg.stype = storage::log_config::storage_type::disk;
         cfg.segment_size_jitter = storage::jitter_percents(0);
         ss::abort_source as;
         storage::log_manager mgr = make_log_manager(cfg);
@@ -3320,7 +3286,6 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
      * Test validating concurrent reads, writes and truncations
      */
     auto cfg = default_log_config(test_dir);
-    cfg.stype = storage::log_config::storage_type::disk;
     cfg.cache = storage::with_cache::no;
     cfg.max_segment_size = config::mock_binding<size_t>(100_MiB);
     storage::ntp_config::default_overrides overrides;

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -245,10 +245,8 @@ public:
 
     /// \brief randomizes the configuration options
     storage::log_config default_log_config(ss::sstring test_dir) {
-        auto stype = storage::log_config::storage_type::disk;
         auto cache = storage::with_cache::yes;
         auto cfg = storage::log_config(
-          stype,
           std::move(test_dir),
           200_MiB,
           storage::debug_sanitize_files::yes,

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -38,10 +38,7 @@ inline static ss::sstring random_dir() {
 }
 
 inline static log_config log_builder_config() {
-    return log_config(
-      random_dir(),
-      100_MiB,
-      debug_sanitize_files::yes);
+    return log_config(random_dir(), 100_MiB, debug_sanitize_files::yes);
 }
 
 inline static log_reader_config reader_config() {

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -39,7 +39,6 @@ inline static ss::sstring random_dir() {
 
 inline static log_config log_builder_config() {
     return log_config(
-      log_config::storage_type::disk,
       random_dir(),
       100_MiB,
       debug_sanitize_files::yes);

--- a/src/v/test_utils/archival.h
+++ b/src/v/test_utils/archival.h
@@ -24,7 +24,6 @@ inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
 
 inline storage::disk_log_builder make_log_builder(std::string_view data_path) {
     return storage::disk_log_builder{storage::log_config{
-      storage::log_config::storage_type::disk,
       {data_path.data(), data_path.size()},
       4_KiB,
       storage::debug_sanitize_files::yes,

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -47,9 +47,7 @@ static inline ss::future<> persist_log_file(
           },
           [base_dir]() {
               return storage::log_config(
-                base_dir,
-                1_GiB,
-                storage::debug_sanitize_files::yes);
+                base_dir, 1_GiB, storage::debug_sanitize_files::yes);
           },
           feature_table);
         storage.start().get();
@@ -117,9 +115,7 @@ read_log_file(ss::sstring base_dir, model::ntp file_ntp) {
           },
           [base_dir]() {
               return storage::log_config(
-                base_dir,
-                1_GiB,
-                storage::debug_sanitize_files::yes);
+                base_dir, 1_GiB, storage::debug_sanitize_files::yes);
           },
           feature_table);
         storage.start().get();

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -47,7 +47,6 @@ static inline ss::future<> persist_log_file(
           },
           [base_dir]() {
               return storage::log_config(
-                storage::log_config::storage_type::disk,
                 base_dir,
                 1_GiB,
                 storage::debug_sanitize_files::yes);
@@ -118,7 +117,6 @@ read_log_file(ss::sstring base_dir, model::ntp file_ntp) {
           },
           [base_dir]() {
               return storage::log_config(
-                storage::log_config::storage_type::disk,
                 base_dir,
                 1_GiB,
                 storage::debug_sanitize_files::yes);


### PR DESCRIPTION
Previously we removed the memory disk type. This removes the storage type which now is redundant since there is only a disk type backend.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

