### PR TITLE
Install helm kubectl in redpanda test node image

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -179,4 +179,31 @@ function install_go_test_clients() {
   go build
 }
 
+function install_k8s_tools() {
+  # install helm
+  if [ $(uname -m) = "aarch64" ]; then
+    export ARCHID="arm64"
+  else
+    export ARCHID="amd64"
+  fi
+  HELM_VERSION=3.11.2
+  HELM_URL="https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCHID}.tar.gz"
+  curl \
+    -sSLf \
+    --retry 3 \
+    --retry-connrefused \
+    --retry-delay 2 \
+    $HELM_URL \
+    -o /tmp/helm.tgz
+  tar -xz -C /tmp --strip 1 -f /tmp/helm.tgz "linux-${ARCHID}/helm"
+  mv /tmp/helm /usr/local/bin/
+  rm -rf /tmp/*
+
+  # install kubectl
+  KUBECTL_VERSION=1.26.0
+  KUBECTL_URL="https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${ARCHID}/kubectl"
+  curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 ${KUBECTL_URL} --retry-all-errors -o /usr/local/bin/kubectl
+  chmod +x /usr/local/bin/kubectl
+}
+
 $@


### PR DESCRIPTION
fixes https://github.com/redpanda-data/devprod/issues/654

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
