### PR TITLE
Add disk usage summary report interface

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1750,7 +1750,7 @@ disk_log_impl::estimate_reclaim_size(compaction_config cfg) {
         }
     }
 
-    auto ret = co_await ss::when_all_succeed(
+    auto [retention, available] = co_await ss::when_all_succeed(
       // reduce segment subject to retention policy
       ss::map_reduce(
         retention_segments,
@@ -1766,7 +1766,9 @@ disk_log_impl::estimate_reclaim_size(compaction_config cfg) {
         [](size_t acc, usage u) { return acc + u.total(); }));
 
     co_return reclaim_size_limits{
-      .retention = std::get<0>(ret), .available = std::get<1>(ret)};
+      .retention = retention,
+      .available = retention + available,
+    };
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -34,22 +34,6 @@
 
 namespace storage {
 
-/*
- * Report number of bytes available for reclaim under different scenarios.
- *
- * retention: number of bytes that would be reclaimed by applying
- *            the log's retention policy.
- *
- * available: number of bytes that could be safely reclaimed if the
- *            retention policy was ignored. for example reclaiming
- *            past the retention limits if the data being reclaimed
- *            has been uploaded to cloud storage.
- */
-struct reclaim_size_limits {
-    size_t retention{0};
-    size_t available{0};
-};
-
 class disk_log_impl final : public log::impl {
 public:
     using failure_probes = storage::log_failure_probes;
@@ -198,7 +182,7 @@ private:
 
     std::optional<model::offset> retention_offset(compaction_config);
 
-    ss::future<reclaim_size_limits> estimate_reclaim_size(compaction_config);
+    ss::future<usage_report> disk_usage(compaction_config);
 
 private:
     size_t max_segment_size() const;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -105,12 +105,24 @@ ss::future<> segment::close() {
     }
 }
 
-ss::future<size_t> segment::persistent_size() {
+ss::future<usage> segment::persistent_size() {
+    usage u;
+
     /*
      * accumulate the size of the segment file and each index.
      */
-    const auto segment_size = file_size();
-    auto total = segment_size + segment_index::estimate_size(segment_size);
+    if (_data_disk_usage_size.has_value()) {
+        u.data = _data_disk_usage_size.value();
+    } else {
+        try {
+            _data_disk_usage_size = co_await ss::file_size(
+              _reader.path().string());
+            u.data = _data_disk_usage_size.value();
+        } catch (...) {
+        }
+    }
+
+    u.index = co_await _idx.disk_usage();
 
     /*
      * lazy load and cache the compaction index size. we could track this
@@ -119,17 +131,17 @@ ss::future<size_t> segment::persistent_size() {
      * will be used.
      */
     if (_compaction_index_size.has_value()) {
-        total += _compaction_index_size.value();
+        u.compaction = _compaction_index_size.value();
     } else {
         auto path = reader().path().to_compacted_index();
         try {
             _compaction_index_size = co_await ss::file_size(path.string());
-            total += _compaction_index_size.value();
+            u.compaction = _compaction_index_size.value();
         } catch (...) {
         }
     }
 
-    co_return total;
+    co_return u;
 }
 
 ss::future<size_t>
@@ -162,8 +174,16 @@ segment::remove_persistent_state(std::filesystem::path path) {
     co_return 0;
 }
 
+void segment::clear_cached_disk_usage() {
+    _idx.clear_cached_disk_usage();
+    _data_disk_usage_size.reset();
+    _compaction_index_size.reset();
+}
+
 ss::future<size_t> segment::remove_persistent_state() {
     vassert(is_closed(), "Cannot clear state from unclosed segment");
+
+    clear_cached_disk_usage();
 
     /*
      * the compaction index is included in the removal list, even if the topic
@@ -211,10 +231,11 @@ ss::future<> segment::do_release_appender(
         std::optional<compacted_index_writer>& compacted_index) {
           return appender->close()
             .then([this] { return _idx.flush(); })
-            .then([&compacted_index] {
+            .then([this, &compacted_index] {
                 if (compacted_index) {
                     return compacted_index->close();
                 }
+                clear_cached_disk_usage();
                 return ss::now();
             });
       });
@@ -339,7 +360,7 @@ ss::future<> segment::truncate(
       [this, prev_last_offset, physical, new_max_timestamp](
         ss::rwlock::holder h) {
           return do_truncate(prev_last_offset, physical, new_max_timestamp)
-            .finally([h = std::move(h)] {});
+            .finally([this, h = std::move(h)] { clear_cached_disk_usage(); });
       });
 }
 
@@ -505,6 +526,7 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
           const bool index_append_failed = index_fut.failed()
                                            && has_compaction_index();
           const bool has_error = append_fut.failed() || index_append_failed;
+          clear_cached_disk_usage();
           if (!has_error) {
               if (
                 !this->_first_write.has_value()

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -96,24 +96,16 @@ ss::future<> segment::close() {
     co_await do_close();
 
     if (is_tombstone()) {
-        _removed_persistent_size = co_await remove_persistent_state();
+        auto size = co_await remove_persistent_state();
         vlog(
           stlog.debug,
           "Removed {} bytes for tombstone segment {}",
-          _removed_persistent_size.value(),
+          size,
           *this);
     }
 }
 
 ss::future<size_t> segment::persistent_size() {
-    /*
-     * this segment has been fully removed, and we can report the total amount
-     * of bytes that were removed from disk.
-     */
-    if (_removed_persistent_size.has_value()) {
-        co_return _removed_persistent_size.value();
-    }
-
     /*
      * accumulate the size of the segment file and each index.
      */

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -162,9 +162,7 @@ public:
 
     /*
      * return an estimate of how much data on disk is associated with this
-     * segment (e.g. the data file, indices, etc...). if the segment has been
-     * removed already (i.e. marked as a tombstone and closed) then the total
-     * amount of bytes actually removed from disk is reported.
+     * segment (e.g. the data file, indices, etc...).
      */
     ss::future<size_t> persistent_size();
 
@@ -211,12 +209,6 @@ private:
     ss::future<> do_compaction_index_batch(const model::record_batch&);
     void release_appender_in_background(readers_cache* readers_cache);
 
-    /*
-     * _removed_persistent_size is the total number of bytes removed when this
-     * segment is deleted. it is set once, after the segment is marked as a
-     * tombstone and closed.
-     */
-    std::optional<size_t> _removed_persistent_size;
     ss::future<size_t> remove_persistent_state(std::filesystem::path);
 
     struct appender_callbacks : segment_appender::callbacks {

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -164,7 +164,7 @@ public:
      * return an estimate of how much data on disk is associated with this
      * segment (e.g. the data file, indices, etc...).
      */
-    ss::future<size_t> persistent_size();
+    ss::future<usage> persistent_size();
 
     /*
      * return the number of bytes removed from disk.
@@ -187,9 +187,7 @@ public:
         return _first_write;
     }
 
-    void invalidate_compaction_index_size() {
-        _compaction_index_size = std::nullopt;
-    }
+    void clear_cached_disk_usage();
 
 private:
     void set_close();
@@ -245,6 +243,7 @@ private:
     segment_index _idx;
     bitflags _flags{bitflags::none};
     segment_appender_ptr _appender;
+    std::optional<size_t> _data_disk_usage_size;
 
     // compaction index size should be cleared whenever the size might change
     // (e.g. after compaction). when cleared it will reset the next time the

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -109,6 +109,12 @@ public:
     bool needs_persistence() const { return _needs_persistence; }
     index_state release_index_state() && { return std::move(_state); }
 
+    /*
+     * Get the on-disk device usage size of the index.
+     */
+    ss::future<size_t> disk_usage();
+    void clear_cached_disk_usage() { _disk_usage_size.reset(); }
+
 private:
     ss::future<bool> materialize_index_from_file(ss::file);
     ss::future<> flush_to_file(ss::file);
@@ -120,6 +126,9 @@ private:
     bool _needs_persistence{false};
     index_state _state;
     debug_sanitize_files _sanitize;
+
+    // invalidate size cache when on-disk size may change
+    std::optional<size_t> _disk_usage_size;
 
     model::timestamp _last_batch_max_timestamp;
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -853,7 +853,6 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
     from_path = from_path.to_compacted_index();
     auto to_path = to->reader().path().to_compacted_index();
     co_await ss::rename_file(from_path.string(), to_path.string());
-    to->invalidate_compaction_index_size();
 
     // clean up replacement segment
     co_await from->remove_persistent_state();

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -125,7 +125,12 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     }
 
     BOOST_CHECK_LT(
-      (builder.gc_estimate(model::timestamp::now(), 0).get().retention - 2_MiB),
+      (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
+       - 2_MiB),
+      20_KiB);
+    BOOST_CHECK_LT(
+      (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
+       - 2_MiB),
       20_KiB);
 
     // second segment
@@ -146,7 +151,12 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
 
     // the first segment is now eligible for reclaim
     BOOST_CHECK_LT(
-      (builder.gc_estimate(model::timestamp::now(), 0).get().retention - 3_MiB),
+      (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
+       - 3_MiB),
+      20_KiB);
+    BOOST_CHECK_LT(
+      (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
+       - 3_MiB),
       20_KiB);
 
     // third segment
@@ -167,7 +177,12 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
 
     // the first,second segment is now eligible for reclaim
     BOOST_CHECK_LT(
-      (builder.gc_estimate(model::timestamp::now(), 0).get().retention - 4_MiB),
+      (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
+       - 4_MiB),
+      20_KiB);
+    BOOST_CHECK_LT(
+      (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
+       - 4_MiB),
       20_KiB);
 
     // active segment
@@ -188,14 +203,22 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
 
     // the first,second segment is now eligible for reclaim
     BOOST_CHECK_LT(
-      (builder.gc_estimate(model::timestamp::now(), 0).get().retention - 5_MiB),
+      (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
+       - 5_MiB),
+      20_KiB);
+    BOOST_CHECK_LT(
+      (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
+       - 5_MiB),
       20_KiB);
 
     builder | storage::garbage_collect(yesterday, 4_MiB);
 
     // right after gc runs there shouldn't be anything reclaimable
     BOOST_CHECK_EQUAL(
-      builder.gc_estimate(model::timestamp::now(), 0).get().retention, 0);
+      builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention,
+      0);
+    BOOST_CHECK_EQUAL(
+      builder.disk_usage(model::timestamp::now(), 0).get().usage.total(), 0);
 
     builder | storage::stop();
 

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "model/fundamental.h"
 #include "storage/tests/utils/disk_log_builder.h"
 // fixture
 #include "test_utils/fixture.h"
@@ -358,4 +359,68 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt)
       | storage::stop();
     BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
+}
+
+FIXTURE_TEST(non_collectible_disk_usage_test, gc_fixture) {
+    // a few helpers
+    const auto last_week = model::to_timestamp(
+      model::timestamp_clock::now() - std::chrono::days(7));
+    const size_t num_records = 10;
+    const auto part_size = [this] {
+        return builder.get_disk_log_impl().get_probe().partition_size();
+    };
+
+    // setup non-collectible
+    auto overrides = std::make_unique<storage::ntp_config::default_overrides>();
+    overrides->cleanup_policy_bitflags = model::cleanup_policy_bitflags::none;
+    storage::ntp_config config(
+      storage::log_builder_ntp(),
+      builder.get_log_config().base_dir,
+      std::move(overrides));
+
+    // first segment
+    model::offset offset{0};
+    builder | storage::start(std::move(config)) | storage::add_segment(offset);
+    size_t start_size = part_size();
+    while ((part_size() - start_size) < 2_MiB) {
+        builder
+          | storage::add_random_batch(
+            offset,
+            num_records,
+            storage::maybe_compress_batches::no,
+            model::record_batch_type::raft_data,
+            storage::append_config(),
+            storage::disk_log_builder::should_flush_after::no,
+            last_week);
+        offset += model::offset(num_records);
+    }
+
+    // second segment
+    builder | storage::add_segment(offset);
+    start_size = part_size();
+    while ((part_size() - start_size) < 1_MiB) {
+        builder
+          | storage::add_random_batch(
+            offset,
+            num_records,
+            storage::maybe_compress_batches::no,
+            model::record_batch_type::raft_data,
+            storage::append_config(),
+            storage::disk_log_builder::should_flush_after::no,
+            last_week);
+        offset += model::offset(num_records);
+    }
+
+    BOOST_REQUIRE_EQUAL(
+      builder.get_disk_log_impl().config().is_collectable(), false);
+
+    BOOST_CHECK_EQUAL(
+      builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention,
+      0);
+    BOOST_CHECK_LT(
+      (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
+       - 3_MiB),
+      20_KiB);
+
+    builder | storage::stop();
 }

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -137,10 +137,10 @@ ss::future<> disk_log_builder::gc(
     return ss::make_ready_future<>();
 }
 
-ss::future<reclaim_size_limits> disk_log_builder::gc_estimate(
+ss::future<usage_report> disk_log_builder::disk_usage(
   model::timestamp collection_upper_bound,
   std::optional<size_t> max_partition_retention_size) {
-    return get_disk_log_impl().estimate_reclaim_size(compaction_config(
+    return get_disk_log_impl().disk_usage(compaction_config(
       collection_upper_bound,
       max_partition_retention_size,
       model::offset::max(),

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -299,7 +299,7 @@ public:
     ss::future<> gc(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);
-    ss::future<reclaim_size_limits> gc_estimate(
+    ss::future<usage_report> disk_usage(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);
     ss::future<std::optional<model::offset>>

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -395,6 +395,22 @@ struct compaction_result {
 };
 
 /*
+ * Report number of bytes available for reclaim under different scenarios.
+ *
+ * retention: number of bytes that would be reclaimed by applying
+ *            the log's retention policy.
+ *
+ * available: number of bytes that could be safely reclaimed if the
+ *            retention policy was ignored. for example reclaiming
+ *            past the retention limits if the data being reclaimed
+ *            has been uploaded to cloud storage.
+ */
+struct reclaim_size_limits {
+    size_t retention{0};
+    size_t available{0};
+};
+
+/*
  * disk usage
  *
  * data: segment data
@@ -407,6 +423,24 @@ struct usage {
     size_t compaction{0};
 
     size_t total() const { return data + index + compaction; }
+
+    friend usage operator+(usage lhs, const usage& rhs) {
+        lhs.data += rhs.data;
+        lhs.index += rhs.index;
+        lhs.compaction += rhs.compaction;
+        return lhs;
+    }
+};
+
+/*
+ * disk usage report
+ *
+ * usage: disk usage summary for log.
+ * reclaim: disk uage reclaim summary for log.
+ */
+struct usage_report {
+    usage usage;
+    reclaim_size_limits reclaim;
 };
 
 } // namespace storage

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -394,4 +394,19 @@ struct compaction_result {
     friend std::ostream& operator<<(std::ostream&, const compaction_result&);
 };
 
+/*
+ * disk usage
+ *
+ * data: segment data
+ * index: offset/time index
+ * compaction: compaction index
+ */
+struct usage {
+    size_t data{0};
+    size_t index{0};
+    size_t compaction{0};
+
+    size_t total() const { return data + index + compaction; }
+};
+
 } // namespace storage


### PR DESCRIPTION
In a previous commit the `gc_estimate` interface was introduced which was effectively a dry-run of retention policy designed to allow future disk space management functionality to reason about which partitions had the most data available for removal from local disk in support of low disk space scenarios.

The flip side of knowing how much data can be reclaimed is to know how much data is being used. For example, future disk space management functionality will need to understand how much space is attributable to a raft vs other sub-systems (e.g. in single-disk setups).

To that end this PR introduces `disk_log_impl::disk_usage()` that replaces `gc_estimate` and returns a report about both disk usage broken out into categories (e.g. data, index) as well as the previous dry-run retention calculation. They are combined because (1) it is more efficient to collect these statistics at once and (2) the only current user will need both pieces of information.

```
ss::future<usage_report> disk_log_impl::disk_usage(compaction_config cfg) 

/*
 * disk usage report
 *
 * usage: disk usage summary for log.
 * reclaim: disk usage reclaim summary for log.
 */
struct usage_report {
    usage usage;
    reclaim_size_limits reclaim;
};
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

