### PR TITLE
rpk: improve message from decommission command

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/decommission.go
@@ -90,7 +90,7 @@ help text for more details on why.`, broker)
 			err = cl.DecommissionBroker(cmd.Context(), broker)
 			out.MaybeDie(err, "unable to decommission broker: %v", err)
 
-			fmt.Printf("Success, broker %d has been decommissioned!\n", broker)
+			fmt.Printf("Success, broker %d decommission started.  Use `rpk redpanda admin brokers decommission-status %d` to monitor data movement.`", broker, broker)
 		},
 	}
 

--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -22,7 +22,7 @@ func VersionFromString(s string) (Version, error) {
 	//   - index 1: the Year
 	//   - index 2: the Feature
 	//   - index 3: the Patch
-	vMatch := regexp.MustCompile(`^v?(\d{2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|$)`).FindStringSubmatch(s)
+	vMatch := regexp.MustCompile(`^v?(\d{2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|-dev|$)`).FindStringSubmatch(s)
 
 	if len(vMatch) == 0 {
 		return Version{}, fmt.Errorf("unable to get the redpanda version from %q", s)


### PR DESCRIPTION
This was misleading: this command does not complete when
a node is decommissioned, but when the decommissioning
process has been started.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none