### PR TITLE
admin: include internal RPC endpoint in /v1/brokers

### DIFF
--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -252,6 +252,14 @@
                     "type": "string",
                     "description": "rack id"
                 },
+                "internal_rpc_address": {
+                    "type": "string",
+                    "description": "Internal RPC address (usually, but not necessarily, a hostname)"
+                },
+                "internal_rpc_port": {
+                    "type": "long",
+                    "description": "Internal RPC port"
+                },
                 "membership_status": {
                     "type": "string",
                     "description": "Broker membership status"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -761,6 +761,9 @@ get_brokers(cluster::controller* const controller) {
               b.is_alive = true;
               b.maintenance_status = fill_maintenance_status(std::nullopt);
 
+              b.internal_rpc_address = nm.broker.rpc_address().host();
+              b.internal_rpc_port = nm.broker.rpc_address().port();
+
               broker_map[id] = b;
           }
 
@@ -2075,6 +2078,8 @@ admin_server::get_broker_handler(std::unique_ptr<ss::httpd::request> req) {
 
     ss::httpd::broker_json::broker ret;
     ret.node_id = node_meta->broker.id();
+    ret.internal_rpc_address = node_meta->broker.rpc_address().host();
+    ret.internal_rpc_port = node_meta->broker.rpc_address().port();
     ret.num_cores = node_meta->broker.properties().cores;
     if (node_meta->broker.rack()) {
         ret.rack = node_meta->broker.rack().value();


### PR DESCRIPTION
(and by extension /v1/cluster_view)

This helps external tools infer which "different nodes" might actually be the same physical server that has been removed and re-added, by inspecting the hostname.

Fixes https://github.com/redpanda-data/redpanda/issues/9796

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* The `/v1/brokers` admin API endpoint now includes the broker's `internal_rpc_address` and `internal_rpc_port`.
