### PR TITLE
tests: update ducktape version

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@5b4c31648d8f94d3f28113a6fa0377339aa222ed',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@fd01d72b8c82ae852986bb288c69818c7ffb4de8',
         'prometheus-client==0.9.0',
         'pyyaml==6.0',
         'kafka-python==2.0.2',


### PR DESCRIPTION
update ducktape to latest version on our fork.

comparison of changes: https://github.com/redpanda-data/ducktape/compare/5b4c31648d8f94d3f28113a6fa0377339aa222ed...fd01d72b8c82ae852986bb288c69818c7ffb4de8

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none