### PR TITLE
net: tolerate EAGAIN errors in is_reconnect_error

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -47,6 +47,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case ECONNRESET:
         case ENOTCONN:
         case ECONNABORTED:
+        case EAGAIN:
         case EPIPE:
             return true;
         default:


### PR DESCRIPTION
It appears that this exception may be thrown during shutdown of a connection with latest seastar, which may be a bug, but in any case we do not want to log it at ERROR severity.

Fixes https://github.com/redpanda-data/redpanda/issues/10089

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
