### PR TITLE
operator: add test for certificate sharing between listeners

### DIFF
--- a/src/go/k8s/pkg/resources/certmanager/type_helpers.go
+++ b/src/go/k8s/pkg/resources/certmanager/type_helpers.go
@@ -426,7 +426,7 @@ func (ac *apiCertificates) resources(
 		return []resources.Resource{}, nil
 	}
 	nodeSecretRef := ac.externalNodeCertificate
-	if nodeSecretRef != nil && nodeSecretRef.Name != "" && nodeSecretRef.Namespace != ac.clusterNamespace {
+	if nodeSecretRef != nil && nodeSecretRef.Name != "" && nodeSecretRef.Namespace != "" && nodeSecretRef.Namespace != ac.clusterNamespace {
 		if err := copyNodeSecretToLocalNamespace(ctx, nodeSecretRef, ac.clusterNamespace, k8sClient, logger); err != nil {
 			return nil, fmt.Errorf("copy node secret for %s cert group: %w", ac.nodeCertificateName().Name, err)
 		}

--- a/src/go/k8s/tests/e2e/shared-tls-cert/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/shared-tls-cert/00-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: shared-tls-cert
+status:
+  readyReplicas: 1
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: shared-tls-cert-redpanda
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/shared-tls-cert/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/shared-tls-cert/00-redpanda-cluster.yaml
@@ -1,0 +1,37 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: shared-tls-cert
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+      tls:
+        enabled: true
+    adminApi:
+    - port: 9644
+    pandaproxyApi:
+    - port: 8080
+      tls:
+        enabled: true
+        nodeSecretRef:
+          name: shared-tls-cert-redpanda
+    schemaRegistry:
+      port: 8081
+      tls:
+        enabled: true
+        nodeSecretRef:
+          name: shared-tls-cert-redpanda
+    developerMode: true

--- a/src/go/k8s/tests/e2e/shared-tls-cert/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/shared-tls-cert/01-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: call-endpoints
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/shared-tls-cert/01-call-endpoints.yaml
+++ b/src/go/k8s/tests/e2e/shared-tls-cert/01-call-endpoints.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: call-endpoints
+spec:
+  template:
+    spec:
+      volumes:
+        - name: sharedtls
+          secret:
+            defaultMode: 420
+            secretName: shared-tls-cert-redpanda
+      containers:
+        - name: curl
+          image: curlimages/curl:latest
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/sh
+            - -c
+            - -ex
+          args:
+            - >
+              echo "Checking that the shared certificate is used for both pandaproxy and schema registry" && 
+              sr_res=$(curl --silent -o /dev/null -w "%{http_code}" -k -i -v --cacert /etc/tls/certs/shared/ca.crt https://shared-tls-cert-0.shared-tls-cert.$POD_NAMESPACE.svc.cluster.local:8081) &&
+              pp_res=$(curl --silent -o /dev/null -w "%{http_code}" -k -i -v --cacert /etc/tls/certs/shared/ca.crt https://shared-tls-cert-0.shared-tls-cert.$POD_NAMESPACE.svc.cluster.local:8080) &&
+              if [[ "$sr_res" != "404" ]] || [[ "$pp_res" != "404" ]]; then
+                exit 1;
+              fi
+          volumeMounts:
+            - mountPath: /etc/tls/certs/shared
+              name: sharedtls
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1


### PR DESCRIPTION
Follow-up for https://github.com/redpanda-data/redpanda/pull/9847

It also fixes a small bug for which the operator was doing copy of the referenced secret if the namespace was unspecified.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
