### PR TITLE
txn: fix invalid pid passed in abort_old_txes

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2261,6 +2261,7 @@ group::store_txn_offsets(txn_offset_commit_request r) {
 
     prepared_tx ptx;
     ptx.tx_seq = tx_seq;
+    ptx.pid = pid;
     const auto now = model::timestamp::now();
     for (const auto& [tp, offset] : offsets) {
         offset_metadata md{

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3273,7 +3273,7 @@ group::do_try_abort_old_tx(model::producer_identity pid) {
         }
         auto r = co_await _tx_frontend.local().try_abort(
           tm,
-          p_it->second.pid,
+          pid,
           tx_seq,
           config::shard_local_cfg().rm_sync_timeout_ms.value());
         if (r.ec != cluster::tx_errc::none) {


### PR DESCRIPTION

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.


Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
