### PR TITLE
Fix CI failure in `ConsumerGroupTest.test_basic_group_join`

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -99,6 +99,9 @@ class ConsumerGroupTest(RedpandaTest):
     def consumed_at_least(consumers, count):
         return all([len(c._messages) > count for c in consumers])
 
+    def group_consumed_at_least(consumers, count):
+        return sum([len(c._messages) for c in consumers]) >= count
+
     def validate_group_state(self, group, expected_state, static_members):
         rpk = RpkTool(self.redpanda)
         # validate group state
@@ -144,8 +147,9 @@ class ConsumerGroupTest(RedpandaTest):
 
         self.start_producer()
         # wait for some messages
-        wait_until(lambda: ConsumerGroupTest.consumed_at_least(consumers, 50),
-                   30, 2)
+        wait_until(
+            lambda: ConsumerGroupTest.group_consumed_at_least(
+                consumers, 50 * len(consumers)), 30, 2)
         self.validate_group_state(group,
                                   expected_state="Stable",
                                   static_members=static_members)


### PR DESCRIPTION
- The test_basic_group_join test was failing due to all members in the group not having consumed at least 50 records.

- It is possible for this to be true and for no problems to occur if the group was balanced in such a way that one member got 0 partitions.

- Modifying the condition so that the test proceeds when the total number records read by all consumers in the group exceeds a certain point.

- Fixes: #9119

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
