### PR TITLE
Limit the kafka API api_keys scope used for throughput limits

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1896,6 +1896,13 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       256,
       {.min = 0})
+  , kafka_throughput_controlled_api_keys(
+      *this,
+      "kafka_throughput_controlled_api_keys",
+      "List of Kafka API keys (numeric) that are subject to cluster-wide "
+      "and node-wide thoughput limit control",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      {0, 1})
   , node_isolation_heartbeat_timeout(
       *this,
       "node_isolation_heartbeat_timeout",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -387,6 +387,7 @@ struct configuration final : public config_store {
       kafka_quota_balancer_node_period;
     property<double> kafka_quota_balancer_min_shard_throughput_ratio;
     bounded_property<int64_t> kafka_quota_balancer_min_shard_throughput_bps;
+    property<std::unordered_set<int16_t>> kafka_throughput_controlled_api_keys;
 
     bounded_property<int64_t> node_isolation_heartbeat_timeout;
 

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -94,6 +94,16 @@ void rjson_serialize(
 
 template<typename T>
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const std::unordered_set<T>& v) {
+    w.StartArray();
+    for (const auto& e : v) {
+        rjson_serialize(w, e);
+    }
+    w.EndArray();
+}
+
+template<typename T>
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const std::unordered_map<typename T::key_type, T>& v) {
     w.StartArray();

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -30,6 +30,7 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <memory>
+#include <unordered_set>
 
 namespace kafka {
 
@@ -97,7 +98,9 @@ public:
       std::optional<security::sasl_server> sasl,
       bool enable_authorizer,
       std::optional<security::tls::mtls_state> mtls_state,
-      config::binding<uint32_t> max_request_size) noexcept
+      config::binding<uint32_t> max_request_size,
+      config::binding<std::unordered_set<int16_t>>
+        kafka_throughput_controlled_api_keys) noexcept
       : _server(s)
       , conn(conn)
       , _sasl(std::move(sasl))
@@ -106,7 +109,9 @@ public:
       , _enable_authorizer(enable_authorizer)
       , _authlog(_client_addr, client_port())
       , _mtls_state(std::move(mtls_state))
-      , _max_request_size(std::move(max_request_size)) {}
+      , _max_request_size(std::move(max_request_size))
+      , _kafka_throughput_controlled_api_keys(
+          std::move(kafka_throughput_controlled_api_keys)) {}
 
     ~connection_context() noexcept = default;
     connection_context(const connection_context&) = delete;
@@ -331,6 +336,8 @@ private:
     std::optional<security::tls::mtls_state> _mtls_state;
     config::binding<uint32_t> _max_request_size;
     ss::lowres_clock::time_point _throttled_until;
+    config::binding<std::unordered_set<int16_t>>
+      _kafka_throughput_controlled_api_keys;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -225,7 +225,8 @@ ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
       std::move(sasl),
       authz_enabled,
       mtls_state,
-      config::shard_local_cfg().kafka_request_max_bytes.bind());
+      config::shard_local_cfg().kafka_request_max_bytes.bind(),
+      config::shard_local_cfg().kafka_throughput_controlled_api_keys.bind());
 
     try {
         co_await ctx->process();

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -51,6 +51,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <unordered_set>
 
 // Whether or not the fixtures should be configured with a node ID.
 // NOTE: several fixtures may still require a node ID be supplied for the sake
@@ -596,7 +597,8 @@ public:
           std::move(sasl),
           false,
           std::nullopt,
-          config::mock_property<uint32_t>(100_MiB).bind());
+          config::mock_property<uint32_t>(100_MiB).bind(),
+          config::mock_property<std::unordered_set<int16_t>>({0, 1}).bind());
 
         kafka::request_header header;
         auto encoder_context = kafka::request_context(

--- a/src/v/utils/to_string.h
+++ b/src/v/utils/to_string.h
@@ -47,4 +47,21 @@ operator<<(std::ostream& o, const ss::lowres_clock::duration& d) {
     return o;
 }
 
+template<typename T, typename Hash, typename KeyEqual, typename Allocator>
+std::ostream& operator<<(
+  std::ostream& os, const std::unordered_set<T, Hash, KeyEqual, Allocator>& v) {
+    bool first = true;
+    os << "{";
+    for (auto&& elem : v) {
+        if (!first) {
+            os << ", ";
+        } else {
+            first = false;
+        }
+        os << elem;
+    }
+    os << "}";
+    return os;
+}
+
 } // namespace std

--- a/tests/rptest/tests/throughput_limits_snc_test.py
+++ b/tests/rptest/tests/throughput_limits_snc_test.py
@@ -65,6 +65,7 @@ class ThroughputLimitsSnc(RedpandaTest):
         BAL_PERIOD_MS = "kafka_quota_balancer_node_period_ms"
         QUOTA_SHARD_MIN_RATIO = "kafka_quota_balancer_min_shard_throughput_ratio"
         QUOTA_SHARD_MIN_BPS = "kafka_quota_balancer_min_shard_throughput_bps"
+        CONTROLLED_API_KEYS = "kafka_throughput_controlled_api_keys"
 
     def binexp_random(self, min: int, max: int):
         min_exp = min.bit_length() - 1
@@ -120,6 +121,13 @@ class ThroughputLimitsSnc(RedpandaTest):
             if r == 0:
                 return 0
             return self.binexp_random(0, 2**22)  # up to ~1.5 months
+
+        if prop == self.ConfigProp.CONTROLLED_API_KEYS:
+            keys_num = 64  # number of KAPI keys
+            keys = set()
+            for _ in range(self.rnd.randrange(keys_num)):
+                keys.add(self.rnd.randrange(keys_num))
+            return list(keys)
 
         raise Exception(f"Unsupported ConfigProp: {prop}")
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Only account for the traffic created by a subset of Kafka API keys for node/cluster-wide limit purposes. The subset of the API keys is configurable so that we can fine tune based on specific customer needs. Only the requests from the subset will be subject to throttling. The default setting for the subset is (Produce, Fetch).

Tests showing the improvement in responsiveness are coming separately.

Fixes #10141.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

-->

### Improvements

* Some Kafka API requests are now exempt from the node-wide throughput limiting, so that functions that are not directly related to the data path can stay responsive even in heavily throttled configurations.
