### PR TITLE
Restrict replicate batcher to 1 flush in flight

### DIFF
--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -164,6 +164,13 @@ private:
     std::vector<item_ptr> _item_cache;
     mutex _lock;
     ss::gate _bg;
+    // If true, a background flush must be pending. Used to coalesce
+    // background flush requests, since one flush dequeues all items
+    // in the item cache. Without this, a high rate of replication may
+    // cause the _item_cache to grow without bound since the rate of
+    // flush task execution can be lower than the rate at which new
+    // items are added to the cache.
+    bool _flush_pending = false;
 };
 
 } // namespace raft


### PR DESCRIPTION

Fixes #9533.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* Fixes an out of memory which could occurring under both high producer load and sustained 100% reactor utilization.

### Bug Fixes

* This change fixes an out of memory in the replicate batcher by ensuring that only one flush task is outstanding at any time.