### PR TITLE
Add a `timeout` parameter to transfer_leadership_request

### DIFF
--- a/src/v/cluster/drain_manager.cc
+++ b/src/v/cluster/drain_manager.cc
@@ -2,6 +2,7 @@
 
 #include "cluster/logger.h"
 #include "cluster/partition_manager.h"
+#include "cluster/types.h"
 #include "random/generators.h"
 #include "vlog.h"
 
@@ -197,7 +198,10 @@ ss::future<> drain_manager::do_drain() {
         std::vector<ss::future<std::error_code>> transfers;
         transfers.reserve(selected.size());
         for (auto& p : selected) {
-            transfers.push_back(p->transfer_leadership(std::nullopt));
+            auto req = transfer_leadership_request{
+              .group = p->group(),
+            };
+            transfers.push_back(p->transfer_leadership(req));
         }
         _status.transferring = transfers.size();
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -852,16 +852,6 @@ partition::transfer_leadership(transfer_leadership_request req) {
       ntp(),
       target.value_or(model::node_id{-1}));
 
-    // Some state machines need a preparatory phase to efficiently transfer
-    // leadership: invoke this, and hold the lock that they return until
-    // the leadership transfer attempt is complete.
-    ss::basic_rwlock<>::holder stm_prepare_lock;
-    if (_rm_stm) {
-        stm_prepare_lock = co_await _rm_stm->prepare_transfer_leadership();
-    } else if (_tm_stm) {
-        stm_prepare_lock = co_await _tm_stm->prepare_transfer_leadership();
-    }
-
     std::optional<ss::deferred_action<std::function<void()>>> complete_archiver;
     auto archival_timeout
       = config::shard_local_cfg().cloud_storage_graceful_transfer_timeout_ms();
@@ -894,6 +884,16 @@ partition::transfer_leadership(transfer_leadership_request req) {
         }
     } else {
         vlog(clusterlog.trace, "transfer_leadership[{}]: no archiver", ntp());
+    }
+
+    // Some state machines need a preparatory phase to efficiently transfer
+    // leadership: invoke this, and hold the lock that they return until
+    // the leadership transfer attempt is complete.
+    ss::basic_rwlock<>::holder stm_prepare_lock;
+    if (_rm_stm) {
+        stm_prepare_lock = co_await _rm_stm->prepare_transfer_leadership();
+    } else if (_tm_stm) {
+        stm_prepare_lock = co_await _tm_stm->prepare_transfer_leadership();
     }
 
     co_return co_await _raft->do_transfer_leadership(req);

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -843,7 +843,9 @@ void partition::set_topic_config(
 }
 
 ss::future<std::error_code>
-partition::transfer_leadership(std::optional<model::node_id> target) {
+partition::transfer_leadership(transfer_leadership_request req) {
+    auto target = req.target;
+
     vlog(
       clusterlog.debug,
       "Transferring {} leadership to {}",
@@ -894,7 +896,7 @@ partition::transfer_leadership(std::optional<model::node_id> target) {
         vlog(clusterlog.trace, "transfer_leadership[{}]: no archiver", ntp());
     }
 
-    co_return co_await _raft->do_transfer_leadership(target);
+    co_return co_await _raft->do_transfer_leadership(req);
 }
 
 std::ostream& operator<<(std::ostream& o, const partition& x) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -166,7 +166,7 @@ public:
     }
 
     ss::future<std::error_code>
-    transfer_leadership(std::optional<model::node_id> target);
+      transfer_leadership(transfer_leadership_request);
 
     ss::future<std::error_code> update_replica_set(
       std::vector<raft::broker_revision> brokers,

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -810,8 +810,12 @@ leader_balancer::do_transfer_local(reassignment transfer) const {
               shard);
             return ss::make_ready_future<bool>(false);
         }
-        return partition->transfer_leadership(transfer.to.node_id)
-          .then([group = transfer.group](std::error_code err) {
+
+        transfer_leadership_request req{
+          .group = transfer.group, .target = transfer.to.node_id};
+
+        return partition->transfer_leadership(req).then(
+          [group = transfer.group](std::error_code err) {
               if (err) {
                   vlog(
                     clusterlog.info,

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -812,7 +812,9 @@ leader_balancer::do_transfer_local(reassignment transfer) const {
         }
 
         transfer_leadership_request req{
-          .group = transfer.group, .target = transfer.to.node_id};
+          .group = transfer.group,
+          .target = transfer.to.node_id,
+          .timeout = transfer_leadership_recovery_timeout};
 
         return partition->transfer_leadership(req).then(
           [group = transfer.group](std::error_code err) {
@@ -837,7 +839,9 @@ leader_balancer::do_transfer_local(reassignment transfer) const {
 ss::future<bool>
 leader_balancer::do_transfer_remote_legacy(reassignment transfer) {
     raft::transfer_leadership_request req{
-      .group = transfer.group, .target = transfer.to.node_id};
+      .group = transfer.group,
+      .target = transfer.to.node_id,
+      .timeout = transfer_leadership_recovery_timeout};
 
     vlog(
       clusterlog.debug,
@@ -875,7 +879,9 @@ leader_balancer::do_transfer_remote_legacy(reassignment transfer) {
 
 ss::future<bool> leader_balancer::do_transfer_remote(reassignment transfer) {
     transfer_leadership_request req{
-      .group = transfer.group, .target = transfer.to.node_id};
+      .group = transfer.group,
+      .target = transfer.to.node_id,
+      .timeout = transfer_leadership_recovery_timeout};
 
     auto res = co_await _connections.local()
                  .with_node_client<controller_client_protocol>(

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -22,6 +22,8 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/timer.hh>
 
+#include <chrono>
+
 using namespace std::chrono_literals;
 
 namespace cluster {
@@ -69,6 +71,14 @@ class leader_balancer {
      * in flight transfers successfully completes.
      */
     static constexpr clock_type::duration throttle_reactivation_delay = 5s;
+
+    /*
+     * Used to specify how long a leader should spend trying to recover a
+     * replica the balancer is trying to transfer leadership to.
+     */
+    static constexpr std::chrono::milliseconds
+      transfer_leadership_recovery_timeout
+      = 25ms;
 
 public:
     leader_balancer(

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -670,7 +670,7 @@ ss::future<transfer_leadership_reply> service::transfer_leadership(
                   return ss::make_ready_future<std::error_code>(
                     raft::errc::group_not_exists);
               } else {
-                  return partition_ptr->transfer_leadership(r.target);
+                  return partition_ptr->transfer_leadership(std::move(r));
               }
           });
         co_return transfer_leadership_reply{

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -118,12 +118,14 @@ struct compat_check<raft::transfer_leadership_request> {
       json::Writer<json::StringBuffer>& wr) {
         json_write(group);
         json_write(target);
+        json_write(timeout);
     }
 
     static raft::transfer_leadership_request from_json(json::Value& rd) {
         raft::transfer_leadership_request obj;
         json_read(group);
         json_read(target);
+        json_read(timeout);
         return obj;
     }
 

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -130,6 +130,7 @@ struct instance_generator<raft::transfer_leadership_request> {
         return {
           .group = tests::random_named_int<raft::group_id>(),
           .target = tests::random_named_int<model::node_id>(),
+          .timeout = tests::random_duration_ms(),
         };
     }
 
@@ -138,22 +139,27 @@ struct instance_generator<raft::transfer_leadership_request> {
           {
             .group = tests::random_named_int<raft::group_id>(),
             .target = std::nullopt,
+            .timeout = std::nullopt,
           },
           {
             .group = raft::group_id::min(),
             .target = std::nullopt,
+            .timeout = std::nullopt,
           },
           {
             .group = raft::group_id::max(),
             .target = std::nullopt,
+            .timeout = std::nullopt,
           },
           {
             .group = raft::group_id::min(),
             .target = tests::random_named_int<model::node_id>(),
+            .timeout = tests::random_duration_ms(),
           },
           {
             .group = raft::group_id::max(),
             .target = tests::random_named_int<model::node_id>(),
+            .timeout = tests::random_duration_ms(),
           },
         };
     }

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2890,7 +2890,7 @@ ss::future<transfer_leadership_reply>
 consensus::transfer_leadership(transfer_leadership_request req) {
     transfer_leadership_reply reply;
     try {
-        auto err = co_await do_transfer_leadership(req.target);
+        auto err = co_await do_transfer_leadership(req);
         if (err) {
             vlog(
               _ctxlog.warn,
@@ -2928,8 +2928,8 @@ consensus::transfer_leadership(transfer_leadership_request req) {
  * is sufficiently up to date that they will win the election when
  * they start it.
  */
-ss::future<std::error_code>
-consensus::prepare_transfer_leadership(vnode target_rni) {
+ss::future<std::error_code> consensus::prepare_transfer_leadership(
+  vnode target_rni, transfer_leadership_options opts) {
     /*
      * the follower's log needs to be up-to-date so that it will
      * receive votes when we ask it to trigger an immediate
@@ -2983,8 +2983,7 @@ consensus::prepare_transfer_leadership(vnode target_rni) {
           _log.offsets().dirty_offset);
     }
 
-    auto timeout = ss::semaphore::clock::duration(
-      config::shard_local_cfg().raft_transfer_leader_recovery_timeout_ms());
+    auto timeout = ss::semaphore::clock::duration(opts.recovery_timeout);
 
     if (meta.is_recovering) {
         vlog(
@@ -3020,7 +3019,13 @@ consensus::prepare_transfer_leadership(vnode target_rni) {
 }
 
 ss::future<std::error_code>
-consensus::do_transfer_leadership(std::optional<model::node_id> target) {
+consensus::do_transfer_leadership(transfer_leadership_request req) {
+    auto target = req.target;
+    transfer_leadership_options opts{
+      .recovery_timeout = req.timeout.value_or(
+        config::shard_local_cfg().raft_transfer_leader_recovery_timeout_ms()),
+    };
+
     if (!is_elected_leader()) {
         vlog(_ctxlog.warn, "Cannot transfer leadership from non-leader");
         return seastar::make_ready_future<std::error_code>(
@@ -3089,7 +3094,7 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
       *target_rni,
       _term);
 
-    auto f = ss::with_gate(_bg, [this, target_rni = *target_rni] {
+    auto f = ss::with_gate(_bg, [this, target_rni = *target_rni, opts] {
         if (_transferring_leadership) {
             vlog(
               _ctxlog.warn,
@@ -3122,7 +3127,7 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
               make_error_code(errc::node_does_not_exists));
         }
 
-        return prepare_transfer_leadership(target_rni)
+        return prepare_transfer_leadership(target_rni, opts)
           .then([this, target_rni](std::error_code prepare_err) {
               if (prepare_err) {
                   return ss::make_ready_future<std::error_code>(prepare_err);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -338,9 +338,10 @@ public:
      */
     ss::future<transfer_leadership_reply>
       transfer_leadership(transfer_leadership_request);
-    ss::future<std::error_code> prepare_transfer_leadership(vnode);
     ss::future<std::error_code>
-      do_transfer_leadership(std::optional<model::node_id>);
+      prepare_transfer_leadership(vnode, transfer_leadership_options);
+    ss::future<std::error_code>
+      do_transfer_leadership(transfer_leadership_request);
 
     ss::future<> remove_persistent_state();
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -506,6 +506,10 @@ struct replicate_options {
     std::optional<std::chrono::milliseconds> timeout;
 };
 
+struct transfer_leadership_options {
+    std::chrono::milliseconds recovery_timeout;
+};
+
 using offset_translator_delta = named_type<int64_t, struct ot_delta_tag>;
 struct snapshot_metadata {
     // we start snasphot metadata version at 64 to leave room for configuration
@@ -725,22 +729,25 @@ struct timeout_now_reply
 struct transfer_leadership_request
   : serde::envelope<
       transfer_leadership_request,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     group_id group;
     std::optional<model::node_id> target;
+    std::optional<std::chrono::milliseconds> timeout;
+
     raft::group_id target_group() const { return group; }
 
     friend bool operator==(
       const transfer_leadership_request&, const transfer_leadership_request&)
       = default;
 
-    auto serde_fields() { return std::tie(group, target); }
+    auto serde_fields() { return std::tie(group, target, timeout); }
 
     friend std::ostream&
     operator<<(std::ostream& o, const transfer_leadership_request& r) {
-        fmt::print(o, "group {} target {}", r.group, r.target);
+        fmt::print(
+          o, "group {} target {} timeout {}", r.group, r.target, r.timeout);
         return o;
     }
 };

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1604,7 +1604,11 @@ admin_server::raft_transfer_leadership_handler(
               throw ss::httpd::not_found_exception();
           }
           const auto ntp = partition->ntp();
-          return partition->transfer_leadership(target).then(
+          auto r = raft::transfer_leadership_request{
+            .group = partition->group(),
+            .target = target,
+          };
+          return partition->transfer_leadership(r).then(
             [this, ntp, req = std::move(req)](auto err) {
                 return throw_on_error(*req, err, ntp).then([] {
                     return ss::json::json_return_type(ss::json::json_void());
@@ -1886,7 +1890,11 @@ admin_server::kafka_transfer_leadership_handler(
           if (!partition) {
               throw ss::httpd::not_found_exception();
           }
-          return partition->transfer_leadership(target).then(
+          auto r = raft::transfer_leadership_request{
+            .group = partition->group(),
+            .target = target,
+          };
+          return partition->transfer_leadership(r).then(
             [this, ntp, req = std::move(req)](auto err) {
                 return throw_on_error(*req, err, ntp).then([] {
                     return ss::json::json_return_type(ss::json::json_void());


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Adds a `timeout` parameter to `transfer_leadership_request` that can be used to change the time the consensus is willing to wait for a replica to recover.

The leader balancer was also changed to use this parameter and sets it to 25ms to avoid instability while transferring leadership to a recovering node. See https://github.com/redpanda-data/redpanda/pull/9929 for details.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Improvements
* Adds a `timeout` parameter to `transfer_leadership_request` to change the recovery timeout.