### PR TITLE
config: validate that strings are non-empty

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -344,7 +344,8 @@ configuration::configuration()
       "cluster_id",
       "Cluster identifier",
       {.needs_restart = needs_restart::no},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , disable_metrics(
       *this,
       "disable_metrics",
@@ -940,7 +941,8 @@ configuration::configuration()
       "sasl_kerberos_principal",
       "The primary of the Kerberos Service Principal Name (SPN) for Redpanda",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      "redpanda")
+      "redpanda",
+      &validate_non_empty_string_opt)
   , sasl_kerberos_principal_mapping(
       *this,
       "sasl_kerberos_principal_mapping",
@@ -1001,14 +1003,16 @@ configuration::configuration()
       "kafka_nodelete_topics",
       "Prevents the topics in the list from being deleted via the kafka api",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      {"__audit", "__consumer_offsets", "__redpanda_e2e_probe", "_schemas"})
+      {"__audit", "__consumer_offsets", "__redpanda_e2e_probe", "_schemas"},
+      &validate_non_empty_string_vec)
   , kafka_noproduce_topics(
       *this,
       "kafka_noproduce_topics",
       "Prevents the topics in the list from having message produced to them "
       "via the kafka api",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      {"__audit"})
+      {"__audit"},
+      &validate_non_empty_string_vec)
   , compaction_ctrl_update_interval_ms(
       *this,
       "compaction_ctrl_update_interval_ms",
@@ -1154,31 +1158,36 @@ configuration::configuration()
       "cloud_storage_access_key",
       "AWS access key",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_secret_key(
       *this,
       "cloud_storage_secret_key",
       "AWS secret key",
       {.visibility = visibility::user, .secret = is_secret::yes},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_region(
       *this,
       "cloud_storage_region",
       "AWS region that houses the bucket used for storage",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_bucket(
       *this,
       "cloud_storage_bucket",
       "AWS bucket that should be used to store data",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_api_endpoint(
       *this,
       "cloud_storage_api_endpoint",
       "Optional API endpoint",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_credentials_source(
       *this,
       "cloud_storage_credentials_source",
@@ -1238,7 +1247,8 @@ configuration::configuration()
       "Path to certificate that should be used to validate server certificate "
       "during TLS handshake",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_initial_backoff_ms(
       *this,
       "cloud_storage_initial_backoff_ms",
@@ -1383,14 +1393,16 @@ configuration::configuration()
       "cloud_storage_azure_storage_account",
       "The name of the Azure storage account to use with Tiered Storage",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_azure_container(
       *this,
       "cloud_storage_azure_container",
       "The name of the Azure container to use with Tiered Storage. Note that "
       "the container must belong to 'cloud_storage_azure_storage_account'",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_azure_shared_key(
       *this,
       "cloud_storage_azure_shared_key",
@@ -1401,7 +1413,8 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .visibility = visibility::user,
        .secret = is_secret::yes},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/tests/validator_tests.cc
+++ b/src/v/config/tests/validator_tests.cc
@@ -67,3 +67,19 @@ SEASTAR_THREAD_TEST_CASE(test_client_groups_byte_rate_quota_invalid_config) {
     result = config::validate_client_groups_byte_rate_quota(valid_config);
     BOOST_TEST(!result.has_value());
 }
+
+SEASTAR_THREAD_TEST_CASE(test_empty_string_vec) {
+    using config::validate_non_empty_string_vec;
+    BOOST_TEST(!(validate_non_empty_string_vec({"apple", "pear"}).has_value()));
+    BOOST_TEST(validate_non_empty_string_vec({"apple", ""}).has_value());
+    BOOST_TEST(validate_non_empty_string_vec({"", "pear"}).has_value());
+    BOOST_TEST(
+      validate_non_empty_string_vec({"apple", "", "pear"}).has_value());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_empty_string_opt) {
+    using config::validate_non_empty_string_opt;
+    BOOST_TEST(!validate_non_empty_string_opt(std::nullopt).has_value());
+    BOOST_TEST(!validate_non_empty_string_opt("apple").has_value());
+    BOOST_TEST(validate_non_empty_string_opt("").has_value());
+}

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -127,4 +127,22 @@ std::optional<ss::sstring> validate_0_to_1_ratio(const double d) {
     return std::nullopt;
 }
 
+std::optional<ss::sstring>
+validate_non_empty_string_vec(const std::vector<ss::sstring>& vs) {
+    for (const auto& s : vs) {
+        if (s.empty()) {
+            return "Empty strings are not valid in this collection";
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<ss::sstring>
+validate_non_empty_string_opt(const std::optional<ss::sstring>& os) {
+    if (os.has_value() && os.value().empty()) {
+        return "Empty string is not valid";
+    } else {
+        return std::nullopt;
+    }
+}
 }; // namespace config

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -35,4 +35,10 @@ validate_sasl_mechanisms(const std::vector<ss::sstring>& mechanisms);
 
 std::optional<ss::sstring> validate_0_to_1_ratio(const double d);
 
+std::optional<ss::sstring>
+validate_non_empty_string_vec(const std::vector<ss::sstring>&);
+
+std::optional<ss::sstring>
+validate_non_empty_string_opt(const std::optional<ss::sstring>&);
+
 }; // namespace config


### PR DESCRIPTION
Folks coming from Go may infer that "" is equivalent to null, but in our type system "" and std::nullopt are different.

To reduce risk of confusion, validate away empty strings for all the nullable and array string properties where an empty string doesn't make sense (like URIs)

Related: https://github.com/redpanda-data/redpanda/issues/9592

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* String configuration properties which ought not to be set to an empty string are now validated as such.  This reduces risk of issues from tools that might treat `""` equivalently to not setting a property.
