### PR TITLE
Controller snapshots: scale and random ops tests

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -155,6 +155,8 @@ public:
         });
     }
 
+    model::offset get_start_offset() const { return _raft0->start_offset(); }
+
     model::offset get_commited_index() const {
         return _raft0->committed_offset();
     }

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -344,6 +344,10 @@
             "id": "controller_status",
             "description": "Controller status",
             "properties": {
+                "start_offset": {
+                    "type": "long",
+                    "description": "start offset for controller log"
+                },
                 "last_applied_offset": {
                     "type": "long",
                     "description": "Last applied offset for controller stm"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3823,6 +3823,7 @@ void admin_server::register_debug_routes() {
                 using result_t = ss::httpd::debug_json::controller_status;
                 result_t ans;
                 ans.last_applied_offset = offset;
+                ans.start_offset = _controller->get_start_offset();
                 ans.commited_index = _controller->get_commited_index();
                 return ss::make_ready_future<ss::json::json_return_type>(
                   ss::json::json_return_type(ans));

--- a/tests/rptest/scale_tests/large_controller_snapshot_test.py
+++ b/tests/rptest/scale_tests/large_controller_snapshot_test.py
@@ -1,0 +1,180 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import concurrent.futures
+
+from ducktape.utils.util import wait_until
+
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
+from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, LoggingConfig
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.mode_checks import skip_debug_mode
+
+
+class LargeControllerSnapshotTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            num_brokers=4,
+            # This configuration allows dangerously high partition counts. That's okay
+            # because we want to stress the controller itself, so we won't apply
+            # produce load.
+            extra_rp_conf={
+                'controller_snapshot_max_age_sec': 3,
+                'topic_partitions_per_shard': 10_000,
+                'topic_memory_per_partition': None,
+                'partition_autobalancing_concurrent_moves': 1000,
+            },
+            # Reduce per-partition log spam
+            log_config=LoggingConfig('info',
+                                     logger_levels={
+                                         'storage': 'warn',
+                                         'storage-gc': 'warn',
+                                         'raft': 'warn',
+                                         'offset_translator': 'warn'
+                                     }),
+            **kwargs)
+
+    def setUp(self):
+        # start the nodes manually
+        pass
+
+    @skip_debug_mode
+    @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_join_restart(self):
+        """
+        Test that Redpanda can handle controller snapshots with a lot of objects:
+        * no new oversized allocations and controller stalls
+        * snapshot is persisted without problems
+        * admin commands can still be executed
+        * cluster is able to stabilize (rebalancing on node addition finishes)
+        """
+
+        seed_nodes = self.redpanda.nodes[0:3]
+        joiner_node = self.redpanda.nodes[3]
+
+        self.redpanda.start(nodes=seed_nodes, omit_seeds_on_idx_one=False)
+
+        admin = Admin(self.redpanda, default_node=seed_nodes[0])
+        rpk = RpkTool(self.redpanda)
+
+        admin.put_feature("controller_snapshots", {"state": "active"})
+
+        if self.redpanda.dedicated_nodes:
+            # approx. 5k partition replicas per shard
+            n_topics = 50
+            n_partitions = min(100 * self.redpanda.get_node_cpu_count(), 1000)
+            n_users = 5_000
+        else:
+            # more benign numbers for running the test locally
+            n_topics = 10
+            n_partitions = 100
+            n_users = 500
+
+        # create a lot of topics
+        self.logger.info(
+            f"creating {n_topics} topics with {n_partitions} partitions each..."
+        )
+
+        topic_names = [f"test_{i:06d}" for i in range(0, n_topics)]
+        for tn in topic_names:
+            self.logger.debug(f"creating topic {tn}")
+            rpk.create_topic(tn, partitions=n_partitions, replicas=3)
+
+        for n in seed_nodes:
+            self.redpanda.wait_for_controller_snapshot(node=n)
+
+        # create a lot of users
+        self.logger.info(f"creating {n_users} users...")
+
+        def create_users(names):
+            # create own admin and rpk instances to avoid concurrent accesses
+            # to common ones
+            admin = Admin(self.redpanda, default_node=seed_nodes[0])
+            rpk = RpkTool(self.redpanda)
+            for un in names:
+                admin.create_user(username=un,
+                                  password='p4ssw0rd',
+                                  algorithm='SCRAM-SHA-256')
+                rpk.acl_create_allow_cluster(username=un, op='describe')
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            step = 10
+            user_names = [[
+                f"user_{i:06d}" for i in range(start, start + step)
+            ] for start in range(0, n_users, step)]
+            executor.map(create_users, user_names)
+
+        # wait until everything is snapshotted
+        self.logger.info(f"waiting until all commands are snapshotted...")
+
+        controller_max_offset = max(
+            admin.get_controller_status(n)['commited_index']
+            for n in seed_nodes)
+        self.logger.info(f"controller max offset is {controller_max_offset}")
+
+        for n in seed_nodes:
+            self.redpanda.wait_for_controller_snapshot(
+                node=n, prev_start_offset=(controller_max_offset - 1))
+
+        # add a node to the cluster
+        self.logger.info(f"adding a node to the cluster...")
+
+        # explicit clean step is needed because we are starting the node manually and not
+        # using redpanda.start()
+        self.redpanda.clean_node(joiner_node)
+        self.redpanda.start_node(joiner_node)
+        wait_until(lambda: self.redpanda.registered(joiner_node),
+                   timeout_sec=60,
+                   backoff_sec=5)
+
+        # reboot the cluster to test that the cluster stabilizes after rebooting with high
+        # partition count and a large controller snapshot
+        self.logger.info(f"rebooting the cluster...")
+
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=len(self.redpanda.nodes)) as executor:
+            futs = []
+            for node in self.redpanda.nodes:
+                futs.append(
+                    executor.submit(self.redpanda.restart_nodes,
+                                    nodes=[node],
+                                    start_timeout=60,
+                                    stop_timeout=60 * 5))
+
+            for f in futs:
+                # Raise on error
+                f.result()
+
+        self.redpanda.wait_for_membership(first_start=False, timeout_sec=60)
+
+        # check that all created users are there
+        for n in self.redpanda.nodes:
+            actual = len(admin.list_users(node=n))
+            # + 1 comes from the admin user which is created autmatically
+            assert actual == n_users + 1, f"unexpected number of users {actual}"
+
+        # wait until rebalance on node addition is finished
+        self.logger.info(
+            f"waiting until partitions are rebalanced to the new node...")
+
+        def rebalance_finished():
+            in_progress = admin.list_reconfigurations(node=seed_nodes[0])
+            self.logger.info(
+                f"current number of reconfigurations: {len(in_progress)}")
+            if len(in_progress) > 0:
+                return False
+
+            partitions_on_joiner = len(admin.get_partitions(node=joiner_node))
+            self.logger.info(f"partitions on joiner: {partitions_on_joiner}")
+            return partitions_on_joiner > (n_topics * n_partitions / 10)
+
+        wait_until(rebalance_finished, timeout_sec=300, backoff_sec=5)

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -664,7 +664,7 @@ class Admin:
         return self._request('post', path, node=node)
 
     def create_user(self, username, password, algorithm):
-        self.redpanda.logger.info(
+        self.redpanda.logger.debug(
             f"Creating user {username}:{password}:{algorithm}")
 
         path = f"security/users"

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -462,9 +462,14 @@ class AdminOperationsFuzzer():
         self._pause_reached = False
 
     def start(self):
+        self.create_initial_entities()
+
         self.thread = threading.Thread(target=lambda: self.thread_loop(),
                                        args=())
         self.thread.daemon = True
+        self.thread.start()
+
+    def create_initial_entities(self):
         # pre-populate cluster with users and topics
         for i in range(0, self.initial_entities):
             tp = CreateTopicOperation(self.prefix, 1, self.min_replication,
@@ -476,7 +481,27 @@ class AdminOperationsFuzzer():
             self.append_to_history(user)
             user.execute(self.operation_ctx)
 
-        self.thread.start()
+    def thread_loop(self):
+        while not self._stopping.is_set():
+            with self._pause_cond:
+                if self._pause_requested:
+                    self._pause_reached = True
+                    self._pause_cond.notify()
+
+                while self._pause_requested:
+                    self._pause_cond.wait()
+
+                self._pause_reached = False
+
+            try:
+                self.execute_one()
+            except Exception as e:
+                self.error = e
+                self._stopping.set()
+
+        with self._pause_cond:
+            self._pause_reached = True
+            self._pause_cond.notify()
 
     def pause(self):
         with self._pause_cond:
@@ -498,50 +523,35 @@ class AdminOperationsFuzzer():
         d['timestamp'] = int(time.time())
         self.history.append(d)
 
-    def thread_loop(self):
-        while not self._stopping.is_set():
-            with self._pause_cond:
-                if self._pause_requested:
-                    self._pause_reached = True
-                    self._pause_cond.notify()
+    def execute_one(self):
+        op_type, op = self.make_random_operation()
+        self.append_to_history(op)
 
-                while self._pause_requested:
-                    self._pause_cond.wait()
-
-                self._pause_reached = False
-
-            op_type, op = self.make_random_operation()
-            self.append_to_history(op)
-
-            def validate_result():
-                try:
-                    return op.validate(self.operation_ctx)
-                except Exception as e:
-                    self.redpanda.logger.debug(
-                        f"Error validating operation {op_type}", exc_info=True)
-                    return False
-
+        def validate_result():
             try:
-                self.attempted += 1
-                if self.execute_with_retries(op_type, op):
-                    wait_until(validate_result,
-                               timeout_sec=self.operation_timeout,
-                               backoff_sec=1)
-                    self.executed += 1
-                    sleep(self.operations_interval)
-                else:
-                    self.redpanda.logger.info(
-                        f"Skipped operation: {op_type}, current cluster state does not allow executing the operation"
-                    )
+                return op.validate(self.operation_ctx)
             except Exception as e:
-                self.redpanda.logger.debug(f"Operation: {op_type}",
-                                           exc_info=True)
-                self.error = e
-                self._stopping.set()
+                self.redpanda.logger.debug(
+                    f"Error validating operation {op_type}", exc_info=True)
+                return False
 
-        with self._pause_cond:
-            self._pause_reached = True
-            self._pause_cond.notify()
+        try:
+            self.attempted += 1
+            if self.execute_with_retries(op_type, op):
+                wait_until(validate_result,
+                           timeout_sec=self.operation_timeout,
+                           backoff_sec=1)
+                self.executed += 1
+                sleep(self.operations_interval)
+                return True
+            else:
+                self.redpanda.logger.info(
+                    f"Skipped operation: {op_type}, current cluster state does not allow executing the operation"
+                )
+                return False
+        except Exception as e:
+            self.redpanda.logger.debug(f"Operation: {op_type}", exc_info=True)
+            raise e
 
     def execute_with_retries(self, op_type, op):
         self.redpanda.logger.info(

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1207,14 +1207,14 @@ class RedpandaService(RedpandaServiceBase):
         """
         return 0.2 if first_start else 1.0
 
-    def wait_for_membership(self, first_start):
+    def wait_for_membership(self, first_start, timeout_sec=30):
         self.logger.info("Waiting for all brokers to join cluster")
         expected = set(self._started)
 
         wait_until(lambda: {n
                             for n in self._started
                             if self.registered(n)} == expected,
-                   timeout_sec=30,
+                   timeout_sec=timeout_sec,
                    backoff_sec=self._startup_poll_interval(first_start),
                    err_msg="Cluster membership did not stabilize")
 

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -60,14 +60,10 @@ class ControllerSnapshotPolicyTest(RedpandaTest):
 
 class ControllerSnapshotTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
-        # TODO: remove partition_autobalancing_mode after applying controller snapshots
-        # to partition_allocator gets implemented (rebalance on node addition doesn't
-        # like empty partition allocator)
         super().__init__(*args,
                          num_brokers=4,
                          extra_rp_conf={
                              'controller_snapshot_max_age_sec': 5,
-                             'partition_autobalancing_mode': 'off',
                          },
                          **kwargs)
 

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -35,11 +35,12 @@ class ControllerSnapshotPolicyTest(RedpandaTest):
         Test that Redpanda creates a controller snapshot some time after controller commands appear.
         """
         self.redpanda.start()
+        admin = Admin(self.redpanda)
 
         for n in self.redpanda.nodes:
-            assert self.redpanda.controller_start_offset(n) == 0
+            controller_status = admin.get_controller_status(n)
+            assert controller_status['start_offset'] == 0
 
-        admin = Admin(self.redpanda)
         admin.put_feature("controller_snapshots", {"state": "active"})
 
         # first snapshot will be triggered by the feature_update command

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -306,6 +306,9 @@ class ControllerSnapshotTest(RedpandaTest):
 
         # make a node join and check its state
 
+        # explicit clean step is needed because we are starting the node manually and not
+        # using redpanda.start()
+        self.redpanda.clean_node(joiner)
         self.redpanda.start_node(joiner)
         wait_until(lambda: self.redpanda.registered(joiner),
                    timeout_sec=30,


### PR DESCRIPTION
* Add a test with a lot of users, partitions and other controller commands and therefore a large controller snapshot.
* Add a test with random controller operations

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none