### PR TITLE
Remove defunct properties

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -7,13 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-# Redpanda Queue configuration file
-
-# organization and cluster_id help Vectorized identify your system.
-organization: ""
-cluster_id: ""
-
-license_key: ""
+# Redpanda configuration file
 
 redpanda:
   # Data directory where all the files will be stored.

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/uuid"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	vnet "github.com/redpanda-data/redpanda/src/go/rpk/pkg/net"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
@@ -238,13 +237,6 @@ func initNode(fs afero.Fs) *cobra.Command {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 			cfg = cfg.FileOrDefaults() // we modify fields in the raw file without writing env / flag overrides
-
-			// Don't reset the node's UUID if it has already been set.
-			if cfg.NodeUUID == "" {
-				id, err := uuid.NewUUID()
-				out.MaybeDie(err, "error creating nodeUUID: %v", err)
-				cfg.NodeUUID = id.String()
-			}
 
 			err = cfg.Write(fs)
 			out.MaybeDie(err, "error writing config file: %v", err)

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -22,7 +22,6 @@ type Config struct {
 	fileLocation string
 	rawFile      []byte
 
-	NodeUUID             string             `yaml:"node_uuid,omitempty" json:"node_uuid"`
 	Redpanda             RedpandaNodeConfig `yaml:"redpanda,omitempty" json:"redpanda"`
 	Rpk                  RpkConfig          `yaml:"rpk,omitempty" json:"rpk"`
 	Pandaproxy           *Pandaproxy        `yaml:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -23,9 +23,6 @@ type Config struct {
 	rawFile      []byte
 
 	NodeUUID             string             `yaml:"node_uuid,omitempty" json:"node_uuid"`
-	Organization         string             `yaml:"organization,omitempty" json:"organization"`
-	LicenseKey           string             `yaml:"license_key,omitempty" json:"license_key"`
-	ClusterID            string             `yaml:"cluster_id,omitempty" json:"cluster_id"`
 	Redpanda             RedpandaNodeConfig `yaml:"redpanda,omitempty" json:"redpanda"`
 	Rpk                  RpkConfig          `yaml:"rpk,omitempty" json:"rpk"`
 	Pandaproxy           *Pandaproxy        `yaml:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -298,7 +298,6 @@ func (ss *seedServers) UnmarshalYAML(n *yaml.Node) error {
 
 func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
-		NodeUUID             weakString         `yaml:"node_uuid"`
 		Redpanda             RedpandaNodeConfig `yaml:"redpanda"`
 		Rpk                  RpkConfig          `yaml:"rpk"`
 		Pandaproxy           *Pandaproxy        `yaml:"pandaproxy"`
@@ -311,7 +310,6 @@ func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 	if err := n.Decode(&internal); err != nil {
 		return err
 	}
-	c.NodeUUID = string(internal.NodeUUID)
 	c.Redpanda = internal.Redpanda
 	c.Rpk = internal.Rpk
 	c.Pandaproxy = internal.Pandaproxy

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -299,9 +299,6 @@ func (ss *seedServers) UnmarshalYAML(n *yaml.Node) error {
 func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
 		NodeUUID             weakString         `yaml:"node_uuid"`
-		Organization         weakString         `yaml:"organization"`
-		LicenseKey           weakString         `yaml:"license_key"`
-		ClusterID            weakString         `yaml:"cluster_id"`
 		Redpanda             RedpandaNodeConfig `yaml:"redpanda"`
 		Rpk                  RpkConfig          `yaml:"rpk"`
 		Pandaproxy           *Pandaproxy        `yaml:"pandaproxy"`
@@ -315,9 +312,6 @@ func (c *Config) UnmarshalYAML(n *yaml.Node) error {
 		return err
 	}
 	c.NodeUUID = string(internal.NodeUUID)
-	c.Organization = string(internal.Organization)
-	c.LicenseKey = string(internal.LicenseKey)
-	c.ClusterID = string(internal.ClusterID)
 	c.Redpanda = internal.Redpanda
 	c.Rpk = internal.Rpk
 	c.Pandaproxy = internal.Pandaproxy

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -858,9 +858,7 @@ func TestConfig_UnmarshalYAML(t *testing.T) {
 	}{
 		{
 			name: "Config file with normal types",
-			data: `organization: "my_organization"
-cluster_id: "cluster_id"
-node_uuid: "node_uuid"
+			data: `node_uuid: "node_uuid"
 redpanda:
   data_directory: "var/lib/redpanda/data"
   node_id: 1
@@ -982,9 +980,7 @@ rpk:
   tune_clocksource: true
 `,
 			exp: &Config{
-				Organization: "my_organization",
-				ClusterID:    "cluster_id",
-				NodeUUID:     "node_uuid",
+				NodeUUID: "node_uuid",
 				Redpanda: RedpandaNodeConfig{
 					Directory:      "var/lib/redpanda/data",
 					ID:             intPtr(1),
@@ -1088,9 +1084,7 @@ rpk:
 		},
 		{
 			name: "Config file with omitted node ID",
-			data: `organization: "my_organization"
-cluster_id: "cluster_id"
-node_uuid: "node_uuid"
+			data: `node_uuid: "node_uuid"
 redpanda:
   data_directory: "var/lib/redpanda/data"
   enable_admin_api: true
@@ -1136,9 +1130,7 @@ redpanda:
   rack: "rack-id"
 `,
 			exp: &Config{
-				Organization: "my_organization",
-				ClusterID:    "cluster_id",
-				NodeUUID:     "node_uuid",
+				NodeUUID: "node_uuid",
 				Redpanda: RedpandaNodeConfig{
 					Directory:      "var/lib/redpanda/data",
 					ID:             nil,
@@ -1182,9 +1174,7 @@ redpanda:
 		},
 		{
 			name: "Config file with weak types",
-			data: `organization: true
-cluster_id: "cluster_id"
-node_uuid: 124.42
+			data: `node_uuid: 124.42
 redpanda:
   data_directory: "var/lib/redpanda/data"
   node_id: 1
@@ -1312,9 +1302,7 @@ rpk:
   tune_clocksource: 1
 `,
 			exp: &Config{
-				Organization: "1",
-				ClusterID:    "cluster_id",
-				NodeUUID:     "124.42",
+				NodeUUID: "124.42",
 				Redpanda: RedpandaNodeConfig{
 					Directory:      "var/lib/redpanda/data",
 					ID:             intPtr(1),

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -858,7 +858,7 @@ func TestConfig_UnmarshalYAML(t *testing.T) {
 	}{
 		{
 			name: "Config file with normal types",
-			data: `node_uuid: "node_uuid"
+			data: `
 redpanda:
   data_directory: "var/lib/redpanda/data"
   node_id: 1
@@ -980,7 +980,6 @@ rpk:
   tune_clocksource: true
 `,
 			exp: &Config{
-				NodeUUID: "node_uuid",
 				Redpanda: RedpandaNodeConfig{
 					Directory:      "var/lib/redpanda/data",
 					ID:             intPtr(1),
@@ -1084,7 +1083,7 @@ rpk:
 		},
 		{
 			name: "Config file with omitted node ID",
-			data: `node_uuid: "node_uuid"
+			data: `
 redpanda:
   data_directory: "var/lib/redpanda/data"
   enable_admin_api: true
@@ -1130,7 +1129,6 @@ redpanda:
   rack: "rack-id"
 `,
 			exp: &Config{
-				NodeUUID: "node_uuid",
 				Redpanda: RedpandaNodeConfig{
 					Directory:      "var/lib/redpanda/data",
 					ID:             nil,
@@ -1174,7 +1172,7 @@ redpanda:
 		},
 		{
 			name: "Config file with weak types",
-			data: `node_uuid: 124.42
+			data: `
 redpanda:
   data_directory: "var/lib/redpanda/data"
   node_id: 1
@@ -1302,7 +1300,6 @@ rpk:
   tune_clocksource: 1
 `,
 			exp: &Config{
-				NodeUUID: "124.42",
 				Redpanda: RedpandaNodeConfig{
 					Directory:      "var/lib/redpanda/data",
 					ID:             intPtr(1),

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-organization: "vectorized"
-
 redpanda:
   developer_mode: true
   data_directory: "{{data_dir}}"

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -35,7 +35,7 @@ class RpkConfigTest(RedpandaTest):
         with tempfile.TemporaryDirectory() as d:
             node.account.copy_from(path, d)
             with open(os.path.join(d, path)) as f:
-                expected_out = '''# node_uuid: (the uuid is random so we don't compare it)
+                expected_out = '''
 pandaproxy: {}
 redpanda:
     data_directory: /var/lib/redpanda/data
@@ -58,12 +58,6 @@ schema_registry: {}
 
                 expected_config = yaml.full_load(expected_out)
                 actual_config = yaml.full_load(f.read())
-
-                assert actual_config['node_uuid'] is not None
-
-                # Delete 'node_uuid' so they can be compared (it's random so
-                # it's probably gonna be different each time)
-                del actual_config['node_uuid']
 
                 if actual_config != expected_config:
                     self.logger.error("Configs differ")


### PR DESCRIPTION
These properties are not used, and in some cases never were.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

