### PR TITLE
archival: remove redundant manifest upload after GC

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1805,12 +1805,8 @@ ss::future<> ntp_archiver::housekeeping() {
             // external housekeeping jobs from upload_housekeeping_service
             // and retention/GC
             auto units = co_await ss::get_units(_mutex, 1, _as);
-            const auto retention_updated_manifest = co_await apply_retention();
-            const auto gc_updated_manifest = co_await garbage_collect();
-            if (retention_updated_manifest || gc_updated_manifest) {
-                co_await upload_manifest(housekeeping_ctx_label);
-                co_await flush_manifest_clean_offset();
-            }
+            co_await apply_retention();
+            co_await garbage_collect();
         }
     } catch (std::exception& e) {
         vlog(_rtclog.warn, "Error occured during housekeeping", e.what());

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -767,9 +767,8 @@ ss::future<bool> ntp_archiver::maybe_upload_manifest(const char* upload_ctx) {
 
 ss::future<> ntp_archiver::maybe_flush_manifest_clean_offset() {
     if (
-      _projected_manifest_clean_at.has_value()
-      && ss::lowres_clock::now() - _last_marked_clean_time
-           > _manifest_upload_interval()) {
+      local_storage_pressure()
+      || (_projected_manifest_clean_at.has_value() && ss::lowres_clock::now() - _last_marked_clean_time > _manifest_upload_interval())) {
         co_return co_await flush_manifest_clean_offset();
     }
 }


### PR DESCRIPTION
The important upload is the one that happens inside garbage_collect(), because we need to update the
manifest to avoid external readers (scrubbers and
read replicas) getting upset that they got a 404
reading a segment that's meant to exist.

The upload _after_ garbage collection only serves
to trim the 'segments' and/or 'replaced' vectors
in the remote copy of the manifest, which has no
logical impact.  We can rely on the next periodic
manifest upload (manifest_upload_interval) to
pick that up.

Followup to https://github.com/redpanda-data/redpanda/pull/10099

## Backports Required

**By hand, together with #10099**

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none