### PR TITLE
Backport make credentials endpoint configurable

### DIFF
--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -10,10 +10,11 @@
 
 #pragma once
 
+#include "cloud_roles/logger.h"
 #include "cloud_roles/probe.h"
 #include "cloud_roles/signature.h"
+#include "config/configuration.h"
 #include "model/metadata.h"
-#include "seastarx.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -184,6 +185,17 @@ refresh_credentials make_refresh_credentials(
   std::optional<net::unresolved_address> endpoint = std::nullopt,
   retry_params retry_params = default_retry_params) {
     auto host = endpoint ? endpoint->host() : CredentialsProvider::default_host;
+    if (auto cfg_host
+        = config::shard_local_cfg().cloud_storage_credentials_host();
+        cfg_host.has_value()) {
+        vlog(
+          clrl_log.info,
+          "overriding default cloud roles credentials host {} with {} set "
+          "in configuration.",
+          host,
+          cfg_host.value());
+        host = cfg_host.value();
+    }
     auto port = endpoint ? endpoint->port() : CredentialsProvider::default_port;
     auto impl = std::make_unique<CredentialsProvider>(
       host.data(), port, region, as, retry_params);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1133,6 +1133,14 @@ configuration::configuration()
       "Enable re-uploading data for compacted topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , cloud_storage_credentials_host(
+      *this,
+      "cloud_storage_credentials_host",
+      "The hostname to connect to for retrieving role based credentials. "
+      "Derived from cloud_storage_credentials_source if not set. Only required "
+      "when using IAM role based access.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      std::nullopt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -235,6 +235,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> cloud_storage_housekeeping_interval_ms;
     property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;
     property<bool> cloud_storage_enable_compacted_topic_reupload;
+    property<std::optional<ss::sstring>> cloud_storage_credentials_host;
 
     // Archival upload controller
     property<std::chrono::milliseconds>


### PR DESCRIPTION
Manually created backport of https://github.com/redpanda-data/redpanda/pull/10146

The conflict was due to multiple config settings of which only one was required for this PR.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
