### PR TITLE
[v23.1.x] cloud_storage: manifest upload efficiency and observability improvements

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1358,6 +1358,11 @@ ss::future<> ntp_archiver::garbage_collect() {
     const auto to_remove
       = _parent.archival_meta_stm()->get_segments_to_cleanup();
 
+    // Avoid replicating 'cleanup_metadata_cmd' if there's nothing to remove.
+    if (to_remove.size() == 0) {
+        co_return updated;
+    }
+
     size_t successful_deletes{0};
     co_await ss::max_concurrent_for_each(
       to_remove,


### PR DESCRIPTION
Previously, 'ntp_archiver::garbage_collect' replicated a 'cleanup_metadata_cmd' even when no segments were removed. The manifest was also re-uploaded each time.

This commit fixes the issue by checking if there are any segments to remove before replicating the command. If that's not the case, indicate to the housekeeping that there's no reasone to re-upload the manifest.

Some ducktape tests have also been updated to upload the manifest more often upon segment uploads. This has been done in order to avoid timeouts when waiting for data to be uploaded to cloud storage.

(cherry picked from commit bc89664640661e576cd0ba5554613ddc645664fb)

Note: the test updates from the original commit have been skipped,
since the manifest was uploaded a lot more eagerly in v23.1.x.