### PR TITLE
Reduce the default for `max_kafka_throttle_delay_ms`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -776,7 +776,7 @@ configuration::configuration()
       "max_kafka_throttle_delay_ms",
       "Fail-safe maximum throttle delay on kafka requests",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      60'000ms)
+      30'000ms)
   , kafka_max_bytes_per_fetch(
       *this,
       "kafka_max_bytes_per_fetch",

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -382,7 +382,7 @@ FIXTURE_TEST(test_node_throughput_limits_static, throughput_limits_fixure) {
       "kafka_throughput_limit_node_out_bps",
       std::make_optional(pershard_rate_limit_out * ss::smp::count));
     config_set("fetch_max_bytes", batch_size);
-    config_set("max_kafka_throttle_delay_ms", 60'000ms);
+    config_set("max_kafka_throttle_delay_ms", 30'000ms);
     config_set_window_width(200ms);
     config_set_balancer_period(0ms);
     config_set_rate_minimum(0);
@@ -414,7 +414,7 @@ FIXTURE_TEST(test_node_throughput_limits_balanced, throughput_limits_fixure) {
       "kafka_throughput_limit_node_out_bps",
       std::make_optional(rate_limit_out));
     config_set("fetch_max_bytes", batch_size);
-    config_set("max_kafka_throttle_delay_ms", 60'000ms);
+    config_set("max_kafka_throttle_delay_ms", 30'000ms);
     config_set("kafka_quota_balancer_min_shard_throughput_ratio", 0.);
     config_set_window_width(100ms);
     config_set_balancer_period(50ms);


### PR DESCRIPTION
`max_kafka_throttle_delay_ms` default value changed to 30s to align with the default setting of `session.timeout.ms` in java client and in librdkafka which is 45s there. By setting the default max throttle delay lower than session timeout, it is possible to avoid heartbeat timeouts for librdkafka clients (librdkafka does not support KIP-219 as of now and therefore relies on broker doing throttling) with default configuration on both client and broker.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.
-->
### Improvements

* Maximum throttle time for Kafka API requests reduced to 30s to avoid heartbeat timeouts in default client configurations.
