### PR TITLE
[v22.2.x] k/metrics: rm static members from consumers count

### DIFF
--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -118,7 +118,7 @@ public:
           prometheus_sanitize::metrics_name("kafka:consumer:group"),
           {sm::make_gauge(
              "consumers",
-             [this] { return _members.size() + _static_members.size(); },
+             [this] { return _members.size(); },
              sm::description("Number of consumers in a group"),
              labels)
              .aggregate({sm::shard_label}),


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10320
Fixes https://github.com/redpanda-data/redpanda/issues/10335,