### PR TITLE
operator: propagate change events to console to let it react on clust…

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -115,7 +115,8 @@ func (r *ConsoleReconciler) Reconcile(
 				corev1.EventTypeWarning, ClusterNotConfiguredEvent,
 				"Unable to reconcile Console as the referenced Cluster %s is not yet configured", console.GetClusterRef(),
 			)
-			return ctrl.Result{Requeue: true}, nil
+			// When Cluster will be configured, Console will receive a notification trigger
+			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
…er state changes

This 

## Backports Required

When console is deployed immediately after a Redpanda Cluster is defined, the cluster may take some time to start because it needs to provision resources (such as certificates or persistent volumes). With current strategy for event handling, the console may miss the notification that a cluster is ready, so that service account creation and console start may be delayed by a long time (i.e. next time the Kubernetes client will do a full refresh and send notifications for all resources).

This change makes sure that a Console is always reconciled whenever a Cluster or one of its Pods change state, to always keep it in sync.

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Console is automatically reconciled when the linked Redpanda cluster changes state
