### PR TITLE
cluster: fix odr violation in rm_stm compat test

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -113,13 +113,6 @@ model::record_batch make_fence_batch_v2(
     return std::move(builder).build();
 }
 
-struct fence_batch_data {
-    model::batch_identity bid;
-    std::optional<model::tx_seq> tx_seq;
-    std::optional<std::chrono::milliseconds> transaction_timeout_ms;
-    model::partition_id tm;
-};
-
 fence_batch_data read_fence_batch(model::record_batch&& b) {
     const auto& hdr = b.header();
     auto bid = model::batch_identity::from(hdr);

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -834,4 +834,26 @@ private:
     ss::metrics::metric_groups _metrics;
 };
 
+struct fence_batch_data {
+    model::batch_identity bid;
+    std::optional<model::tx_seq> tx_seq;
+    std::optional<std::chrono::milliseconds> transaction_timeout_ms;
+    model::partition_id tm;
+};
+
+model::record_batch make_fence_batch_v0(model::producer_identity pid);
+
+model::record_batch make_fence_batch_v1(
+  model::producer_identity pid,
+  model::tx_seq tx_seq,
+  std::chrono::milliseconds transaction_timeout_ms);
+
+model::record_batch make_fence_batch_v2(
+  model::producer_identity pid,
+  model::tx_seq tx_seq,
+  std::chrono::milliseconds transaction_timeout_ms,
+  model::partition_id tm);
+
+fence_batch_data read_fence_batch(model::record_batch&& b);
+
 } // namespace cluster

--- a/src/v/cluster/tests/rm_stm_compatibility_test.cc
+++ b/src/v/cluster/tests/rm_stm_compatibility_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/rm_stm.h"
 #include "model/record.h"
 
 #include <seastar/testing/thread_test_case.hh>
@@ -14,8 +15,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <optional>
-
-#include "cluster/rm_stm.cc"
 
 namespace cluster {
 


### PR DESCRIPTION
```
47: ==648522==ERROR: AddressSanitizer: odr-violation (0x5611f89d4220):
47:   [1] size=240 'vtable for cluster::rm_stm' /home/nwatkins/src/redpanda/src/v/cluster/tests/rm_stm_compatibility_test.cc
47:   [2] size=240 'vtable for cluster::rm_stm' /home/nwatkins/src/redpanda/src/v/cluster/rm_stm.cc
```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

