### PR TITLE
read_replica_e2e_test: remove bad assertion

### DIFF
--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -414,6 +414,7 @@ class ReadReplicasUpgradeTest(EndToEndTest):
             lambda: cluster_has_offsets(self.second_cluster),
             timeout_sec=30,
             backoff_sec=1)
+        self.logger.info(f"pre-upgrade read replica HWMs: {rr_hwms}")
         # Upgrade the read replica cluster first.
         self.second_cluster._installer.install(self.second_cluster.nodes,
                                                RedpandaInstaller.HEAD)
@@ -423,7 +424,7 @@ class ReadReplicasUpgradeTest(EndToEndTest):
             lambda: cluster_has_offsets(self.second_cluster),
             timeout_sec=30,
             backoff_sec=1)
-        assert new_rr_hwms != rr_hwms, f"{new_rr_hwms} vs {rr_hwms}"
+        self.logger.info(f"post-upgrade read replica HWMs: {new_rr_hwms}")
 
         # Then upgrade the source cluster and make sure the source and RRR
         # cluster match.


### PR DESCRIPTION
The test assumes the previous version of Redpanda has broken high watermarks, which will change as #9493 is backported and released.

Fixes https://github.com/redpanda-data/redpanda/issues/9835

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
