### PR TITLE
Make _idempotent_producer_locks an absl::btree_map

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -374,7 +374,7 @@ rm_stm::rm_stm(
                        ss::lw_shared_ptr<inflight_requests>>(
       _tx_root_tracker.create_child("in-flight")))
   , _idempotent_producer_locks(mt::map<
-                               absl::flat_hash_map,
+                               absl::btree_map,
                                model::producer_identity,
                                ss::lw_shared_ptr<ss::basic_rwlock<>>>(
       _tx_root_tracker.create_child("idempotent-producer-locks")))

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -791,8 +791,8 @@ private:
       model::producer_identity,
       ss::lw_shared_ptr<inflight_requests>>
       _inflight_requests;
-    mt::unordered_map_t<
-      absl::flat_hash_map,
+    mt::map_t<
+      absl::btree_map,
       model::producer_identity,
       ss::lw_shared_ptr<ss::basic_rwlock<>>>
       _idempotent_producer_locks;


### PR DESCRIPTION
As recommended on the bug, make this a absl::btree_map to prevent large
contiguous allocs. There are probably other containers in this class
that look like they may need to make a similar switch. Happy to do those
in followups.

Fixes: #10238

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x (This will need to be a manual backport)
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Prevent allocation failures with many idempotent producers
