### PR TITLE
[v23.1.x] cloud_storage_clients/s3: fix shutdown error handling

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -645,7 +645,9 @@ ss::future<> s3_client::do_put_object(
                   });
             })
             .handle_exception_type(
-              [](const ss::abort_requested_exception&) { return ss::now(); })
+              [](const ss::abort_requested_exception& err) {
+                  return ss::make_exception_future<>(err);
+              })
             .handle_exception_type([this](const rest_error_response& err) {
                 _probe->register_failure(err.code(), op_type_tag::upload);
                 return ss::make_exception_future<>(err);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10107
Fixes https://github.com/redpanda-data/redpanda/issues/10115,