### PR TITLE
Controller snapshots: security manager

### DIFF
--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -132,6 +132,11 @@ public:
     std::vector<acl_binding> acls(const acl_binding_filter&) const;
     acl_matches find(resource_type, const ss::sstring&) const;
 
+    // NOTE: the following functions assume that acl_store doesn't change across
+    // yield points.
+    ss::future<fragmented_vector<acl_binding>> all_bindings() const;
+    ss::future<> reset_bindings(const fragmented_vector<acl_binding>& bindings);
+
 private:
     /*
      * resource pattern ordering:

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -121,6 +121,15 @@ public:
           });
     }
 
+    ss::future<fragmented_vector<acl_binding>> all_bindings() const {
+        return _store.all_bindings();
+    }
+
+    ss::future<>
+    reset_bindings(const fragmented_vector<acl_binding>& bindings) {
+        return _store.reset_bindings(bindings);
+    }
+
 private:
     acl_store _store;
 

--- a/src/v/security/credential_store.h
+++ b/src/v/security/credential_store.h
@@ -66,6 +66,8 @@ public:
     const_iterator begin() const { return _credentials.cbegin(); }
     const_iterator end() const { return _credentials.cend(); }
 
+    void clear() { _credentials.clear(); }
+
 private:
     container_type _credentials;
 };


### PR DESCRIPTION
Add `security_manager`-related data to controller snapshots.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

