### PR TITLE
[v22.2.x] c/tm_stm: Convert tm_snapshot to fragmented_vector

### DIFF
--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -400,7 +400,7 @@ ss::future<stm_snapshot> tm_stm::take_snapshot() {
     }
 
     iobuf tm_ss_buf;
-    reflection::adl<tm_snapshot>{}.to(tm_ss_buf, tm_ss);
+    reflection::adl<tm_snapshot>{}.to(tm_ss_buf, std::move(tm_ss));
 
     co_return stm_snapshot::create(
       supported_version, _insync_offset, std::move(tm_ss_buf));
@@ -517,7 +517,7 @@ ss::future<tm_stm::get_txs_result> tm_stm::get_all_transactions() {
         co_return tm_stm::op_status::unknown;
     }
 
-    std::vector<tm_transaction> ans;
+    fragmented_vector<tm_transaction> ans;
     for (const auto& [_, tx] : _mem_txes) {
         ans.push_back(tx);
     }

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -25,6 +25,7 @@
 #include "raft/types.h"
 #include "storage/snapshot.h"
 #include "utils/expiring_promise.h"
+#include "utils/fragmented_vector.h"
 #include "utils/mutex.h"
 
 #include <absl/container/btree_set.h>
@@ -117,7 +118,7 @@ struct tm_transaction {
 
 struct tm_snapshot {
     model::offset offset;
-    std::vector<tm_transaction> transactions;
+    fragmented_vector<tm_transaction> transactions;
 };
 
 /**
@@ -213,7 +214,7 @@ public:
     absl::btree_set<kafka::transactional_id> get_expired_txs();
 
     using get_txs_result
-      = checked<std::vector<tm_transaction>, tm_stm::op_status>;
+      = checked<fragmented_vector<tm_transaction>, tm_stm::op_status>;
     ss::future<get_txs_result> get_all_transactions();
 
     ss::future<checked<tm_transaction, tm_stm::op_status>>

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1226,7 +1226,7 @@ tx_gateway_frontend::get_all_transactions() {
               co_return tx_errc::unknown_server_error;
           }
 
-          co_return res.value();
+          co_return std::move(res).value();
       });
 }
 

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -62,7 +62,8 @@ public:
     ss::future<end_tx_reply>
       end_txn(end_tx_request, model::timeout_clock::duration);
 
-    using return_all_txs_res = result<std::vector<tm_transaction>, tx_errc>;
+    using return_all_txs_res
+      = result<fragmented_vector<tm_transaction>, tx_errc>;
     ss::future<return_all_txs_res> get_all_transactions();
 
     ss::future<tx_errc> delete_partition_from_tx(

--- a/src/v/reflection/adl.h
+++ b/src/v/reflection/adl.h
@@ -33,6 +33,8 @@ struct adl {
     static constexpr bool is_optional = is_std_optional<type>;
     static constexpr bool is_sstring = std::is_same_v<type, ss::sstring>;
     static constexpr bool is_vector = is_std_vector<type>;
+    static constexpr bool is_fragmented_vector
+      = reflection::is_fragmented_vector<type>;
     static constexpr bool is_named_type = is_rp_named_type<type>;
     static constexpr bool is_iobuf = std::is_same_v<type, iobuf>;
     static constexpr bool is_standard_layout = std::is_standard_layout_v<type>;
@@ -83,6 +85,14 @@ struct adl {
             int32_t n = in.template consume_type<int32_t>();
             std::vector<value_type> ret;
             ret.reserve(n);
+            while (n-- > 0) {
+                ret.push_back(adl<value_type>{}.from(in));
+            }
+            return ret;
+        } else if constexpr (is_fragmented_vector) {
+            using value_type = typename type::value_type;
+            int32_t n = in.template consume_type<int32_t>();
+            fragmented_vector<value_type> ret;
             while (n-- > 0) {
                 ret.push_back(adl<value_type>{}.from(in));
             }
@@ -142,8 +152,14 @@ struct adl {
             adl<int32_t>{}.to(out, int32_t(t.size()));
             out.append(t.data(), t.size());
             return;
-        } else if constexpr (is_vector) {
+        } else if constexpr (is_vector || is_fragmented_vector) {
             using value_type = typename type::value_type;
+            if (unlikely(t.size() > std::numeric_limits<int32_t>::max())) {
+                throw std::invalid_argument(fmt::format(
+                  "Vector size {} exceeded int32_max: {}",
+                  t.size(),
+                  std::numeric_limits<int32_t>::max()));
+            }
             adl<int32_t>{}.to(out, t.size());
             for (value_type& i : t) {
                 adl<value_type>{}.to(out, std::move(i));

--- a/src/v/reflection/type_traits.h
+++ b/src/v/reflection/type_traits.h
@@ -13,6 +13,7 @@
 
 #include "seastarx.h"
 #include "tristate.h"
+#include "utils/fragmented_vector.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/circular_buffer.hh>
@@ -32,12 +33,32 @@ template<typename T, template<typename...> class C>
 inline constexpr bool is_specialization_of_v
   = is_specialization_of<T, C>::value;
 
+template<class T, template<class, size_t> class C>
+struct is_specialization_of_sized : std::false_type {};
+template<template<class, size_t> class C, class T, size_t N>
+struct is_specialization_of_sized<C<T, N>, C> : std::true_type {};
+template<typename T, template<class, size_t> class C>
+inline constexpr bool is_specialization_of_sized_v
+  = is_specialization_of_sized<T, C>::value;
+
+template<class T>
+struct is_std_array_t : std::false_type {};
+template<class T, std::size_t N>
+struct is_std_array_t<std::array<T, N>> : std::true_type {};
+
 } // namespace detail
 
 namespace reflection {
 
 template<typename T>
 concept is_std_vector = ::detail::is_specialization_of_v<T, std::vector>;
+
+template<typename T>
+concept is_fragmented_vector
+  = ::detail::is_specialization_of_sized_v<T, fragmented_vector>;
+
+template<typename T>
+concept is_std_array = ::detail::is_std_array_t<T>::value;
 
 template<typename T>
 concept is_ss_circular_buffer

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -66,6 +66,9 @@ class fragmented_vector {
 public:
     using this_type = fragmented_vector<T, max_fragment_size>;
     using value_type = T;
+    using reference = T&;
+    using const_reference = const T&;
+    using size_type = size_t;
 
     /**
      * The maximum number of bytes per fragment as specified in
@@ -78,20 +81,33 @@ public:
 
     fragmented_vector() noexcept = default;
     fragmented_vector& operator=(const fragmented_vector&) noexcept = delete;
-    fragmented_vector(fragmented_vector&&) noexcept = default;
-    fragmented_vector& operator=(fragmented_vector&&) noexcept = default;
+    fragmented_vector(fragmented_vector&& other) noexcept {
+        *this = std::move(other);
+    }
+    fragmented_vector& operator=(fragmented_vector&& other) noexcept {
+        if (this != &other) {
+            this->_size = other._size;
+            this->_capacity = other._capacity;
+            this->_frags = std::move(other._frags);
+            // Move compatibility with std::vector that post move
+            // the vector is empty().
+            other._size = other._capacity = 0;
+        }
+        return *this;
+    }
     ~fragmented_vector() noexcept = default;
 
     fragmented_vector copy() const noexcept { return *this; }
 
-    void push_back(T elem) {
+    template<class E = T>
+    void push_back(E&& elem) {
         if (_size == _capacity) {
             std::vector<T> frag;
             frag.reserve(elems_per_frag);
             _frags.push_back(std::move(frag));
             _capacity += elems_per_frag;
         }
-        _frags.back().push_back(elem);
+        _frags.back().push_back(std::forward<E>(elem));
         ++_size;
     }
 
@@ -115,6 +131,7 @@ public:
         return const_cast<T&>(std::as_const(*this)[index]);
     }
 
+    const T& front() const { return _frags.front().front(); }
     const T& back() const { return _frags.back().back(); }
     bool empty() const noexcept { return _size == 0; }
     size_t size() const noexcept { return _size; }

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -272,6 +272,24 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_comparison) {
     BOOST_CHECK(b1 >= b);
 }
 
+BOOST_AUTO_TEST_CASE(fragmented_vector_empty_after_move) {
+    // Checks that post move, the source vector is empty().
+    // This is inline with std::vector guarantees.
+    fragmented_vector<int> v1;
+    v1.push_back(1);
+    BOOST_CHECK(!v1.empty());
+
+    auto v2 = std::move(v1);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    BOOST_CHECK(v1.empty());
+    BOOST_CHECK(v1.begin() == v1.end());
+
+    auto v3(std::move(v2));
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    BOOST_CHECK(v2.empty());
+    BOOST_CHECK(v2.begin() == v2.end());
+}
+
 BOOST_AUTO_TEST_CASE(fragmented_vector_sort) {
     auto v = make<int64_t, 8>({3, 2, 1});
     auto expected = make<int64_t, 8>({1, 2, 3});


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10035
Partial backport of PR https://github.com/redpanda-data/redpanda/pull/9484

Minor conflicts. E.g., the `tm_stm_cache` doesn't exist.