### PR TITLE
storage: further compression fixes

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -455,21 +455,31 @@ ss::future<> segment::do_compaction_index_batch(const model::record_batch& b) {
 }
 ss::future<> segment::compaction_index_batch(const model::record_batch& b) {
     if (!has_compaction_index()) {
-        return ss::now();
+        co_return;
     }
     // do not index not compactible batches
     if (!internal::is_compactible(b)) {
-        return ss::now();
+        co_return;
     }
 
     if (!b.compressed()) {
-        return do_compaction_index_batch(b);
+        co_return co_await do_compaction_index_batch(b);
     }
-    return internal::decompress_batch(b).then([this](model::record_batch&& b) {
-        return ss::do_with(std::move(b), [this](model::record_batch& b) {
-            return do_compaction_index_batch(b);
-        });
-    });
+
+    // Compressed batches have to be uncompressed before we can index them
+    // by key for compaction.  This is potentially _very_ expensive in memory:
+    // clients can simply send us 100MiB of zeros, which will compress small
+    // enough to pass batch size checks, but consume huge amounts of memory
+    // in this step.
+    //
+    // To mitigate this, we tightly limit how many of these we will do in
+    // parallel.  Users should consider _not_ using compression on their
+    // compacted topics, and/or avoiding huge batches on compacted topics.
+    auto units = co_await _resources.get_compaction_compression_units();
+
+    auto decompressed = co_await internal::decompress_batch(b);
+
+    co_return co_await do_compaction_index_batch(decompressed);
 }
 
 ss::future<append_result> segment::do_append(const model::record_batch& b) {

--- a/src/v/storage/storage_resources.h
+++ b/src/v/storage/storage_resources.h
@@ -79,6 +79,10 @@ public:
         return _inflight_close_flush.get_units(1);
     }
 
+    ss::future<ssx::semaphore_units> get_compaction_compression_units() {
+        return _inflight_compaction_compression.get_units(1);
+    }
+
     /**
      * An adjustable_semaphore will set checkpoint_hint whenever its units
      * are exhausted, but this can happen with pathological frequency if
@@ -147,6 +151,11 @@ private:
     // How many logs may be flushed during segment close concurrently?
     // (e.g. when we shut down and ask everyone to flush)
     adjustable_semaphore _inflight_close_flush{0};
+
+    // Decompressing batches for compaction indexing may have an outsized
+    // memory footprint compared with the batch's original size, we must
+    // limit how many of these we do in parallel.
+    adjustable_semaphore _inflight_compaction_compression{1};
 };
 
 } // namespace storage


### PR DESCRIPTION

New testing in https://github.com/redpanda-data/redpanda/pull/9594 exposed two issues:
- Oversized allocation in ZSTD compression
- Highly concurrent producers can result in many concurrent decompressions of batches, with no realistic upper bound on how much memory it can take.

Limiting decompressions to one per shard is a bit dramatic, but in the "reasonable" traffic case it makes sense: small batches should decompress very quickly, quickly update the compression index, and drop the semaphore.  It only starts blocking in an impactful way if the workload is using pathologically large compressed batches.

Fixes: https://github.com/redpanda-data/redpanda/issues/10155

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* A stability issue is fixed where very large ZSTD-compressed batches could exhaust memory
* A stability issue is fixed where many concurrent Produce requests using very large compressed batches could exhaust memory.
