### PR TITLE
storage/cloud_storage: remove unused functions

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1812,17 +1812,15 @@ ss::future<> ntp_archiver::housekeeping() {
     }
 }
 
-ss::future<ntp_archiver::manifest_updated> ntp_archiver::apply_retention() {
-    manifest_updated updated = manifest_updated::no;
-
+ss::future<> ntp_archiver::apply_retention() {
     if (!may_begin_uploads()) {
-        co_return updated;
+        co_return;
     }
 
     auto retention_calculator = retention_calculator::factory(
       manifest(), _parent.get_ntp_config());
     if (!retention_calculator) {
-        co_return updated;
+        co_return;
     }
 
     auto next_start_offset = retention_calculator->next_start_offset();
@@ -1838,9 +1836,7 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::apply_retention() {
         auto deadline = ss::lowres_clock::now() + sync_timeout;
         auto error = co_await _parent.archival_meta_stm()->truncate(
           *next_start_offset, deadline, _as);
-        if (error == cluster::errc::success) {
-            updated = manifest_updated::yes;
-        } else {
+        if (error != cluster::errc::success) {
             vlog(
               _rtclog.warn,
               "Failed to update archival metadata STM start offest according "
@@ -1853,18 +1849,14 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::apply_retention() {
           "{} Retention policies are already met.",
           retention_calculator->strategy_name());
     }
-
-    co_return updated;
 }
 
 // Garbage collection can be improved as follows:
 // * issue #6843: delete via DeleteObjects S3 api instead of deleting individual
 // segments
-ss::future<ntp_archiver::manifest_updated> ntp_archiver::garbage_collect() {
-    manifest_updated updated = manifest_updated::no;
-
+ss::future<> ntp_archiver::garbage_collect() {
     if (!may_begin_uploads()) {
-        co_return updated;
+        co_return;
     }
 
     const auto to_remove
@@ -1872,7 +1864,7 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::garbage_collect() {
 
     // Avoid replicating 'cleanup_metadata_cmd' if there's nothing to remove.
     if (to_remove.size() == 0) {
-        co_return updated;
+        co_return;
     }
 
     // If we are about to delete segments, we must ensure that the remote
@@ -1892,7 +1884,7 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::garbage_collect() {
         if (result != cloud_storage::upload_result::success) {
             // If we could not write the  manifest, it is not safe to remove
             // segments.
-            co_return updated;
+            co_return;
         }
     }
 
@@ -1941,9 +1933,7 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::garbage_collect() {
         auto error = co_await _parent.archival_meta_stm()->cleanup_metadata(
           deadline, _as);
 
-        if (error == cluster::errc::success) {
-            updated = manifest_updated::yes;
-        } else {
+        if (error != cluster::errc::success) {
             vlog(
               _rtclog.info,
               "Failed to clean up metadata after garbage collection: {}",
@@ -1959,8 +1949,6 @@ ss::future<ntp_archiver::manifest_updated> ntp_archiver::garbage_collect() {
     _probe->segments_deleted(static_cast<int64_t>(successful_deletes));
     vlog(
       _rtclog.debug, "Deleted {} segments from the cloud", successful_deletes);
-
-    co_return updated;
 }
 
 ss::future<cloud_storage::upload_result>

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -148,20 +148,18 @@ public:
     ss::future<std::optional<cloud_storage::partition_manifest>>
     maybe_truncate_manifest();
 
-    using manifest_updated = ss::bool_class<struct manifest_updated_tag>;
-
     /// \brief Perform housekeeping operations.
     ss::future<> housekeeping();
 
     /// \brief Advance the start offest for the remote partition
     /// according to the retention policy specified by the partition
     /// configuration. This function does *not* delete any data.
-    ss::future<manifest_updated> apply_retention();
+    ss::future<> apply_retention();
 
     /// \brief Remove segments that are no longer queriable by:
     /// segments that are below the current start offset and segments
     /// that have been replaced with their compacted equivalent.
-    ss::future<manifest_updated> garbage_collect();
+    ss::future<> garbage_collect();
 
     virtual ~ntp_archiver() = default;
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -816,20 +816,6 @@ bool remote_partition::bounds_timestamp(model::timestamp t) const {
     }
 }
 
-remote_partition::iterator
-remote_partition::seek_by_timestamp(model::timestamp t) {
-    auto segment_meta = _manifest.timequery(t);
-
-    if (segment_meta) {
-        auto found = _segments.find(segment_meta->get().base_offset);
-        if (found == _segments.end()) {
-            found = materialize_segment(*segment_meta);
-        }
-        return found;
-    }
-    return _segments.end();
-}
-
 /**
  * This is an error-handling wrapper around remote::delete_object.
  *

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -187,9 +187,6 @@ private:
     /// Return reader back to segment_state
     void return_reader(std::unique_ptr<remote_segment_batch_reader>);
 
-    /// Iterators used by the partition_record_batch_reader_impl class
-    iterator seek_by_timestamp(model::timestamp);
-
     /// The result of the borrow_next_reader method
     ///
     struct borrow_result_t {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -311,11 +311,6 @@ disk_log_impl::monitor_eviction(ss::abort_source& as) {
       .promise.get_future();
 }
 
-// TODO: Remove this function once mem_log_impl is gone
-void disk_log_impl::set_collectible_offset(model::offset) {
-    vassert(false, "set_collectible_offset called on disk_log_impl");
-}
-
 ss::future<model::offset>
 disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
     vlog(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -316,11 +316,6 @@ void disk_log_impl::set_collectible_offset(model::offset) {
     vassert(false, "set_collectible_offset called on disk_log_impl");
 }
 
-bool disk_log_impl::is_front_segment(const segment_set::type& ptr) const {
-    return !_segs.empty()
-           && ptr->reader().filename() == (*_segs.begin())->reader().filename();
-}
-
 ss::future<model::offset>
 disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
     vlog(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -75,7 +75,6 @@ public:
     ss::future<> do_housekeeping() final override;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;
-    void set_collectible_offset(model::offset) final;
 
     ss::future<model::record_batch_reader> make_reader(log_reader_config) final;
     ss::future<model::record_batch_reader> make_reader(timequery_config);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -174,8 +174,6 @@ private:
     ss::future<>
     retention_adjust_timestamps(std::chrono::seconds ignore_in_future);
 
-    bool is_front_segment(const segment_set::type&) const;
-
     compaction_config apply_overrides(compaction_config) const;
 
     storage_resources& resources();

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -83,7 +83,6 @@ public:
 
         virtual ss::future<model::offset>
         monitor_eviction(ss::abort_source&) = 0;
-        virtual void set_collectible_offset(model::offset) = 0;
         ss::lw_shared_ptr<storage::stm_manager> stm_manager() {
             return _stm_manager;
         }
@@ -193,13 +192,6 @@ public:
     ss::lw_shared_ptr<storage::stm_manager> stm_manager() {
         return _impl->stm_manager();
     }
-    /**
-     * Controls the max offset that may be compacted or evicted by log
-     * retention policy. This offset is non-decreasing.
-     */
-    void set_collectible_offset(model::offset o) {
-        return _impl->set_collectible_offset(o);
-    };
 
     ss::future<> update_configuration(ntp_config::default_overrides o) {
         return _impl->update_configuration(o);


### PR DESCRIPTION
This is pure non-functional cleanup.  Functions that are never called.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
