### PR TITLE
rpk: add interactive flag to generate grafana-dashboard

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
@@ -111,7 +111,7 @@ failure of enabling each logger is individually printed.
 			switch len(loggers) {
 			case 0:
 				choices := append([]string{"all"}, possibleLoggers...)
-				pick, err := out.Pick(choices, "Which logger would you like to set (all selects everything)?")
+				pick, err := out.Pick(choices, nil, "Which logger would you like to set (all selects everything)?")
 				out.MaybeDie(err, "unable to pick logger: %v", err)
 				if pick == "all" {
 					loggers = possibleLoggers

--- a/src/go/rpk/pkg/out/out.go
+++ b/src/go/rpk/pkg/out/out.go
@@ -36,12 +36,17 @@ func Confirm(msg string, args ...interface{}) (bool, error) {
 
 // Pick prompts the user to pick one of many options, returning the selected
 // option or an error.
-func Pick(options []string, msg string, args ...interface{}) (string, error) {
+func Pick(options []string, descFun func(string, int) string, msg string, args ...interface{}) (string, error) {
 	var selected int
-	err := survey.AskOne(&survey.Select{
-		Message: fmt.Sprintf(msg, args...),
-		Options: options,
-	}, &selected)
+	s := &survey.Select{
+		Message:     fmt.Sprintf(msg, args...),
+		Options:     options,
+		Description: descFun,
+	}
+	if descFun != nil {
+		s.Description = descFun
+	}
+	err := survey.AskOne(s, &selected)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #9485

Example:
```
$ rpk generate grafana-dashboard --interactive
```

![image](https://user-images.githubusercontent.com/59714880/233198560-8882bd50-b8e8-4d3e-94a1-b6bdc161fb26.png)

## Backports Required
- [ ] none - issue does not exist in previous branches


No release notes since this is a new feature and the release notes will be in https://github.com/redpanda-data/redpanda/pull/9662

## Release Notes
* none

