### PR TITLE
[v23.1.x] Backport of PR #9430 - Add new metering API to track Kafka traffic

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -259,6 +259,41 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       512_KiB,
       {.min = 128, .max = 5_MiB})
+  , enable_usage(
+      *this,
+      "enable_usage",
+      "Enables the usage tracking mechanism, storing windowed history of "
+      "kafka/cloud_storage metrics over time",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
+  , usage_num_windows(
+      *this,
+      "usage_num_windows",
+      "The number of windows to persist in memory and disk",
+      {.needs_restart = needs_restart::no,
+       .example = "24",
+       .visibility = visibility::tunable},
+      24,
+      {.min = 2, .max = 86400})
+  , usage_window_width_interval_sec(
+      *this,
+      "usage_window_width_interval_sec",
+      "The width of a usage window, tracking cloud and kafka ingress/egress "
+      "traffic each interval",
+      {.needs_restart = needs_restart::no,
+       .example = "3600",
+       .visibility = visibility::tunable},
+      std::chrono::seconds(3600),
+      {.min = std::chrono::seconds(1)})
+  , usage_disk_persistance_interval_sec(
+      *this,
+      "usage_disk_persistance_interval_sec",
+      "The interval in which all usage stats are written to disk",
+      {.needs_restart = needs_restart::no,
+       .example = "300",
+       .visibility = visibility::tunable},
+      std::chrono::seconds(60 * 5),
+      {.min = std::chrono::seconds(1)})
   , use_scheduling_groups(*this, "use_scheduling_groups")
   , enable_admin_api(*this, "enable_admin_api")
   , default_num_windows(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -82,6 +82,10 @@ struct configuration final : public config_store {
     bounded_property<std::optional<size_t>> raft_max_recovery_memory;
     bounded_property<size_t> raft_recovery_default_read_size;
     // Kafka
+    property<bool> enable_usage;
+    bounded_property<size_t> usage_num_windows;
+    bounded_property<std::chrono::seconds> usage_window_width_interval_sec;
+    bounded_property<std::chrono::seconds> usage_disk_persistance_interval_sec;
     deprecated_property use_scheduling_groups;
     deprecated_property enable_admin_api;
     bounded_property<int16_t> default_num_windows;

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -40,6 +40,7 @@ v_cc_library(
     server/group.cc
     server/group_router.cc
     server/group_manager.cc
+    server/usage_manager.cc
     server/rm_group_frontend.cc
     server/connection_context.cc
     server/server.cc

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -181,6 +181,9 @@ struct fetch_response final {
 
     fetch_response_data data;
 
+    // Used for usage/metering to relay this value back to the connection layer
+    size_t internal_topic_bytes{0};
+
     void encode(response_writer& writer, api_version version) {
         data.encode(writer, version);
     }

--- a/src/v/kafka/protocol/produce.h
+++ b/src/v/kafka/protocol/produce.h
@@ -81,6 +81,9 @@ struct produce_response final {
 
     produce_response_data data;
 
+    // Used for usage/metering to relay this value back to the connection layer
+    size_t internal_topic_bytes{0};
+
     void encode(response_writer& writer, api_version version) {
         // normalize errors
         for (auto& r : data.responses) {

--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -24,5 +24,6 @@ class snc_quota_manager;
 class request_context;
 class rm_group_frontend;
 class rm_group_proxy_impl;
+class usage_manager;
 
 } // namespace kafka

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -41,6 +41,7 @@
 #include "kafka/server/quota_manager.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
+#include "kafka/server/usage_manager.h"
 #include "net/connection.h"
 #include "security/errc.h"
 #include "security/exceptions.h"
@@ -81,6 +82,7 @@ server::server(
   ss::sharded<quota_manager>& quota,
   ss::sharded<snc_quota_manager>& snc_quota_mgr,
   ss::sharded<kafka::group_router>& router,
+  ss::sharded<kafka::usage_manager>& usage_manager,
   ss::sharded<cluster::shard_table>& tbl,
   ss::sharded<cluster::partition_manager>& pm,
   ss::sharded<fetch_session_cache>& session_cache,
@@ -102,6 +104,7 @@ server::server(
   , _quota_mgr(quota)
   , _snc_quota_mgr(snc_quota_mgr)
   , _group_router(router)
+  , _usage_manager(usage_manager)
   , _shard_table(tbl)
   , _partition_manager(pm)
   , _fetch_session_cache(session_cache)

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -45,6 +45,7 @@ public:
       ss::sharded<quota_manager>&,
       ss::sharded<snc_quota_manager>&,
       ss::sharded<kafka::group_router>&,
+      ss::sharded<kafka::usage_manager>&,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::partition_manager>&,
       ss::sharded<fetch_session_cache>&,
@@ -102,6 +103,7 @@ public:
         return _fetch_session_cache.local();
     }
     quota_manager& quota_mgr() { return _quota_mgr.local(); }
+    usage_manager& usage_mgr() { return _usage_manager.local(); }
     snc_quota_manager& snc_quota_mgr() { return _snc_quota_mgr.local(); }
     bool is_idempotence_enabled() const { return _is_idempotence_enabled; }
     bool are_transactions_enabled() const { return _are_transactions_enabled; }
@@ -153,6 +155,7 @@ private:
     ss::sharded<quota_manager>& _quota_mgr;
     ss::sharded<snc_quota_manager>& _snc_quota_mgr;
     ss::sharded<kafka::group_router>& _group_router;
+    ss::sharded<kafka::usage_manager>& _usage_manager;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<kafka::fetch_session_cache>& _fetch_session_cache;

--- a/src/v/kafka/server/usage_manager.cc
+++ b/src/v/kafka/server/usage_manager.cc
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/usage_manager.h"
+
+#include "config/configuration.h"
+#include "kafka/server/logger.h"
+#include "storage/api.h"
+#include "vlog.h"
+
+namespace kafka {
+
+static constexpr std::string_view period_key{"period"};
+static constexpr std::string_view max_duration_key{"max_duration"};
+static constexpr std::string_view buckets_key{"buckets"};
+
+static bytes key_to_bytes(std::string_view sv) {
+    bytes k;
+    k.append(reinterpret_cast<const uint8_t*>(sv.begin()), sv.size());
+    return k;
+}
+
+struct persisted_state {
+    std::chrono::seconds configured_period;
+    size_t configured_windows;
+    fragmented_vector<usage_window> current_state;
+};
+
+static ss::future<>
+persist_to_disk(storage::kvstore& kvstore, persisted_state s) {
+    using kv_ks = storage::kvstore::key_space;
+
+    co_await kvstore.put(
+      kv_ks::usage,
+      key_to_bytes(period_key),
+      serde::to_iobuf(s.configured_period));
+    co_await kvstore.put(
+      kv_ks::usage,
+      key_to_bytes(max_duration_key),
+      serde::to_iobuf(s.configured_windows));
+    co_await kvstore.put(
+      kv_ks::usage,
+      key_to_bytes(buckets_key),
+      serde::to_iobuf(std::move(s.current_state)));
+}
+
+static std::optional<persisted_state>
+restore_from_disk(storage::kvstore& kvstore) {
+    using kv_ks = storage::kvstore::key_space;
+    std::optional<iobuf> period, windows, data;
+    try {
+        period = kvstore.get(kv_ks::usage, key_to_bytes(period_key));
+        windows = kvstore.get(kv_ks::usage, key_to_bytes(max_duration_key));
+        data = kvstore.get(kv_ks::usage, key_to_bytes(buckets_key));
+    } catch (const std::exception& ex) {
+        vlog(
+          klog.debug,
+          "Encountered exception when retriving usage data from disk: {}",
+          ex);
+        return std::nullopt;
+    }
+    if (!period && !windows && !data) {
+        /// Data didn't exist
+        return std::nullopt;
+    } else if (!period || !windows || !data) {
+        vlog(
+          klog.error,
+          "Inconsistent usage_manager on disk state detected, failed to "
+          "recover state");
+        return std::nullopt;
+    }
+    return persisted_state{
+      .configured_period = serde::from_iobuf<std::chrono::seconds>(
+        std::move(*period)),
+      .configured_windows = serde::from_iobuf<size_t>(std::move(*windows)),
+      .current_state = serde::from_iobuf<fragmented_vector<usage_window>>(
+        std::move(*data))};
+}
+
+static ss::future<> clear_persisted_state(storage::kvstore& kvstore) {
+    using kv_ks = storage::kvstore::key_space;
+    try {
+        co_await kvstore.remove(kv_ks::usage, key_to_bytes(period_key));
+        co_await kvstore.remove(kv_ks::usage, key_to_bytes(max_duration_key));
+        co_await kvstore.remove(kv_ks::usage, key_to_bytes(buckets_key));
+    } catch (const std::exception& ex) {
+        vlog(klog.debug, "Ignoring exception from storage layer: {}", ex);
+    }
+}
+
+static auto epoch_time_secs(
+  ss::lowres_system_clock::time_point now = ss::lowres_system_clock::now()) {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+             now.time_since_epoch())
+      .count();
+}
+
+void usage_window::reset(ss::lowres_system_clock::time_point now) {
+    begin = epoch_time_secs(now);
+    end = 0;
+    u.bytes_sent = 0;
+    u.bytes_received = 0;
+    u.bytes_cloud_storage = 0;
+}
+
+usage usage::operator+(const usage& other) const {
+    return usage{
+      .bytes_sent = bytes_sent + other.bytes_sent,
+      .bytes_received = bytes_received + other.bytes_received,
+      .bytes_cloud_storage = bytes_cloud_storage + other.bytes_cloud_storage};
+}
+
+usage_manager::accounting_fiber::accounting_fiber(
+  ss::sharded<usage_manager>& um,
+  ss::sharded<storage::api>& storage,
+  size_t usage_num_windows,
+  std::chrono::seconds usage_window_width_interval,
+  std::chrono::seconds usage_disk_persistance_interval)
+  : _usage_num_windows(usage_num_windows)
+  , _usage_window_width_interval(usage_window_width_interval)
+  , _usage_disk_persistance_interval(usage_disk_persistance_interval)
+  , _kvstore(storage.local().kvs())
+  , _um(um) {
+    vlog(
+      klog.info,
+      "Starting accounting fiber with settings, {{usage_num_windows: {} "
+      "usage_window_width_interval: {} "
+      "usage_disk_persistance_interval:{}}}",
+      usage_num_windows,
+      usage_window_width_interval,
+      usage_disk_persistance_interval);
+    /// TODO: This should be refactored when fragmented_vector::resize is
+    /// implemented
+    for (size_t i = 0; i < _usage_num_windows; ++i) {
+        _buckets.push_back(usage_window{});
+    }
+    _buckets[_current_window].reset(ss::lowres_system_clock::now());
+}
+
+ss::future<> usage_manager::accounting_fiber::start() {
+    /// In the event of a quick restart, reset_state() will set the
+    /// _current_index to where it was before restart, however the total time
+    /// until the next window must be accounted for. This is the duration for
+    /// which redpanda was down.
+    auto h = _gate.hold();
+    auto last_window_delta = std::chrono::seconds(0);
+    auto state = restore_from_disk(_kvstore);
+    if (state) {
+        if (
+          state->configured_period != _usage_window_width_interval
+          || state->configured_windows != _usage_num_windows) {
+            vlog(
+              klog.info,
+              "Persisted usage state had been configured with different "
+              "options, clearing state and restarting with current "
+              "configuration options");
+            co_await clear_persisted_state(_kvstore);
+        } else {
+            last_window_delta = reset_state(std::move(state->current_state));
+        }
+    }
+    _persist_disk_timer.set_callback([this] {
+        ssx::background
+          = ssx::spawn_with_gate_then(
+              _gate,
+              [this] {
+                  return persist_to_disk(
+                    _kvstore,
+                    persisted_state{
+                      .configured_period = _usage_window_width_interval,
+                      .configured_windows = _usage_num_windows,
+                      .current_state = _buckets.copy()});
+              })
+              .then([this] {
+                  if (!_gate.is_closed()) {
+                      _persist_disk_timer.arm(
+                        ss::lowres_clock::now()
+                        + _usage_disk_persistance_interval);
+                  }
+              })
+              .handle_exception([this](std::exception_ptr eptr) {
+                  using namespace std::chrono_literals;
+                  vlog(
+                    klog.debug,
+                    "Encountered exception when persisting usage data to disk: "
+                    "{} , retrying",
+                    eptr);
+                  if (!_gate.is_closed()) {
+                      const auto retry = std::min(
+                        _usage_disk_persistance_interval, 5s);
+                      _persist_disk_timer.arm(ss::lowres_clock::now() + retry);
+                  }
+              });
+    });
+    _timer.set_callback([this] {
+        ssx::background = ssx::spawn_with_gate_then(_gate, [this]() {
+                              return close_window();
+                          }).finally([this] {
+            if (!_gate.is_closed()) {
+                _timer.arm(
+                  ss::lowres_clock::now() + _usage_window_width_interval);
+            }
+        });
+    });
+    const auto now = ss::lowres_clock::now();
+    vassert(
+      last_window_delta <= _usage_window_width_interval,
+      "Error correctly detecting last window delta");
+    _timer.arm((now + _usage_window_width_interval) - last_window_delta);
+    _persist_disk_timer.arm(now + _usage_disk_persistance_interval);
+}
+
+std::vector<usage_window>
+usage_manager::accounting_fiber::get_usage_stats() const {
+    std::vector<usage_window> stats;
+    for (size_t i = 1; i < _buckets.size(); ++i) {
+        const auto idx = (_current_window + i) % _usage_num_windows;
+        if (!_buckets[idx].is_uninitialized()) {
+            stats.push_back(_buckets[idx]);
+        }
+    }
+    /// Open bucket last ensures ordering from oldest to newest
+    stats.push_back(_buckets[_current_window]);
+    /// std::reverse returns results in ordering from newest to oldest
+    std::reverse(stats.begin(), stats.end());
+    return stats;
+}
+
+ss::future<> usage_manager::accounting_fiber::stop() {
+    _timer.cancel();
+    _persist_disk_timer.cancel();
+    co_await _gate.close();
+    try {
+        co_await persist_to_disk(
+          _kvstore,
+          persisted_state{
+            .configured_period = _usage_window_width_interval,
+            .configured_windows = _usage_num_windows,
+            .current_state = _buckets.copy()});
+    } catch (const std::exception& ex) {
+        vlog(
+          klog.debug,
+          "Encountered exception when persisting usage data to disk: {}",
+          ex);
+    }
+}
+
+ss::future<> usage_manager::accounting_fiber::close_window() {
+    const auto now = ss::lowres_system_clock::now();
+    _buckets[_current_window].u = co_await _um.map_reduce0(
+      [](usage_manager& um) { return um.sample(); },
+      _buckets[_current_window].u,
+      [](const usage& acc, const usage& x) { return acc + x; });
+    _buckets[_current_window].end = epoch_time_secs(now);
+    _current_window = (_current_window + 1) % _buckets.size();
+    _buckets[_current_window].reset(now);
+}
+
+std::chrono::seconds usage_manager::accounting_fiber::reset_state(
+  fragmented_vector<usage_window> buckets) {
+    /// called after restart to determine which bucket is the 'current' bucket
+    auto last_window_delta = std::chrono::seconds(0);
+    _current_window = 0;
+    if (!buckets.empty()) {
+        std::optional<size_t> open_index;
+        for (size_t i = 0; i < buckets.size(); ++i) {
+            /// There will always be exactly 1 open_window in the result set
+            if (buckets[i].is_open()) {
+                vassert(!open_index, "Data serialization was incorrect");
+                open_index = i;
+                break;
+            }
+        }
+        vassert(open_index, "Data serialization was incorrect");
+        _current_window = *open_index;
+        /// Optimization to begin picking up if wall time is within
+        /// window interval
+        const auto begin = std::chrono::seconds(buckets[*open_index].begin);
+        const auto now_ts = ss::lowres_system_clock::now();
+        const auto now = std::chrono::seconds(epoch_time_secs(now_ts));
+        const auto delta = now - begin;
+        if (delta >= _usage_window_width_interval) {
+            /// Close window and open a new one
+            buckets[*open_index].end = epoch_time_secs(now_ts);
+            _current_window = (*open_index + 1) % buckets.size();
+            buckets[_current_window].reset(now_ts);
+        } else if (delta >= std::chrono::seconds(0)) {
+            /// Keep last window open and adjust delta so next window closes
+            /// that much sooner
+            last_window_delta = delta;
+        }
+    }
+    _buckets = std::move(buckets);
+    return last_window_delta;
+}
+
+usage_manager::usage_manager(ss::sharded<storage::api>& storage)
+  : _usage_enabled(config::shard_local_cfg().enable_usage.bind())
+  , _usage_num_windows(config::shard_local_cfg().usage_num_windows.bind())
+  , _usage_window_width_interval(
+      config::shard_local_cfg().usage_window_width_interval_sec.bind())
+  , _usage_disk_persistance_interval(
+      config::shard_local_cfg().usage_disk_persistance_interval_sec.bind())
+  , _storage(storage) {}
+
+ss::future<> usage_manager::reset() {
+    oncore_debug_verify(_verify_shard);
+    try {
+        auto h = _background_gate.hold();
+        auto u = _background_mutex.get_units();
+        if (_accounting_fiber) {
+            /// Deallocate the accounting_fiber if the feature is disabled,
+            /// otherwise it will keep in memory the number of configured
+            /// historical buckets
+            auto accounting_fiber = std::exchange(_accounting_fiber, nullptr);
+            co_await accounting_fiber->stop();
+        }
+        co_await start_accounting_fiber();
+    } catch (ss::gate_closed_exception&) {
+        // shutting down
+    }
+}
+
+ss::future<> usage_manager::start_accounting_fiber() {
+    if (!_usage_enabled()) {
+        co_return; /// Feature is disabled in config
+    }
+    if (_accounting_fiber) {
+        co_return; /// Double start called, do-nothing
+    }
+    _accounting_fiber = std::make_unique<accounting_fiber>(
+      this->container(),
+      _storage,
+      _usage_num_windows(),
+      _usage_window_width_interval(),
+      _usage_disk_persistance_interval());
+
+    co_await _accounting_fiber->start();
+
+    /// Reset all state
+    co_await container().invoke_on_all(
+      [](usage_manager& um) { (void)um.sample(); });
+}
+
+ss::future<> usage_manager::start() {
+    if (ss::this_shard_id() != usage_manager_main_shard) {
+        co_return; /// Async work only occurs on shard-0
+    }
+    co_await start_accounting_fiber();
+
+    _usage_enabled.watch([this] { (void)reset(); });
+    _usage_num_windows.watch([this] { (void)reset(); });
+    _usage_window_width_interval.watch([this] { (void)reset(); });
+    _usage_disk_persistance_interval.watch([this] { (void)reset(); });
+}
+
+ss::future<> usage_manager::stop() {
+    co_await _background_gate.close();
+    if (!_accounting_fiber) {
+        co_return;
+    }
+    /// Logic could only possibly execute on core-0 since no other cores would
+    /// initialize a local _accounting_fiber
+    co_await _accounting_fiber->stop();
+}
+
+std::vector<usage_window> usage_manager::get_usage_stats() const {
+    if (ss::this_shard_id() != usage_manager_main_shard) {
+        throw std::runtime_error(
+          "Attempt to query results of "
+          "kafka::usage_manager off the main accounting shard");
+    }
+    if (!_accounting_fiber) {
+        return {}; // no stats
+    }
+    return _accounting_fiber->get_usage_stats();
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "bytes/oncore.h"
+#include "config/property.h"
+#include "storage/kvstore.h"
+#include "utils/fragmented_vector.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/timer.hh>
+
+namespace kafka {
+
+/// Main structure of statistics that are being accounted for. These are
+/// periodically serialized to disk, hence why the struct inherits from the
+/// serde::envelope
+struct usage
+  : serde::envelope<usage, serde::version<0>, serde::compat_version<0>> {
+    uint64_t bytes_sent{0};
+    uint64_t bytes_received{0};
+    uint64_t bytes_cloud_storage{0};
+    usage operator+(const usage&) const;
+    auto serde_fields() {
+        return std::tie(bytes_sent, bytes_received, bytes_cloud_storage);
+    }
+};
+
+struct usage_window
+  : serde::envelope<usage_window, serde::version<0>, serde::compat_version<0>> {
+    uint64_t begin{0};
+    uint64_t end{0};
+    usage u;
+
+    bool is_uninitialized() const { return begin == 0 && end == 0; }
+    bool is_open() const { return begin != 0 && end == 0; }
+    void reset(ss::lowres_system_clock::time_point now);
+    auto serde_fields() { return std::tie(begin, end, u); }
+};
+
+/// Class that manages all usage statistics. Usage stats are more accurate
+/// representation of node usage. This class maintains these stats windowed,
+/// a static number of windows that last some predefined interval, all of which
+/// are options that can be configured at runtime.
+///
+/// Periodically these stats are written to disk using the kvstore at a 5min
+/// interval, that way they are somewhat durable in the event of a node crash,
+/// or restart.
+class usage_manager : public ss::peering_sharded_service<usage_manager> {
+public:
+    static constexpr ss::shard_id usage_manager_main_shard{0};
+
+    class accounting_fiber {
+    public:
+        accounting_fiber(
+          ss::sharded<usage_manager>& um,
+          ss::sharded<storage::api>& storage,
+          size_t usage_num_windows,
+          std::chrono::seconds usage_window_width_interval,
+          std::chrono::seconds usage_disk_persistance_interval);
+
+        /// Starts a fiber that manage window interval evolution and disk
+        /// persistance
+        ss::future<> start();
+
+        /// Stops the fiber and flushes current in memory results to disk
+        ss::future<> stop();
+
+        /// Returns aggregate of all \ref usage stats across cores
+        std::vector<usage_window> get_usage_stats() const;
+
+    private:
+        std::chrono::seconds
+        reset_state(fragmented_vector<usage_window> buckets);
+        ss::future<> close_window();
+
+    private:
+        size_t _usage_num_windows;
+        std::chrono::seconds _usage_window_width_interval;
+        std::chrono::seconds _usage_disk_persistance_interval;
+
+        /// Timers for controlling window closure and disk persistance
+        ss::timer<ss::lowres_clock> _timer;
+        ss::timer<ss::lowres_clock> _persist_disk_timer;
+
+        ss::gate _gate;
+        size_t _current_window{0};
+        fragmented_vector<usage_window> _buckets;
+        storage::kvstore& _kvstore;
+        ss::sharded<usage_manager>& _um;
+    };
+
+    /// Class constructor
+    ///
+    /// Context is to be in a sharded service, will grab \ref usage_num_windows
+    /// and \ref usage_window_sec configuration parameters from cluster config
+    explicit usage_manager(ss::sharded<storage::api>& storage);
+
+    /// Allocates and starts the accounting fiber
+    ss::future<> start();
+
+    /// Safely shuts down accounting fiber and deallocates it
+    ss::future<> stop();
+
+    /// Adds bytes to current open window
+    ///
+    /// Should be called at the kafka layer to account for bytes sent via kafka
+    /// port
+    void add_bytes_sent(size_t sent) { _current_bucket.bytes_sent += sent; }
+
+    /// Adds bytes received to current open window
+    ///
+    /// Should be called at the kafka layer to account for bytes received via
+    /// kafka port
+    void add_bytes_recv(size_t recv) { _current_bucket.bytes_received += recv; }
+
+    /// Obtain all current stats - for all shards
+    ///
+    std::vector<usage_window> get_usage_stats() const;
+
+    /// Obtain all current stats - for 'this' shard, resets window
+    ///
+    usage sample() {
+        usage u{};
+        std::swap(_current_bucket, u);
+        return u;
+    }
+
+private:
+    /// Called when config options are modified
+    ss::future<> reset();
+
+    ss::future<> start_accounting_fiber();
+
+    expression_in_debug_mode(oncore _verify_shard);
+
+private:
+    /// Config bindings, usage is visibility::user, others ::tunable
+    config::binding<bool> _usage_enabled;
+    config::binding<size_t> _usage_num_windows;
+    config::binding<std::chrono::seconds> _usage_window_width_interval;
+    config::binding<std::chrono::seconds> _usage_disk_persistance_interval;
+
+    ss::sharded<storage::api>& _storage;
+
+    /// Per-core metric, shard-0 aggregates these values across shards
+    usage _current_bucket;
+    mutex _background_mutex;
+    ss::gate _background_gate;
+
+    /// Valid on core-0 when usage_enabled() == true
+    std::unique_ptr<accounting_fiber> _accounting_fiber;
+};
+
+/// Bytes accounted for by the kafka::usage_manager will not take into
+/// consideration data batches via produce/fetch requests to these topics
+static const auto usage_excluded_topics = std::to_array(
+  {model::topic("_schemas"),
+   model::topic("__audit"),
+   model::topic("__redpanda_e2e_probe")});
+
+} // namespace kafka

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -11,6 +11,7 @@ set(swags
   transaction
   cluster
   debug
+  usage
   shadow_indexing)
 
 set(swag_files)

--- a/src/v/redpanda/admin/api-doc/usage.json
+++ b/src/v/redpanda/admin/api-doc/usage.json
@@ -1,0 +1,58 @@
+{
+    "apiVersion": "0.0.1",
+    "swaggerVersion": "1.2",
+    "basePath": "/v1",
+    "resourcePath": "/usage",
+    "produces": [
+        "application/json"
+    ],
+    "apis": [
+        {
+            "path": "/v1/usage",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get Redpanda usage metrics",
+                    "type": "usage_response",
+                    "nickname": "get_usage",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        }
+    ],
+    "models": {
+        "usage_response": {
+            "id": "usage_response",
+            "description": "Kafka & cloud storage usage metrics for this node",
+            "properties": {
+                "begin_timestamp": {
+                    "type": "long",
+                    "description": "Timestamp when bucket had opened"
+                },
+                "end_timestamp": {
+                    "type": "long",
+                    "description": "Timestamp when bucket was closed"
+                },
+                "open": {
+                    "type": "boolean",
+                    "description": "If this result contains results from window that is not yet closed"
+                },
+                "kafka_bytes_sent_count": {
+                    "type": "long",
+                    "description": "Number of bytes sent to client via the kafka api"
+                },
+                "kafka_bytes_received_count": {
+                    "type": "long",
+                    "description": "Number of bytes received by redpanda via the kafka api"
+                },
+                "cloud_storage_bytes_gauge": {
+                    "type": "long",
+                    "description": "Number of bytes resting in cloud storage at window close"
+                }
+            }
+        }
+    }
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -75,6 +75,7 @@
 #include "redpanda/admin/api-doc/shadow_indexing.json.h"
 #include "redpanda/admin/api-doc/status.json.h"
 #include "redpanda/admin/api-doc/transaction.json.h"
+#include "redpanda/admin/api-doc/usage.json.h"
 #include "rpc/errc.h"
 #include "security/credential_store.h"
 #include "security/scram_algorithm.h"
@@ -3445,7 +3446,58 @@ admin_server::cloud_storage_usage_handler(
     }
 }
 
-void admin_server::register_usage_routes() {}
+static ss::json::json_return_type raw_data_to_usage_response(
+  const std::vector<kafka::usage_window>& total_usage, bool include_open) {
+    std::vector<ss::httpd::usage_json::usage_response> resp;
+    resp.reserve(total_usage.size());
+    for (size_t i = (include_open ? 0 : 1); i < total_usage.size(); ++i) {
+        resp.emplace_back();
+        const auto& e = total_usage[i];
+        resp.back().begin_timestamp = e.begin;
+        resp.back().end_timestamp = e.end;
+        resp.back().open = e.is_open();
+        resp.back().kafka_bytes_received_count = e.u.bytes_received;
+        resp.back().kafka_bytes_sent_count = e.u.bytes_sent;
+        resp.back().cloud_storage_bytes_gauge = e.u.bytes_cloud_storage;
+    }
+    if (include_open && !resp.empty()) {
+        /// Handle case where client does not want to observe
+        /// value of 0 for open buckets end timestamp
+        auto& e = resp.at(0);
+        vassert(e.open(), "Bucket not open when expecting to be");
+        e.end_timestamp = std::chrono::duration_cast<std::chrono::seconds>(
+                            ss::lowres_system_clock::now().time_since_epoch())
+                            .count();
+    }
+    return resp;
+}
+
+void admin_server::register_usage_routes() {
+    register_route<user>(
+      ss::httpd::usage_json::get_usage,
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          if (!config::shard_local_cfg().enable_usage()) {
+              throw ss::httpd::bad_request_exception(
+                "Usage tracking is not enabled");
+          }
+          bool include_open = false;
+          auto include_open_str = req->get_query_param("include_open_bucket");
+          vlog(
+            logger.info,
+            "Request to observe usage info, include_open_bucket={}",
+            include_open_str);
+          if (!include_open_str.empty()) {
+              include_open = str_to_bool(include_open_str);
+          }
+          return _usage_manager
+            .invoke_on(
+              kafka::usage_manager::usage_manager_main_shard,
+              [](kafka::usage_manager& um) { return um.get_usage_stats(); })
+            .then([include_open](auto total_usage) {
+                return raw_data_to_usage_response(total_usage, include_open);
+            });
+      });
+}
 
 void admin_server::register_debug_routes() {
     register_route<user>(

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -14,7 +14,9 @@
 #include "cluster/fwd.h"
 #include "config/endpoint_tls_config.h"
 #include "coproc/partition_manager.h"
+#include "kafka/server/fwd.h"
 #include "model/metadata.h"
+#include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/fwd.h"
 #include "rpc/connection_cache.h"
 #include "seastarx.h"
@@ -64,6 +66,8 @@ public:
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<cluster::node_status_table>&,
       ss::sharded<cluster::self_test_frontend>&,
+      ss::sharded<kafka::usage_manager>&,
+      pandaproxy::rest::api*,
       pandaproxy::schema_registry::api*,
       ss::sharded<cloud_storage::topic_recovery_service>&,
       ss::sharded<cluster::topic_recovery_status_frontend>&);
@@ -284,6 +288,7 @@ private:
     void register_hbadger_routes();
     void register_transaction_routes();
     void register_debug_routes();
+    void register_usage_routes();
     void register_self_test_routes();
     void register_cluster_routes();
     void register_shadow_indexing_routes();
@@ -425,6 +430,8 @@ private:
     bool _ready{false};
     ss::sharded<cluster::node_status_table>& _node_status_table;
     ss::sharded<cluster::self_test_frontend>& _self_test_frontend;
+    ss::sharded<kafka::usage_manager>& _usage_manager;
+    pandaproxy::rest::api* _http_proxy;
     pandaproxy::schema_registry::api* _schema_registry;
     ss::sharded<cloud_storage::topic_recovery_service>& _topic_recovery_service;
     ss::sharded<cluster::topic_recovery_status_frontend>&

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -826,6 +826,8 @@ void application::configure_admin_server() {
       std::ref(_connection_cache),
       std::ref(node_status_table),
       std::ref(self_test_frontend),
+      std::ref(usage_manager),
+      _proxy.get(),
       _schema_registry.get(),
       std::ref(topic_recovery_service),
       std::ref(topic_recovery_status_frontend))
@@ -1476,6 +1478,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         std::ref(quota_mgr),
         std::ref(snc_quota_mgr),
         std::ref(group_router),
+        std::ref(usage_manager),
         std::ref(shard_table),
         std::ref(partition_manager),
         std::ref(fetch_session_cache),

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -123,6 +123,7 @@ public:
     ss::sharded<kafka::quota_manager> quota_mgr;
     ss::sharded<kafka::snc_quota_manager> snc_quota_mgr;
     ss::sharded<kafka::rm_group_frontend> rm_group_frontend;
+    ss::sharded<kafka::usage_manager> usage_manager;
 
     ss::sharded<raft::group_manager> raft_group_manager;
     ss::sharded<raft::recovery_throttle> recovery_throttle;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -120,6 +120,7 @@ public:
           app.quota_mgr,
           app.snc_quota_mgr,
           app.group_router,
+          app.usage_manager,
           app.shard_table,
           app.partition_manager,
           app.fetch_session_cache,

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -96,6 +96,7 @@ public:
         storage = 2,
         controller = 3,
         offset_translator = 4,
+        usage = 5,
         /* your sub-system here */
     };
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -867,3 +867,8 @@ class Admin:
         return int(
             self._request(
                 "GET", "debug/cloud_storage_usage?retries_allowed=10").json())
+
+    def get_usage(self, node, include_open: bool = True):
+        return self._request("GET",
+                             f"usage?include_open_bucket={str(include_open)}",
+                             node=node).json()

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -68,7 +68,7 @@ def get_kvstore_topic_key_counts(redpanda):
             keys = [i['key'] for i in items]
 
             for k in keys:
-                if k['keyspace'] == "cluster":
+                if k['keyspace'] == "cluster" or k['keyspace'] == "usage":
                     # Not a per-partition key
                     continue
 

--- a/tests/rptest/tests/usage_test.py
+++ b/tests/rptest/tests/usage_test.py
@@ -1,0 +1,155 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+from requests.exceptions import HTTPError
+from rptest.services.cluster import cluster
+from ducktape.utils.util import wait_until
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.services.rpk_consumer import RpkConsumer
+
+from datetime import datetime
+from functools import reduce
+
+from rptest.services.admin import Admin
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from rptest.utils.functional import flat_map
+
+
+class UsageTest(RedpandaTest):
+    """
+    Tests that the usage endpoint is tracking kafka metrics
+    """
+    topics = (TopicSpec(), )
+
+    def __init__(self, test_context):
+        extra_conf = {
+            'enable_usage': True,
+            'usage_num_windows': 60,
+            'usage_window_width_interval_sec': 1,
+            'usage_disk_persistance_interval_sec': 5
+        }
+        super(UsageTest, self).__init__(test_context=test_context,
+                                        extra_rp_conf=extra_conf)
+        self._ctx = test_context
+        self._admin = Admin(self.redpanda)
+
+    def _get_all_usage(self, include_open=True):
+        return flat_map(lambda x: self._admin.get_usage(x, include_open),
+                        self.redpanda.nodes)
+
+    def _calculate_total_usage(self, results=None):
+        # Total number of ingress/egress bytes across entire cluster
+        def all_bytes(x):
+            kafka_ingress = x['kafka_bytes_sent_count']
+            kafka_egress = x['kafka_bytes_received_count']
+            return kafka_ingress + kafka_egress
+
+        if results is None:
+            results = self._get_all_usage()
+
+        # Some traffic over the kafka port should be expected at startup
+        # but not a large amount
+        return reduce(lambda acc, x: acc + all_bytes(x), results, 0)
+
+    def _produce_and_consume_data(self, records=10240, size=512):
+        # Test some data is recorded as activity over kafka port begins
+        producer = KafkaCliTools(self.redpanda)
+        producer.produce(self.topic, records, size, acks=1)
+        total_produced = records * size
+
+        consumer = RpkConsumer(self._ctx, self.redpanda, self.topic)
+        consumer.start()
+        self._bytes_received = 0
+
+        def bytes_observed():
+            for msg in consumer.messages:
+                value = msg["value"]
+                if value is not None:
+                    self._bytes_received += len(value)
+            return self._bytes_received >= total_produced
+
+        wait_until(bytes_observed, timeout_sec=30, backoff_sec=1)
+        consumer.stop()
+        return total_produced
+
+    @cluster(num_nodes=4)
+    def test_usage_metrics_collection(self):
+        # Assert windows are closing
+        time.sleep(2)
+        response = self._get_all_usage()
+        assert len(response) >= 2, f"Not enough windows observed, {response}"
+
+        # Some traffic over the kafka port should be expected at startup
+        # but not a large amount
+        total_data = self._calculate_total_usage()
+        assert total_data < 4096, f"More then 4k traffic observed: {total_data}"
+
+        # Produce / consume test data, should observe usage numbers increase
+        total_produced = self._produce_and_consume_data()
+
+        # Assert that more then data the data produced has been recorded, responses
+        # and the initial non 0 recorded data are also included in the total recorded amt
+        total_data = self._calculate_total_usage()
+        assert total_data > total_produced, f"Expected {total_produced} observed: {total_data}"
+
+    @cluster(num_nodes=4)
+    def test_usage_collection_restart(self):
+        self._admin.patch_cluster_config(
+            upsert={'usage_disk_persistance_interval_sec': 1})
+        # Ensure the restarted accounting fiber is up before data begins to be produced
+        time.sleep(2)
+
+        # Produce / consume test data, should observe usage numbers increase
+        _ = self._produce_and_consume_data()
+        time.sleep(3)
+
+        # Query usage of node to restart before restart
+        usage_pre_restart = self._calculate_total_usage(
+            self._admin.get_usage(node=self.redpanda.nodes[0]))
+        assert usage_pre_restart > 0
+
+        self.redpanda.restart_nodes([self.redpanda.nodes[0]])
+
+        # Compare values pre/post restart to ensure data was persisted to disk
+        usage_post_restart = self._calculate_total_usage(
+            self._admin.get_usage(node=self.redpanda.nodes[0]))
+        assert usage_post_restart >= usage_pre_restart, f"Usage post restart: {usage_post_restart} Usage pre restart: {usage_pre_restart}"
+
+    @cluster(num_nodes=3)
+    def test_usage_settings_changed(self):
+        # Should expect maximum of 2 windows per broker
+        self._admin.patch_cluster_config(upsert={'usage_num_windows': 2})
+        time.sleep(2)
+        response = self._get_all_usage()
+        assert len(response) == 6
+
+        # Should expect a 500 from the cluster
+        self._admin.patch_cluster_config(upsert={'enable_usage': False})
+        try:
+            _ = self._get_all_usage()
+            assert False, "Expecting v1/usage to return 400"
+        except HTTPError as e:
+            assert e.response.status_code == 400
+
+        # Should expect windows to have been resized correctly
+        self._admin.patch_cluster_config(
+            upsert={
+                'enable_usage': True,
+                'usage_num_windows': 3,
+                'usage_window_width_interval_sec': 2
+            })
+        time.sleep(3)
+        response = self._get_all_usage(False)
+        for r in response:
+            begin = datetime.fromtimestamp(r['begin_timestamp'])
+            end = datetime.fromtimestamp(r['end_timestamp'])
+            total = end - begin
+            assert total.seconds == 2 or total.seconds == 3, total.seconds

--- a/tools/offline_log_viewer/kvstore.py
+++ b/tools/offline_log_viewer/kvstore.py
@@ -82,6 +82,8 @@ class KvStoreRecordDecoder:
             return "cluster"
         elif ks == 4:
             return "offset_translator"
+        elif ks == 5:
+            return "usage"
         return "unknown"
 
     def decode(self):


### PR DESCRIPTION
## Cover Letter

Backport of PR: #9430

## UX Changes
- Introducing 4 new configuration options:
  - `enable_usage`: To turn feature on/off (defaulted to off)
  - `usage_num_windows`: Number of historical windows of data of usage to track
  - `usage_window_width_interval_sec`: The length of time in seconds of a historical window
  - `usage_disk_persistance_interval_sec`: Length of time between writes of the historical data to disk, for persistence in case of shutdown/crashes

## Release Notes

### Improvements

- Adds a new metering API for fine grained tracking of kafka metrics
  