### PR TITLE
operator: ignore redpanda.com/last-applied annotation when detecting …

### DIFF
--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -142,7 +142,7 @@ func Update(
 		patch.IgnoreStatusFields(),
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
 		patch.IgnorePDBSelector(),
-		utils.IgnoreAnnotation(patch.LastAppliedConfig),
+		utils.IgnoreAnnotation(redpandaAnnotatorKey),
 		utils.IgnoreAnnotation(LastAppliedConfigurationAnnotationKey),
 	}
 	annotator := patch.NewAnnotator(redpandaAnnotatorKey)

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -367,7 +367,7 @@ func (r *StatefulSetResource) shouldUpdate(
 	opts := []patch.CalculateOption{
 		patch.IgnoreStatusFields(),
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
-		utils.IgnoreAnnotation(patch.LastAppliedConfig),
+		utils.IgnoreAnnotation(redpandaAnnotatorKey),
 		utils.IgnoreAnnotation(CentralizedConfigurationHashAnnotationKey),
 	}
 	patchResult, err := patch.NewPatchMaker(patch.NewAnnotator(redpandaAnnotatorKey), &patch.K8sStrategicMergePatcher{}, &patch.BaseJSONMergePatcher{}).Calculate(current, modified, opts...)


### PR DESCRIPTION
…diffs, to avoid endless loops

We're not longer setting the original value in `banzaicloud.com/last-applied`, but in `redpanda.com/last-applied annotation`.

Ignoring the wrong annotation causes an endless-loop because the flag `status.restarting` is continuously flipped:

```
redpanda-controller-manager-956cfbd49-zcl5v manager 2023-04-11T09:13:15Z	INFO	controllers.redpanda.Cluster	Status updated	{"redpandacluster": "default/example", "Kind": "", "restarting": true, "resource name": "example"}
redpanda-controller-manager-956cfbd49-zcl5v manager 2023-04-11T09:13:15Z	INFO	controllers.redpanda.Cluster	Resource example (StatefulSet) changed, updating. Diff: {"metadata":{"annotations":{"redpanda.com/last-applied":"UEsD..."}}}	{"redpandacluster": "default/example", "Kind": ""}

```

cc: @joejulian 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* operator: fixed an issue that caused continue reconciliations on the custom resource

