### PR TITLE
cloud_roles: Initialize hostname with sstring

### DIFF
--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -175,7 +175,12 @@ refresh_credentials make_refresh_credentials(
   aws_region_name region,
   std::optional<net::unresolved_address> endpoint = std::nullopt,
   retry_params retry_params = default_retry_params) {
-    auto host = endpoint ? endpoint->host() : CredentialsProvider::default_host;
+    ss::sstring host = {
+      CredentialsProvider::default_host.data(),
+      CredentialsProvider::default_host.size()};
+    if (endpoint) {
+        host = endpoint->host();
+    }
     if (auto cfg_host
         = config::shard_local_cfg().cloud_storage_credentials_host();
         cfg_host.has_value()) {
@@ -197,8 +202,8 @@ refresh_credentials make_refresh_credentials(
       std::move(impl), as, std::move(creds_update_cb), std::move(region)};
 }
 
-/// Builds a refresh_credentials object based on the credentials source set in
-/// configuration.
+/// Builds a refresh_credentials object based on the credentials source set
+/// in configuration.
 refresh_credentials make_refresh_credentials(
   model::cloud_credentials_source cloud_credentials_source,
   ss::abort_source& as,

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -232,6 +232,9 @@ FIXTURE_TEST(test_sts_credentials, http_imposter_fixture) {
     setenv("AWS_ROLE_ARN", cloud_role_tests::aws_role, 1);
     setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "test_sts_creds_f", 1);
 
+    config::shard_local_cfg().cloud_storage_credentials_host.set_value(
+      std::optional<ss::sstring>{"localhost"});
+
     when()
       .request("/")
       .with_method(ss::httpd::POST)


### PR DESCRIPTION
Fixes a bug in hostname override where the hostname could end up being initialized as a string_view due to the use of `auto` type deduction, thus causing a memory sanitization error. 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
### Bug Fixes

* Fixes a bug in hostname override where the hostname could end up being initialized as a string_view, thus causing a memory sanitization error
