### PR TITLE
c/topic_table: switch _pending_deltas to fragmented_vector

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -633,7 +633,7 @@ controller_backend::bootstrap_ntp(const model::ntp& ntp, deltas_t& deltas) {
 ss::future<> controller_backend::fetch_deltas() {
     return _topics.local()
       .wait_for_changes(_as.local())
-      .then([this](std::vector<topic_table::delta> deltas) {
+      .then([this](fragmented_vector<topic_table::delta> deltas) {
           return ss::with_semaphore(
             _topics_sem, 1, [this, deltas = std::move(deltas)]() mutable {
                 for (auto& d : deltas) {

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -22,7 +22,7 @@
 #include "units.h"
 
 inline void validate_delta(
-  const std::vector<cluster::topic_table::delta>& d,
+  const fragmented_vector<cluster::topic_table::delta>& d,
   int new_partitions,
   int removed_partitions) {
     size_t additions = std::count_if(

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -724,7 +724,6 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
 
     // generate deltas for controller backend
     const auto& assignments = tp->second.get_assignments();
-    _pending_deltas.reserve(_pending_deltas.size() + assignments.size());
     for (auto& p_as : assignments) {
         _pending_deltas.emplace_back(
           model::ntp(cmd.key.ns, cmd.key.tp, p_as.id),
@@ -802,7 +801,7 @@ void topic_table::notify_waiters() {
     auto starting_iter = _pending_deltas.cbegin()
                          + _last_consumed_by_notifier_offset;
 
-    std::span changes{starting_iter, _pending_deltas.cend()};
+    delta_range_t changes{starting_iter, _pending_deltas.cend()};
 
     if (!changes.empty()) {
         for (auto& cb : _notifications) {
@@ -819,7 +818,7 @@ void topic_table::notify_waiters() {
         active_waiters.swap(_waiters);
         for (auto& w :
              std::span{active_waiters.begin(), active_waiters.size() - 1}) {
-            w->promise.set_value(_pending_deltas);
+            w->promise.set_value(_pending_deltas.copy());
         }
 
         active_waiters[active_waiters.size() - 1]->promise.set_value(
@@ -829,9 +828,9 @@ void topic_table::notify_waiters() {
     }
 }
 
-ss::future<std::vector<topic_table::delta>>
+ss::future<fragmented_vector<topic_table::delta>>
 topic_table::wait_for_changes(ss::abort_source& as) {
-    using ret_t = std::vector<topic_table::delta>;
+    using ret_t = fragmented_vector<topic_table::delta>;
     if (!_pending_deltas.empty()) {
         ret_t ret;
         ret.swap(_pending_deltas);

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -226,7 +226,9 @@ public:
       model::topic_namespace_hash,
       model::topic_namespace_eq>;
 
-    using delta_cb_t = ss::noncopyable_function<void(std::span<const delta>)>;
+    using delta_range_t
+      = boost::iterator_range<fragmented_vector<delta>::const_iterator>;
+    using delta_cb_t = ss::noncopyable_function<void(delta_range_t)>;
 
     explicit topic_table()
       : _probe(*this){};
@@ -289,7 +291,7 @@ public:
     /// the \ref _waiters collection by the time the notify occurs, only one
     /// waiter will recieve the updates, leaving the second one to observe
     /// skipped events upon recieving its subsequent notification.
-    ss::future<std::vector<delta>> wait_for_changes(ss::abort_source&);
+    ss::future<fragmented_vector<delta>> wait_for_changes(ss::abort_source&);
 
     bool has_pending_changes() const { return !_pending_deltas.empty(); }
 
@@ -443,7 +445,7 @@ private:
     struct waiter {
         explicit waiter(uint64_t id)
           : id(id) {}
-        ss::promise<std::vector<delta>> promise;
+        ss::promise<fragmented_vector<delta>> promise;
         ss::abort_source::subscription sub;
         uint64_t id;
     };
@@ -468,7 +470,7 @@ private:
     updates_t _updates_in_progress;
     model::revision_id _last_applied_revision_id;
 
-    std::vector<delta> _pending_deltas;
+    fragmented_vector<delta> _pending_deltas;
     std::vector<std::unique_ptr<waiter>> _waiters;
     cluster::notification_id_type _notification_id{0};
     std::vector<std::pair<cluster::notification_id_type, delta_cb_t>>

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -88,7 +88,8 @@ reconciliation_backend::reconciliation_backend(
   , _pacemaker(pacemaker)
   , _sdb(sdb) {}
 
-void reconciliation_backend::enqueue_events(std::span<const update_t> deltas) {
+void reconciliation_backend::enqueue_events(
+  cluster::topic_table::delta_range_t deltas) {
     for (auto& d : deltas) {
         if (is_non_replicable_event(d.type)) {
             _topic_deltas[d.ntp].push_back(d);
@@ -107,7 +108,7 @@ void reconciliation_backend::enqueue_events(std::span<const update_t> deltas) {
 
 ss::future<> reconciliation_backend::start() {
     _id_cb = _topics.local().register_delta_notification(
-      [this](std::span<const update_t> deltas) {
+      [this](cluster::topic_table::delta_range_t deltas) {
           if (!_gate.is_closed()) {
               enqueue_events(deltas);
           } else {

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -72,7 +72,7 @@ private:
     ss::future<> add_to_shard_table(
       model::ntp ntp, ss::shard_id shard, model::revision_id revision);
 
-    void enqueue_events(std::span<const update_t>);
+    void enqueue_events(cluster::topic_table::delta_range_t);
     ss::future<> process_loop();
 
     bool stale_create_non_replicable_partition_request(

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -96,7 +96,7 @@ ss::future<> group_manager::start() {
      */
     _topic_table_notify_handle
       = _topic_table.local().register_delta_notification(
-        [this](std::span<const cluster::topic_table::delta> deltas) {
+        [this](cluster::topic_table::delta_range_t deltas) {
             handle_topic_delta(deltas);
         });
 
@@ -476,7 +476,7 @@ ss::future<> group_manager::cleanup_removed_topic_partitions(
 }
 
 void group_manager::handle_topic_delta(
-  std::span<const cluster::topic_table_delta> deltas) {
+  cluster::topic_table::delta_range_t deltas) {
     // topic-partition deletions in the kafka namespace are the only deltas that
     // are relevant to the group manager
     std::vector<model::topic_partition> tps;

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -224,7 +224,7 @@ private:
       ss::lw_shared_ptr<cluster::partition>,
       std::optional<model::node_id>);
 
-    void handle_topic_delta(std::span<const cluster::topic_table_delta>);
+    void handle_topic_delta(cluster::topic_table::delta_range_t);
 
     ss::future<> cleanup_removed_topic_partitions(
       const std::vector<model::topic_partition>&);

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -99,6 +99,12 @@ public:
 
     fragmented_vector copy() const noexcept { return *this; }
 
+    void swap(fragmented_vector& other) noexcept {
+        std::swap(_size, other._size);
+        std::swap(_capacity, other._capacity);
+        std::swap(_frags, other._frags);
+    }
+
     template<class E = T>
     void push_back(E&& elem) {
         maybe_add_capacity();

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -101,13 +101,15 @@ public:
 
     template<class E = T>
     void push_back(E&& elem) {
-        if (_size == _capacity) {
-            std::vector<T> frag;
-            frag.reserve(elems_per_frag);
-            _frags.push_back(std::move(frag));
-            _capacity += elems_per_frag;
-        }
+        maybe_add_capacity();
         _frags.back().push_back(std::forward<E>(elem));
+        ++_size;
+    }
+
+    template<class... Args>
+    void emplace_back(Args&&... args) {
+        maybe_add_capacity();
+        _frags.back().emplace_back(std::forward<Args>(args)...);
         ++_size;
     }
 
@@ -275,6 +277,16 @@ public:
         }
         os << "]";
         return os;
+    }
+
+private:
+    void maybe_add_capacity() {
+        if (_size == _capacity) {
+            std::vector<T> frag;
+            frag.reserve(elems_per_frag);
+            _frags.push_back(std::move(frag));
+            _capacity += elems_per_frag;
+        }
     }
 
 private:


### PR DESCRIPTION
_pending_deltas can get pretty big at startup and (soon) after applying a controller snapshot. So we switch it to fragmented_vector to avoid large contiguous allocations.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
