### PR TITLE
consensus: Add some missing metrics to the probe

### DIFF
--- a/src/v/raft/probe.cc
+++ b/src/v/raft/probe.cc
@@ -146,6 +146,24 @@ void probe::setup_metrics(const model::ntp& ntp) {
          [this] { return _recovery_request_error; },
          sm::description("Number of failed recovery requests"),
          labels)
+         .aggregate(aggregate_labels),
+       sm::make_counter(
+         "recovery_requests",
+         [this] { return _recovery_requests; },
+         sm::description("Number of recovery requests"),
+         labels)
+         .aggregate(aggregate_labels),
+       sm::make_counter(
+         "group_configuration_updates",
+         [this] { return _configuration_updates; },
+         sm::description("Number of raft group configuration updates"),
+         labels)
+         .aggregate(aggregate_labels),
+       sm::make_counter(
+         "replicate_batch_flush_requests",
+         [this] { return _replicate_batch_flushed; },
+         sm::description("Number of replicate batch flushes"),
+         labels)
          .aggregate(aggregate_labels)});
 }
 


### PR DESCRIPTION
Metrics are tracked but not exposed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
