### PR TITLE
rpk: support go duration in bundle

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
 	github.com/tklauser/go-sysconf v0.3.11
-	github.com/trstringer/go-systemd-time v1.0.0
 	github.com/twmb/franz-go v1.12.0
 	github.com/twmb/franz-go/pkg/kadm v1.7.0
 	github.com/twmb/franz-go/pkg/kmsg v1.4.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -360,8 +360,6 @@ github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+Kd
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
 github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYms=
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
-github.com/trstringer/go-systemd-time v1.0.0 h1:85YYNtMuiDJtbnQveqN5M2+GHVKqYpPvOxLZMOLD4BY=
-github.com/trstringer/go-systemd-time v1.0.0/go.mod h1:zmxXIRFeksWrNr4tdJeHBvxev3nmViuoEZNs+OllX20=
 github.com/twmb/franz-go v1.12.0 h1:HWd7E9p/R15D0kofG5p6e3k3tWd/ewqs/IclKhpw+qc=
 github.com/twmb/franz-go v1.12.0/go.mod h1:Ofc5tSSUJKLmpRNUYSejUsAZKYAHDHywTS322KWdChQ=
 github.com/twmb/franz-go/pkg/kadm v1.7.0 h1:TAgcS+t5q+9jnm8INCD2OJ1MD9y4Ij6pD5CYfZ3tkbg=

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
@@ -26,7 +26,6 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
-	"github.com/trstringer/go-systemd-time/pkg/systemdtime"
 	k8score "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -467,10 +466,11 @@ func parseJournalTime(str string, now time.Time) (time.Time, error) {
 
 	// This is either a relative time (+/-) or an error
 	default:
-		adjustedTime, err := systemdtime.AdjustTime(now, str)
+		dur, err := time.ParseDuration(str)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("unable to parse time %q: %v", str, err)
 		}
+		adjustedTime := now.Add(dur)
 		return adjustedTime, nil
 	}
 }

--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_test.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_test.go
@@ -179,9 +179,9 @@ func TestParseJournalTime(t *testing.T) {
 			exp:    time.Date(2022, time.November, 9, 0o0, 15, 0, 0, time.Local),
 		}, {
 			name:   "- relative time",
-			inStr:  "-5day",
+			inStr:  "-48h",
 			inTime: time.Date(2022, time.February, 18, 8, 0, 0, 0, time.Local),
-			exp:    time.Date(2022, time.February, 13, 8, 0, 0, 0, time.Local),
+			exp:    time.Date(2022, time.February, 16, 8, 0, 0, 0, time.Local),
 		}, {
 			name:   "unrecognized relative time",
 			inStr:  "-5trillions",


### PR DESCRIPTION
Manual backport of #10002, had to adjust the go mod tidy since we still use the UUID package in v23.1.x

(cherry picked from commit 18ca5fa4a4b566940c0ce775bf410c85119e4514)

## Release Notes
### Bug Fixes
* rpk: In k8s `rpk debug bundle` --since flag no longer supports non-standard durations (such as day, week, years), only Go standard durations will be accepted. 

