### PR TITLE
rpk: support go duration in bundle

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/fatih/color v1.14.1
-	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lestrrat-go/jwx v1.2.25
 	github.com/lorenzosaino/go-sysctl v0.3.1
@@ -33,7 +32,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
 	github.com/tklauser/go-sysconf v0.3.11
-	github.com/trstringer/go-systemd-time v1.0.0
 	github.com/twmb/franz-go v1.12.0
 	github.com/twmb/franz-go/pkg/kadm v1.7.0
 	github.com/twmb/franz-go/pkg/kmsg v1.4.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -199,8 +199,6 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
@@ -362,8 +360,6 @@ github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+Kd
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
 github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYms=
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
-github.com/trstringer/go-systemd-time v1.0.0 h1:85YYNtMuiDJtbnQveqN5M2+GHVKqYpPvOxLZMOLD4BY=
-github.com/trstringer/go-systemd-time v1.0.0/go.mod h1:zmxXIRFeksWrNr4tdJeHBvxev3nmViuoEZNs+OllX20=
 github.com/twmb/franz-go v1.12.0 h1:HWd7E9p/R15D0kofG5p6e3k3tWd/ewqs/IclKhpw+qc=
 github.com/twmb/franz-go v1.12.0/go.mod h1:Ofc5tSSUJKLmpRNUYSejUsAZKYAHDHywTS322KWdChQ=
 github.com/twmb/franz-go/pkg/kadm v1.7.0 h1:TAgcS+t5q+9jnm8INCD2OJ1MD9y4Ij6pD5CYfZ3tkbg=

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
@@ -26,7 +26,6 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
-	"github.com/trstringer/go-systemd-time/pkg/systemdtime"
 	k8score "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -467,10 +466,11 @@ func parseJournalTime(str string, now time.Time) (time.Time, error) {
 
 	// This is either a relative time (+/-) or an error
 	default:
-		adjustedTime, err := systemdtime.AdjustTime(now, str)
+		dur, err := time.ParseDuration(str)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("unable to parse time %q: %v", str, err)
 		}
+		adjustedTime := now.Add(dur)
 		return adjustedTime, nil
 	}
 }

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_test.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_test.go
@@ -179,9 +179,9 @@ func TestParseJournalTime(t *testing.T) {
 			exp:    time.Date(2022, time.November, 9, 0o0, 15, 0, 0, time.Local),
 		}, {
 			name:   "- relative time",
-			inStr:  "-5day",
+			inStr:  "-48h",
 			inTime: time.Date(2022, time.February, 18, 8, 0, 0, 0, time.Local),
-			exp:    time.Date(2022, time.February, 13, 8, 0, 0, 0, time.Local),
+			exp:    time.Date(2022, time.February, 16, 8, 0, 0, 0, time.Local),
 		}, {
 			name:   "unrecognized relative time",
 			inStr:  "-5trillions",


### PR DESCRIPTION
More standard in k8s world.

## Backports Required
- [ ] v23.1.x


## Release Notes
### Bug Fixes
* rpk: In k8s `rpk debug bundle` --since flag no longer supports non-standard durations (such as day, week, years), only Go standard durations will be accepted. 
