### PR TITLE
rpk: fix command name in cluster storage recovery

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/status.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/storage/recovery/status.go
@@ -21,7 +21,7 @@ import (
 
 func newStatusCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "start",
+		Use:   "status",
 		Short: "Fetch the status of the topic recovery process",
 		Long: `Fetch the status of the topic recovery process.
 		


### PR DESCRIPTION
From start -> status

This needs to be backported
## Backports Required
- [ ] v23.1.x


## Release Notes

### Bug Fixes

* fixed a bug in `rpk cluster storage recovery` which rendered the `status` command unusable.

