### PR TITLE
schema_registry: Allow a schema id and version to be supplied

### DIFF
--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -136,6 +136,8 @@ struct reply_error_category final : std::error_category {
             return "Invalid compatibility level";
         case reply_error_code::subject_version_has_references:
             return "One or more references exist to the schema";
+        case reply_error_code::subject_version_schema_id_already_exists:
+            return "Schema already registered with another id";
         case reply_error_code::write_collision:
             return "write_collision";
         case reply_error_code::zookeeper_error:

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -134,6 +134,8 @@ struct reply_error_category final : std::error_category {
             return "Invalid schema version";
         case reply_error_code::compatibility_level_invalid:
             return "Invalid compatibility level";
+        case reply_error_code::subject_version_operaton_not_permitted:
+            return "Overwrite new schema is not permitted.";
         case reply_error_code::subject_version_has_references:
             return "One or more references exist to the schema";
         case reply_error_code::subject_version_schema_id_already_exists:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -82,6 +82,7 @@ enum class reply_error_code : uint16_t {
     schema_version_invalid = 42202,
     compatibility_level_invalid = 42203,
     subject_version_has_references = 42206,
+    subject_version_schema_id_already_exists = 42207,
     write_collision = 50301,
     zookeeper_error = 50001,
     kafka_error = 50002,

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -81,6 +81,7 @@ enum class reply_error_code : uint16_t {
     schema_empty = 42201,
     schema_version_invalid = 42202,
     compatibility_level_invalid = 42203,
+    subject_version_operaton_not_permitted = 42205,
     subject_version_has_references = 42206,
     subject_version_schema_id_already_exists = 42207,
     write_collision = 50301,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -50,6 +50,8 @@ struct error_category final : std::error_category {
                    "permanently";
         case error_code::subject_version_not_deleted:
             return "Version not deleted before being permanently deleted";
+        case error_code::subject_version_operaton_not_permitted:
+            return "Overwrite new schema is not permitted.";
         case error_code::subject_version_has_references:
             return "One or more references exist to the schema";
         case error_code::subject_version_schema_id_already_exists:
@@ -96,6 +98,9 @@ struct error_category final : std::error_category {
             return reply_error_code::schema_empty; // 42201
         case error_code::schema_version_invalid:
             return reply_error_code::schema_version_invalid; // 42202
+        case error_code::subject_version_operaton_not_permitted:
+            return reply_error_code::
+              subject_version_operaton_not_permitted; // 42205
         case error_code::subject_version_has_references:
             return reply_error_code::subject_version_has_references; // 42206
         case error_code::subject_version_schema_id_already_exists:

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -52,6 +52,8 @@ struct error_category final : std::error_category {
             return "Version not deleted before being permanently deleted";
         case error_code::subject_version_has_references:
             return "One or more references exist to the schema";
+        case error_code::subject_version_schema_id_already_exists:
+            return "Schema already registered with another id";
         case error_code::subject_schema_invalid:
             return "Error while looking up schema under subject";
         case error_code::write_collision:
@@ -96,6 +98,9 @@ struct error_category final : std::error_category {
             return reply_error_code::schema_version_invalid; // 42202
         case error_code::subject_version_has_references:
             return reply_error_code::subject_version_has_references; // 42206
+        case error_code::subject_version_schema_id_already_exists:
+            return reply_error_code::
+              subject_version_schema_id_already_exists; // 42207
         case error_code::schema_incompatible:
             return reply_error_code::conflict; // 409
         case error_code::topic_parse_error:

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -28,6 +28,7 @@ enum class error_code {
     subject_not_deleted,
     subject_version_soft_deleted,
     subject_version_not_deleted,
+    subject_version_operaton_not_permitted,
     subject_version_has_references,
     subject_version_schema_id_already_exists,
     subject_schema_invalid,

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -29,6 +29,7 @@ enum class error_code {
     subject_version_soft_deleted,
     subject_version_not_deleted,
     subject_version_has_references,
+    subject_version_schema_id_already_exists,
     subject_schema_invalid,
     write_collision,
     topic_parse_error,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -323,8 +323,13 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
       rq.req->content.data(), post_subject_versions_request_handler<>{sub});
     rq.req.reset();
 
-    auto schema = co_await rq.service().schema_store().make_canonical_schema(
-      std::move(unparsed));
+    subject_schema schema{
+      co_await rq.service().schema_store().make_canonical_schema(
+        std::move(unparsed)),
+      invalid_schema_version,
+      invalid_schema_id,
+      is_deleted::no};
+
     auto schema_id = co_await rq.service().writer().write_subject_version(
       std::move(schema));
 

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -288,7 +288,7 @@ post_subject(server::request_t rq, server::reply_t rp) {
         auto unparsed = ppj::rjson_parse(
           rq.req->content.data(), post_subject_versions_request_handler<>{sub});
         schema = co_await rq.service().schema_store().make_canonical_schema(
-          std::move(unparsed));
+          std::move(unparsed.def));
     } catch (const exception& e) {
         if (e.code() == error_code::schema_empty) {
             throw as_exception(invalid_subject_schema(sub));
@@ -325,9 +325,9 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
 
     subject_schema schema{
       co_await rq.service().schema_store().make_canonical_schema(
-        std::move(unparsed)),
-      invalid_schema_version,
-      invalid_schema_id,
+        std::move(unparsed.def)),
+      unparsed.version.value_or(invalid_schema_version),
+      unparsed.id.value_or(invalid_schema_id),
       is_deleted::no};
 
     auto schema_id = co_await rq.service().writer().write_subject_version(
@@ -494,14 +494,14 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     vlog(
       plog.info,
       "compatibility_subject_version: subject: {}, version: {}",
-      unparsed.sub(),
+      unparsed.def.sub(),
       ver);
     auto version = invalid_schema_version;
     if (ver == "latest") {
         auto versions = co_await rq.service().schema_store().get_versions(
-          unparsed.sub(), include_deleted::no);
+          unparsed.def.sub(), include_deleted::no);
         if (versions.empty()) {
-            throw as_exception(not_found(unparsed.sub(), version));
+            throw as_exception(not_found(unparsed.def.sub(), version));
         }
         version = versions.back();
     } else {
@@ -509,7 +509,7 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     }
 
     auto schema = co_await rq.service().schema_store().make_canonical_schema(
-      std::move(unparsed));
+      std::move(unparsed.def));
     auto get_res = co_await get_or_load(rq, [&rq, &schema, version]() {
         return rq.service().schema_store().is_compatible(version, schema);
     });

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -9,14 +9,20 @@
 
 #include "pandaproxy/schema_registry/requests/post_subject_versions.h"
 
+#include "pandaproxy/schema_registry/types.h"
 #include "seastarx.h"
 
 #include <seastar/testing/thread_test_case.hh>
+
+#include <fmt/ostream.h>
 
 #include <type_traits>
 
 namespace ppj = pandaproxy::json;
 namespace pps = pandaproxy::schema_registry;
+
+using parse_result
+  = pps::post_subject_versions_request_handler<>::rjson_parse_result;
 
 SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
     const ss::sstring escaped_schema_def{
@@ -40,24 +46,35 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
   ]
 })"};
     const pps::subject sub{"test_subject"};
-    const pps::unparsed_schema expected{
-      sub,
-      expected_schema_def,
-      {{.name{"com.acme.Referenced"},
-        .sub{pps::subject{"childSubject"}},
-        .version{pps::schema_version{1}}}}};
+    const parse_result expected{
+      {sub,
+       expected_schema_def,
+       {{.name{"com.acme.Referenced"},
+         .sub{pps::subject{"childSubject"}},
+         .version{pps::schema_version{1}}}}},
+      std::nullopt,
+      std::nullopt};
 
     auto result{ppj::rjson_parse(
       payload.data(), pps::post_subject_versions_request_handler{sub})};
 
     // canonicalisation now requires a sharded_store, for now, minify.
     // NOLINTBEGIN(bugprone-use-after-move)
-    result = {
-      std::move(result).sub(),
+    result.def = {
+      std::move(result.def).sub(),
       pps::unparsed_schema_definition{
-        ppj::minify(result.def().raw()()), pps::schema_type::avro},
-      std::move(result).refs()};
+        ppj::minify(result.def.def().raw()()), pps::schema_type::avro},
+      std::move(result.def).refs()};
     // NOLINTEND(bugprone-use-after-move)
 
-    BOOST_REQUIRE_EQUAL(expected, result);
+    BOOST_REQUIRE_EQUAL(expected.def, result.def);
+    BOOST_REQUIRE_EQUAL(expected.id.has_value(), result.id.has_value());
+    if (expected.id.has_value()) {
+        BOOST_REQUIRE_EQUAL(*expected.id, *result.id);
+    }
+    BOOST_REQUIRE_EQUAL(
+      expected.version.has_value(), result.version.has_value());
+    if (expected.version.has_value()) {
+        BOOST_REQUIRE_EQUAL(*expected.version, *result.version);
+    }
 }

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -42,7 +42,7 @@ public:
     // API for readers: notify us when they have read and applied an offset
     ss::future<> advance_offset(model::offset offset);
 
-    ss::future<schema_id> write_subject_version(canonical_schema ref);
+    ss::future<schema_id> write_subject_version(subject_schema schema);
 
     ss::future<bool>
     write_config(std::optional<subject> sub, compatibility_level compat);
@@ -67,7 +67,7 @@ private:
     void advance_offset_inner(model::offset offset);
 
     ss::future<std::optional<schema_id>> do_write_subject_version(
-      canonical_schema ref, model::offset write_at, seq_writer& seq);
+      subject_schema schema, model::offset write_at, seq_writer& seq);
 
     ss::future<std::optional<bool>> do_write_config(
       std::optional<subject> sub,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -189,8 +189,13 @@ sharded_store::project_ids(subject_schema schema) {
           return s.project_version(sub, id);
       });
 
+    const bool is_new = v_id.has_value();
+    if (is_new && schema.version != invalid_schema_version) {
+        v_id = schema.version;
+    }
+
     co_return insert_result{
-      v_id.value_or(invalid_schema_version), s_id.value(), v_id.has_value()};
+      v_id.value_or(invalid_schema_version), s_id.value(), is_new};
 }
 
 ss::future<bool> sharded_store::upsert(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -161,6 +161,13 @@ sharded_store::project_ids(subject_schema schema) {
                 "Schema already registered with id {} instead of input id {}",
                 s_id.value()(),
                 schema.id())));
+        } else if (co_await has_schema(schema.id)) {
+            // The supplied id already exists, but the schema is different
+            co_return ss::coroutine::return_exception(exception(
+              error_code::subject_version_schema_id_already_exists,
+              fmt::format(
+                "Overwrite new schema with id {} is not permitted.",
+                schema.id())));
         } else {
             // Use the supplied id
             s_id = schema.id;
@@ -203,6 +210,13 @@ ss::future<bool> sharded_store::upsert(
       version,
       id,
       deleted);
+}
+
+ss::future<bool> sharded_store::has_schema(schema_id id) {
+    co_return co_await _store.invoke_on(
+      shard_for(id), _smp_opts, [id](store& s) {
+          return s.get_schema_definition(id).has_value();
+      });
 }
 
 ss::future<subject_schema> sharded_store::has_schema(canonical_schema schema) {

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -16,6 +16,7 @@
 #include "kafka/protocol/errors.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/avro.h"
+#include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/protobuf.h"
@@ -26,6 +27,9 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/smp.hh>
+#include <seastar/coroutine/exception.hh>
+
+#include <fmt/core.h>
 
 #include <functional>
 
@@ -113,33 +117,36 @@ sharded_store::make_valid_schema(canonical_schema schema) {
 }
 
 ss::future<sharded_store::insert_result>
-sharded_store::project_ids(canonical_schema schema) {
+sharded_store::project_ids(subject_schema schema) {
     // Validate the schema (may throw)
-    co_await validate_schema(schema);
+    co_await validate_schema(schema.schema);
 
     // Check compatibility
     std::vector<schema_version> versions;
     try {
-        versions = co_await get_versions(schema.sub(), include_deleted::no);
+        versions = co_await get_versions(
+          schema.schema.sub(), include_deleted::no);
     } catch (const exception& e) {
         if (e.code() != error_code::subject_not_found) {
             throw;
         }
     }
     if (!versions.empty()) {
-        auto compat = co_await is_compatible(versions.back(), schema);
+        auto compat = co_await is_compatible(versions.back(), schema.schema);
         if (!compat) {
             throw exception(
               error_code::schema_incompatible,
               fmt::format(
                 "Schema being registered is incompatible with an earlier "
                 "schema for subject \"{}\"",
-                schema.sub()));
+                schema.schema.sub()));
         }
     }
 
     // Figure out if the definition already exists
-    auto map = [&schema](store& s) { return s.get_schema_id(schema.def()); };
+    auto map = [&schema](store& s) {
+        return s.get_schema_id(schema.schema.def());
+    };
     auto reduce = [](
                     std::optional<schema_id> acc,
                     std::optional<schema_id> s_id) { return acc ? acc : s_id; };
@@ -154,9 +161,11 @@ sharded_store::project_ids(canonical_schema schema) {
         vlog(plog.debug, "project_ids: existing ID {}", s_id.value());
     }
 
-    auto sub_shard{shard_for(schema.sub())};
+    auto sub_shard{shard_for(schema.schema.sub())};
     auto v_id = co_await _store.invoke_on(
-      sub_shard, _smp_opts, [sub{schema.sub()}, id{s_id.value()}](store& s) {
+      sub_shard,
+      _smp_opts,
+      [sub{schema.schema.sub()}, id{s_id.value()}](store& s) {
           return s.project_version(sub, id);
       });
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -153,7 +153,20 @@ sharded_store::project_ids(subject_schema schema) {
     auto s_id = co_await _store.map_reduce0(
       map, std::optional<schema_id>{}, reduce);
 
-    if (!s_id) {
+    if (schema.id != invalid_schema_id) {
+        if (s_id.has_value() && s_id != schema.id) {
+            co_return ss::coroutine::return_exception(exception(
+              error_code::subject_version_schema_id_already_exists,
+              fmt::format(
+                "Schema already registered with id {} instead of input id {}",
+                s_id.value()(),
+                schema.id())));
+        } else {
+            // Use the supplied id
+            s_id = schema.id;
+            vlog(plog.debug, "project_ids: using supplied ID {}", s_id.value());
+        }
+    } else if (!s_id) {
         // New schema, project an ID for it.
         s_id = co_await project_schema_id();
         vlog(plog.debug, "project_ids: projected new ID {}", s_id.value());

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -41,7 +41,7 @@ public:
         bool inserted;
     };
 
-    ss::future<insert_result> project_ids(canonical_schema schema);
+    ss::future<insert_result> project_ids(subject_schema schema);
 
     ss::future<bool> upsert(
       seq_marker marker,

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -50,6 +50,7 @@ public:
       schema_version version,
       is_deleted deleted);
 
+    ss::future<bool> has_schema(schema_id id);
     ss::future<subject_schema> has_schema(canonical_schema schema);
 
     ///\brief Return a schema definition by id.

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -36,7 +36,5 @@ rp_test(
     delete_subject_endpoints.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application
-  # TODO(Ben): Make schema_registry properly sharded
-  ARGS "-- -c 1"
   LABELS pandaproxy
 )

--- a/src/v/pandaproxy/schema_registry/test/client_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/client_utils.h
@@ -13,6 +13,7 @@
 #include "json/document.h"
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/types.h"
+#include "pandaproxy/reply.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/test/utils.h"
 
@@ -30,6 +31,18 @@ inline iobuf make_body(const ss::sstring& body) {
     iobuf buf;
     buf.append(body.data(), body.size());
     return buf;
+}
+
+inline auto put_config(
+  http::client& client, const pps::subject& sub, pps::compatibility_level lvl) {
+    return http_request(
+      client,
+      fmt::format("/config/{}", sub()),
+      make_body(
+        fmt::format(R"({{"compatibility": "{}"}})", to_string_view(lvl))),
+      boost::beast::http::verb::put,
+      ppj::serialization_format::schema_registry_v1_json,
+      ppj::serialization_format::schema_registry_v1_json);
 }
 
 inline auto post_schema(
@@ -116,4 +129,38 @@ inline int get_body_error_code(const ss::sstring& body) {
           ppj::error_code::invalid_json, "error_code not an int"};
     }
     return obj["error_code"].Get<int>();
+}
+
+inline ppj::error_body get_error_body(const ss::sstring& body) {
+    json::Document doc;
+    if (doc.Parse(body).HasParseError()) {
+        throw ppj::parse_error(doc.GetErrorOffset());
+    }
+    if (!doc.IsObject()) {
+        throw ppj::exception_base{
+          ppj::error_code::invalid_json, "Body is not an object"};
+    }
+    auto obj = doc.GetObject();
+    auto e_it = obj.FindMember("error_code");
+    if (e_it == obj.MemberEnd()) {
+        throw ppj::exception_base{
+          ppj::error_code::invalid_json, "error_code field doesn't exist"};
+    }
+    if (!e_it->value.IsInt()) {
+        throw ppj::exception_base{
+          ppj::error_code::invalid_json, "error_code field not an int"};
+    }
+
+    auto m_it = obj.FindMember("message");
+    if (m_it == obj.MemberEnd()) {
+        throw ppj::exception_base{
+          ppj::error_code::invalid_json, "message field doesn't exist"};
+    }
+    if (!m_it->value.IsString()) {
+        throw ppj::exception_base{
+          ppj::error_code::invalid_json, "message field not a string"};
+    }
+    return {
+      pp::reply_error_code{static_cast<uint16_t>(e_it->value.Get<unsigned>())},
+      m_it->value.Get<std::string>()};
 }

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -212,6 +212,235 @@ FIXTURE_TEST(
 }
 
 FIXTURE_TEST(
+  schema_registry_post_subjects_subject_version_with_version_no_compat,
+  pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Connecting client");
+    auto client = make_schema_reg_client();
+
+    const ss::sstring schema_string_v2{
+      R"({
+  "schema": "\"string\"",
+  "version": 2,
+  "schemaType": "AVRO"
+})"};
+
+    const ss::sstring schema_int_v2{
+      R"({
+  "schema": "\"int\"",
+  "version": 2,
+  "schemaType": "AVRO"
+})"};
+
+    const ss::sstring schema_int_v3{
+      R"({
+  "schema": "\"int\"",
+  "version": 3,
+  "schemaType": "AVRO"
+})"};
+
+    const pps::subject subject{"test-key"};
+    put_config(client, subject, pps::compatibility_level::none);
+
+    {
+        info("Post schema as v2 (higher than next_version)");
+        auto res = post_schema(client, subject, schema_string_v2);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{2}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Repost schema v2 (expect success, existing schema id)");
+        auto res = post_schema(client, subject, schema_string_v2);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{2}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Overwrite schema v2 (expect success, new schema id)");
+        auto res = post_schema(client, subject, schema_int_v2);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(res.body, R"({"id":2})");
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{2}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+
+        res = http_request(
+          client,
+          fmt::format("/subjects/{}/versions/2/schema", subject()),
+          boost::beast::http::verb::get,
+          ppj::serialization_format::schema_registry_v1_json,
+          ppj::serialization_format::schema_registry_v1_json);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(res.body, R"("int")");
+    }
+
+    {
+        info("Post existing schema as v3 (expect existing schema id, no new "
+             "version)");
+        auto res = post_schema(client, subject, schema_int_v3);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(res.body, R"({"id":2})");
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{2}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+}
+
+FIXTURE_TEST(
+  schema_registry_post_subjects_subject_version_with_version_with_compat,
+  pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Connecting client");
+    auto client = make_schema_reg_client();
+
+    const ss::sstring schema_v2{
+      R"({
+  "schema": "{\"type\": \"record\", \"name\": \"r1\", \"fields\" : [{\"name\": \"f1\", \"type\": \"string\"}]}",
+  "version": 2,
+  "schemaType": "AVRO"
+})"};
+
+    const ss::sstring schema_v3_no_default{
+      R"({
+  "schema": "{\"type\": \"record\", \"name\": \"r1\", \"fields\" : [{\"name\": \"f1\", \"type\": \"string\"}, {\"name\": \"f2\", \"type\": \"string\"}]}",
+  "version": 3,
+  "schemaType": "AVRO"
+})"};
+
+    const ss::sstring schema_v3{
+      R"({
+  "schema": "{\"type\": \"record\", \"name\": \"r1\", \"fields\" : [{\"name\": \"f1\", \"type\": \"string\"}, {\"name\": \"f2\", \"type\": \"string\", \"default\": \"f2\"}]}",
+  "version": 3,
+  "schemaType": "AVRO"
+})"};
+
+    pps::subject subject{"in-version-order"};
+    put_config(client, subject, pps::compatibility_level::backward);
+
+    {
+        info("Post schema v2");
+        auto res = post_schema(client, subject, schema_v2);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{2}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Post schema v3_no_default (expect conflict)");
+        auto res = post_schema(client, subject, schema_v3_no_default);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::conflict);
+    }
+
+    {
+        info("Post schema v3");
+        auto res = post_schema(client, subject, schema_v3);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{
+          pps::schema_version{2}, pps::schema_version{3}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    subject = pps::subject{"in-reverse-order"};
+    put_config(client, subject, pps::compatibility_level::backward);
+
+    {
+        info("Post schema v3_no_default");
+        auto res = post_schema(client, subject, schema_v3_no_default);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{3}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Post schema v2 (expect success, despite incompatibility)");
+        auto res = post_schema(client, subject, schema_v2);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{
+          pps::schema_version{2}, pps::schema_version{3}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Post schema v3 (expect success)");
+        auto res = post_schema(client, subject, schema_v3);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        res = get_subject_versions(client, subject);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{
+          pps::schema_version{2}, pps::schema_version{3}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+}
+
+FIXTURE_TEST(
   schema_registry_post_subjects_subject_version_invalid_payload,
   pandaproxy_test_fixture) {
     using namespace std::chrono_literals;


### PR DESCRIPTION
When inserting a schema, allow a schema id and a schema version to be supplied.

This should only be allowed when the subject is in mode `IMPORT`, but mode is not currently supported.

For example:
```bash
curl -X POST http://localhost:8081/subjects/test_versions_other/versions -H 'Content-Type: application/json' -d '{
  "schema": "\"int\"",
  "version": 3,
  "id": 4,
  "schemaType": "AVRO"
}'
```

Fixes #8899 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Improvements

* schema_registry: Allow a schema id and version to be supplied
