### PR TITLE
Add available memory to internal metrics

### DIFF
--- a/src/v/resource_mgmt/available_memory.cc
+++ b/src/v/resource_mgmt/available_memory.cc
@@ -67,7 +67,7 @@ void available_memory::register_metrics() {
     }
 
     auto& m = _metrics.emplace();
-    m.groups.add_group(
+    m.add_group(
       prometheus_sanitize::metrics_name("memory"),
       {ss::metrics::make_gauge(
          "available_memory",

--- a/src/v/resource_mgmt/available_memory.h
+++ b/src/v/resource_mgmt/available_memory.h
@@ -154,7 +154,7 @@ private:
       _local_instance; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     intrusive_list<reporter, &reporter::hook> _reporters;
-    std::optional<ssx::metrics::public_metrics_group> _metrics;
+    std::optional<ssx::metrics::all_metrics_groups> _metrics;
     size_t _lwm;
 };
 

--- a/src/v/ssx/metrics.h
+++ b/src/v/ssx/metrics.h
@@ -16,6 +16,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_registration.hh>
 
 namespace ssx::metrics {
 
@@ -48,6 +49,32 @@ struct public_metrics_group {
         groups.clear();
         return ss::make_ready_future<>();
     }
+};
+
+/**
+ * @brief A class bundling together public and internal metrics.
+ *
+ * Intended to replace an ss::metrics::metric_groups instance when
+ * you want a metric exposed on both the /metrics (aka "internal")
+ * and /public_metrics (aka "public") metrics endpoint.
+ */
+class all_metrics_groups {
+    ss::metrics::metric_groups _public{public_metrics_handle}, _internal;
+
+public:
+    /**
+     * @brief Adds the given metric group to public and internal metrics.
+     *
+     * The behavior is same as ss::metrics::metric_groups::add_group but for
+     * both metric endpoints.
+     */
+    all_metrics_groups& add_group(
+      const seastar::metrics::group_name_type& name,
+      const std::initializer_list<seastar::metrics::metric_definition>& l) {
+        _internal.add_group(name, l);
+        _public.add_group(name, l);
+        return *this;
+    };
 };
 
 } // namespace ssx::metrics


### PR DESCRIPTION
This change adds the available_memory metric, which has been very useful, to the internal metrics endpoint in addition to the public metrics one (where it is today).

Currently, some users are pulling only /metrics or have dashboards or other integrations oriented towards /metrics, and can't use this key memory metric. Furthermore, all of the other memory metrics are in /metrics so it is odd that the most important memory metric is stranded elsewhere.

This change reverses this decision and put available_memory in both places, in line with all other memory metrics and the majority of metrics in general.

See https://github.com/redpanda-data/core-internal/issues/103 for background on this metric.

Fixes #9982.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* The vectorized_memory_available_memory metric is now available on the /metrics endpoint in addition to /public_metrics.
