### PR TITLE
[v23.1.x] Make _idempotent_producer_locks an absl::btree_map

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -276,7 +276,7 @@ rm_stm::rm_stm(
                        ss::lw_shared_ptr<inflight_requests>>(
       _tx_root_tracker.create_child("in-flight")))
   , _idempotent_producer_locks(mt::map<
-                               absl::flat_hash_map,
+                               absl::btree_map,
                                model::producer_identity,
                                ss::lw_shared_ptr<ss::basic_rwlock<>>>(
       _tx_root_tracker.create_child("idempotent-producer-locks")))

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -781,8 +781,8 @@ private:
       model::producer_identity,
       ss::lw_shared_ptr<inflight_requests>>
       _inflight_requests;
-    mt::unordered_map_t<
-      absl::flat_hash_map,
+    mt::map_t<
+      absl::btree_map,
       model::producer_identity,
       ss::lw_shared_ptr<ss::basic_rwlock<>>>
       _idempotent_producer_locks;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10250
Fixes https://github.com/redpanda-data/redpanda/issues/10275,