### PR TITLE
c/tm_stm: Convert tm_snapshot to fragmented_vector

### DIFF
--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -711,7 +711,7 @@ ss::future<stm_snapshot> tm_stm::do_take_snapshot() {
     tm_ss.transactions = _cache.local().get_log_transactions();
 
     iobuf tm_ss_buf;
-    reflection::adl<tm_snapshot>{}.to(tm_ss_buf, tm_ss);
+    reflection::adl<tm_snapshot>{}.to(tm_ss_buf, std::move(tm_ss));
 
     co_return stm_snapshot::create(
       supported_version, _insync_offset, std::move(tm_ss_buf));

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -27,6 +27,7 @@
 #include "raft/types.h"
 #include "storage/snapshot.h"
 #include "utils/expiring_promise.h"
+#include "utils/fragmented_vector.h"
 #include "utils/mutex.h"
 
 #include <absl/container/btree_set.h>
@@ -41,7 +42,7 @@ using use_tx_version_with_last_pid_bool
 
 struct tm_snapshot {
     model::offset offset;
-    std::vector<tm_transaction> transactions;
+    fragmented_vector<tm_transaction> transactions;
 };
 
 /**
@@ -167,7 +168,7 @@ public:
     absl::btree_set<kafka::transactional_id> get_expired_txs();
 
     using get_txs_result
-      = checked<std::vector<tm_transaction>, tm_stm::op_status>;
+      = checked<fragmented_vector<tm_transaction>, tm_stm::op_status>;
     ss::future<get_txs_result> get_all_transactions();
 
     ss::future<checked<tm_transaction, tm_stm::op_status>>

--- a/src/v/cluster/tm_stm_cache.h
+++ b/src/v/cluster/tm_stm_cache.h
@@ -228,8 +228,8 @@ public:
 
     void erase_log(kafka::transactional_id);
 
-    std::vector<tm_transaction> get_log_transactions() {
-        std::vector<tm_transaction> txes;
+    fragmented_vector<tm_transaction> get_log_transactions() {
+        fragmented_vector<tm_transaction> txes;
         for (auto& entry : _log_txes) {
             txes.push_back(entry.second);
         }
@@ -280,8 +280,8 @@ public:
         return ids;
     }
 
-    std::vector<tm_transaction> get_all_transactions() {
-        std::vector<tm_transaction> ans;
+    fragmented_vector<tm_transaction> get_all_transactions() {
+        fragmented_vector<tm_transaction> ans;
         if (_mem_term) {
             auto entry_it = _state.find(_mem_term.value());
             if (entry_it != _state.end()) {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -2996,7 +2996,7 @@ tx_gateway_frontend::get_all_transactions() {
               co_return tx_errc::unknown_server_error;
           }
 
-          co_return res.value();
+          co_return std::move(res).value();
       });
 }
 

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -70,7 +70,8 @@ public:
     ss::future<end_tx_reply>
       end_txn(end_tx_request, model::timeout_clock::duration);
 
-    using return_all_txs_res = result<std::vector<tm_transaction>, tx_errc>;
+    using return_all_txs_res
+      = result<fragmented_vector<tm_transaction>, tx_errc>;
     ss::future<return_all_txs_res> get_all_transactions();
     ss::future<result<tm_transaction, tx_errc>>
       describe_tx(kafka::transactional_id);


### PR DESCRIPTION
An OOM was reported:
```
seastar - Failed to allocate 18874368 bytes
```

Backtrace:
```
pthread_key_delete at ??:?
raise at ??:?
abort at ??:?
seastar::memory::cpu_pages::free_large(void*) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:880
 (inlined by) seastar::memory::free_large(void*) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:1358
seastar::memory::object_size(void*) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:1362
 (inlined by) realloc at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:1939
std::__1::vector<cluster::tm_transaction, std::__1::allocator<cluster::tm_transaction> >::push_back(cluster::tm_transaction const&) at /vectorized/llvm/bin/../include/c++/v1/vector:1529
vector at /vectorized/llvm/bin/../include/c++/v1/vector:650
 (inlined by) cluster::tm_stm_cache::get_log_transactions() at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-00b5d93b2049284be-1/redpanda/redpanda/src/v/cluster/tm_stm_cache.h:232
 (inlined by) cluster::tm_stm::do_take_snapshot() at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-00b5d93b2049284be-1/redpanda/redpanda/src/v/cluster/tm_stm.cc:759
tm_transaction at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-00b5d93b2049284be-1/redpanda/redpanda/src/v/cluster/tm_stm_cache.h:44
 (inlined by) cluster::tm_stm::apply_snapshot(cluster::stm_snapshot_header, iobuf&&) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-00b5d93b2049284be-1/redpanda/redpanda/src/v/cluster/tm_stm.cc:743
cluster::persisted_stm::do_make_snapshot() at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-00b5d93b2049284be-1/redpanda/redpanda/src/v/cluster/persisted_stm.cc:139
?? ??:0
seastar::futurize<std::__1::invoke_result<cluster::persisted_stm::make_snapshot()::$_2>::type>::type seastar::with_semaphore<seastar::named_semaphore_exception_factory, cluster::persisted_stm::make_snapshot()::$_2, std::__1::chrono::steady_clock>(seastar::basic_semaphore<seastar::named_semaphore_exception_factory, std::__1::chrono::steady_clock>&, unsigned long, cluster::persisted_stm::make_snapshot()::$_2&&) at /vectorized/include/seastar/core/semaphore.hh:741
 (inlined by) auto mutex::with<cluster::persisted_stm::make_snapshot()::$_2>(cluster::persisted_stm::make_snapshot()::$_2&&) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-00b5d93b2049284be-1/redpanda/redpanda/src/v/utils/mutex.h:42
 (inlined by) cluster::persisted_stm::make_snapshot() at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-00b5d93b2049284be-1/redpanda/redpanda/src/v/cluster/persisted_stm.cc:152
```

Convert to a `fragmented_vector` to alleviate the pressure on the allocator.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* Convert tm_snapshot to fragmented_vector to reduce memory pressure.
