### PR TITLE
u/prefix_logger: reintroduce _prefix to prefix_logger::format

### DIFF
--- a/src/v/utils/prefix_logger.h
+++ b/src/v/utils/prefix_logger.h
@@ -61,8 +61,9 @@ public:
     template<typename... Args>
     ss::sstring format(const char* format, Args&&... args) const {
         auto line_fmt = ss::sstring("{} - ") + format;
-        return fmt::format(
+        return ssx::sformat(
           fmt::runtime(fmt::string_view(line_fmt.begin(), line_fmt.length())),
+          _prefix,
           std::forward<Args>(args)...);
     }
 


### PR DESCRIPTION
It got lost in 8c05afcb23ccfcb9405fbcedcde0a67186d8e186

Fixes https://github.com/redpanda-data/redpanda/issues/9689

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes
* none

