### PR TITLE
[v23.1.x] c/topics_table: do not generate deltas for no op update properties

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -641,6 +641,7 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
         co_return make_error_code(errc::topic_not_exists);
     }
     auto& properties = tp->second.get_configuration().properties;
+    auto properties_snapshot = properties;
     auto& overrides = cmd.value;
     /**
      * Update topic properties
@@ -670,7 +671,10 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
       overrides.remote_delete,
       storage::ntp_config::default_remote_delete);
     incremental_update(properties.segment_ms, overrides.segment_ms);
-
+    // no configuration change, no need to generate delta
+    if (properties == properties_snapshot) {
+        co_return errc::success;
+    }
     // generate deltas for controller backend
     const auto& assignments = tp->second.get_assignments();
     _pending_deltas.reserve(_pending_deltas.size() + assignments.size());


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9739
