### PR TITLE
[v23.1.x] archival: sync manifest before GC'ing segments

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1425,6 +1425,12 @@ ss::future<> ntp_archiver::garbage_collect() {
               _rtclog.info,
               "Failed to clean up metadata after garbage collection: {}",
               error);
+        } else {
+            // Upload the manifest to reflect removal of segments.  This
+            // eases testing, and avoids a situation where we might never
+            // update the manifest if the partition became idle right
+            // after finishing a GC.
+            co_await upload_manifest();
         }
     } else {
         vlog(

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1356,6 +1356,11 @@ ss::future<> ntp_archiver::garbage_collect() {
     const auto to_remove
       = _parent.archival_meta_stm()->get_segments_to_cleanup();
 
+    // Avoid replicating 'cleanup_metadata_cmd' if there's nothing to remove.
+    if (to_remove.size() == 0) {
+        co_return;
+    }
+
     size_t successful_deletes{0};
     co_await ss::max_concurrent_for_each(
       to_remove,


### PR DESCRIPTION
This change is a bit cruder than the one on `dev`:
- because there is no knowledge of whether the manifest is clean, so we must upload unconditionally or not at all.
- to avoid a situation where we might _never_ upload the manifest again after completing GC (if there are no writes to the partition), we must do a second manifest upload after GC.

So this change is less efficient than the original #10099 -- on housekeeping passes where we truncate and GC, we end up doing two manifest uploads instead of one.  On balance this still feels worthwhile to have a well defined behavior (that readers can count on an up-to-date manifest).

Backport of #10099 

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
