### PR TITLE
storage: refine retention_adjust_timestamps

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -801,7 +801,7 @@ ss::future<> disk_log_impl::retention_adjust_timestamps(
       model::timestamp::now().value() + ignore_in_future / 1ms);
 
     for (const auto& s : _segs) {
-        auto max_ts = s->index().max_timestamp();
+        auto max_ts = s->index().retention_timestamp();
 
         // If the actual max timestamp from user records is out of bounds, clamp
         // it to something more plausible, either from other batches or from


### PR DESCRIPTION
(This is an efficiency improvement follow up to https://github.com/redpanda-data/redpanda/pull/10028)

Previously, this was adjusting segments with
bogus max_timestamp on each call.  That works,
but is inefficient, as it will mean redundantly
re-adjusting timestamps as long as a segment
with a bogus timestamp is ahead of the retention
time cutoff (on each housekeeping call).

Instead, compare to retention_timestamp(), so that if we already adjusted the timestamp on a segment, we will see a valid TS and drop out of our loop.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none