### PR TITLE
archival: don't instantiate merger on read replicas

### DIFF
--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -43,7 +43,12 @@ adjacent_segment_merger::adjacent_segment_merger(
   , _target_segment_size(
       config::shard_local_cfg().cloud_storage_segment_size_target.bind())
   , _min_segment_size(
-      config::shard_local_cfg().cloud_storage_segment_size_min.bind()) {}
+      config::shard_local_cfg().cloud_storage_segment_size_min.bind()) {
+    vassert(
+      !_archiver.ntp_config().is_read_replica_mode_enabled(),
+      "Constructed adjacent segment merger on read replica {}",
+      _archiver.get_ntp());
+}
 
 ss::future<> adjacent_segment_merger::stop() { return _gate.close(); }
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -56,7 +56,9 @@ static std::unique_ptr<adjacent_segment_merger>
 maybe_make_adjacent_segment_merger(
   ntp_archiver& self, retry_chain_logger& log, const storage::ntp_config& cfg) {
     std::unique_ptr<adjacent_segment_merger> result = nullptr;
-    if (cfg.is_archival_enabled() && !cfg.is_compacted()) {
+    if (
+      cfg.is_archival_enabled() && !cfg.is_compacted()
+      && !cfg.is_read_replica_mode_enabled()) {
         result = std::make_unique<adjacent_segment_merger>(self, log, true);
         result->set_enabled(config::shard_local_cfg()
                               .cloud_storage_enable_segment_merging.value());
@@ -104,9 +106,7 @@ ntp_archiver::ntp_archiver(
     // Override bucket for read-replica
     if (_parent.is_read_replica_mode_enabled()) {
         _bucket_override = _parent.get_read_replica_bucket();
-    }
-
-    if (
+    } else if (
       parent.log().config().is_archival_enabled()
       && !parent.log().config().is_compacted()) {
         _segment_merging_enabled.watch([this] {

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -247,6 +247,10 @@ public:
     /// it will resume uploads.
     void complete_transfer_leadership();
 
+    const storage::ntp_config& ntp_config() const {
+        return _parent.log().config();
+    }
+
 private:
     ss::future<bool> do_upload_local(
       upload_candidate_with_locks candidate,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -494,15 +494,18 @@ void partition::maybe_construct_archiver() {
     // NOTE: construct and archiver even if shadow indexing isn't enabled, e.g.
     // in the case of read replicas -- we still need the archiver to drive
     // manifest updates, etc.
+    auto& ntp_config = _raft->log().config();
     if (
       config::shard_local_cfg().cloud_storage_enabled()
       && _cloud_storage_api.local_is_initialized()
       && _raft->ntp().ns == model::kafka_namespace
-      && (_raft->log().config().is_archival_enabled() || _raft->log().config().is_read_replica_mode_enabled())) {
+      && (ntp_config.is_archival_enabled() || ntp_config.is_read_replica_mode_enabled())) {
         _archiver = std::make_unique<archival::ntp_archiver>(
-          log().config(), _archival_conf, _cloud_storage_api.local(), *this);
-        _upload_housekeeping.local().register_jobs(
-          _archiver->get_housekeeping_jobs());
+          ntp_config, _archival_conf, _cloud_storage_api.local(), *this);
+        if (!ntp_config.is_read_replica_mode_enabled()) {
+            _upload_housekeeping.local().register_jobs(
+              _archiver->get_housekeeping_jobs());
+        }
     }
 }
 


### PR DESCRIPTION
Read replicas should perform no mutations on storage state. We previously instantiated a segment merger and register

I just noticed this running in read replica tests; I haven't see this actually merge anything locally, but I also don't see why read replicas _wouldn't_ merge anything, if the right upload settings were set.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Fixed a bug in which the segment merging could run from read replicas.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
