### PR TITLE
archival/cloud_storage: Fix sname format tests

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -365,7 +365,7 @@ FIXTURE_TEST(test_sname_derivation, archival_metadata_stm_base_fixture) {
         .base_offset = model::offset(0),
         .committed_offset = model::offset(99),
         .archiver_term = model::term_id(1),
-        .segment_term = model::term_id(1),
+        .segment_term = model::term_id(2),
         .sname_format = cloud_storage::segment_name_format::v1,
       });
 
@@ -375,7 +375,7 @@ FIXTURE_TEST(test_sname_derivation, archival_metadata_stm_base_fixture) {
         .base_offset = model::offset(100),
         .committed_offset = model::offset(199),
         .archiver_term = model::term_id(1),
-        .segment_term = model::term_id(1),
+        .segment_term = model::term_id(2),
         .sname_format = cloud_storage::segment_name_format::v2,
       });
 
@@ -385,7 +385,7 @@ FIXTURE_TEST(test_sname_derivation, archival_metadata_stm_base_fixture) {
         .base_offset = model::offset(200),
         .committed_offset = model::offset(299),
         .archiver_term = model::term_id(1),
-        .segment_term = model::term_id(1),
+        .segment_term = model::term_id(2),
         .sname_format = cloud_storage::segment_name_format::v3,
       });
 

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -994,6 +994,7 @@ SEASTAR_THREAD_TEST_CASE(test_replaced_sname_format_version) {
         .size_bytes = 0,
         .base_offset = model::offset{10},
         .committed_offset = model::offset{19},
+        .segment_term = model::term_id{3},
       });
     m.add(
       segment_name("20-1-v1.log"),
@@ -1001,6 +1002,7 @@ SEASTAR_THREAD_TEST_CASE(test_replaced_sname_format_version) {
         .size_bytes = 1,
         .base_offset = model::offset{20},
         .committed_offset = model::offset{29},
+        .segment_term = model::term_id{3},
       });
     m.add(
       segment_name("30-1-v1.log"),
@@ -1008,6 +1010,7 @@ SEASTAR_THREAD_TEST_CASE(test_replaced_sname_format_version) {
         .size_bytes = 0,
         .base_offset = model::offset{30},
         .committed_offset = model::offset{39},
+        .segment_term = model::term_id{3},
         .sname_format = segment_name_format::v2,
       });
     m.add(
@@ -1016,6 +1019,7 @@ SEASTAR_THREAD_TEST_CASE(test_replaced_sname_format_version) {
         .size_bytes = 0,
         .base_offset = model::offset{40},
         .committed_offset = model::offset{49},
+        .segment_term = model::term_id{3},
         .sname_format = segment_name_format::v3,
       });
 


### PR DESCRIPTION
The segment name format tests relied on re-adding the same segment to the manifest to test the names for replaced segments. Since there are now checks in place to prohibit adding the same segment to a manifest, these tests need to be adjusted to change the segment term.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

