### PR TITLE
storage: shrink index vectors on flush

### DIFF
--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -82,6 +82,12 @@ struct index_state
           relative_offset_index[i], relative_time_index[i], position_index[i]};
     }
 
+    void shrink_to_fit() {
+        relative_offset_index.shrink_to_fit();
+        relative_time_index.shrink_to_fit();
+        position_index.shrink_to_fit();
+    }
+
     bool maybe_index(
       size_t accumulator,
       size_t step,

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -224,6 +224,12 @@ ss::future<> segment_index::flush() {
         return ss::now();
     }
     _needs_persistence = false;
+
+    // Flush is usually called when we either shrunk the index (truncate)
+    // or when we're no longer going to append (close): in either case,
+    // it is a good time to free speculatively allocated memory.
+    _state.shrink_to_fit();
+
     return with_file(open(), [this](ss::file backing_file) {
         return flush_to_file(std::move(backing_file));
     });


### PR DESCRIPTION
Backport of #9904 

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Reduced memory consumption on configurations with very large numbers of small segments.