### PR TITLE
cloud_storage: Add coarse grained map helper to index

### DIFF
--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -78,6 +78,13 @@ public:
     /// returned.
     std::optional<find_result> find_kaf_offset(kafka::offset upper_bound);
 
+    /// Builds a coarse index mapping kafka offsets to file positions. The step
+    /// size is the resolution of the index. So given a step size of 16MiB, the
+    /// result contains mappings of kafka offset to file position from the index
+    /// where entries are _roughly_ 16MiB apart in terms of file position.
+    using coarse_index_t = absl::btree_map<kafka::offset, int64_t>;
+    coarse_index_t build_coarse_index(uint64_t step_size) const;
+
     /// Serialize offset_index
     iobuf to_iobuf();
 


### PR DESCRIPTION
The index can produce a coarse grained (lower resolution than the original index) map of kafka offsets to file positions. This map can then be used to find which byte range of a segment a given kafka offset may lie in.

Because entries are only added to the index at batch start, using this map makes sure that batch boundaries are not compromised, because the file offsets here correspond to the start of a batch.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
