### PR TITLE
k8s: fix bug where secret not initialized

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -921,10 +921,10 @@ func (r *ClusterReconciler) setInitialSuperUserPassword(
 		// This should have been done by this point, if not
 		// requeue, this is created by the controller and is
 		// the source of truth, not the admin API
-		var secret *corev1.Secret
-		err := r.Get(ctx, obj, secret)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("could not fetch user secret (%s): %w", obj.String(), err))
+		secret := &corev1.Secret{}
+		errGet := r.Get(ctx, obj, secret)
+		if errGet != nil {
+			errs = append(errs, fmt.Errorf("could not fetch user secret (%s): %w", obj.String(), errGet))
 			continue
 		}
 		// if we do not find the user in the list, we should create them


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fix bug where secret object is not initialized before getting the object from the api. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none
