### PR TITLE
Do not store redundant `rack_id` information in allocator state

### DIFF
--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -52,6 +52,15 @@ members_table::get_node_metadata_ref(model::node_id id) const {
     return std::make_optional(std::cref(it->second));
 }
 
+std::optional<model::rack_id>
+members_table::get_node_rack_id(model::node_id id) const {
+    auto it = _nodes.find(id);
+    if (it == _nodes.end()) {
+        return std::nullopt;
+    }
+    return it->second.broker.rack();
+}
+
 std::optional<node_metadata>
 members_table::get_node_metadata(model::node_id id) const {
     auto it = _nodes.find(id);

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -39,6 +39,8 @@ public:
 
     std::optional<node_metadata> get_node_metadata(model::node_id) const;
 
+    std::optional<model::rack_id> get_node_rack_id(model::node_id) const;
+
     /// Returns reference to removed node metadata
     ///  TODO: remove after we stop keeping track of configuration in raft
     std::optional<std::reference_wrapper<const node_metadata>>

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -398,7 +398,7 @@ void partition_balancer_planner::get_rack_constraint_repair_reassignments(
     absl::flat_hash_set<model::rack_id> available_racks;
     for (auto node_id : rrs.all_nodes) {
         if (!rrs.timed_out_unavailable_nodes.contains(node_id)) {
-            auto rack = _partition_allocator.state().get_rack_id(node_id);
+            auto rack = _state.members().get_node_rack_id(node_id);
             if (rack) {
                 available_racks.insert(*rack);
             }
@@ -425,7 +425,7 @@ void partition_balancer_planner::get_rack_constraint_repair_reassignments(
         std::vector<model::broker_shard> stable_replicas;
         absl::flat_hash_set<model::rack_id> cur_racks;
         for (const auto& bs : orig_replicas) {
-            auto rack = _partition_allocator.state().get_rack_id(bs.node_id);
+            auto rack = _state.members().get_node_rack_id(bs.node_id);
             if (rack) {
                 auto [it, inserted] = cur_racks.insert(*rack);
                 if (inserted) {

--- a/src/v/cluster/partition_balancer_state.cc
+++ b/src/v/cluster/partition_balancer_state.cc
@@ -12,6 +12,7 @@
 
 #include "cluster/controller_snapshot.h"
 #include "cluster/logger.h"
+#include "cluster/members_table.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "config/configuration.h"
 #include "prometheus/prometheus_sanitize.h"
@@ -42,7 +43,7 @@ void partition_balancer_state::handle_ntp_update(
         absl::flat_hash_set<model::rack_id> racks;
         bool is_rack_constraint_violated = false;
         for (const auto& bs : next) {
-            auto rack = _partition_allocator.state().get_rack_id(bs.node_id);
+            auto rack = _members_table.get_node_rack_id(bs.node_id);
             if (rack) {
                 auto res = racks.insert(std::move(*rack));
                 if (!res.second) {

--- a/src/v/cluster/scheduling/allocation_node.cc
+++ b/src/v/cluster/scheduling/allocation_node.cc
@@ -19,13 +19,11 @@ namespace cluster {
 allocation_node::allocation_node(
   model::node_id id,
   uint32_t cpus,
-  std::optional<model::rack_id> rack,
   config::binding<uint32_t> partitions_per_shard,
   config::binding<uint32_t> partitions_reserve_shard0)
   : _id(id)
   , _weights(cpus)
   , _max_capacity((cpus * partitions_per_shard()) - partitions_reserve_shard0())
-  , _rack(std::move(rack))
   , _partitions_per_shard(std::move(partitions_per_shard))
   , _partitions_reserve_shard0(std::move(partitions_reserve_shard0))
   , _cpus(cpus) {

--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -34,7 +34,6 @@ public:
     allocation_node(
       model::node_id,
       uint32_t,
-      std::optional<model::rack_id>,
       config::binding<uint32_t>,
       config::binding<uint32_t>);
 
@@ -46,7 +45,6 @@ public:
 
     uint32_t cpus() const { return _weights.size(); }
     model::node_id id() const { return _id; }
-    const std::optional<model::rack_id>& rack() const noexcept { return _rack; }
 
     // Free partition space left for allocation in the node.
     // Reserved partitions are considered allocated
@@ -96,9 +94,6 @@ public:
     bool is_removed() const { return _state == state::deleted; }
 
     void update_core_count(uint32_t);
-    void update_rack(std::optional<model::rack_id> rack) {
-        _rack = std::move(rack);
-    }
 
     allocation_capacity allocated_partitions() const {
         return _allocated_partitions;
@@ -135,7 +130,6 @@ private:
     absl::flat_hash_map<partition_allocation_domain, allocation_capacity>
       _allocated_domain_partitions;
     state _state = state::active;
-    std::optional<model::rack_id> _rack;
 
     config::binding<uint32_t> _partitions_per_shard;
     config::binding<uint32_t> _partitions_reserve_shard0;

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -100,7 +100,6 @@ void allocation_state::register_node(
     auto node = std::make_unique<allocation_node>(
       broker.id(),
       broker.properties().cores,
-      broker.rack(),
       _partitions_per_shard,
       _partitions_reserve_shard0);
 
@@ -135,12 +134,10 @@ void allocation_state::update_allocation_nodes(
               std::make_unique<allocation_node>(
                 b.id(),
                 b.properties().cores,
-                b.rack(),
                 _partitions_per_shard,
                 _partitions_reserve_shard0));
         } else {
             it->second->update_core_count(b.properties().cores);
-            it->second->update_rack(b.rack());
             // node was added back to the cluster
             if (it->second->is_removed()) {
                 it->second->mark_as_active();
@@ -158,12 +155,10 @@ void allocation_state::upsert_allocation_node(const model::broker& broker) {
           std::make_unique<allocation_node>(
             broker.id(),
             broker.properties().cores,
-            broker.rack(),
             _partitions_per_shard,
             _partitions_reserve_shard0));
     } else {
         it->second->update_core_count(broker.properties().cores);
-        it->second->update_rack(broker.rack());
         // node was added back to the cluster
         if (it->second->is_removed()) {
             it->second->mark_as_active();
@@ -231,14 +226,6 @@ result<uint32_t> allocation_state::allocate(
     }
 
     return errc::node_does_not_exists;
-}
-
-std::optional<model::rack_id>
-allocation_state::get_rack_id(model::node_id id) const {
-    if (auto it = _nodes.find(id); it != _nodes.end()) {
-        return it->second->rack();
-    }
-    vassert(false, "unexpected node id {}", id);
 }
 
 void allocation_state::verify_shard() const {

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -68,12 +68,6 @@ public:
     raft::group_id last_group_id() const { return _highest_group; }
     void set_last_group_id(raft::group_id id) { _highest_group = id; }
 
-    // Get rack information
-    //
-    // Return rack id or nullopt if rack id is not configured
-    // for the broker.
-    std::optional<model::rack_id> get_rack_id(model::node_id) const;
-
 private:
     /**
      * This function verifies that the current shard matches the shard the

--- a/src/v/cluster/scheduling/constraints.cc
+++ b/src/v/cluster/scheduling/constraints.cc
@@ -10,6 +10,7 @@
  */
 #include "cluster/scheduling/constraints.h"
 
+#include "cluster/members_table.h"
 #include "cluster/scheduling/allocation_node.h"
 #include "cluster/scheduling/allocation_state.h"
 #include "cluster/scheduling/types.h"
@@ -341,10 +342,10 @@ soft_constraint make_soft_constraint(hard_constraint constraint) {
     return soft_constraint(std::make_unique<impl>(std::move(constraint)));
 }
 
-soft_constraint distinct_rack_preferred(const allocation_state& state) {
+soft_constraint distinct_rack_preferred(const members_table& members) {
     return distinct_labels_preferred(
       rack_label.data(),
-      [&state](model::node_id id) { return state.get_rack_id(id); });
+      [&members](model::node_id id) { return members.get_node_rack_id(id); });
 }
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "cluster/members_table.h"
 #include "cluster/partition_balancer_types.h"
 #include "cluster/scheduling/allocation_node.h"
 #include "cluster/scheduling/types.h"
@@ -137,6 +138,6 @@ distinct_labels_preferred(const char* label_name, Mapper&& mapper) {
       std::make_unique<impl>(label_name, std::forward<Mapper>(mapper)));
 }
 
-soft_constraint distinct_rack_preferred(const allocation_state& state);
+soft_constraint distinct_rack_preferred(const members_table&);
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -69,7 +69,7 @@ allocation_constraints partition_allocator::default_constraints(
         req.add(least_allocated_in_domain(domain));
     }
     if (_enable_rack_awareness()) {
-        req.add(distinct_rack_preferred(*_state));
+        req.add(distinct_rack_preferred(_members.local()));
     }
     return req;
 }

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -78,8 +78,8 @@ FIXTURE_TEST(unregister_node, partition_allocator_fixture) {
 }
 
 FIXTURE_TEST(invalid_allocation_over_capacity, partition_allocator_fixture) {
-    register_node(0, 8);
-    register_node(1, 4);
+    register_node(0, 6);
+    register_node(1, 6);
     register_node(2, 6);
 
     saturate_all_machines();
@@ -401,7 +401,6 @@ FIXTURE_TEST(updating_nodes_properties, partition_allocator_fixture) {
       it->second->max_capacity(),
       10 * partition_allocator_fixture::partitions_per_shard
         - partition_allocator_fixture::partitions_reserve_shard0);
-    BOOST_REQUIRE_EQUAL(it->second->rack(), new_rack);
 }
 
 FIXTURE_TEST(change_replication_factor, partition_allocator_fixture) {

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -38,14 +38,11 @@ constexpr std::chrono::seconds node_unavailable_timeout = std::chrono::minutes(
 static constexpr uint32_t partitions_per_shard = 7000;
 static constexpr uint32_t partitions_reserve_shard0 = 2;
 
-static std::unique_ptr<cluster::allocation_node> create_allocation_node(
-  model::node_id nid,
-  uint32_t cores,
-  const std::optional<model::rack_id>& rack_id = std::nullopt) {
+static std::unique_ptr<cluster::allocation_node>
+create_allocation_node(model::node_id nid, uint32_t cores) {
     return std::make_unique<cluster::allocation_node>(
       nid,
       cores,
-      rack_id,
       config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
       config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}));
 }
@@ -192,8 +189,8 @@ struct partition_balancer_planner_fixture {
                 rack_id = model::rack_id{rack_ids[i]};
             }
 
-            workers.allocator.local().register_node(create_allocation_node(
-              model::node_id(last_node_idx), 4, rack_id));
+            workers.allocator.local().register_node(
+              create_allocation_node(model::node_id(last_node_idx), 4));
             new_brokers.push_back(model::broker(
               model::node_id(last_node_idx),
               net::unresolved_address{},

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -891,8 +891,7 @@ FIXTURE_TEST(test_rack_awareness_repair, partition_balancer_planner_fixture) {
         BOOST_REQUIRE_EQUAL(new_replicas.size(), 3);
         absl::node_hash_set<model::rack_id> racks;
         for (const auto& bs : new_replicas) {
-            auto rack = workers.allocator.local().state().get_rack_id(
-              bs.node_id);
+            auto rack = workers.members.local().get_node_rack_id(bs.node_id);
             BOOST_REQUIRE(rack);
             racks.insert(*rack);
         }

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -77,7 +77,6 @@ struct topic_table_fixture {
         return std::make_unique<cluster::allocation_node>(
           nid,
           cores,
-          std::nullopt,
           config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
           config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}));
     }


### PR DESCRIPTION
Rack information is alredy stored in members table. There is no reason to keep it in the partition allocator. More flexible constraints interfaces allow us to use the `rack_id` coming from the `members_table`. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none