### PR TITLE
cloud_storage_clients/s3: fix shutdown error handling

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -645,7 +645,9 @@ ss::future<> s3_client::do_put_object(
                   });
             })
             .handle_exception_type(
-              [](const ss::abort_requested_exception&) { return ss::now(); })
+              [](const ss::abort_requested_exception& err) {
+                  return ss::make_exception_future<>(err);
+              })
             .handle_exception_type([this](const rest_error_response& err) {
                 _probe->register_failure(err.code(), op_type_tag::upload);
                 return ss::make_exception_future<>(err);


### PR DESCRIPTION
We were returning ss::now(), indicating success, when the underlying http client threw an abort_requested exception during a PUT.

If we very unlucky, then:
- A PUT is ongoing during shutdown
- We do early shutdown of cloud_storage_clients in application::shutdown
- The PUT has not yet been acked by the server.
- The PUT appears to succeed to ntp_archiver, and it proceeds to compose an archival_metadata_stm batch and issue a write.
- application::shutdown hasn't yet got far enough to shut down raft, so the stm write is accepted.
- The end state is that archival_metadata_stm thinks a segment has been uploaded, but the segment is not present in the object store.

Fixes https://github.com/redpanda-data/redpanda/issues/10100

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* A bug is fixed where if a PUT to object storage was in flight during shutdown, Redpanda might incorrectly record a failed upload as successful.