### PR TITLE
http: Close output stream in exceptional cases

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -589,7 +589,7 @@ ss::future<client::response_stream_ref> client::request(
               fsend = ss::do_with(
                 request->as_output_stream(),
                 [&input](ss::output_stream<char>& output) {
-                    return ss::copy(input, output).then([&output] {
+                    return ss::copy(input, output).finally([&output] {
                         return output.close();
                     });
                 });


### PR DESCRIPTION
- Ensure that in the case of an exception when streaming http requests, the output stream is closed in both the success or failure cases.

- Failure to do so will result in an assertion thrown by seastar when the output_stream goes out of scope and is deallocated.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in our http client that may crash redpanda in exceptional cases   
