### PR TITLE
vim: Add search paths for coc-clangd plugin

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,3 +1,4 @@
 {
-    "clangd.path": "vbuild/llvm/install/bin/clangd"
+    "clangd.path": "vbuild/llvm/install/bin/clangd",
+    "clangd.compilationDatabaseCandidates": ["vbuild/debug/clang", "vbuild/release/clang"]
 }

--- a/src/v/.vim/coc-settings.json
+++ b/src/v/.vim/coc-settings.json
@@ -1,3 +1,4 @@
 {
-  "clangd.path": "../../vbuild/llvm/install/bin/clangd"
+  "clangd.path": "../../vbuild/llvm/install/bin/clangd",
+  "clangd.compilationDatabaseCandidates": ["../../vbuild/debug/clang", "../../vbuild/release/clang"]
 }


### PR DESCRIPTION
Instead of symlinking compilation_commands.json from the source
directory into the root, we can configure the clangd plugin to search
in build directories. This removes a manual step and supports release or
debug builds. We default to searching for the file in debug build
directory as we expect most folks default to building redpanda in dev
mode.

See full list of configuration options for coc-clangd:
https://github.com/clangd/coc-clangd/tree/master#configurations

Logic for locating a compilation_commands.json file:
https://github.com/clangd/coc-clangd/blob/bb97d96db42f6ed567157fa87113779fbcda7b9d/src/ctx.ts#L165

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
