### PR TITLE
[v23.1.x] Add available memory to internal metrics

### DIFF
--- a/src/v/resource_mgmt/available_memory.cc
+++ b/src/v/resource_mgmt/available_memory.cc
@@ -67,7 +67,7 @@ void available_memory::register_metrics() {
     }
 
     auto& m = _metrics.emplace();
-    m.groups.add_group(
+    m.add_group(
       prometheus_sanitize::metrics_name("memory"),
       {ss::metrics::make_gauge(
          "available_memory",

--- a/src/v/resource_mgmt/available_memory.h
+++ b/src/v/resource_mgmt/available_memory.h
@@ -154,7 +154,7 @@ private:
       _local_instance; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     intrusive_list<reporter, &reporter::hook> _reporters;
-    std::optional<ssx::metrics::public_metrics_group> _metrics;
+    std::optional<ssx::metrics::all_metrics_groups> _metrics;
     size_t _lwm;
 };
 

--- a/src/v/ssx/metrics.h
+++ b/src/v/ssx/metrics.h
@@ -16,6 +16,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_registration.hh>
 
 namespace ssx::metrics {
 
@@ -48,6 +49,32 @@ struct public_metrics_group {
         groups.clear();
         return ss::make_ready_future<>();
     }
+};
+
+/**
+ * @brief A class bundling together public and internal metrics.
+ *
+ * Intended to replace an ss::metrics::metric_groups instance when
+ * you want a metric exposed on both the /metrics (aka "internal")
+ * and /public_metrics (aka "public") metrics endpoint.
+ */
+class all_metrics_groups {
+    ss::metrics::metric_groups _public{public_metrics_handle}, _internal;
+
+public:
+    /**
+     * @brief Adds the given metric group to public and internal metrics.
+     *
+     * The behavior is same as ss::metrics::metric_groups::add_group but for
+     * both metric endpoints.
+     */
+    all_metrics_groups& add_group(
+      const seastar::metrics::group_name_type& name,
+      const std::initializer_list<seastar::metrics::metric_definition>& l) {
+        _internal.add_group(name, l);
+        _public.add_group(name, l);
+        return *this;
+    };
 };
 
 } // namespace ssx::metrics


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10018
Fixes https://github.com/redpanda-data/redpanda/issues/10068, [v23.1.x] available_memory metric should be exposed in /metrics.