### PR TITLE
cloud_storage: handle 'partial message' errors

### DIFF
--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -47,7 +47,9 @@ error_outcome handle_client_transport_error(
         // from the S3 endpoint and subsequent connection attmpts failed.
         vlog(logger.warn, "Connection timeout {}", terr.what());
     } catch (const boost::system::system_error& err) {
-        if (err.code() != boost::beast::http::error::short_read) {
+        if (
+          err.code() != boost::beast::http::error::short_read
+          && err.code() != boost::beast::http::error::partial_message) {
             vlog(logger.warn, "Connection failed {}", err.what());
             outcome = error_outcome::fail;
         } else {


### PR DESCRIPTION
This is a way that connections can go down uncleanly, that we see on arm64 testing.

Fixes https://github.com/redpanda-data/redpanda/issues/9203

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Reduced "partial message" error logging when object storage backends uncleanly terminate connections.
