### PR TITLE
Fixed issue with offset translation that may lead to offset gaps

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -378,7 +378,6 @@ private:
 
     ss::shared_ptr<cloud_storage::remote_partition> _cloud_storage_partition;
     std::unique_ptr<archival::ntp_archiver> _archiver;
-    ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
     std::optional<cloud_storage_clients::bucket_name> _read_replica_bucket{
       std::nullopt};
     bool _remote_delete_enabled{storage::ntp_config::default_remote_delete};

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -745,19 +745,8 @@ private:
         return it->second;
     }
 
-    kafka::offset from_log_offset(model::offset old_offset) {
-        if (old_offset > model::offset{-1}) {
-            return kafka::offset(_translator->from_log_offset(old_offset)());
-        }
-        return kafka::offset(old_offset());
-    }
-
-    model::offset to_log_offset(kafka::offset new_offset) {
-        if (new_offset > model::offset{-1}) {
-            return _translator->to_log_offset(model::offset(new_offset()));
-        }
-        return model::offset(new_offset());
-    }
+    kafka::offset from_log_offset(model::offset old_offset) const;
+    model::offset to_log_offset(kafka::offset new_offset) const;
 
     transaction_info::status_t
     get_tx_status(model::producer_identity pid) const;
@@ -824,7 +813,6 @@ private:
     storage::snapshot_manager _abort_snapshot_mgr;
     absl::flat_hash_map<std::pair<model::offset, model::offset>, uint64_t>
       _abort_snapshot_sizes{};
-    ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
     ss::sharded<features::feature_table>& _feature_table;
     config::binding<std::chrono::seconds> _log_stats_interval_s;
     ss::timer<clock_type> _log_stats_timer;

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -104,7 +104,7 @@ offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
     if (reset) {
         vlog(_logger.info, "resetting offset translation state");
 
-        _state = storage::offset_translator_state(
+        *_state = storage::offset_translator_state(
           _state->ntp(), model::offset::min(), 0);
         ++_map_version;
         _highest_known_offset = model::offset::min();
@@ -118,7 +118,7 @@ offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
           highest_known_offset_key());
 
         if (map_buf && highest_known_offset_buf) {
-            _state = storage::offset_translator_state::from_serialized_map(
+            *_state = storage::offset_translator_state::from_serialized_map(
               _state->ntp(), std::move(*map_buf));
             _highest_known_offset = reflection::from_iobuf<model::offset>(
               std::move(*highest_known_offset_buf));
@@ -135,7 +135,7 @@ offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
               "offset translation kvstore state not found, loading from "
               "provided bootstrap state");
 
-            _state = storage::offset_translator_state::from_bootstrap_state(
+            *_state = storage::offset_translator_state::from_bootstrap_state(
               _state->ntp(), bootstrap.offset2delta);
             ++_map_version;
             _highest_known_offset = bootstrap.highest_known_offset;
@@ -292,7 +292,7 @@ offset_translator::prefix_truncate_reset(model::offset offset, int64_t delta) {
       _highest_known_offset,
       _state);
 
-    _state = storage::offset_translator_state(_state->ntp(), offset, delta);
+    *_state = storage::offset_translator_state(_state->ntp(), offset, delta);
     ++_map_version;
 
     _highest_known_offset = offset;

--- a/tests/rptest/tests/idempotency_test.py
+++ b/tests/rptest/tests/idempotency_test.py
@@ -7,7 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from rptest.clients.default import DefaultClient
+from rptest.clients.types import TopicSpec
+from rptest.services.action_injector import ActionConfig, random_process_kills
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
+from ducktape.utils.util import wait_until
+from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
+from rptest.services.redpanda import SISettings
+from rptest.tests.prealloc_nodes import PreallocNodesTest
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool
@@ -47,3 +55,54 @@ class IdempotencyTest(RedpandaTest):
                          value="value1".encode('utf-8'),
                          callback=on_delivery)
         producer.flush()
+
+
+class IdempotencySnapshotDelivery(PreallocNodesTest):
+    def __init__(self, test_context):
+        extra_rp_conf = {"enable_leader_balancer": False}
+
+        si_settings = SISettings(test_context,
+                                 log_segment_size=1024 * 1024,
+                                 fast_uploads=True)
+        super(IdempotencySnapshotDelivery,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=extra_rp_conf,
+                             node_prealloc_count=1,
+                             si_settings=si_settings)
+
+    @cluster(num_nodes=4)
+    def test_recovery_after_snapshot_is_delivered(self):
+        segment_bytes = 1024 * 1024
+        msg_size = 128
+        rate_limit = 10 * (1024 * 1024) if not self.debug_mode else 1024 * 1024
+        msg_cnt = int(15 * rate_limit / msg_size)
+
+        topic = TopicSpec(partition_count=1,
+                          replication_factor=3,
+                          segment_bytes=segment_bytes,
+                          retention_bytes=2 * segment_bytes,
+                          redpanda_remote_read=True,
+                          redpanda_remote_write=True)
+
+        # create topic with small segments and short retention
+        DefaultClient(self.redpanda).create_topic(topic)
+
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       topic.name,
+                                       msg_size,
+                                       msg_cnt,
+                                       custom_node=self.preallocated_nodes,
+                                       rate_limit_bps=rate_limit)
+
+        producer.start(clean=False)
+
+        pkill_config = ActionConfig(cluster_start_lead_time_sec=10,
+                                    min_time_between_actions_sec=10,
+                                    max_time_between_actions_sec=20)
+        with random_process_kills(self.redpanda, pkill_config) as ctx:
+            wait_until(lambda: producer.produce_status.acked >= msg_cnt, 240,
+                       1)
+            producer.stop()
+
+        assert producer.produce_status.bad_offsets == 0, "Producer bad offsets detected"


### PR DESCRIPTION
When `hydrate_snapshot` happens in Raft the `offset_translator_state` in `offset_translator` is reset with the `prefix_truncate_reset`. The underlying data structure wasn't updated and that lead the situation in which the `rm_stm` accessed the old not updated version of `offset_translator_state`.

Fixes: #8289 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- Fixed issue with offset translation in `rm_stm` on snapshot hydrate