### PR TITLE
[backport] [v23.1.x] rm_stm/snapshots: switch to async (de)serialization

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -204,61 +204,6 @@ rm_stm::parse_tx_control_batch(const model::record_batch& b) {
     return parse_control_batch(b);
 }
 
-struct seq_entry_v0 {
-    model::producer_identity pid;
-    int32_t seq;
-    model::timestamp::type last_write_timestamp;
-};
-
-struct tx_snapshot_v0 {
-    static constexpr uint8_t version = 0;
-
-    fragmented_vector<model::producer_identity> fenced;
-    fragmented_vector<rm_stm::tx_range> ongoing;
-    fragmented_vector<rm_stm::prepare_marker> prepared;
-    fragmented_vector<rm_stm::tx_range> aborted;
-    fragmented_vector<rm_stm::abort_index> abort_indexes;
-    model::offset offset;
-    fragmented_vector<seq_entry_v0> seqs;
-};
-
-struct seq_cache_entry_v1 {
-    int32_t seq{-1};
-    model::offset offset;
-};
-
-struct seq_entry_v1 {
-    model::producer_identity pid;
-    int32_t seq{-1};
-    model::offset last_offset{-1};
-    ss::circular_buffer<seq_cache_entry_v1> seq_cache;
-    model::timestamp::type last_write_timestamp;
-};
-
-struct tx_snapshot_v1 {
-    static constexpr uint8_t version = 1;
-
-    fragmented_vector<model::producer_identity> fenced;
-    fragmented_vector<rm_stm::tx_range> ongoing;
-    fragmented_vector<rm_stm::prepare_marker> prepared;
-    fragmented_vector<rm_stm::tx_range> aborted;
-    fragmented_vector<rm_stm::abort_index> abort_indexes;
-    model::offset offset;
-    fragmented_vector<seq_entry_v1> seqs;
-};
-
-struct tx_snapshot_v2 {
-    static constexpr uint8_t version = 2;
-
-    fragmented_vector<model::producer_identity> fenced;
-    fragmented_vector<rm_stm::tx_range> ongoing;
-    fragmented_vector<rm_stm::prepare_marker> prepared;
-    fragmented_vector<rm_stm::tx_range> aborted;
-    fragmented_vector<rm_stm::abort_index> abort_indexes;
-    model::offset offset;
-    fragmented_vector<rm_stm::seq_entry> seqs;
-};
-
 rm_stm::rm_stm(
   ss::logger& logger,
   raft::consensus* c,

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -282,6 +282,61 @@ public:
         }
     };
 
+    struct seq_entry_v0 {
+        model::producer_identity pid;
+        int32_t seq;
+        model::timestamp::type last_write_timestamp;
+    };
+
+    struct tx_snapshot_v0 {
+        static constexpr uint8_t version = 0;
+
+        fragmented_vector<model::producer_identity> fenced;
+        fragmented_vector<rm_stm::tx_range> ongoing;
+        fragmented_vector<rm_stm::prepare_marker> prepared;
+        fragmented_vector<rm_stm::tx_range> aborted;
+        fragmented_vector<rm_stm::abort_index> abort_indexes;
+        model::offset offset;
+        fragmented_vector<seq_entry_v0> seqs;
+    };
+
+    struct seq_cache_entry_v1 {
+        int32_t seq{-1};
+        model::offset offset;
+    };
+
+    struct seq_entry_v1 {
+        model::producer_identity pid;
+        int32_t seq{-1};
+        model::offset last_offset{-1};
+        ss::circular_buffer<seq_cache_entry_v1> seq_cache;
+        model::timestamp::type last_write_timestamp;
+    };
+
+    struct tx_snapshot_v1 {
+        static constexpr uint8_t version = 1;
+
+        fragmented_vector<model::producer_identity> fenced;
+        fragmented_vector<rm_stm::tx_range> ongoing;
+        fragmented_vector<rm_stm::prepare_marker> prepared;
+        fragmented_vector<rm_stm::tx_range> aborted;
+        fragmented_vector<rm_stm::abort_index> abort_indexes;
+        model::offset offset;
+        fragmented_vector<seq_entry_v1> seqs;
+    };
+
+    struct tx_snapshot_v2 {
+        static constexpr uint8_t version = 2;
+
+        fragmented_vector<model::producer_identity> fenced;
+        fragmented_vector<rm_stm::tx_range> ongoing;
+        fragmented_vector<rm_stm::prepare_marker> prepared;
+        fragmented_vector<rm_stm::tx_range> aborted;
+        fragmented_vector<rm_stm::abort_index> abort_indexes;
+        model::offset offset;
+        fragmented_vector<rm_stm::seq_entry> seqs;
+    };
+
     using transaction_set
       = absl::btree_map<model::producer_identity, rm_stm::transaction_info>;
     ss::future<result<transaction_set>> get_transactions();

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -66,6 +66,8 @@ public:
     struct abort_index {
         model::offset first;
         model::offset last;
+
+        bool operator==(const abort_index&) const = default;
     };
 
     struct prepare_marker {
@@ -75,11 +77,15 @@ public:
         // tx_seq identifies a transaction within a session
         model::tx_seq tx_seq;
         model::producer_identity pid;
+
+        bool operator==(const prepare_marker&) const = default;
     };
 
     struct seq_cache_entry {
         int32_t seq{-1};
         kafka::offset offset;
+
+        bool operator==(const seq_cache_entry&) const = default;
     };
 
     struct seq_entry {
@@ -125,6 +131,20 @@ public:
             seq = new_seq;
             last_offset = new_offset;
         }
+
+        bool operator==(const seq_entry& other) const {
+            if (this == &other) {
+                return true;
+            }
+            return pid == other.pid && seq == other.seq
+                   && last_offset == other.last_offset
+                   && last_write_timestamp == other.last_write_timestamp
+                   && std::equal(
+                     seq_cache.begin(),
+                     seq_cache.end(),
+                     other.seq_cache.begin(),
+                     other.seq_cache.end());
+        }
     };
 
     struct tx_snapshot {
@@ -141,15 +161,21 @@ public:
         struct tx_seqs_snapshot {
             model::producer_identity pid;
             model::tx_seq tx_seq;
+
+            bool operator==(const tx_seqs_snapshot&) const = default;
         };
 
         struct expiration_snapshot {
             model::producer_identity pid;
             duration_type timeout;
+
+            bool operator==(const expiration_snapshot&) const = default;
         };
 
         fragmented_vector<tx_seqs_snapshot> tx_seqs;
         fragmented_vector<expiration_snapshot> expiration;
+
+        bool operator==(const tx_snapshot&) const = default;
     };
 
     struct abort_snapshot {
@@ -161,6 +187,8 @@ public:
             return idx.first == first && idx.last == last;
         }
         friend std::ostream& operator<<(std::ostream&, const abort_snapshot&);
+
+        bool operator==(const abort_snapshot&) const = default;
     };
 
     static constexpr int8_t prepare_control_record_version{0};
@@ -286,6 +314,8 @@ public:
         model::producer_identity pid;
         int32_t seq;
         model::timestamp::type last_write_timestamp;
+
+        bool operator==(const seq_entry_v0&) const = default;
     };
 
     struct tx_snapshot_v0 {
@@ -298,11 +328,15 @@ public:
         fragmented_vector<rm_stm::abort_index> abort_indexes;
         model::offset offset;
         fragmented_vector<seq_entry_v0> seqs;
+
+        bool operator==(const tx_snapshot_v0&) const = default;
     };
 
     struct seq_cache_entry_v1 {
         int32_t seq{-1};
         model::offset offset;
+
+        bool operator==(const seq_cache_entry_v1&) const = default;
     };
 
     struct seq_entry_v1 {
@@ -311,6 +345,21 @@ public:
         model::offset last_offset{-1};
         ss::circular_buffer<seq_cache_entry_v1> seq_cache;
         model::timestamp::type last_write_timestamp;
+
+        bool operator==(const seq_entry_v1& other) const {
+            if (this == &other) {
+                return true;
+            }
+
+            return pid == other.pid && seq == other.seq
+                   && last_offset == other.last_offset
+                   && last_write_timestamp == other.last_write_timestamp
+                   && std::equal(
+                     seq_cache.begin(),
+                     seq_cache.end(),
+                     other.seq_cache.begin(),
+                     other.seq_cache.end());
+        };
     };
 
     struct tx_snapshot_v1 {
@@ -323,6 +372,8 @@ public:
         fragmented_vector<rm_stm::abort_index> abort_indexes;
         model::offset offset;
         fragmented_vector<seq_entry_v1> seqs;
+
+        bool operator==(const tx_snapshot_v1&) const = default;
     };
 
     struct tx_snapshot_v2 {
@@ -335,6 +386,8 @@ public:
         fragmented_vector<rm_stm::abort_index> abort_indexes;
         model::offset offset;
         fragmented_vector<rm_stm::seq_entry> seqs;
+
+        bool operator==(const tx_snapshot_v2&) const = default;
     };
 
     using transaction_set

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/health_monitor_types.h"
+#include "cluster/rm_stm.h"
 #include "model/tests/randoms.h"
 #include "random/generators.h"
 #include "storage/tests/randoms.h"
@@ -143,6 +144,66 @@ inline cluster_report_filter random_cluster_report_filter() {
       {}, random_node_report_filter(), tests::random_vector([] {
           return tests::random_named_int<model::node_id>();
       })};
+}
+
+inline rm_stm::tx_snapshot::expiration_snapshot random_expiration_snapshot() {
+    return rm_stm::tx_snapshot::expiration_snapshot{
+      model::random_producer_identity(),
+      tests::random_duration<rm_stm::duration_type>()};
+}
+
+inline rm_stm::prepare_marker random_prepare_marker() {
+    return {
+      tests::random_named_int<model::partition_id>(),
+      tests::random_named_int<model::tx_seq>(),
+      model::random_producer_identity()};
+}
+
+inline rm_stm::abort_index random_abort_index() {
+    return {model::random_offset(), model::random_offset()};
+}
+
+inline rm_stm::seq_cache_entry random_seq_cache_entry() {
+    return {
+      random_generators::get_int<int32_t>(),
+      tests::random_named_int<kafka::offset>()};
+}
+
+inline rm_stm::seq_cache_entry_v1 random_seq_cache_entry_v1() {
+    return {
+      random_generators::get_int<int32_t>(),
+      tests::random_named_int<model::offset>()};
+}
+
+inline rm_stm::seq_entry_v0 random_seq_entry_v0() {
+    return {
+      model::random_producer_identity(),
+      random_generators::get_int<int32_t>(),
+      random_generators::get_int<int64_t>()};
+}
+
+inline rm_stm::seq_entry_v1 random_seq_entry_v1() {
+    return {
+      model::random_producer_identity(),
+      random_generators::get_int<int32_t>(),
+      tests::random_named_int<model::offset>(),
+      tests::random_circular_buffer(random_seq_cache_entry_v1),
+      random_generators::get_int<int64_t>()};
+}
+
+inline rm_stm::seq_entry random_seq_entry() {
+    return {
+      model::random_producer_identity(),
+      random_generators::get_int<int32_t>(),
+      tests::random_named_int<kafka::offset>(),
+      tests::random_circular_buffer(random_seq_cache_entry),
+      random_generators::get_int<int64_t>()};
+}
+
+inline rm_stm::tx_snapshot::tx_seqs_snapshot random_tx_seqs_snapshot() {
+    return {
+      model::random_producer_identity(),
+      tests::random_named_int<model::tx_seq>()};
 }
 
 } // namespace cluster

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -9,12 +9,15 @@
 
 #include "cluster/errc.h"
 #include "cluster/rm_stm.h"
+#include "cluster/tests/randoms.h"
+#include "cluster/tx_snapshot_adl_utils.h"
 #include "features/feature_table.h"
 #include "finjector/hbadger.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
 #include "model/tests/random_batch.h"
+#include "model/tests/randoms.h"
 #include "model/timestamp.h"
 #include "raft/consensus_utils.h"
 #include "raft/tests/mux_state_machine_fixture.h"
@@ -24,6 +27,7 @@
 #include "storage/record_batch_builder.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/async.h"
+#include "test_utils/randoms.h"
 #include "utils/directory_walker.h"
 
 #include <seastar/util/defer.hh>
@@ -805,4 +809,104 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
     }
 
     check_snapshot_sizes(stm, _raft.get());
+}
+
+template<class T>
+void sync_ser_verify(T type) {
+    // Serialize synchronously
+    iobuf buf;
+    reflection::adl<T>{}.to(buf, std::move(type));
+    iobuf copy = buf.copy();
+
+    // Deserialize sync/async and compare
+    iobuf_parser sync_in(std::move(buf));
+    iobuf_parser async_in(std::move(copy));
+
+    auto sync_deser_type = reflection::adl<T>{}.from(sync_in);
+    auto async_deser_type = reflection::async_adl<T>{}.from(async_in).get0();
+    BOOST_REQUIRE(sync_deser_type == async_deser_type);
+}
+
+template<class T>
+void async_ser_verify(T type) {
+    // Serialize asynchronously
+    iobuf buf;
+    reflection::async_adl<T>{}.to(buf, std::move(type)).get();
+    iobuf copy = buf.copy();
+
+    // Deserialize sync/async and compare
+    iobuf_parser sync_in(std::move(buf));
+    iobuf_parser async_in(std::move(copy));
+
+    auto sync_deser_type = reflection::adl<T>{}.from(sync_in);
+    auto async_deser_type = reflection::async_adl<T>{}.from(async_in).get0();
+    BOOST_REQUIRE(sync_deser_type == async_deser_type);
+}
+
+SEASTAR_THREAD_TEST_CASE(async_adl_snapshot_validation) {
+    // Checks equivalence of async and sync adl serialized snapshots.
+    // Serialization of snapshots is switched to async with this commit,
+    // makes sure the snapshots are compatible pre/post upgrade.
+
+    auto make_tx_snapshot = []() {
+        return reflection::tx_snapshot{
+          .fenced = tests::random_frag_vector(model::random_producer_identity),
+          .ongoing = tests::random_frag_vector(model::random_tx_range),
+          .prepared = tests::random_frag_vector(cluster::random_prepare_marker),
+          .aborted = tests::random_frag_vector(model::random_tx_range),
+          .abort_indexes = tests::random_frag_vector(
+            cluster::random_abort_index),
+          .offset = model::random_offset(),
+          .seqs = tests::random_frag_vector(cluster::random_seq_entry),
+          .tx_seqs = tests::random_frag_vector(
+            cluster::random_tx_seqs_snapshot),
+          .expiration = tests::random_frag_vector(
+            cluster::random_expiration_snapshot)};
+    };
+
+    sync_ser_verify(make_tx_snapshot());
+    async_ser_verify(make_tx_snapshot());
+
+    auto make_tx_snapshot_v0 = []() {
+        return reflection::tx_snapshot_v0{
+          .fenced = tests::random_frag_vector(model::random_producer_identity),
+          .ongoing = tests::random_frag_vector(model::random_tx_range),
+          .prepared = tests::random_frag_vector(cluster::random_prepare_marker),
+          .aborted = tests::random_frag_vector(model::random_tx_range),
+          .abort_indexes = tests::random_frag_vector(
+            cluster::random_abort_index),
+          .offset = model::random_offset(),
+          .seqs = tests::random_frag_vector(cluster::random_seq_entry_v0)};
+    };
+
+    sync_ser_verify(make_tx_snapshot_v0());
+    async_ser_verify(make_tx_snapshot_v0());
+
+    auto make_tx_snapshot_v1 = []() {
+        return reflection::tx_snapshot_v1{
+          .fenced = tests::random_frag_vector(model::random_producer_identity),
+          .ongoing = tests::random_frag_vector(model::random_tx_range),
+          .prepared = tests::random_frag_vector(cluster::random_prepare_marker),
+          .aborted = tests::random_frag_vector(model::random_tx_range),
+          .offset = model::random_offset(),
+          .seqs = tests::random_frag_vector(cluster::random_seq_entry_v1)};
+    };
+
+    sync_ser_verify(make_tx_snapshot_v1());
+    async_ser_verify(make_tx_snapshot_v1());
+
+    auto make_tx_snapshot_v2 = []() {
+        return reflection::tx_snapshot_v2{
+          .fenced = tests::random_frag_vector(model::random_producer_identity),
+          .ongoing = tests::random_frag_vector(model::random_tx_range),
+          .prepared = tests::random_frag_vector(cluster::random_prepare_marker),
+          .aborted = tests::random_frag_vector(model::random_tx_range),
+          .abort_indexes = tests::random_frag_vector(
+            cluster::random_abort_index),
+          .offset = model::random_offset(),
+          .seqs = tests::random_frag_vector(cluster::random_seq_entry)};
+    };
+
+    sync_ser_verify(make_tx_snapshot_v2());
+    async_ser_verify(make_tx_snapshot_v2());
 }

--- a/src/v/cluster/tx_snapshot_adl_utils.h
+++ b/src/v/cluster/tx_snapshot_adl_utils.h
@@ -1,0 +1,225 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/rm_stm.h"
+#include "reflection/async_adl.h"
+
+namespace reflection {
+
+template<class T>
+using fvec = fragmented_vector<T>;
+
+using tx_snapshot = cluster::rm_stm::tx_snapshot;
+using tx_snapshot_v0 = cluster::rm_stm::tx_snapshot_v0;
+using tx_snapshot_v1 = cluster::rm_stm::tx_snapshot_v1;
+using tx_snapshot_v2 = cluster::rm_stm::tx_snapshot_v2;
+
+using tx_range = cluster::rm_stm::tx_range;
+using prepare_marker = cluster::rm_stm::prepare_marker;
+using abort_index = cluster::rm_stm::abort_index;
+using seq_entry = cluster::rm_stm::seq_entry;
+using seq_entry_v0 = cluster::rm_stm::seq_entry_v0;
+using seq_entry_v1 = cluster::rm_stm::seq_entry_v1;
+
+template<>
+struct async_adl<tx_snapshot> {
+    ss::future<> to(iobuf& out, tx_snapshot snap) {
+        co_await detail::async_adl_list<
+          fragmented_vector<model::producer_identity>>{}
+          .to(out, std::move(snap.fenced));
+        co_await detail::async_adl_list<fvec<tx_range>>{}.to(
+          out, std::move(snap.ongoing));
+        co_await detail::async_adl_list<fvec<prepare_marker>>{}.to(
+          out, std::move(snap.prepared));
+        co_await detail::async_adl_list<fvec<tx_range>>{}.to(
+          out, std::move(snap.aborted));
+        co_await detail::async_adl_list<fvec<abort_index>>{}.to(
+          out, std::move(snap.abort_indexes));
+        reflection::serialize(out, snap.offset);
+        co_await detail::async_adl_list<fvec<seq_entry>>{}.to(
+          out, std::move(snap.seqs));
+        co_await detail::async_adl_list<fvec<tx_snapshot::tx_seqs_snapshot>>{}
+          .to(out, std::move(snap.tx_seqs));
+        co_await detail::async_adl_list<
+          fvec<tx_snapshot::expiration_snapshot>>{}
+          .to(out, std::move(snap.expiration));
+    }
+
+    ss::future<tx_snapshot> from(iobuf_parser& in) {
+        auto fenced
+          = co_await detail::async_adl_list<fvec<model::producer_identity>>{}
+              .from(in);
+        auto ongoing = co_await detail::async_adl_list<fvec<tx_range>>{}.from(
+          in);
+        auto prepared
+          = co_await detail::async_adl_list<fvec<prepare_marker>>{}.from(in);
+        auto aborted = co_await detail::async_adl_list<fvec<tx_range>>{}.from(
+          in);
+        auto abort_indexes
+          = co_await detail::async_adl_list<fvec<abort_index>>{}.from(in);
+        auto offset = reflection::adl<model::offset>{}.from(in);
+        auto seqs = co_await detail::async_adl_list<fvec<seq_entry>>{}.from(in);
+        auto tx_seqs = co_await detail::async_adl_list<
+                         fvec<tx_snapshot::tx_seqs_snapshot>>{}
+                         .from(in);
+        auto expiration = co_await detail::async_adl_list<
+                            fvec<tx_snapshot::expiration_snapshot>>{}
+                            .from(in);
+
+        co_return tx_snapshot{
+          .fenced = std::move(fenced),
+          .ongoing = std::move(ongoing),
+          .prepared = std::move(prepared),
+          .aborted = std::move(aborted),
+          .abort_indexes = std::move(abort_indexes),
+          .offset = offset,
+          .seqs = std::move(seqs),
+          .tx_seqs = std::move(tx_seqs),
+          .expiration = std::move(expiration)};
+    }
+};
+
+template<>
+struct async_adl<tx_snapshot_v0> {
+    ss::future<> to(iobuf& out, tx_snapshot_v0 snap) {
+        co_await detail::async_adl_list<
+          fragmented_vector<model::producer_identity>>{}
+          .to(out, std::move(snap.fenced));
+        co_await detail::async_adl_list<fvec<tx_range>>{}.to(
+          out, std::move(snap.ongoing));
+        co_await detail::async_adl_list<fvec<prepare_marker>>{}.to(
+          out, std::move(snap.prepared));
+        co_await detail::async_adl_list<fvec<tx_range>>{}.to(
+          out, std::move(snap.aborted));
+        co_await detail::async_adl_list<fvec<abort_index>>{}.to(
+          out, std::move(snap.abort_indexes));
+        reflection::serialize(out, snap.offset);
+        co_await detail::async_adl_list<fvec<seq_entry_v0>>{}.to(
+          out, std::move(snap.seqs));
+    }
+
+    ss::future<tx_snapshot_v0> from(iobuf_parser& in) {
+        auto fenced
+          = co_await detail::async_adl_list<fvec<model::producer_identity>>{}
+              .from(in);
+        auto ongoing = co_await detail::async_adl_list<fvec<tx_range>>{}.from(
+          in);
+        auto prepared
+          = co_await detail::async_adl_list<fvec<prepare_marker>>{}.from(in);
+        auto aborted = co_await detail::async_adl_list<fvec<tx_range>>{}.from(
+          in);
+        auto abort_indexes
+          = co_await detail::async_adl_list<fvec<abort_index>>{}.from(in);
+        auto offset = reflection::adl<model::offset>{}.from(in);
+        auto seqs = co_await detail::async_adl_list<fvec<seq_entry_v0>>{}.from(
+          in);
+
+        co_return tx_snapshot_v0{
+          .fenced = std::move(fenced),
+          .ongoing = std::move(ongoing),
+          .prepared = std::move(prepared),
+          .aborted = std::move(aborted),
+          .abort_indexes = std::move(abort_indexes),
+          .offset = offset,
+          .seqs = std::move(seqs)};
+    }
+};
+
+template<>
+struct async_adl<tx_snapshot_v1> {
+    ss::future<> to(iobuf& out, tx_snapshot_v1 snap) {
+        co_await detail::async_adl_list<
+          fragmented_vector<model::producer_identity>>{}
+          .to(out, std::move(snap.fenced));
+        co_await detail::async_adl_list<fvec<tx_range>>{}.to(
+          out, std::move(snap.ongoing));
+        co_await detail::async_adl_list<fvec<prepare_marker>>{}.to(
+          out, std::move(snap.prepared));
+        co_await detail::async_adl_list<fvec<tx_range>>{}.to(
+          out, std::move(snap.aborted));
+        co_await detail::async_adl_list<fvec<abort_index>>{}.to(
+          out, std::move(snap.abort_indexes));
+        reflection::serialize(out, snap.offset);
+        co_await detail::async_adl_list<fvec<seq_entry_v1>>{}.to(
+          out, std::move(snap.seqs));
+    }
+
+    ss::future<tx_snapshot_v1> from(iobuf_parser& in) {
+        auto fenced
+          = co_await detail::async_adl_list<fvec<model::producer_identity>>{}
+              .from(in);
+        auto ongoing = co_await detail::async_adl_list<fvec<tx_range>>{}.from(
+          in);
+        auto prepared
+          = co_await detail::async_adl_list<fvec<prepare_marker>>{}.from(in);
+        auto aborted = co_await detail::async_adl_list<fvec<tx_range>>{}.from(
+          in);
+        auto abort_indexes
+          = co_await detail::async_adl_list<fvec<abort_index>>{}.from(in);
+        auto offset = reflection::adl<model::offset>{}.from(in);
+        auto seqs = co_await detail::async_adl_list<fvec<seq_entry_v1>>{}.from(
+          in);
+
+        co_return tx_snapshot_v1{
+          .fenced = std::move(fenced),
+          .ongoing = std::move(ongoing),
+          .prepared = std::move(prepared),
+          .aborted = std::move(aborted),
+          .abort_indexes = std::move(abort_indexes),
+          .offset = offset,
+          .seqs = std::move(seqs)};
+    }
+};
+
+template<>
+struct async_adl<tx_snapshot_v2> {
+    ss::future<> to(iobuf& out, tx_snapshot_v2 snap) {
+        co_await detail::async_adl_list<
+          fragmented_vector<model::producer_identity>>{}
+          .to(out, std::move(snap.fenced));
+        co_await detail::async_adl_list<fvec<tx_range>>{}.to(
+          out, std::move(snap.ongoing));
+        co_await detail::async_adl_list<fvec<prepare_marker>>{}.to(
+          out, std::move(snap.prepared));
+        co_await detail::async_adl_list<fvec<tx_range>>{}.to(
+          out, std::move(snap.aborted));
+        co_await detail::async_adl_list<fvec<abort_index>>{}.to(
+          out, std::move(snap.abort_indexes));
+        reflection::serialize(out, snap.offset);
+        co_await detail::async_adl_list<fvec<seq_entry>>{}.to(
+          out, std::move(snap.seqs));
+    }
+
+    ss::future<tx_snapshot_v2> from(iobuf_parser& in) {
+        auto fenced
+          = co_await detail::async_adl_list<fvec<model::producer_identity>>{}
+              .from(in);
+        auto ongoing = co_await detail::async_adl_list<fvec<tx_range>>{}.from(
+          in);
+        auto prepared
+          = co_await detail::async_adl_list<fvec<prepare_marker>>{}.from(in);
+        auto aborted = co_await detail::async_adl_list<fvec<tx_range>>{}.from(
+          in);
+        auto abort_indexes
+          = co_await detail::async_adl_list<fvec<abort_index>>{}.from(in);
+        auto offset = reflection::adl<model::offset>{}.from(in);
+        auto seqs = co_await detail::async_adl_list<fvec<seq_entry>>{}.from(in);
+
+        co_return tx_snapshot_v2{
+          .fenced = std::move(fenced),
+          .ongoing = std::move(ongoing),
+          .prepared = std::move(prepared),
+          .aborted = std::move(aborted),
+          .abort_indexes = std::move(abort_indexes),
+          .offset = offset,
+          .seqs = std::move(seqs)};
+    }
+};
+
+}; // namespace reflection

--- a/src/v/model/tests/randoms.h
+++ b/src/v/model/tests/randoms.h
@@ -148,6 +148,14 @@ inline model::producer_identity random_producer_identity() {
       random_generators::get_int<int16_t>()};
 }
 
+inline model::offset random_offset() {
+    return tests::random_named_int<model::offset>();
+}
+
+inline model::tx_range random_tx_range() {
+    return {random_producer_identity(), random_offset(), random_offset()};
+}
+
 inline model::broker_shard random_broker_shard() {
     return {
       tests::random_named_int<model::node_id>(),

--- a/src/v/reflection/async_adl.h
+++ b/src/v/reflection/async_adl.h
@@ -35,6 +35,11 @@ struct async_adl {
 
 namespace detail {
 
+template<typename T>
+concept Reservable = requires(T t, int32_t i) {
+    t.reserve(i);
+};
+
 template<typename List>
 struct async_adl_list {
     using T = typename List::value_type;
@@ -52,7 +57,9 @@ struct async_adl_list {
     ss::future<List> from(iobuf_parser& in) {
         const auto size = adl<int32_t>{}.from(in);
         List list;
-        list.reserve(size);
+        if constexpr (Reservable<List>) {
+            list.reserve(size);
+        }
         auto range = boost::irange<int32_t>(0, size);
         return ss::do_with(
           std::move(list),

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -75,6 +75,25 @@ inline auto random_vector(Fn&& gen, size_t size = 20) -> std::vector<T> {
     return v;
 }
 
+template<typename Fn, typename T = std::invoke_result_t<Fn>>
+inline auto random_frag_vector(Fn&& gen, size_t size = 20)
+  -> fragmented_vector<T> {
+    fragmented_vector<T> v;
+    while (size-- > 0) {
+        v.push_back(gen());
+    }
+    return v;
+}
+
+template<typename Fn, typename T = std::invoke_result_t<Fn>>
+inline auto random_circular_buffer(Fn&& gen, size_t size = 5)
+  -> ss::circular_buffer<T> {
+    ss::circular_buffer<T> v;
+    v.reserve(size);
+    std::generate_n(v.begin(), size, gen);
+    return v;
+}
+
 inline std::vector<std::string> random_strings(size_t size = 20) {
     return random_vector(
       [] { return random_named_string<std::string>(); }, size);


### PR DESCRIPTION
Switches the snapshot serialization to async adl specializations for tx_snapshot* to avoid reactor stalls.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Fix reactor stalls when serializing/deserializing large snapshots.


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Fix reactor stalls when serializing/deserializing large snapshots.

-->
