### PR TITLE
rpk: send maintenance disable reqs to the controller leader

### DIFF
--- a/src/go/k8s/pkg/admin/admin.go
+++ b/src/go/k8s/pkg/admin/admin.go
@@ -101,7 +101,7 @@ type AdminAPIClient interface {
 	RecommissionBroker(ctx context.Context, node int) error
 
 	EnableMaintenanceMode(ctx context.Context, node int) error
-	DisableMaintenanceMode(ctx context.Context, node int) error
+	DisableMaintenanceMode(ctx context.Context, node int, useLeaderNode bool) error
 
 	GetHealthOverview(ctx context.Context) (admin.ClusterHealthOverview, error)
 }

--- a/src/go/k8s/pkg/admin/mock_admin.go
+++ b/src/go/k8s/pkg/admin/mock_admin.go
@@ -419,7 +419,7 @@ func (m *MockAdminAPI) EnableMaintenanceMode(_ context.Context, _ int) error {
 	return nil
 }
 
-func (m *MockAdminAPI) DisableMaintenanceMode(_ context.Context, _ int) error {
+func (m *MockAdminAPI) DisableMaintenanceMode(_ context.Context, _ int, _ bool) error {
 	m.Log.WithName("DisableMaintenanceMode").Info("called")
 	return nil
 }

--- a/src/go/k8s/pkg/resources/statefulset_scale.go
+++ b/src/go/k8s/pkg/resources/statefulset_scale.go
@@ -302,7 +302,7 @@ func (r *StatefulSetResource) disableMaintenanceModeOnDecommissionedNodes(
 	}
 
 	r.logger.Info("Forcing deletion of maintenance mode for the decommissioned node", "node_id", ordinal)
-	err = adminAPI.DisableMaintenanceMode(ctx, int(ordinal))
+	err = adminAPI.DisableMaintenanceMode(ctx, int(ordinal), false)
 	if err != nil {
 		var httpErr *admin.HTTPResponseError
 		if errors.As(err, &httpErr) {

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -325,7 +325,7 @@ func (r *StatefulSetResource) checkMaintenanceMode(ctx context.Context, ordinal 
 	if br.Maintenance != nil && br.Maintenance.Draining {
 		r.logger.Info("Disable broker maintenance mode as patch is empty",
 			"pod-ordinal", ordinal)
-		err = adminAPIClient.DisableMaintenanceMode(ctx, nodeConf.NodeID)
+		err = adminAPIClient.DisableMaintenanceMode(ctx, nodeConf.NodeID, false)
 		if err != nil {
 			return fmt.Errorf("disabling maintenance mode: %w", err)
 		}

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -138,14 +138,24 @@ func (a *AdminAPI) EnableMaintenanceMode(ctx context.Context, nodeID int) error 
 }
 
 // DisableMaintenanceMode disables maintenance mode for a node.
-func (a *AdminAPI) DisableMaintenanceMode(ctx context.Context, nodeID int) error {
-	return a.sendAny(
-		ctx,
-		http.MethodDelete,
-		fmt.Sprintf("%s/%d/maintenance", brokersEndpoint, nodeID),
-		nil,
-		nil,
-	)
+func (a *AdminAPI) DisableMaintenanceMode(ctx context.Context, nodeID int, useLeaderNode bool) error {
+	if useLeaderNode {
+		return a.sendToLeader(
+			ctx,
+			http.MethodDelete,
+			fmt.Sprintf("%s/%d/maintenance", brokersEndpoint, nodeID),
+			nil,
+			nil,
+		)
+	} else {
+		return a.sendAny(
+			ctx,
+			http.MethodDelete,
+			fmt.Sprintf("%s/%d/maintenance", brokersEndpoint, nodeID),
+			nil,
+			nil,
+		)
+	}
 }
 
 func (a *AdminAPI) CancelNodePartitionsMovement(ctx context.Context, node int) ([]PartitionsMovementResult, error) {

--- a/src/go/rpk/pkg/cli/cluster/maintenance/disable.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/disable.go
@@ -48,11 +48,9 @@ func newDisableCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			if b.Maintenance == nil {
 				out.Die("maintenance mode not supported or upgrade in progress?")
-			} else if !b.Maintenance.Draining {
-				out.Exit("Maintenance mode is already disabled for node %d. Check the status with 'rpk cluster maintenance status'.", nodeID)
 			}
 
-			err = client.DisableMaintenanceMode(cmd.Context(), nodeID)
+			err = client.DisableMaintenanceMode(cmd.Context(), nodeID, true)
 			if he := (*admin.HTTPResponseError)(nil); errors.As(err, &he) {
 				if he.Response.StatusCode == 404 {
 					body, bodyErr := he.DecodeGenericErrorBody()


### PR DESCRIPTION
Maintenance status is determined by the health cache on nodes that are not the controller leader and it is possible for maintenance disable to fail because the health cache was not updated yet. See [issue comment](https://github.com/redpanda-data/redpanda/issues/9284#issuecomment-1456927970) for details.

There are several solutions to this: 
1. Remove the check in RPK that stops maintenance disable so the request always fires. Then modify the response from Redpanda such that the response indicates if the disable was successful. Then RPK can check that response.
2. Implement a new rpc and Admin API endpoint that queries maintenance status without the cache
3. Modify RPK to always send maintenance enable/disable requests to the controller leader

This PR implements option (3) because options (1) and (2) involve bypassing the cache; but maintenance mode is designed to use a cache so users of this feature should keep that in mind. 

Fixes: #9284 

Changes from force-push `9e16498`:
- Force health info refresh in Redpanda instead of the test

Changes from force-push `05616ad`:
- Move the check for node drain status from RPK into Redpanda
- Added a new cluster error for a node that already has maintenance mode disabled
- Added an option to RPK to send maintenance disable requests to the controller leader node

Changes from force-push `1cf790e`:
- Removed `"status with 'rpk cluster maintenance status'.` from the exception message
- In node_drain_status wrapper, log a message and return a generic error message if the controller is undefined.
- Added a retry into the maintenance disable test 

Changes from force-push `1c9412a`:
- Removed node drain status checks on the Redpanda side
- Removed retry from the maintenance disable test

Changes from force-push `37b7cf7`:
- Account for new method signature in `src/go/k8s/pkg/admin/admin.go`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Removed a check for disabled maintenance mode in RPK and forced any maintenance disable request to go to the controller leader.