### PR TITLE
Adjust ducktape timeouts

### DIFF
--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -364,7 +364,8 @@ class ClusterRateQuotaTest(RedpandaTest):
         producer = KafkaProducer(acks="all",
                                  bootstrap_servers=self.leader_node,
                                  value_serializer=str.encode,
-                                 retries=1,
+                                 retries=2,
+                                 request_timeout_ms=60000,
                                  client_id="producer")
 
         consumer = KafkaConsumer(

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -67,7 +67,7 @@ class KgoRepeaterSelfTest(RedpandaTest):
                               msg_size=4096,
                               workers=1) as repeater:
             repeater.await_group_ready()
-            repeater.await_progress(1024, timeout_sec=60)
+            repeater.await_progress(1024, timeout_sec=75)
 
 
 class KgoVerifierSelfTest(PreallocNodesTest):


### PR DESCRIPTION
The shared library build in debug mode (likely due to sanitizers) runs slower than the equivalent static build (sanitizers already add 2-4x performance impact). For some tests whose timeouts were very close to the edge, we observed some additional timeouts with the shared library build. This PR adjusts them up a bit.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
