### PR TITLE
tests: update log allow list for XFS message

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -62,9 +62,12 @@ SaslCredentials = collections.namedtuple("SaslCredentials",
 FileToChecksumSize = dict[str, Tuple[str, int]]
 
 DEFAULT_LOG_ALLOW_LIST = [
-    # Tests currently don't run on XFS, although in future they should.
-    # https://github.com/redpanda-data/redpanda/issues/2376
+    # Tests may be run on workstations that do not have XFS filesystem volumes
+    # for containers.
+    # Pre-23.2 version of the message
     re.compile("not on XFS. This is a non-supported setup."),
+    # >= 23.2 version of the message
+    re.compile("not on XFS or ext4. This is a non-supported"),
 
     # This is expected when tests are intentionally run on low memory configurations
     re.compile(r"Memory: '\d+' below recommended"),


### PR DESCRIPTION
This is needed for running tests locally on
non-supported filesystems like overlayfs.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none