### PR TITLE
feat: new flag for configurator check period

### DIFF
--- a/src/go/k8s/config/e2e-tests/manager.yaml
+++ b/src/go/k8s/config/e2e-tests/manager.yaml
@@ -19,3 +19,4 @@ spec:
         - "--configurator-image-pull-policy=Never"
         - "--allow-pvc-deletion=true"
         - "--superusers-prefix=__redpanda_system__"
+        - "--configurator-drift-check-period=10s"

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
@@ -15,13 +15,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
-	adminutils "github.com/redpanda-data/redpanda/src/go/k8s/pkg/admin"
-	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/networking"
-	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources"
-	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/certmanager"
-	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/configuration"
-	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/featuregates"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,10 +22,18 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	adminutils "github.com/redpanda-data/redpanda/src/go/k8s/pkg/admin"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/networking"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/certmanager"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/configuration"
+	"github.com/redpanda-data/redpanda/src/go/k8s/pkg/resources/featuregates"
 )
 
 const (
-	defaultDriftCheckPeriod = 1 * time.Minute
+	DefaultDriftCheckPeriod = 1 * time.Minute
 
 	debugLogLevel = 4
 )
@@ -194,7 +195,7 @@ func (r *ClusterConfigurationDriftReconciler) getDriftCheckPeriod() time.Duratio
 	if r.DriftCheckPeriod != nil {
 		return *r.DriftCheckPeriod
 	}
-	return defaultDriftCheckPeriod
+	return DefaultDriftCheckPeriod
 }
 
 // createOrDeleteEventFilter selects only the events of creation and deletion of a cluster,

--- a/src/go/k8s/main.go
+++ b/src/go/k8s/main.go
@@ -55,18 +55,19 @@ func init() {
 //nolint:funlen // length looks good
 func main() {
 	var (
-		clusterDomain               string
-		metricsAddr                 string
-		probeAddr                   string
-		pprofAddr                   string
-		enableLeaderElection        bool
-		webhookEnabled              bool
-		configuratorBaseImage       string
-		configuratorTag             string
-		configuratorImagePullPolicy string
-		decommissionWaitInterval    time.Duration
-		metricsTimeout              time.Duration
-		restrictToRedpandaVersion   string
+		clusterDomain                  string
+		metricsAddr                    string
+		probeAddr                      string
+		pprofAddr                      string
+		enableLeaderElection           bool
+		webhookEnabled                 bool
+		configuratorBaseImage          string
+		configuratorTag                string
+		configuratorDriftCheckInterval time.Duration
+		configuratorImagePullPolicy    string
+		decommissionWaitInterval       time.Duration
+		metricsTimeout                 time.Duration
+		restrictToRedpandaVersion      string
 
 		// allowPVCDeletion controls the PVC deletion feature in the Cluster custom resource.
 		// PVCs will be deleted when its Pod has been deleted and the Node that Pod is assigned to
@@ -86,6 +87,7 @@ func main() {
 	flag.BoolVar(&webhookEnabled, "webhook-enabled", false, "Enable webhook Manager")
 	flag.StringVar(&configuratorBaseImage, "configurator-base-image", defaultConfiguratorContainerImage, "Set the configurator base image")
 	flag.StringVar(&configuratorTag, "configurator-tag", "latest", "Set the configurator tag")
+	flag.DurationVar(&configuratorDriftCheckInterval, "configurator-drift-check-period", redpandacontrollers.DefaultDriftCheckPeriod, "Set the time interval to check for configuration drift")
 	flag.StringVar(&configuratorImagePullPolicy, "configurator-image-pull-policy", "Always", "Set the configurator image pull policy")
 	flag.DurationVar(&decommissionWaitInterval, "decommission-wait-interval", 8*time.Second, "Set the time to wait for a node decommission to happen in the cluster")
 	flag.DurationVar(&metricsTimeout, "metrics-timeout", 8*time.Second, "Set the timeout for a checking metrics Admin API endpoint. If set to 0, then the 2 seconds default will be used")
@@ -161,6 +163,7 @@ func main() {
 		Scheme:                    mgr.GetScheme(),
 		AdminAPIClientFactory:     adminutils.NewInternalAdminAPI,
 		RestrictToRedpandaVersion: restrictToRedpandaVersion,
+		DriftCheckPeriod:          &configuratorDriftCheckInterval,
 	}).WithClusterDomain(clusterDomain).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "ClusterConfigurationDrift")
 		os.Exit(1)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
In order to determine if there are problems with reconciliation, such as feedback loops, for testing, we may way to enable for requeues to happen at a quicker pace that the default. Here we open a new flag to enable that possibility.

Partially for #9781

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none
