### PR TITLE
k8s implementation for ducktape service redpanda to run throughput tests

### DIFF
--- a/tests/rptest/clients/helm.py
+++ b/tests/rptest/clients/helm.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import json
 import subprocess
 
 
@@ -16,11 +17,14 @@ class HelmTool:
     """
     def __init__(self, redpanda):
         self._redpanda = redpanda
+        self._release = 'redpanda'
+        self._chart = 'redpanda/redpanda'
+        self._namespace = 'redpanda'
 
     def install(self):
         cmd = [
-            'helm', 'install', 'redpanda', 'redpanda/redpanda', '--namespace',
-            'redpanda', '--create-namespace', '--set',
+            'helm', 'install', self._release, self._chart, '--namespace',
+            self._namespace, '--create-namespace', '--set',
             'external.domain=customredpandadomain.local', '--set',
             'statefulset.initContainers.setDataDirOwnership.enabled=true',
             '--wait'
@@ -34,8 +38,27 @@ class HelmTool:
 
     def uninstall(self):
         cmd = [
-            'helm', 'uninstall', '--namespace', 'redpanda', 'redpanda',
+            'helm', 'uninstall', self._release, '--namespace', self._namespace,
             '--wait'
+        ]
+        try:
+            subprocess.check_output(cmd)
+        except subprocess.CalledProcessError as e:
+            # log but ignore for now
+            self._redpanda.logger.info("helm error {}: {}".format(
+                e.returncode, e.output))
+
+    def upgrade_config_cluster(self, values: dict = {}, timeout: int = 300):
+        """
+        Changes the redpanda cluster config settings in 'values',
+        but leaves other values alone. Default timeout for helm is 5 minutes.
+        """
+
+        cmd = [
+            'helm', 'upgrade', self._release, self._chart, '--namespace',
+            self._namespace, '--wait', '--reuse-values', '--timeout',
+            '{}s'.format(timeout), '--set-json',
+            'config.cluster={}'.format(json.dumps(values))
         ]
         try:
             subprocess.check_output(cmd)

--- a/tests/rptest/clients/helm.py
+++ b/tests/rptest/clients/helm.py
@@ -15,11 +15,15 @@ class HelmTool:
     """
     Wrapper around helm.
     """
-    def __init__(self, redpanda):
+    def __init__(self,
+                 redpanda,
+                 release='redpanda',
+                 chart='redpanda/redpanda',
+                 namespace='redpanda'):
         self._redpanda = redpanda
-        self._release = 'redpanda'
-        self._chart = 'redpanda/redpanda'
-        self._namespace = 'redpanda'
+        self._release = release
+        self._chart = chart
+        self._namespace = namespace
 
     def install(self):
         cmd = [

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -14,13 +14,14 @@ class KubectlTool:
     """
     Wrapper around kubectl.
     """
-    def __init__(self, redpanda):
+    def __init__(self, redpanda, namespace='redpanda'):
         self._redpanda = redpanda
+        self._namespace = namespace
 
     def exec(self, remote_cmd):
         cmd = [
-            'kubectl', 'exec', '-n', 'redpanda', 'redpanda-0', '--', 'bash',
-            '-c'
+            'kubectl', 'exec', '-n', self._namespace, 'redpanda-0', '--',
+            'bash', '-c'
         ] + [remote_cmd]
         try:
             res = subprocess.check_output(cmd)
@@ -32,7 +33,8 @@ class KubectlTool:
 
     def exists(self, remote_path):
         cmd = [
-            'kubectl', 'exec', '-n', 'redpanda', 'redpanda-0', '--', 'stat'
+            'kubectl', 'exec', '-n', self._namespace, 'redpanda-0', '--',
+            'stat'
         ] + [remote_path]
         try:
             subprocess.check_output(cmd)

--- a/tests/rptest/k8s_tests/simple_k8s_test.py
+++ b/tests/rptest/k8s_tests/simple_k8s_test.py
@@ -29,6 +29,9 @@ class SimpleK8sTest(Test):
         node_memory = float(self.redpanda.get_node_memory_mb())
         assert node_memory > 1.0
 
+        node_cpu_count = self.redpanda.get_node_cpu_count()
+        assert node_cpu_count > 0
+
         node_disk_free = self.redpanda.get_node_disk_free()
         assert node_disk_free > 0
 

--- a/tests/rptest/k8s_tests/simple_k8s_test.py
+++ b/tests/rptest/k8s_tests/simple_k8s_test.py
@@ -31,3 +31,5 @@ class SimpleK8sTest(Test):
 
         node_disk_free = self.redpanda.get_node_disk_free()
         assert node_disk_free > 0
+
+        self.redpanda.set_cluster_config({})

--- a/tests/rptest/k8s_tests/simple_k8s_test.py
+++ b/tests/rptest/k8s_tests/simple_k8s_test.py
@@ -35,4 +35,6 @@ class SimpleK8sTest(Test):
         node_disk_free = self.redpanda.get_node_disk_free()
         assert node_disk_free > 0
 
+        self.redpanda.lsof_node(1)
+
         self.redpanda.set_cluster_config({})

--- a/tests/rptest/k8s_tests/simple_k8s_test.py
+++ b/tests/rptest/k8s_tests/simple_k8s_test.py
@@ -28,3 +28,6 @@ class SimpleK8sTest(Test):
         self.redpanda.start_node(None)
         node_memory = float(self.redpanda.get_node_memory_mb())
         assert node_memory > 1.0
+
+        node_disk_free = self.redpanda.get_node_disk_free()
+        assert node_disk_free > 0

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1085,7 +1085,7 @@ class RedpandaServiceK8s(RedpandaServiceBase):
         :return: yields strings
         """
         first = True
-        cmd = f"lsof -nP -p {self.redpanda_pid(node)}"
+        cmd = f"ls -l /proc/$(ls -l /proc/*/exe | grep /opt/redpanda/libexec/redpanda | head -1 | cut -d' ' -f 9 | cut -d / -f 3)/fd"
         if filter is not None:
             cmd += f" | grep {filter}"
         for line in self._kubectl.exec(cmd):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1009,7 +1009,6 @@ class RedpandaServiceK8s(RedpandaServiceBase):
 
     def clean_node(self, node, **kwargs):
         self._helm.uninstall()
-        pass
 
     def get_node_memory_mb(self):
         line = self._kubectl.exec("cat /proc/meminfo | grep MemTotal")
@@ -1059,12 +1058,11 @@ class RedpandaServiceK8s(RedpandaServiceBase):
     def node_id(self, node, force_refresh=False, timeout_sec=30):
         pass
 
-    def set_cluster_config(self,
-                           values: dict,
-                           expect_restart: bool = False,
-                           admin_client: Optional[Admin] = None,
-                           timeout: int = 10):
-        pass
+    def set_cluster_config(self, values: dict, timeout: int = 300):
+        """
+        Updates the values of the helm release
+        """
+        self._helm.upgrade_config_cluster(values)
 
 
 class RedpandaService(RedpandaServiceBase):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -757,6 +757,7 @@ class RedpandaServiceBase(Service):
         self,
         context,
         num_brokers,
+        *,
         extra_rp_conf=None,
         resource_settings=None,
         si_settings=None,
@@ -1085,8 +1086,11 @@ class RedpandaService(RedpandaServiceBase):
                  schema_registry_config: Optional[SchemaRegistryConfig] = None,
                  disable_cloud_storage_diagnostics=False):
         super(RedpandaService,
-              self).__init__(context, num_brokers, extra_rp_conf,
-                             resource_settings, si_settings)
+              self).__init__(context,
+                             num_brokers,
+                             extra_rp_conf=extra_rp_conf,
+                             resource_settings=resource_settings,
+                             si_settings=si_settings)
         self._security = security
         self._installer: RedpandaInstaller = RedpandaInstaller(self)
         self._pandaproxy_config = pandaproxy_config

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -986,6 +986,7 @@ class RedpandaServiceBase(Service):
 class RedpandaServiceK8s(RedpandaServiceBase):
     def __init__(self, context, num_brokers):
         super(RedpandaServiceK8s, self).__init__(context, num_brokers)
+        self._trim_logs = False
         self._helm = HelmTool(self)
         self._kubectl = KubectlTool(self)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1027,7 +1027,7 @@ class RedpandaServiceK8s(RedpandaServiceBase):
         else:
             # If dir doesn't exist yet, use the parent.
             df_path = os.path.dirname(self.PERSISTENT_ROOT)
-        df_out = node.account.ssh_output(f"df --output=avail {df_path}")
+        df_out = self._kubectl.exec(f"df --output=avail {df_path}")
         avail_kb = int(df_out.strip().split(b"\n")[1].strip())
         return avail_kb * 1024
 


### PR DESCRIPTION
Fixes #10264

This PR builds upon PR #10133 to flesh out more of the implementation of `RedpandaServiceK8s`

The new `RedpandaServiceK8s` class overrides at least these methods:
- [x] ~start_node~ (already part of #10133) 
- [x] ~stop_node~ (already part of #10133)
- [x] ~clean_node~ (already part of #10133)
- [x] get_node_memory_mb
- [x] get_node_cpu_count
- [x] get_node_disk_free
- [x] node_id
- [x] lsof_node
- [x] set_cluster_config

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

output of manual run of ductape tests in the `tests/rptest/k8s_tests` folder:
```console
bash$ ducktape --cluster=ducktape.cluster.json.JsonCluster --cluster-file=dbuild/ducktape/cluster/ducktape_cluster.json tests/rptest/k8s_tests/simple_k8s_test.py
[INFO:2023-04-28 13:24:50,773]: starting test run with session id 2023-04-28--003...
[INFO:2023-04-28 13:24:50,773]: running 1 tests...
[INFO:2023-04-28 13:24:50,773]: Triggering test 1 of 1...
[INFO:2023-04-28 13:24:50,778]: RunnerClient: Loading test {'directory': '/home/a/src/redpanda/tests/rptest/k8s_tests', 'file_name': 'simple_k8s_test.py', 'cls_name': 'SimpleK8sTest', 'method_name': 'test_k8s', 'injected_args': None}
[INFO:2023-04-28 13:24:50,781]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Setting up...
[INFO:2023-04-28 13:24:50,781]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Running...
Defaulted container "redpanda" out of: redpanda, tuning (init), set-datadir-ownership (init), redpanda-configurator (init)
Defaulted container "redpanda" out of: redpanda, tuning (init), set-datadir-ownership (init), redpanda-configurator (init)
Defaulted container "redpanda" out of: redpanda, tuning (init), set-datadir-ownership (init), redpanda-configurator (init)
Defaulted container "redpanda" out of: redpanda, tuning (init), set-datadir-ownership (init), redpanda-configurator (init)
[INFO:2023-04-28 13:25:48,981]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: PASS
[INFO:2023-04-28 13:25:48,981]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Tearing down...
Error: uninstall: Release not loaded: redpanda: release: not found
[INFO:2023-04-28 13:25:55,898]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Summary:
[INFO:2023-04-28 13:25:55,898]: RunnerClient: rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s: Data: None
test_id:    rptest.k8s_tests.simple_k8s_test.SimpleK8sTest.test_k8s
status:     PASS
run time:   1 minute 5.117 seconds
------------------------------------------------------------------------------------------------------------------------
========================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-04-28--003
run time:         1 minute 5.128 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
========================================================================================================================
```

## Release Notes

* none
