### PR TITLE
Make credentials endpoint configurable

### DIFF
--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -10,10 +10,11 @@
 
 #pragma once
 
+#include "cloud_roles/logger.h"
 #include "cloud_roles/probe.h"
 #include "cloud_roles/signature.h"
+#include "config/configuration.h"
 #include "model/metadata.h"
-#include "seastarx.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -175,6 +176,17 @@ refresh_credentials make_refresh_credentials(
   std::optional<net::unresolved_address> endpoint = std::nullopt,
   retry_params retry_params = default_retry_params) {
     auto host = endpoint ? endpoint->host() : CredentialsProvider::default_host;
+    if (auto cfg_host
+        = config::shard_local_cfg().cloud_storage_credentials_host();
+        cfg_host.has_value()) {
+        vlog(
+          clrl_log.info,
+          "overriding default cloud roles credentials host {} with {} set "
+          "in configuration.",
+          host,
+          cfg_host.value());
+        host = cfg_host.value();
+    }
     auto port = endpoint ? endpoint->port() : CredentialsProvider::default_port;
     auto impl = std::make_unique<CredentialsProvider>(
       net::unresolved_address{{host.data(), host.size()}, port},

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1394,6 +1394,15 @@ configuration::configuration()
        model::cloud_storage_backend::azure,
        model::cloud_storage_backend::minio,
        model::cloud_storage_backend::unknown})
+  , cloud_storage_credentials_host(
+      *this,
+      "cloud_storage_credentials_host",
+      "The hostname to connect to for retrieving role based credentials. "
+      "Derived from cloud_storage_credentials_source if not set. Only required "
+      "when using IAM role based access.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -274,6 +274,7 @@ struct configuration final : public config_store {
     property<std::optional<std::chrono::milliseconds>>
       cloud_storage_graceful_transfer_timeout_ms;
     enum_property<model::cloud_storage_backend> cloud_storage_backend;
+    property<std::optional<ss::sstring>> cloud_storage_credentials_host;
 
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/10139

Additionally also allows the AWS and GCP endpoints to be configured.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

### Features

* The credentials host for the IAM roles subsystem can be overridden by setting the new optional string property `cloud_storage_credentials_host` to a valid hostname. The credentials will then be requested from this hostname. Change to this property requires a restart.

