### PR TITLE
cloud_storage: Continue hydrate loop on materialize error

### DIFF
--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -366,7 +366,7 @@ struct hydration_loop_state {
     // Call materialize actions for all registered paths. Called after
     // hydration. If there was an exception thrown during hydration,
     // materialization is skipped.
-    ss::future<> materialize();
+    ss::future<bool> materialize();
 
     // Returns the last error seen during hydration. Reset during each hydration
     // request.


### PR DESCRIPTION
During a recent refactor there was a change introduced in the hydration loop behavior. Whereas it earlier handled a materialization failure by making the caller wait for the next hydration attempt, the refactor ignored materialization failures.

This change fixes the hydration loop to match previous behavior.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
