### PR TITLE
storage: apply conservative size-based retention

### DIFF
--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -289,7 +289,7 @@ FIXTURE_TEST(retention_by_size_with_remote_write, gc_fixture) {
         auto segment_count_after_gc = builder.get_log().segment_count();
 
         if (partition_size > size_limit) {
-            BOOST_CHECK_GT(segment_count_before_gc, segment_count_after_gc);
+            BOOST_CHECK_GE(segment_count_before_gc, segment_count_after_gc);
         } else {
             BOOST_CHECK_EQUAL(segment_count_before_gc, segment_count_after_gc);
         }
@@ -298,7 +298,7 @@ FIXTURE_TEST(retention_by_size_with_remote_write, gc_fixture) {
     auto final_partition_size
       = builder.get_disk_log_impl().get_probe().partition_size();
 
-    BOOST_CHECK_GE(size_limit, final_partition_size);
+    BOOST_CHECK_LE(size_limit, final_partition_size);
 
     builder.stop().get();
 }

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -24,6 +24,10 @@ class Segment:
         # Size of data_file, if caller chooses to populate it via set_size
         self.size = None
 
+        m = re.match(r"^(\d+)\-\d+\-v\d+$", name)
+        assert m, f"Unexpected segment name {name}"
+        self.offset = m.group(1)
+
     def add_file(self, fn, ext):
         assert fn
         assert ext

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -28,6 +28,7 @@ from rptest.util import Scale, wait_until_segments
 from rptest.util import (
     produce_until_segments,
     wait_for_removal_of_n_segments,
+    wait_for_local_storage_truncate,
 )
 from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView
 from rptest.utils.mode_checks import skip_debug_mode
@@ -286,11 +287,10 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
 
         assert self.redpanda
         with random_process_kills(self.redpanda) as ctx:
-            wait_for_removal_of_n_segments(redpanda=self.redpanda,
-                                           topic=self.topic,
-                                           partition_idx=0,
-                                           n=6,
-                                           original_snapshot=original_snapshot)
+            wait_for_local_storage_truncate(redpanda=self.redpanda,
+                                            topic=self.topic,
+                                            target_bytes=5 * self.segment_size,
+                                            partition_idx=0)
 
             self.start_consumer()
             self.run_validation(consumer_timeout_sec=90)

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -206,15 +206,18 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
         if expect_deletion:
             # Wait up to just a bit longer than the 10s default config value
             # for `cloud_storage_upload_loop_max_backoff_ms`.
-            wait_until(
-                lambda: self.segments_removed(self.default_retention_segments),
-                timeout_sec=15,
-                backoff_sec=1,
-                err_msg=f"Segments were not removed")
+            # the target segments limit is one higher than expected because
+            # retention policy won't violate the target max size. that is: it
+            # won't reclaim the last segment if it puts it over the edge.
+            wait_until(lambda: self.segments_removed(
+                self.default_retention_segments + 1),
+                       timeout_sec=15,
+                       backoff_sec=1,
+                       err_msg=f"Segments were not removed")
         else:
             with expect_exception(TimeoutError, lambda e: True):
                 wait_until(lambda: self.segments_removed(
-                    self.default_retention_segments),
+                    self.default_retention_segments + 1),
                            timeout_sec=5,
                            backoff_sec=1)
 
@@ -247,7 +250,10 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
 
         # Wait up to just bit a longer than the 10s default config value for
         # `cloud_storage_upload_loop_max_backoff_ms`.
-        wait_until(lambda: self.segments_removed(self.retention_segments),
+        # the target segments limit is one higher than expected because
+        # retention policy won't violate the target max size. that is: it
+        # won't reclaim the last segment if it puts it over the edge.
+        wait_until(lambda: self.segments_removed(self.retention_segments + 1),
                    timeout_sec=15,
                    backoff_sec=1,
                    err_msg=f"Segments were not removed")


### PR DESCRIPTION
When deleting segments for size-based retention policy a segment should not be deleted if it would delete more than the target retention size. This is the same semantics as kafka, and avoids a problematic case where we might delete a large segment, say 1 GB, just to reclaim a few additional bytes according to the policy. This could lead to unexpected behavior.

Fixes: https://github.com/redpanda-data/redpanda/issues/9526

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

-->
### Improvements

* Size-based retention is now more conservative. Instead of reclaiming at least the configured max size, it will reclaim as close to max size as possible without exceeding the limit.
