### PR TITLE
removes KICS scannign from /src/go/k8s/config dir

### DIFF
--- a/.github/workflows/kics-iac.yml
+++ b/.github/workflows/kics-iac.yml
@@ -18,7 +18,7 @@ jobs:
           path: .
           ignore_on_exit: results
           output_path: res/
-          exclude_paths: tests/,src/go/k8s/tests/,src/go/rpk/pkg/testfs/
+          exclude_paths: tests/,src/go/k8s/tests/,src/go/rpk/pkg/testfs/,src/go/k8s/config/
       - name: display kics results
         run: |
           cat res/results.json


### PR DESCRIPTION
## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none