### PR TITLE
r/configuration_manager: add highest_known_offset checkpoint mutex

### DIFF
--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -129,7 +129,8 @@ public:
      * last append. Configuration manager tracks number of bytes that were
      * appended since last write of `highest_known_offset` to kv-store
      */
-    ss::future<> maybe_store_highest_known_offset(model::offset, size_t);
+    void maybe_store_highest_known_offset_in_background(
+      model::offset, size_t bytes, ss::gate&);
 
     /**
      * Returns the highest offset for which the configuration manager
@@ -189,6 +190,8 @@ private:
 
     void add_configuration(model::offset, group_configuration);
 
+    ss::future<> do_maybe_store_highest_known_offset(size_t bytes);
+
     raft::group_id _group;
     underlying_t _configurations;
     /**
@@ -209,6 +212,9 @@ private:
     // Units issued by the storage resource manager to track how many bytes
     // of data is currently pending checkpoint.
     ssx::semaphore_units _bytes_since_last_offset_update_units;
+
+    // set to true when we checkpoint the highest known offset.
+    bool _hko_checkpoint_in_progress = false;
 
     model::revision_id _initial_revision{};
     ctx_log& _ctxlog;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2514,11 +2514,10 @@ ss::future<storage::append_result> consensus::disk_append(
               ssx::spawn_with_gate(
                 _bg, [this] { return _offset_translator.maybe_checkpoint(); });
 
-              ssx::spawn_with_gate(
-                _bg, [this, last_offset = ret.last_offset, sz = ret.byte_size] {
-                    return _configuration_manager
-                      .maybe_store_highest_known_offset(last_offset, sz);
-                });
+              _configuration_manager
+                .maybe_store_highest_known_offset_in_background(
+                  ret.last_offset, ret.byte_size, _bg);
+
               return ret;
           });
       });

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -156,11 +156,13 @@ FIXTURE_TEST(test_getting_configurations, config_manager_fixture) {
     BOOST_REQUIRE_EQUAL(
       _cfg_mgr.get_highest_known_offset(), model::offset(1254));
     validate_recovery();
-    _cfg_mgr
-      .maybe_store_highest_known_offset(
-        model::offset(10000),
-        raft::configuration_manager::offset_update_treshold + 1_KiB)
-      .get0();
+
+    ss::gate gate;
+    _cfg_mgr.maybe_store_highest_known_offset_in_background(
+      model::offset(10000),
+      raft::configuration_manager::offset_update_treshold + 1_KiB,
+      gate);
+    gate.close().get();
 
     validate_recovery();
     BOOST_REQUIRE_EQUAL(


### PR DESCRIPTION
Previously, several background fibers spawned by consensus::disk_append could run configuration_manager::maybe_store_highest_known_offset in parallel. Because the storage_resources units were not released until we actually finished the kvstore write, every bg fiber launched during the kvstore debounce period would do a kvstore write on its own. This commit adds a flag that makes sure that we do only one checkpoint at a time.

Fixes https://github.com/redpanda-data/redpanda/issues/9309

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes
### Bug Fixes
* Fixed excessive kvstore writes that could lead to memory fragmentation issues during heavy produce load.