### PR TITLE
cloud_storage: list objects for s3_imposter

### DIFF
--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -66,19 +66,6 @@ static constexpr std::string_view manifest_payload = R"json({
     }
 })json";
 
-static constexpr std::string_view list_response = R"XML(
-<ListBucketResult>
-   <IsTruncated>false</IsTruncated>
-   <Contents>
-      <Key>a</Key>
-   </Contents>
-  <Contents>
-      <Key>b</Key>
-   </Contents>
-   <NextContinuationToken>n</NextContinuationToken>
-</ListBucketResult>
-)XML";
-
 static cloud_storage::lazy_abort_source always_continue{
   []() { return std::nullopt; }};
 
@@ -491,61 +478,114 @@ FIXTURE_TEST(test_concat_segment_upload, remote_fixture) {
 }
 
 FIXTURE_TEST(test_list_bucket, remote_fixture) {
-    set_expectations_and_listen(
-      {{.url = "/?list-type=2",
-        .body = ss::sstring{list_response.data(), list_response.size()}}});
-
+    set_expectations_and_listen({});
     cloud_storage_clients::bucket_name bucket{"test"};
-    retry_chain_node fib(never_abort, 100ms, 20ms);
-    auto result = remote.local().list_objects(bucket, fib).get();
-    BOOST_REQUIRE(result.has_value());
+    retry_chain_node fib(never_abort, 10s, 20ms);
 
-    auto items = result.value();
-    BOOST_REQUIRE_EQUAL(items.contents.size(), 2);
+    int first = 2;
+    int second = 3;
+    int third = 4;
+    for (int i = 0; i < first; i++) {
+        for (int j = 0; j < second; j++) {
+            for (int k = 0; k < third; k++) {
+                cloud_storage_clients::object_key path{
+                  fmt::format("{}/{}/{}", i, j, k)};
+                auto result = remote.local()
+                                .upload_object(
+                                  bucket, path, iobuf{}, fib, upload_tags)
+                                .get();
+                BOOST_REQUIRE_EQUAL(
+                  cloud_storage::upload_result::success, result);
+            }
+        }
+    }
+    {
+        auto result = remote.local().list_objects(bucket, fib).get();
+        BOOST_REQUIRE(result.has_value());
+        BOOST_REQUIRE_EQUAL(
+          result.value().contents.size(), first * second * third);
+        BOOST_REQUIRE(result.value().common_prefixes.empty());
+    }
+    {
+        cloud_storage_clients::object_key prefix("/");
+        auto result
+          = remote.local().list_objects(bucket, fib, prefix, '/').get();
+        BOOST_REQUIRE(result.has_value());
+        BOOST_REQUIRE_EQUAL(
+          result.value().contents.size(), first * second * third);
+        BOOST_REQUIRE_EQUAL(result.value().common_prefixes.size(), first);
+    }
+    {
+        cloud_storage_clients::object_key prefix("/1/");
+        auto result = remote.local().list_objects(bucket, fib, prefix).get();
+        BOOST_REQUIRE(result.has_value());
+        BOOST_REQUIRE_EQUAL(result.value().contents.size(), second * third);
+        BOOST_REQUIRE(result.value().common_prefixes.empty());
+    }
+    {
+        cloud_storage_clients::object_key prefix("/1/");
+        auto result
+          = remote.local().list_objects(bucket, fib, prefix, '/').get();
+        BOOST_REQUIRE(result.has_value());
+        BOOST_REQUIRE_EQUAL(result.value().contents.size(), second * third);
+        BOOST_REQUIRE_EQUAL(result.value().common_prefixes.size(), second);
+    }
 }
 
 FIXTURE_TEST(test_list_bucket_with_prefix, remote_fixture) {
-    set_expectations_and_listen(
-      {{.url = "/?list-type=2&prefix=x",
-        .body = ss::sstring{list_response.data(), list_response.size()}}});
-
+    set_expectations_and_listen({});
     cloud_storage_clients::bucket_name bucket{"test"};
     retry_chain_node fib(never_abort, 100ms, 20ms);
+    for (const char first : {'x', 'y'}) {
+        for (const char second : {'a', 'b'}) {
+            cloud_storage_clients::object_key path{
+              fmt::format("{}/{}", first, second)};
+            auto result = remote.local()
+                            .upload_object(
+                              bucket, path, iobuf{}, fib, upload_tags)
+                            .get();
+            BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
+        }
+    }
+
     auto result = remote.local()
                     .list_objects(
-                      bucket, fib, cloud_storage_clients::object_key{"x"})
+                      bucket, fib, cloud_storage_clients::object_key{"/x/"})
                     .get();
     BOOST_REQUIRE(result.has_value());
     auto items = result.value().contents;
     BOOST_REQUIRE_EQUAL(items.size(), 2);
-    BOOST_REQUIRE_EQUAL(items[0].key, "a");
-    BOOST_REQUIRE_EQUAL(items[1].key, "b");
-    auto request = get_requests()[0];
+    BOOST_REQUIRE_EQUAL(items[0].key, "/x/a");
+    BOOST_REQUIRE_EQUAL(items[1].key, "/x/b");
+    auto request = get_requests().back();
     BOOST_REQUIRE_EQUAL(request.method, "GET");
     BOOST_REQUIRE_EQUAL(request.q_list_type, "2");
-    BOOST_REQUIRE_EQUAL(request.q_prefix, "x");
-    BOOST_REQUIRE_EQUAL(request.h_prefix, "x");
+    BOOST_REQUIRE_EQUAL(request.q_prefix, "/x/");
+    BOOST_REQUIRE_EQUAL(request.h_prefix, "/x/");
 }
 
 FIXTURE_TEST(test_list_bucket_with_filter, remote_fixture) {
-    set_expectations_and_listen(
-      {{.url = "/?list-type=2",
-        .body = ss::sstring{list_response.data(), list_response.size()}}});
-
-    cloud_storage_clients::bucket_name bucket{"test"};
+    set_expectations_and_listen({});
     retry_chain_node fib(never_abort, 100ms, 20ms);
+    cloud_storage_clients::bucket_name bucket{"test"};
+    cloud_storage_clients::object_key path{"b"};
+    auto upl_result = remote.local()
+                        .upload_object(bucket, path, iobuf{}, fib, upload_tags)
+                        .get();
+    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, upl_result);
+
     auto result = remote.local()
                     .list_objects(
                       bucket,
                       fib,
                       std::nullopt,
                       std::nullopt,
-                      [](const auto& item) { return item.key == "b"; })
+                      [](const auto& item) { return item.key == "/b"; })
                     .get();
     BOOST_REQUIRE(result.has_value());
     auto items = result.value().contents;
     BOOST_REQUIRE_EQUAL(items.size(), 1);
-    BOOST_REQUIRE_EQUAL(items[0].key, "b");
+    BOOST_REQUIRE_EQUAL(items[0].key, "/b");
 }
 
 FIXTURE_TEST(test_put_string, remote_fixture) {

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -73,6 +73,8 @@ public:
 
     cloud_storage_clients::s3_configuration get_configuration();
 
+    void disable_search_on_get_list() { _search_on_get_list = false; }
+
 private:
     void set_routes(
       ss::httpd::routes& r, const std::vector<expectation>& expectations);
@@ -85,6 +87,10 @@ private:
     std::vector<http_test_utils::request_info> _requests;
     /// Contains all accessed target urls
     std::multimap<ss::sstring, http_test_utils::request_info> _targets;
+
+    /// Whether or not to search through expectations for content when handling
+    /// a list GET request.
+    bool _search_on_get_list{true};
 };
 
 class enable_cloud_storage_fixture {

--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -108,7 +108,10 @@ public:
     fixture()
       : redpanda_thread_fixture(
         redpanda_thread_fixture::init_cloud_storage_tag{},
-        httpd_port_number()) {}
+        httpd_port_number()) {
+        // This test will manually set expectations for list requests.
+        disable_search_on_get_list();
+    }
 
     void wait_for_topic(model::topic_namespace tp_ns) {
         tests::cooperative_spin_wait_with_timeout(


### PR DESCRIPTION
This adds handling of list_objects GET requests to the s3_imposter. It does a basic scan through all expectations, filtering by a possible prefix, and grouping based on a delimiter.

I didn't do much to make it robust -- things like upload timestamps and tags are completely fake. That said, this is good enough for some basic list queries.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none