### PR TITLE
tests/pp: add a leadership transfer test

### DIFF
--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -8,32 +8,32 @@
 # by the Apache License, Version 2.0
 
 from concurrent.futures import ThreadPoolExecutor
-import http.client
-import json
-import uuid
-import requests
-import socket
-import urllib.request
-import ssl
-import threading
-import urllib.parse
-from rptest.services.cluster import cluster
 from ducktape.mark import matrix, parametrize
 from ducktape.utils.util import wait_until
+import http.client
+import json
+import requests
+import socket
+import ssl
+import threading
+from typing import Optional, List, Dict, Union
+import urllib.parse
+import urllib.request
+import uuid
 
-from rptest.clients.rpk import RpkTool
-from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SecurityConfig, LoggingConfig, ResourceSettings, PandaproxyConfig, TLSProvider
+from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
+from rptest.services import tls
 from rptest.tests.group_membership_test import GroupCoordinatorTransferUtils
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import search_logs_with_timeout
-from rptest.services.redpanda import SecurityConfig, LoggingConfig, ResourceSettings, PandaproxyConfig, TLSProvider
-from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
-from rptest.services.admin import Admin
-from rptest.services import tls
 from rptest.utils.utf8 import CONTROL_CHARS_MAP
-from typing import Optional, List, Dict, Union
 
 
 def create_topic_names(count):


### PR DESCRIPTION
## Cover letter

This PR adds a ducktape test to check that Pandaproxy producer and consumer requests continue to work when leadership changes occur for topic-partitions.

Fixes: #9210 

Changes from force-push `b73d6ec`:
- Renamed `get_partition` to `get_partition_metadata`
- Spelling
- Create `repeat_for_x_seconds` wrapper
- Make a new string generator
- Improve logging
- Drive producer and consumer to have faster loops
- Cleanup imports
- Remove unused code
- Add and use a priority queue to validate events

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Improves test coverage of the HTTP Proxy to include leadership changes while there is active load on a cluster
