### PR TITLE
[v22.3.x] cloud_storage: fix HWM on read replicas

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -680,9 +680,7 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
     start_upload_offset = offset + model::offset(1);
     auto ot_state = _partition->get_offset_translator_state();
     auto delta = base - model::offset_cast(ot_state->from_log_offset(base));
-    auto delta_offset_end = upload.final_offset
-                            - model::offset_cast(
-                              ot_state->from_log_offset(upload.final_offset));
+    auto delta_offset_next = ot_state->next_offset_delta(upload.final_offset);
 
     // The upload is successful only if both segment and tx_range are uploaded.
     auto upl_fut
@@ -716,7 +714,7 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
         .ntp_revision = _rev,
         .archiver_term = _start_term,
         .segment_term = upload.term,
-        .delta_offset_end = delta_offset_end,
+        .delta_offset_end = delta_offset_next,
         .sname_format = cloud_storage::segment_name_format::v2,
       },
       .name = upload.exposed_name, .delta = offset - base,

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -250,6 +250,14 @@ const model::offset partition_manifest::get_last_offset() const {
     return _last_offset;
 }
 
+const std::optional<kafka::offset>
+partition_manifest::get_last_kafka_offset() const {
+    if (_segments.empty()) {
+        return std::nullopt;
+    }
+    return _segments.rbegin()->second.committed_kafka_offset();
+}
+
 const model::offset partition_manifest::get_insync_offset() const {
     return _insync_offset;
 }

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -251,11 +251,11 @@ const model::offset partition_manifest::get_last_offset() const {
 }
 
 const std::optional<kafka::offset>
-partition_manifest::get_last_kafka_offset() const {
+partition_manifest::get_next_kafka_offset() const {
     if (_segments.empty()) {
         return std::nullopt;
     }
-    return _segments.rbegin()->second.committed_kafka_offset();
+    return _segments.rbegin()->second.next_kafka_offset();
 }
 
 const model::offset partition_manifest::get_insync_offset() const {
@@ -325,7 +325,7 @@ partition_manifest::segment_containing(kafka::offset o) const {
         // check using delta_offset_end. If the field is not set then we
         // will return the last segment. This is OK since delta_offset_end
         // will always be set for new segments.
-        if (back->second.committed_kafka_offset() < o) {
+        if (back->second.next_kafka_offset() <= o) {
             return end();
         }
     }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -165,6 +165,7 @@ public:
 
     // Get last offset
     const model::offset get_last_offset() const;
+    const std::optional<kafka::offset> get_last_kafka_offset() const;
 
     // Get insync offset of the archival_metadata_stm
     //

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -166,6 +166,7 @@ public:
     // Get last offset
     const model::offset get_last_offset() const;
     const std::optional<kafka::offset> get_last_kafka_offset() const;
+    const std::optional<kafka::offset> get_next_kafka_offset() const;
 
     // Get insync offset of the archival_metadata_stm
     //

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -492,12 +492,14 @@ kafka::offset remote_partition::first_uploaded_offset() {
     return so;
 }
 
-model::offset remote_partition::last_uploaded_offset() {
+kafka::offset remote_partition::last_uploaded_offset() {
     vassert(
       _manifest.size() > 0,
       "The manifest for {} is not expected to be empty",
       _manifest.get_ntp());
-    return _manifest.get_last_offset();
+    auto last = _manifest.get_last_kafka_offset().value();
+    vlog(_ctxlog.debug, "remote partition last_kafka_offset: {}", last);
+    return last;
 }
 
 const model::ntp& remote_partition::get_ntp() const {

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -127,8 +127,8 @@ remote_partition::borrow_result_t remote_partition::borrow_next_reader(
                 break;
             }
             auto b = mit->second.base_kafka_offset();
-            auto m = mit->second.committed_kafka_offset();
-            if (b != m) {
+            auto end = mit->second.next_kafka_offset() - kafka::offset(1);
+            if (b != end) {
                 break;
             }
             mit++;
@@ -492,14 +492,14 @@ kafka::offset remote_partition::first_uploaded_offset() {
     return so;
 }
 
-kafka::offset remote_partition::last_uploaded_offset() {
+kafka::offset remote_partition::next_kafka_offset() {
     vassert(
       _manifest.size() > 0,
       "The manifest for {} is not expected to be empty",
       _manifest.get_ntp());
-    auto last = _manifest.get_last_kafka_offset().value();
-    vlog(_ctxlog.debug, "remote partition last_kafka_offset: {}", last);
-    return last;
+    auto next = _manifest.get_next_kafka_offset().value();
+    vlog(_ctxlog.debug, "remote partition next_kafka_offset: {}", next);
+    return next;
 }
 
 const model::ntp& remote_partition::get_ntp() const {
@@ -532,8 +532,9 @@ remote_partition::get_term_last_offset(model::term_id term) const {
         }
     }
     // if last segment term is equal to the one we look for return it
-    if (_manifest.rbegin()->second.segment_term == term) {
-        return _manifest.rbegin()->second.committed_kafka_offset();
+    auto last = _manifest.rbegin()->second;
+    if (last.segment_term == term) {
+        return last.next_kafka_offset() - kafka::offset(1);
     }
 
     return std::nullopt;

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -95,7 +95,7 @@ public:
     kafka::offset first_uploaded_offset();
 
     /// Return last uploaded kafka offset
-    model::offset last_uploaded_offset();
+    kafka::offset last_uploaded_offset();
 
     /// Get partition NTP
     const model::ntp& get_ntp() const;

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -94,8 +94,9 @@ public:
     /// Return first uploaded kafka offset
     kafka::offset first_uploaded_offset();
 
-    /// Return last uploaded kafka offset
-    kafka::offset last_uploaded_offset();
+    /// Return the offset one past the end of the last offset (i.e. the high
+    /// watermark as reported by object storage).
+    kafka::offset next_kafka_offset();
 
     /// Get partition NTP
     const model::ntp& get_ntp() const;

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -318,7 +318,7 @@ SEASTAR_THREAD_TEST_CASE(test_segment_contains_by_kafka_offset) {
                        // ...and as a sanity check, make sure the kafka::offset
                        // falls in the segment.
                        && it->second.base_kafka_offset() <= ko
-                       && it->second.committed_kafka_offset() >= ko;
+                       && it->second.next_kafka_offset() > ko;
         if (success) {
             return true;
         }

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -140,7 +140,9 @@ struct segment_meta {
     model::term_id archiver_term;
     /// Term of the segment (included in segment file name)
     model::term_id segment_term;
-    /// Offset translation delta at the end of the range
+    /// Offset translation delta just past the end of this segment. This is
+    /// useful in determining the next Kafka offset, e.g. when reporting the
+    /// high watermark.
     model::offset_delta delta_offset_end;
     /// Segment name format specifier
     segment_name_format sname_format{segment_name_format::v1};
@@ -156,14 +158,19 @@ struct segment_meta {
         return base_offset - delta;
     }
 
-    kafka::offset committed_kafka_offset() const {
+    // NOTE: in older versions of Redpanda, delta_offset_end may have been
+    // under-reported by 1 if the last segment contained no data batches,
+    // meaning next_kafka_offset could over-report the next offset by 1.
+    kafka::offset next_kafka_offset() const {
         // Manifests created with the old version of redpanda won't have the
         // delta_offset_end field. In this case offset translation couldn't be
         // performed.
         auto delta = delta_offset_end == model::offset_delta::min()
                        ? model::offset_delta(0)
                        : delta_offset_end;
-        return committed_offset - delta;
+        // NOTE: delta_offset_end is a misnomer and actually refers to the
+        // offset delta of the next offset after this segment.
+        return model::next_offset(committed_offset) - delta;
     }
 
     auto operator<=>(const segment_meta&) const = default;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -161,12 +161,12 @@ model::offset partition::start_cloud_offset() const {
       _cloud_storage_partition->first_uploaded_offset());
 }
 
-model::offset partition::last_cloud_offset() const {
+model::offset partition::next_cloud_offset() const {
     vassert(
       cloud_data_available(),
       "Method can only be called if cloud data is available, ntp: {}",
       _raft->ntp());
-    return kafka::offset_cast(_cloud_storage_partition->last_uploaded_offset());
+    return kafka::offset_cast(_cloud_storage_partition->next_kafka_offset());
 }
 
 ss::future<storage::translating_reader> partition::make_cloud_reader(

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -166,7 +166,7 @@ model::offset partition::last_cloud_offset() const {
       cloud_data_available(),
       "Method can only be called if cloud data is available, ntp: {}",
       _raft->ntp());
-    return _cloud_storage_partition->last_uploaded_offset();
+    return kafka::offset_cast(_cloud_storage_partition->last_uploaded_offset());
 }
 
 ss::future<storage::translating_reader> partition::make_cloud_reader(

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -241,8 +241,9 @@ public:
     /// Starting offset in the object store
     model::offset start_cloud_offset() const;
 
-    /// Last available cloud offset
-    model::offset last_cloud_offset() const;
+    /// Kafka offset one past the end of the last offset (i.e. the high
+    /// watermark as reported by object storage).
+    model::offset next_cloud_offset() const;
 
     /// Create a reader that will fetch data from remote storage
     ss::future<storage::translating_reader> make_cloud_reader(

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -58,7 +58,7 @@ public:
     model::offset high_watermark() const final {
         if (_partition->is_read_replica_mode_enabled()) {
             if (_partition->cloud_data_available()) {
-                return model::next_offset(_partition->last_cloud_offset());
+                return _partition->next_cloud_offset();
             } else {
                 return model::offset(0);
             }
@@ -70,7 +70,7 @@ public:
         if (_partition->is_read_replica_mode_enabled()) {
             if (_partition->cloud_data_available()) {
                 // There is no difference between HWM and LO in this mode
-                return model::next_offset(_partition->last_cloud_offset());
+                return _partition->next_cloud_offset();
             } else {
                 return model::offset(0);
             }

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -39,6 +39,10 @@ int64_t offset_translator_state::delta(model::offset o) const {
         return delta + (o - it->second.base_offset);
     }
 }
+model::offset_delta
+offset_translator_state::next_offset_delta(model::offset o) const {
+    return model::offset_delta(delta(model::next_offset(o)));
+}
 
 model::offset offset_translator_state::from_log_offset(model::offset o) const {
     const auto d = delta(o);

--- a/src/v/storage/offset_translator_state.h
+++ b/src/v/storage/offset_translator_state.h
@@ -57,6 +57,10 @@ public:
     /// Difference between the log offset and the kafka offset.
     int64_t delta(model::offset) const;
 
+    /// Returns the difference between the log offset and the Kafka offset one
+    /// offset past the input.
+    model::offset_delta next_offset_delta(model::offset) const;
+
     /// Translate log offset into kafka offset.
     model::offset from_log_offset(model::offset) const;
 

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -19,6 +19,8 @@ from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 
 from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda_installer import InstallOptions, RedpandaInstaller
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.utils.expect_rate import ExpectRate, RateTarget
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
@@ -30,6 +32,67 @@ class BucketUsage(NamedTuple):
     num_objects: int
     total_bytes: int
     keys: set[str]
+
+
+# These tests do not wait for data to be written by the origin cluster
+# before creating read replicas, so it is expected to see log errors
+# when the destination cluster can't find manifests.
+# See https://github.com/redpanda-data/redpanda/issues/8965
+READ_REPLICA_LOG_ALLOW_LIST = [
+    "Failed to download partition manifest",
+    "Failed to download manifest",
+]
+
+
+def get_hwm_per_partition(cluster: RedpandaService, topic_name,
+                          partition_count):
+    id_to_hwm = dict()
+    rpk = RpkTool(cluster)
+    for prt in rpk.describe_topic(topic_name):
+        id_to_hwm[prt.id] = prt.high_watermark
+    if len(id_to_hwm) != partition_count:
+        return False, None
+    return True, id_to_hwm
+
+
+def hwms_are_identical(logger, src_cluster, dst_cluster, topic_name,
+                       partition_count):
+    # Collect the HWMs for each partition before stopping.
+    src_hwms = wait_until_result(lambda: get_hwm_per_partition(
+        src_cluster, topic_name, partition_count),
+                                 timeout_sec=30,
+                                 backoff_sec=1)
+
+    # Ensure that our HWMs on the destination are the same.
+    rr_hwms = wait_until_result(lambda: get_hwm_per_partition(
+        dst_cluster, topic_name, partition_count),
+                                timeout_sec=30,
+                                backoff_sec=1)
+    logger.info(f"{src_hwms} vs {rr_hwms}")
+    return src_hwms == rr_hwms
+
+
+def create_read_replica_topic(dst_cluster, topic_name, bucket_name) -> None:
+    rpk_dst_cluster = RpkTool(dst_cluster)
+    # NOTE: we set 'redpanda.remote.readreplica' to ORIGIN
+    # cluster's bucket
+    conf = {
+        'redpanda.remote.readreplica': bucket_name,
+    }
+    rpk_dst_cluster.create_topic(topic_name, config=conf)
+
+    def has_leader():
+        partitions = list(
+            rpk_dst_cluster.describe_topic(topic_name, tolerant=True))
+        for part in partitions:
+            if part.leader == -1:
+                return False
+        return True
+
+    wait_until(has_leader,
+               timeout_sec=60,
+               backoff_sec=10,
+               err_msg="No leader in read-replica")
 
 
 class TestReadReplicaService(EndToEndTest):
@@ -65,14 +128,8 @@ class TestReadReplicaService(EndToEndTest):
         self.second_cluster.start(start_si=False)
 
     def create_read_replica_topic(self) -> None:
-        rpk_second_cluster = RpkTool(self.second_cluster)
-        # NOTE: we set 'redpanda.remote.readreplica' to ORIGIN
-        # cluster's bucket
-        conf = {
-            'redpanda.remote.readreplica':
-            self.si_settings.cloud_storage_bucket,
-        }
-        rpk_second_cluster.create_topic(self.topic_name, config=conf)
+        create_read_replica_topic(self.second_cluster, self.topic_name,
+                                  self.si_settings.cloud_storage_bucket)
 
     def start_consumer(self) -> None:
         # important side effect for superclass; we will use the replica
@@ -178,38 +235,25 @@ class TestReadReplicaService(EndToEndTest):
         self.start_consumer()
         self.run_validation(min_records=1000)  # calls self.consumer.stop()
 
-        def get_hwm_per_partition(cluster: RedpandaService):
-            id_to_hwm = dict()
-            rpk = RpkTool(cluster)
-            for prt in rpk.describe_topic(self.topic_name):
-                id_to_hwm[prt.id] = prt.high_watermark
-            if len(id_to_hwm) != partition_count:
-                return False, None
-            return True, id_to_hwm
+        def clusters_report_identical_hwms():
+            return hwms_are_identical(self.logger, self.redpanda,
+                                      self.second_cluster, self.topic_name,
+                                      partition_count)
 
-        def hwms_are_identical():
-            # Collect the HWMs for each partition before stopping.
-            src_hwms = wait_until_result(
-                lambda: get_hwm_per_partition(self.redpanda),
-                timeout_sec=30,
-                backoff_sec=1)
-
-            # Ensure that our HWMs on the destination are the same.
-            rr_hwms = wait_until_result(
-                lambda: get_hwm_per_partition(self.second_cluster),
-                timeout_sec=30,
-                backoff_sec=1)
-            self.logger.info(f"{src_hwms} vs {rr_hwms}")
-            return src_hwms == rr_hwms
-
-        wait_until(hwms_are_identical, timeout_sec=30, backoff_sec=1)
+        wait_until(clusters_report_identical_hwms,
+                   timeout_sec=30,
+                   backoff_sec=1)
 
         # As a sanity check, ensure the same is true after a restart.
         self.redpanda.restart_nodes(self.redpanda.nodes)
-        wait_until(hwms_are_identical, timeout_sec=30, backoff_sec=1)
+        wait_until(clusters_report_identical_hwms,
+                   timeout_sec=30,
+                   backoff_sec=1)
 
         self.second_cluster.restart_nodes(self.second_cluster.nodes)
-        wait_until(hwms_are_identical, timeout_sec=30, backoff_sec=1)
+        wait_until(clusters_report_identical_hwms,
+                   timeout_sec=30,
+                   backoff_sec=1)
 
     @cluster(num_nodes=7)
     @matrix(partition_count=[10])
@@ -287,3 +331,125 @@ class TestReadReplicaService(EndToEndTest):
         if delta:
             m = f"S3 Bucket usage changed during read replica test: {delta}"
             assert False, m
+
+
+class ReadReplicasUpgradeTest(EndToEndTest):
+    log_segment_size = 1024 * 1024
+    topic_name = "panda-topic"
+
+    def __init__(self, test_context: TestContext):
+        super(ReadReplicasUpgradeTest, self).__init__(
+            test_context=test_context,
+            si_settings=SISettings(
+                test_context,
+                cloud_storage_max_connections=5,
+                log_segment_size=self.log_segment_size,
+                cloud_storage_readreplica_manifest_sync_timeout_ms=500,
+                cloud_storage_segment_max_upload_interval_sec=3))
+
+        # Read replica shouldn't have it's own bucket.
+        # We're adding 'none' as a bucket name without creating
+        # an actual bucket with such name.
+        self.rr_settings = SISettings(
+            test_context,
+            bypass_bucket_creation=True,
+            cloud_storage_max_connections=5,
+            log_segment_size=self.log_segment_size,
+            cloud_storage_readreplica_manifest_sync_timeout_ms=500,
+            cloud_storage_segment_max_upload_interval_sec=1,
+            cloud_storage_housekeeping_interval_ms=1)
+        self.second_cluster = None
+
+    @cluster(num_nodes=8)
+    def test_upgrades(self):
+        partition_count = 1
+        install_opts = InstallOptions(install_previous_version=True)
+        self.start_redpanda(3,
+                            si_settings=self.si_settings,
+                            install_opts=install_opts)
+        spec = TopicSpec(name=self.topic_name,
+                         partition_count=partition_count,
+                         replication_factor=3)
+        DefaultClient(self.redpanda).create_topic(spec)
+        self.producer = VerifiableProducer(
+            self.test_context,
+            num_nodes=1,
+            redpanda=self.redpanda,
+            topic=self.topic_name,
+            throughput=100,
+            message_validator=is_int_with_prefix)
+        self.producer.start()
+        wait_until(lambda: self.producer.num_acked > 1000,
+                       timeout_sec=30,
+                       err_msg="Producer failed to produce messages for %ds." %\
+                       30)
+        self.producer.stop()
+
+        self.second_cluster = RedpandaService(self.test_context,
+                                              num_brokers=3,
+                                              si_settings=self.rr_settings)
+        previous_version = self.second_cluster._installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD)
+        self.second_cluster._installer.install(self.second_cluster.nodes,
+                                               previous_version)
+        self.second_cluster.start(start_si=False)
+        create_read_replica_topic(self.second_cluster, self.topic_name,
+                                  self.si_settings.cloud_storage_bucket)
+
+        def cluster_has_offsets(cluster):
+            hwms = wait_until_result(lambda: get_hwm_per_partition(
+                cluster, self.topic_name, partition_count),
+                                     timeout_sec=30,
+                                     backoff_sec=1)
+            if len(hwms) != partition_count:
+                return False, None
+            if any([hwms[p] == 0 for p in range(partition_count)]):
+                return False, None
+            return True, hwms
+
+        rr_hwms = wait_until_result(
+            lambda: cluster_has_offsets(self.second_cluster),
+            timeout_sec=30,
+            backoff_sec=1)
+        # Upgrade the read replica cluster first.
+        self.second_cluster._installer.install(self.second_cluster.nodes,
+                                               RedpandaInstaller.HEAD)
+        self.second_cluster.restart_nodes(self.second_cluster.nodes)
+
+        new_rr_hwms = wait_until_result(
+            lambda: cluster_has_offsets(self.second_cluster),
+            timeout_sec=30,
+            backoff_sec=1)
+        assert new_rr_hwms != rr_hwms, f"{new_rr_hwms} vs {rr_hwms}"
+
+        # Then upgrade the source cluster and make sure the source and RRR
+        # cluster match.
+        self.redpanda._installer.install(self.redpanda.nodes,
+                                         RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        def clusters_report_identical_hwms():
+            return hwms_are_identical(self.logger, self.redpanda,
+                                      self.second_cluster, self.topic_name,
+                                      partition_count)
+
+        # NOTE: immediately after restarting, on older versions the HWMs may
+        # not be identical until after we upload some data.
+
+        # Writes some more to update the manifest with the new version.
+        self.producer = VerifiableProducer(
+            self.test_context,
+            num_nodes=1,
+            redpanda=self.redpanda,
+            topic=self.topic_name,
+            throughput=100,
+            message_validator=is_int_with_prefix)
+        self.producer.start()
+        wait_until(lambda: self.producer.num_acked > 1000,
+                       timeout_sec=30,
+                       err_msg="Producer failed to produce messages for %ds." %\
+                       30)
+        self.producer.stop()
+        wait_until(clusters_report_identical_hwms,
+                   timeout_sec=30,
+                   backoff_sec=1)


### PR DESCRIPTION
Pre-emptive backport of https://github.com/redpanda-data/redpanda/pull/9493

We were previously doing no offset translation of the HWM in read replicas, meaning the returned offset would almost always be higher than it should've been.

This PR updates the behavior of delta_offset_end to return the delta one past the end of each segment, allowing translation to occur by translating the next offset after the end with delta_offset_end (vs translating the end and adding 1).

The caveat here is reconciling the updated semantics with data written in older versions. We need to be mindful that older versions may have a delta_offset_end that is 1 lower than what it should be, meaning the reported HWM and next_kafka_offset calls may be 1 higher than they should be.

Looking at their usages, it seems like this should be a benign change, but it would be good to be wary of this moving forward.

Fixes https://github.com/redpanda-data/redpanda/issues/9513

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes
* Fixed a bug that would result in read replicas reporting a high watermark that was too high.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
