### PR TITLE
admin: drop no-op user requests before writing to controller log

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1689,6 +1689,12 @@ bool is_no_op_user_write(
 
 ss::future<ss::json::json_return_type>
 admin_server::create_user_handler(std::unique_ptr<ss::httpd::request> req) {
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        // In order that we can do a reliably ordered validation of
+        // the request (and drop no-op requests), run on controller leader;
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
+
     auto doc = parse_json_body(*req);
 
     auto credential = parse_scram_credential(doc);
@@ -1734,6 +1740,12 @@ admin_server::create_user_handler(std::unique_ptr<ss::httpd::request> req) {
 
 ss::future<ss::json::json_return_type>
 admin_server::delete_user_handler(std::unique_ptr<ss::httpd::request> req) {
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        // In order that we can do a reliably ordered validation of
+        // the request (and drop no-op requests), run on controller leader;
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
+
     auto user = security::credential_user(req->param["user"]);
 
     if (!_controller->get_credential_store().local().contains(user)) {
@@ -1755,6 +1767,12 @@ admin_server::delete_user_handler(std::unique_ptr<ss::httpd::request> req) {
 
 ss::future<ss::json::json_return_type>
 admin_server::update_user_handler(std::unique_ptr<ss::httpd::request> req) {
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        // In order that we can do a reliably ordered validation of
+        // the request (and drop no-op requests), run on controller leader;
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
+
     auto user = security::credential_user(req->param["user"]);
 
     auto doc = parse_json_body(*req);


### PR DESCRIPTION
Clients should also avoid issuing these requests to begin
with, but in case of bad behavior, let's avoid generating
unnecessary writes to the controller log.

This is backportable defense-in-depth: although we now have
controller snapshots that avoid the worst consequences of
oversized controller logs, it is still beneficial to avoid writing
this kind of record to the controller log to begin with, if we
experience clients that make the assumption that issuing
the same PUT twice in a row will not result in two I/Os.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Duplicate PUT/POST/DELETE admin API requests for user management are now handled more efficiently.
