### PR TITLE
[v22.3.x] test: replace rpk tune list output if its running in GCP

### DIFF
--- a/tests/rptest/tests/rpk_tuner_test.py
+++ b/tests/rptest/tests/rpk_tuner_test.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import os
+
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk_remote import RpkRemoteTool
@@ -93,6 +95,11 @@ transparent_hugepages  true     true
             "clocksource            true     true       ",
             "clocksource            true     false      Clocksource setting not available for this architecture"
         ) if is_not_x86 else expected
+
+        expected = expected.replace(
+            "disk_write_cache       true     false      Disk write cache tuner is only supported in GCP",
+            "disk_write_cache       true     true       ") if os.environ.get(
+                'CDT_CLOUD_PROVIDER', None) == 'gcp' else expected
 
         output = rpk.tune("list")
         self.logger.debug(output)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9977
Fixes https://github.com/redpanda-data/redpanda/issues/10005,