### PR TITLE
cloud_storage: provide in-memory manifest dumps via the Admin API

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -540,7 +540,7 @@ bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
             // This branch should never be taken. It indicates that the
             // in-memory manifest may be is in some sort of inconsistent state.
             vlog(
-              cst_log.warn,
+              cst_log.error,
               "Previous start offset is not within segment in "
               "manifest for {}: previous_start_offset={}",
               _ntp,

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -286,6 +286,13 @@ public:
     /// \param out output stream that should be used to output the json
     void serialize(std::ostream& out) const;
 
+    // Serialize the manifest to an ss::output_stream in JSON format
+    /// \param out output stream to serialize into; must be kept alive
+    /// by the caller until the returned future completes.
+    ///
+    /// \return a future that completes after serialization is done
+    ss::future<> serialize(ss::output_stream<char>& out) const;
+
     /// Compare two manifests for equality. Don't compare the mem_tracker.
     bool operator==(const partition_manifest& other) const {
         return _ntp == other._ntp && _rev == other._rev

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -611,6 +611,11 @@ uint64_t remote_partition::cloud_log_size() const {
     return _manifest.cloud_log_size();
 }
 
+ss::future<> remote_partition::serialize_manifest_to_output_stream(
+  ss::output_stream<char>& output) const {
+    return _manifest.serialize(output);
+}
+
 // returns term last kafka offset
 std::optional<kafka::offset>
 remote_partition::get_term_last_offset(model::term_id term) const {

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -114,6 +114,12 @@ public:
 
     uint64_t cloud_log_size() const;
 
+    // Serialize the manifest to an ss::output_stream in JSON format.
+    // Note that the caller must hold the archival_metadat_stm::_manifest_lock
+    // and keep the stream alive until the future completes.
+    ss::future<>
+    serialize_manifest_to_output_stream(ss::output_stream<char>& output) const;
+
     // returns term last kafka offset
     std::optional<kafka::offset> get_term_last_offset(model::term_id) const;
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -151,6 +151,11 @@ public:
 
     storage::log log() const { return _raft->log(); }
 
+    ss::shared_ptr<const cloud_storage::remote_partition>
+    remote_partition() const {
+        return _cloud_storage_partition;
+    }
+
     ss::future<std::optional<storage::timequery_result>>
       timequery(storage::timequery_config);
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -323,6 +323,20 @@ public:
      */
     void set_topic_config(std::unique_ptr<cluster::topic_configuration> cfg);
 
+    // If the partition is enabled for cloud storage, serialize the manifest to
+    // an ss::output_stream in JSON format. Otherwise, throw an
+    // std::runtime_error.
+    //
+    // If the serialization does not complete within
+    // manifest_serialization_timeout, a ss::timed_out_error is thrown.
+    //
+    //
+    // Note that the caller must keep the stream alive until the future
+    // completes.
+    static constexpr std::chrono::seconds manifest_serialization_timeout{3s};
+    ss::future<>
+    serialize_manifest_to_output_stream(ss::output_stream<char>& output);
+
     std::optional<std::reference_wrapper<cluster::topic_configuration>>
     get_topic_config() {
         if (_topic_cfg) {

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -92,6 +92,31 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/v1/cloud_storage/manifest/{topic}/{partition}",
+      "operations": [
+        {
+          "method": "GET",
+          "summary": "Get the in-memory partition manifest in JSON format",
+          "operationId": "get_manifest",
+          "nickname": "get_manifest",
+          "parameters": [
+            {
+              "name": "topic",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "partition",
+              "in": "path",
+              "required": true,
+              "type": "integer"
+            }
+          ]
+        }
+      ]
     }
   ],
   "models": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -984,7 +984,7 @@ bool str_to_bool(std::string_view s) {
 }
 
 void admin_server::register_config_routes() {
-    register_route_raw<superuser>(
+    register_route_raw_sync<superuser>(
       ss::httpd::config_json::get_config,
       [](ss::httpd::const_req, ss::http::reply& reply) {
           json::StringBuffer buf;
@@ -996,7 +996,7 @@ void admin_server::register_config_routes() {
           return "";
       });
 
-    register_route_raw<superuser>(
+    register_route_raw_sync<superuser>(
       ss::httpd::cluster_config_json::get_cluster_config,
       [](ss::httpd::const_req req, ss::http::reply& reply) {
           json::StringBuffer buf;
@@ -1019,7 +1019,7 @@ void admin_server::register_config_routes() {
           return "";
       });
 
-    register_route_raw<superuser>(
+    register_route_raw_sync<superuser>(
       ss::httpd::config_json::get_node_config,
       [](ss::httpd::const_req, ss::http::reply& reply) {
           json::StringBuffer buf;
@@ -1030,7 +1030,7 @@ void admin_server::register_config_routes() {
           return "";
       });
 
-    register_route_raw<superuser>(
+    register_route_raw_sync<superuser>(
       ss::httpd::config_json::get_loggers,
       [](ss::httpd::const_req, ss::http::reply& reply) {
           json::StringBuffer buf;

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -196,15 +196,53 @@ private:
     }
 
     /**
-     * Variant of register_route for routes that use the raw `handle_function`
-     * callback interface (for returning raw strings) rather than the usual
-     * json handlers.
-     *
+     * Variant of register_route_raw_sync for routes that require async
+     * processing.
      * This is 'raw' in the sense that less auto-serialization is going on,
      * and the handler has direct access to the `reply` object
      */
+    template<auth_level required_auth, bool peek_auth = false, typename F>
+    void register_route_raw_async(
+      ss::httpd::path_description const& path, F handler) {
+        auto wrapped_handler = [this, handler](
+                                 std::unique_ptr<ss::http::request> req,
+                                 std::unique_ptr<ss::http::reply> rep)
+          -> ss::future<std::unique_ptr<ss::http::reply>> {
+            auto auth_state = apply_auth<required_auth>(*req);
+
+            // Note: a request is only logged if it does not throw
+            // from authenticate().
+            log_request(*req, auth_state);
+
+            // Intercept exceptions
+            const auto url = req->get_url();
+            if constexpr (peek_auth) {
+                return ss::futurize_invoke(
+                         handler, std::move(req), std::move(rep), auth_state)
+                  .handle_exception(
+                    exception_intercepter<
+                      decltype(handler(
+                                 std::move(req), std::move(rep), auth_state)
+                                 .get0())>(url, auth_state));
+
+            } else {
+                return ss::futurize_invoke(
+                         handler, std::move(req), std::move(rep))
+                  .handle_exception(
+                    exception_intercepter<
+                      decltype(handler(std::move(req), std::move(rep)).get0())>(
+                      url, auth_state));
+            }
+        };
+
+        auto handler_f = new ss::httpd::function_handler{
+          std::move(wrapped_handler), "json"};
+
+        path.set(_server._routes, handler_f);
+    }
+
     template<auth_level required_auth>
-    void register_route_raw(
+    void register_route_raw_sync(
       ss::httpd::path_description const& path,
       ss::httpd::handle_function handler) {
         auto handler_f = new ss::httpd::function_handler{

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -419,6 +419,9 @@ private:
     query_automated_recovery(std::unique_ptr<ss::http::request> req);
     ss::future<ss::json::json_return_type>
     get_partition_cloud_storage_status(std::unique_ptr<ss::http::request> req);
+    ss::future<std::unique_ptr<ss::http::reply>> get_manifest(
+      std::unique_ptr<ss::http::request> req,
+      std::unique_ptr<ss::http::reply> rep);
 
     /// Self test routes
     ss::future<ss::json::json_return_type>

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -897,3 +897,10 @@ class Admin:
         return self._request("GET",
                              f"cloud_storage/status/{topic}/{partition}",
                              node=node).json()
+
+    def get_partition_manifest(self, topic: str, partition: int):
+        """
+        Get the in-memory partition manifest for the requested ntp
+        """
+        return self._request(
+            "GET", f"cloud_storage/manifest/{topic}/{partition}").json()


### PR DESCRIPTION
This PR introduce a new route to the admin API which dumps the JSON formatted in-memory
manifest for a given partition: `/v1/cloud_storage/manifest/{topic}/{partition}`.

A follow-up PR should extend this route to allow it to dump the uploaded manifest.

Related https://github.com/redpanda-data/redpanda/issues/7459

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features
* A new admin API endpoint is added at `/v1/cloud_storage/manifest/{topic}/{partition}` which allows for retrieving the in-memory manifest for a partition in JSON format.
