### PR TITLE
[archival] Close stream on leadership changes

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -376,26 +376,12 @@ private:
       std::optional<std::reference_wrapper<retry_chain_node>> source_rtc
       = std::nullopt);
 
-    /// Holds a stream reference, and conditionally closes the stream if
-    /// possible. This structure is useful where a stream is passed to another
-    /// function by reference, which may or may not close the stream at the end.
-    /// This wrapper has a close method which tracks whether the wrapped stream
-    /// has been moved out, and if the stream is still held it can be closed.
-    struct stream_reference {
-        using stream_ref_t
-          = std::optional<std::reference_wrapper<ss::input_stream<char>>>;
-        stream_ref_t stream_ref;
-
-        /// Closes the wrapped stream if it has not been moved out
-        ss::future<> maybe_close_ref();
-    };
-
     /// Isolates segment upload and accepts a stream reference, so that if the
     /// upload fails the exception can be handled in the caller and the stream
     /// can be closed.
     ss::future<cloud_storage::upload_result> do_upload_segment(
       upload_candidate candidate,
-      stream_reference& stream_state,
+      ss::input_stream<char> stream,
       std::optional<std::reference_wrapper<retry_chain_node>> source_rtc
       = std::nullopt);
 


### PR DESCRIPTION
Here is the situation:

We're uploading a segment and as we start we lose leadership.
`ntp_archiver::upload_segment` is called. Then we call
`do_upload_segment` with `stream_reference`. Within
`ntp_archiver::do_upload_segment` we call `_remote._upload_segment`. We
acquire the lease, then the `lazy_abort_source` requests an abort. We
return normally and the stream ref is still held because we never made
it around to taking the stream from `stream_reference` and nobody closes
the stream (we only close the stream in exceptional cases). This causes
the assertion to be triggered when the stream is destroyed.

The proper thing is to always call `maybe_close_ref()` because if an
upload actually was attempted, then the stream reference will be taken.

Fixes: #10242

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Fixes an assertion during archival when a leadership change occurs

