### PR TITLE
ducktape test service for redpanda on k8s for a simple test

### DIFF
--- a/tests/rptest/clients/helm.py
+++ b/tests/rptest/clients/helm.py
@@ -1,0 +1,45 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import subprocess
+
+
+class HelmTool:
+    """
+    Wrapper around helm.
+    """
+    def __init__(self, redpanda):
+        self._redpanda = redpanda
+
+    def install(self):
+        cmd = [
+            'helm', 'install', 'redpanda', 'redpanda/redpanda', '--namespace',
+            'redpanda', '--create-namespace', '--set',
+            'external.domain=customredpandadomain.local', '--set',
+            'statefulset.initContainers.setDataDirOwnership.enabled=true',
+            '--wait'
+        ]
+        try:
+            subprocess.check_output(cmd)
+        except subprocess.CalledProcessError as e:
+            # log but ignore for now
+            self._redpanda.logger.info("helm error {}: {}".format(
+                e.returncode, e.output))
+
+    def uninstall(self):
+        cmd = [
+            'helm', 'uninstall', '--namespace', 'redpanda', 'redpanda',
+            '--wait'
+        ]
+        try:
+            subprocess.check_output(cmd)
+        except subprocess.CalledProcessError as e:
+            # log but ignore for now
+            self._redpanda.logger.info("helm error {}: {}".format(
+                e.returncode, e.output))

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import subprocess
+
+
+class KubectlTool:
+    """
+    Wrapper around kubectl.
+    """
+    def __init__(self, redpanda):
+        self._redpanda = redpanda
+
+    def exec(self, remote_cmd):
+        cmd = [
+            'kubectl', 'exec', '-n', 'redpanda', 'redpanda-0', '--', 'bash',
+            '-c'
+        ] + [remote_cmd]
+        try:
+            res = subprocess.check_output(cmd)
+        except subprocess.CalledProcessError as e:
+            # log but ignore for now
+            self._redpanda.logger.info("kubectl error {}: {}".format(
+                e.returncode, e.output))
+        return res
+
+    def exists(self, remote_path):
+        cmd = [
+            'kubectl', 'exec', '-n', 'redpanda', 'redpanda-0', '--', 'stat'
+        ] + [remote_path]
+        try:
+            subprocess.check_output(cmd)
+            return True
+        except subprocess.CalledProcessError as e:
+            return False

--- a/tests/rptest/k8s_tests/README.md
+++ b/tests/rptest/k8s_tests/README.md
@@ -1,0 +1,3 @@
+# k8s_tests
+
+Tests in this directory are intended to only run on k8s deployments of redpanda.

--- a/tests/rptest/k8s_tests/simple_k8s_test.py
+++ b/tests/rptest/k8s_tests/simple_k8s_test.py
@@ -1,0 +1,30 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.tests.test import Test
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RedpandaServiceK8s
+
+
+class SimpleK8sTest(Test):
+    def __init__(self, test_context):
+        """
+        Keep it simple.
+        """
+        super(SimpleK8sTest, self).__init__(test_context)
+        self.redpanda = RedpandaServiceK8s(test_context, 1)
+
+    @cluster(num_nodes=1, check_allowed_error_logs=False)
+    def test_k8s(self):
+        '''
+        Validate startup of k8s.
+        '''
+        self.redpanda.start_node(None)
+        node_memory = float(self.redpanda.get_node_memory_mb())
+        assert node_memory > 1.0


### PR DESCRIPTION
Fixes #9709

This PR gets some of the functionality implemented for `RedpandaServiceK8s` so vtools task targets can be worked on in tracking issue https://github.com/redpanda-data/vtools/issues/1731. This does not implement all of the methods in `RedpandaServiceBase` that need to be implemented yet, but it does allow for a small test `simple_k8s_test.py` to exercise use of `helm` and `kubectl`. 

Note: the `--cluster-file=dbuild/ducktape/cluster/ducktape_cluster.json` still expects the docker format of cluster information, but is totally not used for launching k8s in this PR. This will be fixed in a following PR.

I've put the `simple_k8s_test.py` in a new dir `k8s_tests` so it is not lumped in with existing ducktape tests in our testing pipeline. Here is an output of a manual run:
```console
bash$ ducktape --cluster=ducktape.cluster.json.JsonCluster --cluster-file=dbuild/ducktape/cluster/ducktape_cluster.json tests/rptest/k8s_tests/simple_k8s_test.py
[INFO:2023-04-21 06:51:20,723]: starting test run with session id 2023-04-21--001...
[INFO:2023-04-21 06:51:20,723]: running 1 tests...
[INFO:2023-04-21 06:51:20,723]: Triggering test 1 of 1...
[INFO:2023-04-21 06:51:20,728]: RunnerClient: Loading test {'directory': '/home/a/src/redpanda/tests/rptest/k8s_tests', 'file_name': 'simple_k8s_test.py', 'cls_name': 'SimpleK8sTest', 'method_name': 'test_k8s', 'injected_args': None}
[INFO:2023-04-21 06:51:20,731]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Setting up...
[INFO:2023-04-21 06:51:20,731]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Running...
Defaulted container "redpanda" out of: redpanda, tuning (init), set-datadir-ownership (init), redpanda-configurator (init)
[INFO:2023-04-21 06:52:20,514]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: PASS
[INFO:2023-04-21 06:52:20,515]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Tearing down...
Error: uninstall: Release not loaded: redpanda: release: not found
[INFO:2023-04-21 06:52:22,678]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Summary:
[INFO:2023-04-21 06:52:22,678]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Data: None
test_id:    rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s
status:     PASS
run time:   1 minute 1.946 seconds
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
==================================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-04-21--001
run time:         1 minute 1.958 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
==================================================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none