### PR TITLE
storage: shrink index vectors on flush

### DIFF
--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -156,6 +156,12 @@ struct index_state
           position_index[i]};
     }
 
+    void shrink_to_fit() {
+        relative_offset_index.shrink_to_fit();
+        relative_time_index.shrink_to_fit();
+        position_index.shrink_to_fit();
+    }
+
     std::optional<std::tuple<uint32_t, offset_time_index, uint64_t>>
     find_entry(model::timestamp ts) {
         const auto idx = offset_time_index{ts, with_offset};

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -240,6 +240,12 @@ ss::future<> segment_index::flush() {
     }
     _needs_persistence = false;
     clear_cached_disk_usage();
+
+    // Flush is usually called when we either shrunk the index (truncate)
+    // or when we're no longer going to append (close): in either case,
+    // it is a good time to free speculatively allocated memory.
+    _state.shrink_to_fit();
+
     return with_file(open(), [this](ss::file backing_file) {
         return flush_to_file(std::move(backing_file));
     });


### PR DESCRIPTION
This saves up to 24kib of memory per index, where
a segment is closed with very few entries in its index.

Related: https://github.com/redpanda-data/redpanda/issues/9375

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Reduced memory consumption on configurations with very large numbers of small segments.
