### PR TITLE
Cluster-wide rate limits: avoid log pollution by quota balancer

### DIFF
--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -370,7 +370,6 @@ ss::future<> snc_quota_manager::quota_balancer_step() {
     const auto units = co_await _balancer_mx.get_units();
     _balancer_gate.check();
     _balancer_timer_last_ran = ss::lowres_clock::now();
-    vlog(klog.trace, "qb - Step");
     _probe.rec_balancer_step();
 
     // determine the borrowers and whether any balancing is needed now
@@ -391,14 +390,14 @@ ss::future<> snc_quota_manager::quota_balancer_step() {
       [](const ingress_egress_state<shard_count_t>& s, const borrower_t& b) {
           return s + b.borrowers_count;
       });
+    if (is_zero(borrowers_count)) {
+        co_return;
+    }
     vlog(
       klog.trace,
       "qb - Borrowers count: {}, borrowers:",
       borrowers_count,
       borrowers);
-    if (is_zero(borrowers_count)) {
-        co_return;
-    }
 
     // collect quota from lenders
     const ingress_egress_state<quota_t> collected


### PR DESCRIPTION
Quota balancer used to dump two lines to the log on every invocation, which is by default 0.75s. Although at TRACE level, that used to pollute the log with no reason.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Re #6453

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
