### PR TITLE
log errors when reallocating partitions

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -85,6 +85,7 @@ calculate_total_replicas(const node_replicas_map_t& node_replicas) {
 }
 
 void reassign_replicas(
+  const model::ntp& ntp,
   partition_allocator& allocator,
   partition_assignment current_assignment,
   members_backend::partition_reallocation& reallocation) {
@@ -101,6 +102,13 @@ void reassign_replicas(
       get_allocation_domain(reallocation.ntp));
     if (res.has_value()) {
         reallocation.set_new_replicas(std::move(res.value()));
+    } else {
+        vlog(
+          clusterlog.info,
+          "failed to reallocate partition {} with assignment {}, error: {}",
+          ntp,
+          current_assignment.replicas,
+          res.error());
     }
 }
 
@@ -659,7 +667,8 @@ void members_backend::default_reallocation_strategy::
                         continue;
                     }
                     reallocation.replicas_to_remove.emplace(id);
-                    reassign_replicas(allocator, p, reallocation);
+                    reassign_replicas(
+                      reallocation.ntp, allocator, p, reallocation);
 
                     if (!reallocation.allocation_units.has_value()) {
                         continue;
@@ -1075,7 +1084,7 @@ ss::future<> members_backend::reallocate_replica_set(
         // initial state, try to reassign partition replicas
 
         reassign_replicas(
-          _allocator.local(), std::move(*current_assignment), meta);
+          meta.ntp, _allocator.local(), std::move(*current_assignment), meta);
         if (meta.new_replica_set.empty()) {
             // if partition allocator failed to reassign partitions return
             // and wait for next retry

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -258,7 +258,7 @@ result<allocation_units> partition_balancer_planner::get_reallocation(
 
     if (!reallocation) {
         vlog(
-          clusterlog.debug,
+          clusterlog.info,
           "attempt to find reallocation for ntp {} with "
           "stable_replicas: {} failed, error: {}",
           ntp,


### PR DESCRIPTION
Added info level logging when reallocating partitions in members backend or partition balancer failed. 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none