### PR TITLE
tests: use SIGKILL in test_upgrade_assertion

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -528,7 +528,7 @@ class FeaturesUpgradeAssertionTest(FeaturesTestBase):
             self.redpanda.start_node(upgrade_node)
 
         # Don't assume that the asserted node will have exited promptly: explicitly kill it.
-        self.redpanda.stop_node(upgrade_node)
+        self.redpanda.stop_node(upgrade_node, forced=True)
 
         # With the config set to override checks, start should succeed
         self.redpanda.start_node(


### PR DESCRIPTION
For reasons that are not entirely clear, the process that has asserted out on startup may not end promptly.

Use a `forced=True` call to stop_node() to avoid the test potentially failing on a timeout in stop_node

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none