### PR TITLE
archival: avoid lock inversion in segment merger

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2015,19 +2015,22 @@ ntp_archiver::get_housekeeping_jobs() {
     return res;
 }
 
-ss::future<std::optional<upload_candidate_with_locks>>
+ss::future<std::pair<
+  std::optional<ssx::semaphore_units>,
+  std::optional<upload_candidate_with_locks>>>
 ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
     ss::gate::holder holder(_gate);
     if (!may_begin_uploads()) {
-        co_return std::nullopt;
+        co_return std::make_pair(std::nullopt, std::nullopt);
     }
     auto run = scanner(_parent.start_offset(), manifest());
     if (!run.has_value()) {
         vlog(_rtclog.debug, "Scan didn't resulted in upload candidate");
-        co_return std::nullopt;
+        co_return std::make_pair(std::nullopt, std::nullopt);
     } else {
         vlog(_rtclog.debug, "Scan result: {}", run);
     }
+    auto units = co_await ss::get_units(_mutex, 1, _as);
     if (run->meta.base_offset >= _parent.start_offset()) {
         auto log_generic = _parent.log();
         auto& log = dynamic_cast<storage::disk_log_impl&>(
@@ -2044,7 +2047,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
           _conf->upload_io_priority, _conf->segment_upload_timeout);
         if (candidate.candidate.exposed_name().empty()) {
             vlog(_rtclog.warn, "Failed to make upload candidate");
-            co_return std::nullopt;
+            co_return std::make_pair(std::nullopt, std::nullopt);
         }
         if (candidate.candidate.content_length != run->meta.size_bytes) {
             vlog(
@@ -2053,9 +2056,9 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
               "actual {}",
               candidate.candidate,
               run->meta);
-            co_return std::nullopt;
+            co_return std::make_pair(std::nullopt, std::nullopt);
         }
-        co_return candidate;
+        co_return std::make_pair(std::move(units), std::move(candidate));
     }
     // segment_name exposed_name;
     upload_candidate candidate = {};
@@ -2072,13 +2075,16 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
       = cloud_storage::partition_manifest::generate_remote_segment_name(
         run->meta);
     // Create a remote upload candidate
-    co_return upload_candidate_with_locks{std::move(candidate)};
+    co_return std::make_pair(
+      std::move(units), upload_candidate_with_locks{std::move(candidate)});
 }
 
 ss::future<bool> ntp_archiver::upload(
+  ssx::semaphore_units archiver_units,
   upload_candidate_with_locks upload_locks,
   std::optional<std::reference_wrapper<retry_chain_node>> source_rtc) {
     ss::gate::holder holder(_gate);
+    auto units = std::move(archiver_units);
     if (upload_locks.candidate.sources.size() > 0) {
         co_return co_await do_upload_local(std::move(upload_locks), source_rtc);
     }
@@ -2115,8 +2121,6 @@ ss::future<bool> ntp_archiver::do_upload_local(
           upload.exposed_name);
         co_return false;
     }
-
-    auto units = co_await ss::get_units(_mutex, 1, _as);
 
     auto offset = upload.final_offset;
     auto base = upload.starting_offset;

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -210,16 +210,20 @@ public:
     /// candidate.remote_segments).
     ///
     /// \param scanner is a user provided function used to find upload candidate
-    /// \return nullopt or the upload candidate
-    ss::future<std::optional<upload_candidate_with_locks>>
+    /// \return {nullopt, nullopt} or the archiver lock and upload candidate
+    ss::future<std::pair<
+      std::optional<ssx::semaphore_units>,
+      std::optional<upload_candidate_with_locks>>>
     find_reupload_candidate(manifest_scanner_t scanner);
 
     /**
-     * Upload segment provided from the outside of the ntp_archiver
+     * Upload segment provided from the outside of the ntp_archiver.
      *
      * The method can be used to upload segments stored locally in the
      * redpanda data directory or remotely in cloud storage.
      *
+     * \param archiver_units are the units for the archiver that must have
+     *        already been taken
      * \param candidate is an upload candidate
      * \param source_rtc is used to pass retry_chain_node that belongs
      *        to the caller. This way the caller can use its own abort_source
@@ -228,6 +232,7 @@ public:
      * \return true on success and false otherwise
      */
     ss::future<bool> upload(
+      ssx::semaphore_units archiver_units,
       upload_candidate_with_locks candidate,
       std::optional<std::reference_wrapper<retry_chain_node>> source_rtc);
 
@@ -488,7 +493,15 @@ private:
     ss::abort_source _as;
     retry_chain_node _rtcnode;
     retry_chain_logger _rtclog;
+
+    // Ensures that operations on the archival state are only performed by a
+    // single driving fiber (archiver loop, housekeeping job, etc) at a time.
+    //
+    // NOTE: must be taken before doing anything that acquires segment read
+    // locks (e.g. selecting segments for upload, replicating and waiting on
+    // the underlying Raft STM).
     ssx::semaphore _mutex{1, "archive/ntp"};
+
     ss::lw_shared_ptr<const configuration> _conf;
     config::binding<std::chrono::milliseconds> _sync_manifest_timeout;
     config::binding<size_t> _max_segments_pending_deletion;


### PR DESCRIPTION
The main archival loop currently takes locks in the order 1)
ntp_archiver_service::_mutex, 2) segment locks. The segment merging
housekeeping job takes locks in the opposite order.

This could result in a deadlock when attempting to take a lock on the
same segment if the segment merger attempts to merge a partially
uploaded segment, and concurrently the archival loop attempts to do
another partial segment upload of that segment.

This commit extends the ntp_archiver_service interface to force callers
of ntp_archival_service::upload() to already have a lock, rather than
acquiring the lock therein.

Fixes https://github.com/redpanda-data/redpanda/issues/10085

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

NOTE: on `dev`, this surfaces as a shutdown hang, but in older versions the timeout in the archival_metadata_stm made the issue a matter of timing out the stm rather than a hang.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
