### PR TITLE
cloud_storage: unit test to exercise produce and consume from the Kafka layer

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -257,6 +257,16 @@ public:
         return _parent.log().config();
     }
 
+    /// If we have a projected manifest clean offset, then flush it to
+    /// the persistent stm clean offset.
+    ss::future<> flush_manifest_clean_offset();
+
+    /// Upload manifest to the pre-defined S3 location
+    ss::future<cloud_storage::upload_result> upload_manifest(
+      const char* upload_ctx,
+      std::optional<std::reference_wrapper<retry_chain_node>> source_rtc
+      = std::nullopt);
+
 private:
     // Labels for contexts in which manifest uploads occur. Used for logging.
     static constexpr const char* housekeeping_ctx_label = "housekeeping";
@@ -434,21 +444,11 @@ private:
     /// will have been updated if so)
     ss::future<bool> maybe_upload_manifest(const char* upload_ctx);
 
-    /// If we have a projected manifest clean offset, then flush it to
-    /// the persistent stm clean offset.
-    ss::future<> flush_manifest_clean_offset();
-
     /// Lazy variant of flush_manifest_clean_offset, for use in situations
     /// where we didn't just upload the manifest, but want to make sure we
     /// will eventually flush projected_manifest_clean_at in case it was
     /// set by some background operation.
     ss::future<> maybe_flush_manifest_clean_offset();
-
-    /// Upload manifest to the pre-defined S3 location
-    ss::future<cloud_storage::upload_result> upload_manifest(
-      const char* upload_ctx,
-      std::optional<std::reference_wrapper<retry_chain_node>> source_rtc
-      = std::nullopt);
 
     /// While leader, within a particular term, keep trying to upload data
     /// from local storage to remote storage until our term changes or

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ rp_test(
     remote_segment_test.cc
     remote_partition_test.cc
     topic_recovery_service_test.cc
+    cloud_storage_e2e_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     Boost::unit_test_framework
@@ -35,6 +36,7 @@ rp_test(
     v::storage_test_utils
     v::cloud_roles
     v::application
+    v::kafka_test_utils
   ARGS "-- -c 1"
   LABELS cloud_storage
 )

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/ntp_archiver_service.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "config/configuration.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "model/fundamental.h"
+#include "redpanda/tests/fixture.h"
+#include "storage/disk_log_impl.h"
+
+#include <seastar/core/io_priority_class.hh>
+
+using tests::kafka_consume_transport;
+using tests::kafka_produce_transport;
+using tests::kv_t;
+
+class e2e_fixture
+  : public s3_imposter_fixture
+  , public redpanda_thread_fixture
+  , public enable_cloud_storage_fixture {
+public:
+    e2e_fixture()
+      : redpanda_thread_fixture(
+        redpanda_thread_fixture::init_cloud_storage_tag{},
+        httpd_port_number()) {
+        // No expectations: tests will PUT and GET organically.
+        set_expectations_and_listen({});
+        wait_for_controller_leadership().get();
+    }
+};
+
+FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.retention_local_target_bytes = tristate<size_t>(1);
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    // Do some sanity checks that our partition looks the way we expect (has a
+    // log, archiver, etc).
+    auto partition = app.partition_manager.local().get(ntp);
+    auto* log = dynamic_cast<storage::disk_log_impl*>(
+      partition->log().get_impl());
+    auto archiver_ref = partition->archiver();
+    BOOST_REQUIRE(archiver_ref.has_value());
+    auto& archiver = archiver_ref.value().get();
+
+    kafka_produce_transport producer(make_kafka_client().get());
+    producer.start().get();
+    std::vector<kv_t> records{
+      {"key0", "val0"},
+      {"key1", "val1"},
+      {"key2", "val2"},
+    };
+    producer.produce_to_partition(topic_name, model::partition_id(0), records)
+      .get();
+
+    // Create a new segment so we have data to upload.
+    log->flush().get();
+    log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(2, log->segments().size());
+
+    // Upload the closed segment to object storage.
+    auto res = archiver.upload_next_candidates().get();
+    BOOST_REQUIRE_EQUAL(0, res.compacted_upload_result.num_succeeded);
+    BOOST_REQUIRE_EQUAL(1, res.non_compacted_upload_result.num_succeeded);
+    auto manifest_res = archiver.upload_manifest("test").get();
+    BOOST_REQUIRE_EQUAL(manifest_res, cloud_storage::upload_result::success);
+    archiver.flush_manifest_clean_offset().get();
+
+    // Compact the local log to GC to the collectible offset.
+    ss::abort_source as;
+    storage::compaction_config compaction_conf(
+      model::timestamp::min(),
+      1,
+      log->stm_manager()->max_collectible_offset(),
+      ss::default_priority_class(),
+      as);
+    partition->log().compact(compaction_conf).get();
+    // NOTE: the storage layer only initially requests eviction; it relies on
+    // Raft to write a snapshot and subsequently truncate.
+    tests::cooperative_spin_wait_with_timeout(3s, [log] {
+        return log->segments().size() == 1;
+    }).get();
+
+    // Attempt to consume from the beginning of the log. Since our local log
+    // has been truncated, this exercises reading from cloud storage.
+    kafka_consume_transport consumer(make_kafka_client().get());
+    consumer.start().get();
+    auto consumed_records = consumer
+                              .consume_from_partition(
+                                topic_name,
+                                model::partition_id(0),
+                                model::offset(0))
+                              .get();
+    BOOST_CHECK_EQUAL(records.size(), consumed_records.size());
+    for (int i = 0; i < records.size(); ++i) {
+        BOOST_CHECK_EQUAL(records[i].first, consumed_records[i].first);
+        BOOST_CHECK_EQUAL(records[i].second, consumed_records[i].second);
+    }
+}

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -14,6 +14,19 @@ rp_test(
 )
 
 
+v_cc_library(
+  NAME
+    kafka_test_utils
+  HDRS
+    "produce_consume_utils.h"
+  SRCS
+    "produce_consume_utils.cc"
+  DEPS
+    v::bytes
+    v::kafka
+    v::storage
+)
+
 set(srcs
   consumer_groups_test.cc
   token_bucket_algorithm_test.cc

--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "kafka/server/tests/produce_consume_utils.h"
+
+#include "bytes/iobuf.h"
+#include "kafka/client/transport.h"
+#include "kafka/protocol/produce.h"
+#include "kafka/protocol/schemata/produce_request.h"
+#include "storage/record_batch_builder.h"
+
+namespace tests {
+
+// Produces the given records per partition to the given topic.
+// NOTE: inputs must remain valid for the duration of the call.
+ss::future<kafka_produce_transport::pid_to_offset_map_t>
+kafka_produce_transport::produce(
+  model::topic topic_name,
+  pid_to_kvs_map_t records_per_partition,
+  std::optional<model::timestamp> ts) {
+    kafka::produce_request::topic tp;
+    tp.name = topic_name;
+    tp.partitions = produce_partition_requests(records_per_partition, ts);
+    std::vector<kafka::produce_request::topic> topics;
+    topics.push_back(std::move(tp));
+    kafka::produce_request req(std::nullopt, 1, std::move(topics));
+    req.data.timeout_ms = std::chrono::seconds(10);
+    req.has_idempotent = false;
+    req.has_transactional = false;
+    auto resp = co_await _transport.dispatch(std::move(req));
+
+    pid_to_offset_map_t ret;
+    for (auto& data_resp : resp.data.responses) {
+        for (auto& prt_resp : data_resp.partitions) {
+            if (prt_resp.error_code != kafka::error_code::none) {
+                throw std::runtime_error(fmt::format(
+                  "produce error: {}, message:{}",
+                  prt_resp.error_code,
+                  prt_resp.error_message));
+            }
+            ret.emplace(prt_resp.partition_index, prt_resp.base_offset);
+        }
+    }
+    co_return ret;
+}
+
+std::vector<kafka::partition_produce_data>
+kafka_produce_transport::produce_partition_requests(
+  const pid_to_kvs_map_t& records_per_partition,
+  std::optional<model::timestamp> ts) {
+    std::vector<kafka::partition_produce_data> ret;
+    ret.reserve(records_per_partition.size());
+    for (const auto& [pid, records] : records_per_partition) {
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, model::offset(0));
+        kafka::produce_request::partition partition;
+        for (auto& [k, v] : records) {
+            iobuf key_buf;
+            key_buf.append(k.data(), k.size());
+            iobuf val_buf;
+            val_buf.append(v.data(), v.size());
+            builder.add_raw_kv(std::move(key_buf), std::move(val_buf));
+        }
+        if (ts.has_value()) {
+            builder.set_timestamp(ts.value());
+        }
+        partition.partition_index = pid;
+        partition.records.emplace(std::move(builder).build());
+        ret.emplace_back(std::move(partition));
+    }
+    return ret;
+}
+
+ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
+  model::topic topic_name,
+  std::vector<model::partition_id> pids,
+  model::offset offset_inclusive) {
+    kafka::fetch_request::topic topic;
+    topic.name = topic_name;
+    topic.fetch_partitions.reserve(pids.size());
+    for (const auto& pid : pids) {
+        kafka::fetch_request::partition partition;
+        partition.fetch_offset = offset_inclusive;
+        partition.partition_index = pid;
+        partition.log_start_offset = model::offset(0);
+        partition.max_bytes = 1_MiB;
+        topic.fetch_partitions.emplace_back(std::move(partition));
+    }
+
+    kafka::fetch_request req;
+    req.data.min_bytes = 1;
+    req.data.max_bytes = 10_MiB;
+    req.data.max_wait_ms = 1000ms;
+    req.data.topics.push_back(std::move(topic));
+    auto fetch_resp = co_await _transport.dispatch(
+      std::move(req), kafka::api_version(4));
+    if (fetch_resp.data.error_code != kafka::error_code::none) {
+        throw std::runtime_error(
+          fmt::format("fetch error: {}", fetch_resp.data.error_code));
+    }
+    pid_to_kvs_map_t ret;
+    for (const auto& pid : pids) {
+        ret.emplace(pid, std::vector<kv_t>{});
+    }
+    auto& data = fetch_resp.data;
+    for (auto& topic : data.topics) {
+        for (auto& partition : topic.partitions) {
+            if (!partition.records.has_value()) {
+                continue;
+            }
+            auto batch_adapter = partition.records.value().consume_batch();
+            if (!batch_adapter.batch.has_value()) {
+                continue;
+            }
+            auto records = batch_adapter.batch->copy_records();
+            auto& records_for_partition = ret[partition.partition_index];
+            for (auto& r : records) {
+                iobuf_const_parser key_buf(r.key());
+                iobuf_const_parser val_buf(r.value());
+                records_for_partition.emplace_back(kv_t{
+                  key_buf.read_string(key_buf.bytes_left()),
+                  val_buf.read_string(val_buf.bytes_left())});
+            }
+        }
+    }
+    co_return ret;
+}
+
+} // namespace tests

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "kafka/client/transport.h"
+#include "kafka/protocol/produce.h"
+#include "kafka/protocol/schemata/produce_request.h"
+#include "storage/record_batch_builder.h"
+
+namespace tests {
+
+using kv_t = std::pair<ss::sstring, ss::sstring>;
+using pid_to_kvs_map_t
+  = absl::flat_hash_map<model::partition_id, std::vector<kv_t>>;
+
+// Wrapper around a Kafka transport that encapsulates producing to a node.
+//
+// The primary goal of this class is to allow tests to produce without dealing
+// with the Kafka protocol. To that end, it exposes a protocol-agnostic API.
+class kafka_produce_transport {
+public:
+    using pid_to_offset_map_t
+      = absl::flat_hash_map<model::partition_id, model::offset>;
+
+    explicit kafka_produce_transport(kafka::client::transport&& t)
+      : _transport(std::move(t)) {}
+
+    ss::future<> start() { return _transport.connect(); }
+
+    // Produces the given records per partition to the given topic.
+    ss::future<pid_to_offset_map_t> produce(
+      model::topic topic_name,
+      pid_to_kvs_map_t records_per_partition,
+      std::optional<model::timestamp> ts = std::nullopt);
+
+    // Produces the given records to the given topic partition.
+    ss::future<pid_to_offset_map_t> produce_to_partition(
+      model::topic topic_name,
+      model::partition_id pid,
+      std::vector<kv_t> records,
+      std::optional<model::timestamp> ts = std::nullopt) {
+        pid_to_kvs_map_t m;
+        m.emplace(pid, std::move(records));
+        return produce(std::move(topic_name), std::move(m), ts);
+    }
+
+private:
+    // Convert the given records-per-partition mapping to a set of per-partition
+    // produce requests. Each request, once sent, will correspond to a
+    // replicated Raft batch.
+    // NOTE: input must remain valid for the lifetimes of the returned requests.
+    static std::vector<kafka::partition_produce_data>
+    produce_partition_requests(
+      const pid_to_kvs_map_t& records_per_partition,
+      std::optional<model::timestamp> ts);
+
+    kafka::client::transport _transport;
+};
+
+class kafka_consume_transport {
+public:
+    explicit kafka_consume_transport(kafka::client::transport&& t)
+      : _transport(std::move(t)) {}
+
+    ss::future<> start() { return _transport.connect(); }
+
+    ss::future<pid_to_kvs_map_t> consume(
+      model::topic topic_name,
+      std::vector<model::partition_id> pids,
+      model::offset kafka_offset_inclusive);
+
+    ss::future<std::vector<kv_t>> consume_from_partition(
+      model::topic topic_name,
+      model::partition_id pid,
+      model::offset kafka_offset_inclusive) {
+        auto m = co_await consume(
+          std::move(topic_name), {pid}, kafka_offset_inclusive);
+        if (m.empty()) {
+            throw std::runtime_error(
+              fmt::format("empty fetch {}/{}", topic_name(), pid()));
+        }
+        auto it = m.find(pid);
+        if (it == m.end()) {
+            throw std::runtime_error(fmt::format(
+              "fetch result missing partition {}/{}", topic_name(), pid()));
+        }
+        co_return it->second;
+    }
+
+private:
+    kafka::client::transport _transport;
+};
+
+} // namespace tests

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -30,6 +30,7 @@
 #include "kafka/protocol/fetch.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
 #include "kafka/server/server.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/timeout_clock.h"
@@ -433,6 +434,25 @@ public:
           });
     }
 
+    // Wait for the Raft leader of the given partition to become leader.
+    ss::future<> wait_for_leader(
+      model::ntp ntp, model::timeout_clock::duration timeout = 3s) {
+        return tests::cooperative_spin_wait_with_timeout(
+          timeout, [this, ntp = std::move(ntp)]() {
+              auto shard = app.shard_table.local().shard_for(ntp);
+              if (!shard) {
+                  return ss::make_ready_future<bool>(false);
+              }
+              return app.partition_manager.invoke_on(
+                *shard, [ntp](cluster::partition_manager& mgr) {
+                    auto partition = mgr.get(ntp);
+                    return partition
+                           && partition->raft()->term() != model::term_id{}
+                           && partition->raft()->is_leader();
+                });
+          });
+    }
+
     ss::future<kafka::client::transport>
     make_kafka_client(std::optional<ss::sstring> client_id = "test_client") {
         return ss::make_ready_future<kafka::client::transport>(
@@ -474,10 +494,15 @@ public:
           });
     }
 
-    ss::future<>
-    add_topic(model::topic_namespace_view tp_ns, int partitions = 1) {
-        std::vector<cluster::topic_configuration> cfgs{
-          cluster::topic_configuration(tp_ns.ns, tp_ns.tp, partitions, 1)};
+    ss::future<> add_topic(
+      model::topic_namespace_view tp_ns,
+      int partitions = 1,
+      std::optional<cluster::topic_properties> props = std::nullopt) {
+        std::vector<cluster::topic_configuration> cfgs = {
+          cluster::topic_configuration{tp_ns.ns, tp_ns.tp, partitions, 1}};
+        if (props.has_value()) {
+            cfgs[0].properties = std::move(props.value());
+        }
         return app.controller->get_topics_frontend()
           .local()
           .create_topics(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

As a part of cluster recovery work, I'd like to introduce tests that exercise tiered storage starting from the Kafka layer (i.e. with real produce and consume requests). It's generally important to cover from the Kafka layer down because there is significant business logic in determining which storage subsystem to direct to in this layer.

To that end, this adds some unit test utilities to facilitate writing such tests: they're just wrappers around `kafka::client::transport` that expose a simple key-value API, allowing test authors to omit constructing Kafka-serialization-specific structs.

A simple test is added to exercise these, and to exercise tiered storage from produce to consume end-to-end in the context of a single-node fixture test.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
