### PR TITLE
[v23.1.x] cloud_storage: fix HWM on read replicas

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -262,6 +262,14 @@ const model::offset partition_manifest::get_last_offset() const {
     return _last_offset;
 }
 
+const std::optional<kafka::offset>
+partition_manifest::get_last_kafka_offset() const {
+    if (_segments.empty()) {
+        return std::nullopt;
+    }
+    return _segments.rbegin()->second.committed_kafka_offset();
+}
+
 const model::offset partition_manifest::get_insync_offset() const {
     return _insync_offset;
 }

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -263,11 +263,11 @@ const model::offset partition_manifest::get_last_offset() const {
 }
 
 const std::optional<kafka::offset>
-partition_manifest::get_last_kafka_offset() const {
+partition_manifest::get_next_kafka_offset() const {
     if (_segments.empty()) {
         return std::nullopt;
     }
-    return _segments.rbegin()->second.committed_kafka_offset();
+    return _segments.rbegin()->second.next_kafka_offset();
 }
 
 const model::offset partition_manifest::get_insync_offset() const {
@@ -337,7 +337,7 @@ partition_manifest::segment_containing(kafka::offset o) const {
         // check using delta_offset_end. If the field is not set then we
         // will return the last segment. This is OK since delta_offset_end
         // will always be set for new segments.
-        if (back->second.committed_kafka_offset() < o) {
+        if (back->second.next_kafka_offset() <= o) {
             return end();
         }
     }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -176,6 +176,7 @@ public:
     // Get last offset
     const model::offset get_last_offset() const;
     const std::optional<kafka::offset> get_last_kafka_offset() const;
+    const std::optional<kafka::offset> get_next_kafka_offset() const;
 
     // Get insync offset of the archival_metadata_stm
     //

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -175,6 +175,7 @@ public:
 
     // Get last offset
     const model::offset get_last_offset() const;
+    const std::optional<kafka::offset> get_last_kafka_offset() const;
 
     // Get insync offset of the archival_metadata_stm
     //

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -496,12 +496,14 @@ kafka::offset remote_partition::first_uploaded_offset() {
     return so;
 }
 
-model::offset remote_partition::last_uploaded_offset() {
+kafka::offset remote_partition::last_uploaded_offset() {
     vassert(
       _manifest.size() > 0,
       "The manifest for {} is not expected to be empty",
       _manifest.get_ntp());
-    return _manifest.get_last_offset();
+    auto last = _manifest.get_last_kafka_offset().value();
+    vlog(_ctxlog.debug, "remote partition last_kafka_offset: {}", last);
+    return last;
 }
 
 const model::ntp& remote_partition::get_ntp() const {

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -127,8 +127,8 @@ remote_partition::borrow_result_t remote_partition::borrow_next_reader(
                 break;
             }
             auto b = mit->second.base_kafka_offset();
-            auto m = mit->second.committed_kafka_offset();
-            if (b != m) {
+            auto end = mit->second.next_kafka_offset() - kafka::offset(1);
+            if (b != end) {
                 break;
             }
             mit++;
@@ -496,14 +496,14 @@ kafka::offset remote_partition::first_uploaded_offset() {
     return so;
 }
 
-kafka::offset remote_partition::last_uploaded_offset() {
+kafka::offset remote_partition::next_kafka_offset() {
     vassert(
       _manifest.size() > 0,
       "The manifest for {} is not expected to be empty",
       _manifest.get_ntp());
-    auto last = _manifest.get_last_kafka_offset().value();
-    vlog(_ctxlog.debug, "remote partition last_kafka_offset: {}", last);
-    return last;
+    auto next = _manifest.get_next_kafka_offset().value();
+    vlog(_ctxlog.debug, "remote partition next_kafka_offset: {}", next);
+    return next;
 }
 
 const model::ntp& remote_partition::get_ntp() const {
@@ -540,8 +540,9 @@ remote_partition::get_term_last_offset(model::term_id term) const {
         }
     }
     // if last segment term is equal to the one we look for return it
-    if (_manifest.rbegin()->second.segment_term == term) {
-        return _manifest.rbegin()->second.committed_kafka_offset();
+    auto last = _manifest.rbegin()->second;
+    if (last.segment_term == term) {
+        return last.next_kafka_offset() - kafka::offset(1);
     }
 
     return std::nullopt;

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -95,7 +95,7 @@ public:
     kafka::offset first_uploaded_offset();
 
     /// Return last uploaded kafka offset
-    model::offset last_uploaded_offset();
+    kafka::offset last_uploaded_offset();
 
     /// Get partition NTP
     const model::ntp& get_ntp() const;

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -94,8 +94,9 @@ public:
     /// Return first uploaded kafka offset
     kafka::offset first_uploaded_offset();
 
-    /// Return last uploaded kafka offset
-    kafka::offset last_uploaded_offset();
+    /// Return the offset one past the end of the last offset (i.e. the high
+    /// watermark as reported by object storage).
+    kafka::offset next_kafka_offset();
 
     /// Get partition NTP
     const model::ntp& get_ntp() const;

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -319,7 +319,7 @@ SEASTAR_THREAD_TEST_CASE(test_segment_contains_by_kafka_offset) {
                        // ...and as a sanity check, make sure the kafka::offset
                        // falls in the segment.
                        && it->second.base_kafka_offset() <= ko
-                       && it->second.committed_kafka_offset() >= ko;
+                       && it->second.next_kafka_offset() > ko;
         if (success) {
             return true;
         }

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -144,7 +144,9 @@ struct segment_meta {
     model::term_id archiver_term;
     /// Term of the segment (included in segment file name)
     model::term_id segment_term;
-    /// Offset translation delta at the end of the range
+    /// Offset translation delta just past the end of this segment. This is
+    /// useful in determining the next Kafka offset, e.g. when reporting the
+    /// high watermark.
     model::offset_delta delta_offset_end;
     /// Segment name format specifier
     segment_name_format sname_format{segment_name_format::v1};
@@ -160,14 +162,19 @@ struct segment_meta {
         return base_offset - delta;
     }
 
-    kafka::offset committed_kafka_offset() const {
+    // NOTE: in older versions of Redpanda, delta_offset_end may have been
+    // under-reported by 1 if the last segment contained no data batches,
+    // meaning next_kafka_offset could over-report the next offset by 1.
+    kafka::offset next_kafka_offset() const {
         // Manifests created with the old version of redpanda won't have the
         // delta_offset_end field. In this case offset translation couldn't be
         // performed.
         auto delta = delta_offset_end == model::offset_delta::min()
                        ? model::offset_delta(0)
                        : delta_offset_end;
-        return committed_offset - delta;
+        // NOTE: delta_offset_end is a misnomer and actually refers to the
+        // offset delta of the next offset after this segment.
+        return model::next_offset(committed_offset) - delta;
     }
 
     auto operator<=>(const segment_meta&) const = default;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -193,7 +193,7 @@ model::offset partition::last_cloud_offset() const {
       cloud_data_available(),
       "Method can only be called if cloud data is available, ntp: {}",
       _raft->ntp());
-    return _cloud_storage_partition->last_uploaded_offset();
+    return kafka::offset_cast(_cloud_storage_partition->last_uploaded_offset());
 }
 
 ss::future<storage::translating_reader> partition::make_cloud_reader(

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -188,12 +188,12 @@ model::offset partition::start_cloud_offset() const {
       _cloud_storage_partition->first_uploaded_offset());
 }
 
-model::offset partition::last_cloud_offset() const {
+model::offset partition::next_cloud_offset() const {
     vassert(
       cloud_data_available(),
       "Method can only be called if cloud data is available, ntp: {}",
       _raft->ntp());
-    return kafka::offset_cast(_cloud_storage_partition->last_uploaded_offset());
+    return kafka::offset_cast(_cloud_storage_partition->next_kafka_offset());
 }
 
 ss::future<storage::translating_reader> partition::make_cloud_reader(

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -248,8 +248,9 @@ public:
     /// Starting offset in the object store
     model::offset start_cloud_offset() const;
 
-    /// Last available cloud offset
-    model::offset last_cloud_offset() const;
+    /// Kafka offset one past the end of the last offset (i.e. the high
+    /// watermark as reported by object storage).
+    model::offset next_cloud_offset() const;
 
     /// Create a reader that will fetch data from remote storage
     ss::future<storage::translating_reader> make_cloud_reader(

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -58,7 +58,7 @@ public:
     model::offset high_watermark() const final {
         if (_partition->is_read_replica_mode_enabled()) {
             if (_partition->cloud_data_available()) {
-                return model::next_offset(_partition->last_cloud_offset());
+                return _partition->next_cloud_offset();
             } else {
                 return model::offset(0);
             }
@@ -70,7 +70,7 @@ public:
         if (_partition->is_read_replica_mode_enabled()) {
             if (_partition->cloud_data_available()) {
                 // There is no difference between HWM and LO in this mode
-                return model::next_offset(_partition->last_cloud_offset());
+                return _partition->next_cloud_offset();
             } else {
                 return model::offset(0);
             }

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -68,6 +68,10 @@ int64_t offset_translator_state::delta(model::offset o) const {
         return delta + (o - it->second.base_offset);
     }
 }
+model::offset_delta
+offset_translator_state::next_offset_delta(model::offset o) const {
+    return model::offset_delta(delta(model::next_offset(o)));
+}
 
 model::offset offset_translator_state::from_log_offset(model::offset o) const {
     const auto d = delta(o);

--- a/src/v/storage/offset_translator_state.h
+++ b/src/v/storage/offset_translator_state.h
@@ -57,6 +57,10 @@ public:
     /// Difference between the log offset and the kafka offset.
     int64_t delta(model::offset) const;
 
+    /// Returns the difference between the log offset and the Kafka offset one
+    /// offset past the input.
+    model::offset_delta next_offset_delta(model::offset) const;
+
     /// Translate log offset into kafka offset.
     model::offset from_log_offset(model::offset) const;
 

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -23,8 +23,7 @@ from rptest.tests.end_to_end import EndToEndTest
 from rptest.utils.expect_rate import ExpectRate, RateTarget
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
 from rptest.services.verifiable_consumer import VerifiableConsumer
-from rptest.util import (
-    wait_until, )
+from rptest.util import (wait_until, wait_until_result)
 
 
 class BucketUsage(NamedTuple):
@@ -182,6 +181,48 @@ class TestReadReplicaService(EndToEndTest):
             return BucketUsage(obj_delta, bytes_delta, keys_delta)
         else:
             return None
+
+    @cluster(num_nodes=8)
+    @matrix(partition_count=[5], cloud_storage_type=[CloudStorageType.S3])
+    def test_identical_hwms(self, partition_count: int,
+                            cloud_storage_type: CloudStorageType) -> None:
+        self._setup_read_replica(partition_count=partition_count,
+                                 num_messages=1000)
+        self.start_consumer()
+        self.run_validation(min_records=1000)  # calls self.consumer.stop()
+
+        def get_hwm_per_partition(cluster: RedpandaService):
+            id_to_hwm = dict()
+            rpk = RpkTool(cluster)
+            for prt in rpk.describe_topic(self.topic_name):
+                id_to_hwm[prt.id] = prt.high_watermark
+            if len(id_to_hwm) != partition_count:
+                return False, None
+            return True, id_to_hwm
+
+        def hwms_are_identical():
+            # Collect the HWMs for each partition before stopping.
+            src_hwms = wait_until_result(
+                lambda: get_hwm_per_partition(self.redpanda),
+                timeout_sec=30,
+                backoff_sec=1)
+
+            # Ensure that our HWMs on the destination are the same.
+            rr_hwms = wait_until_result(
+                lambda: get_hwm_per_partition(self.second_cluster),
+                timeout_sec=30,
+                backoff_sec=1)
+            self.logger.info(f"{src_hwms} vs {rr_hwms}")
+            return src_hwms == rr_hwms
+
+        wait_until(hwms_are_identical, timeout_sec=30, backoff_sec=1)
+
+        # As a sanity check, ensure the same is true after a restart.
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        wait_until(hwms_are_identical, timeout_sec=30, backoff_sec=1)
+
+        self.second_cluster.restart_nodes(self.second_cluster.nodes)
+        wait_until(hwms_are_identical, timeout_sec=30, backoff_sec=1)
 
     @cluster(num_nodes=7)
     @matrix(partition_count=[10],


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Pre-emptive backport of https://github.com/redpanda-data/redpanda/pull/9493

We were previously doing no offset translation of the HWM in read replicas, meaning the returned offset would almost always be higher than it should've been.

This PR updates the behavior of delta_offset_end to return the delta one past the end of each segment, allowing translation to occur by translating the next offset after the end with delta_offset_end (vs translating the end and adding 1).

The caveat here is reconciling the updated semantics with data written in older versions. We need to be mindful that older versions may have a delta_offset_end that is 1 lower than what it should be, meaning the reported HWM and next_kafka_offset calls may be 1 higher than they should be.

Looking at their usages, it seems like this should be a benign change, but it would be good to be wary of this moving forward.

Fixes https://github.com/redpanda-data/redpanda/issues/9513

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Fixed a bug that would result in read replicas reporting a high watermark that was too high.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
