### PR TITLE
[v23.1.x] storage: optionally ignore timestamps in the future for retention

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -894,6 +894,17 @@ configuration::configuration()
        .example = "10737418240",
        .visibility = visibility::tunable},
       5_GiB)
+  , storage_ignore_timestamps_in_future_sec(
+      *this,
+      "storage_ignore_timestamps_in_future_sec",
+      "If set, timestamps more than this many seconds in the future relative to"
+      "the server's clock will be ignored for data retention purposes, and "
+      "retention will act based on another timestamp in the same segment, or "
+      "the mtime of the segment file if no valid timestamp is available",
+      {.needs_restart = needs_restart::no,
+       .example = "3600",
+       .visibility = visibility::tunable},
+      std::nullopt)
   , id_allocator_log_capacity(
       *this,
       "id_allocator_log_capacity",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -186,6 +186,9 @@ struct configuration final : public config_store {
     bounded_property<uint64_t> storage_max_concurrent_replay;
     bounded_property<uint64_t> storage_compaction_index_memory;
     property<size_t> max_compacted_log_segment_size;
+    property<std::optional<std::chrono::seconds>>
+      storage_ignore_timestamps_in_future_sec;
+
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -229,6 +229,15 @@ model::offset disk_log_impl::time_based_gc_max_offset(model::timestamp time) {
 
     // if the segment max timestamp is bigger than now plus threshold we
     // will report the segment max timestamp as bogus timestamp
+    vlog(
+      gclog.debug,
+      "[{}] time retention timestamp: {}, first segment retention timestamp: "
+      "{}",
+      config().ntp(),
+      time,
+      _segs.empty() ? model::timestamp::min()
+                    : _segs.front()->index().retention_timestamp());
+
     static constexpr auto const_threshold = 1min;
     auto bogus_threshold = model::timestamp(
       model::timestamp::now().value() + const_threshold / 1ms);
@@ -237,18 +246,23 @@ model::offset disk_log_impl::time_based_gc_max_offset(model::timestamp time) {
       std::cbegin(_segs),
       std::cend(_segs),
       [this, time, bogus_threshold](const ss::lw_shared_ptr<segment>& s) {
-          auto max_ts = s->index().max_timestamp();
-          // first that is not going to be collected
-          if (max_ts > bogus_threshold) {
+          auto retention_ts = s->index().retention_timestamp();
+
+          if (retention_ts > bogus_threshold) {
+              // Warn on timestamps more than the "bogus" threshold in future
               vlog(
                 gclog.warn,
-                "[{}] found segment with bogus max timestamp: {} - {}",
+                "[{}] found segment with bogus retention timestamp: {} (base "
+                "{}, max {}) - {}",
                 config().ntp(),
-                max_ts,
+                retention_ts,
+                s->index().base_timestamp(),
+                s->index().max_timestamp(),
                 s);
           }
 
-          return max_ts > time;
+          // first that is not going to be collected
+          return retention_ts > time;
       });
 
     if (it == _segs.cbegin()) {
@@ -759,6 +773,62 @@ ss::future<> disk_log_impl::compact(compaction_config cfg) {
     _probe.set_compaction_ratio(_compaction_ratio.get());
 }
 
+ss::future<> disk_log_impl::retention_adjust_timestamps(
+  std::chrono::seconds ignore_in_future) {
+    auto ignore_threshold = model::timestamp(
+      model::timestamp::now().value() + ignore_in_future / 1ms);
+
+    for (const auto& s : _segs) {
+        auto max_ts = s->index().max_timestamp();
+
+        // If the actual max timestamp from user records is out of bounds, clamp
+        // it to something more plausible, either from other batches or from
+        // filesystem metadata if no batches with valid timestamps are
+        // available.
+        if (max_ts >= ignore_threshold) {
+            auto alternate_batch_ts = s->index().find_highest_timestamp_before(
+              ignore_threshold);
+            if (alternate_batch_ts.has_value()) {
+                // Some batch in the segment has a timestamp within threshold,
+                // use that instead of the official max ts.
+                vlog(
+                  gclog.warn,
+                  "[{}] Timestamp in future detected, check client clocks.  "
+                  "Adjusting retention timestamp from {} to max valid record "
+                  "timestamp {} on {}",
+                  config().ntp(),
+                  max_ts,
+                  alternate_batch_ts.value(),
+                  s->path().string());
+                s->index().set_retention_timestamp(alternate_batch_ts.value());
+            } else {
+                // No indexed batch in the segment has a usable timestamp: fall
+                // back to using the mtime of the file.  This is not accurate
+                // at all (the file might have been created long
+                // after the data was written) but is better than nothing.
+                auto file_timestamp = co_await s->get_file_timestamp();
+                vlog(
+                  gclog.warn,
+                  "[{}] Timestamp in future detected, check client clocks.  "
+                  "Adjusting retention timestamp from {} to file mtime {} on "
+                  "{}",
+                  config().ntp(),
+                  max_ts,
+                  file_timestamp,
+                  s->path().string());
+                s->index().set_retention_timestamp(file_timestamp);
+            }
+        } else {
+            // We may drop out as soon as we see a segment with a valid
+            // timestamp: this is collectible by time_based_gc_max_offset
+            // without us making an adjustment, and if there are any later
+            // segments that require correction we will hit them after
+            // this earlier segment has  been collected.
+            break;
+        }
+    }
+}
+
 ss::future<std::optional<model::offset>>
 disk_log_impl::gc(compaction_config cfg) {
     vassert(!_closed, "gc on closed log - {}", *this);
@@ -767,6 +837,7 @@ disk_log_impl::gc(compaction_config cfg) {
       "[{}] applying 'deletion' log cleanup policy with config: {}",
       config().ntp(),
       cfg);
+
     if (deletion_exempt(config().ntp())) {
         vlog(
           gclog.trace,
@@ -774,6 +845,16 @@ disk_log_impl::gc(compaction_config cfg) {
           config().ntp());
         co_return std::nullopt;
     }
+
+    auto ignore_timestamps_in_future
+      = config::shard_local_cfg().storage_ignore_timestamps_in_future_sec();
+    if (ignore_timestamps_in_future.has_value()) {
+        // Correct any timestamps too far in future, before calculating the
+        // retention offset.
+        co_await retention_adjust_timestamps(
+          ignore_timestamps_in_future.value());
+    }
+
     if (cfg.max_bytes) {
         size_t max = cfg.max_bytes.value();
         vlog(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -165,6 +165,11 @@ private:
     model::offset size_based_gc_max_offset(size_t);
     model::offset time_based_gc_max_offset(model::timestamp);
 
+    /// Conditionally adjust retention timestamp on any segment that appears
+    /// to have invalid timestamps, to ensure retention can proceed.
+    ss::future<>
+    retention_adjust_timestamps(std::chrono::seconds ignore_in_future);
+
     bool is_front_segment(const segment_set::type&) const;
 
     compaction_config apply_overrides(compaction_config) const;

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -149,7 +149,8 @@ struct index_state
             non_data_timestamps = false;
         }
     }
-    std::tuple<uint32_t, offset_time_index, uint64_t> get_entry(size_t i) {
+    std::tuple<uint32_t, offset_time_index, uint64_t>
+    get_entry(size_t i) const {
         return {
           relative_offset_index[i],
           offset_time_index{relative_time_index[i], with_offset},

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -726,4 +726,14 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
       });
 }
 
+ss::future<model::timestamp> segment::get_file_timestamp() const {
+    auto file_path = path().string();
+
+    auto stat = co_await ss::file_stat(file_path);
+    co_return model::timestamp(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+        stat.time_modified.time_since_epoch())
+        .count());
+}
+
 } // namespace storage

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -178,6 +178,10 @@ public:
         return _first_write;
     }
 
+    /// Fallback timestamp method, for use if the timestamps in the index
+    /// appear to be invalid (e.g. too far in the future)
+    ss::future<model::timestamp> get_file_timestamp() const;
+
 private:
     void set_close();
     void cache_truncate(model::offset offset);

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -282,4 +282,23 @@ std::ostream& operator<<(std::ostream& o, const segment_index::entry& e) {
              << ", filepos:" << e.filepos << "}";
 }
 
+std::optional<model::timestamp>
+segment_index::find_highest_timestamp_before(model::timestamp t) const {
+    if (_state.base_timestamp > t || _state.empty()) {
+        return std::nullopt;
+    }
+
+    auto relative_t = (t - _state.base_timestamp).value();
+
+    for (int i = _state.size() - 1; i >= 0; --i) {
+        auto [relative_offset, offset_time, position] = _state.get_entry(i);
+        if (offset_time() < relative_t) {
+            return model::timestamp(
+              _state.base_timestamp.value() + offset_time());
+        }
+    }
+
+    return std::nullopt;
+}
+
 } // namespace storage

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -69,6 +69,11 @@ public:
     std::optional<entry> find_nearest(model::offset);
     std::optional<entry> find_nearest(model::timestamp);
 
+    /// Fallback timestamp search for if the recorded max ts appears to be
+    /// invalid, e.g. too far in the future
+    std::optional<model::timestamp>
+      find_highest_timestamp_before(model::timestamp) const;
+
     model::offset base_offset() const { return _state.base_offset; }
     model::offset max_offset() const { return _state.max_offset; }
     model::timestamp max_timestamp() const { return _state.max_timestamp; }
@@ -77,6 +82,22 @@ public:
         return _state.batch_timestamps_are_monotonic;
     }
     bool non_data_timestamps() const { return _state.non_data_timestamps; }
+
+    void set_retention_timestamp(model::timestamp t) {
+        _retention_timestamp = t;
+    }
+    model::timestamp retention_timestamp() const {
+        if (unlikely(config::shard_local_cfg()
+                       .storage_ignore_timestamps_in_future_sec())) {
+            return _retention_timestamp.value_or(_state.max_timestamp);
+        } else {
+            // If storage_ignore_timestamps_in_future_sec is disabled, then
+            // we should not respect _retention_timestamp even if it has
+            // been set (this corresponds to the property being toggled on
+            // then off again at runtime).
+            return _state.max_timestamp;
+        }
+    }
 
     ss::future<bool> materialize_index();
     ss::future<> flush();
@@ -110,6 +131,10 @@ private:
     bool _needs_persistence{false};
     index_state _state;
     debug_sanitize_files _sanitize;
+
+    // Override the timestamp used for retention, in case what's in
+    // the index _state is no good.
+    std::optional<model::timestamp> _retention_timestamp;
 
     model::timestamp _last_batch_max_timestamp;
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2390,7 +2390,7 @@ class RedpandaService(Service):
 
         return None
 
-    def node_storage(self, node, sizes: bool = False):
+    def node_storage(self, node, sizes: bool = False) -> NodeStorage:
         """
         Retrieve a summary of storage on a node.
 

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -8,11 +8,12 @@
 # by the Apache License, Version 2.0
 
 from time import sleep
+import time
 from ducktape.errors import TimeoutError
 from ducktape.mark import matrix, parametrize
 from ducktape.utils.util import wait_until
 
-from rptest.clients.kafka_cat import KafkaCat
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
@@ -600,3 +601,134 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Too many bytes in the cloud")
+
+
+class BogusTimestampTest(RedpandaTest):
+    segment_size = 1048576
+    topics = (
+        TopicSpec(
+            partition_count=1,
+            replication_factor=1,
+            cleanup_policy=TopicSpec.CLEANUP_DELETE,
+            # 1 megabyte segments
+            segment_bytes=segment_size,
+            # 1 second retention: any non-open segment should be collected almost immediately
+            retention_ms=1000), )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         extra_rp_conf={'log_compaction_interval_ms': 1000},
+                         **kwargs)
+
+    @cluster(num_nodes=2)
+    @parametrize(mixed_timestamps=False)
+    @parametrize(mixed_timestamps=True)
+    def test_bogus_timestamps(self, mixed_timestamps):
+        """
+        :param mixed_timestamps: if true, test with a mixture of valid and invalid
+        timestamps in the same segment (i.e. timestamp adjustment should use the
+        valid timestamps rather than falling back to mtime)
+        """
+        self.client().alter_topic_config(self.topic, 'segment.bytes',
+                                         str(self.segment_size))
+
+        # A fictional artificial timestamp base in milliseconds
+        future_timestamp = (int(time.time()) + 24 * 3600) * 1000
+
+        # Produce a run of messages with CreateTime-style timestamps, each
+        # record having a timestamp 1ms greater than the last.
+        msg_size = 14000
+        segments_count = 10
+        msg_count = (self.segment_size // msg_size) * segments_count
+
+        if mixed_timestamps:
+            valid_records = (self.segment_size // msg_size) // 2
+
+            # Write enough valid-timestamped records that one should appear in the index
+            producer = KgoVerifierProducer(context=self.test_context,
+                                           redpanda=self.redpanda,
+                                           topic=self.topic,
+                                           msg_size=msg_size,
+                                           msg_count=valid_records,
+                                           batch_max_bytes=msg_size * 2)
+            producer.start()
+            producer.wait()
+            producer.free()
+
+            # Write the rest of the messages with invalid timestamps
+            producer = KgoVerifierProducer(context=self.test_context,
+                                           redpanda=self.redpanda,
+                                           topic=self.topic,
+                                           msg_size=msg_size,
+                                           msg_count=msg_count - valid_records,
+                                           fake_timestamp_ms=future_timestamp,
+                                           batch_max_bytes=msg_size * 2)
+            producer.start()
+            producer.wait()
+        else:
+            # Write msg_count messages with timestamps in the future
+            producer = KgoVerifierProducer(
+                context=self.test_context,
+                redpanda=self.redpanda,
+                topic=self.topic,
+                msg_size=msg_size,
+                msg_count=(self.segment_size // msg_size) * segments_count,
+                fake_timestamp_ms=future_timestamp,
+                batch_max_bytes=msg_size * 2)
+            producer.start()
+            producer.wait()
+
+        # We should have written the expected number of segments, and nothing can
+        # have been gc'd yet because all the segments have max timestmap in the future
+        segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+            "kafka", self.topic, 0)
+        self.logger.debug(f"Segments after write: {segs}")
+        assert len(segs) >= segments_count
+
+        # Give retention code some time to kick in: we are expecting that it does not
+        # remove anything because the timestamps are too far in the future.
+        with self.redpanda.monitor_log(self.redpanda.nodes[0]) as mon:
+            # Time period much larger than what we set log_compaction_interval_ms to
+            sleep(10)
+
+            # Even without setting the storage_ignore_timestamps_in_future_sec parameter,
+            # we should get warnings about the timestamps.
+            mon.wait_until("found segment with bogus retention timestamp",
+                           timeout_sec=30,
+                           backoff_sec=1)
+
+        # The GC should not have deleted anything
+        segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+            "kafka", self.topic, 0)
+        self.logger.debug(f"Segments after first GC: {segs}")
+        assert len(segs) >= segments_count
+
+        # Enable the escape hatch to tell Redpanda to correct timestamps that are
+        # too far in the future
+        with self.redpanda.monitor_log(self.redpanda.nodes[0]) as mon:
+            self.redpanda.set_cluster_config({
+                'storage_ignore_timestamps_in_future_sec':
+                60,
+            })
+
+            if mixed_timestamps:
+                mon.wait_until(
+                    "Adjusting retention timestamp.*to max valid record",
+                    timeout_sec=30,
+                    backoff_sec=1)
+            else:
+                mon.wait_until("Adjusting retention timestamp.*to file mtime",
+                               timeout_sec=30,
+                               backoff_sec=1)
+
+        def prefix_truncated():
+            segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+                "kafka", self.topic, 0)
+            self.logger.debug(f"Segments: {segs}")
+            return len(segs) <= 1
+
+        # Segments should be cleaned up now that we've switched on force-correction
+        # of timestamps in the future
+        self.redpanda.wait_until(prefix_truncated,
+                                 timeout_sec=30,
+                                 backoff_sec=1)


### PR DESCRIPTION
Backport of #10028 

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none