### PR TITLE
k/client: check for quota in `kafka::client::create_topic`

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -158,6 +158,9 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
               if (ex.node_id == unknown_node_id) {
                   vlog(kclog.warn, "broker_error: {}", ex);
                   return connect();
+              } else if (ex.error == error_code::not_controller) {
+                  vlog(kclog.debug, "broker_error: {}", ex);
+                  return _wait_or_start_update_metadata();
               } else {
                   vlog(kclog.debug, "broker_error: {}", ex);
                   return _brokers.erase(ex.node_id).then([this]() {

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -19,6 +19,28 @@ namespace kc = kafka::client;
 
 class kafka_client_fixture : public redpanda_thread_fixture {
 public:
+    kafka_client_fixture()
+      : redpanda_thread_fixture() {}
+
+    kafka_client_fixture(std::optional<uint32_t> kafka_admin_topic_api_rate)
+      : redpanda_thread_fixture(
+        model::node_id(1),
+        9092,
+        33145,
+        8082,
+        8081,
+        43189,
+        {},
+        ssx::sformat("test.dir_{}", time(0)),
+        std::nullopt,
+        true,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        configure_node_id::yes,
+        empty_seed_starts_cluster::yes,
+        kafka_admin_topic_api_rate) {}
+
     void restart(bool test_mode = false) {
         shutdown();
         app_signal = std::make_unique<::stop_signal>();

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -201,7 +201,7 @@ public:
         } else if constexpr (std::is_same_v<type, list_groups_request>) {
             return dispatch(std::move(r), api_version(2));
         } else if constexpr (std::is_same_v<type, create_topics_request>) {
-            return dispatch(std::move(r), api_version(4));
+            return dispatch(std::move(r), api_version(6));
         } else if constexpr (std::is_same_v<type, sasl_handshake_request>) {
             return dispatch(std::move(r), api_version(1));
         } else if constexpr (std::is_same_v<type, sasl_authenticate_request>) {


### PR DESCRIPTION
## Cover letter

#5763 Lists a few areas in our internal kafka client that are missing exceptions and error handling. This PR adds exceptions and unit tests for the `throttling_quota_exceeded` error that could occur in `kafka::client::create_topic()`.

Changes from force-push `a042d9f`:
- Do not change logger levels
- Refactor the retry unit test for topic creation such that adding `kafka_admin_topic_api_rate` does not affect all kafka_client_fixture tests

Changes from force-push `3d87bbe`:
- Replace `BOOST_CHECK_EQUAL` with `BOOST_REQUIRE_EQUAL`

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* The Redpanda kafka client will throw an exception on `throttling_quota_exceeded` when creating a topic that exceeds the `kafka_admin_topic_api_rate` config.

### Bug Fixes

* Do not remove the controller broker on `not_controller` error from `kafka::client::create_topic()`

