### PR TITLE
k/client: auto-retry on consumer offsets commit and fetch

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -507,8 +507,10 @@ ss::future<offset_fetch_response> client::consumer_offset_fetch(
   const member_id& name,
   std::vector<offset_fetch_request_topic> topics) {
     return get_consumer(g_id, name)
-      .then([topics{std::move(topics)}](shared_consumer_t c) mutable {
-          return c->offset_fetch(std::move(topics));
+      .then([this, topics{std::move(topics)}](shared_consumer_t c) mutable {
+          return gated_retry_with_mitigation([c, topics{std::move(topics)}]() {
+              return c->offset_fetch(topics);
+          });
       });
 }
 
@@ -517,8 +519,10 @@ ss::future<offset_commit_response> client::consumer_offset_commit(
   const member_id& name,
   std::vector<offset_commit_request_topic> topics) {
     return get_consumer(g_id, name)
-      .then([topics{std::move(topics)}](shared_consumer_t c) mutable {
-          return c->offset_commit(std::move(topics));
+      .then([this, topics{std::move(topics)}](shared_consumer_t c) mutable {
+          return gated_retry_with_mitigation([c, topics{std::move(topics)}]() {
+              return c->offset_commit(topics);
+          });
       });
 }
 


### PR DESCRIPTION
## Cover letter

Add an auto-retry loop to both consumer offset methods in-case of retriable errors such as network problems.

Merge this PR before #9921 

Fixes: #5763 

Changes from force-push `bb89fd6`:
- Remove error handling in consumer offset commit
- Add auto-retry loop to consumer offset fetch

Changes from force-push `7bc1622`:
- Adds Pandaproxy verifiable producer and consumer
- Adds a network delay DT test

Changes from force-push `51fafdb` and `548bc29`:
- Rebase dev to resolve conflicts
- Added method to RedpandaService that does a word count in redpanda logs
- Added a retries check in the network delay test
- Typo fixes

Changes from force-push `e0b95c1`:
- Use `set_default` on `kwargs`
- Removed method in RedpandaService that does a word count in redpanda logs
- Removed retries check in Network delay test

Changes from force-push `dd1c9f7`:
- Retry partition-offset verification process in the consumer

Changes from force-push `666e832`:
- Removed commits for verifiable producer, consumer, and network delay test. Those will go into #9921 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none

