### PR TITLE
Lower `raft_transfer_leader_recovery_timeout_ms`'s default value from 10s to 25ms

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -807,7 +807,7 @@ configuration::configuration()
       "raft_transfer_leader_recovery_timeout_ms",
       "Timeout waiting for follower recovery when transferring leadership",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      10s)
+      25ms)
   , release_cache_on_segment_roll(
       *this,
       "release_cache_on_segment_roll",


### PR DESCRIPTION
When leadership of a partition is explicitly transferred the consensus will currently wait 10 seconds for the replica to recover if need be. And during this wait period all appends to the partition are blocked. This can cause instability during recovery when the leader balancer is trying to move a lot leaders back to the recovered node.  In this case, especially for longer recoveries, the leader balancer will issue a bunch of transfer requests to recovering replicas and effectively block appends to random partitions for 10s. This instability can be seen using the reproducer from #9718;
![image](https://user-images.githubusercontent.com/3487600/230757716-32b2f49f-3b79-4fca-9b66-98e55189891a.png)

By reducing this timeout to 25ms in the reproducer we avoid this instability;
![image](https://user-images.githubusercontent.com/3487600/230757749-4a539cc7-b158-4dc3-add1-f6e078c5e592.png)


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Partially fixes: #9718 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none