### PR TITLE
refactor ducktape redpanda service in prep for k8s

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -717,6 +717,15 @@ class RedpandaServiceBase(Service):
     def add_extra_rp_conf(self, conf):
         self._extra_rp_conf = {**self._extra_rp_conf, **conf}
 
+    def get_node_memory_mb(self):
+        pass
+
+    def get_node_cpu_count(self):
+        pass
+
+    def get_node_disk_free(self):
+        pass
+
 
 class RedpandaService(RedpandaServiceBase):
     PERSISTENT_ROOT = "/var/lib/redpanda"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -828,6 +828,13 @@ class RedpandaServiceBase(Service):
                                 use_maintenance_mode=use_maintenance_mode,
                                 omit_seeds_on_idx_one=omit_seeds_on_idx_one)
 
+    def set_cluster_config(self,
+                           values: dict,
+                           expect_restart: bool = False,
+                           admin_client: Optional[Admin] = None,
+                           timeout: int = 10):
+        pass
+
 
 class RedpandaService(RedpandaServiceBase):
     PERSISTENT_ROOT = "/var/lib/redpanda"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -675,7 +675,23 @@ class SchemaRegistryConfig(TlsConfig):
         super(SchemaRegistryConfig, self).__init__()
 
 
-class RedpandaService(Service):
+class RedpandaServiceBase(Service):
+    def __init__(self, context, num_brokers):
+        super(RedpandaServiceBase, self).__init__(context,
+                                                  num_nodes=num_brokers)
+        self._context = context
+
+    def start_node(self, node, **kwargs):
+        pass
+
+    def stop_node(self, node, **kwargs):
+        pass
+
+    def clean_node(self, node, **kwargs):
+        pass
+
+
+class RedpandaService(RedpandaServiceBase):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
     NODE_CONFIG_FILE = "/etc/redpanda/redpanda.yaml"
@@ -769,8 +785,7 @@ class RedpandaService(Service):
                  pandaproxy_config: Optional[PandaproxyConfig] = None,
                  schema_registry_config: Optional[SchemaRegistryConfig] = None,
                  disable_cloud_storage_diagnostics=False):
-        super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
-        self._context = context
+        super(RedpandaService, self).__init__(context, num_brokers)
         self._extra_rp_conf = extra_rp_conf or dict()
         self._security = security
         self._installer: RedpandaInstaller = RedpandaInstaller(self)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -812,6 +812,22 @@ class RedpandaServiceBase(Service):
 
         return result
 
+    def rolling_restart_nodes(self,
+                              nodes,
+                              override_cfg_params=None,
+                              start_timeout=None,
+                              stop_timeout=None,
+                              use_maintenance_mode=True,
+                              omit_seeds_on_idx_one=True):
+        nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
+        restarter = RollingRestarter(self)
+        restarter.restart_nodes(nodes,
+                                override_cfg_params=override_cfg_params,
+                                start_timeout=start_timeout,
+                                stop_timeout=stop_timeout,
+                                use_maintenance_mode=use_maintenance_mode,
+                                omit_seeds_on_idx_one=omit_seeds_on_idx_one)
+
 
 class RedpandaService(RedpandaServiceBase):
     PERSISTENT_ROOT = "/var/lib/redpanda"
@@ -2393,22 +2409,6 @@ class RedpandaService(RedpandaServiceBase):
                         timeout=start_timeout,
                         auto_assign_node_id=auto_assign_node_id,
                         omit_seeds_on_idx_one=omit_seeds_on_idx_one), nodes))
-
-    def rolling_restart_nodes(self,
-                              nodes,
-                              override_cfg_params=None,
-                              start_timeout=None,
-                              stop_timeout=None,
-                              use_maintenance_mode=True,
-                              omit_seeds_on_idx_one=True):
-        nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
-        restarter = RollingRestarter(self)
-        restarter.restart_nodes(nodes,
-                                override_cfg_params=override_cfg_params,
-                                start_timeout=start_timeout,
-                                stop_timeout=stop_timeout,
-                                use_maintenance_mode=use_maintenance_mode,
-                                omit_seeds_on_idx_one=omit_seeds_on_idx_one)
 
     def get_node_by_id(self, node_id):
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -785,6 +785,9 @@ class RedpandaServiceBase(Service):
                         counts[idx] += int(sample.value)
         return all(map(lambda count: count == 0, counts.values()))
 
+    def node_id(self, node, force_refresh=False, timeout_sec=30):
+        pass
+
 
 class RedpandaService(RedpandaServiceBase):
     PERSISTENT_ROOT = "/var/lib/redpanda"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -726,6 +726,9 @@ class RedpandaServiceBase(Service):
     def get_node_disk_free(self):
         pass
 
+    def lsof_node(self, node: ClusterNode, filter: Optional[str] = None):
+        pass
+
 
 class RedpandaService(RedpandaServiceBase):
     PERSISTENT_ROOT = "/var/lib/redpanda"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -681,6 +681,7 @@ class RedpandaServiceBase(Service):
         context,
         num_brokers,
         extra_rp_conf=None,
+        resource_settings=None,
         si_settings=None,
     ):
         super(RedpandaServiceBase, self).__init__(context,
@@ -692,6 +693,10 @@ class RedpandaServiceBase(Service):
             self.set_si_settings(si_settings)
         else:
             self._si_settings = None
+
+        if resource_settings is None:
+            resource_settings = ResourceSettings()
+        self._resource_settings = resource_settings
 
     def start_node(self, node, **kwargs):
         pass
@@ -835,6 +840,9 @@ class RedpandaServiceBase(Service):
                            timeout: int = 10):
         pass
 
+    def set_resource_settings(self, rs):
+        self._resource_settings = rs
+
 
 class RedpandaService(RedpandaServiceBase):
     PERSISTENT_ROOT = "/var/lib/redpanda"
@@ -930,8 +938,9 @@ class RedpandaService(RedpandaServiceBase):
                  pandaproxy_config: Optional[PandaproxyConfig] = None,
                  schema_registry_config: Optional[SchemaRegistryConfig] = None,
                  disable_cloud_storage_diagnostics=False):
-        super(RedpandaService, self).__init__(context, num_brokers,
-                                              extra_rp_conf, si_settings)
+        super(RedpandaService,
+              self).__init__(context, num_brokers, extra_rp_conf,
+                             resource_settings, si_settings)
         self._security = security
         self._installer: RedpandaInstaller = RedpandaInstaller(self)
         self._pandaproxy_config = pandaproxy_config
@@ -983,9 +992,6 @@ class RedpandaService(RedpandaServiceBase):
 
         self._trim_logs = self._context.globals.get(self.TRIM_LOGS_KEY, True)
 
-        if resource_settings is None:
-            resource_settings = ResourceSettings()
-        self._resource_settings = resource_settings
         self.logger.info(
             f"ResourceSettings: dedicated_nodes={self._dedicated_nodes}")
 
@@ -1029,9 +1035,6 @@ class RedpandaService(RedpandaServiceBase):
 
     def set_environment(self, environment: dict[str, str]):
         self._environment.update(environment)
-
-    def set_resource_settings(self, rs):
-        self._resource_settings = rs
 
     @property
     def si_settings(self):


### PR DESCRIPTION
Fixes #9687

This PR adds a `RedpandaServiceBase` class for `RedpandaService` to inherit from. This is a stepping-stone refactor in preparation for addressing issue #9709. A follow-up PR will add a class like `RedpandaK8sService` defined that inherits from `RedpandaServiceBase` and overrides the methods required to operate on a k8s deployment.

There should be no functionality change in this PR in regards to how the tests are run today.

To limit the scope of this refactor, i've only added the public methods In the `RedpandaServiceBase` class that need override based on what is used by the tests in PR https://github.com/redpanda-data/redpanda/pull/9535

The new `RedpandaServiceBase` class has these methods that need to be overridden in its sublcass:
* start_node
* stop_node
* clean_node
* get_node_memory_mb
* get_node_cpu_count
* get_node_disk_free
* lsof_node
* node_id
* set_cluster_config

And these methods look to be generic enough to be moved from `RedpandaService` into `RedpandaServiceBase` class:
* set_extra_rp_conf
* set_si_settings
* add_extra_rp_conf
* metrics
* metric_sum
* healthy
* partitions
* restart_nodes
* rolling_restart_nodes
* set_resource_settings

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
