### PR TITLE
rpk: add admin API TLS flag to generate grafana

### DIFF
--- a/src/go/rpk/pkg/cli/generate/generate.go
+++ b/src/go/rpk/pkg/cli/generate/generate.go
@@ -21,7 +21,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short: "Generate a configuration template for related services",
 	}
 	cmd.AddCommand(
-		newGrafanaDashboardCmd(),
+		newGrafanaDashboardCmd(p),
 		newPrometheusConfigCmd(fs, p),
 		newShellCompletionCommand(),
 	)

--- a/src/go/rpk/pkg/cli/generate/grafana.go
+++ b/src/go/rpk/pkg/cli/generate/grafana.go
@@ -29,9 +29,11 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/generate/graf"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -100,7 +102,7 @@ func newRowSet() *RowSet {
 	}
 }
 
-func newGrafanaDashboardCmd() *cobra.Command {
+func newGrafanaDashboardCmd(p *config.Params) *cobra.Command {
 	var (
 		dashboard       string
 		datasource      string
@@ -191,6 +193,15 @@ To see a list of all available dashboards, use the '--dashboard help' flag.
 			opts = append(opts, s)
 		}
 		return opts, cobra.ShellCompDirectiveDefault
+	})
+
+	// We install the Admin Flags in case TLS is enabled in the metric endpoint.
+	p.InstallAdminFlags(cmd)
+	// And the kafka flags in case basic authentication is used too.
+	p.InstallKafkaFlags(cmd)
+	// Then we hide all these flags, so it doesn't show in the help text.
+	cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		cmd.PersistentFlags().MarkHidden(flag.Name)
 	})
 
 	return cmd

--- a/src/go/rpk/pkg/cli/generate/grafana_test.go
+++ b/src/go/rpk/pkg/cli/generate/grafana_test.go
@@ -19,11 +19,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrometheusURLFlagDeprecation(t *testing.T) {
-	cmd := newGrafanaDashboardCmd()
+	p := new(config.Params)
+	cmd := newGrafanaDashboardCmd(p)
 	cmd.SetArgs([]string{
 		"--prometheus-url", "localhost:8888/metrics",
 		"--datasource", "prometheus",


### PR DESCRIPTION
But these flags will be hidden since they will be
only used by the legacy dashboard.


Fixes #5623
## Backports Required
- [ ] none - papercut/not impactful enough to backport


## Release Notes
### Features

* Add the ability to pass rpk TLS configuration flags to the legacy dashboard.

