### PR TITLE
c/bootstrap_backend: set feature table applied offset

### DIFF
--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -57,7 +57,7 @@ public:
     ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
 
 private:
-    ss::future<std::error_code> apply(bootstrap_cluster_cmd);
+    ss::future<std::error_code> apply(bootstrap_cluster_cmd, model::offset);
     ss::future<> apply_cluster_uuid(model::cluster_uuid);
 
     ss::sharded<security::credential_store>& _credentials;

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -510,6 +510,9 @@ private:
     // applying raft0 log events.
     friend class cluster::feature_backend;
 
+    // for set_applied_offset when applying the bootstrap cmd
+    friend class cluster::bootstrap_backend;
+
     // Unit testing hook.
     friend class feature_table_fixture;
 


### PR DESCRIPTION
Previously, when we fast-forwarded the feature table on applying the bootstrap command, we didn't set the applied offset of the feature table. This could trip up the check in the code that applies a controller snapshot and compares the applied offset of the feature table and the snapshot to decide if we need to apply the snapshot.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
