### PR TITLE
rpk -X work: fixup missing import on darwin

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/redpanda_darwin.go
+++ b/src/go/rpk/pkg/cli/redpanda/redpanda_darwin.go
@@ -14,6 +14,7 @@ package redpanda
 
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/redpanda/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none