### PR TITLE
tests: improve CloudRetentionTest

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1806,7 +1806,7 @@ ss::future<> ntp_archiver::housekeeping() {
             co_await garbage_collect();
         }
     } catch (std::exception& e) {
-        vlog(_rtclog.warn, "Error occured during housekeeping", e.what());
+        vlog(_rtclog.warn, "Error occurred during housekeeping: {}", e.what());
     }
 }
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1805,7 +1805,17 @@ ss::future<> ntp_archiver::housekeeping() {
             co_await apply_retention();
             co_await garbage_collect();
         }
+    } catch (const ss::abort_requested_exception&) {
+    } catch (const ss::sleep_aborted&) {
+    } catch (const ss::gate_closed_exception&) {
+    } catch (const ss::broken_semaphore&) {
+    } catch (const ss::semaphore_timed_out&) {
+        // Shutdown-type exceptions are thrown, to promptly drop out
+        // of the upload loop.
+        throw;
     } catch (std::exception& e) {
+        // Unexpected exceptions are logged, and suppressed: we do not
+        // want to stop who upload loop because of issues in housekeeping
         vlog(_rtclog.warn, "Error occurred during housekeeping: {}", e.what());
     }
 }

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -134,12 +134,36 @@ class CloudRetentionTest(PreallocNodesTest):
         # Wait for some segments to be deleted.
         wait_until(first_segment_missing, timeout_sec=60, backoff_sec=5)
 
-        def check_bucket_size():
+        def all_data_uploaded():
+            s3_snapshot = BucketView(self.redpanda, topics=topics)
+            total_of_hwms = 0
+            for p in range(0, num_partitions):
+                try:
+                    manifest = s3_snapshot.manifest_for_ntp(self.topic_name, 0)
+                except:
+                    return False
+
+                kafka_last_offset = BucketView.kafka_last_offset(manifest)
+                self.logger.info(
+                    f"Partition {p} kafka last offset: {kafka_last_offset}")
+                total_of_hwms += kafka_last_offset
+
+            # Require that all data is uploaded except for up to one segment's
+            # worth of messages for each partition
+            msgs_per_segment = segment_size // msg_size
+            if total_of_hwms >= msg_count - (msgs_per_segment *
+                                             num_partitions):
+                return True
+
+        # Wait for the last data to be uploaded
+        wait_until(all_data_uploaded, timeout_sec=60, backoff_sec=10)
+
+        def check_total_size(include_below_start_offset):
             try:
-                size = sum(obj.content_length
-                           for obj in self.cloud_storage_client.list_objects(
-                               si_settings.cloud_storage_bucket))
-                self.logger.info(f"bucket size: {size}")
+                view = BucketView(self.redpanda)
+                size = view.total_cloud_log_size(
+                    include_below_start_offset=include_below_start_offset)
+                self.logger.info(f"all partitions size: {size}")
                 # check that for each partition there is more than 1
                 # and less than 10 segments in the cloud (generous limits)
                 return size >= segment_size * num_partitions \
@@ -148,7 +172,16 @@ class CloudRetentionTest(PreallocNodesTest):
                 self.logger.warn(f"error getting bucket size: {e}")
                 return False
 
-        wait_until(check_bucket_size, timeout_sec=60, backoff_sec=5)
+        # Wait for retention to be enforced in metadata terms (i.e. start_offset may
+        # have advanced but segments might not be deleted yet)
+        wait_until(lambda: check_total_size(include_below_start_offset=False),
+                   timeout_sec=60,
+                   backoff_sec=5)
+
+        # Wait for retention to be enforced in data terms: segments must be removed
+        wait_until(lambda: check_total_size(include_below_start_offset=True),
+                   timeout_sec=60,
+                   backoff_sec=5)
 
         consumer.wait()
         self.logger.info("finished consuming")

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -524,13 +524,14 @@ class BucketView:
 
         return last_model_offset - delta
 
-    def total_cloud_log_size(self) -> int:
+    def total_cloud_log_size(self,
+                             include_below_start_offset: bool = False) -> int:
         self._do_listing()
 
         total = 0
         for pm in self._state.partition_manifests.values():
             total += BucketView.cloud_log_size_from_ntp_manifest(
-                pm, include_below_start_offset=False)
+                pm, include_below_start_offset=include_below_start_offset)
 
         return total
 


### PR DESCRIPTION
  
    This test was:
    - Checking for retention enforcement in a way that
      overlapped with ongoing uploads, so had unpredictable
      runtime.
    - Checking total object size rather than logical partition
      size, so its stability was influenced by extra objects
      like indices.

While working on this, I also noticed some logging issues with the archival housekeeping that I've fixed opportunistically.
    
Fixes https://github.com/redpanda-data/redpanda/issues/10282


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none