### PR TITLE
cloud_storage: remove dependency on raft

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -902,46 +902,10 @@ ss::future<bool> remote_partition::tolerant_delete_objects(
 
 static constexpr ss::lowres_clock::duration erase_timeout = 60s;
 static constexpr ss::lowres_clock::duration erase_backoff = 1s;
-static constexpr ss::lowres_clock::duration erase_non_0th_delay = 200ms;
 
-/**
- * Return the index of this node in the list of voters, or nullopt if it
- * is not a voter.
- */
-std::optional<size_t>
-voter_position(raft::vnode self, const raft::group_configuration& raft_config) {
-    const auto& voters = raft_config.current_config().voters;
-    auto position = std::find(voters.begin(), voters.end(), self);
-    if (position == voters.end()) {
-        return std::nullopt;
-    } else {
-        return position - voters.begin();
-    }
-}
-
-ss::future<remote_partition::finalize_result> remote_partition::finalize(
-  ss::abort_source& as,
-  raft::vnode self,
-  raft::group_configuration raft_config) {
+ss::future<remote_partition::finalize_result>
+remote_partition::finalize(ss::abort_source& as) {
     vlog(_ctxlog.info, "Finalizing remote storage state...");
-
-    // To reduce redundant re-uploads in the typical case of all replicas
-    // being alive, have all non-0th replicas delay before attempting to
-    // reconcile the manifest. This is just a best-effort thing, it is
-    // still okay for them to step on each other: finalization is best
-    // effort and the worst case outcome is to leave behind a few orphan
-    // objects if writes were ongoing while deletion happened.
-    auto my_position = voter_position(self, raft_config);
-    if (my_position.has_value()) {
-        auto p = my_position.value();
-        if (p != 0) {
-            co_await ss::sleep_abortable(erase_non_0th_delay * p, as);
-        }
-    } else {
-        co_return finalize_result{
-          // Synthetic success, as we will no-op on non-voters
-          .get_status = download_result::success};
-    }
 
     // This function is called after ::stop, so we may not use our
     // main retry_chain_node which is bound to our abort source,
@@ -1026,22 +990,19 @@ ss::future<remote_partition::finalize_result> remote_partition::finalize(
  *    S3, not the state of the archival metadata stm (which can be out
  *    of date if e.g. we were not the leader)
  */
-ss::future<> remote_partition::erase(
-  ss::abort_source& as,
-  raft::vnode self,
-  raft::group_configuration raft_config) {
-    if (!raft_config.is_voter(self)) {
-        // Learners are excluded from deletion, because they have a high
-        // risk of having some out of date state, and because there will
-        // always be some voter peers to do the work.
-        co_return;
-    }
-
+ss::future<> remote_partition::erase(ss::abort_source& as, bool do_finalize) {
     // Even though we are going to delete objects, it is still important
     // to flush metadata first, so that if we are interrupted, a future
     // node doing a tombstone-driven deletion can accurately get the
     // segment list.
-    auto finalize_result = co_await finalize(as, self, raft_config);
+    remote_partition::finalize_result finalize_result;
+    if (do_finalize) {
+        finalize_result = co_await finalize(as);
+    } else {
+        finalize_result = remote_partition::finalize_result{
+          // Synthetic success, as we will no-op on non-voters
+          .get_status = download_result::success};
+    }
 
     if (finalize_result.get_status != download_result::success) {
         // If we couldn't read a remote manifest at all, give up here rather

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -147,12 +147,10 @@ public:
 
     /// Flush metadata to object storage, prior to a topic deletion with
     /// remote deletion disabled.
-    ss::future<finalize_result>
-    finalize(ss::abort_source&, raft::vnode, raft::group_configuration);
+    ss::future<finalize_result> finalize(ss::abort_source&);
 
     /// Remove objects from S3
-    ss::future<>
-    erase(ss::abort_source&, raft::vnode, raft::group_configuration);
+    ss::future<> erase(ss::abort_source&, bool finalize);
 
     /// Hook for materialized_segment to notify us when a segment is evicted
     void offload_segment(model::offset);


### PR DESCRIPTION
The business logic for sleeping and skipping finalization that is baked into remote_partition::{finalize,erase} depended on raft configuration state. This resulted in an inconvenient dependency between the two subsystems. This PR removes this dependency by moving the business logic for this behavior that depends on the raft state to the user of the remote partition.

The goal of this transformation is to preserve exactly the same semantics. A reviewer will likely notice what appears to be two separate mechanisms for determining if the current node is a voter or not. It is not obvious that these two mechanisms (APIs) are identical. If so, a future clean-up may be useful to remove the ambiguity in the the voter check.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

