### PR TITLE
Made compaction test topics compactable

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -586,7 +586,8 @@ class KgoVerifierProducer(KgoVerifierService):
                  use_transactions=False,
                  transaction_abort_rate=None,
                  msgs_per_transaction=None,
-                 rate_limit_bps=None):
+                 rate_limit_bps=None,
+                 key_set_cardinality=None):
         super(KgoVerifierProducer,
               self).__init__(context, redpanda, topic, msg_size, custom_node,
                              debug_logs, trace_logs)
@@ -598,6 +599,7 @@ class KgoVerifierProducer(KgoVerifierService):
         self._transaction_abort_rate = transaction_abort_rate
         self._msgs_per_transaction = msgs_per_transaction
         self._rate_limit_bps = rate_limit_bps
+        self._key_set_cardinality = key_set_cardinality
 
     @property
     def produce_status(self):
@@ -663,6 +665,9 @@ class KgoVerifierProducer(KgoVerifierService):
 
         if self._rate_limit_bps is not None:
             cmd = cmd + f' --produce-throughput-bps {self._rate_limit_bps}'
+
+        if self._key_set_cardinality is not None:
+            cmd += f" --key-set-cardinality {self._key_set_cardinality}"
 
         self.spawn(cmd, node)
 

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -135,8 +135,17 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                                 omit_seeds_on_idx_one=False)
 
     class producer_consumer:
-        def __init__(self, test_context, logger, topic_spec, redpanda, nodes,
-                     msg_size, rate_limit_bps, msg_count, consumers_count):
+        def __init__(self,
+                     test_context,
+                     logger,
+                     topic_spec,
+                     redpanda,
+                     nodes,
+                     msg_size,
+                     rate_limit_bps,
+                     msg_count,
+                     consumers_count,
+                     key_set_cardinality=None):
             self.test_context = test_context
             self.logger = logger
             self.topic = topic_spec
@@ -146,6 +155,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             self.rate_limit_bps = rate_limit_bps
             self.msg_count = msg_count
             self.consumer_count = consumers_count
+            self.key_set_cardinality = key_set_cardinality
 
         def _start_producer(self):
             self.producer = KgoVerifierProducer(
@@ -155,7 +165,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                 self.msg_size,
                 self.msg_count,
                 custom_node=self.nodes,
-                rate_limit_bps=self.rate_limit_bps)
+                rate_limit_bps=self.rate_limit_bps,
+                key_set_cardinality=self.key_set_cardinality)
 
             self.producer.start(clean=False)
 
@@ -260,7 +271,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             msg_size=self.msg_size,
             rate_limit_bps=self.rate_limit,
             msg_count=self.msg_count,
-            consumers_count=self.consumers_count)
+            consumers_count=self.consumers_count,
+            key_set_cardinality=500)
 
         regular_producer_consumer.start()
         compacted_producer_consumer.start()


### PR DESCRIPTION
Made topics configured with `compaction` cleanup policy actually compactible by reducing key set cardinality

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none