### PR TITLE
Validate resulting configuration only in terms of changed field

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -396,17 +396,54 @@ partition_raft_state get_partition_raft_state(consensus_ptr ptr) {
 
 std::optional<ss::sstring> check_result_configuration(
   const members_table::cache_t& current_brokers,
-  const model::broker& to_update) {
+  const model::broker& new_configuration) {
+    auto it = current_brokers.find(new_configuration.id());
+    vassert(
+      it != current_brokers.end(),
+      "When broker configuration is being updated the broker must exists. "
+      "Updating broker {} configuration.",
+      new_configuration);
+    auto& current_configuration = it->second.broker;
+    /**
+     * do no allow to decrease node core count
+     */
+    if (
+      current_configuration.properties().cores
+      > new_configuration.properties().cores) {
+        return fmt::format(
+          "core count must not decrease on any broker, currently configured "
+          "core count: {}, requested core count: {}",
+          current_configuration.properties().cores,
+          new_configuration.properties().cores);
+    }
+    /**
+     * When cluster member configuration changes Redpanda by default doesn't
+     * allow the change if a new cluster configuration would have two
+     * listeners pointing to the same address. This was in conflict with the
+     * logic of join request which didn't execute validation of resulting
+     * configuration. Change the validation logic to only check configuration
+     * fields which were changed and are going to be updated.
+     */
+    const bool rpc_address_changed = current_configuration.rpc_address()
+                                     != new_configuration.rpc_address();
+    std::vector<model::broker_endpoint> changed_endpoints;
+    for (auto& new_ep : new_configuration.kafka_advertised_listeners()) {
+        auto it = std::find_if(
+          current_configuration.kafka_advertised_listeners().begin(),
+          current_configuration.kafka_advertised_listeners().end(),
+          [&new_ep](const model::broker_endpoint& ep) {
+              return ep.name == new_ep.name;
+          });
+
+        if (
+          it == current_configuration.kafka_advertised_listeners().end()
+          || it->address != new_ep.address) {
+            changed_endpoints.push_back(new_ep);
+        }
+    }
+
     for (const auto& [id, current] : current_brokers) {
-        if (id == to_update.id()) {
-            /**
-             * do no allow to decrease node core count
-             */
-            if (
-              current.broker.properties().cores
-              > to_update.properties().cores) {
-                return "core count must not decrease on any broker";
-            }
+        if (id == new_configuration.id()) {
             continue;
         }
 
@@ -414,26 +451,29 @@ std::optional<ss::sstring> check_result_configuration(
          * validate if any two of the brokers would listen on the same addresses
          * after applying configuration update
          */
-        if (current.broker.rpc_address() == to_update.rpc_address()) {
+        if (
+          rpc_address_changed
+          && current.broker.rpc_address() == new_configuration.rpc_address()) {
             // error, nodes would listen on the same rpc addresses
             return fmt::format(
               "duplicate rpc endpoint {} with existing node {}",
-              to_update.rpc_address(),
+              new_configuration.rpc_address(),
               id);
         }
-        for (auto& current_ep : current.broker.kafka_advertised_listeners()) {
+
+        for (auto& changed_ep : changed_endpoints) {
             auto any_is_the_same = std::any_of(
-              to_update.kafka_advertised_listeners().begin(),
-              to_update.kafka_advertised_listeners().end(),
-              [&current_ep](const model::broker_endpoint& ep) {
-                  return current_ep == ep;
+              current.broker.kafka_advertised_listeners().begin(),
+              current.broker.kafka_advertised_listeners().end(),
+              [&changed_ep](const model::broker_endpoint& ep) {
+                  return changed_ep == ep;
               });
             // error, kafka endpoint would point to the same addresses
             if (any_is_the_same) {
                 return fmt::format(
-                  "duplicate kafka advertised endpoint {} with existing node "
+                  "duplicated kafka advertised endpoint {} with existing node "
                   "{}",
-                  current_ep,
+                  changed_ep,
                   id);
                 ;
             }

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -394,4 +394,51 @@ partition_raft_state get_partition_raft_state(consensus_ptr ptr) {
     return raft_state;
 }
 
+std::optional<ss::sstring> check_result_configuration(
+  const members_table::cache_t& current_brokers,
+  const model::broker& to_update) {
+    for (const auto& [id, current] : current_brokers) {
+        if (id == to_update.id()) {
+            /**
+             * do no allow to decrease node core count
+             */
+            if (
+              current.broker.properties().cores
+              > to_update.properties().cores) {
+                return "core count must not decrease on any broker";
+            }
+            continue;
+        }
+
+        /**
+         * validate if any two of the brokers would listen on the same addresses
+         * after applying configuration update
+         */
+        if (current.broker.rpc_address() == to_update.rpc_address()) {
+            // error, nodes would listen on the same rpc addresses
+            return fmt::format(
+              "duplicate rpc endpoint {} with existing node {}",
+              to_update.rpc_address(),
+              id);
+        }
+        for (auto& current_ep : current.broker.kafka_advertised_listeners()) {
+            auto any_is_the_same = std::any_of(
+              to_update.kafka_advertised_listeners().begin(),
+              to_update.kafka_advertised_listeners().end(),
+              [&current_ep](const model::broker_endpoint& ep) {
+                  return current_ep == ep;
+              });
+            // error, kafka endpoint would point to the same addresses
+            if (any_is_the_same) {
+                return fmt::format(
+                  "duplicate kafka advertised endpoint {} with existing node "
+                  "{}",
+                  current_ep,
+                  id);
+                ;
+            }
+        }
+    }
+    return {};
+}
 } // namespace cluster

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -14,6 +14,7 @@
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
 #include "cluster/logger.h"
+#include "cluster/members_table.h"
 #include "cluster/types.h"
 #include "config/node_config.h"
 #include "config/tls_config.h"
@@ -384,5 +385,18 @@ get_allocation_domain(const model::ntp& ntp) {
 
 partition_state get_partition_state(ss::lw_shared_ptr<cluster::partition>);
 partition_raft_state get_partition_raft_state(consensus_ptr);
+
+/**
+ * Check that the configuration is valid, if not return a string with the
+ * error cause.
+ *
+ * @param current_brokers current broker vector
+ * @param to_update broker being added
+ * @return std::optional<ss::sstring> - present if there is an error, nullopt
+ * otherwise
+ */
+std::optional<ss::sstring> check_result_configuration(
+  const members_table::cache_t& current_brokers,
+  const model::broker& to_update);
 
 } // namespace cluster

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1436,63 +1436,6 @@ members_manager::dispatch_configuration_update(model::broker broker) {
     }
 }
 
-/**
- * @brief Check that the configuration is valid, if not return a string with the
- * error cause.
- *
- * @param current_brokers current broker vector
- * @param to_update broker being added
- * @return std::optional<ss::sstring> - present if there is an error, nullopt
- * otherwise
- */
-std::optional<ss::sstring> check_result_configuration(
-  const members_table::cache_t& current_brokers,
-  const model::broker& to_update) {
-    for (const auto& [id, current] : current_brokers) {
-        if (id == to_update.id()) {
-            /**
-             * do no allow to decrease node core count
-             */
-            if (
-              current.broker.properties().cores
-              > to_update.properties().cores) {
-                return "core count must not decrease on any broker";
-            }
-            continue;
-        }
-
-        /**
-         * validate if any two of the brokers would listen on the same addresses
-         * after applying configuration update
-         */
-        if (current.broker.rpc_address() == to_update.rpc_address()) {
-            // error, nodes would listen on the same rpc addresses
-            return fmt::format(
-              "duplicate rpc endpoint {} with existing node {}",
-              to_update.rpc_address(),
-              id);
-        }
-        for (auto& current_ep : current.broker.kafka_advertised_listeners()) {
-            auto any_is_the_same = std::any_of(
-              to_update.kafka_advertised_listeners().begin(),
-              to_update.kafka_advertised_listeners().end(),
-              [&current_ep](const model::broker_endpoint& ep) {
-                  return current_ep == ep;
-              });
-            // error, kafka endpoint would point to the same addresses
-            if (any_is_the_same) {
-                return fmt::format(
-                  "duplicate kafka advertised endpoint {} with existing node "
-                  "{}",
-                  current_ep,
-                  id);
-                ;
-            }
-        }
-    }
-    return {};
-}
-
 ss::future<result<configuration_update_reply>>
 members_manager::handle_configuration_update_request(
   configuration_update_request req) {

--- a/src/v/cluster/tests/cluster_utils_tests.cc
+++ b/src/v/cluster/tests/cluster_utils_tests.cc
@@ -8,8 +8,10 @@
 // by the Apache License, Version 2.0
 
 #include "cluster/cluster_utils.h"
+#include "cluster/members_table.h"
 #include "cluster/types.h"
 #include "model/metadata.h"
+#include "net/unresolved_address.h"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/net/inet_address.hh>
@@ -31,4 +33,139 @@ SEASTAR_THREAD_TEST_CASE(test_has_local_replicas) {
 
     BOOST_REQUIRE_EQUAL(cluster::has_local_replicas(id, replicas_1), false);
     BOOST_REQUIRE_EQUAL(cluster::has_local_replicas(id, replicas_2), true);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_check_result_configuration) {
+    cluster::members_table::cache_t members;
+
+    model::broker b_0(
+      model::node_id(0),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9092)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.10", 19092))},
+      net::unresolved_address("localhost", 31345),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    model::broker b_1(
+      model::node_id(1),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9093)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.11", 19093))},
+      net::unresolved_address("localhost", 31346),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    model::broker b_2(
+      model::node_id(2),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9094)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.12", 19094))},
+      net::unresolved_address("localhost", 31347),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    members.emplace(
+      model::node_id(0),
+      cluster::node_metadata{.broker = b_0, .state = cluster::broker_state{}});
+    members.emplace(
+      model::node_id(1),
+      cluster::node_metadata{.broker = b_1, .state = cluster::broker_state{}});
+    members.emplace(
+      model::node_id(2),
+      cluster::node_metadata{.broker = b_2, .state = cluster::broker_state{}});
+
+    // try updating broker with exactly the same configuration
+    auto error = cluster::check_result_configuration(members, b_0);
+    BOOST_REQUIRE(!error);
+
+    // change rpc listener address to different value
+
+    model::broker b_1_changed_rpc(
+      model::node_id(1),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9093)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.11", 19093))},
+      net::unresolved_address("localhost", 41346),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    error = cluster::check_result_configuration(members, b_1_changed_rpc);
+    BOOST_REQUIRE(!error);
+
+    model::broker b_1_changed_rpc_same_value(
+      model::node_id(1),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9092)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.11", 19093))},
+      net::unresolved_address("localhost", 31345),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    error = cluster::check_result_configuration(
+      members, b_1_changed_rpc_same_value);
+    BOOST_REQUIRE(error);
+
+    model::broker b_1_changed_listener(
+      model::node_id(1),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9093)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.11", 29093))},
+      net::unresolved_address("localhost", 31346),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    error = cluster::check_result_configuration(members, b_1_changed_listener);
+    BOOST_REQUIRE(!error);
+
+    model::broker b_1_changed_listener_same_value(
+      model::node_id(1),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9093)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.10", 19092))},
+      net::unresolved_address("localhost", 31346),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    error = cluster::check_result_configuration(
+      members, b_1_changed_listener_same_value);
+    BOOST_REQUIRE(error);
+    model::broker b_1_add_listener(
+      model::node_id(1),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9093)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.10", 19093)),
+       model::broker_endpoint(
+         "new", net::unresolved_address("192.168.2.10", 29092))},
+      net::unresolved_address("localhost", 31346),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    error = cluster::check_result_configuration(members, b_1_add_listener);
+    BOOST_REQUIRE(!error);
+
+    model::broker b_1_add_listener_the_same(
+      model::node_id(1),
+      {model::broker_endpoint(
+         "internal", net::unresolved_address("localhost", 9093)),
+       model::broker_endpoint(
+         "external", net::unresolved_address("192.168.1.10", 19092)),
+       model::broker_endpoint(
+         "new", net::unresolved_address("192.168.1.11", 19092))},
+      net::unresolved_address("localhost", 31346),
+      std::nullopt,
+      model::broker_properties{.cores = 10});
+
+    error = cluster::check_result_configuration(
+      members, b_1_add_listener_the_same);
+
+    BOOST_REQUIRE(error);
 }


### PR DESCRIPTION
When cluster member configuration changes Redpanda by default doesn't
allow the change if a new cluster configuration would have two
listeners pointing to the same address. This was in conflict with the
logic of join request which didn't execute validation of resulting
configuration. Change the validation logic to only check configuration
fields which were changed and are going to be updated.

Fixes: #9602

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Made Join and configuration change validation logic consistent