### PR TITLE
Kafka: Add support for the delete-records API

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -111,6 +111,7 @@ v_cc_library(
     tm_stm_cache.cc
     tm_stm.cc
     rm_stm.cc
+    log_eviction_stm.cc
     tx_helpers.cc
     security_manager.cc
     security_frontend.cc

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -19,6 +19,7 @@ class controller_stm;
 class controller_stm_shard;
 class id_allocator_frontend;
 class rm_partition_frontend;
+class log_eviction_stm;
 class tx_registry_frontend;
 class tx_coordinator_mapper;
 class tm_stm_cache;

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -7,17 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "raft/log_eviction_stm.h"
+#include "cluster/log_eviction_stm.h"
 
 #include "raft/consensus.h"
 #include "raft/types.h"
 
 #include <seastar/core/future-util.hh>
 
-namespace raft {
+namespace cluster {
 
 log_eviction_stm::log_eviction_stm(
-  consensus* raft,
+  raft::consensus* raft,
   ss::logger& logger,
   ss::lw_shared_ptr<storage::stm_manager> stm_manager,
   ss::abort_source& as)
@@ -105,8 +105,8 @@ log_eviction_stm::handle_deletion_notification(model::offset last_evicted) {
 
           return f.then([this, last_evicted]() {
               return _raft->write_snapshot(
-                write_snapshot_cfg(last_evicted, iobuf()));
+                raft::write_snapshot_cfg(last_evicted, iobuf()));
           });
       });
 }
-} // namespace raft
+} // namespace cluster

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -9,104 +9,339 @@
 
 #include "cluster/log_eviction_stm.h"
 
+#include "bytes/iostream.h"
 #include "raft/consensus.h"
 #include "raft/types.h"
+#include "utils/gate_guard.h"
 
 #include <seastar/core/future-util.hh>
 
 namespace cluster {
 
+struct snapshot_data
+  : serde::
+      envelope<snapshot_data, serde::version<0>, serde::compat_version<0>> {
+    model::offset effective_start_offset{};
+
+    auto serde_fields() { return std::tie(effective_start_offset); }
+
+    friend std::ostream& operator<<(std::ostream& os, const snapshot_data& d) {
+        fmt::print(
+          os, "{{ effective_start_offset: {} }}", d.effective_start_offset);
+        return os;
+    }
+};
+
 log_eviction_stm::log_eviction_stm(
   raft::consensus* raft,
   ss::logger& logger,
-  ss::lw_shared_ptr<storage::stm_manager> stm_manager,
-  ss::abort_source& as)
-  : _raft(raft)
+  ss::abort_source& as,
+  storage::kvstore& kvstore)
+  : persisted_stm("log_eviction_stm.snapshot", logger, raft, kvstore)
   , _logger(logger)
-  , _stm_manager(std::move(stm_manager))
   , _as(as) {}
 
 ss::future<> log_eviction_stm::start() {
-    monitor_log_eviction();
-    return ss::now();
+    ssx::spawn_with_gate(_gate, [this] { return monitor_log_eviction(); });
+    ssx::spawn_with_gate(
+      _gate, [this] { return write_raft_snapshots_in_background(); });
+    return persisted_stm::start();
 }
 
-ss::future<> log_eviction_stm::stop() { return _gate.close(); }
+ss::future<> log_eviction_stm::stop() {
+    _reap_condition.broken();
+    co_await persisted_stm::stop();
+}
 
-void log_eviction_stm::monitor_log_eviction() {
-    ssx::spawn_with_gate(_gate, [this] {
-        return ss::do_until(
-          [this] { return _gate.is_closed(); },
-          [this] {
-              return _raft->monitor_log_eviction(_as)
-                .then([this](model::offset last_evicted) {
-                    return handle_deletion_notification(last_evicted);
-                })
-                .handle_exception_type(
-                  [](const ss::abort_requested_exception&) {
-                      // ignore abort requested exception, shutting down
-                  })
-                .handle_exception_type([](const ss::gate_closed_exception&) {
-                    // ignore gate closed exception, shutting down
-                })
-                .handle_exception([this](std::exception_ptr e) {
+ss::future<> log_eviction_stm::write_raft_snapshots_in_background() {
+    /// This method is executed as a background fiber and it attempts to write
+    /// snapshots as close to effective_start_offset as possible.
+    auto gh = _gate.hold();
+    while (!_as.abort_requested()) {
+        try {
+            /// This background fiber can be woken-up via apply() when special
+            /// batches are processed or by the storage layer when local
+            /// eviction is triggered.
+            co_await _reap_condition.wait();
+        } catch (const ss::broken_condition_variable&) {
+            /// stop() has been called
+            break;
+        }
+        auto evict_until = std::max(
+          _delete_records_eviction_offset, _storage_eviction_offset);
+        if (evict_until > model::offset{}) {
+            auto index_lb = _raft->log().index_lower_bound(evict_until);
+            if (index_lb) {
+                vassert(
+                  index_lb <= evict_until,
+                  "Calculated boundary {} must be <= effective_start {} ",
+                  index_lb,
+                  evict_until);
+                try {
+                    co_await do_write_raft_snapshot(*index_lb);
+                } catch (const std::exception& e) {
                     vlog(
-                      _logger.trace,
-                      "Error handling log eviction - {}, ntp: {}",
+                      _logger.error,
+                      "Error occurred when attempting to write snapshot: "
+                      "{}, ntp: {}",
                       e,
                       _raft->ntp());
-                });
-          });
-    });
+                }
+            }
+        }
+    }
 }
 
-ss::future<>
-log_eviction_stm::handle_deletion_notification(model::offset last_evicted) {
-    vlog(
-      _logger.trace,
-      "Handling log deletion notification for offset: {}, ntp: {}",
-      last_evicted,
-      _raft->ntp());
+ss::future<> log_eviction_stm::monitor_log_eviction() {
+    /// This method is executed as a background fiber and is listening for
+    /// eviction events from the storage layer. These events will trigger a
+    /// write snapshot, and the log will be prefix truncated.
+    auto gh = _gate.hold();
+    while (!_as.abort_requested()) {
+        try {
+            _storage_eviction_offset = co_await _raft->monitor_log_eviction(
+              _as);
+            vlog(
+              _logger.trace,
+              "Handling log deletion notification for offset: {}, ntp: {}",
+              _storage_eviction_offset,
+              _raft->ntp());
+            const auto max_collectible_offset
+              = _raft->log().stm_manager()->max_collectible_offset();
+            const auto next_eviction_offset = std::min(
+              max_collectible_offset, _storage_eviction_offset);
+            _reap_condition.signal();
+            /// Do not attempt to process another eviction event from storage
+            /// until the current has completed fully
+            co_await _last_snapshot_monitor.wait(
+              next_eviction_offset, model::no_timeout, _as);
+        } catch (const ss::abort_requested_exception&) {
+            // ignore abort requested exception, shutting down
+        } catch (const ss::gate_closed_exception&) {
+            // ignore gate closed exception, shutting down
+        } catch (const std::exception& e) {
+            vlog(
+              _logger.info,
+              "Error handling log eviction - {}, ntp: {}",
+              e,
+              _raft->ntp());
+        }
+    }
+}
 
-    // Store where the local storage layer has requested eviction up to,
-    // irrespective of whether we can actually evict up to this point yet.
-    _requested_eviction_offset = last_evicted;
-
-    model::offset max_collectible_offset
-      = _stm_manager->max_collectible_offset();
-    if (last_evicted > max_collectible_offset) {
+ss::future<> log_eviction_stm::do_write_raft_snapshot(model::offset index_lb) {
+    if (index_lb <= _raft->last_snapshot_index()) {
+        co_return;
+    }
+    co_await _raft->visible_offset_monitor().wait(
+      index_lb, model::no_timeout, _as);
+    co_await _raft->refresh_commit_index();
+    co_await _raft->log().stm_manager()->ensure_snapshot_exists(index_lb);
+    const auto max_collectible_offset
+      = _raft->log().stm_manager()->max_collectible_offset();
+    if (index_lb > max_collectible_offset) {
         vlog(
           _logger.trace,
           "Can only evict up to offset: {}, ntp: {}",
           max_collectible_offset,
           _raft->ntp());
-        last_evicted = max_collectible_offset;
+        index_lb = max_collectible_offset;
     }
-
-    // do nothing, we already taken the snapshot
-    if (last_evicted <= _previous_eviction_offset) {
-        return ss::now();
-    }
-
-    // persist empty snapshot, we can have no timeout in here as we are passing
-    // in an abort source
-    _previous_eviction_offset = last_evicted;
-
-    return _raft->visible_offset_monitor()
-      .wait(last_evicted, model::no_timeout, _as)
-      .then([this, last_evicted]() mutable {
-          auto f = ss::now();
-
-          if (_stm_manager) {
-              f = _raft->refresh_commit_index().then([this, last_evicted] {
-                  return _stm_manager->ensure_snapshot_exists(last_evicted);
-              });
-          }
-
-          return f.then([this, last_evicted]() {
-              return _raft->write_snapshot(
-                raft::write_snapshot_cfg(last_evicted, iobuf()));
-          });
-      });
+    co_await _raft->write_snapshot(raft::write_snapshot_cfg(index_lb, iobuf()));
+    _last_snapshot_monitor.notify(index_lb);
 }
+
+model::offset log_eviction_stm::effective_start_offset() const {
+    /// The start offset is the max of either the last snapshot index or the
+    /// most recent delete records eviciton offset. This is because even after
+    /// bootstrap the larger of the two will reflect the most recent event that
+    /// has occurred, and will be the correct start offset.
+    ///
+    /// NOTE: Cannot replace last_snapshot_index with _storage_eviction_offset
+    /// as this is the requested eviction offset and its not persisted anywhere.
+    /// In the event this is set but a crash occurred before write_snapshot was
+    /// called (occurs in background) it would appear that the start offset was
+    /// incremented then returned to a previous value.
+    return model::next_offset(
+      std::max(_raft->last_snapshot_index(), _delete_records_eviction_offset));
+}
+
+ss::future<std::error_code> log_eviction_stm::truncate(
+  model::offset rp_truncate_offset,
+  ss::lowres_clock::time_point deadline,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    /// Create the special prefix_truncate batch, it is a model::record_batch
+    /// with exactly one record within it, the point at which to truncate
+    storage::record_batch_builder builder(
+      model::record_batch_type::prefix_truncate, model::offset(0));
+    /// Everything below the requested offset should be truncated, requested
+    /// offset itself will be the new low_watermark (readable)
+    auto key = serde::to_iobuf(rp_truncate_offset - model::offset{1});
+    builder.add_raw_kv(std::move(key), iobuf());
+    auto batch = std::move(builder).build();
+
+    /// After command replication all that can be guaranteed is that the command
+    /// was replicated
+    vlog(
+      _logger.info,
+      "Replicating prefix_truncate command, truncate_offset: {} current "
+      "start offset: {}, current last snapshot offset: {}, current last "
+      "visible "
+      "offset: {}",
+      rp_truncate_offset,
+      effective_start_offset(),
+      _raft->last_snapshot_index(),
+      _raft->last_visible_index());
+
+    auto ec = co_await replicate_command(std::move(batch), deadline, as);
+    if (ec) {
+        vlog(
+          _logger.error,
+          "Failed to observe replicated command in log, reason: {}",
+          ec.message());
+        co_return ec;
+    }
+    co_return errc::success;
+}
+
+ss::future<std::error_code> log_eviction_stm::replicate_command(
+  model::record_batch batch,
+  ss::lowres_clock::time_point deadline,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    auto fut = _raft->replicate(
+      _raft->term(),
+      model::make_memory_record_batch_reader(std::move(batch)),
+      raft::replicate_options{raft::consistency_level::quorum_ack});
+
+    /// Execute the replicate command bound by timeout and cancellable via
+    /// abort_source mechanism
+    result<raft::replicate_result> result{{}};
+    try {
+        if (as) {
+            result = co_await ssx::with_timeout_abortable(
+              std::move(fut), deadline, *as);
+        } else {
+            result = co_await ss::with_timeout(deadline, std::move(fut));
+        }
+    } catch (const ss::timed_out_error&) {
+        result = errc::timeout;
+    }
+
+    if (!result) {
+        vlog(
+          _logger.error,
+          "Failed to replicate prefix_truncate command, reason: {}",
+          result.error());
+        co_return result.error();
+    }
+
+    /// The following will return when the command replicated above has been
+    /// processed by the apply() method. This effectively bumps the start offset
+    /// to the requested value and since apply is deterministic this is
+    /// guaranteed to occur. No guarantees of data removal / availability can be
+    /// made at or after this point, since that occurs in a background fiber.
+    auto applied = co_await wait_no_throw(
+      result.value().last_offset, deadline, as);
+    if (!applied) {
+        if (as && as->get().abort_requested()) {
+            co_return errc::shutting_down;
+        }
+        co_return errc::timeout;
+    }
+    co_return errc::success;
+}
+
+ss::future<> log_eviction_stm::apply(model::record_batch batch) {
+    /// The work done within apply() must be deterministic that way the start
+    /// offset will always be the same value across all replicas
+    ///
+    /// Here all apply() does is move forward the in memory start offset, a
+    /// background fiber is responsible for evicting as much as possible
+    if (unlikely(
+          batch.header().type == model::record_batch_type::prefix_truncate)) {
+        /// record_batches of type ::prefix_truncate are always of size 1
+        const auto truncate_offset = serde::from_iobuf<model::offset>(
+          batch.copy_records().begin()->release_key());
+        if (truncate_offset > _delete_records_eviction_offset) {
+            vlog(
+              _logger.debug,
+              "Moving effective start offset to "
+              "truncate_point: {} last_applied: {} ntp: {}",
+              truncate_offset,
+              last_applied_offset(),
+              _raft->ntp());
+
+            /// Set the new in memory start offset
+            _delete_records_eviction_offset = truncate_offset;
+            /// Wake up the background reaping thread
+            _reap_condition.signal();
+            /// Writing a local snapshot is just an optimization, delete-records
+            /// is infrequently called and theres no better time to persist the
+            /// fact that a new start offset has been written to disk
+            co_await make_snapshot();
+        }
+    }
+}
+
+ss::future<> log_eviction_stm::handle_eviction() {
+    /// In the case there is a gap detected in the log, the only path
+    /// forward is to read the raft snapshot and begin processing from the
+    /// raft last_snapshot_index
+    auto raft_snapshot = co_await _raft->open_snapshot();
+    if (!raft_snapshot) {
+        throw std::runtime_error{fmt_with_ctx(
+          fmt::format,
+          "encountered a gap in the raft log (last_applied: {}, log start "
+          "offset: {}), but can't find the snapshot - ntp: {}",
+          last_applied_offset(),
+          _raft->start_offset(),
+          _raft->ntp())};
+    }
+
+    auto last_snapshot_index = raft_snapshot->metadata.last_included_index;
+    co_await raft_snapshot->close();
+    _delete_records_eviction_offset = model::offset{};
+    _storage_eviction_offset = last_snapshot_index;
+    set_next(model::next_offset(last_snapshot_index));
+    vlog(
+      _logger.info,
+      "Handled log eviction new effective start offset: {} for ntp: {}",
+      effective_start_offset(),
+      _c->ntp());
+}
+
+ss::future<>
+log_eviction_stm::apply_snapshot(stm_snapshot_header header, iobuf&& data) {
+    auto snapshot = serde::from_iobuf<snapshot_data>(std::move(data));
+    vlog(
+      _logger.info,
+      "Applying snapshot {} at offset: {} for ntp: {}",
+      snapshot,
+      header.offset,
+      _raft->ntp());
+
+    _delete_records_eviction_offset = snapshot.effective_start_offset;
+    _last_snapshot_offset = header.offset;
+    _insync_offset = header.offset;
+    return ss::now();
+}
+
+ss::future<stm_snapshot> log_eviction_stm::take_snapshot() {
+    vlog(
+      _logger.trace,
+      "Taking snapshot at offset: {} for ntp: {}",
+      last_applied_offset(),
+      _raft->ntp());
+    iobuf snap_data = serde::to_iobuf(
+      snapshot_data{.effective_start_offset = _delete_records_eviction_offset});
+    co_return stm_snapshot::create(
+      0, last_applied_offset(), std::move(snap_data));
+}
+
+ss::future<> log_eviction_stm::ensure_snapshot_exists(model::offset) {
+    /// This class drives eviction, therefore it cannot wait until its own
+    /// snapshot exists until writing a snapshot
+    return ss::now();
+}
+
 } // namespace cluster

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -10,11 +10,13 @@
  */
 
 #pragma once
+#include "cluster/persisted_stm.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"
 #include "raft/fwd.h"
 #include "seastarx.h"
 #include "storage/types.h"
+#include "utils/mutex.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
@@ -33,40 +35,84 @@ class consensus;
  * adjust that offset with _stm_manager->max_collectible_offset(), write the
  * raft snapshot and notify the storage layer that log eviction can safely
  * proceed up to the adjusted offset.
+ *
+ * This class also initiates and responds to delete-records events. Call
+ * truncate() pushes a special prefix_truncate batch onto the log for which this
+ * stm will be searching for. Upon processing of this record a new snapshot will
+ * be written which may also trigger deletion of data on disk.
  */
-class log_eviction_stm {
+class log_eviction_stm final
+  : public persisted_stm<kvstore_backed_stm_snapshot> {
 public:
     log_eviction_stm(
-      raft::consensus*,
-      ss::logger&,
-      ss::lw_shared_ptr<storage::stm_manager>,
-      ss::abort_source&);
+      raft::consensus*, ss::logger&, ss::abort_source&, storage::kvstore&);
 
-    ss::future<> start();
+    ss::future<> start() override;
 
-    ss::future<> stop();
+    ss::future<> stop() override;
+
+    /// Truncate local log
+    ///
+    /// This method doesn't immediately delete the entries of the log below the
+    /// requested offset but pushes a special record batch onto the log which
+    /// when read by brokers, will invoke a routine that will perform the
+    /// deletion
+    ss::future<std::error_code> truncate(
+      model::offset kafka_offset,
+      ss::lowres_clock::time_point deadline,
+      std::optional<std::reference_wrapper<ss::abort_source>> as
+      = std::nullopt);
 
     /// Return the offset up to which the storage layer would like to
     /// prefix truncate the log, if any.
     std::optional<model::offset> eviction_requested_offset() const {
-        if (_requested_eviction_offset == model::offset{}) {
+        const auto requested_eviction_offset = std::max(
+          _delete_records_eviction_offset, _storage_eviction_offset);
+        if (!requested_eviction_offset) {
             return std::nullopt;
-        } else {
-            return _requested_eviction_offset;
         }
+        return requested_eviction_offset;
     }
 
-private:
-    ss::future<> handle_deletion_notification(model::offset);
-    void monitor_log_eviction();
+    /// This class drives eviction, it works differently then other stms in this
+    /// regard
+    ///
+    /// Override to ensure it never unnecessarily waits
+    ss::future<> ensure_snapshot_exists(model::offset) override;
 
-    raft::consensus* _raft;
+    /// The actual start offset of the log with the delta factored in
+    model::offset effective_start_offset() const;
+
+protected:
+    ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
+
+    ss::future<stm_snapshot> take_snapshot() override;
+
+private:
+    void increment_start_offset(model::offset);
+    bool should_process_evict(model::offset);
+
+    ss::future<> monitor_log_eviction();
+    ss::future<> do_write_raft_snapshot(model::offset);
+    ss::future<> write_raft_snapshots_in_background();
+    ss::future<> apply(model::record_batch) override;
+    ss::future<> handle_eviction() override;
+
+    ss::future<std::error_code> replicate_command(
+      model::record_batch batch,
+      ss::lowres_clock::time_point deadline,
+      std::optional<std::reference_wrapper<ss::abort_source>> as);
+
+private:
     ss::logger& _logger;
-    ss::lw_shared_ptr<storage::stm_manager> _stm_manager;
     ss::abort_source& _as;
-    ss::gate _gate;
-    model::offset _previous_eviction_offset;
-    model::offset _requested_eviction_offset;
+    model::offset _storage_eviction_offset;
+    model::offset _delete_records_eviction_offset;
+
+    /// Signaled when a snapshot should be taken, and data deleted
+    ss::condition_variable _reap_condition;
+    /// To maintain backpressure on snapshot writes from storage
+    raft::offset_monitor _last_snapshot_monitor;
 };
 
 } // namespace cluster

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -83,6 +83,11 @@ public:
     /// The actual start offset of the log with the delta factored in
     model::offset effective_start_offset() const;
 
+    /// Ensure followers have processed up until the most recent known version
+    /// of the batch representing the start offset
+    ss::future<result<model::offset, std::error_code>>
+    sync_effective_start(model::timeout_clock::duration timeout);
+
 protected:
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
 

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "config/configuration.h"
 #include "model/fundamental.h"
+#include "raft/fwd.h"
 #include "seastarx.h"
 #include "storage/types.h"
 
@@ -19,7 +20,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/util/log.hh>
 
-namespace raft {
+namespace cluster {
 
 class consensus;
 
@@ -36,7 +37,7 @@ class consensus;
 class log_eviction_stm {
 public:
     log_eviction_stm(
-      consensus*,
+      raft::consensus*,
       ss::logger&,
       ss::lw_shared_ptr<storage::stm_manager>,
       ss::abort_source&);
@@ -59,7 +60,7 @@ private:
     ss::future<> handle_deletion_notification(model::offset);
     void monitor_log_eviction();
 
-    consensus* _raft;
+    raft::consensus* _raft;
     ss::logger& _logger;
     ss::lw_shared_ptr<storage::stm_manager> _stm_manager;
     ss::abort_source& _as;
@@ -68,4 +69,4 @@ private:
     model::offset _requested_eviction_offset;
 };
 
-} // namespace raft
+} // namespace cluster

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -194,6 +194,14 @@ ss::future<std::error_code> partition::prefix_truncate(
           _raft->ntp());
         co_return make_error_code(errc::topic_invalid_config);
     }
+    if (!feature_table().local().is_active(features::feature::delete_records)) {
+        vlog(
+          clusterlog.info,
+          "Cannot prefix-truncate topic/partition {} feature is currently "
+          "disabled",
+          _raft->ntp());
+        co_return make_error_code(cluster::errc::feature_disabled);
+    }
     co_return co_await _log_eviction_stm->truncate(
       truncation_offset, deadline, _as);
 }

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -73,7 +73,7 @@ partition::partition(
           clusterlog, _raft.get());
     } else if (is_tx_manager_topic(_raft->ntp())) {
         if (_raft->log_config().is_collectable()) {
-            _log_eviction_stm = ss::make_lw_shared<raft::log_eviction_stm>(
+            _log_eviction_stm = ss::make_lw_shared<cluster::log_eviction_stm>(
               _raft.get(), clusterlog, stm_manager, _as);
         }
 
@@ -86,7 +86,7 @@ partition::partition(
         }
     } else {
         if (_raft->log_config().is_collectable()) {
-            _log_eviction_stm = ss::make_lw_shared<raft::log_eviction_stm>(
+            _log_eviction_stm = ss::make_lw_shared<cluster::log_eviction_stm>(
               _raft.get(), clusterlog, stm_manager, _as);
         }
         const model::topic_namespace tp_ns(

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -71,6 +71,11 @@ public:
     ss::future<result<kafka_result>>
     replicate(model::record_batch_reader&&, raft::replicate_options);
 
+    /// Truncate the beginning of the log up until a given offset
+    /// Can only be performed on logs that are deletable and non internal
+    ss::future<std::error_code>
+    prefix_truncate(model::offset o, ss::lowres_clock::time_point deadline);
+
     kafka_stages replicate_in_stages(
       model::batch_identity,
       model::record_batch_reader&&,
@@ -381,7 +386,7 @@ private:
 
     consensus_ptr _raft;
     ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;
-    ss::lw_shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
+    ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<cluster::tm_stm> _tm_stm;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -92,6 +92,14 @@ public:
         return _raft->make_reader(std::move(config), deadline);
     }
 
+    ss::future<result<model::offset, std::error_code>>
+    sync_effective_start(model::timeout_clock::duration timeout) {
+        if (_log_eviction_stm) {
+            co_return co_await _log_eviction_stm->sync_effective_start(timeout);
+        }
+        co_return start_offset();
+    }
+
     model::offset start_offset() const {
         if (_log_eviction_stm) {
             return _log_eviction_stm->effective_start_offset();

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/archival_metadata_stm.h"
 #include "cluster/id_allocator_stm.h"
+#include "cluster/log_eviction_stm.h"
 #include "cluster/partition_probe.h"
 #include "cluster/rm_stm.h"
 #include "cluster/tm_stm.h"
@@ -29,7 +30,6 @@
 #include "raft/consensus.h"
 #include "raft/consensus_utils.h"
 #include "raft/group_configuration.h"
-#include "raft/log_eviction_stm.h"
 #include "raft/types.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
@@ -375,7 +375,7 @@ private:
 
     consensus_ptr _raft;
     ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;
-    ss::lw_shared_ptr<raft::log_eviction_stm> _log_eviction_stm;
+    ss::lw_shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<cluster::tm_stm> _tm_stm;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -235,6 +235,7 @@ ss::future<consensus_ptr> partition_manager::manage(
       _feature_table,
       _tm_stm_cache_manager,
       _upload_hks,
+      _storage.kvs(),
       _max_concurrent_producer_ids,
       read_replica_bucket);
 

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -157,7 +157,7 @@ public:
       ss::sstring, ss::logger&, raft::consensus*, Args&&...);
 
     void make_snapshot_in_background() final;
-    ss::future<> ensure_snapshot_exists(model::offset) final;
+    ss::future<> ensure_snapshot_exists(model::offset) override;
     model::offset max_collectible_offset() override;
     ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2761,6 +2761,7 @@ rm_stm::apply_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
         _log_state.lru_idempotent_pids.push_back(it->second);
     }
 
+    _bootstrap_committed_offset = data.offset;
     _last_snapshot_offset = data.offset;
     _insync_offset = data.offset;
 }

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ rp_test(
 endforeach()
 
 set(srcs
+        manual_log_deletion_test.cc
         cluster_tests.cc
         configuration_change_test.cc
         autocreate_test.cc

--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/log_eviction_stm.h"
 #include "config/configuration.h"
 #include "finjector/hbadger.h"
 #include "model/fundamental.h"
@@ -35,6 +36,48 @@ struct manual_deletion_fixture : public raft_test_fixture {
         config::shard_local_cfg().log_segment_size_min.set_value(
           std::optional<uint64_t>());
         gr.enable_all();
+        auto& members = gr.get_members();
+        for (auto& [id, member] : members) {
+            maybe_init_eviction_stm(id);
+        }
+    }
+
+    virtual ~manual_deletion_fixture() {
+        std::vector<model::node_id> to_delete;
+        for (auto& [id, _] : gr.get_members()) {
+            to_delete.push_back(id);
+        }
+        for (auto id : to_delete) {
+            auto& member = gr.get_member(id);
+            if (member.started) {
+                gr.disable_node(id);
+            }
+        }
+    }
+
+    void maybe_init_eviction_stm(model::node_id id) {
+        auto& member = gr.get_member(id);
+        if (member.log->config().is_collectable()) {
+            auto eviction_stm = std::make_unique<cluster::log_eviction_stm>(
+              member.consensus.get(), tstlog, member._as);
+            eviction_stm->start().get0();
+            eviction_stms.emplace(id, std::move(eviction_stm));
+            member.kill_eviction_stm_cb
+              = std::make_unique<ss::noncopyable_function<ss::future<>()>>(
+                [this, id = id]() {
+                    tstlog.info("Stopping eviction stm: {}", id);
+                    auto found = eviction_stms.find(id);
+                    if (found != eviction_stms.end()) {
+                        if (found->second != nullptr) {
+                            return found->second->stop().then([this, id]() {
+                                tstlog.info("eviction stm stopped: {}", id);
+                                eviction_stms.erase(id);
+                            });
+                        }
+                    }
+                    return ss::now();
+                });
+        }
     }
 
     void prepare_raft_group() {
@@ -84,6 +127,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
             to_delete.push_back(std::filesystem::path(
               gr.get_member(id).log->config().topic_directory()));
             gr.disable_node(id);
+            tstlog.info("node disabled: {}", id);
         }
         for (auto& path : to_delete) {
             std::filesystem::remove_all(path);
@@ -91,6 +135,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
         // enable back
         for (auto id : nodes) {
             gr.enable_node(id);
+            maybe_init_eviction_stm(id);
         }
     }
 
@@ -102,9 +147,12 @@ struct manual_deletion_fixture : public raft_test_fixture {
         remove_data(nodes);
     }
 
+    using stm_map_t = std::
+      unordered_map<model::node_id, std::unique_ptr<cluster::log_eviction_stm>>;
     raft_group gr;
     model::timestamp retention_timestamp;
     ss::abort_source as;
+    stm_map_t eviction_stms;
 };
 
 FIXTURE_TEST(

--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -58,8 +58,9 @@ struct manual_deletion_fixture : public raft_test_fixture {
     void maybe_init_eviction_stm(model::node_id id) {
         auto& member = gr.get_member(id);
         if (member.log->config().is_collectable()) {
+            auto& kvstore = member.storage.local().kvs();
             auto eviction_stm = std::make_unique<cluster::log_eviction_stm>(
-              member.consensus.get(), tstlog, member._as);
+              member.consensus.get(), tstlog, member._as, kvstore);
             eviction_stm->start().get0();
             eviction_stms.emplace(id, std::move(eviction_stm));
             member.kill_eviction_stm_cb

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -71,6 +71,8 @@ std::string_view to_string_view(feature f) {
         return "force_partition_reconfiguration";
     case feature::raft_append_entries_serde:
         return "raft_append_entries_serde";
+    case feature::delete_records:
+        return "delete_records";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -60,6 +60,7 @@ enum class feature : std::uint64_t {
     transaction_partitioning = 1ULL << 25U,
     force_partition_reconfiguration = 1ULL << 26U,
     raft_append_entries_serde = 1ULL << 28U,
+    delete_records = 1ULL << 29U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -270,6 +271,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{10},
     "raft_append_entries_serde",
     feature::raft_append_entries_serde,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{10},
+    "delete_records",
+    feature::delete_records,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -22,6 +22,7 @@ set(handlers_srcs
   server/handlers/handler_interface.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc
+  server/handlers/delete_records.cc
   server/handlers/describe_producers.cc
   server/handlers/describe_transactions.cc
   server/handlers/handler_probe.cc

--- a/src/v/kafka/protocol/delete_records.h
+++ b/src/v/kafka/protocol/delete_records.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/schemata/delete_records_request.h"
+#include "kafka/protocol/schemata/delete_records_response.h"
+#include "kafka/types.h"
+
+namespace kafka {
+
+struct delete_records_request final {
+    using api_type = delete_records_api;
+
+    delete_records_request_data data;
+
+    void encode(protocol::encoder& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(protocol::decoder& reader, api_version version) {
+        data.decode(reader, version);
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const delete_records_request& r) {
+        return os << r.data;
+    }
+};
+
+struct delete_records_response final {
+    using api_type = delete_records_api;
+
+    delete_records_response_data data;
+
+    void encode(protocol::encoder& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const delete_records_response& r) {
+        return os << r.data;
+    }
+};
+
+} // namespace kafka

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -73,6 +73,8 @@ set(schemata
   add_offsets_to_txn_response.json
   offset_delete_request.json
   offset_delete_response.json
+  delete_records_request.json
+  delete_records_response.json
   offset_for_leader_epoch_request.json
   offset_for_leader_epoch_response.json
   alter_partition_reassignments_request.json

--- a/src/v/kafka/protocol/schemata/delete_records_request.json
+++ b/src/v/kafka/protocol/schemata/delete_records_request.json
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 21,
+  "type": "request",
+  "listeners": ["zkBroker", "broker"],
+  "name": "DeleteRecordsRequest",
+  // Version 1 is the same as version 0.
+
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
+  "fields": [
+    { "name": "Topics", "type": "[]DeleteRecordsTopic", "versions": "0+",
+      "about": "Each topic that we want to delete records from.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]DeleteRecordsPartition", "versions": "0+",
+        "about": "Each partition that we want to delete records from.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "Offset", "type": "int64", "versions": "0+",
+          "about": "The deletion offset." }
+      ]}
+    ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "How long to wait for the deletion to complete, in milliseconds." }
+  ]
+}

--- a/src/v/kafka/protocol/schemata/delete_records_response.json
+++ b/src/v/kafka/protocol/schemata/delete_records_response.json
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 21,
+  "type": "response",
+  "name": "DeleteRecordsResponse",
+  // Starting in version 1, on quota violation, brokers send out responses before throttling.
+
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Topics", "type": "[]DeleteRecordsTopicResult", "versions": "0+",
+      "about": "Each topic that we wanted to delete records from.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]DeleteRecordsPartitionResult", "versions": "0+",
+        "about": "Each partition that we wanted to delete records from.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+", "mapKey": true,
+          "about": "The partition index." },
+        { "name": "LowWatermark", "type": "int64", "versions": "0+",
+          "about": "The partition low water mark." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The deletion error code, or 0 if the deletion succeeded." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -309,6 +309,25 @@ path_type_map = {
             }
         }
     },
+    "DeleteRecordsRequestData": {
+        "Topics": {
+            "Partitions": {
+                "PartitionIndex": ("model::partition_id", "int32"),
+                "Offset": ("model::offset", "int64"),
+            }
+        },
+        "TimeoutMs": ("std::chrono::milliseconds", "int32")
+    },
+    "DeleteRecordsResponseData": {
+        "ThrottleTimeMs": ("std::chrono::milliseconds", "int32"),
+        "Topics": {
+            "Partitions": {
+                "PartitionIndex": ("model::partition_id", "int32"),
+                "LowWatermark": ("model::offset", "int64"),
+                "ErrorCode": ("kafka::error_code", "int16")
+            }
+        }
+    },
     "AlterPartitionReassignmentsRequestData": {
         "TimeoutMs": ("std::chrono::milliseconds", "int32"),
         "Topics": {
@@ -555,6 +574,10 @@ STRUCT_TYPES = [
     "DescribeTransactionState",
     "TopicData",
     "ListTransactionState",
+    "DeleteRecordsTopic",
+    "DeleteRecordsPartition",
+    "DeleteRecordsTopicResult",
+    "DeleteRecordsPartitionResult",
 ]
 
 # a list of struct types which are ineligible to have default-generated

--- a/src/v/kafka/server/handlers/delete_records.cc
+++ b/src/v/kafka/server/handlers/delete_records.cc
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/handlers/delete_records.h"
+
+#include "cluster/metadata_cache.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
+#include "kafka/server/partition_proxy.h"
+#include "model/fundamental.h"
+#include "model/ktp.h"
+
+#include <vector>
+
+namespace kafka {
+
+namespace {
+
+/// Returned in responses where kafka::error_code is anything else then a value
+/// of error_code::none
+constexpr auto invalid_low_watermark = model::offset(-1);
+
+/// Compare against user provided value of truncation offset, this value will
+/// indicate to truncate at  the current partition high watermark
+constexpr auto at_current_high_watermark = model::offset(-1);
+
+std::vector<delete_records_partition_result>
+make_partition_errors(const delete_records_topic& t, error_code ec) {
+    std::vector<delete_records_partition_result> r;
+    for (const auto& p : t.partitions) {
+        r.push_back(delete_records_partition_result{
+          .partition_index = p.partition_index,
+          .low_watermark = invalid_low_watermark,
+          .error_code = ec});
+    }
+    return r;
+}
+
+/// Performs validation of topics, any failures will result in a list of
+/// partitions that all contain the identical error codes
+std::vector<delete_records_partition_result>
+validate_at_topic_level(request_context& ctx, const delete_records_topic& t) {
+    const auto is_authorized = [&ctx](const delete_records_topic& t) {
+        return ctx.authorized(security::acl_operation::remove, t.name);
+    };
+    const auto is_deletable = [](const cluster::topic_configuration& cfg) {
+        /// Immitates the logic in ntp_config::is_collectible
+        if (
+          !cfg.properties.has_overrides()
+          || !cfg.properties.cleanup_policy_bitflags) {
+            return true;
+        }
+        const auto& bitflags = cfg.properties.cleanup_policy_bitflags;
+        return (*bitflags & model::cleanup_policy_bitflags::deletion)
+               == model::cleanup_policy_bitflags::deletion;
+    };
+    const auto is_cloud_enabled = [](const cluster::topic_configuration& cfg) {
+        const auto& si_flags = cfg.properties.shadow_indexing;
+        return si_flags && *si_flags != model::shadow_indexing_mode::disabled;
+    };
+    const auto is_nodelete_topic = [](const delete_records_topic& t) {
+        const auto& nodelete_topics
+          = config::shard_local_cfg().kafka_nodelete_topics();
+        return std::find_if(
+                 nodelete_topics.begin(),
+                 nodelete_topics.end(),
+                 [t](const ss::sstring& name) { return name == t.name; })
+               != nodelete_topics.end();
+    };
+
+    const auto cfg = ctx.metadata_cache().get_topic_cfg(
+      model::topic_namespace_view(model::kafka_namespace, t.name));
+    if (!cfg) {
+        return make_partition_errors(t, error_code::unknown_topic_or_partition);
+    }
+    if (!is_authorized(t)) {
+        return make_partition_errors(t, error_code::topic_authorization_failed);
+    } else if (!is_deletable(*cfg)) {
+        return make_partition_errors(t, error_code::policy_violation);
+    } else if (is_cloud_enabled(*cfg) || is_nodelete_topic(t)) {
+        return make_partition_errors(t, error_code::invalid_topic_exception);
+    }
+    return {};
+}
+
+/// Result set includes topic for later group-by topic logic
+using result_t = std::tuple<model::topic, delete_records_partition_result>;
+
+result_t make_partition_error(const model::ktp& ktp, error_code err) {
+    return std::make_tuple(
+      ktp.get_topic(),
+      delete_records_partition_result{
+        .partition_index = ktp.get_partition(),
+        .low_watermark = invalid_low_watermark,
+        .error_code = err});
+}
+
+result_t
+make_partition_response(const model::ktp& ktp, model::offset low_watermark) {
+    return std::make_tuple(
+      ktp.get_topic(),
+      delete_records_partition_result{
+        .partition_index = ktp.get_partition(),
+        .low_watermark = low_watermark,
+        .error_code = error_code::none});
+}
+
+/// If validation passes, attempts to prefix truncate the raft log at the given
+/// offset. Returns a response that includes the new low watermark
+ss::future<result_t> prefix_truncate(
+  cluster::partition_manager& pm,
+  model::ktp ktp,
+  model::offset kafka_truncation_offset,
+  std::chrono::milliseconds timeout_ms) {
+    auto raw_partition = pm.get(ktp);
+    if (!raw_partition) {
+        co_return make_partition_error(
+          ktp, error_code::unknown_topic_or_partition);
+    }
+    auto partition = make_partition_proxy(ktp, pm);
+    if (!partition->is_leader()) {
+        co_return make_partition_error(
+          ktp, error_code::not_leader_for_partition);
+    }
+    if (kafka_truncation_offset == at_current_high_watermark) {
+        /// User is requesting to truncate all data
+        kafka_truncation_offset = partition->high_watermark();
+    }
+    if (kafka_truncation_offset < model::offset(0)) {
+        co_return make_partition_error(ktp, error_code::offset_out_of_range);
+    }
+
+    /// Perform truncation at the requested offset. A special batch will be
+    /// written to the log, eventually consumed by replicas via the
+    /// new_log_eviction_stm, which will perform a prefix truncation at the
+    /// given offset
+    auto errc = co_await partition->prefix_truncate(
+      kafka_truncation_offset, ss::lowres_clock::now() + timeout_ms);
+    if (errc != error_code::none) {
+        vlog(
+          klog.info,
+          "Possible failed attempted to truncate partition: {} error: {}",
+          ktp,
+          errc);
+        co_return make_partition_error(ktp, errc);
+    }
+    /// Its ok to not call sync_start_offset() over start_offset() here because
+    /// prefix_truncate() was called on the leader (this node) and it waits
+    /// until the local start offset was updated
+    const auto kafka_start_offset = partition->start_offset();
+    vlog(
+      klog.info,
+      "Truncated partition: {} to offset: {}",
+      ktp,
+      kafka_start_offset);
+    /// prefix_truncate() will return when the start_offset has been incremented
+    /// to the desired new low watermark. No other guarantees about the system
+    /// are made at this point. (i.e. if data on disk on this node or a replica
+    /// has yet been deleted)
+    co_return make_partition_response(ktp, kafka_start_offset);
+}
+
+} // namespace
+
+template<>
+ss::future<response_ptr>
+delete_records_handler::handle(request_context ctx, ss::smp_service_group) {
+    delete_records_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    log_request(ctx.header(), request);
+
+    delete_records_response response;
+    std::vector<ss::future<result_t>> fs;
+    for (auto& topic : request.data.topics) {
+        /// Topic level validation, errors will be all the same for each
+        /// partition under the topic. Validation for individual partitions may
+        /// happen in the inner for loop below.
+        auto topic_level_errors = validate_at_topic_level(ctx, topic);
+        if (!topic_level_errors.empty()) {
+            response.data.topics.push_back(delete_records_topic_result{
+              .name = topic.name, .partitions = std::move(topic_level_errors)});
+            continue;
+        }
+        for (auto& partition : topic.partitions) {
+            auto ktp = model::ktp(topic.name, partition.partition_index);
+            auto shard = ctx.shards().shard_for(ktp);
+            if (!shard) {
+                fs.push_back(
+                  ss::make_ready_future<result_t>(make_partition_error(
+                    ktp, error_code::unknown_topic_or_partition)));
+                continue;
+            }
+            auto f
+              = ctx.partition_manager()
+                  .invoke_on(
+                    *shard,
+                    [ktp,
+                     timeout = request.data.timeout_ms,
+                     o = partition.offset](cluster::partition_manager& pm) {
+                        return prefix_truncate(pm, ktp, o, timeout);
+                    })
+                  .handle_exception([ktp](std::exception_ptr eptr) {
+                      vlog(klog.error, "Caught unexpected exception: {}", eptr);
+                      return make_partition_error(
+                        ktp, error_code::unknown_server_error);
+                  });
+            fs.push_back(std::move(f));
+        }
+    }
+
+    /// Perform prefix truncation on partitions
+    auto results = co_await ss::when_all_succeed(fs.begin(), fs.end());
+
+    /// Group results by topic
+    using partition_results = std::vector<delete_records_partition_result>;
+    absl::flat_hash_map<model::topic, partition_results> group_by_topic;
+    for (auto& [name, partitions] : results) {
+        group_by_topic[name].push_back(std::move(partitions));
+    }
+
+    /// Map to kafka response type
+    for (auto& [topic, partition_results] : group_by_topic) {
+        response.data.topics.push_back(delete_records_topic_result{
+          .name = topic, .partitions = std::move(partition_results)});
+    }
+    co_return co_await ctx.respond(std::move(response));
+}
+} // namespace kafka

--- a/src/v/kafka/server/handlers/delete_records.h
+++ b/src/v/kafka/server/handlers/delete_records.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/delete_records.h"
+#include "kafka/server/handlers/handler.h"
+#include "kafka/server/response.h"
+
+namespace kafka {
+
+using delete_records_handler = single_stage_handler<delete_records_api, 0, 2>;
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -20,6 +20,7 @@
 #include "kafka/server/handlers/create_topics.h"
 #include "kafka/server/handlers/delete_acls.h"
 #include "kafka/server/handlers/delete_groups.h"
+#include "kafka/server/handlers/delete_records.h"
 #include "kafka/server/handlers/delete_topics.h"
 #include "kafka/server/handlers/describe_acls.h"
 #include "kafka/server/handlers/describe_configs.h"
@@ -70,6 +71,7 @@ using request_types = make_request_types<
   api_versions_handler,
   join_group_handler,
   heartbeat_handler,
+  delete_records_handler,
   leave_group_handler,
   sync_group_handler,
   create_topics_handler,

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -42,6 +42,8 @@ public:
         virtual bool is_elected_leader() const = 0;
         virtual bool is_leader() const = 0;
         virtual ss::future<std::error_code> linearizable_barrier() = 0;
+        virtual ss::future<error_code>
+          prefix_truncate(model::offset, ss::lowres_clock::time_point) = 0;
         virtual ss::future<storage::translating_reader> make_reader(
           storage::log_reader_config,
           std::optional<model::timeout_clock::time_point>)
@@ -76,6 +78,11 @@ public:
 
     ss::future<std::error_code> linearizable_barrier() {
         return _impl->linearizable_barrier();
+    }
+
+    ss::future<error_code>
+    prefix_truncate(model::offset o, ss::lowres_clock::time_point deadline) {
+        return _impl->prefix_truncate(o, deadline);
     }
 
     bool is_elected_leader() const { return _impl->is_elected_leader(); }

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -32,6 +32,8 @@ class partition_proxy {
 public:
     struct impl {
         virtual const model::ntp& ntp() const = 0;
+        virtual ss::future<result<model::offset, error_code>>
+          sync_effective_start(model::timeout_clock::duration) = 0;
         virtual model::offset start_offset() const = 0;
         virtual model::offset high_watermark() const = 0;
         virtual checked<model::offset, error_code>
@@ -67,6 +69,11 @@ public:
 
     explicit partition_proxy(std::unique_ptr<impl> impl) noexcept
       : _impl(std::move(impl)) {}
+
+    ss::future<result<model::offset, error_code>> sync_effective_start(
+      model::timeout_clock::duration timeout = std::chrono::seconds(5)) {
+        return _impl->sync_effective_start(timeout);
+    }
 
     model::offset start_offset() const { return _impl->start_offset(); }
 

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -331,6 +331,7 @@ ss::future<error_code> replicated_partition::prefix_truncate(
             kerr = error_code::request_timed_out;
             break;
         case cluster::errc::topic_invalid_config:
+        case cluster::errc::feature_disabled:
         default:
             vlog(
               klog.error,

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -112,6 +112,9 @@ public:
 
     bool is_leader() const final { return _partition->is_leader(); }
 
+    ss::future<error_code>
+      prefix_truncate(model::offset, ss::lowres_clock::time_point) final;
+
     ss::future<std::error_code> linearizable_barrier() final {
         auto r = co_await _partition->linearizable_barrier();
         if (r) {

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -37,6 +37,46 @@ public:
 
     const model::ntp& ntp() const final { return _partition->ntp(); }
 
+    ss::future<result<model::offset, error_code>>
+    sync_effective_start(model::timeout_clock::duration timeout) final {
+        if (
+          _partition->is_read_replica_mode_enabled()
+          && _partition->cloud_data_available()) {
+            // Always assume remote read in this case.
+            co_return _partition->start_cloud_offset();
+        }
+
+        auto synced_local_start_offset
+          = co_await _partition->sync_effective_start(timeout);
+        if (!synced_local_start_offset) {
+            auto err = synced_local_start_offset.error();
+            auto error_code = error_code::unknown_server_error;
+            if (err.category() == cluster::error_category()) {
+                switch (cluster::errc(err.value())) {
+                case cluster::errc::shutting_down:
+                case cluster::errc::not_leader:
+                    error_code = error_code::not_leader_for_partition;
+                    break;
+                case cluster::errc::timeout:
+                    error_code = error_code::request_timed_out;
+                    break;
+                default:
+                    error_code = error_code::unknown_server_error;
+                }
+            }
+            co_return error_code;
+        }
+        auto local_kafka_start_offset = _translator->from_log_offset(
+          synced_local_start_offset.value());
+        if (
+          _partition->is_remote_fetch_enabled()
+          && _partition->cloud_data_available()
+          && (_partition->start_cloud_offset() < local_kafka_start_offset)) {
+            co_return _partition->start_cloud_offset();
+        }
+        co_return local_kafka_start_offset;
+    }
+
     model::offset start_offset() const final {
         if (
           _partition->is_read_replica_mode_enabled()

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -357,6 +357,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::version_fence";
     case record_batch_type::tx_tm_hosted_trasactions:
         return o << "batch_type::tx_tm_hosted_trasactions";
+    case record_batch_type::prefix_truncate:
+        return o << "batch_type::prefix_truncate";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -42,7 +42,8 @@ enum class record_batch_type : int8_t {
     cluster_bootstrap_cmd = 22,      // cluster bootsrap command
     version_fence = 23,              // version fence/epoch
     tx_tm_hosted_trasactions = 24,   // tx_tm_hosted_trasactions_batch_type
-    MAX = tx_tm_hosted_trasactions
+    prefix_truncate = 25,            // log prefix truncation type
+    MAX = prefix_truncate
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/raft/CMakeLists.txt
+++ b/src/v/raft/CMakeLists.txt
@@ -27,7 +27,6 @@ v_cc_library(
     offset_monitor.cc
     event_manager.cc
     state_machine.cc
-    log_eviction_stm.cc
     configuration_manager.cc
     group_configuration.cc
     append_entries_buffer.cc

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -80,7 +80,8 @@ offset_translator_batch_types(const model::ntp& ntp) {
         return {
           model::record_batch_type::raft_configuration,
           model::record_batch_type::archival_metadata,
-          model::record_batch_type::version_fence};
+          model::record_batch_type::version_fence,
+          model::record_batch_type::prefix_truncate};
     } else {
         return {};
     }

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -32,7 +32,6 @@ set(srcs
     offset_monitor_test.cc
     mux_state_machine_test.cc
     mutex_buffer_test.cc
-    manual_log_deletion_test.cc
     state_removal_test.cc
     configuration_manager_test.cc
     coordinated_recovery_throttle_test.cc

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -22,7 +22,6 @@
 #include "raft/consensus.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/heartbeat_manager.h"
-#include "raft/log_eviction_stm.h"
 #include "raft/rpc_client_protocol.h"
 #include "raft/service.h"
 #include "random/generators.h"
@@ -223,14 +222,6 @@ struct raft_node {
         hbeats->register_group(consensus).get();
         started = true;
         consensus->start().get0();
-        if (log->config().is_collectable()) {
-            _nop_stm = std::make_unique<raft::log_eviction_stm>(
-              consensus.get(),
-              tstlog,
-              ss::make_lw_shared<storage::stm_manager>(),
-              _as);
-            _nop_stm->start().get0();
-        }
     }
 
     ss::future<> stop_node() {
@@ -263,8 +254,9 @@ struct raft_node {
               return consensus->stop();
           })
           .then([this] {
-              if (_nop_stm != nullptr) {
-                  return _nop_stm->stop();
+              if (kill_eviction_stm_cb) {
+                  return (*kill_eviction_stm_cb)().then(
+                    [this] { kill_eviction_stm_cb = nullptr; });
               }
               return ss::now();
           })
@@ -358,11 +350,12 @@ struct raft_node {
     ss::sharded<rpc::connection_cache> cache;
     ss::sharded<rpc::rpc_server> server;
     ss::sharded<test_raft_manager> raft_manager;
+    std::unique_ptr<ss::noncopyable_function<ss::future<>()>>
+      kill_eviction_stm_cb;
     leader_clb_t leader_callback;
     raft::recovery_memory_quota recovery_mem_quota;
     std::unique_ptr<raft::heartbeat_manager> hbeats;
     consensus_ptr consensus;
-    std::unique_ptr<raft::log_eviction_stm> _nop_stm;
     ss::sharded<features::feature_table> feature_table;
     ss::sharded<memory_sampling> memory_sampling_service;
     ss::abort_source _as;
@@ -921,6 +914,8 @@ struct raft_test_fixture {
               .set_value((size_t)0);
         }).get();
     }
+
+    virtual ~raft_test_fixture(){};
 
     consensus_ptr get_leader_raft(raft_group& gr) {
         auto leader_id = gr.get_leader_id();

--- a/src/v/raft/tests/state_removal_test.cc
+++ b/src/v/raft/tests/state_removal_test.cc
@@ -64,9 +64,6 @@ void stop_node(raft_node& node) {
     node.recovery_throttle.stop().get();
     node.server.stop().get0();
     node._as.request_abort();
-    if (node._nop_stm != nullptr) {
-        node._nop_stm->stop().get0();
-    }
     node.raft_manager.stop().get0();
     node.consensus = nullptr;
     node.hbeats->stop().get0();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -51,7 +51,7 @@
 
 using namespace std::literals::chrono_literals;
 
-namespace {
+namespace storage {
 /*
  * Some logs must be exempt from the cleanup=delete policy such that their full
  * history is retained. This function explicitly protects against any accidental
@@ -68,9 +68,6 @@ bool deletion_exempt(const model::ntp& ntp) {
                              && ntp.tp.topic == model::tx_manager_topic;
     return !is_tx_manager_ntp && is_internal_namespace;
 }
-} // namespace
-
-namespace storage {
 
 disk_log_impl::disk_log_impl(
   ntp_config cfg,

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -90,6 +90,7 @@ public:
     std::optional<model::term_id> get_term(model::offset) const final;
     std::optional<model::offset>
     get_term_last_offset(model::term_id term) const final;
+    std::optional<model::offset> index_lower_bound(model::offset o) const final;
     std::ostream& print(std::ostream&) const final;
 
     ss::future<> maybe_roll(

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -81,6 +81,8 @@ public:
         virtual std::optional<model::term_id> get_term(model::offset) const = 0;
         virtual std::optional<model::offset>
           get_term_last_offset(model::term_id) const = 0;
+        virtual std::optional<model::offset>
+        index_lower_bound(model::offset o) const = 0;
 
         virtual ss::future<model::offset>
         monitor_eviction(ss::abort_source&) = 0;
@@ -168,6 +170,10 @@ public:
     std::optional<model::offset>
     get_term_last_offset(model::term_id term) const {
         return _impl->get_term_last_offset(term);
+    }
+
+    std::optional<model::offset> index_lower_bound(model::offset o) const {
+        return _impl->index_lower_bound(o);
     }
 
     ss::future<std::optional<timequery_result>>

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -238,4 +238,6 @@ log make_disk_backed_log(
   kvstore&,
   ss::sharded<features::feature_table>& feature_table);
 
+bool deletion_exempt(const model::ntp& ntp);
+
 } // namespace storage

--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -1,0 +1,558 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import random
+import signal
+import string
+import threading
+import confluent_kafka as ck
+import ducktape
+
+from ducktape.mark import parametrize
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.kcl import KCL
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
+from ducktape.utils.util import wait_until
+from rptest.clients.types import TopicSpec
+from rptest.util import produce_until_segments, segments_count, wait_for_removal_of_n_segments, search_logs_with_timeout
+from rptest.services.storage import Segment
+
+
+class DeleteRecordsTest(RedpandaTest):
+    """
+    The purpose of this test is to exercise the delete-records API which
+    prefix truncates the log at a user defined offset.
+    """
+    topics = (TopicSpec(), )
+
+    def __init__(self, test_context):
+        extra_rp_conf = dict(
+            enable_leader_balancer=False,
+            log_compaction_interval_ms=5000,
+            log_segment_size=1048576,
+        )
+        super(DeleteRecordsTest, self).__init__(test_context=test_context,
+                                                num_brokers=3,
+                                                extra_rp_conf=extra_rp_conf)
+        self._ctx = test_context
+
+        self.kcl = KCL(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+
+    def get_topic_info(self):
+        topics_info = list(self.rpk.describe_topic(self.topic))
+        self.logger.info(topics_info)
+        assert len(topics_info) == 1
+        return topics_info[0]
+
+    def wait_until_records(self, offset, timeout_sec=30, backoff_sec=1):
+        def expect_high_watermark():
+            topic_info = self.get_topic_info()
+            return topic_info.high_watermark == offset
+
+        wait_until(expect_high_watermark,
+                   timeout_sec=timeout_sec,
+                   backoff_sec=backoff_sec)
+
+    def delete_records(self, topic, partition, truncate_offset):
+        """
+        Makes delete records call with 1 topic partition in the request body.
+
+        Asserts that the response contains 1 element, with matching topic &
+        partition contents.
+        """
+        response = self.kcl.delete_records(
+            {topic: {
+                partition: truncate_offset
+            }})
+        assert len(response) == 1
+        assert response[0].topic == topic
+        assert response[0].partition == partition
+        assert response[0].error == 'OK', f"Err msg: {response[0].error}"
+        return response[0].new_low_watermark
+
+    def assert_start_partition_boundaries(self, truncate_offset):
+        def check_bound_start(offset):
+            try:
+                r = self.rpk.consume(self.topic,
+                                     n=1,
+                                     offset=f'{offset}-{offset+1}',
+                                     quiet=True,
+                                     timeout=10)
+                return r.count('_') == 1
+            except Exception as _:
+                return False
+
+        assert check_bound_start(
+            truncate_offset
+        ), f"new log start: {truncate_offset} not consumable"
+        assert not check_bound_start(
+            truncate_offset -
+            1), f"before log start: {truncate_offset - 1} is consumable"
+
+    def assert_new_partition_boundaries(self, truncate_offset, high_watermark):
+        """
+        Returns true if the partition contains records at the expected boundaries,
+        ensuring the truncation worked at the exact requested point and that the
+        number of remaining records is as expected.
+        """
+        def check_bound_end(offset):
+            try:
+                # Not timing out means data was available to read
+                _ = self.rpk.consume(self.topic,
+                                     n=1,
+                                     offset=offset,
+                                     timeout=10)
+            except Exception as _:
+                return False
+            return True
+
+        assert truncate_offset <= high_watermark, f"Test malformed"
+
+        if truncate_offset == high_watermark:
+            # Assert no data at all can be read
+            assert not check_bound_end(truncate_offset)
+            return
+
+        # truncate_offset is inclusive start of log
+        # high_watermark is exclusive end of log
+        # Readable offsets: [truncate_offset, high_watermark)
+        self.assert_start_partition_boundaries(truncate_offset)
+        assert check_bound_end(
+            high_watermark -
+            1), f"log end: {high_watermark - 1} not consumable"
+        assert not check_bound_end(
+            high_watermark), f"high watermark: {high_watermark} is consumable"
+
+    @cluster(num_nodes=3)
+    def test_delete_records_topic_start_delta(self):
+        """
+        Test that delete-records moves forward the segment offset delta
+
+        Perform this by creating only 1 segment and moving forward the start
+        offset within that segment, performing verifications at each step
+        """
+        num_records = 10240
+        records_size = 512
+        truncate_offset_start = 100
+
+        # Produce some data, wait for it all to arrive
+        kafka_tools = KafkaCliTools(self.redpanda)
+        kafka_tools.produce(self.topic, num_records, records_size)
+        self.wait_until_records(num_records, timeout_sec=10, backoff_sec=1)
+
+        # Call delete-records in a loop incrementing new point each time
+        for truncate_offset in range(truncate_offset_start,
+                                     truncate_offset_start + 5):
+            # Perform truncation
+            low_watermark = self.delete_records(self.topic, 0, truncate_offset)
+            assert low_watermark == truncate_offset, f"Expected low watermark: {truncate_offset} observed: {low_watermark}"
+
+            # Assert correctness of start and end offsets in topic metadata
+            topic_info = self.get_topic_info()
+            assert topic_info.id == 0, f"Partition id: {topic_info.id}"
+            assert topic_info.start_offset == truncate_offset, f"Start offset: {topic_info.start_offset}"
+            assert topic_info.high_watermark == num_records, f"High watermark: {topic_info.high_watermark}"
+
+            # ... and in actual fetch requests
+            self.assert_new_partition_boundaries(truncate_offset,
+                                                 topic_info.high_watermark)
+
+    @cluster(num_nodes=3)
+    @parametrize(truncate_point="at_segment_boundary")
+    @parametrize(truncate_point="within_segment")
+    @parametrize(truncate_point="one_below_high_watermark")
+    @parametrize(truncate_point="at_high_watermark")
+    def test_delete_records_segment_deletion(self, truncate_point: str):
+        """
+        Test that prefix truncation actually deletes data
+
+        In the case the desired truncation point passes multiple segments it
+        can be asserted that all of those segments will be deleted once the
+        log_eviction_stm processes the deletion event
+        """
+        segments_to_write = 10
+
+        # Produce 10 segments, then issue a truncation, assert corect number
+        # of segments are deleted
+        produce_until_segments(
+            self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=segments_to_write,
+            acks=-1,
+        )
+
+        # Grab a snapshot of the segments to determine the final segment
+        # indicies of all segments. This is to test corner cases where the
+        # user happens to pass a segment index as a truncation index.
+        snapshot = self.redpanda.storage().segments_by_node(
+            "kafka", self.topic, 0)
+        assert len(snapshot) > 0, "empty snapshot"
+        self.redpanda.logger.info(f"Snapshot: {snapshot}")
+
+        def get_segment_boundaries(node):
+            def to_final_indicies(seg):
+                return int(seg.data_file.split('-')[0]) - 1
+
+            indicies = [to_final_indicies(seg) for seg in node]
+            return sorted([idx for idx in indicies if idx != -1])
+
+        # Tests for 3 different types of scenarios
+        # 1. User wants to truncate all data - high_watermark
+        # 2. User wants to truncate at a segment boundary - at_segment_boundary
+        # 3. User wants to trunate between a boundary - within_segment
+        def obtain_test_parameters(snapshot):
+            node = snapshot[list(snapshot.keys())[-1]]
+            segment_boundaries = get_segment_boundaries(node)
+            self.redpanda.logger.info(
+                f"Segment boundaries: {segment_boundaries}")
+            truncate_offset = None
+            expected_segments_removed = None
+            high_watermark = int(self.get_topic_info().high_watermark)
+            if truncate_point == "one_below_high_watermark":
+                truncate_offset = high_watermark - 1  # Leave 1 record
+                expected_segments_removed = len(segment_boundaries)
+            elif truncate_point == "at_high_watermark":
+                truncate_offset = high_watermark  # Delete all data
+                expected_segments_removed = len(segment_boundaries)
+            elif truncate_point == "within_segment":
+                random_seg = random.randint(0, len(segment_boundaries) - 2)
+                truncate_offset = random.randint(
+                    segment_boundaries[random_seg] + 1,
+                    segment_boundaries[random_seg + 1] - 1)
+                expected_segments_removed = random_seg
+            elif truncate_point == "at_segment_boundary":
+                random_seg = random.randint(0, len(segment_boundaries) - 1)
+                truncate_offset = segment_boundaries[random_seg]
+                expected_segments_removed = random_seg
+            else:
+                assert False, "unknown test parameter encountered"
+
+            self.redpanda.logger.info(
+                f"Truncate offset: {truncate_offset} expected segments to remove: {expected_segments_removed}"
+            )
+            return (truncate_offset, expected_segments_removed, high_watermark)
+
+        (truncate_offset, expected_segments_removed,
+         high_watermark) = obtain_test_parameters(snapshot)
+
+        # Make delete-records call, assert response looks ok
+        try:
+            low_watermark = self.delete_records(self.topic, 0, truncate_offset)
+            assert low_watermark == truncate_offset, f"Expected low watermark: {truncate_offset} observed: {low_watermark}"
+        except Exception as e:
+            topic_info = self.get_topic_info()
+            self.redpanda.logger.info(
+                f"Start offset: {topic_info.start_offset}")
+            raise e
+
+        # Restart one node while the effect is propogating
+        node = random.choice(self.redpanda.nodes)
+        self.redpanda.signal_redpanda(node, signal=signal.SIGKILL)
+        self.redpanda.start_node(node)
+
+        # Assert start offset is correct and there aren't any off-by-one errors
+        self.assert_new_partition_boundaries(low_watermark, high_watermark)
+
+        try:
+            # All segments except for the current should be removed
+            self.redpanda.logger.info(
+                f"Waiting until {expected_segments_removed} segs are deleted")
+            wait_for_removal_of_n_segments(redpanda=self.redpanda,
+                                           topic=self.topic,
+                                           partition_idx=0,
+                                           n=expected_segments_removed,
+                                           original_snapshot=snapshot)
+        except ducktape.errors.TimeoutError as e:
+            # If there are some segments remaining, this is due to the fact that truncation
+            # occured in the middle of the prefix_truncate call, so tombstones were written,
+            # but not persisted to disk, on restart these segments are orphaned. This is not
+            # a bug since on subsequent truncate calls, these segments will be removed.
+            self.redpanda.logger.info(
+                "Timed out waiting for segments, looking to see if leftover segments are segments that are to be recovered"
+            )
+
+            def failed_nodes_num_segments(node):
+                failed_node_storage = self.redpanda.node_storage(node)
+                segments = failed_node_storage.segments("kafka", self.topic, 0)
+                self.redpanda.logger.info(f"Failed node segments: {segments}")
+                return len(segments)
+
+            expected_to_remain = len(snapshot) - expected_segments_removed
+            segments = failed_nodes_num_segments(node)
+            assert segments >= expected_to_remain
+
+            # Delete the topic so post storage checks don't fail on inconsistencies across nodes
+            self.rpk.delete_topic(self.topic)
+            wait_until(lambda: failed_nodes_num_segments(node) == 0,
+                       timeout_sec=10,
+                       backoff_sec=2)
+
+    @cluster(num_nodes=3)
+    def test_delete_records_bounds_checking(self):
+        """
+        Ensure that the delete-records handler returns the appropriate error
+        code when a user attempts to truncate at an offset that is not within
+        the boundaries of the partition.
+        """
+        num_records = 10240
+        records_size = 512
+        out_of_range_prefix = "OFFSET_OUT_OF_RANGE"
+
+        # Produce some data, wait for it all to arrive
+        kafka_tools = KafkaCliTools(self.redpanda)
+        kafka_tools.produce(self.topic, num_records, records_size)
+        self.wait_until_records(num_records, timeout_sec=10, backoff_sec=1)
+
+        def check_bad_response(response):
+            assert len(response) == 1
+            assert response[0].topic == self.topic
+            assert response[0].partition == 0
+            assert response[0].new_low_watermark == -1
+            return response[0].error
+
+        def bad_truncation(truncate_offset):
+            response = self.kcl.delete_records(
+                {self.topic: {
+                    0: truncate_offset
+                }})
+            assert check_bad_response(response).startswith(
+                out_of_range_prefix
+            ), f"Unexpected error msg: {response[0].error}"
+
+        # Try truncating past the end of the log
+        bad_truncation(num_records + 1)
+
+        # Truncate to attempt to truncate before new beginning
+        truncate_offset = 125
+        low_watermark = self.delete_records(self.topic, 0, truncate_offset)
+        assert low_watermark == truncate_offset
+
+        # Try to truncate before and at the low_watermark
+        bad_truncation(0)
+        bad_truncation(low_watermark)
+
+        # Try to truncate at a specific edge case where the start and end
+        # are 1 offset away from eachother
+        truncate_offset = num_records - 2
+        for t_ofs in range(truncate_offset, num_records + 1):
+            low_watermark = self.delete_records(self.topic, 0, t_ofs)
+            assert low_watermark == t_ofs
+
+        # Assert that nothing is readable
+        bad_truncation(truncate_offset)
+        bad_truncation(num_records)
+        bad_truncation(num_records + 1)
+
+    @cluster(num_nodes=3)
+    def test_delete_records_empty_or_missing_topic_or_partition(self):
+        missing_topic = "foo_bar"
+        out_of_range_prefix = "OFFSET_OUT_OF_RANGE"
+        unknown_topic_or_partition = "UNKNOWN_TOPIC_OR_PARTITION"
+        missing_partition = "partition was not returned"
+
+        # Assert failure condition on unknown topic
+        response = self.kcl.delete_records({missing_topic: {0: 0}})
+        assert len(response) == 1
+        assert response[0].new_low_watermark == -1
+        assert response[0].error.find(unknown_topic_or_partition) != -1
+
+        # Assert failure condition on unknown partition index
+        missing_idx = 15
+        response = self.kcl.delete_records({self.topic: {missing_idx: 0}})
+        assert len(response) == 1
+        assert response[0].new_low_watermark == -1
+        assert response[0].error.find(missing_partition) != -1
+
+        # Assert out of range occurs on an empty topic
+        attempts = 5
+        response = []
+        while attempts > 0:
+            response = self.kcl.delete_records({self.topic: {0: 0}})
+            assert len(response) == 1
+            assert response[0].topic == self.topic
+            assert response[0].partition == 0
+            assert response[0].new_low_watermark == -1
+            if not response[0].error.startswith("NOT_LEADER"):
+                break
+            time.sleep(1)
+            attempts -= 1
+        assert response[0].error.startswith(out_of_range_prefix)
+
+        # Assert correct behavior on a topic with 1 record
+        kafka_tools = KafkaCliTools(self.redpanda)
+        kafka_tools.produce(self.topic, 1, 512)
+        self.wait_until_records(1, timeout_sec=5, backoff_sec=1)
+        response = self.kcl.delete_records({self.topic: {0: 0}})
+        assert len(response) == 1
+        assert response[0].new_low_watermark == -1
+        assert response[0].error.startswith(out_of_range_prefix)
+
+        # ... truncating at high watermark 1 should delete all data
+        low_watermark = self.delete_records(self.topic, 0, 1)
+        assert low_watermark == 1
+        topic_info = self.get_topic_info()
+        assert topic_info.high_watermark == 1
+
+    @cluster(num_nodes=3)
+    def test_delete_records_with_transactions(self):
+        """
+        Tests that the log_eviction_stm is respecting the max_collectible_offset
+        """
+        payload = ''.join(
+            random.choice(string.ascii_letters) for _ in range(512))
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+        })
+        producer.init_transactions()
+
+        def delete_records_within_transaction(reporter):
+            try:
+                high_watermark = int(self.get_topic_info().high_watermark)
+                response = self.kcl.delete_records(
+                    {self.topic: {
+                        0: high_watermark
+                    }}, timeout_ms=5000)
+                assert len(response) == 1
+                # Even though the on disk data may be late to evict, the start offset
+                # should have been immediately updated
+                assert response[0].new_low_watermark == high_watermark
+                assert response[0].error == 'OK'
+            except Exception as e:
+                reporter.exc = e
+
+        # Write 20 records and leave the transaction open
+        producer.begin_transaction()
+        for idx in range(0, 20):
+            producer.produce(self.topic, '0', payload, 0)
+            producer.flush()
+
+        # The eviction_stm will be re-queuing the event until the max collectible
+        # offset is moved ahead of the eviction offset, or until a timeout occurs
+        class ThreadReporter:
+            exc = None
+
+        eviction_thread = threading.Thread(
+            target=delete_records_within_transaction, args=(ThreadReporter, ))
+        eviction_thread.start()
+
+        # Committing the transaction will allow the eviction_stm to move forward
+        # and process the event.
+        time.sleep(1)
+        producer.commit_transaction()
+        eviction_thread.join()
+        # Rethrow exception encountered in thread if observed
+        if ThreadReporter.exc is not None:
+            raise ThreadReporter.exc
+
+    @cluster(num_nodes=5)
+    def test_delete_records_concurrent_truncations(self):
+        """
+        This tests verifies that issuing DeleteRecords requests with concurrent
+        producers and consumers has no effect on correctness
+        """
+
+        # Should complete producing within 20s
+        producer = KgoVerifierProducer(self._ctx,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=512,
+                                       msg_count=20000,
+                                       rate_limit_bps=500000)  # 0.5/mbs
+        consumer = KgoVerifierConsumerGroupConsumer(self._ctx,
+                                                    self.redpanda,
+                                                    self.topic,
+                                                    512,
+                                                    1,
+                                                    max_msgs=20000)
+
+        def periodic_delete_records():
+            topic_info = self.get_topic_info()
+            start_offset = topic_info.start_offset + 1
+            high_watermark = topic_info.high_watermark - 1
+            if high_watermark - start_offset <= 0:
+                self.redpanda.logger.info("Waiting on log to populate")
+                return
+            truncate_point = random.randint(start_offset, high_watermark)
+            self.redpanda.logger.info(
+                f"Issuing delete_records request at offset: {truncate_point}")
+            response = self.kcl.delete_records(
+                {self.topic: {
+                    0: truncate_point
+                }}, timeout_ms=5000)
+            assert len(response) == 1
+            assert response[0].new_low_watermark == truncate_point
+            assert response[0].error == 'OK'
+            # Cannot assert end boundaries as there is a concurrent producer
+            # moving the hwm forward
+            self.assert_start_partition_boundaries(truncate_point)
+
+        def periodic_delete_records_loop(reporter,
+                                         iterations,
+                                         sleep_sec,
+                                         allowable_retrys=3):
+            """
+            Periodicially issue delete records requests within a loop. allowable_reties
+            exists so that the test doesn't automatically fail when a leadership change occurs.
+            The implementation guaratntees that the special prefix_truncation batch is
+            replicated before the client is acked, it however does not guarantee that the effect
+            has occured. Have the test retry on some failures to account for this.
+            """
+            try:
+                try:
+                    while iterations > 0:
+                        periodic_delete_records()
+                        iterations -= 1
+                        time.sleep(sleep_sec)
+                except AssertionError as e:
+                    if allowable_retrys == 0:
+                        raise e
+                    allowable_retrys = allowable_retrys - 1
+            except Exception as e:
+                reporter.exc = e
+
+        class ThreadReporter:
+            exc = None
+
+        n_attempts = 10
+        thread_sleep = 1  # 10s of uptime, less if exception thrown
+        delete_records_thread = threading.Thread(
+            target=periodic_delete_records_loop,
+            args=(
+                ThreadReporter,
+                n_attempts,
+                thread_sleep,
+            ))
+
+        # Start up producer/consumer and thread that periodically issues delete records requests
+        delete_records_thread.start()
+        producer.start()
+        consumer.start()
+
+        # Shut down all threads started above
+        self.redpanda.logger.info("Joining on delete-records thread")
+        delete_records_thread.join()
+        self.redpanda.logger.info("Joining on producer thread")
+        producer.wait()
+        self.redpanda.logger.info("Calling consumer::stop")
+        consumer.stop()
+        self.redpanda.logger.info("Joining on consumer thread")
+        consumer.wait()
+        if ThreadReporter.exc is not None:
+            raise ThreadReporter.exc
+
+        status = consumer.consumer_status
+        assert status.validator.invalid_reads == 0
+        assert status.validator.out_of_scope_invalid_reads == 0


### PR DESCRIPTION
This PR adds the delete-records feature to redpanda. This feature allows a kafka client to truncate data from a topic/partition at a given offset. To support this in redpanda two non-trivial tasks were implemented:

1. Addition of new stm (and corresponding special batch type) to process prefix truncation events.
2. Addition of new concept (visible_start_offset) which is a delta into the first segment of the log representing the first offset a fetch request could read from.

Note, as of this branch delete-records requests for cloud enabled topics will be rejected. Work on supporting this is slated to be completed in a follow up PR, ~~which depends on a currently still in review PR~~ #9994  

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features

* Adds support for the delete-records API
