### PR TITLE
metrics: correct description of requests_pending

### DIFF
--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -99,8 +99,8 @@ void server_probe::setup_metrics(
         sm::make_gauge(
           "requests_pending",
           [this] { return _requests_received - _requests_completed; },
-          sm::description(ssx::sformat(
-            "{}: Number of requests being processed by server", proto)))
+          sm::description(
+            ssx::sformat("{}: Number of requests pending in the queue", proto)))
           .aggregate(aggregate_labels),
         sm::make_counter(
           "connections_wait_rate",


### PR DESCRIPTION
The metric value of 'vectorized_internal_rpc_requests_pending' indicates the number of requests pending in the queue without being processed but the description was not intuitive. This commit makes the description clear.

Fixes #9836

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* `vectorized_internal_rpc_requests_pending` now has better description
