### PR TITLE
[v23.1.x] cloud_storage: Prevent segment reuploads from adjacent segment merger

### DIFF
--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -134,6 +134,10 @@ adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
       .consumed = run_quota_t(0),
       .remaining = quota,
     };
+    vlog(
+      _ctxlog.debug,
+      "Adjacent segment merger run begin, last offset is {}",
+      _last);
     for (int i = 0; i < max_reuploads_per_run; i++) {
         if (!_enabled || _as.abort_requested()) {
             co_return result;
@@ -141,7 +145,6 @@ adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
         if (result.remaining <= 0) {
             co_return result;
         }
-        vlog(_ctxlog.debug, "Adjacent segment merger run begin");
         auto scanner = [this](
                          model::offset local_start_offset,
                          const cloud_storage::partition_manifest& manifest) {
@@ -159,6 +162,13 @@ adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
           upl->candidate.exposed_name,
           upl->candidate.sources.size(),
           upl->candidate.final_offset);
+        for (const auto& src : upl->candidate.sources) {
+            vlog(
+              _ctxlog.debug,
+              "Local log segment {} found, size {}",
+              src->filename(),
+              src->size_bytes());
+        }
         auto uploaded = co_await _archiver.upload(
           std::move(*upl), std::ref(rtc));
         if (uploaded) {
@@ -169,11 +179,23 @@ adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
             result.metadata_syncs += 1;
             result.consumed = result.consumed + run_quota_t{1};
             result.remaining = result.remaining - run_quota_t{1};
+            vlog(
+              _ctxlog.debug,
+              "Successfuly uploaded segment, new last offfset is {}",
+              _last);
         } else {
             // Upload failed
             result.status = run_status::failed;
+            vlog(
+              _ctxlog.debug,
+              "Failed to upload segment, last offfset is {}",
+              _last);
         }
     }
+    vlog(
+      _ctxlog.debug,
+      "Adjacent segment merger run completed, last offset is {}",
+      _last);
     co_return result;
 }
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1489,6 +1489,15 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
             vlog(_rtclog.warn, "Failed to make upload candidate");
             co_return std::nullopt;
         }
+        if (candidate.candidate.content_length != run->meta.size_bytes) {
+            vlog(
+              _rtclog.error,
+              "Failed to make upload candidate with correct size, expected {}, "
+              "actual {}",
+              candidate.candidate,
+              run->meta);
+            co_return std::nullopt;
+        }
         co_return candidate;
     }
     // segment_name exposed_name;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1480,7 +1480,11 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
         auto& log = dynamic_cast<storage::disk_log_impl&>(
           *log_generic.get_impl());
         segment_collector collector(
-          run->meta.base_offset, manifest(), log, run->meta.size_bytes);
+          run->meta.base_offset,
+          manifest(),
+          log,
+          run->meta.size_bytes,
+          run->meta.committed_offset);
         collector.collect_segments(
           segment_collector_mode::collect_non_compacted);
         auto candidate = co_await collector.make_upload_candidate(

--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -24,11 +24,13 @@ segment_collector::segment_collector(
   model::offset begin_inclusive,
   const cloud_storage::partition_manifest& manifest,
   const storage::disk_log_impl& log,
-  size_t max_uploaded_segment_size)
+  size_t max_uploaded_segment_size,
+  std::optional<model::offset> end_inclusive)
   : _begin_inclusive(begin_inclusive)
   , _manifest(manifest)
   , _log(log)
   , _max_uploaded_segment_size(max_uploaded_segment_size)
+  , _target_end_inclusive(end_inclusive)
   , _collected_size(0) {}
 
 void segment_collector::collect_segments(segment_collector_mode mode) {
@@ -51,6 +53,29 @@ void segment_collector::collect_segments(segment_collector_mode mode) {
           _manifest.get_ntp());
         return;
     }
+    if (_target_end_inclusive.has_value()) {
+        if (_target_end_inclusive.value() < _log.offsets().start_offset) {
+            vlog(
+              archival_log.debug,
+              "Provided end offset is below the start offset of the local log: "
+              "{} < {} for ntp {}. Advancing to the beginning of the local "
+              "log.",
+              _target_end_inclusive.value(),
+              _log.offsets().start_offset,
+              _manifest.get_ntp());
+            return;
+        }
+        if (_target_end_inclusive.value() > _manifest.get_last_offset()) {
+            vlog(
+              archival_log.debug,
+              "Target end offset {} is ahead of manifest last offset {} for "
+              "ntp {}",
+              _target_end_inclusive.value(),
+              _manifest.get_last_offset(),
+              _manifest.get_ntp());
+            return;
+        }
+    }
 
     do_collect(mode);
 }
@@ -60,10 +85,12 @@ segment_collector::segment_seq segment_collector::segments() {
 }
 
 void segment_collector::do_collect(segment_collector_mode mode) {
-    auto replace_boundary = find_replacement_boundary();
+    auto replace_boundary = _target_end_inclusive.value_or(
+      find_replacement_boundary());
     auto start = _begin_inclusive;
     model::offset current_segment_end{0};
-    while (current_segment_end < _manifest.get_last_offset()) {
+    bool done = false;
+    while (!done && current_segment_end < _manifest.get_last_offset()) {
         auto result = find_next_segment(start, mode);
         if (result.segment.get() == nullptr) {
             break;
@@ -74,7 +101,25 @@ void segment_collector::do_collect(segment_collector_mode mode) {
         }
 
         auto segment_size = result.segment->size_bytes();
-        if (_collected_size + segment_size > _max_uploaded_segment_size) {
+        if (
+          _target_end_inclusive.has_value()
+          && result.segment->offsets().committed_offset
+               >= _target_end_inclusive.value()) {
+            // In this case the collected size may overflow
+            // _max_uploaded_segment_size a bit so we could actually find
+            // _target_end_inclusive inside the last segment.
+            vlog(
+              archival_log.debug,
+              "Segment collect for ntp {} stopping collection, total size: {} "
+              "reached target end offset: {}, current collected size: {}",
+              _manifest.get_ntp(),
+              _collected_size + segment_size,
+              _target_end_inclusive.value(),
+              _collected_size);
+            // Current segment has to be added to the list of results
+            done = true;
+        } else if (
+          _collected_size + segment_size > _max_uploaded_segment_size) {
             vlog(
               archival_log.debug,
               "Segment collect for ntp {} stopping collection, total "
@@ -103,7 +148,8 @@ void segment_collector::do_collect(segment_collector_mode mode) {
         _can_replace_manifest_segment = true;
     }
 
-    align_end_offset_to_manifest(current_segment_end);
+    align_end_offset_to_manifest(
+      _target_end_inclusive.value_or(current_segment_end));
 }
 
 model::offset segment_collector::find_replacement_boundary() const {

--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -404,7 +404,23 @@ segment_collector::make_upload_candidate(
           "No segments to reupload for {}",
           _manifest.get_ntp());
         co_return upload_candidate_with_locks{upload_candidate{}, {}};
+    } else {
+        if (archival_log.is_enabled(ss::log_level::debug)) {
+            std::stringstream seg;
+            for (const auto& s : _segments) {
+                fmt::print(
+                  seg,
+                  "{}-{}/{}; ",
+                  s->offsets().base_offset,
+                  s->offsets().committed_offset,
+                  s->size_bytes());
+            }
+            vlog(archival_log.debug, "Collected segments: {}", seg.str());
+        }
     }
+
+    auto last = _segments.back();
+    auto last_size_bytes = last->size_bytes();
 
     // Take the locks before opening any readers on the segments.
     auto deadline = std::chrono::steady_clock::now() + segment_lock_duration;
@@ -430,7 +446,6 @@ segment_collector::make_upload_candidate(
         co_return upload_candidate_with_locks{upload_candidate{}, {}};
     }
 
-    auto last = _segments.back();
     auto tail_seek_result = co_await storage::convert_end_offset_to_file_pos(
       _end_inclusive, last, last->index().max_timestamp(), io_priority_class);
 
@@ -441,8 +456,19 @@ segment_collector::make_upload_candidate(
     auto head_seek = head_seek_result.value();
     auto tail_seek = tail_seek_result.value();
 
+    vlog(
+      archival_log.debug,
+      "collected size: {}, last segment {}-{}/{}, head seek bytes: {}, tail "
+      "seek bytes: {}",
+      _collected_size,
+      last->offsets().base_offset,
+      last->offsets().committed_offset,
+      last_size_bytes,
+      head_seek.bytes,
+      tail_seek.bytes);
+
     size_t content_length = _collected_size
-                            - (head_seek.bytes + last->size_bytes());
+                            - (head_seek.bytes + last_size_bytes);
     content_length += tail_seek.bytes;
 
     auto starting_offset = head_seek.offset;

--- a/src/v/archival/segment_reupload.h
+++ b/src/v/archival/segment_reupload.h
@@ -37,11 +37,20 @@ class segment_collector {
 public:
     using segment_seq = std::vector<ss::lw_shared_ptr<storage::segment>>;
 
+    /// C-tor
+    ///
+    /// \param begin_inclusive is a first offset in range
+    /// \param manifest is a partition manifest
+    /// \param log is a partition log
+    /// \param max_uploaded_segment_size is a size limit for the offset range
+    /// \param end_inclusive is a target for the end offset (if not set the
+    ///        collector will try to match the size only)
     segment_collector(
       model::offset begin_inclusive,
       const cloud_storage::partition_manifest& manifest,
       const storage::disk_log_impl& log,
-      size_t max_uploaded_segment_size);
+      size_t max_uploaded_segment_size,
+      std::optional<model::offset> end_inclusive = std::nullopt);
 
     /// Collect segments
     ///
@@ -119,6 +128,7 @@ private:
     bool _can_replace_manifest_segment{false};
 
     size_t _max_uploaded_segment_size;
+    std::optional<model::offset> _target_end_inclusive;
     size_t _collected_size;
 };
 

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -491,13 +491,10 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
           meta.base_offset, meta.segment_term);
         vlog(
           _logger.info,
-          "new remote segment added (name: {}, base_offset: {} "
-          "last_offset: "
-          "{}), "
+          "new remote segment added (name: {}, meta: {}"
           "remote start_offset: {}, last_offset: {}",
           name,
-          meta.base_offset,
-          meta.committed_offset,
+          meta,
           get_start_offset(),
           get_last_offset());
     }
@@ -717,10 +714,11 @@ void archival_metadata_stm::apply_add_segment(const segment& segment) {
     vlog(
       _logger.debug,
       "Add segment command applied with {}, new start offset: {}, new last "
-      "offset: {}",
+      "offset: {}, meta: {}",
       segment.name,
       get_start_offset(),
-      get_last_offset());
+      get_last_offset(),
+      segment.meta);
 
     if (meta.committed_offset > get_last_offset()) {
         if (meta.base_offset > model::next_offset(get_last_offset())) {


### PR DESCRIPTION
Backport #9657

This PR fixes #9651

Currently, the `segment_collector` is initialised using desired size of the segment reupload. The adjacent segment merger scans the manifest and finds the right upload candidate (a series of small segments). Then it calculates its size and uses it to create `segment_collector`. This is not correct because if the last segment is not aligned perfectly the collector will return a result without one last segment. This last segment will overflow the size target and be discarded.

With some configurations (close min and target values for adjacent segment merger) this can lead to a situation when the segment gets re uploaded multiple times. 

To avoid this several things were added:
- The `adjacent_segment_merger` checks the size of the segment run that it gets out of the `segment_collector` before uploading. If the size is smaller it discards the result.
- The `segment_collector` is updated to accept extra parameter which is used as a target offset for the end of the offset range. If this parameter is set the `segment _collector` will continue scanning until it will reach the segment that contains the target offset. Then it will adjust the upload so this last segment won't be fully uploaded. Instead, it will be uploaded up to the target offset.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Improve precision of the adjacent segment merger to avoid unnecessary segment reuploads