### PR TITLE
Fix 9850: return committed_leader_epoch on offset_fetch

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2683,6 +2683,7 @@ group::handle_offset_fetch(offset_fetch_request&& r) {
                 if (res) {
                     p.partition_index = id;
                     p.committed_offset = res->offset;
+                    p.committed_leader_epoch = res->committed_leader_epoch;
                     p.metadata = res->metadata;
                     p.error_code = error_code::none;
                 }


### PR DESCRIPTION
Return committed_leader_epoch on offset_fetch when topic/topics are provided

Fixes #9850

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* fix consumer group kafka incompatibilities (update `offset_fetch` to return `committed_leader_epoch`)