### PR TITLE
storage: fix duplicate logger registration error

### DIFF
--- a/src/v/storage/tests/utils/log_gap_analysis.cc
+++ b/src/v/storage/tests/utils/log_gap_analysis.cc
@@ -14,7 +14,7 @@
 #include "model/fundamental.h"
 #include "storage/parser_utils.h"
 
-static ss::logger slog{"test"};
+static ss::logger slog{"log_gap_test"};
 namespace storage {
 
 log_gap_analysis make_log_gap_analysis(


### PR DESCRIPTION
Other loggers that get linked into the same test binary also have a logger named "test", leading to duplicate logger name exceptions being thrown. This behavior doesn't happen, largely by chance, in static builds because clang appears to be smart enough to identify unused code. In shared library builds the initialization happens at load time.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
