### PR TITLE
k/metrics: rm static members from consumers count

### DIFF
--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -118,7 +118,7 @@ public:
           prometheus_sanitize::metrics_name("kafka:consumer:group"),
           {sm::make_gauge(
              "consumers",
-             [this] { return _members.size() + _static_members.size(); },
+             [this] { return _members.size(); },
              sm::description("Number of consumers in a group"),
              labels)
              .aggregate({sm::shard_label}),


### PR DESCRIPTION
Static members are a subset of members; therefore, it was possible for this metric to report double the real count of consumers. This commit removes static members from the count.

Fixes #10270

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* Fixed an issue where the metric `redpanda_kafka_consumer_group_consumers` was reporting double the real count of consumers.

### Bug Fixes

* Fixed an issue where the metric `redpanda_kafka_consumer_group_consumers` was reporting double the real count of consumers.