### PR TITLE
cloud_storage: fix abs client shutdown leak

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -262,7 +262,14 @@ abs_client::abs_client(
   , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
 
-ss::future<> abs_client::stop() { return _client.stop(); }
+ss::future<> abs_client::stop() {
+    vlog(abs_log.debug, "Stopping ABS client");
+
+    co_await _client.stop();
+    co_await _client.wait_input_shutdown();
+
+    vlog(abs_log.debug, "Stopped ABS client");
+}
 
 void abs_client::shutdown() { _client.shutdown(); }
 

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -81,6 +81,7 @@ public:
 
     ss::future<> stop();
     using net::base_transport::shutdown;
+    using net::base_transport::wait_input_shutdown;
 
     /// Return immediately if connected or make connection attempts
     /// until success, timeout or error

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -41,6 +41,7 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
           server_address()));
     }
     try {
+        base_transport::reset_state();
         reset_state();
         auto resolved_address = co_await net::resolve_dns(server_address());
         ss::connected_socket fd = co_await connect_with_timeout(
@@ -110,10 +111,9 @@ ss::future<> base_transport::stop() {
 
 void base_transport::shutdown() noexcept {
     try {
-        if (_fd) {
+        if (_fd && !std::exchange(_shutdown, true)) {
             _fd->shutdown_input();
             _fd->shutdown_output();
-            _fd.reset();
         }
     } catch (...) {
         vlog(

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -123,4 +123,10 @@ void base_transport::shutdown() noexcept {
     }
 }
 
+ss::future<> base_transport::wait_input_shutdown() {
+    if (_fd && _shutdown) {
+        co_return co_await _fd->wait_input_shutdown();
+    }
+}
+
 } // namespace net

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -63,12 +63,17 @@ public:
 
     // override this method to reset internal state when connection attempt is
     // being made
-    virtual void reset_state() {}
+    virtual void reset_state() {
+        _fd.reset();
+        _shutdown = false;
+    }
 
     ss::future<> stop();
     void shutdown() noexcept;
 
-    [[gnu::always_inline]] bool is_valid() const { return _fd && !_in.eof(); }
+    [[gnu::always_inline]] bool is_valid() const {
+        return _fd && !_shutdown && !_in.eof();
+    }
 
     const unresolved_address& server_address() const { return _server_addr; }
 
@@ -87,6 +92,9 @@ private:
     unresolved_address _server_addr;
     ss::shared_ptr<ss::tls::certificate_credentials> _creds;
     std::optional<ss::sstring> _tls_sni_hostname;
+
+    // Track if shutdown was called on the current `_fd`
+    bool _shutdown{false};
 };
 
 } // namespace net

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -70,6 +70,7 @@ public:
 
     ss::future<> stop();
     void shutdown() noexcept;
+    ss::future<> wait_input_shutdown();
 
     [[gnu::always_inline]] bool is_valid() const {
         return _fd && !_shutdown && !_in.eof();


### PR DESCRIPTION
When using Tiered Storage with ABS and TLS enabled, one could get memory leaks
upon shutdown due to Azure not terminating the connection promptly enough. In order
to gracefully close a TLS connection, Seastar spawns a background fiber which will wait on the
peer for a maximum of 10 seconds. Redpanda shutdown is much faster than that, so if Azure
doesn't terminate the connection before tear down is complete, we'd see a memory leak from said fiber.

Recent versions of Seastar expose a `wait_input_shutdown` method on connections which waits
until the peer drops the connection. This PR uses it to wait on the Azure peer when shutting down.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->
In theory, this can and should be backported to v23.1.x, but we'd also have to backport the
recent Seastar update.

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Bug Fixes

* Fix memory leak upon shutdown which can occur when using tiered storage with ABS and TLS.