### PR TITLE
rptest: fix cloud start kafka offset computation

### DIFF
--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -17,7 +17,6 @@ from rptest.utils.si_utils import BucketView
 from rptest.clients.types import TopicSpec
 from rptest.tests.partition_movement import PartitionMovementMixin
 from ducktape.utils.util import wait_until
-from ducktape.mark import matrix, ok_to_fail
 from rptest.utils.mode_checks import skip_debug_mode
 
 import concurrent.futures
@@ -440,7 +439,6 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
 
             self.logger.info(f"All checks completed successfuly")
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/10241
     @cluster(num_nodes=5)
     def test_cloud_storage(self):
         """
@@ -455,7 +453,6 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
 
         self.epilogue()
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/10241
     @cluster(
         num_nodes=5,
         log_allow_list=[r"Error in hydraton loop: .*Connection reset by peer"])


### PR DESCRIPTION
Previously, `BucketView.kafka_start_offset` computed the start Kafka offset from the manifest from the segment with the min `base_offset`. Since the manifest is allowed to have entries in 'segments' that are below 'start_offset', it broke when, in a recent change, we stopped uploading after the housekeeping.

This commit fixes the failures in `CloudStorageTimingStressTest` by correcting the util function mentioned above. Cloud retention always operats on segment boundaries. There are two cases:
1. Start offset is advanced to the `base_offset` of another segment
2. Start offset is advanced to the `commited_offset + 1` of the latest segment at the time. This happens when retention decides to remove all segments from the cloud to satisfy the retention policy.

Both cases are now handled correctly.

Related https://github.com/redpanda-data/redpanda/pull/10130
Fixes https://github.com/redpanda-data/redpanda/issues/10241
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
