### PR TITLE
cloud_storage: use "lifecycle markers" in topic table to remember to delete remote content

### DIFF
--- a/src/v/archival/fwd.h
+++ b/src/v/archival/fwd.h
@@ -16,5 +16,6 @@ class upload_controller;
 class ntp_archiver;
 struct configuration;
 class upload_housekeeping_service;
+class scrubber;
 
 } // namespace archival

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/scrubber.h"
+
+#include "archival/logger.h"
+#include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/remote_partition.h"
+#include "cloud_storage/topic_manifest.h"
+#include "cloud_storage/tx_range_manifest.h"
+#include "cluster/members_table.h"
+#include "cluster/topic_table.h"
+#include "cluster/topics_frontend.h"
+#include "config/configuration.h"
+#include "config/node_config.h"
+#include "hashing/xx.h"
+#include "vlog.h"
+
+namespace archival {
+
+using cloud_storage::download_result;
+using cloud_storage::upload_result;
+
+scrubber::scrubber(
+  cloud_storage::remote& r,
+  cluster::topic_table& tt,
+  ss::sharded<cluster::topics_frontend>& tf,
+  ss::sharded<cluster::members_table>& mt)
+  : _api(r)
+  , _topic_table(tt)
+  , _topics_frontend(tf)
+  , _members_table(mt) {}
+
+ss::future<scrubber::purge_result> scrubber::purge_partition(
+  const cloud_storage_clients::bucket_name& bucket,
+  model::ntp ntp,
+  model::initial_revision_id remote_revision,
+  retry_chain_node& parent_rtc) {
+    retry_chain_node manifest_rtc(
+      ss::lowres_clock::now() + 5s, 1s, &parent_rtc);
+
+    purge_result result{.status = purge_status::success, .ops = 0};
+
+    // TODO: tip off remote() to not retry on SlowDown responses: if we hit
+    // one during housekeeping we should drop out.  Maybe retry_chain_node
+    // could have a "drop out on slowdown" flag?
+
+    cloud_storage::partition_manifest manifest(ntp, remote_revision);
+    auto manifest_path = manifest.get_manifest_path();
+    auto manifest_get_result = co_await _api.maybe_download_manifest(
+      bucket, manifest_path, manifest, manifest_rtc);
+
+    if (manifest_get_result == download_result::notfound) {
+        vlog(
+          archival_log.debug,
+          "Partition manifest get {} not found",
+          manifest_path);
+        result.status = purge_status::permanent_failure;
+        co_return result;
+    } else if (manifest_get_result != download_result::success) {
+        vlog(
+          archival_log.debug,
+          "Partition manifest get {} failed: {}",
+          manifest_path,
+          manifest_get_result);
+        result.status = purge_status::retryable_failure;
+        co_return result;
+    }
+
+    auto partition_r = co_await cloud_storage::remote_partition::erase(
+      _api, bucket, std::move(manifest), _as);
+
+    if (partition_r != cloud_storage::remote_partition::erase_result::erased) {
+        vlog(
+          archival_log.debug,
+          "One or more objects deletions failed for {}",
+          ntp);
+        result.status = purge_status::retryable_failure;
+        co_return result;
+    }
+
+    // Erase the partition manifest
+    vlog(archival_log.debug, "Erasing partition manifest {}", manifest_path);
+    retry_chain_node manifest_delete_rtc(
+      ss::lowres_clock::now() + 5s, 1s, &parent_rtc);
+    result.ops += 1;
+    auto manifest_delete_result = co_await _api.delete_object(
+      bucket,
+      cloud_storage_clients::object_key(manifest_path),
+      manifest_delete_rtc);
+    if (manifest_delete_result != upload_result::success) {
+        result.status = purge_status::retryable_failure;
+        co_return result;
+    }
+
+    vlog(
+      archival_log.info,
+      "Finished erasing partition {} from object storage in {} requests",
+      ntp,
+      result.ops);
+    co_return result;
+}
+
+scrubber::global_position scrubber::get_global_position() {
+    const auto& nodes = _members_table.local().nodes();
+    auto self = config::node().node_id();
+
+    // members_table doesn't store nodes in sorted container, so
+    // we compose a sorted order first.
+    auto node_ids = _members_table.local().node_ids();
+    std::sort(node_ids.begin(), node_ids.end());
+
+    uint32_t result = 0;
+    uint32_t total = 0;
+
+    // Iterate over node IDs earlier than ours, sum their core counts
+    for (auto i : node_ids) {
+        const auto cores = nodes.at(i).broker.properties().cores;
+        if (i < self) {
+            result += cores;
+        }
+        total += cores;
+    }
+
+    result += ss::this_shard_id();
+
+    return global_position{.self = result, .total = total};
+}
+
+ss::future<housekeeping_job::run_result>
+scrubber::run(retry_chain_node& parent_rtc, run_quota_t quota) {
+    auto gate_holder = _gate.hold();
+
+    run_result result{
+      .status = run_status::skipped,
+      .consumed = run_quota_t(0),
+      .remaining = quota,
+    };
+
+    if (!_enabled) {
+        co_return result;
+    }
+
+    // Take a copy, as we will iterate over it asynchronously
+    cluster::topic_table::lifecycle_markers_t markers
+      = _topic_table.get_lifecycle_markers();
+
+    const auto my_global_position = get_global_position();
+
+    // TODO: grace period to let individual cluster::partitions finish
+    // deleting their own partitions under normal circumstances.
+
+    vlog(
+      archival_log.info,
+      "Running with {} quota, {} topic lifecycle markers",
+      result.remaining,
+      markers.size());
+    for (auto& [nt_revision, marker] : markers) {
+        // Double check the topic config is elegible for remote deletion
+        if (!marker.config.properties.requires_remote_erase()) {
+            vlog(
+              archival_log.warn,
+              "Dropping lifecycle marker {}, is not suitable for remote purge",
+              marker.config.tp_ns);
+
+            co_await _topics_frontend.local().purged_topic(nt_revision, 5s);
+            continue;
+        }
+
+        auto& bucket_config_property
+          = cloud_storage::configuration::get_bucket_config();
+        if (!bucket_config_property().has_value()) {
+            vlog(
+              archival_log.error,
+              "Lifecycle marker exists but cannot be purged because "
+              "{} is not set.",
+              bucket_config_property.name());
+            co_return result;
+        }
+
+        auto bucket = cloud_storage_clients::bucket_name{
+          bucket_config_property().value()};
+
+        // TODO: share work at partition granularity, not topic.  Requires
+        // a feedback mechanism for the work done on partitions to be made
+        // visible to the shard handling the total topic.
+
+        // Map topics to shards based on simple hash, to distribute work
+        // if there are many topics to clean up.
+        incremental_xxhash64 inc_hash;
+        inc_hash.update(nt_revision.nt.ns);
+        inc_hash.update(nt_revision.nt.tp);
+        inc_hash.update(nt_revision.initial_revision_id);
+        uint32_t hash = static_cast<uint32_t>(inc_hash.digest() & 0xffffffff);
+
+        if (my_global_position.self == hash % my_global_position.total) {
+            vlog(
+              archival_log.info,
+              "Processing topic lifecycle marker {} ({} partitions)",
+              marker.config.tp_ns,
+              marker.config.partition_count);
+            auto& topic_config = marker.config;
+
+            for (model::partition_id i = model::partition_id{0};
+                 i < marker.config.partition_count;
+                 ++i) {
+                model::ntp ntp(nt_revision.nt.ns, nt_revision.nt.tp, i);
+
+                if (result.remaining <= run_quota_t(0)) {
+                    // Exhausted quota, drop out.
+                    vlog(archival_log.debug, "Exhausted quota, dropping out");
+                    co_return result;
+                }
+
+                auto purge_r = co_await purge_partition(
+                  bucket, ntp, marker.initial_revision_id, parent_rtc);
+
+                result.consumed += run_quota_t(purge_r.ops);
+                result.remaining
+                  = result.remaining
+                    - std::min(run_quota_t(purge_r.ops), result.remaining);
+
+                if (purge_r.status == purge_status::success) {
+                    result.status = run_status::ok;
+                } else if (purge_r.status == purge_status::permanent_failure) {
+                    // If we permanently fail to purge a partition, we pretend
+                    // to succeed and proceed to clean up the tombstone, to
+                    // avoid remote storage issues blocking us from cleaning
+                    // up tombstones
+                    result.status = run_status::ok;
+                } else {
+                    vlog(
+                      archival_log.info,
+                      "Failed to purge {}, will retry on next scrub",
+                      ntp);
+                    result.status = run_status::failed;
+                    co_return result;
+                }
+            }
+
+            // At this point, all partition deletions either succeeded or
+            // permanently failed: clean up the topic manifest and erase
+            // the controller tombstone.
+            auto topic_manifest_path
+              = cloud_storage::topic_manifest::get_topic_manifest_path(
+                topic_config.tp_ns.ns, topic_config.tp_ns.tp);
+            vlog(
+              archival_log.debug,
+              "Erasing topic manifest {}",
+              topic_manifest_path);
+            retry_chain_node topic_manifest_rtc(5s, 1s, &parent_rtc);
+            auto manifest_delete_result = co_await _api.delete_object(
+              bucket,
+              cloud_storage_clients::object_key(topic_manifest_path),
+              topic_manifest_rtc);
+            if (manifest_delete_result != upload_result::success) {
+                vlog(
+                  archival_log.info,
+                  "Failed to erase topic manifest {}, will retry on next scrub",
+                  nt_revision.nt);
+                result.status = run_status::failed;
+                co_return result;
+            }
+
+            // All topic-specific bucket contents are gone, we may erase
+            // our controller tombstone.
+            auto purge_result = co_await _topics_frontend.local().purged_topic(
+              nt_revision, 5s);
+            if (purge_result.ec != cluster::errc::success) {
+                // Just log: this will get retried next time the scrubber runs
+                vlog(
+                  archival_log.info,
+                  "Failed to mark topic {} purged: {}, will retry on next "
+                  "scrub",
+                  nt_revision.nt,
+                  purge_result.ec);
+            }
+        }
+    }
+
+    co_return result;
+}
+
+ss::future<> scrubber::stop() {
+    vlog(archival_log.info, "Stopping ({})...", _gate.get_count());
+    if (!_as.abort_requested()) {
+        _as.request_abort();
+    }
+    return _gate.close();
+}
+
+void scrubber::interrupt() { _as.request_abort(); }
+
+bool scrubber::interrupted() const { return _as.abort_requested(); }
+
+void scrubber::set_enabled(bool e) { _enabled = e; }
+
+void scrubber::acquire() { _holder = ss::gate::holder(_gate); }
+
+void scrubber::release() { _holder.release(); }
+
+} // namespace archival

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/types.h"
+#include "cloud_storage/fwd.h"
+#include "cluster/fwd.h"
+
+#include <seastar/core/future.hh>
+
+namespace archival {
+
+/**
+ * The scrubber is a global sharded service: it runs on all shards, and
+ * decides internally which shard will scrub which ranges of objects
+ * in object storage.
+ */
+class scrubber : public housekeeping_job {
+public:
+    explicit scrubber(
+      cloud_storage::remote&,
+      cluster::topic_table&,
+      ss::sharded<cluster::topics_frontend>&,
+      ss::sharded<cluster::members_table>&);
+
+    ss::future<run_result>
+    run(retry_chain_node& rtc, run_quota_t quota) override;
+
+    void interrupt() override;
+
+    bool interrupted() const override;
+
+    ss::future<> stop() override;
+
+    void set_enabled(bool) override;
+
+    void acquire() override;
+    void release() override;
+
+private:
+    enum class purge_status : uint8_t {
+        success,
+
+        // Unavailability of backend, timeouts, etc.  We should drop out
+        // but the purge can be retried in a future housekeeping iteration.
+        retryable_failure,
+
+        // If we cannot possibly finish, for example because we got a 404
+        // reading manifest.
+        permanent_failure,
+    };
+
+    struct purge_result {
+        purge_status status;
+        size_t ops{0};
+    };
+
+    ss::future<purge_result> purge_partition(
+      const cloud_storage_clients::bucket_name& bucket,
+      model::ntp,
+      model::initial_revision_id,
+      retry_chain_node& rtc);
+
+    struct global_position {
+        uint32_t self;
+        uint32_t total;
+    };
+
+    /// Find our index out of all shards in the cluster
+    global_position get_global_position();
+
+    ss::abort_source _as;
+    ss::gate _gate;
+
+    // A gate holder we keep on behalf of the housekeeping service, when
+    // it acquire()s us.
+    ss::gate::holder _holder;
+
+    bool _enabled{true};
+
+    cloud_storage::remote& _api;
+    cluster::topic_table& _topic_table;
+    ss::sharded<cluster::topics_frontend>& _topics_frontend;
+    ss::sharded<cluster::members_table>& _members_table;
+};
+
+} // namespace archival

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -11,6 +11,7 @@
 #include "archival/types.h"
 #include "cloud_storage/fwd.h"
 #include "cluster/fwd.h"
+#include "cluster/types.h"
 
 #include <seastar/core/future.hh>
 
@@ -62,6 +63,7 @@ private:
     };
 
     ss::future<purge_result> purge_partition(
+      const cluster::nt_lifecycle_marker&,
       const cloud_storage_clients::bucket_name& bucket,
       model::ntp,
       model::initial_revision_id,

--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -324,6 +324,10 @@ ss::future<> housekeeping_workflow::run_jobs_bg() {
                 jobs_executed++;
                 quota = res.remaining;
                 maybe_update_probe(res);
+            } catch (const ss::gate_closed_exception&) {
+                // Shutting down
+            } catch (const ss::abort_requested_exception&) {
+                // Shutting down
             } catch (...) {
                 vlog(
                   archival_log.warn,

--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -73,6 +73,9 @@ upload_housekeeping_service::upload_housekeeping_service(
         _api_utilization = std::make_unique<sliding_window_t>(
           initial, _idle_timeout(), ma_resolution);
     });
+
+    _epoch_duration.watch(
+      [this] { _epoch_timer.rearm_periodic(_epoch_duration()); });
 }
 
 upload_housekeeping_service::~upload_housekeeping_service() {}

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -171,6 +171,7 @@ v_cc_library(
     ../archival/retention_calculator.cc
     ../archival/upload_housekeeping_service.cc
     ../archival/adjacent_segment_merger.cc
+    ../archival/scrubber.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -93,6 +93,7 @@ static constexpr int8_t create_non_replicable_topic_cmd_type = 6;
 static constexpr int8_t cancel_moving_partition_replicas_cmd_type = 7;
 static constexpr int8_t move_topic_replicas_cmd_type = 8;
 static constexpr int8_t revert_cancel_partition_move_cmd_type = 9;
+static constexpr int8_t topic_lifecycle_transition_cmd_type = 10;
 
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
@@ -138,6 +139,13 @@ using delete_topic_cmd = controller_command<
   delete_topic_cmd_type,
   model::record_batch_type::topic_management_cmd,
   serde_opts::adl_and_serde>;
+
+using topic_lifecycle_transition_cmd = controller_command<
+  model::topic_namespace,
+  topic_lifecycle_transition,
+  topic_lifecycle_transition_cmd_type,
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::serde_only>;
 
 using move_partition_replicas_cmd = controller_command<
   model::ntp,

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -27,6 +27,11 @@
             "output_type": "create_topics_reply"
         },
         {
+            "name": "purged_topic",
+            "input_type": "purged_topic_request",
+            "output_type": "purged_topic_reply"
+        },
+        {
             "name": "create_non_replicable_topics",
             "input_type": "create_non_replicable_topics_request",
             "output_type": "create_non_replicable_topics_reply"

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -175,6 +175,13 @@ struct topics_t
     absl::node_hash_map<model::topic_namespace, topic_t> topics;
     raft::group_id highest_group_id;
 
+    absl::node_hash_map<
+      nt_revision,
+      nt_lifecycle_marker,
+      nt_revision_hash,
+      nt_revision_eq>
+      lifecycle_markers;
+
     friend bool operator==(const topics_t&, const topics_t&) = default;
 
     ss::future<> serde_async_write(iobuf&);

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -144,6 +144,18 @@ service::create_topics(create_topics_request&& r, rpc::streaming_context&) {
       });
 }
 
+ss::future<purged_topic_reply>
+service::purged_topic(purged_topic_request&& r, rpc::streaming_context&) {
+    return ss::with_scheduling_group(
+             get_scheduling_group(),
+             [this, r = std::move(r)]() mutable {
+                 return _topics_frontend.local().do_purged_topic(
+                   std::move(r.topic), model::timeout_clock::now() + r.timeout);
+             })
+      .then(
+        [](topic_result res) { return purged_topic_reply(std::move(res)); });
+}
+
 ss::future<create_non_replicable_topics_reply>
 service::create_non_replicable_topics(
   create_non_replicable_topics_request&& r, rpc::streaming_context&) {

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -50,6 +50,9 @@ public:
     virtual ss::future<create_topics_reply>
     create_topics(create_topics_request&&, rpc::streaming_context&) override;
 
+    virtual ss::future<purged_topic_reply>
+    purged_topic(purged_topic_request&&, rpc::streaming_context&) override;
+
     ss::future<create_non_replicable_topics_reply> create_non_replicable_topics(
       create_non_replicable_topics_request&&, rpc::streaming_context&) final;
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -911,6 +911,10 @@ topic_table::fill_snapshot(controller_snapshot& controller_snap) const {
             .updates = std::move(updates),
           });
     }
+
+    for (const auto& [ntr, lm] : _lifecycle_markers) {
+        snap.lifecycle_markers.emplace(ntr, lm);
+    }
 }
 
 // helper class to hold context needed for adding/deleting ntps when applying a
@@ -1298,6 +1302,10 @@ ss::future<> topic_table::apply_snapshot(
 
     // 3. notify delta waiters
     notify_waiters();
+
+    // Lifecycle markers is a simple static collection without notifications
+    // etc, so we can just copy directly into place.
+    _lifecycle_markers = controller_snap.topics.lifecycle_markers;
 
     _last_applied_revision_id = snap_revision;
 }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -106,35 +106,40 @@ ss::future<> topic_table::stop() {
 ss::future<std::error_code>
 topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
     _last_applied_revision_id = model::revision_id(offset);
+
+    co_return do_local_delete(cmd.key, offset);
+}
+
+std::error_code
+topic_table::do_local_delete(model::topic_namespace nt, model::offset offset) {
     auto delete_type = delta::op_type::del;
-    if (auto tp = _topics.find(cmd.value); tp != _topics.end()) {
+    if (auto tp = _topics.find(nt); tp != _topics.end()) {
         if (!tp->second.is_topic_replicable()) {
             delete_type = delta::op_type::del_non_replicable;
             model::topic_namespace_view tp_nsv{
-              cmd.key.ns, tp->second.get_source_topic()};
+              nt.ns, tp->second.get_source_topic()};
             auto found = _topics_hierarchy.find(tp_nsv);
             vassert(
               found != _topics_hierarchy.end(),
               "Missing source for non_replicable topic: {}",
               tp_nsv);
             vassert(
-              found->second.erase(cmd.value) > 0,
+              found->second.erase(nt) > 0,
               "non_replicable_topic should exist in hierarchy: {}",
               tp_nsv);
         } else {
             /// Prevent deletion of source topics that have non_replicable
             /// topics. To delete this topic all of its non_replicable descedent
             /// topics must first be deleted
-            auto found = _topics_hierarchy.find(cmd.value);
+            auto found = _topics_hierarchy.find(nt);
             if (found != _topics_hierarchy.end() && !found->second.empty()) {
-                return ss::make_ready_future<std::error_code>(
-                  errc::source_topic_still_in_use);
+                return std::error_code(errc::source_topic_still_in_use);
             }
         }
 
         for (auto& p_as : tp->second.get_assignments()) {
             _partition_count--;
-            auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, p_as.id);
+            auto ntp = model::ntp(nt.ns, nt.tp, p_as.id);
             _updates_in_progress.erase(ntp);
             _pending_deltas.emplace_back(
               std::move(ntp), p_as, offset, delete_type);
@@ -142,13 +147,68 @@ topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
 
         _topics.erase(tp);
         notify_waiters();
-        _probe.handle_topic_deletion(cmd.key);
+        _probe.handle_topic_deletion(nt);
 
-        return ss::make_ready_future<std::error_code>(errc::success);
+        return errc::success;
     }
 
-    return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
+    return errc::topic_not_exists;
 }
+
+ss::future<std::error_code>
+topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
+    _last_applied_revision_id = model::revision_id(offset);
+
+    if (soft_del.mode == topic_lifecycle_transition_mode::pending_gc) {
+        // Create tombstone
+        auto tp = _topics.find(soft_del.topic.nt);
+        if (tp == _topics.end()) {
+            return ss::make_ready_future<std::error_code>(
+              errc::topic_not_exists);
+        }
+
+        auto tombstone = nt_lifecycle_marker{
+          .config = tp->second.get_configuration(),
+          .initial_revision_id = tp->second.get_remote_revision().value_or(
+            model::initial_revision_id(tp->second.get_revision()))};
+
+        _lifecycle_markers.emplace(soft_del.topic, tombstone);
+        vlog(
+          clusterlog.debug,
+          "Created tombstone for topic {} {}",
+          soft_del.topic.nt,
+          soft_del.topic.initial_revision_id);
+    } else if (soft_del.mode == topic_lifecycle_transition_mode::drop) {
+        if (_lifecycle_markers.contains(soft_del.topic)) {
+            vlog(
+              clusterlog.debug,
+              "Purged tombstone for {} {}",
+              soft_del.topic.nt,
+              soft_del.topic.initial_revision_id);
+            _lifecycle_markers.erase(soft_del.topic);
+            return ss::make_ready_future<std::error_code>(errc::success);
+        } else {
+            // This is harmless but should not happen and indicates a bug.
+            vlog(
+              clusterlog.error,
+              "Unexpected request to drop non-existent tombstone {} {}",
+              soft_del.topic.nt,
+              soft_del.topic.initial_revision_id);
+            return ss::make_ready_future<std::error_code>(
+              errc::topic_not_exists);
+        }
+    }
+
+    if (
+      soft_del.mode == topic_lifecycle_transition_mode::pending_gc
+      || soft_del.mode == topic_lifecycle_transition_mode::oneshot_delete) {
+        return ss::make_ready_future<std::error_code>(
+          do_local_delete(soft_del.topic.nt, offset));
+    } else {
+        return ss::make_ready_future<std::error_code>(errc::success);
+    }
+}
+
 ss::future<std::error_code>
 topic_table::apply(create_partition_cmd cmd, model::offset offset) {
     _last_applied_revision_id = model::revision_id(offset);

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -65,6 +65,7 @@ public:
     static constexpr auto commands = make_commands_list<
       create_topic_cmd,
       delete_topic_cmd,
+      topic_lifecycle_transition_cmd,
       move_partition_replicas_cmd,
       finish_moving_partition_replicas_cmd,
       update_topic_properties_cmd,
@@ -87,6 +88,8 @@ private:
 
     ss::future<std::error_code> apply(create_topic_cmd, model::offset);
     ss::future<std::error_code> apply(delete_topic_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(topic_lifecycle_transition_cmd, model::offset);
     ss::future<std::error_code>
       apply(move_partition_replicas_cmd, model::offset);
     ss::future<std::error_code>
@@ -114,6 +117,9 @@ private:
       const assignments_set&,
       const in_progress_map&,
       partition_allocation_domain);
+
+    ss::future<std::error_code>
+      do_topic_delete(topic_lifecycle_transition, model::offset);
 
     in_progress_map
     collect_in_progress(const model::topic_namespace&, const assignments_set&);

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -61,6 +61,14 @@ public:
     ss::future<std::vector<topic_result>> delete_topics(
       std::vector<model::topic_namespace>, model::timeout_clock::time_point);
 
+    // May be called on any node
+    ss::future<topic_result>
+      purged_topic(nt_revision, model::timeout_clock::duration);
+
+    // May only be called on leader
+    ss::future<topic_result>
+      do_purged_topic(nt_revision, model::timeout_clock::time_point);
+
     ss::future<std::vector<topic_result>> autocreate_topics(
       std::vector<topic_configuration>, model::timeout_clock::duration);
 
@@ -165,6 +173,9 @@ private:
       model::node_id,
       std::vector<topic_configuration>,
       model::timeout_clock::duration);
+
+    ss::future<topic_result> dispatch_purged_topic_to_leader(
+      model::node_id, nt_revision, model::timeout_clock::duration);
 
     ss::future<std::vector<topic_result>>
     dispatch_create_non_replicable_to_leader(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1878,6 +1878,46 @@ struct create_topics_reply
     auto serde_fields() { return std::tie(results, metadata, configs); }
 };
 
+struct purged_topic_request
+  : serde::envelope<
+      purged_topic_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    nt_revision topic;
+    model::timeout_clock::duration timeout;
+
+    friend bool
+    operator==(const purged_topic_request&, const purged_topic_request&)
+      = default;
+
+    friend std::ostream& operator<<(std::ostream&, const purged_topic_request&);
+
+    auto serde_fields() { return std::tie(topic, timeout); }
+};
+
+struct purged_topic_reply
+  : serde::envelope<
+      purged_topic_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    topic_result result;
+
+    purged_topic_reply() noexcept = default;
+    purged_topic_reply(topic_result r)
+      : result(r) {}
+
+    friend bool operator==(const purged_topic_reply&, const purged_topic_reply&)
+      = default;
+
+    friend std::ostream& operator<<(std::ostream&, const purged_topic_reply&);
+
+    auto serde_fields() { return std::tie(result); }
+};
+
 struct finish_partition_update_request
   : serde::envelope<
       finish_partition_update_request,

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -251,6 +251,7 @@ private:
     ss::sharded<archival::upload_housekeeping_service>
       _archival_upload_housekeeping;
     std::unique_ptr<monitor_unsafe_log_flag> _monitor_unsafe_log_flag;
+    ss::sharded<archival::scrubber> _archival_scrubber;
 
     ss::metrics::metric_groups _metrics;
     ss::sharded<ssx::metrics::public_metrics_group> _public_metrics;

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -369,6 +369,11 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             # Use all nodes as brokers: enables each test to set num_nodes
             # and get a cluster of that size
             num_brokers=test_context.cluster.available().size(),
+
+            # We rely on the scrubber to delete topic manifests, and to eventually
+            # delete data if cloud storage was unavailable during initial delete.  To
+            # control test runtimes, set a short interval.
+            rp_extra_conf={'cloud_storage_housekeeping_interval_ms': 5000},
             si_settings=self.si_settings)
 
         self._s3_port = self.si_settings.cloud_storage_api_endpoint_port
@@ -507,6 +512,10 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                    backoff_sec=1)
 
         wait_until(lambda: self._topic_remote_deleted(next_topic),
+                   timeout_sec=30,
+                   backoff_sec=1)
+
+        wait_until(lambda: self._topic_remote_deleted(self.topic),
                    timeout_sec=30,
                    backoff_sec=1)
 


### PR DESCRIPTION
Currently, deletion of remote data happens on a best-effort basis: if redpanda is interrupted (e.g. restarted) while issuing deletions, objects are left behind.

To fix this, the topic table is extended with "lifecycle markers", to record the status of topics which are no longer active but not yet totally deleted.  These have been called tombstones in earlier discussions, the idea of the "lifecycle marker" name is to make this code amenable to being used for hibernate/restore of topics in future: as well as having a "deleted" (tombstone) state, a lifecycle marker might just record that a topic has been offloaded from a cluster but may be rehydrated in future.

The deletion process for tiered storage topics is now:
- Write a `topic_lifecycle_transition` record to controller log with state `pending_gc`.  When applied, this moves the topic from the main body of the topics table into the list of lifecycle markers.
- The new `scrubber` background task in the archival subsystem periodically wakes up and checks for lifecycle markers that require work.  When it sees a lifecycle marker for a topic pending purge, it proceeds to remove all the remote data.  If this succeeds, then it issues a `purged_topic_request` RPC to the controller leader.
- When the controller receives a `purged_topic_request` RPC it writes another `topic_lifecycle_transition` record with `drop` status.  When applied, this record drops the topic's lifecycle marker from the topics table.

The `erase()` code in `remote_partition` may be simplified now, as it is purely an optimistic first try at deleting partition content, and we may be confident that the scrubber will later ensure that the partition is fully deleted.  This means it no longer needs to selectively ignore certain errors, is no longer run on all replicas, and it may omit the special case of removing the topic manifest on partition 0.

After this PR, the next step will be to write lifecycle markers to object storage when we drop them from the topic table, and have the scrubber do another 'backward scrub' of all objects in object storage, to detect and delete any orphan objects which were left behind due to not being referenced in the manifest of a deleted topic.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* If object storage is unavailable while deleting a tiered storage topic, Redpanda will now try again later rather than leaving objects behind.