### PR TITLE
[v23.1.x] Backport ok_to_fail on cloud deletion tests

### DIFF
--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -231,6 +231,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             self.si_settings.cloud_storage_bucket, topic=topic_name)
         assert sum(1 for _ in objects) > 0
 
+    @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=3)
     def topic_delete_installed_snapshots_test(self):
         """
@@ -356,6 +357,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         return empty
 
+    @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=3)
     @matrix(disable_delete=[False, True],
             cloud_storage_type=[CloudStorageType.ABS, CloudStorageType.S3])
@@ -408,6 +410,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # catch the case where there are segments in S3 not reflected in the
         # manifest.
 
+    @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=4)
     @parametrize(cloud_storage_type=CloudStorageType.ABS)
     @parametrize(cloud_storage_type=CloudStorageType.S3)

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -12,6 +12,8 @@ import json
 from typing import Optional
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import ok_to_fail
+
 from ducktape.mark import matrix, parametrize
 from requests.exceptions import HTTPError
 
@@ -231,6 +233,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             self.si_settings.cloud_storage_bucket, topic=topic_name)
         assert sum(1 for _ in objects) > 0
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8496
     @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=3)
     def topic_delete_installed_snapshots_test(self):
@@ -272,6 +275,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                    timeout_sec=30,
                    backoff_sec=1)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/9629
     @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(
         num_nodes=3,


### PR DESCRIPTION
These aren't going to be fully stable until 23.2 https://github.com/redpanda-data/redpanda/issues/9726

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
