### PR TITLE
http_imposter: require explict port configuration

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -74,7 +74,8 @@ struct archival_metadata_stm_base_fixture
         return conf;
     }
 
-    archival_metadata_stm_base_fixture() {
+    archival_metadata_stm_base_fixture()
+      : http_imposter_fixture(4446) {
         // Blank feature table to satisfy constructor interface
         feature_table.start().get();
         // Cloud storage config

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -43,9 +43,6 @@
 
 #include <optional>
 
-/// For http_imposter to run this binary with a unique port
-uint16_t unit_test_httpd_port_number() { return 4441; }
-
 namespace archival {
 
 using namespace std::chrono_literals;
@@ -53,7 +50,7 @@ using namespace std::chrono_literals;
 inline ss::logger fixt_log("fixture"); // NOLINT
 
 archiver_fixture::archiver_fixture()
-  : http_imposter_fixture()
+  : http_imposter_fixture(4441)
   , redpanda_thread_fixture(
       redpanda_thread_fixture::init_cloud_storage_no_archiver_tag{}) {
     ss::smp::invoke_on_all([port = httpd_port_number()]() {

--- a/src/v/cloud_roles/tests/role_client_tests.cc
+++ b/src/v/cloud_roles/tests/role_client_tests.cc
@@ -27,7 +27,13 @@ namespace ba = boost::algorithm;
 
 static const cloud_roles::aws_region_name region{""};
 
-FIXTURE_TEST(test_simple_token_request, http_imposter_fixture) {
+class fixture : public http_imposter_fixture {
+public:
+    fixture()
+      : http_imposter_fixture(4445) {}
+};
+
+FIXTURE_TEST(test_simple_token_request, fixture) {
     when()
       .request(cloud_role_tests::gcp_url)
       .then_reply_with(cloud_role_tests::gcp_oauth_token);
@@ -42,7 +48,7 @@ FIXTURE_TEST(test_simple_token_request, http_imposter_fixture) {
     BOOST_REQUIRE(has_call(cloud_role_tests::gcp_url));
 }
 
-FIXTURE_TEST(test_bad_response_handling, http_imposter_fixture) {
+FIXTURE_TEST(test_bad_response_handling, fixture) {
     listen();
     ss::abort_source as;
 
@@ -55,7 +61,7 @@ FIXTURE_TEST(test_bad_response_handling, http_imposter_fixture) {
     BOOST_REQUIRE_EQUAL(error.reason, "http request failed:Not Found");
 }
 
-FIXTURE_TEST(test_gateway_down, http_imposter_fixture) {
+FIXTURE_TEST(test_gateway_down, fixture) {
     when()
       .request(cloud_role_tests::gcp_url)
       .then_reply_with(ss::http::reply::status_type::gateway_timeout);
@@ -71,7 +77,7 @@ FIXTURE_TEST(test_gateway_down, http_imposter_fixture) {
     BOOST_REQUIRE_EQUAL(error.reason, "http request failed:Gateway Timeout");
 }
 
-FIXTURE_TEST(test_aws_role_fetch_on_startup, http_imposter_fixture) {
+FIXTURE_TEST(test_aws_role_fetch_on_startup, fixture) {
     when()
       .request(cloud_role_tests::aws_role_query_url)
       .then_reply_with(cloud_role_tests::aws_role);
@@ -94,7 +100,7 @@ FIXTURE_TEST(test_aws_role_fetch_on_startup, http_imposter_fixture) {
       iobuf_to_bytes(std::get<iobuf>(resp)), cloud_role_tests::aws_creds);
 }
 
-FIXTURE_TEST(test_sts_credentials_fetch, http_imposter_fixture) {
+FIXTURE_TEST(test_sts_credentials_fetch, fixture) {
     when()
       .request("/")
       .with_method(ss::httpd::POST)

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -19,36 +19,18 @@
 
 static ss::logger http_imposter_log("http_imposter"); // NOLINT
 
-/**
- * Listening on TCP ports from a unit test is not a great practice, but we
- * do it in some places.  To enable these unit tests to run in parallel,
- * each unit test binary must declare its own function to pick a port that
- * no other unit test uses.
- */
-extern uint16_t unit_test_httpd_port_number();
-
-http_imposter_fixture::http_imposter_fixture()
-  : _server_addr{ss::ipv4_addr{
-    httpd_host_name.data(), unit_test_httpd_port_number()}}
+http_imposter_fixture::http_imposter_fixture(uint16_t port)
+  : _port(port)
+  , _server_addr{ss::ipv4_addr{httpd_host_name.data(), httpd_port_number()}}
   , _address{
-      {httpd_host_name.data(), httpd_host_name.size()},
-      unit_test_httpd_port_number()} {
-    _id = fmt::format("{}", uuid_t::create());
-    _server.start().get();
-}
-
-http_imposter_fixture::http_imposter_fixture(net::unresolved_address address)
-  : _server_addr{ss::ipv4_addr{address.host().data(), address.port()}}
-  , _address{address} {
+      {httpd_host_name.data(), httpd_host_name.size()}, httpd_port_number()} {
     _id = fmt::format("{}", uuid_t::create());
     _server.start().get();
 }
 
 http_imposter_fixture::~http_imposter_fixture() { _server.stop().get(); }
 
-uint16_t http_imposter_fixture::httpd_port_number() {
-    return unit_test_httpd_port_number();
-}
+uint16_t http_imposter_fixture::httpd_port_number() { return _port; }
 
 void http_imposter_fixture::start_request_masking(
   http_test_utils::response canned_response,

--- a/src/v/http/tests/http_imposter.h
+++ b/src/v/http/tests/http_imposter.h
@@ -30,8 +30,14 @@ public:
 
     using predicates = std::vector<request_predicate>;
 
-    http_imposter_fixture();
-    http_imposter_fixture(net::unresolved_address address);
+    /**
+     * Listening on TCP ports from a unit test is not a great practice, but we
+     * do it in some places. To enable these unit tests to run in parallel,
+     * each unit test binary must declare its own function to pick a port that
+     * no other unit test uses.
+     */
+    explicit http_imposter_fixture(uint16_t port);
+
     virtual ~http_imposter_fixture();
 
     http_imposter_fixture(const http_imposter_fixture&) = delete;
@@ -133,6 +139,7 @@ private:
 
     void set_routes(ss::httpd::routes& r);
 
+    uint16_t _port;
     ss::socket_address _server_addr;
     ss::httpd::http_server_control _server;
 

--- a/src/v/http/tests/http_imposter_test.cc
+++ b/src/v/http/tests/http_imposter_test.cc
@@ -17,10 +17,13 @@
 
 namespace bh = boost::beast::http;
 
-/// For http_imposter to run this binary with a unique port
-uint16_t unit_test_httpd_port_number() { return 4443; }
+class fixture : public http_imposter_fixture {
+public:
+    fixture()
+      : http_imposter_fixture(4443) {}
+};
 
-FIXTURE_TEST(test_get, http_imposter_fixture) {
+FIXTURE_TEST(test_get, fixture) {
     when()
       .request("/foo")
       .with_method(ss::httpd::GET)
@@ -52,7 +55,7 @@ FIXTURE_TEST(test_get, http_imposter_fixture) {
     BOOST_REQUIRE(has_call("/foo"));
 }
 
-FIXTURE_TEST(test_post, http_imposter_fixture) {
+FIXTURE_TEST(test_post, fixture) {
     when()
       .request("/foo")
       .with_method(ss::httpd::POST)
@@ -85,7 +88,7 @@ FIXTURE_TEST(test_post, http_imposter_fixture) {
     BOOST_REQUIRE(has_call("/foo"));
 }
 
-FIXTURE_TEST(test_forbidden, http_imposter_fixture) {
+FIXTURE_TEST(test_forbidden, fixture) {
     when()
       .request("/super-secret-area")
       .with_method(ss::httpd::GET)


### PR DESCRIPTION
For static builds the trick to configure port for test executables using

  extern uint16_t unit_test_httpd_port_number()

worked good, but not so much for shared libraries. This PR updates users of http imposter to specify the port explicitly in the constructor of the imposter.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
