### PR TITLE
licenses: update direct dependencies of rpk

### DIFF
--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -49,61 +49,46 @@ please keep this up to date with every new library use.
 
 | software                                              | license                   |
 | :----------                                           | :------------:            |
-| cloud.google.com/go                                   | Apache License 2          |
-| github.com/AlecAivazis/survey/v2                      | Apache License 2          |
-| github.com/Microsoft/go-winio                         | MIT License               |
-| github.com/Shopify/sarama                             | MIT License               |
+| cloud.google.com/go                                   | Apache License 2.0        |
+| github.com/AlecAivazis/survey/v2                      | MIT License               |
 | github.com/avast/retry-go                             | MIT License               |
 | github.com/aws/aws-sdk-go                             | Apache License 2.0        |
 | github.com/beevik/ntp                                 | BSD 2-Clause License      |
-| github.com/burdiyan/kafkautil                         | MIT License               |
 | github.com/cespare/xxhash                             | MIT License               |
-| github.com/containerd/containerd                      | Apache License 2.0        |
 | github.com/coreos/go-systemd/v22                      | Apache License 2.0        |
-| github.com/docker/distribution                        | Apache License 2.0        |
 | github.com/docker/docker                              | Apache License 2.0        |
 | github.com/docker/go-connections                      | Apache License 2.0        |
 | github.com/docker/go-units                            | Apache License 2.0        |
 | github.com/fatih/color                                | MIT License               |
-| github.com/golang/snappy                              | BSD 3-Clause License      |
-| github.com/google/go-cmp                              | BSD 3-Clause License      |
-| github.com/google/uuid                                | BSD 3-Clause License      |
-| github.com/hashicorp/go-multierror                    | Mozilla Public License 2.0|
-| github.com/icza/dyno                                  | Apache License 2.0        |
-| github.com/konsorten/go-windows-terminal-sequences    | MIT License               |
+| github.com/hashicorp/go-multierror                    | MPL-2.0                   |
+| github.com/lestrrat-go/jwx                            | MIT License               |
 | github.com/lorenzosaino/go-sysctl                     | BSD 3-Clause License      |
-| github.com/lovoo/goka                                 | BSD 3-Clause License      |
-| github.com/mattn/go-colorable                         | MIT License               |
-| github.com/mattn/go-isatty                            | MIT License               |
-| github.com/mattn/go-runewidth                         | MIT License               |
-| github.com/mgutz/ansi                                 | MIT License               |
-| github.com/mitchellh/mapstructure                     | MIT License               |
 | github.com/moby/term                                  | Apache License 2.0        |
-| github.com/morikuni/aec                               | MIT License               |
 | github.com/olekukonko/tablewriter                     | MIT License               |
-| github.com/opencontainers/go-digest                   | Apache License 2.0        |
-| github.com/opencontainers/image-spec                  | Apache License 2.0        |
+| github.com/opencontainers/image-spec/specs-go         | Apache License 2.0        |
+| github.com/pkg/browser                                | BSD 2-Clause License      |
 | github.com/pkg/errors                                 | BSD 2-Clause License      |
-| github.com/prometheus/client_model                    | Apache License 2.0        |
+| github.com/prometheus/client_model/go                 | Apache License 2.0        |
 | github.com/prometheus/common                          | Apache License 2.0        |
 | github.com/safchain/ethtool                           | Apache License 2.0        |
+| github.com/sethgrid/pester                            | MIT License               |
 | github.com/sirupsen/logrus                            | MIT License               |
 | github.com/spf13/afero                                | Apache License 2.0        |
 | github.com/spf13/cobra                                | Apache License 2.0        |
 | github.com/spf13/pflag                                | BSD 3-Clause License      |
-| github.com/spf13/viper                                | MIT License               |
-| github.com/stretchr/testify                           | MIT License               |
 | github.com/tklauser/go-sysconf                        | BSD 3-Clause License      |
-| github.com/twmb/franz-go                              | BSD 3-Clause License      |
+| github.com/twmb/franz-go/pkg                          | BSD 3-Clause License      |
+| github.com/twmb/franz-go/pkg/kadm                     | BSD 3-Clause License      |
+| github.com/twmb/franz-go/pkg/kmsg                     | BSD 3-Clause License      |
 | github.com/twmb/tlscfg                                | BSD 3-Clause License      |
-| github.com/xdg/scram                                  | Apache License 2.0        |
-| golang.org/x/crypto                                   | BSD 3-Clause License      |
-| golang.org/x/mod                                      | BSD 3-Clause License      |
-| golang.org/x/sync                                     | BSD 3-Clause License      |
-| golang.org/x/sys                                      | BSD 3-Clause License      |
-| golang.org/x/tools                                    | BSD 3-Clause License      |
-| gopkg.in/yaml.v2                                      | Apache License 2.0        |
-| mvdan.cc/sh/v3                                        | BSD 3-Clause License      |
+| github.com/twmb/types                                 | BSD 3-Clause License      |
+| golang.org/x/sync/errgroup                            | BSD 3-Clause License      |
+| golang.org/x/sys/unix                                 | BSD 3-Clause License      |
+| golang.org/x/term                                     | BSD 3-Clause License      |
+| gopkg.in/yaml.v3                                      | MIT License               |
+| k8s.io/api                                            | Apache License 2.0        |
+| k8s.io/apimachinery/pkg                               | Apache License 2.0        |
+| k8s.io/client-go                                      | Apache License 2.0        |
 
 # GO deps _used_ in production in K8S (exclude all test dependencies)
 


### PR DESCRIPTION
Updated with the tip of dev. Only Direct Dependencies included.

## Backports Required
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
