### PR TITLE
tests: adjust BucketView kafka_start_offset to match Redpanda

### DIFF
--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -489,9 +489,20 @@ class BucketView:
             return None
 
         start_model_offset = manifest['start_offset']
-        first_segment = min(manifest['segments'].values(),
-                            key=lambda seg: seg['base_offset'])
-        delta = first_segment['delta_offset']
+        segments_at_offset = list(
+            filter(lambda seg: seg['base_offset'] == start_model_offset,
+                   manifest['segments'].values()))
+        delta = -1
+        if len(segments_at_offset) == 0:
+            # If there's no segment that matches exactly, just use the first
+            # segment's delta, provided it's ahead of the start.
+            first_segment = min(manifest['segments'].values(),
+                                key=lambda seg: seg['base_offset'])
+            if first_segment['base_offset'] < start_model_offset:
+                return None
+            delta = first_segment['delta_offset']
+        else:
+            delta = segments_at_offset[0]['delta_offset']
 
         return start_model_offset - delta
 


### PR DESCRIPTION
The bucket view previously always used the first segment's delta offset to translate the start offset. This is no longer how Redpanda reports the start offset.

Instead, it finds the segment whose base offset matches the start offset, or the first segment if its base offset is higher than the start offset, and uses its delta to do the translation[1].

\[1] https://github.com/redpanda-data/redpanda/blob/e133de2fe76ae34d8e9972eb8a225dd346d3628a/src/v/cloud_storage/partition_manifest.cc#L308

Fixes #10241

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
