### PR TITLE
Do not wait for the reallocation batch to finish

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -20,29 +20,6 @@
 #include "random/generators.h"
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/loop.hh>
-#include <seastar/core/metrics.hh>
-#include <seastar/core/sleep.hh>
-#include <seastar/core/sstring.hh>
-#include <seastar/util/later.hh>
-#include <seastar/util/optimized_optional.hh>
-
-#include <absl/container/node_hash_map.h>
-#include <absl/container/node_hash_set.h>
-#include <fmt/ostream.h>
-
-#include <algorithm>
-#include <bitset>
-#include <cstddef>
-#include <cstdint>
-#include <exception>
-#include <functional>
-#include <iterator>
-#include <limits>
-#include <optional>
-#include <ostream>
-#include <system_error>
-#include <vector>
 
 namespace cluster {
 namespace {

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -921,7 +921,7 @@ ss::future<std::error_code> members_backend::reconcile() {
     // execute reallocations
     co_await ss::parallel_for_each(
       meta.partition_reallocations, [this](auto& pair) {
-          return reallocate_replica_set(pair.first, pair.second);
+          return reconcile_reallocation_state(pair.first, pair.second);
       });
 
     // remove those decommissioned nodes which doesn't have any pending
@@ -1056,7 +1056,7 @@ members_backend::try_to_finish_update(members_backend::update_meta& meta) {
     }
 }
 
-ss::future<> members_backend::reallocate_replica_set(
+ss::future<> members_backend::reconcile_reallocation_state(
   const model::ntp& ntp, members_backend::partition_reallocation& meta) {
     auto current_assignment = _topics.local().get_partition_assignment(ntp);
     // topic was deleted, we are done with reallocation

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -142,6 +142,7 @@ void reassign_replicas(
 double calculate_unevenness_error(
   const partition_allocator& allocator,
   const members_backend::update_meta& update,
+  const topic_table& topics,
   partition_allocation_domain domain) {
     static const std::vector<partition_allocation_domain> domains{
       partition_allocation_domains::consumer_offsets,
@@ -153,9 +154,40 @@ double calculate_unevenness_error(
     /**
      * adjust per node replicas with the replicas that are going to be removed
      * from the node after successful reallocation
+     * based on the state of reallocation the following adjustments are made:
+     *
+     * reallocation_state::initial - no adjustment required
+     * reallocation_state::reassigned - allocator already updated, adjusting
+     * reallocation_state::requested - allocator already updated, adjusting
+     * reallocation_state::finished - no adjustment required
+     *
+     * Do not need to care about the cancel related state here as no
+     * cancellations are requested when node is added to the cluster.
      */
+
     for (const auto& [ntp, r] : update.partition_reallocations) {
-        if (get_allocation_domain(ntp) == domain && r.allocation_units) {
+        using state = members_backend::reallocation_state;
+        /**
+         * In the initial or finished state the adjustment doesn't have
+         * to be taken into account as partition balancer is already updated.
+         */
+        if (
+          r.state == state::initial || r.state == state::finished
+          || r.state == state::cancelled || r.state == state::request_cancel) {
+            continue;
+        }
+        /**
+         * if a partition move was already requested it might have already been
+         * finished, consult topic table to check if the update is still in
+         * progress. If no move is in progress the adjustment must be skipped as
+         * allocator state is already up to date. Reallocation will be marked as
+         * finished in reconciliation loop pass.
+         */
+        if (r.state == state::requested && !topics.is_update_in_progress(ntp)) {
+            continue;
+        }
+
+        if (get_allocation_domain(ntp) == domain) {
             for (const auto& to_remove : r.replicas_to_remove) {
                 auto it = node_replicas.find(to_remove);
                 if (it != node_replicas.end()) {
@@ -449,10 +481,15 @@ void members_backend::default_reallocation_strategy::
     topic_table& topics,
     members_backend::update_meta& meta,
     partition_allocation_domain domain) {
-    size_t prev_reallocations_count = meta.partition_reallocations.size();
+    absl::flat_hash_set<model::ntp> previously_allocated_ntps;
+    previously_allocated_ntps.reserve(meta.partition_reallocations.size());
+    for (const auto& [ntp, _] : meta.partition_reallocations) {
+        previously_allocated_ntps.emplace(ntp);
+    }
     calculate_reallocations_batch(
       max_batch_size, allocator, topics, meta, domain);
-    auto current_error = calculate_unevenness_error(allocator, meta, domain);
+    auto current_error = calculate_unevenness_error(
+      allocator, meta, topics, domain);
     auto [it, _] = meta.last_unevenness_error.try_emplace(domain, 1.0);
 
     auto improvement = it->second - current_error;
@@ -464,15 +501,16 @@ void members_backend::default_reallocation_strategy::
       it->second,
       improvement);
 
-    it->second = current_error;
+    it->second = std::min(current_error, it->second);
 
-    // drop all reallocations if there is no improvement
+    // drop all new reallocations if there is no improvement
     if (improvement <= 0) {
-        meta.partition_reallocations.erase(
-          std::next(
-            meta.partition_reallocations.begin(),
-            static_cast<long>(prev_reallocations_count)),
-          meta.partition_reallocations.end());
+        absl::erase_if(
+          meta.partition_reallocations,
+          [domain, &previously_allocated_ntps](const auto& p) {
+              return !previously_allocated_ntps.contains(p.first)
+                     && domain == get_allocation_domain(p.first);
+          });
     }
 }
 
@@ -507,6 +545,8 @@ ss::future<> members_backend::calculate_reallocations_after_decommissioned(
         }
 
         for (const auto& pas : cfg.get_assignments()) {
+            // skip over reallocations that are already present
+
             // break when we already scheduled more than allowed reallocations
             if (
               meta.partition_reallocations.size()
@@ -518,6 +558,10 @@ ss::future<> members_backend::calculate_reallocations_after_decommissioned(
                 break;
             }
             model::ntp ntp(tp_ns.ns, tp_ns.tp, pas.id);
+            // skip over reallocation that is already requested
+            if (meta.partition_reallocations.contains(ntp)) {
+                continue;
+            }
             if (is_in_replica_set(pas.replicas, meta.update->id)) {
                 auto previous_replica_set
                   = _topics.local().get_previous_replica_set(ntp);
@@ -791,6 +835,10 @@ ss::future<> members_backend::calculate_reallocations_after_recommissioned(
     // decommissioned node
     meta.partition_reallocations.reserve(ntps.size());
     for (auto& ntp : ntps) {
+        // skip over reallocations that are already present
+        if (meta.partition_reallocations.contains(ntp)) {
+            continue;
+        }
         partition_reallocation reallocation;
         reallocation.state = reallocation_state::request_cancel;
         auto current_assignment = _topics.local().get_partition_assignment(ntp);
@@ -885,7 +933,7 @@ ss::future<std::error_code> members_backend::reconcile() {
     }
 
     // calculate necessary reallocations
-    if (meta.partition_reallocations.empty()) {
+    if (meta.partition_reallocations.size() < _max_concurrent_reallocations()) {
         co_await calculate_reallocations(meta);
         // if there is nothing to reallocate, just finish this update
         vlog(

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -76,7 +76,6 @@ public:
         // unevenness error is normalized to be at most 1.0, set to max
         absl::flat_hash_map<partition_allocation_domain, double>
           last_unevenness_error;
-        absl::flat_hash_map<partition_allocation_domain, size_t> last_ntp_index;
     };
 
     struct reallocation_strategy {

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -133,7 +133,7 @@ private:
     ss::future<> reconciliation_loop();
     ss::future<std::error_code> reconcile();
     ss::future<>
-    reallocate_replica_set(const model::ntp&, partition_reallocation&);
+    reconcile_reallocation_state(const model::ntp&, partition_reallocation&);
 
     ss::future<> try_to_finish_update(update_meta&);
     ss::future<> calculate_reallocations(update_meta&);

--- a/src/v/cluster/tests/backend_reallocation_strategy_test.cc
+++ b/src/v/cluster/tests/backend_reallocation_strategy_test.cc
@@ -209,7 +209,7 @@ struct strategy_test_fixture {
 
     ss::future<>
     apply_reallocations(cluster::members_backend::update_meta& meta) {
-        for (auto& pr : meta.partition_reallocations) {
+        for (auto& [ntp, pr] : meta.partition_reallocations) {
             auto added = cluster::subtract_replica_sets(
               pr.new_replica_set, pr.current_replica_set);
             auto removed = cluster::subtract_replica_sets(
@@ -221,13 +221,13 @@ struct strategy_test_fixture {
               removed, cluster::partition_allocation_domains::common);
 
             auto ec = co_await topics.apply(
-              cluster::move_partition_replicas_cmd(pr.ntp, pr.new_replica_set),
+              cluster::move_partition_replicas_cmd(ntp, pr.new_replica_set),
               ++rev_offset);
             BOOST_REQUIRE(!ec);
 
             ec = co_await topics.apply(
               cluster::finish_moving_partition_replicas_cmd(
-                pr.ntp, pr.new_replica_set),
+                ntp, pr.new_replica_set),
               ++rev_offset);
             BOOST_REQUIRE(!ec);
         }


### PR DESCRIPTION
Changed the logic in `cluster::members_backend` to calculate
reallocations when pending reallocation count is smaller than max
reallocation batch size. This way the available learner recovery
bandwidth may be fully utilised and node operations may finish faster.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- faster rebalancing after node is added or decommissioned
