### PR TITLE
rpk: bugfix: preventing login to use default prod url

### DIFF
--- a/src/go/rpk/pkg/oauth/providers/auth0/auth0.go
+++ b/src/go/rpk/pkg/oauth/providers/auth0/auth0.go
@@ -52,6 +52,8 @@ func NewClient(cfg *cloudcfg.Config) *Client {
 	}
 	if auth0Endpoint.URL == "" && auth0Endpoint.Audience == "" {
 		auth0Endpoint = prodAuth0Endpoint
+		cfg.AuthURL = prodAuth0Endpoint.URL
+		cfg.AuthAudience = prodAuth0Endpoint.Audience
 	}
 
 	if cfg.AuthClientID == "" {


### PR DESCRIPTION
This change fixes a bug introduced in the recent
SSO changes which made rpk to not take the
default prod URL when `rpk cloud login` was
executed.


## Backports Required
- [ ] none - issue does not exist in previous branches


No release notes since the commit that introduced the bug is not released yet.

## Release Notes

* none
