### PR TITLE
cloud_storage: handle transport errors during manifest download

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -267,7 +267,9 @@ ss::future<> ntp_archiver::sync_manifest_until_abort() {
               e);
         } catch (...) {
             vlog(
-              _rtclog.error, "upload loop error: {}", std::current_exception());
+              _rtclog.error,
+              "sync manifest loop error: {}",
+              std::current_exception());
         }
     }
 }


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda/pull/9991 we started handling 'partial message' responses, but only in the paths where transport errors were being explicitly handled.

The manifest download loop on read replicas was reading from the response stream of a request without any such check.

Fixes https://github.com/redpanda-data/redpanda/issues/9203

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none