### PR TITLE
cloud_storage: Make tiered-storage disabled by default

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -334,8 +334,8 @@ class SISettings:
                  cloud_storage_api_endpoint: str = 'minio-s3',
                  cloud_storage_api_endpoint_port: int = 9000,
                  cloud_storage_cache_size: int = 160 * 1000000,
-                 cloud_storage_enable_remote_read: bool = True,
-                 cloud_storage_enable_remote_write: bool = True,
+                 cloud_storage_enable_remote_read: bool = False,
+                 cloud_storage_enable_remote_write: bool = False,
                  cloud_storage_max_connections: Optional[int] = None,
                  cloud_storage_disable_tls: bool = True,
                  cloud_storage_segment_max_upload_interval_sec: Optional[

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -143,7 +143,8 @@ class ArchivalTest(RedpandaTest):
     s3_topic_name = "panda-topic"
     topics = (TopicSpec(name=s3_topic_name,
                         partition_count=1,
-                        replication_factor=3), )
+                        replication_factor=3,
+                        redpanda_remote_write=True), )
 
     def __init__(self, test_context):
         self.si_settings = SISettings(test_context,

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -39,11 +39,11 @@ class EndToEndShadowIndexingBase(EndToEndTest):
 
     num_brokers = 3
 
-    topics = (TopicSpec(
-        name=s3_topic_name,
-        partition_count=1,
-        replication_factor=3,
-    ), )
+    topics = (TopicSpec(name=s3_topic_name,
+                        partition_count=1,
+                        replication_factor=3,
+                        redpanda_remote_read=True,
+                        redpanda_remote_write=True), )
 
     def __init__(self, test_context, extra_rp_conf=None, environment=None):
         super(EndToEndShadowIndexingBase,
@@ -129,7 +129,9 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         partition_count=1,
         replication_factor=3,
         cleanup_policy="compact,delete",
-        segment_bytes=EndToEndShadowIndexingBase.segment_size // 2), )
+        segment_bytes=EndToEndShadowIndexingBase.segment_size // 2,
+        redpanda_remote_read=True,
+        redpanda_remote_write=True), )
 
     def _prime_compacted_topic(self, segment_count):
         # Set compaction interval high at first, so we can get enough segments in log
@@ -309,7 +311,9 @@ class ShadowIndexingInfiniteRetentionTest(EndToEndShadowIndexingBase):
                         replication_factor=1,
                         retention_bytes=-1,
                         retention_ms=-1,
-                        segment_bytes=small_segment_size), )
+                        segment_bytes=small_segment_size,
+                        redpanda_remote_read=True,
+                        redpanda_remote_write=True), )
 
     def __init__(self, test_context):
         self.num_brokers = 1

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -16,7 +16,9 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
     topics = (TopicSpec(name='panda-topic',
                         partition_count=1,
                         replication_factor=3,
-                        cleanup_policy='compact,delete'), )
+                        cleanup_policy='compact,delete',
+                        redpanda_remote_read=True,
+                        redpanda_remote_write=True), )
 
     def __init__(self, test_context):
         super().__init__(test_context)


### PR DESCRIPTION
Disable 'cloud_storage_remote_read' and 'cloud_storage_remote_write' by default in ducktape tests to bring test setup closer to defaults in the field.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none