### PR TITLE
[v23.1.x] Remove cloud-specific topics from topic protection defaults

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1002,7 +1002,7 @@ configuration::configuration()
       "kafka_nodelete_topics",
       "Prevents the topics in the list from being deleted via the kafka api",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      {"__audit", "__consumer_offsets", "__redpanda_e2e_probe", "_schemas"},
+      {"__audit", "__consumer_offsets", "_schemas"},
       &validate_non_empty_string_vec)
   , kafka_noproduce_topics(
       *this,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9453
