### PR TITLE
tests: use low manifest upload interval in UpgradeFromPriorFeatureVersionCloudStorageTest

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1604,6 +1604,7 @@ ss::future<> ntp_archiver::housekeeping() {
             const auto gc_updated_manifest = co_await garbage_collect();
             if (retention_updated_manifest || gc_updated_manifest) {
                 co_await upload_manifest(housekeeping_ctx_label);
+                co_await maybe_flush_manifest_clean_offset();
             }
         }
     } catch (std::exception& e) {
@@ -1943,6 +1944,10 @@ ss::future<bool> ntp_archiver::do_upload_local(
         vlog(
           _rtclog.info,
           "archival metadata replicated but manifest is not re-uploaded");
+    } else {
+        // Write to archival_metadata_stm to mark our updated clean offset
+        // as a result of uploading the manifest successfully.
+        co_await maybe_flush_manifest_clean_offset();
     }
     co_return true;
 }

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -493,6 +493,15 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
             or initial_version > Version("23.1.0")
             and initial_version < Version("23.2.0"))
 
+        #  23.1.x -> 23.2.x: the `cloud_storage_manifest_max_upload_interval_sec` is new,
+        #                    and needs to be set to avoid the test timing out waiting for
+        #                    local log trim, as in 23.2.x we are lazy about uploading manifests by default.
+        if initial_version > Version("23.1.0") and initial_version < Version(
+                "23.2.0"):
+            admin.patch_cluster_config(
+                upsert={'cloud_storage_manifest_max_upload_interval_sec': 1},
+                node=new_version_node)
+
         if block_uploads_during_upgrade:
             # If uploads are blocked during upgrade, we expect the new
             # nodes not to be able to trim their local logs.


### PR DESCRIPTION

This makes calls to `wait_for_local_storage_truncate` complete reliably within modest 30 second timeouts, and also makes the "sleep" in block_uploads_during_upgrade a stronger check (otherwise a 10 second sleep has an excellent chance of missing uploads even if they are going to happen).

Fixes https://github.com/redpanda-data/redpanda/issues/9756

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none