### PR TITLE
storage: quieten "errc::end_of_stream" log messages

### DIFF
--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -314,8 +314,11 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
                   // Readers do not know their ntp directly: discover
                   // it by checking the segments in our lease
                   auto seg_ptr = *(_lease->range.begin());
-                  vlog(stlog.info, "stopped reading stream[{}]: {}",
-                        seg_ptr->path().get_ntp(), recs.error().message());
+                  vlog(
+                    stlog.info,
+                    "stopped reading stream[{}]: {}",
+                    seg_ptr->path().get_ntp(),
+                    recs.error().message());
               } else {
                   // Leases should always have a segment, but this is
                   // not a strict invariant at present, so handle the

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -309,10 +309,22 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
       .then([this, timeout](result<records_t> recs) -> ss::future<storage_t> {
           if (!recs) {
               set_end_of_stream();
-              vlog(
-                stlog.info,
-                "stopped reading stream: {}",
-                recs.error().message());
+
+              if (!_lease->range.empty()) {
+                  // Readers do not know their ntp directly: discover
+                  // it by checking the segments in our lease
+                  auto seg_ptr = *(_lease->range.begin());
+                  vlog(stlog.info, "stopped reading stream[{}]: {}",
+                        seg_ptr->path().get_ntp(), recs.error().message());
+              } else {
+                  // Leases should always have a segment, but this is
+                  // not a strict invariant at present, so handle the
+                  // empty case.
+                  vlog(
+                    stlog.info,
+                    "stopped reading stream: {}",
+                    recs.error().message());
+              }
 
               auto const batch_parse_err
                 = recs.error() == parser_errc::header_only_crc_missmatch


### PR DESCRIPTION
We already silenced these in the most common case
where they came after consuming some records: also
silence them in the case where the error status
is set when we enter ::consume

The logs in question are the ones that look like:
```
INFO  2023-04-11 11:22:08,450 [shard 2] storage - log_reader.cc:321 - stopped reading stream: parser_errc::end_of_stream
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Spurious `end_of_stream` log messages under normal operation are reduced.