### PR TITLE
Avoid caching batches when only one node is recovering

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -533,6 +533,12 @@ void consensus::successfull_append_entries_reply(
       idx.next_index);
 }
 
+size_t consensus::estimate_recovering_followers() const {
+    return std::count_if(_fstats.begin(), _fstats.end(), [](const auto& idx) {
+        return idx.second.is_recovering;
+    });
+}
+
 bool consensus::needs_recovery(
   const follower_index_metadata& idx, model::offset dirty_offset) {
     // follower match_index is behind, we have to recover it

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -507,6 +507,7 @@ private:
     void successfull_append_entries_reply(
       follower_index_metadata&, append_entries_reply);
 
+    size_t estimate_recovering_followers() const;
     bool needs_recovery(const follower_index_metadata&, model::offset);
     void dispatch_recovery(follower_index_metadata&);
     void maybe_update_leader_commit_idx();

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -222,9 +222,12 @@ recovery_stm::read_range_for_recovery(
       std::nullopt,
       _ptr->_as);
 
-    if (is_learner) {
+    if (is_learner || _ptr->estimate_recovering_followers() == 1) {
         // skip cache insertion on miss for learners which are throttled and
         // often catching up from the beginning of the log (e.g. new nodes)
+        //
+        // also skip if there is only one replica recovering as there is no
+        // need to add batches to the cache for read-once workloads.
         cfg.skip_batch_cache = true;
     }
 


### PR DESCRIPTION
In cases where one follower falls far behind(like when a node goes down) it is often the case that we are reading large amounts of old batches only once. If these reads are placed in the batch cache then newer, more likely to be consumed, batches will be evicted. This can cause a noticeable increase in batch cache misses during recovery.

This PR avoids this problem by not adding read batches to the cache in cases where only one follower is recovering. In the cases where more than one follower is recovering its no longer a read-once workload and it may be optimal to put read batches in the cache.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
