### PR TITLE
cloud_storage: Cleanup 'remote' api error codes and configs

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -227,9 +227,6 @@ ss::future<download_result> remote::do_download_manifest(
         lease.client->shutdown();
 
         switch (resp.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -316,9 +313,6 @@ ss::future<upload_result> remote::upload_manifest(
         lease.client->shutdown();
 
         switch (res.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -443,9 +437,6 @@ ss::future<upload_result> remote::upload_segment(
 
         lease.client->shutdown();
         switch (res.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -525,9 +516,6 @@ ss::future<download_result> remote::download_segment(
         lease.client->shutdown();
 
         switch (resp.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -601,9 +589,6 @@ ss::future<download_result> remote::download_index(
         lease.client->shutdown();
 
         switch (resp.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -672,9 +657,6 @@ ss::future<download_result> remote::segment_exists(
         // Error path
         lease.client->shutdown();
         switch (resp.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -741,9 +723,6 @@ ss::future<upload_result> remote::delete_object(
         lease.client->shutdown();
 
         switch (res.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -820,9 +799,6 @@ ss::future<upload_result> remote::delete_objects(
         lease.client->shutdown();
 
         switch (res.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -999,9 +975,6 @@ ss::future<remote::list_result> remote::list_objects(
         lease.client->shutdown();
 
         switch (res.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -1079,9 +1052,6 @@ ss::future<upload_result> remote::upload_object(
 
         lease.client->shutdown();
         switch (res.error()) {
-        case cloud_storage_clients::error_outcome::none:
-            vassert(
-              false, "s3:error_outcome::none not expected on failure path");
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -230,8 +230,6 @@ ss::future<download_result> remote::do_download_manifest(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -321,8 +319,6 @@ ss::future<upload_result> remote::upload_manifest(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -450,8 +446,6 @@ ss::future<upload_result> remote::upload_segment(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -534,8 +528,6 @@ ss::future<download_result> remote::download_segment(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -612,8 +604,6 @@ ss::future<download_result> remote::download_index(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -685,8 +675,6 @@ ss::future<download_result> remote::segment_exists(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -756,8 +744,6 @@ ss::future<upload_result> remote::delete_object(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -837,8 +823,6 @@ ss::future<upload_result> remote::delete_objects(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -1018,8 +1002,6 @@ ss::future<remote::list_result> remote::list_objects(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,
@@ -1100,8 +1082,6 @@ ss::future<upload_result> remote::upload_object(
         case cloud_storage_clients::error_outcome::none:
             vassert(
               false, "s3:error_outcome::none not expected on failure path");
-        case cloud_storage_clients::error_outcome::retry_slowdown:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::retry:
             vlog(
               ctxlog.debug,

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -244,8 +244,6 @@ ss::future<download_result> remote::do_download_manifest(
               retry_permit.delay, fib.root_abort_source());
             retry_permit = fib.retry();
             break;
-        case cloud_storage_clients::error_outcome::bucket_not_found:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = download_result::failed;
             vlog(
@@ -339,8 +337,6 @@ ss::future<upload_result> remote::upload_manifest(
             break;
         case cloud_storage_clients::error_outcome::key_not_found:
             // not expected during upload
-            [[fallthrough]];
-        case cloud_storage_clients::error_outcome::bucket_not_found:
             [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
@@ -474,8 +470,6 @@ ss::future<upload_result> remote::upload_segment(
         case cloud_storage_clients::error_outcome::key_not_found:
             // not expected during upload
             [[fallthrough]];
-        case cloud_storage_clients::error_outcome::bucket_not_found:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
             break;
@@ -553,8 +547,6 @@ ss::future<download_result> remote::download_segment(
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
-        case cloud_storage_clients::error_outcome::bucket_not_found:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = download_result::failed;
             break;
@@ -633,8 +625,6 @@ ss::future<download_result> remote::download_index(
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
-        case cloud_storage_clients::error_outcome::bucket_not_found:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = download_result::failed;
             break;
@@ -707,8 +697,6 @@ ss::future<download_result> remote::segment_exists(
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
-        case cloud_storage_clients::error_outcome::bucket_not_found:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = download_result::failed;
             break;
@@ -780,8 +768,6 @@ ss::future<upload_result> remote::delete_object(
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
-        case cloud_storage_clients::error_outcome::bucket_not_found:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
             break;
@@ -863,8 +849,6 @@ ss::future<upload_result> remote::delete_objects(
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();
             break;
-        case cloud_storage_clients::error_outcome::bucket_not_found:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
             break;
@@ -1046,8 +1030,6 @@ ss::future<remote::list_result> remote::list_objects(
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();
             break;
-        case cloud_storage_clients::error_outcome::bucket_not_found:
-            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = cloud_storage_clients::error_outcome::fail;
             break;
@@ -1133,8 +1115,6 @@ ss::future<upload_result> remote::upload_object(
             permit = fib.retry();
             break;
         case cloud_storage_clients::error_outcome::key_not_found:
-            [[fallthrough]];
-        case cloud_storage_clients::error_outcome::bucket_not_found:
             [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -293,7 +293,7 @@ ss::future<result<T, error_outcome>> abs_client::send_request(
               err.http_code(),
               err.code_string(),
               err.message());
-            outcome = error_outcome::retry_slowdown;
+            outcome = error_outcome::retry;
             _probe->register_retryable_failure(op_type);
         } else if (
           err.http_code() == status::forbidden

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -427,7 +427,7 @@ ss::future<result<T, error_outcome>> s3_client::send_request(
             // In principle only slow_down should occur, but in practice
             // AWS S3 does return internal_error as well sometimes.
             vlog(s3_log.warn, "{} response received {}", err.code(), bucket);
-            outcome = error_outcome::retry_slowdown;
+            outcome = error_outcome::retry;
         } else {
             // Unexpected REST API error, we can't recover from this
             // because the issue is not temporary (e.g. bucket doesn't

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -418,7 +418,7 @@ ss::future<result<T, error_outcome>> s3_client::send_request(
               "cloud_storage_region cluster configs are correct.",
               bucket());
 
-            outcome = error_outcome::bucket_not_found;
+            outcome = error_outcome::fail;
         } else if (
           err.code() == s3_error_code::slow_down
           || err.code() == s3_error_code::internal_error) {

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -507,8 +507,7 @@ SEASTAR_TEST_CASE(test_delete_bucket_not_found) {
 
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE(
-          result.error()
-          == cloud_storage_clients::error_outcome::bucket_not_found);
+          result.error() == cloud_storage_clients::error_outcome::fail);
         server->stop().get();
     });
 }

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -383,7 +383,7 @@ SEASTAR_TEST_CASE(test_put_object_failure) {
                               .get();
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
-          result.error(), cloud_storage_clients::error_outcome::retry_slowdown);
+          result.error(), cloud_storage_clients::error_outcome::retry);
         server->stop().get();
     });
 }
@@ -426,7 +426,7 @@ SEASTAR_TEST_CASE(test_get_object_failure) {
                               .get0();
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
-          result.error(), cloud_storage_clients::error_outcome::retry_slowdown);
+          result.error(), cloud_storage_clients::error_outcome::retry);
         server->stop().get();
     });
 }
@@ -463,7 +463,7 @@ SEASTAR_TEST_CASE(test_delete_object_failure) {
 
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
-          result.error(), cloud_storage_clients::error_outcome::retry_slowdown);
+          result.error(), cloud_storage_clients::error_outcome::retry);
         server->stop().get();
     });
 }
@@ -628,7 +628,7 @@ SEASTAR_TEST_CASE(test_list_objects_failure) {
 
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
-          result.error(), cloud_storage_clients::error_outcome::retry_slowdown);
+          result.error(), cloud_storage_clients::error_outcome::retry);
         server->stop().get();
     });
 }
@@ -711,8 +711,7 @@ SEASTAR_TEST_CASE(test_delete_object_retry) {
                         .get();
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE(
-          result.error()
-          == cloud_storage_clients::error_outcome::retry_slowdown);
+          result.error() == cloud_storage_clients::error_outcome::retry);
 
         server->stop().get();
     });

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -36,8 +36,6 @@ enum class error_outcome {
     fail,
     /// Missing key API error (only suitable for downloads and deletions)
     key_not_found,
-    /// The bucket couldn't be found. Indicates misconfiguration.
-    bucket_not_found
 };
 
 struct error_outcome_category final : public std::error_category {

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -30,8 +30,6 @@ enum class error_outcome {
     none = 0,
     /// Error condition that could be retried
     retry,
-    /// The service asked us to retry (SlowDown response)
-    retry_slowdown,
     /// Error condition that couldn't be retried
     fail,
     /// Missing key API error (only suitable for downloads and deletions)
@@ -49,8 +47,6 @@ struct error_outcome_category final : public std::error_category {
             return "No error";
         case error_outcome::retry:
             return "Retryable error";
-        case error_outcome::retry_slowdown:
-            return "Cloud service asked us to slow down";
         case error_outcome::fail:
             return "Non retriable error";
         case error_outcome::key_not_found:

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -27,8 +27,6 @@ using ca_trust_file
   = named_type<std::filesystem::path, struct s3_ca_trust_file>;
 
 enum class error_outcome {
-    none = 0,
-    /// Error condition that could be retried
     retry,
     /// Error condition that couldn't be retried
     fail,
@@ -43,8 +41,6 @@ struct error_outcome_category final : public std::error_category {
 
     std::string message(int c) const final {
         switch (static_cast<error_outcome>(c)) {
-        case error_outcome::none:
-            return "No error";
         case error_outcome::retry:
             return "Retryable error";
         case error_outcome::fail:

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -113,8 +113,8 @@ recovery_task_config recovery_task_config::make_config() {
       .operation_timeout_ms
       = config::shard_local_cfg()
           .cloud_storage_manifest_upload_timeout_ms.value(),
-      .backoff_ms = config::shard_local_cfg()
-                      .cloud_storage_upload_loop_initial_backoff_ms.value()};
+      .backoff_ms
+      = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value()};
 }
 
 topic_recovery_service::topic_recovery_service(


### PR DESCRIPTION
Remove/merge unused or redundant error codes to lower the entropy. Use different config parameter to set backoff interval in the recovery code.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none