### PR TITLE
[v22.3.x] cloud_storage_clients/s3: fix shutdown error handling

### DIFF
--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -632,7 +632,9 @@ ss::future<> client::put_object(
                 });
             })
             .handle_exception_type(
-              [](const ss::abort_requested_exception&) { return ss::now(); })
+              [](const ss::abort_requested_exception& err) {
+                  return ss::make_exception_future<>(err);
+              })
             .handle_exception_type([this](const rest_error_response& err) {
                 _probe->register_failure(err.code());
                 return ss::make_exception_future<>(err);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10107
Fixes https://github.com/redpanda-data/redpanda/issues/10113,