### PR TITLE
[v22.3.x] Make _idempotent_producer_locks an absl::btree_map

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -633,10 +633,9 @@ private:
     ss::basic_rwlock<> _state_lock;
     bool _is_abort_idx_reduction_requested{false};
     absl::flat_hash_map<model::producer_id, ss::lw_shared_ptr<mutex>> _tx_locks;
-    absl::flat_hash_map<
-      model::producer_identity,
-      ss::lw_shared_ptr<ss::basic_rwlock<>>>
-      _idempotent_producer_locks;
+    absl::
+      btree_map<model::producer_identity, ss::lw_shared_ptr<ss::basic_rwlock<>>>
+        _idempotent_producer_locks;
     absl::flat_hash_map<
       model::producer_identity,
       ss::lw_shared_ptr<inflight_requests>>


### PR DESCRIPTION
Manual backport of #10250

Fixes: https://github.com/redpanda-data/redpanda/issues/10278

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [ ] not a bug fix
- [x] none - this is a backport
- [ ] issue does not exist in previous branches
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none
