### PR TITLE
tests: check controller log length during teardown

### DIFF
--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -138,7 +138,7 @@
             "operations": [
                 {
                     "method": "GET",
-                    "summary": "Get last_applied_offset and commited_index for controller log",
+                    "summary": "Get last_applied_offset and committed_index for controller log",
                     "type": "controller_status",
                     "nickname": "get_controller_status",
                     "produces": [
@@ -388,9 +388,9 @@
                     "type": "long",
                     "description": "Last applied offset for controller stm"
                 },
-                "commited_index": {
+                "committed_index": {
                     "type": "long",
-                    "description": "Commited index for controller consensus"
+                    "description": "Committed index for controller consensus"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3903,7 +3903,7 @@ void admin_server::register_debug_routes() {
                 result_t ans;
                 ans.last_applied_offset = offset;
                 ans.start_offset = _controller->get_start_offset();
-                ans.commited_index = _controller->get_commited_index();
+                ans.committed_index = _controller->get_commited_index();
                 return ss::make_ready_future<ss::json::json_return_type>(
                   ss::json::json_return_type(ans));
             });

--- a/tests/rptest/scale_tests/large_controller_snapshot_test.py
+++ b/tests/rptest/scale_tests/large_controller_snapshot_test.py
@@ -117,7 +117,7 @@ class LargeControllerSnapshotTest(RedpandaTest):
         self.logger.info(f"waiting until all commands are snapshotted...")
 
         controller_max_offset = max(
-            admin.get_controller_status(n)['commited_index']
+            admin.get_controller_status(n)['committed_index']
             for n in seed_nodes)
         self.logger.info(f"controller max offset is {controller_max_offset}")
 

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -96,6 +96,8 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                         redpanda.cloud_storage_diagnostics()
                         raise
 
+                self.redpanda.validate_controller_log()
+
                 if self.redpanda.si_settings is not None:
                     try:
                         self.redpanda.stop_and_scrub_object_storage()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3265,7 +3265,7 @@ class RedpandaService(RedpandaServiceBase):
                     f"Object storage scrub detected fatal anomalies of type {fatal_anomalies}"
                 )
 
-    def set_expected_controller_records(self, max_records: int):
+    def set_expected_controller_records(self, max_records: Optional[int]):
         self._expect_max_controller_records = max_records
 
     def validate_controller_log(self):

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -280,7 +280,7 @@ class ControllerSnapshotTest(RedpandaTest):
 
         def wait_for_everything_snapshotted(nodes):
             controller_max_offset = max(
-                admin.get_controller_status(n)['commited_index']
+                admin.get_controller_status(n)['committed_index']
                 for n in nodes)
             self.logger.info(
                 f"controller max offset is {controller_max_offset}")

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -1851,6 +1851,10 @@ class BasicAuthScaleTest(PandaProxyEndpoints):
         super_username, super_password, super_algorithm = self.redpanda.SUPERUSER_CREDENTIALS
         rpk = RpkTool(self.redpanda)
 
+        # One user + one ACL record per user, plus the usual baseline
+        # allowance for controller log records
+        self.redpanda.set_expected_controller_records(num_users * 2 + 1000)
+
         # First create all users and their acls
         for idx in range(num_users):
             user = User(idx)

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -109,6 +109,12 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             self.rate_limit = 1024 * 1024
             self.total_data = 50 * 1024 * 1024
 
+        # Tip off the end-of-test controller log validation that we will
+        # create a large number of records, scaling with partition count
+        # and operation count.
+        self.redpanda.set_expected_controller_records(
+            self.max_partitions * self.node_operations * 10)
+
         self.consumers_count = int(self.max_partitions / 4)
         self.msg_count = int(self.total_data / self.msg_size)
 

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -230,6 +230,10 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             enable_controller_snapshots=[True, False])
     def test_node_operations(self, enable_failures, num_to_upgrade,
                              enable_controller_snapshots):
+        if not enable_controller_snapshots:
+            # Without snapshots, there is not bound on how large
+            # the controller log may grow.
+            self.redpanda.set_expected_controller_records(None)
 
         lock = threading.Lock()
 


### PR DESCRIPTION
(This branch is based on https://github.com/redpanda-data/redpanda/pull/9610, just the last commits related to the purpose of this PR)

If we had a bug in our controller code that e.g. spat out
log writes in a tight loop, most tests wouldn't notice unless
something else broke as a consequence.
    
This commit adds an explicit check that the number of records
in the controller log doesn't exceed a limit, which is by default
1000, as most tests do relatively few controller operations, and
those that do more can use `set_expected_controller_records`
as needed

This also ensures the hygiene of underlying Redpanda behavior, so
that automated tests for other tools like the operator can do an equivalent check, and
if they see a high number of controller records they may treat that
as a test failure indicating some bad behavior in the tool.
    
Fixes https://github.com/redpanda-data/redpanda/issues/9735


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none