### PR TITLE
storage: optionally ignore timestamps in the future for retention

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -901,6 +901,17 @@ configuration::configuration()
        .example = "10737418240",
        .visibility = visibility::tunable},
       5_GiB)
+  , storage_ignore_timestamps_in_future_sec(
+      *this,
+      "storage_ignore_timestamps_in_future_sec",
+      "If set, timestamps more than this many seconds in the future relative to"
+      "the server's clock will be ignored for data retention purposes, and "
+      "retention will act based on another timestamp in the same segment, or "
+      "the mtime of the segment file if no valid timestamp is available",
+      {.needs_restart = needs_restart::no,
+       .example = "3600",
+       .visibility = visibility::tunable},
+      std::nullopt)
   , id_allocator_log_capacity(
       *this,
       "id_allocator_log_capacity",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -187,6 +187,9 @@ struct configuration final : public config_store {
     bounded_property<uint64_t> storage_max_concurrent_replay;
     bounded_property<uint64_t> storage_compaction_index_memory;
     property<size_t> max_compacted_log_segment_size;
+    property<std::optional<std::chrono::seconds>>
+      storage_ignore_timestamps_in_future_sec;
+
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -169,6 +169,11 @@ private:
     std::optional<model::offset> size_based_gc_max_offset(compaction_config);
     std::optional<model::offset> time_based_gc_max_offset(compaction_config);
 
+    /// Conditionally adjust retention timestamp on any segment that appears
+    /// to have invalid timestamps, to ensure retention can proceed.
+    ss::future<>
+    retention_adjust_timestamps(std::chrono::seconds ignore_in_future);
+
     bool is_front_segment(const segment_set::type&) const;
 
     compaction_config apply_overrides(compaction_config) const;

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -149,7 +149,8 @@ struct index_state
             non_data_timestamps = false;
         }
     }
-    std::tuple<uint32_t, offset_time_index, uint64_t> get_entry(size_t i) {
+    std::tuple<uint32_t, offset_time_index, uint64_t>
+    get_entry(size_t i) const {
         return {
           relative_offset_index[i],
           offset_time_index{relative_time_index[i], with_offset},

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -798,4 +798,14 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
       });
 }
 
+ss::future<model::timestamp> segment::get_file_timestamp() const {
+    auto file_path = path().string();
+
+    auto stat = co_await ss::file_stat(file_path);
+    co_return model::timestamp(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+        stat.time_modified.time_since_epoch())
+        .count());
+}
+
 } // namespace storage

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -189,6 +189,10 @@ public:
 
     void clear_cached_disk_usage();
 
+    /// Fallback timestamp method, for use if the timestamps in the index
+    /// appear to be invalid (e.g. too far in the future)
+    ss::future<model::timestamp> get_file_timestamp() const;
+
 private:
     void set_close();
     void cache_truncate(model::offset offset);

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -303,4 +303,23 @@ ss::future<size_t> segment_index::disk_usage() {
     co_return _disk_usage_size.value();
 }
 
+std::optional<model::timestamp>
+segment_index::find_highest_timestamp_before(model::timestamp t) const {
+    if (_state.base_timestamp > t || _state.empty()) {
+        return std::nullopt;
+    }
+
+    auto relative_t = (t - _state.base_timestamp).value();
+
+    for (int i = _state.size() - 1; i >= 0; --i) {
+        auto [relative_offset, offset_time, position] = _state.get_entry(i);
+        if (offset_time() < relative_t) {
+            return model::timestamp(
+              _state.base_timestamp.value() + offset_time());
+        }
+    }
+
+    return std::nullopt;
+}
+
 } // namespace storage

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2399,7 +2399,7 @@ class RedpandaService(Service):
 
         return None
 
-    def node_storage(self, node, sizes: bool = False):
+    def node_storage(self, node, sizes: bool = False) -> NodeStorage:
         """
         Retrieve a summary of storage on a node.
 


### PR DESCRIPTION
This is an off-by-default behavior to enable systems where a user has sent in a dramatically wrong timestamp to ask Redpanda to ignore timestamps in the future, and do its best to infer an alternative timestamp for use in retention.

Fixes https://github.com/redpanda-data/redpanda/issues/9820

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Added `storage_ignore_timestamps_in_future_sec` cluster configuration property (default null).  If set to non-null, then timestamps more than this many seconds in the future will be ignored by Redpanda when considering whether a segment is old enough to garbage collect.
