### PR TITLE
security: break config<->security circular depdendency

### DIFF
--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -455,7 +455,9 @@ ss::future<response_ptr> sasl_handshake_handler::handle(
             ctx.sasl()->set_mechanism(
               std::make_unique<security::gssapi_authenticator>(
                 ctx.connection()->server().thread_worker(),
-                ctx.connection()->server().gssapi_principal_mapper().rules()));
+                ctx.connection()->server().gssapi_principal_mapper().rules(),
+                config::shard_local_cfg().sasl_kerberos_principal(),
+                config::shard_local_cfg().sasl_kerberos_keytab()));
         }
     }
 

--- a/src/v/security/gssapi_authenticator.cc
+++ b/src/v/security/gssapi_authenticator.cc
@@ -10,7 +10,6 @@
 #include "security/gssapi_authenticator.h"
 
 #include "bytes/bytes.h"
-#include "config/configuration.h"
 #include "kafka/protocol/wire.h"
 #include "security/acl.h"
 #include "security/errc.h"
@@ -170,12 +169,13 @@ private:
 };
 
 gssapi_authenticator::gssapi_authenticator(
-  ssx::thread_worker& thread_worker, std::vector<gssapi_rule> rules)
+  ssx::thread_worker& thread_worker,
+  std::vector<gssapi_rule> rules,
+  ss::sstring principal,
+  ss::sstring keytab)
   : _worker{thread_worker}
   , _impl{std::make_unique<impl>(
-      config::shard_local_cfg().sasl_kerberos_principal(),
-      config::shard_local_cfg().sasl_kerberos_keytab(),
-      std::move(rules))} {}
+      std::move(principal), std::move(keytab), std::move(rules))} {}
 
 gssapi_authenticator::~gssapi_authenticator() = default;
 

--- a/src/v/security/gssapi_authenticator.h
+++ b/src/v/security/gssapi_authenticator.h
@@ -21,7 +21,10 @@ public:
     static constexpr const char* name = "GSSAPI";
 
     gssapi_authenticator(
-      ssx::thread_worker& thread_worker, std::vector<gssapi_rule> rules);
+      ssx::thread_worker& thread_worker,
+      std::vector<gssapi_rule> rules,
+      ss::sstring principal,
+      ss::sstring keytab);
     ~gssapi_authenticator() override;
 
     ss::future<result<bytes>> authenticate(bytes) override;


### PR DESCRIPTION
Break dependency.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

