### PR TITLE
tests: ok_to_fail unstable cloud deletion tests

### DIFF
--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -12,6 +12,8 @@ import json
 from typing import Optional
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import ok_to_fail
+
 from ducktape.mark import matrix, parametrize
 from requests.exceptions import HTTPError
 
@@ -402,6 +404,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             self.si_settings.cloud_storage_bucket, topic=topic_name)
         assert sum(1 for _ in objects) > 0
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8496
     @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=3)
     def topic_delete_installed_snapshots_test(self):
@@ -443,6 +446,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                    timeout_sec=30,
                    backoff_sec=1)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/9629
     @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(
         num_nodes=3,


### PR DESCRIPTION
This code is giong to get revised ahead  of 23.2 with tombstones, which will generally make it more reliable but also involvev test changes, so let's defer stabilizing these until then.

Related: https://github.com/redpanda-data/redpanda/issues/9629
Related: https://github.com/redpanda-data/redpanda/issues/8496

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
