### PR TITLE
[v23.1.x] u/prefix_logger: reintroduce _prefix to prefix_logger::format

### DIFF
--- a/src/v/utils/prefix_logger.h
+++ b/src/v/utils/prefix_logger.h
@@ -61,8 +61,9 @@ public:
     template<typename... Args>
     ss::sstring format(const char* format, Args&&... args) const {
         auto line_fmt = ss::sstring("{} - ") + format;
-        return fmt::format(
+        return ssx::sformat(
           fmt::runtime(fmt::string_view(line_fmt.begin(), line_fmt.length())),
+          _prefix,
           std::forward<Args>(args)...);
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9705
Fixes https://github.com/redpanda-data/redpanda/issues/9728,