### PR TITLE
raft: expose partition/raft state via admin API

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -12,6 +12,7 @@
 #include "cluster/errc.h"
 #include "cluster/logger.h"
 #include "cluster/metadata_cache.h"
+#include "cluster/partition.h"
 #include "cluster/simple_batch_builder.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
@@ -299,6 +300,98 @@ get_allocation_domain(const model::topic_namespace_view tp_ns) {
         return partition_allocation_domains::consumer_offsets;
     }
     return partition_allocation_domains::common;
+}
+
+partition_state get_partition_state(ss::lw_shared_ptr<partition> partition) {
+    partition_state state{};
+    if (unlikely(!partition)) {
+        return state;
+    }
+    state.start_offset = partition->start_offset();
+    state.committed_offset = partition->committed_offset();
+    state.last_stable_offset = partition->last_stable_offset();
+    state.high_water_mark = partition->high_watermark();
+    state.dirty_offset = partition->dirty_offset();
+    state.latest_configuration_offset
+      = partition->get_latest_configuration_offset();
+    state.revision_id = partition->get_revision_id();
+    state.log_size_bytes = partition->size_bytes();
+    state.non_log_disk_size_bytes = partition->non_log_disk_size_bytes();
+    state.is_read_replica_mode_enabled
+      = partition->is_read_replica_mode_enabled();
+    state.is_remote_fetch_enabled = partition->is_remote_fetch_enabled();
+    state.is_cloud_data_available = partition->cloud_data_available();
+    state.read_replica_bucket = partition->is_read_replica_mode_enabled()
+                                  ? partition->get_read_replica_bucket()()
+                                  : "";
+    if (state.is_cloud_data_available) {
+        state.start_cloud_offset = partition->start_cloud_offset();
+        state.next_cloud_offset = partition->next_cloud_offset();
+    } else {
+        state.start_cloud_offset = state.next_cloud_offset = model::offset{-1};
+    }
+    state.raft_state = get_partition_raft_state(partition->raft());
+    return state;
+}
+
+partition_raft_state get_partition_raft_state(consensus_ptr ptr) {
+    partition_raft_state raft_state{};
+    if (unlikely(!ptr)) {
+        return raft_state;
+    }
+    raft_state.node = ptr->self().id();
+    raft_state.term = ptr->term();
+    raft_state.offset_translator_state = fmt::format(
+      "{}", *(ptr->get_offset_translator_state()));
+    raft_state.group_configuration = fmt::format("{}", ptr->config());
+    raft_state.confirmed_term = ptr->confirmed_term();
+    raft_state.flushed_offset = ptr->flushed_offset();
+    raft_state.commit_index = ptr->committed_offset();
+    raft_state.majority_replicated_index = ptr->majority_replicated_index();
+    raft_state.visibility_upper_bound_index
+      = ptr->visibility_upper_bound_index();
+    raft_state.last_quorum_replicated_index
+      = ptr->last_quorum_replicated_index();
+    raft_state.last_snapshot_index = ptr->last_snapshot_index();
+    raft_state.last_snapshot_term = ptr->last_snapshot_term();
+    raft_state.received_snapshot_index = ptr->received_snapshot_index();
+    raft_state.received_snapshot_bytes = ptr->received_snapshot_bytes();
+    raft_state.has_pending_flushes = ptr->has_pending_flushes();
+    raft_state.is_leader = ptr->is_leader();
+    raft_state.is_elected_leader = ptr->is_elected_leader();
+
+    const auto& fstats = ptr->get_follower_stats();
+    if (ptr->is_elected_leader() && fstats.size() > 0) {
+        using follower_state = partition_raft_state::follower_state;
+        std::vector<follower_state> followers;
+        followers.reserve(fstats.size());
+        for (const auto& fstat : fstats) {
+            const auto& md = fstat.second;
+            follower_state state;
+            state.node = md.node_id.id();
+            state.last_dirty_log_index = md.last_dirty_log_index;
+            state.last_flushed_log_index = md.last_flushed_log_index;
+            state.match_index = md.match_index;
+            state.next_index = md.next_index;
+            state.last_sent_offset = md.last_sent_offset;
+            state.heartbeats_failed = md.heartbeats_failed;
+            state.is_learner = md.is_learner;
+            state.is_recovering = md.is_recovering;
+            state.ms_since_last_heartbeat
+              = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  raft::clock_type::now() - md.last_received_reply_timestamp)
+                  .count();
+            state.last_sent_seq = md.last_sent_seq;
+            state.last_received_seq = md.last_received_seq;
+            state.last_successful_received_seq
+              = md.last_successful_received_seq;
+            state.suppress_heartbeats = md.suppress_heartbeats
+                                        == raft::heartbeats_suppressed::yes;
+            followers.push_back(std::move(state));
+        }
+        raft_state.followers = std::move(followers);
+    }
+    return raft_state;
 }
 
 } // namespace cluster

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -51,6 +51,7 @@ struct configuration;
 namespace cluster {
 
 class metadata_cache;
+class partition;
 
 /// Creates the same topic_result for all requests
 template<typename T>
@@ -380,5 +381,8 @@ inline partition_allocation_domain
 get_allocation_domain(const model::ntp& ntp) {
     return get_allocation_domain(model::topic_namespace_view(ntp));
 }
+
+partition_state get_partition_state(ss::lw_shared_ptr<cluster::partition>);
+partition_raft_state get_partition_raft_state(consensus_ptr);
 
 } // namespace cluster

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -265,6 +265,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_cloud_storage_api),
             std::ref(_feature_table),
             std::ref(_members_table),
+            std::ref(_partition_manager),
+            std::ref(_shard_table),
             ss::sharded_parameter([] {
                 return config::shard_local_cfg()
                   .storage_space_alert_free_threshold_percent.bind();

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -135,6 +135,11 @@
             "name": "cloud_storage_usage",
             "input_type": "cloud_storage_usage_request",
             "output_type": "cloud_storage_usage_reply"
+        },
+        {
+            "name": "get_partition_state",
+            "input_type": "partition_state_request",
+            "output_type": "partition_state_reply"
         }
     ]
 }

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -745,4 +745,16 @@ service::do_cloud_storage_usage(cloud_storage_usage_request req) {
       .missing_partitions = std::move(result.missing_partitions)};
 }
 
+ss::future<partition_state_reply> service::get_partition_state(
+  partition_state_request&& req, rpc::streaming_context&) {
+    return ss::with_scheduling_group(get_scheduling_group(), [this, req]() {
+        return do_get_partition_state(req);
+    });
+}
+
+ss::future<partition_state_reply>
+service::do_get_partition_state(partition_state_request) {
+    co_return partition_state_reply{};
+}
+
 } // namespace cluster

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -753,8 +753,28 @@ ss::future<partition_state_reply> service::get_partition_state(
 }
 
 ss::future<partition_state_reply>
-service::do_get_partition_state(partition_state_request) {
-    co_return partition_state_reply{};
+service::do_get_partition_state(partition_state_request req) {
+    const auto ntp = req.ntp;
+    const auto shard = _api.local().shard_for(ntp);
+    partition_state_reply reply{};
+    if (!shard) {
+        reply.error_code = errc::partition_not_exists;
+        co_return reply;
+    }
+
+    co_return co_await _partition_manager.invoke_on(
+      *shard,
+      [req = std::move(req),
+       reply = std::move(reply)](cluster::partition_manager& pm) mutable {
+          auto partition = pm.get(req.ntp);
+          if (!partition) {
+              reply.error_code = errc::partition_not_exists;
+              return ss::make_ready_future<partition_state_reply>(reply);
+          }
+          reply.state = ::cluster::get_partition_state(partition);
+          reply.error_code = errc::success;
+          return ss::make_ready_future<partition_state_reply>(reply);
+      });
 }
 
 } // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -118,6 +118,9 @@ public:
     ss::future<cloud_storage_usage_reply> cloud_storage_usage(
       cloud_storage_usage_request&& r, rpc::streaming_context&) final;
 
+    ss::future<partition_state_reply> get_partition_state(
+      partition_state_request&&, rpc::streaming_context&) final;
+
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
     std::
@@ -154,6 +157,9 @@ private:
 
     ss::future<cloud_storage_usage_reply>
       do_cloud_storage_usage(cloud_storage_usage_request);
+
+    ss::future<partition_state_reply>
+      do_get_partition_state(partition_state_request);
 
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -21,8 +21,10 @@
 #include "cluster/logger.h"
 #include "cluster/members_table.h"
 #include "cluster/partition_leaders_table.h"
+#include "cluster/partition_manager.h"
 #include "cluster/scheduling/constraints.h"
 #include "cluster/scheduling/partition_allocator.h"
+#include "cluster/shard_table.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "model/errc.h"
@@ -1393,6 +1395,121 @@ ss::future<std::error_code> topics_frontend::move_partition_replicas(
 
     co_return co_await move_partition_replicas(
       ntp, std::move(assignments.value().front().replicas), tout, term);
+}
+
+ss::future<result<partition_state_reply>>
+topics_frontend::do_get_partition_state(model::node_id node, model::ntp ntp) {
+    if (node == _self) {
+        partition_state_reply reply{};
+        auto shard = _shard_table.local().shard_for(ntp);
+        if (!shard) {
+            reply.error_code = errc::partition_not_exists;
+            return ss::make_ready_future<result<partition_state_reply>>(reply);
+        }
+        return _pm.invoke_on(
+          *shard,
+          [ntp = std::move(ntp),
+           reply = std::move(reply)](partition_manager& pm) mutable {
+              auto partition = pm.get(ntp);
+              if (!partition) {
+                  reply.error_code = errc::partition_not_exists;
+                  return ss::make_ready_future<result<partition_state_reply>>(
+                    reply);
+              }
+              reply.state = ::cluster::get_partition_state(partition);
+              reply.error_code = errc::success;
+              return ss::make_ready_future<result<partition_state_reply>>(
+                reply);
+          });
+    }
+    auto timeout = model::timeout_clock::now() + 5s;
+    return _connections.local().with_node_client<controller_client_protocol>(
+      _self,
+      ss::this_shard_id(),
+      node,
+      timeout,
+      [ntp = std::move(ntp),
+       timeout](controller_client_protocol client) mutable {
+          return client
+            .get_partition_state(
+              partition_state_request{.ntp = ntp}, rpc::client_opts(timeout))
+            .then(&rpc::get_ctx_data<partition_state_reply>);
+      });
+}
+
+ss::future<result<std::vector<partition_state>>>
+topics_frontend::get_partition_state(model::ntp ntp) {
+    const auto& topics = _topics.local();
+    if (!topics.contains(model::topic_namespace_view(ntp))) {
+        co_return errc::partition_not_exists;
+    }
+    std::set<model::node_id> nodes_to_query;
+    const auto& current = topics.get_partition_assignment(ntp);
+    if (current) {
+        const auto& bss = current->replicas;
+        std::for_each(
+          bss.begin(),
+          bss.end(),
+          [&nodes_to_query](const model::broker_shard& bs) {
+              nodes_to_query.insert(bs.node_id);
+          });
+    }
+    const auto& prev = topics.get_previous_replica_set(ntp);
+    if (prev) {
+        std::for_each(
+          prev.value().begin(),
+          prev.value().end(),
+          [&nodes_to_query](const model::broker_shard& bs) {
+              nodes_to_query.insert(bs.node_id);
+          });
+    }
+
+    if (nodes_to_query.empty()) {
+        co_return errc::no_partition_assignments;
+    }
+
+    std::vector<ss::future<result<partition_state_reply>>> futures;
+    futures.reserve(nodes_to_query.size());
+    for (const auto& node : nodes_to_query) {
+        futures.push_back(do_get_partition_state(node, ntp));
+    }
+
+    auto finished_futures = co_await ss::when_all(
+      futures.begin(), futures.end());
+    std::vector<partition_state> results;
+    results.reserve(finished_futures.size());
+    for (auto& fut : finished_futures) {
+        if (fut.failed()) {
+            auto ex = fut.get_exception();
+            vlog(
+              clusterlog.debug,
+              "Failed to get partition state for ntp: {}, failure: {}",
+              ntp,
+              ex);
+            continue;
+        }
+        auto result = fut.get();
+        if (result.has_error()) {
+            vlog(
+              clusterlog.debug,
+              "Failed to get partition state for ntp: {}, result: {}",
+              ntp,
+              result.error());
+            continue;
+        }
+        auto res = std::move(result.value());
+        if (res.error_code != errc::success || !res.state) {
+            vlog(
+              clusterlog.debug,
+              "Error during partition state fetch for ntp: {}, error: "
+              "{}",
+              ntp,
+              res.error_code);
+            continue;
+        }
+        results.push_back(std::move(*res.state));
+    }
+    co_return results;
 }
 
 } // namespace cluster

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -64,6 +64,8 @@ topics_frontend::topics_frontend(
   ss::sharded<cloud_storage::remote>& cloud_storage_api,
   ss::sharded<features::feature_table>& features,
   ss::sharded<cluster::members_table>& members_table,
+  ss::sharded<partition_manager>& pm,
+  ss::sharded<shard_table>& shard_table,
   config::binding<unsigned> hard_max_disk_usage_ratio)
   : _self(self)
   , _stm(s)
@@ -76,6 +78,8 @@ topics_frontend::topics_frontend(
   , _cloud_storage_api(cloud_storage_api)
   , _features(features)
   , _members_table(members_table)
+  , _pm(pm)
+  , _shard_table(shard_table)
   , _hard_max_disk_usage_ratio(hard_max_disk_usage_ratio) {}
 
 static bool

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -49,6 +49,8 @@ public:
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<features::feature_table>&,
       ss::sharded<cluster::members_table>&,
+      ss::sharded<partition_manager>&,
+      ss::sharded<shard_table>&,
       config::binding<unsigned>);
 
     ss::future<std::vector<topic_result>> create_topics(
@@ -231,6 +233,8 @@ private:
     ss::sharded<features::feature_table>& _features;
 
     ss::sharded<cluster::members_table>& _members_table;
+    ss::sharded<partition_manager>& _pm;
+    ss::sharded<shard_table>& _shard_table;
 
     config::binding<unsigned> _hard_max_disk_usage_ratio;
 

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -140,6 +140,9 @@ public:
     ss::future<topic_result> do_update_topic_properties(
       topic_properties_update, model::timeout_clock::time_point);
 
+    ss::future<result<std::vector<partition_state>>>
+      get_partition_state(model::ntp);
+
 private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
@@ -220,6 +223,9 @@ private:
     ss::future<result<std::vector<partition_assignment>>>
     generate_reassignments(
       model::ntp, std::vector<model::node_id> new_replicas);
+
+    ss::future<result<partition_state_reply>>
+      do_get_partition_state(model::node_id, model::ntp);
 
     model::node_id _self;
     ss::sharded<controller_stm>& _stm;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3065,6 +3065,37 @@ struct cloud_storage_usage_reply
     }
 };
 
+struct partition_state_request
+  : serde::envelope<
+      partition_state_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    model::ntp ntp;
+    friend bool
+    operator==(const partition_state_request&, const partition_state_request&)
+      = default;
+
+    auto serde_fields() { return std::tie(ntp); }
+};
+
+struct partition_state_reply
+  : serde::envelope<
+      partition_state_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    model::ntp ntp;
+
+    friend bool
+    operator==(const partition_state_reply&, const partition_state_reply&)
+      = default;
+
+    auto serde_fields() { return std::tie(ntp); }
+};
+
 struct revert_cancel_partition_move_cmd_data
   : serde::envelope<
       revert_cancel_partition_move_cmd_data,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1835,6 +1835,7 @@ struct update_topic_properties_reply
 
     friend bool operator==(
       const update_topic_properties_reply&,
+
       const update_topic_properties_reply&)
       = default;
 
@@ -3080,6 +3081,148 @@ struct partition_state_request
     auto serde_fields() { return std::tie(ntp); }
 };
 
+struct partition_raft_state
+  : serde::envelope<
+      partition_raft_state,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    model::node_id node;
+    model::term_id term;
+    ss::sstring offset_translator_state;
+    ss::sstring group_configuration;
+    model::term_id confirmed_term;
+    model::offset flushed_offset;
+    model::offset commit_index;
+    model::offset majority_replicated_index;
+    model::offset visibility_upper_bound_index;
+    model::offset last_quorum_replicated_index;
+    model::term_id last_snapshot_term;
+    model::offset last_snapshot_index;
+    model::offset received_snapshot_index;
+    size_t received_snapshot_bytes;
+    bool has_pending_flushes;
+    bool is_leader;
+    bool is_elected_leader;
+
+    struct follower_state
+      : serde::envelope<
+          follower_state,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        using rpc_adl_exempt = std::true_type;
+
+        model::node_id node;
+        model::offset last_flushed_log_index;
+        model::offset last_dirty_log_index;
+        model::offset match_index;
+        model::offset next_index;
+        model::offset last_sent_offset;
+        size_t heartbeats_failed;
+        bool is_learner;
+        uint64_t ms_since_last_heartbeat;
+        uint64_t last_sent_seq;
+        uint64_t last_received_seq;
+        uint64_t last_successful_received_seq;
+        bool suppress_heartbeats;
+        bool is_recovering;
+
+        auto serde_fields() {
+            return std::tie(
+              node,
+              last_flushed_log_index,
+              last_dirty_log_index,
+              match_index,
+              next_index,
+              last_sent_offset,
+              heartbeats_failed,
+              is_learner,
+              ms_since_last_heartbeat,
+              last_sent_seq,
+              last_received_seq,
+              last_successful_received_seq,
+              suppress_heartbeats,
+              is_recovering);
+        }
+    };
+
+    // Set only on leaders.
+    std::optional<std::vector<follower_state>> followers;
+
+    auto serde_fields() {
+        return std::tie(
+          node,
+          term,
+          offset_translator_state,
+          group_configuration,
+          confirmed_term,
+          flushed_offset,
+          commit_index,
+          majority_replicated_index,
+          visibility_upper_bound_index,
+          last_quorum_replicated_index,
+          last_snapshot_term,
+          last_snapshot_index,
+          received_snapshot_index,
+          received_snapshot_bytes,
+          has_pending_flushes,
+          is_leader,
+          is_elected_leader,
+          followers);
+    }
+
+    friend bool
+    operator==(const partition_raft_state&, const partition_raft_state&)
+      = default;
+};
+
+struct partition_state
+  : serde::
+      envelope<partition_state, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    model::offset start_offset;
+    model::offset committed_offset;
+    model::offset last_stable_offset;
+    model::offset high_water_mark;
+    model::offset dirty_offset;
+    model::offset latest_configuration_offset;
+    model::offset start_cloud_offset;
+    model::offset next_cloud_offset;
+    model::revision_id revision_id;
+    size_t log_size_bytes;
+    size_t non_log_disk_size_bytes;
+    bool is_read_replica_mode_enabled;
+    bool is_remote_fetch_enabled;
+    bool is_cloud_data_available;
+    ss::sstring read_replica_bucket;
+    partition_raft_state raft_state;
+
+    auto serde_fields() {
+        return std::tie(
+          start_offset,
+          committed_offset,
+          last_stable_offset,
+          high_water_mark,
+          dirty_offset,
+          latest_configuration_offset,
+          start_cloud_offset,
+          next_cloud_offset,
+          revision_id,
+          log_size_bytes,
+          non_log_disk_size_bytes,
+          is_read_replica_mode_enabled,
+          is_remote_fetch_enabled,
+          is_cloud_data_available,
+          read_replica_bucket,
+          raft_state);
+    }
+
+    friend bool operator==(const partition_state&, const partition_state&)
+      = default;
+};
+
 struct partition_state_reply
   : serde::envelope<
       partition_state_reply,
@@ -3088,12 +3231,14 @@ struct partition_state_reply
     using rpc_adl_exempt = std::true_type;
 
     model::ntp ntp;
+    std::optional<partition_state> state;
+    errc error_code;
 
     friend bool
     operator==(const partition_state_reply&, const partition_state_reply&)
       = default;
 
-    auto serde_fields() { return std::tie(ntp); }
+    auto serde_fields() { return std::tie(ntp, state, error_code); }
 };
 
 struct revert_cancel_partition_move_cmd_data

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -256,6 +256,17 @@ public:
 
     model::offset get_latest_configuration_offset() const;
     model::offset committed_offset() const { return _commit_index; }
+    model::offset flushed_offset() const { return _flushed_offset; }
+    model::offset last_quorum_replicated_index() const {
+        return _last_quorum_replicated_index;
+    }
+    model::offset majority_replicated_index() const {
+        return _majority_replicated_index;
+    }
+    model::offset visibility_upper_bound_index() const {
+        return _visibility_upper_bound_index;
+    }
+    model::term_id confirmed_term() const { return _confirmed_term; }
 
     /**
      * Last visible index is an offset that is safe to be fetched by the
@@ -313,6 +324,12 @@ public:
     timequery(storage::timequery_config cfg);
 
     model::offset last_snapshot_index() const { return _last_snapshot_index; }
+    model::term_id last_snapshot_term() const { return _last_snapshot_term; }
+    model::offset received_snapshot_index() const {
+        return _received_snapshot_index;
+    }
+    size_t received_snapshot_bytes() const { return _received_snapshot_bytes; }
+    bool has_pending_flushes() const { return _has_pending_flushes; }
 
     model::offset start_offset() const {
         return model::next_offset(_last_snapshot_index);
@@ -410,6 +427,8 @@ public:
      * Allow the current node to become a leader for this group.
      */
     void unblock_new_leadership() { _node_priority_override.reset(); }
+
+    const follower_stats& get_follower_stats() const { return _fstats; }
 
 private:
     friend replicate_entries_stm;

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -255,6 +255,40 @@
                     }
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/partition/{namespace}/{topic}/{partition}",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get partition state for current node",
+                    "type": "partition_state",
+                    "nickname": "get_partition_state",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -404,6 +438,236 @@
                         "type": "self_test_result"
                     },
                     "description": "Recordings of test runs from a single node"
+                }
+            }
+        },
+        "raft_follower_state": {
+            "id": "raft_follower_state",
+            "description": "Information about raft state for ntp for follower",
+            "properties": {
+                "id": {
+                    "type": "int",
+                    "description": "Node id"
+                },
+                "last_flushed_log_index": {
+                    "type": "long",
+                    "description": "Last flushed log index"
+                },
+                "last_dirty_log_index": {
+                    "type": "long",
+                    "description": "Last dirty log index"
+                },
+                "match_index": {
+                    "type": "long",
+                    "description": "Match index"
+                },
+                "next_index": {
+                    "type": "long",
+                    "description": "Next index"
+                },
+                "last_sent_offset": {
+                    "type": "long",
+                    "description": "Last sent offset"
+                },
+                "heartbeats_failed": {
+                    "type": "long",
+                    "description": "Heartbeats failed"
+                },
+                "is_learner": {
+                    "type": "boolean",
+                    "description": "Is node learner"
+                },
+                "ms_since_last_heartbeat": {
+                    "type": "long",
+                    "description": "Mlliseconds since last heartbeat"
+                },
+                "last_sent_seq": {
+                    "type": "long",
+                    "description": "Last sent seq"
+                },
+                "last_received_seq": {
+                    "type": "long",
+                    "description": "Last received seq"
+                },
+                "last_successful_received_seq": {
+                    "type": "long",
+                    "description": "Last successful received seq"
+                },
+                "suppress_heartbeats": {
+                    "type": "boolean",
+                    "description": "Suppress heartbeats"
+                },
+                "is_recovering": {
+                    "type": "boolean",
+                    "description": "Is node recovering"
+                }
+            }
+        },
+        "raft_replica_state": {
+            "id": "raft_replica_state",
+            "description": "Raft level state for a single replica of a partition",
+            "properties": {
+                "node_id": {
+                    "type": "int",
+                    "description": "node_id of the broker hosting partition"
+                },
+                "term": {
+                    "type": "long",
+                    "description": "Current raft term"
+                },
+                "offset_translator_state": {
+                    "type" : "string",
+                    "description": "State of the offset translator"
+                },
+                "group_configuration": {
+                    "type" : "string",
+                    "description": "Local raft replica configuration"
+                },
+                "confirmed_term": {
+                    "type": "long",
+                    "description": "Confirmed term as seen by consensus"
+                },
+                "flushed_offset": {
+                    "type": "long",
+                    "description": "Current flushed offset"
+                },
+                "commit_index": {
+                    "type": "long",
+                    "description": "Current commit index"
+                },
+                "majority_replicated_index": {
+                    "type": "long",
+                    "description": "Majority replicated index"
+                },
+                "visibility_upper_bound_index": {
+                    "type": "long",
+                    "description": "Visibility upper bound index"
+                },
+                "last_quorum_replicated_index": {
+                    "type": "long",
+                    "description": "Last quorum replicated index"
+                },
+                "last_snapshot_term": {
+                    "type": "long",
+                    "description": "Last snapshot term"
+                },
+                "received_snapshot_bytes": {
+                    "type": "long",
+                    "description": "Size in bytes of snapshot recieved"
+                },
+                "last_snapshot_index": {
+                    "type": "long",
+                    "description": "Last snapshot index"
+                },
+                "received_snapshot_index": {
+                    "type": "long",
+                    "description": "Received snapshot index"
+                },
+                "has_pending_flushes": {
+                    "type": "boolean",
+                    "descrption": "True if there are any pending flushes"
+                },
+                "is_leader": {
+                    "type": "boolean",
+                    "description": "True if voted a leader and term confirmed"
+                },
+                "is_elected_leader": {
+                    "type": "boolean",
+                    "description": "True of voted a leader"
+                },
+                "followers" : {
+                    "type": "array",
+                    "items": {
+                        "type" : "raft_follower_state"
+                    },
+                    "description": "Follower metadata for this leader."
+                }
+            }
+        },
+        "partition_replica_state": {
+            "id": "partition_replica_state",
+            "description": "Partition state of a replica",
+            "properties": {
+                "start_offset": {
+                    "type": "long",
+                    "description": "Start offset"
+                },
+                "committed_offset": {
+                    "type": "long",
+                    "description": "Commmited offset"
+                },
+                "last_stable_offset": {
+                    "type": "long",
+                    "description": "Last stable offset"
+                },
+                "high_watermark": {
+                    "type": "long",
+                    "description": "High watermark"
+                },
+                "dirty_offset": {
+                    "type": "long",
+                    "description": "Dirty offset"
+                },
+                "latest_configuration_offset": {
+                    "type": "long",
+                    "description": "Get latest configuration offset"
+                },
+                "revision_id": {
+                    "type": "long",
+                    "description": "Revision id"
+                },
+                "log_size_bytes": {
+                    "type": "long",
+                    "description": "Log size bytes"
+                },
+                "non_log_disk_size_bytes": {
+                    "type": "long",
+                    "description": "Non log disk size bytes"
+                },
+                "is_read_replica_mode_enabled": {
+                    "type": "boolean",
+                    "description": "Is read replica mode enabled"
+                },
+                "read_replica_bucket": {
+                    "type": "string",
+                    "description": "Read replica bucket"
+                },
+                "is_remote_fetch_enabled": {
+                    "type": "boolean",
+                    "description": "Is remote fetch enabled"
+                },
+                "is_cloud_data_available": {
+                    "type": "boolean",
+                    "description": "Is cloud data available"
+                },
+                "start_cloud_offset": {
+                    "type": "long",
+                    "description": "Start cloud offset"
+                },
+                "next_cloud_offset": {
+                    "type": "long",
+                    "description": "Next cloud offset"
+                },
+                "raft_state": {
+                    "type" : "raft_replica_state",
+                    "description": "Underlying raft replica state of the partition instance"
+                }
+            }
+        },
+        "partition_state": {
+            "id": "partition_state",
+            "description": "Partition states of all the instances of this partition",
+            "properties": {
+                "ntp": {
+                    "type": "string",
+                    "description": "Partition that is queried"
+                },
+                "replicas": {
+                    "type": "array",
+                    "items": {
+                        "type": "partition_replica_state"
+                    },
+                    "description": "All replicas of this partition"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3598,6 +3598,98 @@ void admin_server::register_usage_routes() {
       });
 }
 
+namespace {
+
+void fill_raft_state(
+  ss::httpd::debug_json::partition_replica_state& replica,
+  cluster::partition_state state) {
+    ss::httpd::debug_json::raft_replica_state raft_state;
+    auto& src = state.raft_state;
+    raft_state.node_id = src.node();
+    raft_state.term = src.term();
+    raft_state.offset_translator_state = std::move(src.offset_translator_state);
+    raft_state.group_configuration = std::move(src.group_configuration);
+    raft_state.confirmed_term = src.confirmed_term();
+    raft_state.flushed_offset = src.flushed_offset();
+    raft_state.commit_index = src.commit_index();
+    raft_state.majority_replicated_index = src.majority_replicated_index();
+    raft_state.visibility_upper_bound_index
+      = src.visibility_upper_bound_index();
+    raft_state.last_quorum_replicated_index
+      = src.last_quorum_replicated_index();
+    raft_state.last_snapshot_term = src.last_snapshot_term();
+    raft_state.received_snapshot_bytes = src.received_snapshot_bytes;
+    raft_state.last_snapshot_index = src.last_snapshot_index();
+    raft_state.received_snapshot_index = src.received_snapshot_index();
+    raft_state.has_pending_flushes = src.has_pending_flushes;
+    raft_state.is_leader = src.is_leader;
+    raft_state.is_elected_leader = src.is_elected_leader;
+    if (src.followers) {
+        for (const auto& f : *src.followers) {
+            ss::httpd::debug_json::raft_follower_state follower_state;
+            follower_state.id = f.node();
+            follower_state.last_flushed_log_index = f.last_flushed_log_index();
+            follower_state.last_dirty_log_index = f.last_dirty_log_index();
+            follower_state.match_index = f.match_index();
+            follower_state.next_index = f.next_index();
+            follower_state.last_sent_offset = f.last_sent_offset();
+            follower_state.heartbeats_failed = f.heartbeats_failed;
+            follower_state.is_learner = f.is_learner;
+            follower_state.ms_since_last_heartbeat = f.ms_since_last_heartbeat;
+            follower_state.last_sent_seq = f.last_sent_seq;
+            follower_state.last_received_seq = f.last_received_seq;
+            follower_state.last_successful_received_seq
+              = f.last_successful_received_seq;
+            follower_state.suppress_heartbeats = f.suppress_heartbeats;
+            follower_state.is_recovering = f.is_recovering;
+            raft_state.followers.push(std::move(follower_state));
+        }
+    }
+    replica.raft_state = std::move(raft_state);
+}
+} // namespace
+
+ss::future<ss::json::json_return_type>
+admin_server::get_partition_state_handler(
+  std::unique_ptr<ss::http::request> req) {
+    const model::ntp ntp = parse_ntp_from_request(req->param);
+    auto result
+      = co_await _controller->get_topics_frontend().local().get_partition_state(
+        ntp);
+    if (result.has_error()) {
+        throw ss::httpd::server_error_exception(fmt::format(
+          "Error {} processing partition state for ntp: {}",
+          result.error(),
+          ntp));
+    }
+
+    ss::httpd::debug_json::partition_state response;
+    response.ntp = fmt::format("{}", ntp);
+    const auto& states = result.value();
+    for (const auto& state : states) {
+        ss::httpd::debug_json::partition_replica_state replica;
+        replica.start_offset = state.start_offset;
+        replica.committed_offset = state.committed_offset;
+        replica.last_stable_offset = state.last_stable_offset;
+        replica.high_watermark = state.high_water_mark;
+        replica.dirty_offset = state.dirty_offset;
+        replica.latest_configuration_offset = state.latest_configuration_offset;
+        replica.revision_id = state.revision_id;
+        replica.log_size_bytes = state.log_size_bytes;
+        replica.non_log_disk_size_bytes = state.non_log_disk_size_bytes;
+        replica.is_read_replica_mode_enabled
+          = state.is_read_replica_mode_enabled;
+        replica.read_replica_bucket = state.read_replica_bucket;
+        replica.is_remote_fetch_enabled = state.is_remote_fetch_enabled;
+        replica.is_cloud_data_available = state.is_cloud_data_available;
+        replica.start_cloud_offset = state.start_cloud_offset;
+        replica.next_cloud_offset = state.next_cloud_offset;
+        fill_raft_state(replica, std::move(state));
+        response.replicas.push(std::move(replica));
+    }
+    co_return ss::json::json_return_type(std::move(response));
+}
+
 void admin_server::register_debug_routes() {
     register_route<user>(
       ss::httpd::debug_json::reset_leaders_info,
@@ -3774,6 +3866,13 @@ void admin_server::register_debug_routes() {
       ss::httpd::debug_json::restart_service,
       [this](std::unique_ptr<ss::http::request> req) {
           return restart_service_handler(std::move(req));
+      });
+
+    register_route<user>(
+      seastar::httpd::debug_json::get_partition_state,
+      [this](std::unique_ptr<ss::http::request> req)
+        -> ss::future<ss::json::json_return_type> {
+          return get_partition_state_handler(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -431,6 +431,9 @@ private:
     ss::future<ss::json::json_return_type>
       self_test_get_results_handler(std::unique_ptr<ss::http::request>);
 
+    ss::future<ss::json::json_return_type>
+      get_partition_state_handler(std::unique_ptr<ss::http::request>);
+
     // Debug routes
     ss::future<ss::json::json_return_type>
       cloud_storage_usage_handler(std::unique_ptr<ss::http::request>);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -904,3 +904,7 @@ class Admin:
         """
         return self._request(
             "GET", f"cloud_storage/manifest/{topic}/{partition}").json()
+
+    def get_partition_state(self, namespace, topic, partition, node=None):
+        path = f"debug/partition/{namespace}/{topic}/{partition}"
+        return self._request("GET", path, node=node).json()

--- a/tests/rptest/tests/partition_state_api_test.py
+++ b/tests/rptest/tests/partition_state_api_test.py
@@ -1,0 +1,107 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.admin import Admin
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+
+
+class PartitionStateAPItest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, num_brokers=5)
+
+    def _validate_states(self, states, num_replicas, has_leader=True):
+        """Does some sanity checks on partition states from all nodes"""
+
+        for s in states:
+            assert len(s["replicas"]) == num_replicas
+            self.logger.debug(f"validing state {s}")
+            leaders = list(
+                filter(lambda r: r["raft_state"]["is_elected_leader"],
+                       s["replicas"]))
+            assert (has_leader
+                    and len(leaders) == 1) or (not has_leader
+                                               and len(leaders) == 0), leaders
+            if has_leader:
+                # Verify the leader reports followers
+                leader = leaders[0]["raft_state"]
+                assert "followers" in leader.keys() and len(
+                    leader["followers"]) > 0, leader
+
+    def _has_stable_leadership(self, no_leader=False):
+        """Checks if all nodes report same leadership information. When no_leader is set ensures
+        that no node reports a leader for the partition."""
+        all_leaders = []
+        nodes = self.redpanda.started_nodes()
+        for node in nodes:
+            p_state = self.redpanda._admin.get_partition_state(
+                "kafka", self.topic, 0, node)
+            replicas = p_state["replicas"]
+            leaders = list(
+                filter(lambda r: r["raft_state"]["is_elected_leader"],
+                       replicas))
+            assert len(leaders) <= 1
+            if leaders:
+                all_leaders.append(leaders[0]['raft_state']['node_id'])
+        if no_leader:
+            # No node reports a leader
+            return len(all_leaders) == 0
+        # Check all nodes report the leader and there is only one unique leader
+        return len(all_leaders) == len(nodes) and len(set(all_leaders)) == 1
+
+    def _wait_for_stable_leader(self):
+        self.redpanda.wait_until(self._has_stable_leadership,
+                                 timeout_sec=30,
+                                 backoff_sec=2)
+
+    def _wait_for_no_leader(self):
+        self.redpanda.wait_until(
+            lambda: self._has_stable_leadership(no_leader=True),
+            timeout_sec=30,
+            backoff_sec=2)
+
+    def _get_partition_state(self):
+        nodes = self.redpanda.started_nodes()
+        admin = self.redpanda._admin
+        return [
+            admin.get_partition_state("kafka", self.topic, 0, n) for n in nodes
+        ]
+
+    def _stop_first_replica_node(self, states):
+        # Node id of first replica of first state.
+        node_id = states[0]["replicas"][0]["raft_state"]["node_id"]
+        self.redpanda.logger.debug(f"Stopping node: {node_id}")
+        node = self.redpanda.get_node_by_id(node_id)
+        self.redpanda.stop_node(node)
+
+    @cluster(num_nodes=5)
+    def test_partition_state(self):
+        num_replicas = 3
+        self.topics = [
+            TopicSpec(partition_count=1, replication_factor=num_replicas)
+        ]
+        self._create_initial_topics()
+
+        self._wait_for_stable_leader()
+        # Validate ntp state from each node.
+        states = self._get_partition_state()
+        self._validate_states(states, num_replicas, has_leader=True)
+
+        # kill a replica, validate leader
+        self._stop_first_replica_node(states)
+        self._wait_for_stable_leader()
+        states = self._get_partition_state()
+        self._validate_states(states, num_replicas - 1, has_leader=True)
+
+        # kill another replica, no leader.
+        self._stop_first_replica_node(states)
+        self._wait_for_no_leader()
+        states = self._get_partition_state()
+        self._validate_states(states, num_replicas - 2, has_leader=False)


### PR DESCRIPTION
Implements `GET /v1/debug/partition/{namespace}/{topic}/{partition}` to fetch a detailed partition debug json that includes internal state at the partition (cluster) and raft layer.  Can be queried on any a node. Handling node aggregates the output from all replicas of a given partition (including learners, if a reconfiguration is in progress).

Fixes #9097

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Adds an admin API that provides insight into partition/raft state of all replicas of a partition.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
