### PR TITLE
[v23.1.x] Use `chunk_cache` as source of truth for chunk size

### DIFF
--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -75,6 +75,8 @@ public:
           [this](ssx::semaphore_units) { return do_get(); });
     }
 
+    size_t chunk_size() const { return _chunk_size; }
+
 private:
     ss::future<chunk_ptr> do_get() {
         if (auto c = pop_or_allocate(); c) {

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -58,7 +58,7 @@ segment_appender::segment_appender(ss::file f, options opts)
   , _concurrent_flushes(ss::semaphore::max_counter(), "s/append-flush")
   , _prev_head_write(ss::make_lw_shared<ssx::semaphore>(1, head_sem_name))
   , _inactive_timer([this] { handle_inactive_timer(); })
-  , _chunk_size(config::shard_local_cfg().append_chunk_size()) {
+  , _chunk_size(internal::chunks().chunk_size()) {
     const auto alignment = _out.disk_write_dma_alignment();
     vassert(
       internal::chunk_cache::alignment % alignment == 0,

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -18,6 +18,7 @@
 #include "random/generators.h"
 #include "reflection/adl.h"
 #include "ssx/future-util.h"
+#include "storage/chunk_cache.h"
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
@@ -176,7 +177,7 @@ ss::future<segment_appender_ptr> make_segment_appender(
 
 size_t number_of_chunks_from_config(const ntp_config& ntpc) {
     auto def = segment_appender::write_behind_memory
-               / config::shard_local_cfg().append_chunk_size();
+               / internal::chunks().chunk_size();
 
     if (!ntpc.has_overrides()) {
         return def;
@@ -359,7 +360,7 @@ ss::future<storage::index_state> do_copy_segment_data(
                    tmpname,
                    cfg.sanitize,
                    segment_appender::write_behind_memory
-                     / config::shard_local_cfg().append_chunk_size(),
+                     / internal::chunks().chunk_size(),
                    std::nullopt,
                    cfg.iopc,
                    resources)

--- a/src/v/storage/storage_resources.cc
+++ b/src/v/storage/storage_resources.cc
@@ -12,6 +12,7 @@
 #include "storage_resources.h"
 
 #include "config/configuration.h"
+#include "storage/chunk_cache.h"
 #include "storage/logger.h"
 #include "vlog.h"
 
@@ -32,7 +33,7 @@ storage_resources::storage_resources(
   , _global_target_replay_bytes(target_replay_bytes)
   , _max_concurrent_replay(max_concurrent_replay)
   , _compaction_index_mem_limit(compaction_index_memory)
-  , _append_chunk_size(config::shard_local_cfg().append_chunk_size())
+  , _append_chunk_size(internal::chunks().chunk_size())
   , _offset_translator_dirty_bytes(
       _global_target_replay_bytes() / ss::smp::count)
   , _configuration_manager_dirty_bytes(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10032
Fixes https://github.com/redpanda-data/redpanda/issues/10052,