### PR TITLE
cloud_storage: Support byte ranges on download

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -506,7 +506,8 @@ ss::future<download_result> remote::download_segment(
   const cloud_storage_clients::bucket_name& bucket,
   const remote_segment_path& segment_path,
   const try_consume_stream& cons_str,
-  retry_chain_node& parent) {
+  retry_chain_node& parent,
+  std::optional<cloud_storage_clients::http_byte_range> byte_range) {
     gate_guard guard{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(cst_log, fib);
@@ -520,7 +521,7 @@ ss::future<download_result> remote::download_segment(
         notify_external_subscribers(
           api_activity_notification::segment_download, parent);
         auto resp = co_await lease.client->get_object(
-          bucket, path, fib.get_timeout());
+          bucket, path, fib.get_timeout(), false, byte_range);
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -253,7 +253,9 @@ public:
       const cloud_storage_clients::bucket_name& bucket,
       const remote_segment_path& path,
       const try_consume_stream& cons_str,
-      retry_chain_node& parent);
+      retry_chain_node& parent,
+      std::optional<cloud_storage_clients::http_byte_range> byte_range
+      = std::nullopt);
 
     /// \brief Download segment index from S3
     /// \param ix is the index which will be populated from data from the object

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -77,28 +77,37 @@ s3_imposter_fixture::get_targets() const {
 }
 
 void s3_imposter_fixture::set_expectations_and_listen(
-  const std::vector<s3_imposter_fixture::expectation>& expectations) {
+  const std::vector<s3_imposter_fixture::expectation>& expectations,
+  std::optional<absl::flat_hash_set<ss::sstring>> headers_to_store) {
     _server
-      ->set_routes([this, &expectations](ss::httpd::routes& r) {
-          set_routes(r, expectations);
-      })
+      ->set_routes(
+        [this, &expectations, headers_to_store = std::move(headers_to_store)](
+          ss::httpd::routes& r) mutable {
+            set_routes(r, expectations, std::move(headers_to_store));
+        })
       .get();
     _server->listen(_server_addr).get();
 }
 
 void s3_imposter_fixture::set_routes(
   ss::httpd::routes& r,
-  const std::vector<s3_imposter_fixture::expectation>& expectations) {
+  const std::vector<s3_imposter_fixture::expectation>& expectations,
+  std::optional<absl::flat_hash_set<ss::sstring>> headers_to_store) {
     using namespace ss::httpd;
     using reply = ss::http::reply;
     struct content_handler {
         content_handler(
-          const std::vector<expectation>& exp, s3_imposter_fixture& imp)
-          : fixture(imp) {
+          const std::vector<expectation>& exp,
+          s3_imposter_fixture& imp,
+          std::optional<absl::flat_hash_set<ss::sstring>> headers_to_store
+          = std::nullopt)
+          : fixture(imp)
+          , headers(std::move(headers_to_store)) {
             for (const auto& e : exp) {
                 expectations[e.url] = e;
             }
         }
+
         ss::sstring handle(const_req request, reply& repl) {
             static const ss::sstring error_payload
               = R"xml(<?xml version="1.0" encoding="UTF-8"?>
@@ -109,6 +118,13 @@ void s3_imposter_fixture::set_routes(
                             <RequestId>requestid</RequestId>
                         </Error>)xml";
             http_test_utils::request_info ri(request);
+
+            if (headers) {
+                for (const auto& h : headers.value()) {
+                    ri.headers[h] = request.get_header(h);
+                }
+            }
+
             fixture._requests.push_back(ri);
             fixture._targets.insert(std::make_pair(ri.url, ri));
             vlog(
@@ -176,8 +192,10 @@ void s3_imposter_fixture::set_routes(
         }
         std::map<ss::sstring, expectation> expectations;
         s3_imposter_fixture& fixture;
+        std::optional<absl::flat_hash_set<ss::sstring>> headers = std::nullopt;
     };
-    auto hd = ss::make_shared<content_handler>(expectations, *this);
+    auto hd = ss::make_shared<content_handler>(
+      expectations, *this, std::move(headers_to_store));
     _handler = std::make_unique<function_handler>(
       [hd](const_req req, reply& repl) { return hd->handle(req, repl); },
       "txt");

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -61,8 +61,10 @@ public:
     /// The expectations are statefull. If the body of the expectation was set
     /// to null but there was PUT call that sent some data, subsequent GET call
     /// will retrieve this data.
-    void
-    set_expectations_and_listen(const std::vector<expectation>& expectations);
+    void set_expectations_and_listen(
+      const std::vector<expectation>& expectations,
+      std::optional<absl::flat_hash_set<ss::sstring>> headers_to_store
+      = std::nullopt);
 
     /// Access all http requests ordered by time
     const std::vector<http_test_utils::request_info>& get_requests() const;
@@ -75,7 +77,10 @@ public:
 
 private:
     void set_routes(
-      ss::httpd::routes& r, const std::vector<expectation>& expectations);
+      ss::httpd::routes& r,
+      const std::vector<expectation>& expectations,
+      std::optional<absl::flat_hash_set<ss::sstring>> headers_to_store
+      = std::nullopt);
 
     ss::socket_address _server_addr;
     ss::shared_ptr<ss::httpd::http_server_control> _server;

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -46,8 +46,10 @@ public:
     /// \param name is container name
     /// \param key is the blob identifier
     /// \return initialized and signed http header or error
-    result<http::client::request_header>
-    make_get_blob_request(bucket_name const& name, object_key const& key);
+    result<http::client::request_header> make_get_blob_request(
+      bucket_name const& name,
+      object_key const& key,
+      std::optional<http_byte_range> byte_range = std::nullopt);
 
     /// \brief Create a 'Get Blob Metadata' request header
     ///
@@ -120,7 +122,8 @@ public:
       bucket_name const& name,
       object_key const& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false) override;
+      bool expect_no_such_key = false,
+      std::optional<http_byte_range> byte_range = std::nullopt) override;
 
     /// Send Get Blob Metadata request.
     /// \param name is a container name
@@ -197,7 +200,8 @@ private:
       bucket_name const& name,
       object_key const& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false);
+      bool expect_no_such_key = false,
+      std::optional<http_byte_range> byte_range = std::nullopt);
 
     ss::future<> do_put_object(
       bucket_name const& name,

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -58,6 +58,8 @@ private:
     ss::sstring _tags;
 };
 
+using http_byte_range = std::pair<uint64_t, uint64_t>;
+
 class client {
 public:
     struct no_response {};
@@ -82,7 +84,8 @@ public:
       bucket_name const& name,
       object_key const& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false)
+      bool expect_no_such_key = false,
+      std::optional<http_byte_range> byte_range = std::nullopt)
       = 0;
 
     struct head_object_result {

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -59,8 +59,10 @@ public:
     /// \param name is a bucket that has the object
     /// \param key is an object name
     /// \return initialized and signed http header or error
-    result<http::client::request_header>
-    make_get_object_request(bucket_name const& name, object_key const& key);
+    result<http::client::request_header> make_get_object_request(
+      bucket_name const& name,
+      object_key const& key,
+      std::optional<http_byte_range> byte_range = std::nullopt);
 
     /// \brief Create a 'HeadObject' request header
     ///
@@ -142,7 +144,8 @@ public:
       bucket_name const& name,
       object_key const& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false) override;
+      bool expect_no_such_key = false,
+      std::optional<http_byte_range> byte_range = std::nullopt) override;
 
     /// HeadObject request.
     /// \param name is a bucket name
@@ -197,7 +200,8 @@ private:
       bucket_name const& name,
       object_key const& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false);
+      bool expect_no_such_key = false,
+      std::optional<http_byte_range> byte_range = std::nullopt);
 
     ss::future<> do_put_object(
       bucket_name const& name,

--- a/src/v/http/tests/registered_urls.h
+++ b/src/v/http/tests/registered_urls.h
@@ -16,6 +16,7 @@
 #include <seastar/http/httpd.hh>
 
 #include <absl/container/flat_hash_map.h>
+#include <boost/beast/http/field.hpp>
 
 #include <iosfwd>
 
@@ -33,12 +34,14 @@ struct request_info {
     ss::sstring content;
     size_t content_length;
 
+    absl::flat_hash_map<ss::sstring, ss::sstring> headers;
+
     /*
      * an ugly hack for cloud_storage remote_test.cc. these are cherry-picked
      * out of the request for convenience rather than copying over the entire
-     * header and query parameter data structures and search routines for those
-     * containers. if more request info was needed it might be worth copying
-     * over all the state and the accessors.
+     * header and query parameter data structures and search routines for
+     * those containers. if more request info was needed it might be worth
+     * copying over all the state and the accessors.
      */
     ss::sstring q_list_type;
     ss::sstring q_prefix;
@@ -54,6 +57,13 @@ struct request_info {
         q_prefix = req.get_query_param("prefix");
         h_prefix = req.get_header("prefix");
         has_q_delete = req.query_parameters.contains("delete");
+    }
+
+    std::optional<ss::sstring> header(const ss::sstring& key) const {
+        if (!headers.contains(key)) {
+            return std::nullopt;
+        }
+        return headers.at(key);
     }
 };
 


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/9425

Implements byte range download. An optional byte range can be supplied when downloading segments, so that only the specified section of the segment is downloaded.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

