### PR TITLE
cloud_storage: fix usage bytes accounting

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -480,6 +480,8 @@ bool partition_manifest::contains(const segment_name& name) const {
 void partition_manifest::delete_replaced_segments() { _replaced.clear(); }
 
 bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
+    const auto previous_start_offset = _start_offset;
+
     if (new_start_offset > _start_offset && !_segments.empty()) {
         auto it = _segments.upper_bound(new_start_offset);
         if (it == _segments.begin()) {
@@ -491,14 +493,44 @@ bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
             new_head_segment = std::next(new_head_segment);
         }
 
-        if (new_head_segment == _segments.end()) {
-            _start_offset = new_start_offset;
-        } else {
-            _start_offset = new_head_segment->second.base_offset;
+        model::offset advanced_start_offset
+          = new_head_segment == end() ? new_start_offset
+                                      : new_head_segment->second.base_offset;
+
+        if (previous_start_offset > advanced_start_offset) {
+            vlog(
+              cst_log.error,
+              "Previous start offset is greater than the new one: "
+              "previous_start_offset={}, computed_new_start_offset={}, "
+              "requested_new_start_offset={}",
+              previous_start_offset,
+              advanced_start_offset,
+              new_start_offset);
+            return false;
         }
 
-        for (auto iter = _segments.begin(); iter != new_head_segment; ++iter) {
-            subtract_from_cloud_log_size(iter->second.size_bytes);
+        _start_offset = advanced_start_offset;
+
+        auto previous_head_segment = segment_containing(previous_start_offset);
+        if (previous_head_segment == end()) {
+            // This branch should never be taken. It indicates that the
+            // in-memory manifest may be is in some sort of inconsistent state.
+            vlog(
+              cst_log.error,
+              "Previous start offset is not within segment in "
+              "manifest for {}: previous_start_offset={}",
+              _ntp,
+              previous_start_offset);
+            previous_head_segment = _segments.begin();
+        }
+
+        // Note that we start subtracting from the cloud log size from the
+        // previous head segments. This is required in order to account for
+        // the case when two `truncate` commands are applied sequentially,
+        // without a `cleanup_metadata` command in between to trim the list of
+        // segments.
+        for (auto it = previous_head_segment; it != new_head_segment; ++it) {
+            subtract_from_cloud_log_size(it->second.size_bytes);
         }
 
         return true;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -165,7 +165,12 @@ public:
               nm.name);
             nm.meta.segment_term = maybe_key->term;
             _segments.insert(std::make_pair(nm.meta.base_offset, nm.meta));
-            _cloud_log_size_bytes += nm.meta.size_bytes;
+
+            if (
+              nm.meta.base_offset >= _start_offset
+              && nm.meta.committed_offset <= _last_offset) {
+                _cloud_log_size_bytes += nm.meta.size_bytes;
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes two issues with the accounting of the total size for the cloud log.

1. Double truncations
```
Previously, when advancing the start offset
(`partition_manifest::advance_start_offset`), we would always subtract
the size of all present segments which are below the new start offset
from the total cloud log size. This works correctly only if there is a
`cleanup_metadata` command between every two consecutive `truncate`
commands. Otherwise, the segments in the manifest which are below the
start offset remain the same and we will subtract the ones from the
first `truncate` twice.
```
2. Recovery where the last command in the snapshot is a `truncate`
```
Previously, when the state of archival metadata STM was recovered from a
snapshot, the total size of the cloud log was computed as the sum of all
segments which are not in the replaced list. This is incorrect if the
last command included in the snapshot is a `truncate`, as it causes
segments that are not accesible by fetch requests to be included in the
total size.
```

In both cases, the fix is to disregard segments below the start offset.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
