### PR TITLE
cloud_storage: Read path hardening

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -271,6 +271,49 @@ public:
                     co_await set_end_of_stream();
                     co_return storage_t{};
                 }
+                auto reader_delta = _reader->current_delta();
+                if (
+                  !_ot_state->empty()
+                  && _ot_state->last_delta() > reader_delta) {
+                    // It's not safe to call 'read_sone' with the current
+                    // offset translator state becuase delta offset of the
+                    // current reader is below last delta registred by the
+                    // offset translator. The offset translator contains data
+                    // from the previous segment and there is an inconsistency
+                    // between them.
+                    //
+                    // If the reader never produced any data we can simply reset
+                    // the offset translator state and continue. Otherwise, we
+                    // need to stop producing.
+                    //
+                    // This trick should guarantee us forward progress. If the
+                    // reader will stop right away before it will be able to
+                    // produce any batches (in the first branch) that belong to
+                    // the current segment the next fetch request will likely
+                    // have start_offset that corresponds to the previous
+                    // segment. In this case the reader will have to skip all
+                    // previously seen batches and _first_produced_offset will
+                    // be set to default value. This will allow reader to reset
+                    // the ot_state and move to the current segment in the
+                    // second branch. This is safe because the ot_state won't
+                    // have any information about the previous segment.
+                    vlog(
+                      _ctxlog.info,
+                      "Detected inconsistency. Reader config: {}, delta offset "
+                      "of the current reader: {}, delta offset of the offset "
+                      "translator: {}, first offset produced by this reader: "
+                      "{}",
+                      _reader->config(),
+                      reader_delta,
+                      _ot_state->last_delta(),
+                      _first_produced_offset);
+                    if (_first_produced_offset != model::offset{}) {
+                        co_await set_end_of_stream();
+                        co_return storage_t{};
+                    } else {
+                        _ot_state->reset();
+                    }
+                }
                 vlog(
                   _ctxlog.debug,
                   "Invoking 'read_some' on current log reader with config: "
@@ -290,6 +333,9 @@ public:
                     _partition->_probe.add_bytes_read(
                       batch.header().size_bytes);
                     _partition->_probe.add_records_read(batch.record_count());
+                }
+                if (_first_produced_offset == model::offset{} && !d.empty()) {
+                    _first_produced_offset = d.front().base_offset();
                 }
                 co_return storage_t{std::move(d)};
             }
@@ -475,6 +521,9 @@ private:
     /// Guard for the partition gate
     gate_guard _gate_guard;
     model::offset _next_segment_base_offset{};
+    /// Contains offset of the first produced record batch or min()
+    /// if no data were produced yet
+    model::offset _first_produced_offset{};
 };
 
 remote_partition::remote_partition(

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -266,6 +266,8 @@ public:
         return _cur_rp_offset - _cur_delta;
     }
 
+    model::offset_delta current_delta() const { return _cur_delta; }
+
     bool reads_from_segment(const remote_segment& segm) const {
         return &segm == _seg.get();
     }

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -251,6 +251,8 @@ bool offset_translator_state::add_absolute_delta(
     return false;
 }
 
+void offset_translator_state::reset() { _last_offset2batch.clear(); }
+
 bool offset_translator_state::truncate(model::offset offset) {
     vassert(
       !_last_offset2batch.empty(),

--- a/src/v/storage/offset_translator_state.h
+++ b/src/v/storage/offset_translator_state.h
@@ -80,6 +80,9 @@ public:
     /// the map changed.
     bool add_absolute_delta(model::offset offset, int64_t delta);
 
+    /// Remove all gaps from offset translator
+    void reset();
+
     /// Removes the offset translation state starting from the offset
     /// (inclusive). Returns true if the map changed.
     bool truncate(model::offset);


### PR DESCRIPTION
In the restored partition the delta-offset values of uploaded segments will reset and stop being monotonic. This breaks our read path because the `offset_translator_state` instance is crated per fetch request and every fetch request can read from more than one segment. If the partition reader reads from two segments and the second segment has delta offset which is lower than delta offset of the previous segment the `offset_translator_state` will throw.

To avoid this the reader detects this situation and exits early or resets the `offset_translator_state`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix offset translation failure that could be triggered after topic recovery 