### PR TITLE
vlog, storage, cloud_storage: Structured errors

### DIFF
--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -24,6 +24,7 @@
 #include "storage/ntp_config.h"
 #include "storage/parser.h"
 #include "utils/gate_guard.h"
+#include "vlog_error.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/file-types.hh>
@@ -208,8 +209,9 @@ ss::future<log_recovery_result> partition_downloader::download_log() {
         //
         // Normally, this will happen when one of the partitions doesn't
         // have any data.
-        vlog(
-          _ctxlog.error,
+        vlog_error(
+          _ctxlog,
+          io_error::cloud_storage_recovery_fatal,
           "Error during log recovery: {}",
           std::current_exception());
     }

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -239,6 +239,8 @@ public:
       const cloud_storage_clients::object_tag_formatter& tags
       = default_segment_tags);
 
+    using existence_required = ss::bool_class<struct existence_required_tag>;
+
     /// \brief Download segment from S3
     ///
     /// The method downloads the segment while tolerating some errors. It can
@@ -247,11 +249,15 @@ public:
     /// segment's data
     /// \param name is a segment's name in S3
     /// \param manifest is a manifest that should have the segment metadata
+    /// \param require_exists if true, then we will log an error if the object
+    ///                       is not found: use this if absence indicates
+    ///                       corruption.
     ss::future<download_result> download_segment(
       const cloud_storage_clients::bucket_name& bucket,
       const remote_segment_path& path,
       const try_consume_stream& cons_str,
-      retry_chain_node& parent);
+      retry_chain_node& parent,
+      existence_required require_exists = existence_required::no);
 
     /// Checks if the segment exists in the bucket
     ss::future<download_result> segment_exists(

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -18,6 +18,7 @@
 #include "cloud_storage/segment_state.h"
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/types.h"
+#include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/types.h"

--- a/src/v/vlog_error.h
+++ b/src/v/vlog_error.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "vlog.h"
+
+namespace detail {
+
+class structured_error_code {
+public:
+    constexpr explicit structured_error_code(const char* cat, uint16_t i)
+      : category(cat)
+      , number(i) {}
+
+    const char* category;
+    const uint16_t number;
+};
+} // namespace detail
+
+/**
+ * ======================
+ * Error code definitions
+ * ======================
+ *
+ * These are defined centrally in this file for all subsystems, so that we
+ * can easily avoid accidentally re-using codes for different subsystems.
+ */
+
+/**
+ * Soft assertions are cases that should never happen if our code is bug free,
+ * but which can be recovered and do not necessitate panicking the process.
+ */
+namespace soft_assert {
+constexpr const char* prefix = "ESA";
+
+// We violated internal rules about where start_offset may be set relative
+// to existent segments.
+constexpr auto cloud_storage_start_offset_out_of_range
+  = detail::structured_error_code(prefix, 1);
+
+// We failed to cover all the error types that could occur during a call
+// to object storage.
+constexpr auto cloud_storage_unhandled_client_error
+  = detail::structured_error_code(prefix, 2);
+
+} // namespace soft_assert
+
+/**
+ * I/O errors are cases that indicate an external system is misbehaving in a way
+ * that prevents us from doing our job, for example if a disk gives us an EIO
+ * or if a cloud storage API behaves outside its spec.
+ */
+namespace io_error {
+constexpr const char* prefix = "EIO";
+
+// Operating system indicates I/O error on block device, we cannot proceed.
+constexpr auto local_disk_eio = detail::structured_error_code(prefix, 1);
+
+// Failure reading while doing topic recovery
+constexpr auto cloud_storage_recovery_fatal = detail::structured_error_code(
+  prefix, 2);
+
+// Failure to load data from remote storage to serve a read
+constexpr auto cloud_storage_hydration_fatal = detail::structured_error_code(
+  prefix, 3);
+
+// Backend sent a malformed response body, not compliant with S3 spec
+constexpr auto cloud_storage_bad_response = detail::structured_error_code(
+  prefix, 4);
+
+} // namespace io_error
+
+/**
+ * Consistency errors may indicate corruption in storage.  For example if
+ * a cloud storage manifest refers to a segment that does not exist.  This
+ * can be a bug in redpanda, a bug in the storage backend, or external
+ * interference.
+ */
+namespace consistency_error {
+constexpr const char* prefix = "ECR";
+constexpr auto cloud_storage_missing_segment = detail::structured_error_code(
+  prefix, 1);
+} // namespace consistency_error
+
+/**
+ * Configuration errors indicate that while configuration might have been
+ * syntactically correct, something is wrong with it in practice: for example
+ * we are configured to use an object storage bucket that does not exist.
+ */
+namespace configuration_error {
+constexpr const char* prefix = "ECN";
+constexpr auto cloud_storage_missing_bucket = detail::structured_error_code(
+  prefix, 1);
+
+} // namespace configuration_error
+
+/**
+ * Structured error logging: pass a subclass of `structured_error_code` as
+ * the code, so that the error can be uniquely mapped back to a specific
+ * condition in a way that is robust across versions of Redpanda and does
+ * not rely on the exact formatting of the string, the line number, or
+ * the naming of loggers.
+ *
+ * Prefer this to using plain `vlog` for errors.
+ */
+// NOLINTNEXTLINE
+#define vlog_error(logger, code, fmt, args...)                                 \
+    fmt_with_ctx_level(                                                        \
+      logger,                                                                  \
+      ss::log_level::error,                                                    \
+      "code={}{:05d} " fmt,                                                    \
+      code.category,                                                           \
+      code.number,                                                             \
+      ##args)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -547,7 +547,7 @@ class SISettings:
         self._expected_damage_types = damage_types
 
     def is_damage_expected(self, damage_types: set[str]):
-        return (damage_types & self._expected_damage_types) == damage_types
+        return damage_types.issubset(self._expected_damage_types)
 
 
 class TLSProvider:

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -200,7 +200,7 @@ class BucketScrubSelfTest(RedpandaTest):
         segment_key = None
         for o in self.redpanda.cloud_storage_client.list_objects(
                 self.si_settings.cloud_storage_bucket):
-            if ".log" in o.key and view.is_segment_part_of_a_manifest(o):
+            if view.is_segment_part_of_a_manifest(o):
                 segment_key = o.key
                 break
 


### PR DESCRIPTION
`vlog_error` is introduced with a new `code` parameters to enable logging errors in a format that includes a consistent error code, from a central directory of error codes defined in the vlog_error.h header.

This enables
- monitoring which errors are happening at what frequency across a fleet of clusters.
- quickly distinguishing broad classes of error (e.g. I/O errors vs. internal soft assertions vs. data consistency issues)
- simpler communication with the field about errors, where issues can be reported with one or more error codes rather than snippets of log message and/or line numbers that might not be the same across different versions.
- documentation of what specific error codes mean, so that users can go from logs of concern to explanations of what the log message means.

These codes will also be the foundation for future error counter infrastructure, so that we may report any non-zero counts of these conditions via `rpk cluster health`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Some error logs now include error codes (e.g. "EIO00001") to simplify log monitoring and reporting issues.
