### PR TITLE
storage: error injection for disk mutations

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -224,7 +224,8 @@ archiver_fixture::get_started_log_builder(
     auto conf = storage::log_config(
       config::node().data_directory().as_sstring(),
       1_MiB,
-      storage::debug_sanitize_files::yes);
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config());
     auto builder = std::make_unique<storage::disk_log_builder>(std::move(conf));
     builder->start(std::move(ntp_cfg)).get();
     return builder;

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -497,8 +497,8 @@ FIXTURE_TEST(test_concat_segment_upload, remote_fixture) {
     disk_log_builder b{log_config{
       data_path.string(),
       1024,
-      debug_sanitize_files::yes,
-    }};
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()}};
     b | start(ntp_config{test_ntp, {data_path}});
 
     auto defer = ss::defer([&b]() { b.stop().get(); });

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -44,13 +44,16 @@ local_monitor_fixture::local_monitor_fixture()
     _storage_node_api.start_single().get0();
 
     auto log_conf = storage::log_config{
-      "test.dir", 1024, storage::debug_sanitize_files::yes};
+      "test.dir",
+      1024,
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()};
 
     auto kvstore_conf = storage::kvstore_config(
       1_MiB,
       config::mock_binding(10ms),
       log_conf.base_dir,
-      storage::debug_sanitize_files::yes);
+      storage::make_sanitized_file_config());
 
     _feature_table.start().get();
     _feature_table

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -449,7 +449,7 @@ inline void rjson_serialize(
           ss.rdstate()));
     }
     w.Key("address");
-    rjson_serialize(w, ss.str());
+    rjson_serialize<std::string_view>(w, ss.str());
     w.EndObject();
 }
 

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -393,4 +393,18 @@ struct convert<model::leader_balancer_mode> {
     }
 };
 
+template<>
+struct convert<std::filesystem::path> {
+    using type = std::filesystem::path;
+
+    static Node encode(const type& rhs) { return Node(rhs.native()); }
+
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+        rhs = std::filesystem::path{value};
+
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -155,6 +155,20 @@ node_config::node_config() noexcept
       "Enables log messages for allocations greater than the given size.",
       {.visibility = visibility::tunable},
       std::nullopt)
+  , storage_failure_injection_enabled(
+      *this,
+      "storage_failure_injection_enabled",
+      "If true, inject low level storage failures on the write path. **Not** "
+      "for production usage.",
+      {.visibility = visibility::tunable},
+      false)
+  , storage_failure_injection_config_path(
+      *this,
+      "storage_failure_injection_config_path",
+      "Path to the configuration file used for low level storage failure "
+      "injection",
+      {.visibility = visibility::tunable},
+      std::nullopt)
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -67,6 +67,14 @@ public:
     property<bool> upgrade_override_checks;
     property<std::optional<size_t>> memory_allocation_warning_threshold;
 
+    // If true, inject low level failures in the storage layer according
+    // to the configuration at `storage_failure_injection_config_path`.
+    property<bool> storage_failure_injection_enabled;
+
+    // Path to the configuration file for low level storage failure injection.
+    property<std::optional<std::filesystem::path>>
+      storage_failure_injection_config_path;
+
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {
         return data_directory().path / "pid.lock";

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -611,6 +611,8 @@ consteval std::string_view property_type_name() {
         return "string";
     } else if constexpr (std::is_same_v<type, model::leader_balancer_mode>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, std::filesystem::path>) {
+        return "string";
     } else {
         static_assert(dependent_false<T>::value, "Type name not defined");
     }

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -105,4 +105,9 @@ void rjson_serialize(
     w.EndObject();
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const std::filesystem::path& path) {
+    rjson_serialize(w, std::string_view{path.native()});
+}
+
 } // namespace json

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -61,6 +61,9 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>&, const model::broker_endpoint&);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const std::filesystem::path& path);
+
 template<typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
 void rjson_serialize(json::Writer<json::StringBuffer>& w, T v) {
     rjson_serialize(w, static_cast<std::underlying_type_t<T>>(v));

--- a/src/v/json/tests/json_serialization_test.cc
+++ b/src/v/json/tests/json_serialization_test.cc
@@ -61,7 +61,7 @@ void rjson_serialize(json::Writer<json::StringBuffer>& w, const personne_t& p) {
     w.StartObject();
 
     w.Key("full_name");
-    json::rjson_serialize(w, p.full_name);
+    json::rjson_serialize<std::string_view>(w, p.full_name);
 
     w.Key("nic");
     json::rjson_serialize(w, p.nic);

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -41,6 +41,7 @@ enum class record_batch_type : int8_t {
     feature_update = 21,             // Node logical versions updates
     cluster_bootstrap_cmd = 22,      // cluster bootsrap command
     version_fence = 23,              // version fence/epoch
+    MAX = version_fence
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -543,7 +543,7 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
             model::offset::max(),
             ss::default_priority_class(),
             as,
-            storage::debug_sanitize_files::yes))
+            storage::ntp_sanitizer_config{.sanitize_only = true}))
           .then([] { return true; });
     }).get0();
 

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -39,15 +39,15 @@ struct bootstrap_fixture : raft::simple_record_fixture {
               1_MiB,
               config::mock_binding(10ms),
               "test.dir",
-              storage::debug_sanitize_files::yes);
+              storage::make_sanitized_file_config());
         },
         []() {
             return storage::log_config(
               "test.dir",
               1_GiB,
-              storage::debug_sanitize_files::yes,
               ss::default_priority_class(),
-              storage::with_cache::no);
+              storage::with_cache::no,
+              storage::make_sanitized_file_config());
         },
         _feature_table) {
         _feature_table.start().get();

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -42,11 +42,14 @@ struct config_manager_fixture {
               100_MiB,
               config::mock_binding(std::chrono::milliseconds(10)),
               base_dir,
-              storage::debug_sanitize_files::yes);
+              storage::make_sanitized_file_config());
         },
         [this]() {
             return storage::log_config(
-              base_dir, 100_MiB, storage::debug_sanitize_files::yes);
+              base_dir,
+              100_MiB,
+              ss::default_priority_class(),
+              storage::make_sanitized_file_config());
         },
         _feature_table))
       , _logger(

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -52,11 +52,14 @@ struct foreign_entry_fixture {
               1_MiB,
               config::mock_binding(10ms),
               test_dir,
-              storage::debug_sanitize_files::yes);
+              storage::make_sanitized_file_config());
         },
         [this]() {
             return storage::log_config(
-              test_dir, 1_GiB, storage::debug_sanitize_files::yes);
+              test_dir,
+              1_GiB,
+              ss::default_priority_class(),
+              storage::make_sanitized_file_config());
         },
         _feature_table) {
         _feature_table.start().get();

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -64,7 +64,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
                       model::offset::max(),
                       ss::default_priority_class(),
                       as,
-                      storage::debug_sanitize_files::yes))
+                      storage::ntp_sanitizer_config{.sanitize_only = true}))
                     .get0();
                   if (n.log->offsets().start_offset <= model::offset(0)) {
                       return false;

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -51,7 +51,7 @@ struct mux_state_machine_fixture {
           8192,
           config::mock_binding(std::chrono::milliseconds(10)),
           _data_dir,
-          storage::debug_sanitize_files::yes);
+          storage::make_sanitized_file_config());
 
         _storage
           .start(
@@ -143,9 +143,9 @@ struct mux_state_machine_fixture {
         return storage::log_config(
           _data_dir,
           100_MiB,
-          storage::debug_sanitize_files::yes,
           ss::default_priority_class(),
-          storage::with_cache::yes);
+          storage::with_cache::yes,
+          storage::make_sanitized_file_config());
     }
 
     model::broker self_broker() {

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -64,12 +64,15 @@ struct base_fixture {
           1_MiB,
           config::mock_binding(10ms),
           _test_dir,
-          storage::debug_sanitize_files::yes);
+          storage::make_sanitized_file_config());
     }
 
     storage::log_config make_log_cfg() const {
         return storage::log_config(
-          _test_dir, 100_MiB, storage::debug_sanitize_files::yes);
+          _test_dir,
+          100_MiB,
+          ss::default_priority_class(),
+          storage::make_sanitized_file_config());
     }
 
     raft::offset_translator make_offset_translator() {

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -119,13 +119,14 @@ struct raft_node {
                   1_MiB,
                   config::mock_binding(10ms),
                   storage_dir,
-                  storage::debug_sanitize_files::yes);
+                  storage::make_sanitized_file_config());
             },
             [storage_dir, segment_size]() {
                 return storage::log_config(
                   storage_dir,
                   segment_size,
-                  storage::debug_sanitize_files::yes);
+                  ss::default_priority_class(),
+                  storage::make_sanitized_file_config());
             },
             std::ref(feature_table))
           .get();

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -289,6 +289,28 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/set_storage_failure_injection_enabled",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Set the value of the storage_failure_injection_enabled node config",
+                    "type": "void",
+                    "nickname": "set_storage_failure_injection_enabled",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                        "name": "value",
+                        "in": "query",
+                        "required": true,
+                        "type": "boolean"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright 2020 Redpanda Data, Inc.
- *
+
  * Use of this software is governed by the Business Source License
  * included in the file licenses/BSL.md
  *

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -473,7 +473,10 @@ public:
 
     storage::log_config make_default_config() {
         return storage::log_config(
-          data_dir.string(), 1_GiB, storage::debug_sanitize_files::yes);
+          data_dir.string(),
+          1_GiB,
+          ss::default_priority_class(),
+          storage::make_sanitized_file_config());
     }
 
     ss::future<> wait_for_topics(std::vector<cluster::topic_result> results) {

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -35,6 +35,7 @@ v_cc_library(
     compaction_controller.cc
     offset_to_filepos.cc
     fs_utils.cc
+    file_sanitizer_types.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -14,6 +14,7 @@
 #include "model/fundamental.h"
 #include "model/record_batch_types.h"
 #include "storage/compacted_index.h"
+#include "storage/file_sanitizer_types.h"
 #include "storage/types.h"
 
 #include <seastar/core/file.hh>
@@ -163,8 +164,8 @@ inline ss::future<> compacted_index_writer::close() { return _impl->close(); }
 compacted_index_writer make_file_backed_compacted_index(
   ss::sstring filename,
   ss::io_priority_class p,
-  debug_sanitize_files debug,
   bool truncate,
-  storage_resources& resources);
+  storage_resources& resources,
+  std::optional<ntp_sanitizer_config> sanitizer_config);
 
 } // namespace storage

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -273,7 +273,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
             || batch.header().type == model::record_batch_type::raft_data)) {
         _acc = 0;
     }
-    co_await storage::write(*_appender, batch);
+    co_await _appender->append(batch);
     vassert(
       _appender->file_byte_offset() == start_offset + header_size,
       "Size must be deterministic. Expected:{} == {}",

--- a/src/v/storage/file_sanitizer.h
+++ b/src/v/storage/file_sanitizer.h
@@ -29,6 +29,8 @@ namespace bi = boost::intrusive;
 
 #include "seastarx.h"
 
+namespace storage {
+
 struct sanitizer_op
   : public bi::list_base_hook<bi::link_mode<bi::auto_unlink>> {
     ss::sstring name_op;
@@ -239,3 +241,5 @@ private:
     ss::file _file;
     std::optional<ss::saved_backtrace> _closed;
 };
+
+} // namespace storage

--- a/src/v/storage/file_sanitizer.h
+++ b/src/v/storage/file_sanitizer.h
@@ -174,17 +174,6 @@ public:
 
     ss::future<> flush() final {
         assert_file_not_closed();
-        if (!_pending_ops.empty()) {
-            vlog(
-              finjectlog.error,
-              "flush called concurrently with other operations on file "
-              "{}. inflight_writes={}, pending_flushes={}",
-              _path,
-              maybe_dump_appender_inflight_writes(),
-              maybe_dump_appender_pending_flushes());
-
-            output_pending_ops();
-        }
         return with_op(
           ssx::sformat("ss::future<> flush(void)"),
           maybe_inject_failure(failable_op_type::flush).then([this]() {

--- a/src/v/storage/file_sanitizer_types.cc
+++ b/src/v/storage/file_sanitizer_types.cc
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "storage/file_sanitizer_types.h"
+
+#include "json/document.h"
+#include "json/schema.h"
+#include "json/stringbuffer.h"
+#include "json/validator.h"
+#include "json/writer.h"
+#include "model/fundamental.h"
+#include "storage/logger.h"
+#include "utils/file_io.h"
+#include "utils/string_switch.h"
+
+#include <seastar/core/seastar.hh>
+
+#include <functional>
+
+namespace {
+std::optional<model::record_batch_type>
+batch_type_from_string_view(std::string_view sv) {
+    using bt = model::record_batch_type;
+    return string_switch<std::optional<bt>>(sv)
+      .match("batch_type::raft_data", bt::raft_data)
+      .match("batch_type::raft_configuration", bt::raft_configuration)
+      .match("batch_type::controller", bt::controller)
+      .match("batch_type::kvstore", bt::kvstore)
+      .match("batch_type::checkpoint", bt::checkpoint)
+      .match("batch_type::topic_management_cmd", bt::topic_management_cmd)
+      .match("batch_type::ghost_batch", bt::ghost_batch)
+      .match("batch_type::id_allocator", bt::id_allocator)
+      .match("batch_type::tx_prepare", bt::tx_prepare)
+      .match("batch_type::tx_fence", bt::tx_fence)
+      .match("batch_type::tm_update", bt::tm_update)
+      .match("batch_type::user_management_cmd", bt::user_management_cmd)
+      .match("batch_type::acl_management_cmd", bt::acl_management_cmd)
+      .match("batch_type::group_prepare_tx", bt::group_prepare_tx)
+      .match("batch_type::group_commit_tx", bt::group_commit_tx)
+      .match("batch_type::group_abort_tx", bt::group_abort_tx)
+      .match("batch_type::node_management_cmd", bt::node_management_cmd)
+      .match(
+        "batch_type::data_policy_management_cmd",
+        bt::data_policy_management_cmd)
+      .match("batch_type::archival_metadata", bt::archival_metadata)
+      .match("batch_type::cluster_config_cmd", bt::cluster_config_cmd)
+      .match("batch_type::feature_update", bt::feature_update)
+      .match("batch_type::cluster_bootstrap_cmd", bt::cluster_bootstrap_cmd)
+      .match("batch_type::version_fence", bt::version_fence)
+      .default_match(std::nullopt);
+}
+
+storage::failable_op_type op_type_from_string_view(const std::string_view& s) {
+    using namespace storage;
+
+    return string_switch<failable_op_type>(s)
+      .match("write", failable_op_type::write)
+      .match("falloc", failable_op_type::falloc)
+      .match("flush", failable_op_type::flush)
+      .match("truncate", failable_op_type::truncate)
+      .match("close", failable_op_type::close);
+}
+
+storage::failable_op_config
+from_json(const json::Value& key, const json::Value& value) {
+    storage::failable_op_config op_config;
+    op_config.op_type = op_type_from_string_view(
+      std::string_view{key.GetString(), key.GetStringLength()});
+
+    if (auto it = value.FindMember("batch_type"); it != value.MemberEnd()) {
+        auto batch_type = batch_type_from_string_view(
+          std::string_view{it->value.GetString(), it->value.GetStringLength()});
+
+        if (!batch_type.has_value()) {
+            throw std::runtime_error(fmt::format(
+              "JSON failure injection config specifies invalid batch type: {}",
+              key.GetString()));
+        }
+
+        op_config.batch_type = batch_type;
+    }
+
+    if (auto it = value.FindMember("failure_probability");
+        it != value.MemberEnd()) {
+        op_config.failure_probability = it->value.GetDouble();
+    }
+
+    if (auto it = value.FindMember("delay_probability");
+        it != value.MemberEnd()) {
+        op_config.delay_probability = it->value.GetDouble();
+    }
+
+    if (auto it = value.FindMember("min_delay_ms"); it != value.MemberEnd()) {
+        op_config.min_delay_ms = it->value.GetInt();
+    } else {
+        throw std::runtime_error("JSON failure injection config specifies "
+                                 "'delay_probability', but no 'min_delay_ms'");
+    }
+
+    if (auto it = value.FindMember("max_delay_ms"); it != value.MemberEnd()) {
+        op_config.max_delay_ms = it->value.GetInt();
+    } else {
+        throw std::runtime_error("JSON failure injection config specifies "
+                                 "'delay_probability', but no 'max_delay_ms'");
+    }
+
+    return op_config;
+}
+
+storage::ntp_sanitizer_config
+from_json(const json::Value& ntp_cfg, size_t seed) {
+    auto ns = ntp_cfg["namespace"].GetString();
+    auto topic = ntp_cfg["topic"].GetString();
+    auto partition = ntp_cfg["partition"].GetInt();
+
+    model::ntp ntp{ns, topic, partition};
+    const auto& failure_configs = ntp_cfg["failure_configs"].GetObject();
+
+    std::vector<storage::failable_op_config> op_configs;
+    for (auto it = failure_configs.MemberBegin();
+         it != failure_configs.MemberEnd();
+         ++it) {
+        op_configs.push_back(from_json(it->name, it->value));
+    }
+
+    storage::ntp_failure_injection_config finject_cfg{
+      .ntp = std::move(ntp), .seed = seed, .op_configs = std::move(op_configs)};
+
+    return {.sanitize_only = false, .finjection_cfg = std::move(finject_cfg)};
+}
+
+} // namespace
+
+namespace storage {
+file_sanitize_config::file_sanitize_config(bool sanitize_only)
+  : _sanitize_only(sanitize_only) {}
+
+file_sanitize_config::file_sanitize_config(json::Document json) {
+    auto validator = json::validator(failure_injector_schema);
+    json::validate(validator, json);
+
+    auto global_seed = json["seed"].GetInt();
+    const auto& ntp_failure_configs = json["ntps"];
+    for (const auto& ntp_cfg : ntp_failure_configs.GetArray()) {
+        auto ns = ntp_cfg["namespace"].GetString();
+        auto topic = ntp_cfg["topic"].GetString();
+        auto partition = ntp_cfg["partition"].GetInt();
+
+        model::ntp ntp{ns, topic, partition};
+        auto mapped_ntp_cfg = from_json(ntp_cfg, global_seed);
+        _ntp_failure_configs[ntp] = std::move(mapped_ntp_cfg);
+    }
+}
+
+std::optional<ntp_sanitizer_config>
+file_sanitize_config::get_config_for_ntp(const model::ntp& ntp) const {
+    auto iter = _ntp_failure_configs.find(ntp);
+    if (iter != _ntp_failure_configs.end()) {
+        return iter->second;
+    }
+
+    return std::nullopt;
+}
+
+std::ostream& operator<<(std::ostream& o, const ntp_sanitizer_config& cfg) {
+    o << "{sanitize_only=" << cfg.sanitize_only
+      << ", failure_injection=" << static_cast<bool>(cfg.finjection_cfg) << "}";
+
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const file_sanitize_config& cfg) {
+    o << "{sanitize_only=" << cfg._sanitize_only
+      << ", ntps_with_failure_injection_count: "
+      << cfg._ntp_failure_configs.size() << "}";
+
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, failable_op_type op) {
+    switch (op) {
+    case failable_op_type::write:
+        return o << "write";
+    case failable_op_type::falloc:
+        return o << "falloc";
+    case failable_op_type::flush:
+        return o << "flush";
+    case failable_op_type::truncate:
+        return o << "truncate";
+    case failable_op_type::close:
+        return o << "close";
+    }
+}
+
+std::istream& operator>>(std::istream& i, failable_op_type& op) {
+    ss::sstring s;
+    i >> s;
+
+    op = op_type_from_string_view(s);
+
+    return i;
+}
+
+ss::future<std::optional<file_sanitize_config>>
+make_finjector_file_config(std::filesystem::path config_path) {
+    if (!co_await ss::file_exists(config_path.native())) {
+        vlog(
+          storage::stlog.warn,
+          "Failure injection config not present at {}",
+          config_path);
+
+        co_return std::nullopt;
+    }
+
+    auto json_config = co_await read_fully_to_string(config_path);
+
+    json::Document doc;
+    if (doc.Parse(json_config.data()).HasParseError()) {
+        vlog(
+          storage::stlog.warn,
+          "Failed to read failure injection config file at {}: {}",
+          config_path,
+          doc.GetParseError());
+    }
+
+    try {
+        co_return file_sanitize_config{std::move(doc)};
+    } catch (const std::exception& e) {
+        vlog(
+          storage::stlog.warn,
+          "Failed to parse failure injection config file at {}: {}",
+          config_path,
+          e.what());
+    }
+
+    co_return std::nullopt;
+}
+
+file_sanitize_config make_sanitized_file_config() {
+    return file_sanitize_config{true};
+}
+} // namespace storage

--- a/src/v/storage/file_sanitizer_types.h
+++ b/src/v/storage/file_sanitizer_types.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "json/document.h"
+#include "model/fundamental.h"
+#include "model/record_batch_types.h"
+
+#include <optional>
+#include <string_view>
+
+namespace storage {
+
+const std::string failure_injector_schema = R"(
+{
+    "type": "object",
+    "properties": {
+        "seed": {
+            "type": "integer"
+        },
+        "ntps": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/ntp_failure_config" }
+        }
+    },
+    "additionalProperties": false,
+    "required": ["seed", "ntps"],
+    "definitions": {
+        "ntp_failure_config": {
+            "type": "object",
+            "properties": {
+                "namespace": {
+                    "type": "string"
+                },
+                "topic": {
+                    "type": "string"
+                },
+                "partition": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "failure_configs": {
+                    "type": "object",
+                    "properties": {
+                        "write": { "$ref": "#/definitions/failure_config" },
+                        "falloc": { "$ref": "#/definitions/failure_config" },
+                        "flush": { "$ref": "#/definitions/failure_config" },
+                        "truncate": { "$ref": "#/definitions/failure_config" },
+                        "close": { "$ref": "#/definitions/failure_config" }
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": ["namespace", "topic", "partition", "failure_configs"]
+        },
+        "failure_config": {
+            "type": "object",
+            "properties": {
+                "batch_type": {
+                    "type": "string"
+                },
+                "failure_probability": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100
+                },
+                "delay_probability": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100
+                },
+                "min_delay_ms": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "max_delay_ms": {
+                    "type": "integer",
+                    "minimum": 0
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}
+)";
+
+enum class failable_op_type : uint8_t { write, falloc, truncate, flush, close };
+std::ostream& operator<<(std::ostream& o, failable_op_type op);
+std::istream& operator>>(std::istream& o, failable_op_type op);
+
+struct failable_op_config {
+    failable_op_type op_type;
+    std::optional<model::record_batch_type> batch_type;
+    std::optional<double> failure_probability;
+    std::optional<double> delay_probability;
+    std::optional<int> min_delay_ms;
+    std::optional<int> max_delay_ms;
+};
+
+struct ntp_failure_injection_config {
+    model::ntp ntp;
+    size_t seed;
+    std::vector<failable_op_config> op_configs;
+};
+
+// Copy held by the log injector file
+struct ntp_sanitizer_config {
+    bool sanitize_only;
+    std::optional<ntp_failure_injection_config> finjection_cfg;
+};
+
+std::ostream& operator<<(std::ostream& o, const ntp_sanitizer_config& cfg);
+
+// Held by log manager
+class file_sanitize_config {
+public:
+    explicit file_sanitize_config(bool sanitize_only = false);
+    explicit file_sanitize_config(json::Document);
+
+    std::optional<ntp_sanitizer_config>
+    get_config_for_ntp(const model::ntp&) const;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const file_sanitize_config& cfg);
+
+private:
+    bool _sanitize_only{false};
+    absl::flat_hash_map<model::ntp, ntp_sanitizer_config> _ntp_failure_configs;
+};
+
+ss::future<std::optional<file_sanitize_config>>
+make_finjector_file_config(std::filesystem::path config_path);
+
+file_sanitize_config make_sanitized_file_config();
+} // namespace storage

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -75,17 +75,17 @@ struct kvstore_config {
     size_t max_segment_size;
     config::binding<std::chrono::milliseconds> commit_interval;
     ss::sstring base_dir;
-    debug_sanitize_files sanitize_fileops;
+    std::optional<storage::file_sanitize_config> sanitizer_config;
 
     kvstore_config(
       size_t max_segment_size,
       config::binding<std::chrono::milliseconds> commit_interval,
       ss::sstring base_dir,
-      debug_sanitize_files sanitize_fileops)
+      std::optional<storage::file_sanitize_config> sanitizer_config)
       : max_segment_size(max_segment_size)
       , commit_interval(commit_interval)
       , base_dir(std::move(base_dir))
-      , sanitize_fileops(sanitize_fileops) {}
+      , sanitizer_config(std::move(sanitizer_config)) {}
 };
 
 class kvstore {
@@ -152,6 +152,7 @@ private:
     ss::lw_shared_ptr<segment> _segment;
     model::offset _next_offset;
     absl::node_hash_map<bytes, iobuf, bytes_type_hash, bytes_type_eq> _db;
+    std::optional<ntp_sanitizer_config> _ntp_sanitizer_config;
 
     ss::future<> put(key_space ks, bytes key, std::optional<iobuf> value);
     void apply_op(bytes key, std::optional<iobuf> value);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -21,6 +21,7 @@
 #include "ssx/future-util.h"
 #include "storage/batch_cache.h"
 #include "storage/compacted_index_writer.h"
+#include "storage/file_sanitizer.h"
 #include "storage/fs_utils.h"
 #include "storage/kvstore.h"
 #include "storage/log.h"
@@ -33,7 +34,6 @@
 #include "storage/segment_utils.h"
 #include "storage/storage_resources.h"
 #include "utils/directory_walker.h"
-#include "utils/file_sanitizer.h"
 #include "utils/gate_guard.h"
 #include "vlog.h"
 

--- a/src/v/storage/logger.cc
+++ b/src/v/storage/logger.cc
@@ -12,4 +12,5 @@
 namespace storage {
 ss::logger stlog("storage");
 ss::logger gclog("storage-gc");
+ss::logger finjectlog("finject");
 } // namespace storage

--- a/src/v/storage/logger.h
+++ b/src/v/storage/logger.h
@@ -18,4 +18,5 @@
 namespace storage {
 extern ss::logger stlog;
 extern ss::logger gclog;
+extern ss::logger finjectlog;
 } // namespace storage

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -509,7 +509,7 @@ struct compact_op final : opfuzz::op {
           model::offset::max(),
           ss::default_priority_class(),
           *(ctx._as),
-          debug_sanitize_files::yes);
+          storage::ntp_sanitizer_config{.sanitize_only = true});
         if (random_generators::get_int(0, 100) > 70) {
             cfg.eviction_time = model::timestamp::now();
             cfg.max_bytes = 10_MiB;

--- a/src/v/storage/opfuzz/opfuzz_test.cc
+++ b/src/v/storage/opfuzz/opfuzz_test.cc
@@ -9,11 +9,11 @@
 
 #include "model/fundamental.h"
 #include "random/generators.h"
+#include "storage/file_sanitizer.h"
 #include "storage/opfuzz/opfuzz.h"
 #include "storage/tests/storage_test_fixture.h"
 #include "storage/types.h"
 #include "test_utils/fixture.h"
-#include "utils/file_sanitizer.h"
 
 #include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>

--- a/src/v/storage/opfuzz/opfuzz_test.cc
+++ b/src/v/storage/opfuzz/opfuzz_test.cc
@@ -36,7 +36,6 @@ FIXTURE_TEST(test_random_workload, storage_test_fixture) {
     storage::log_manager mngr = make_log_manager(storage::log_config(
       std::move(test_dir),
       200_MiB,
-      storage::debug_sanitize_files::no,
       ss::default_priority_class(),
       storage::with_cache::yes));
     auto deferred = ss::defer([&mngr]() mutable { mngr.stop().get0(); });
@@ -84,7 +83,6 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
     storage::log_manager mngr = make_log_manager(storage::log_config(
       std::move(test_dir),
       200_MiB,
-      storage::debug_sanitize_files::no,
       ss::default_priority_class(),
       storage::with_cache::yes));
     auto deferred = ss::defer([&mngr]() mutable { mngr.stop().get0(); });

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -13,6 +13,7 @@
 #include "config/configuration.h"
 #include "ssx/future-util.h"
 #include "storage/compacted_index_writer.h"
+#include "storage/file_sanitizer.h"
 #include "storage/fs_utils.h"
 #include "storage/fwd.h"
 #include "storage/logger.h"
@@ -23,7 +24,6 @@
 #include "storage/segment_utils.h"
 #include "storage/types.h"
 #include "storage/version.h"
-#include "utils/file_sanitizer.h"
 #include "vassert.h"
 #include "vlog.h"
 

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -13,6 +13,7 @@
 
 #include "storage/batch_cache.h"
 #include "storage/compacted_index_writer.h"
+#include "storage/file_sanitizer_types.h"
 #include "storage/fs_utils.h"
 #include "storage/fwd.h"
 #include "storage/segment_appender.h"
@@ -286,12 +287,12 @@ private:
  */
 ss::future<ss::lw_shared_ptr<segment>> open_segment(
   segment_full_path path,
-  debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size,
   unsigned read_ahead,
   storage_resources&,
-  ss::sharded<features::feature_table>& feature_table);
+  ss::sharded<features::feature_table>& feature_table,
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
   const ntp_config& ntpc,
@@ -301,10 +302,10 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   record_version_type version,
   size_t buf_size,
   unsigned read_ahead,
-  debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
   storage_resources&,
-  ss::sharded<features::feature_table>& feature_table);
+  ss::sharded<features::feature_table>& feature_table,
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
 
 // bitflags operators
 [[gnu::always_inline]] inline segment::bitflags

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -111,6 +111,8 @@ segment_appender::segment_appender(segment_appender&& o) noexcept
 }
 
 ss::future<> segment_appender::append(const model::record_batch& batch) {
+    _batch_types_to_write |= 1U << static_cast<uint8_t>(batch.header().type);
+
     auto hdrbuf = std::make_unique<iobuf>(
       storage::disk_header_to_iobuf(batch.header()));
     auto ptr = hdrbuf.get();

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -127,6 +127,11 @@ private:
         return _committed_offset + (_head ? _head->bytes_pending() : 0);
     }
 
+    // Reset the bit-map tracking unwritten batch types in the `_head` chunk.
+    void reset_batch_types_to_write() { _batch_types_to_write = 0; }
+
+    uint32_t batch_types_to_write() const { return _batch_types_to_write; }
+
     ss::file _out;
     options _opts;
     bool _closed{false};
@@ -171,6 +176,11 @@ private:
     void handle_inactive_timer();
 
     size_t _chunk_size{0};
+
+    // Bit-map tracking the types of batches in the `_head` chunk that have
+    // not been written to disk yet.
+    static_assert(static_cast<uint8_t>(model::record_batch_type::MAX) <= 32);
+    uint32_t _batch_types_to_write{0};
 
     friend std::ostream& operator<<(std::ostream&, const segment_appender&);
 };

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -14,6 +14,7 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "likely.h"
+#include "model/record.h"
 #include "seastarx.h"
 #include "storage/segment_appender_chunk.h"
 #include "storage/storage_resources.h"
@@ -72,6 +73,7 @@ public:
         return _committed_offset + _bytes_flush_pending;
     }
 
+    ss::future<> append(const model::record_batch& batch);
     ss::future<> append(const char* buf, const size_t n);
     ss::future<> append(bytes_view s);
     ss::future<> append(const iobuf& io);

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -147,6 +147,11 @@ private:
           : offset(offset) {}
         size_t offset;
         ss::promise<> p;
+
+        friend std::ostream& operator<<(std::ostream& s, const flush_op& op) {
+            fmt::print(s, "{{offest: {}}}", op.offset);
+            return s;
+        }
     };
 
     std::vector<flush_op> _flush_ops;
@@ -164,6 +169,12 @@ private:
         explicit inflight_write(size_t offset)
           : done(false)
           , offset(offset) {}
+
+        friend std::ostream&
+        operator<<(std::ostream& s, const inflight_write& op) {
+            fmt::print(s, "{{done: {}, offest: {}}}", op.done, op.offset);
+            return s;
+        }
     };
 
     ss::chunked_fifo<ss::lw_shared_ptr<inflight_write>> _inflight;
@@ -183,6 +194,7 @@ private:
     uint32_t _batch_types_to_write{0};
 
     friend std::ostream& operator<<(std::ostream&, const segment_appender&);
+    friend class file_io_sanitizer;
 };
 
 using segment_appender_ptr = std::unique_ptr<segment_appender>;

--- a/src/v/storage/segment_appender_utils.cc
+++ b/src/v/storage/segment_appender_utils.cc
@@ -10,19 +10,8 @@
 #include "storage/segment_appender_utils.h"
 
 #include "model/record.h"
-#include "model/timestamp.h"
 #include "reflection/adl.h"
-#include "storage/logger.h"
-#include "utils/vint.h"
-#include "vassert.h"
 
-#include <seastar/core/byteorder.hh>
-#include <seastar/core/future-util.hh>
-
-#include <bits/stdint-uintn.h>
-
-#include <memory>
-#include <type_traits>
 namespace storage {
 
 iobuf disk_header_to_iobuf(const model::record_batch_header& h) {
@@ -48,16 +37,6 @@ iobuf disk_header_to_iobuf(const model::record_batch_header& h) {
       model::packed_record_batch_header_size,
       b.size_bytes());
     return b;
-}
-
-ss::future<>
-write(segment_appender& appender, const model::record_batch& batch) {
-    auto hdrbuf = std::make_unique<iobuf>(disk_header_to_iobuf(batch.header()));
-    auto ptr = hdrbuf.get();
-    return appender.append(*ptr).then(
-      [&appender, &batch, cpy = std::move(hdrbuf)] {
-          return appender.append(batch.data());
-      });
 }
 
 } // namespace storage

--- a/src/v/storage/segment_appender_utils.h
+++ b/src/v/storage/segment_appender_utils.h
@@ -18,7 +18,4 @@ namespace storage {
 
 iobuf disk_header_to_iobuf(const model::record_batch_header& h);
 
-ss::future<>
-write(segment_appender& appender, const model::record_batch& batch);
-
 } // namespace storage

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -45,13 +45,13 @@ segment_index::segment_index(
   model::offset base,
   size_t step,
   ss::sharded<features::feature_table>& feature_table,
-  debug_sanitize_files sanitize)
+  std::optional<ntp_sanitizer_config> sanitizer_config)
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
   , _state(index_state::make_empty_index(
       storage::internal::should_apply_delta_time_offset(_feature_table)))
-  , _sanitize(sanitize) {
+  , _sanitizer_config(std::move(sanitizer_config)) {
     _state.base_offset = base;
 }
 
@@ -77,7 +77,10 @@ ss::future<ss::file> segment_index::open() {
     }
 
     return internal::make_handle(
-      _path, ss::open_flags::create | ss::open_flags::rw, {}, _sanitize);
+      _path,
+      ss::open_flags::create | ss::open_flags::rw,
+      {},
+      _sanitizer_config);
 }
 
 void segment_index::reset() {

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -14,6 +14,7 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/timestamp.h"
+#include "storage/file_sanitizer_types.h"
 #include "storage/fs_utils.h"
 #include "storage/index_state.h"
 #include "storage/types.h"
@@ -57,7 +58,7 @@ public:
       model::offset base,
       size_t step,
       ss::sharded<features::feature_table>& feature_table,
-      debug_sanitize_files);
+      std::optional<ntp_sanitizer_config> sanitizer_config);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -146,7 +147,7 @@ private:
     size_t _acc{0};
     bool _needs_persistence{false};
     index_state _state;
-    debug_sanitize_files _sanitize;
+    std::optional<ntp_sanitizer_config> _sanitizer_config;
 
     // Override the timestamp used for retention, in case what's in
     // the index _state is no good.

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -13,6 +13,7 @@
 
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "storage/file_sanitizer_types.h"
 #include "storage/fs_utils.h"
 #include "storage/types.h"
 #include "utils/intrusive_list_helpers.h"
@@ -111,7 +112,8 @@ public:
       segment_full_path filename,
       size_t buffer_size,
       unsigned read_ahead,
-      debug_sanitize_files) noexcept;
+      std::optional<ntp_sanitizer_config> ntp_sanitizer_config
+      = std::nullopt) noexcept;
     ~segment_reader() noexcept;
     segment_reader(segment_reader&&) noexcept;
     segment_reader& operator=(segment_reader&&) noexcept;
@@ -164,7 +166,7 @@ private:
     size_t _file_size{0};
     size_t _buffer_size{0};
     unsigned _read_ahead{0};
-    debug_sanitize_files _sanitize;
+    std::optional<ntp_sanitizer_config> _sanitizer_config;
 
     // Keeps track of operations that cannot be pre-empted by close()
     ss::gate _gate;

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -92,7 +92,6 @@ private:
 
 ss::future<segment_set> recover_segments(
   partition_path path,
-  debug_sanitize_files sanitize_fileops,
   bool is_compaction_enabled,
   std::function<std::optional<batch_cache_index>()> batch_cache_factory,
   ss::abort_source& as,
@@ -100,6 +99,7 @@ ss::future<segment_set> recover_segments(
   unsigned read_readahead_count,
   std::optional<ss::sstring> last_clean_segment,
   storage_resources&,
-  ss::sharded<features::feature_table>& feature_table);
+  ss::sharded<features::feature_table>& feature_table,
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -86,13 +86,14 @@ maybe_disable_cow(const std::filesystem::path& path, ss::file& file) {
 }
 
 static inline ss::file wrap_handle(
-  [[maybe_unused]] std::filesystem::path path,
+  std::filesystem::path path,
   ss::file f,
   std::optional<ntp_sanitizer_config> ntp_sanitizer_config) {
     if (ntp_sanitizer_config) {
-        return ss::file(ss::make_shared(file_io_sanitizer(std::move(f))));
-        // std::move(path),
-        // std::move(ntp_sanitizer_config.value()))));
+        return ss::file(ss::make_shared(file_io_sanitizer(
+          std::move(f),
+          std::move(path),
+          std::move(ntp_sanitizer_config.value()))));
     }
     return f;
 }

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -22,6 +22,7 @@
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
+#include "storage/file_sanitizer.h"
 #include "storage/fs_utils.h"
 #include "storage/fwd.h"
 #include "storage/index_state.h"
@@ -33,7 +34,6 @@
 #include "storage/segment.h"
 #include "storage/types.h"
 #include "units.h"
-#include "utils/file_sanitizer.h"
 #include "vassert.h"
 #include "vlog.h"
 

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -94,30 +94,31 @@ ss::future<std::vector<ss::rwlock::holder>> write_lock_segments(
 /// make file handle with default opts
 ss::future<ss::file> make_writer_handle(
   const std::filesystem::path&,
-  storage::debug_sanitize_files,
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
   bool truncate = false);
 /// make file handle with default opts
-ss::future<ss::file>
-make_reader_handle(const std::filesystem::path&, storage::debug_sanitize_files);
+ss::future<ss::file> make_reader_handle(
+  const std::filesystem::path&,
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
 ss::future<ss::file> make_handle(
-  const std::filesystem::path path,
+  std::filesystem::path path,
   ss::open_flags flags,
   ss::file_open_options opt,
-  debug_sanitize_files debug);
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
 
 ss::future<compacted_index_writer> make_compacted_index_writer(
   const std::filesystem::path& path,
-  storage::debug_sanitize_files debug,
   ss::io_priority_class iopc,
-  storage_resources& resources);
+  storage_resources& resources,
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
 
 ss::future<segment_appender_ptr> make_segment_appender(
   const segment_full_path& path,
-  storage::debug_sanitize_files debug,
   size_t number_of_chunks,
   std::optional<uint64_t> segment_size,
   ss::io_priority_class iopc,
-  storage_resources& resources);
+  storage_resources& resources,
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
 
 size_t number_of_chunks_from_config(const storage::ntp_config&);
 uint64_t segment_size_from_config(const storage::ntp_config&);

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -49,8 +49,8 @@ public:
       ss::sstring filename,
       ss::io_priority_class,
       bool truncate,
-      storage::debug_sanitize_files debug,
-      storage_resources&);
+      storage_resources&,
+      std::optional<ntp_sanitizer_config> sanitizer_config);
 
     spill_key_index(
       ss::sstring name,
@@ -113,7 +113,7 @@ private:
     ss::future<> add_key(compaction_key, value_type);
     ss::future<> spill(compacted_index::entry_type, bytes_view, value_type);
 
-    storage::debug_sanitize_files _debug;
+    std::optional<ntp_sanitizer_config> _sanitizer_config;
     storage_resources& _resources;
     ss::io_priority_class _pc;
     bool _truncate;

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ rp_test(
     concat_segment_reader_test.cc
     offset_to_filepos_test.cc
     offset_translator_state_test.cc
+    file_sanitizer_test.cc
   LIBRARIES v::seastar_testing_main v::storage_test_utils v::model_test_utils
   LABELS storage
   ARGS "-- -c 1"

--- a/src/v/storage/tests/concat_segment_reader_test.cc
+++ b/src/v/storage/tests/concat_segment_reader_test.cc
@@ -49,8 +49,8 @@ SEASTAR_THREAD_TEST_CASE(
     disk_log_builder b{log_config{
       data_path.string(),
       segment_size,
-      debug_sanitize_files::yes,
-    }};
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()}};
 
     b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
     auto defer = ss::defer([&b] { b.stop().get(); });
@@ -142,8 +142,8 @@ SEASTAR_THREAD_TEST_CASE(test_single_segment_read_with_bounds) {
     disk_log_builder b{log_config{
       data_path.string(),
       segment_size,
-      debug_sanitize_files::yes,
-    }};
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()}};
 
     b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}})
       | add_segment(0) | add_random_batch(0, 10);
@@ -170,8 +170,8 @@ SEASTAR_THREAD_TEST_CASE(test_single_segment_read_full) {
     disk_log_builder b{log_config{
       data_path.string(),
       segment_size,
-      debug_sanitize_files::yes,
-    }};
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()}};
 
     b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}})
       | add_segment(0) | add_random_batch(0, 10);
@@ -196,8 +196,8 @@ SEASTAR_THREAD_TEST_CASE(test_multiple_segments_read_full) {
     disk_log_builder b{log_config{
       data_path.string(),
       segment_size,
-      debug_sanitize_files::yes,
-    }};
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()}};
 
     b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
     auto defer = ss::defer([&b] { b.stop().get(); });

--- a/src/v/storage/tests/file_sanitizer_test.cc
+++ b/src/v/storage/tests/file_sanitizer_test.cc
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iostream.h"
+#include "storage/file_sanitizer_types.h"
+#include "test_utils/tmp_dir.h"
+
+#include <seastar/core/fstream.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+const ss::sstring valid_schema = R"(
+{
+  "seed": 0,
+  "ntps": [
+    {
+      "namespace": "kafka",
+      "topic": "test",
+      "partition": 1,
+      "failure_configs": {
+        "write": {
+          "batch_type": "batch_type::raft_data",
+          "failure_probability": 0.1,
+          "delay_probability": 100,
+          "min_delay_ms": 0,
+          "max_delay_ms": 100
+        }
+      }
+    }
+  ]
+}
+)";
+
+const ss::sstring missing_seed_schema = R"(
+{
+  "ntps": [
+    {
+      "namespace": "kafka",
+      "topic": "test",
+      "partition": 1,
+      "failure_configs": {
+        "write": {
+          "batch_type": "batch_type::raft_data",
+          "failure_probability": 100,
+          "delay_probability": 100,
+          "min_delay_ms": 0,
+          "max_delay_ms": 100
+        }
+      }
+    }
+  ]
+}
+)";
+
+const ss::sstring invalid_op_schema = R"(
+{
+  "ntps": [
+    {
+      "namespace": "kafka",
+      "topic": "test",
+      "partition": 1,
+      "failure_configs": {
+        "write_and_flush": {
+          "batch_type": "batch_type::raft_data",
+          "failure_probability": 100,
+          "delay_probability": 100,
+          "min_delay_ms": 0,
+          "max_delay_ms": 100
+        }
+      }
+    }
+  ]
+}
+)";
+
+const ss::sstring invalid_probs_schema = R"(
+{
+  "ntps": [
+    {
+      "namespace": "kafka",
+      "topic": "test",
+      "partition": 1,
+      "failure_configs": {
+        "write_and_flush": {
+          "batch_type": "batch_type::raft_data",
+          "failure_probability": -1,
+          "delay_probability": 101,
+          "min_delay_ms": 0,
+          "max_delay_ms": 100
+        }
+      }
+    }
+  ]
+}
+)";
+
+const ss::sstring invalid_batch_schema = R"(
+{
+  "ntps": [
+    {
+      "namespace": "kafka",
+      "topic": "test",
+      "partition": 1,
+      "failure_configs": {
+        "write_and_flush": {
+          "batch_type": "batch_type::not_a_batch_type",
+          "failure_probability": 0,
+          "delay_probability": 100,
+          "min_delay_ms": 0,
+          "max_delay_ms": 100
+        }
+      }
+    }
+  ]
+}
+)";
+
+void write_to_file(ss::file& f, const ss::sstring& cfg) {
+    iobuf buf;
+    buf.append(cfg.data(), cfg.length());
+
+    auto input = make_iobuf_input_stream(std::move(buf));
+    auto out = ss::make_file_output_stream(f).get();
+
+    ss::copy(input, out).get();
+    out.flush().get();
+    out.close().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(file_sanitizer_config_parse_test) {
+    temporary_dir tmp_dir("file_sanitizer_test");
+    auto path = tmp_dir.get_path();
+
+    auto valid_path = path / "valid.json";
+
+    auto missing_seed_path = path / "missing_seed.json";
+    auto invalid_op_path = path / "invalid_op.json";
+    auto invalid_probs_path = path / "invalid_probs.json";
+    auto invalid_batch_path = path / "invalid_batch.json";
+    auto missing_path = path / "missing.json";
+
+    auto flags = ss::open_flags::rw | ss::open_flags::create
+                 | ss::open_flags::exclusive;
+
+    for (const auto& [path, schema] :
+         {std::make_pair(valid_path, valid_schema),
+          std::make_pair(missing_seed_path, missing_seed_schema),
+          std::make_pair(invalid_op_path, invalid_op_schema),
+          std::make_pair(invalid_probs_path, invalid_probs_schema),
+          std::make_pair(invalid_batch_path, invalid_batch_schema)}) {
+        auto f = ss::open_file_dma(path.native(), flags).get();
+        write_to_file(f, schema);
+    }
+
+    // Attempt to create a config from files with incorrect or missing
+    // schemas.
+    for (const auto& path :
+         {missing_seed_path,
+          invalid_op_path,
+          invalid_probs_path,
+          invalid_batch_path,
+          missing_path}) {
+        auto res = storage::make_finjector_file_config(path).get();
+        BOOST_REQUIRE(!res.has_value());
+    }
+
+    // Create a configuration from the valid input and validate its contents.
+    auto cfg = storage::make_finjector_file_config(valid_path).get();
+    BOOST_REQUIRE(cfg.has_value());
+
+    model::ntp ntp{"kafka", "test", 1};
+    const auto& ntp_cfg = cfg->get_config_for_ntp(ntp);
+    BOOST_REQUIRE(ntp_cfg.has_value());
+
+    BOOST_REQUIRE_EQUAL(ntp_cfg->sanitize_only, false);
+    BOOST_REQUIRE_EQUAL(ntp_cfg->finjection_cfg.has_value(), true);
+
+    const auto& finject_cfg = ntp_cfg->finjection_cfg.value();
+
+    BOOST_REQUIRE_EQUAL(finject_cfg.ntp, ntp);
+    BOOST_REQUIRE_EQUAL(finject_cfg.op_configs.size(), 1);
+
+    const auto& write_failure_cfg = finject_cfg.op_configs[0];
+    BOOST_REQUIRE_EQUAL(
+      write_failure_cfg.op_type, storage::failable_op_type::write);
+    BOOST_REQUIRE_EQUAL(
+      write_failure_cfg.batch_type.value(),
+      model::record_batch_type::raft_data);
+    BOOST_REQUIRE_EQUAL(write_failure_cfg.failure_probability.value(), 0.1);
+    BOOST_REQUIRE_EQUAL(write_failure_cfg.delay_probability.value(), 100);
+    BOOST_REQUIRE_EQUAL(write_failure_cfg.min_delay_ms.value(), 0);
+    BOOST_REQUIRE_EQUAL(write_failure_cfg.max_delay_ms.value(), 100);
+}

--- a/src/v/storage/tests/half_page_concurrent_dispatch.cc
+++ b/src/v/storage/tests/half_page_concurrent_dispatch.cc
@@ -19,9 +19,9 @@ struct fixture {
     storage::disk_log_builder b{storage::log_config(
       storage::random_dir(),
       1_GiB,
-      storage::debug_sanitize_files::yes,
       ss::default_priority_class(),
-      storage::with_cache::no)};
+      storage::with_cache::no,
+      storage::make_sanitized_file_config())};
     ~fixture() { b.stop().get(); }
 };
 

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -66,7 +66,7 @@ private:
           8192,
           config::mock_binding(std::chrono::milliseconds(10)),
           _test_dir,
-          storage::debug_sanitize_files::yes);
+          storage::make_sanitized_file_config());
     }
 
     storage::storage_resources resources{};

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -14,10 +14,10 @@
 #include "storage/api.h"
 #include "storage/directories.h"
 #include "storage/disk_log_appender.h"
+#include "storage/file_sanitizer.h"
 #include "storage/segment_appender.h"
 #include "storage/segment_appender_utils.h"
 #include "storage/segment_reader.h"
-#include "utils/file_sanitizer.h"
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/thread_test_case.hh>

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -44,7 +44,11 @@ void write_batches(ss::lw_shared_ptr<segment> seg) {
 }
 
 log_config make_config() {
-    return log_config{"test.dir", 1024, debug_sanitize_files::yes};
+    return log_config{
+      "test.dir",
+      1024,
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()};
 }
 
 ntp_config config_from_ntp(const model::ntp& ntp) {
@@ -70,7 +74,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
             1_MiB,
             config::mock_binding(10ms),
             conf.base_dir,
-            storage::debug_sanitize_files::yes);
+            storage::make_sanitized_file_config());
       },
       [conf]() { return conf; },
       feature_table);

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -53,8 +53,14 @@ public:
                       base_name + ".index",
                       ss::open_flags::create | ss::open_flags::rw)
                       .get0();
-        fd = ss::file(ss::make_shared(file_io_sanitizer(std::move(fd))));
-        fidx = ss::file(ss::make_shared(file_io_sanitizer(std::move(fidx))));
+        fd = ss::file(ss::make_shared(file_io_sanitizer(
+          std::move(fd),
+          std::filesystem::path{base_name},
+          ntp_sanitizer_config{.sanitize_only = true})));
+        fidx = ss::file(ss::make_shared(file_io_sanitizer(
+          std::move(fidx),
+          std::filesystem::path{base_name + ".index"},
+          ntp_sanitizer_config{.sanitize_only = true})));
 
         auto appender = std::make_unique<segment_appender>(
           fd,
@@ -67,10 +73,7 @@ public:
           4096,
           _feature_table);
         auto reader = segment_reader(
-          segment_full_path::mock(base_name),
-          128_KiB,
-          10,
-          debug_sanitize_files::no);
+          segment_full_path::mock(base_name), 128_KiB, 10);
         reader.load_size().get();
         _seg = ss::make_lw_shared<segment>(
           segment::offset_tracker(model::term_id(0), base),
@@ -96,7 +99,10 @@ public:
         auto fd = ss::open_file_dma(
                     name, ss::open_flags::create | ss::open_flags::rw)
                     .get0();
-        fd = ss::file(ss::make_shared(file_io_sanitizer(std::move(fd))));
+        fd = ss::file(ss::make_shared(file_io_sanitizer(
+          std::move(fd),
+          std::filesystem::path{name},
+          ntp_sanitizer_config{.sanitize_only = true})));
         auto out = ss::make_file_output_stream(std::move(fd)).get0();
         const auto b = random_generators::gen_alphanum_string(100);
         out.write(b.data(), b.size()).get();

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -13,13 +13,13 @@
 #include "random/generators.h"
 #include "seastarx.h"
 #include "storage/disk_log_appender.h"
+#include "storage/file_sanitizer.h"
 #include "storage/log_replayer.h"
 #include "storage/logger.h"
 #include "storage/segment.h"
 #include "storage/segment_appender_utils.h"
 #include "storage/segment_index.h"
 #include "storage/segment_reader.h"
-#include "utils/file_sanitizer.h"
 
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -115,7 +115,7 @@ public:
               for (auto& b : batches) {
                   b.header().header_crc = model::internal_header_only_crc(
                     b.header());
-                  storage::write(appender, b).get();
+                  appender.append(b).get();
               }
           },
           batches.begin()->base_offset());

--- a/src/v/storage/tests/log_segment_reader_test.cc
+++ b/src/v/storage/tests/log_segment_reader_test.cc
@@ -14,13 +14,13 @@
 #include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "storage/disk_log_appender.h"
+#include "storage/file_sanitizer.h"
 #include "storage/log_reader.h"
 #include "storage/segment.h"
 #include "storage/segment_appender.h"
 #include "storage/segment_appender_utils.h"
 #include "storage/segment_reader.h"
 #include "utils/disk_log_builder.h"
-#include "utils/file_sanitizer.h"
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/thread_test_case.hh>

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2038,7 +2038,7 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.cache = storage::with_cache::no;
     cfg.max_segment_size = config::mock_binding<size_t>(500_MiB);
-    cfg.sanitize_fileops = storage::debug_sanitize_files::no;
+    cfg.file_config = std::nullopt;
     storage::ntp_config::default_overrides overrides;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -198,7 +198,7 @@ public:
             1_MiB,
             config::mock_binding(10ms),
             test_dir,
-            storage::debug_sanitize_files::yes),
+            storage::make_sanitized_file_config()),
           resources,
           feature_table) {
         configure_unit_test_logging();
@@ -249,9 +249,9 @@ public:
         auto cfg = storage::log_config(
           std::move(test_dir),
           200_MiB,
-          storage::debug_sanitize_files::yes,
           ss::default_priority_class(),
-          cache);
+          cache,
+          storage::make_sanitized_file_config());
         return cfg;
     }
 

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -29,7 +29,7 @@ disk_log_builder::disk_log_builder(storage::log_config config)
             1_MiB,
             config::mock_binding(10ms),
             _log_config.base_dir,
-            debug_sanitize_files::yes);
+            storage::make_sanitized_file_config());
       },
       [this]() { return _log_config; },
       _feature_table) {}

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -38,7 +38,11 @@ inline static ss::sstring random_dir() {
 }
 
 inline static log_config log_builder_config() {
-    return log_config(random_dir(), 100_MiB, debug_sanitize_files::yes);
+    return log_config(
+      random_dir(),
+      100_MiB,
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config());
 }
 
 inline static log_reader_config reader_config() {

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -161,7 +161,7 @@ std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
       c.eviction_time,
       c.max_bytes.value_or(-1),
       c.max_collectible_offset,
-      c.sanitize);
+      c.sanitizer_config);
     return o;
 }
 

--- a/src/v/test_utils/archival.h
+++ b/src/v/test_utils/archival.h
@@ -26,8 +26,8 @@ inline storage::disk_log_builder make_log_builder(std::string_view data_path) {
     return storage::disk_log_builder{storage::log_config{
       {data_path.data(), data_path.size()},
       4_KiB,
-      storage::debug_sanitize_files::yes,
-    }};
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()}};
 }
 
 struct segment_spec {

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -43,11 +43,14 @@ static inline ss::future<> persist_log_file(
                 1_MiB,
                 config::mock_binding(10ms),
                 base_dir,
-                storage::debug_sanitize_files::yes);
+                storage::make_sanitized_file_config());
           },
           [base_dir]() {
               return storage::log_config(
-                base_dir, 1_GiB, storage::debug_sanitize_files::yes);
+                base_dir,
+                1_GiB,
+                ss::default_priority_class(),
+                storage::make_sanitized_file_config());
           },
           feature_table);
         storage.start().get();
@@ -111,11 +114,14 @@ read_log_file(ss::sstring base_dir, model::ntp file_ntp) {
                 1_MiB,
                 config::mock_binding(10ms),
                 base_dir,
-                storage::debug_sanitize_files::yes);
+                storage::make_sanitized_file_config());
           },
           [base_dir]() {
               return storage::log_config(
-                base_dir, 1_GiB, storage::debug_sanitize_files::yes);
+                base_dir,
+                1_GiB,
+                ss::default_priority_class(),
+                storage::make_sanitized_file_config());
           },
           feature_table);
         storage.start().get();


### PR DESCRIPTION
This PR introduces error injection capabilities to the storage layer.
The RFC can be found [here](https://docs.google.com/document/d/1Cvv-UyXNq51Rj3IjgcpARg9PHWnHHQR1AFscmlpPQdA/edit#heading=h.fxgc4ycrks86); I've not strayed too far from it, so it can be used as a rough guide.

### General approach description
A file is provided on disk via a node configuration which contains the failure injector configuration in JSON format.
This file is read from disk at start-up, then it's parsed and the required metadata is propagated through the storage
layer. This metadata is then used to construct an `ss::file` wrapper that performs failure injections according to the
config.

### Failure Injection Configuration
The JSON schema for the failure config is defined in `storage/file_sanitizer_types.h`. It allows for injecting failure on `write`, `falloc`, `truncate` and close operations. Each ntp can be configured differently and `write` operations also support batch type granularity.

Two types of failures are supported: `EIO` failures and configurable delays.

### Node Configurations
Failure injection runs independently on each node. Two new node configurations have been added to drive it:
* `storage_failure_injection_config_path` is an optional config that
  points to an on-disk path which contains the failure injection
  configuration. When this property is set, Redpanda will attempt to
  read the config and propagate it throughout the storage layer.
  Failures to read or parse this file are not critical, so are simply
  logged and ignored.
* `use_storage_failure_injection` is boolean config (defaulted to false)
  that, when set to true, enables the injection of failures and delays
  to disk mutating operations. A failure injection configuration
  specified throught the property above must also be present for
  failures to be injected.

### Potential Questions:
* Why JSON and not Serde?
I'm planning on using this with ducktape tests, so using a human readable format is easiest. If I went for serde,
I would have had to write a tool that translates from a human readable format to serde and include it in the ducktape
env.
* Is failure injection deterministic?
As much as possible, yes. A seed must be included in the failure injection configuration.
The failure configuration for each ntp uses combined hash obtained from the original seed and the ntp name hash.
Hence, given the same sequence of writes and the same seed, failures will be injected in the same manner. Achieving reproducible sequence of writes is difficult in practice, but we can take certain steps on the client side (e.g. disable batching).


Fixes https://github.com/redpanda-data/redpanda/issues/7714

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Features
* Introduce file-system error injection capabilities for use in testing.