### PR TITLE
archival: fix noisy log on read replica shutdown

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2157,7 +2157,7 @@ ss::future<bool> ntp_archiver::do_upload_local(
 
     auto deadline = ss::lowres_clock::now() + _conf->manifest_upload_timeout;
     auto error = co_await _parent.archival_meta_stm()->add_segments(
-      {meta}, std::nullopt, deadline);
+      {meta}, std::nullopt, deadline, _as);
     if (error != cluster::errc::success && error != cluster::errc::not_leader) {
         vlog(
           _rtclog.warn,

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -844,7 +844,8 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
         old_segments.push_back(s.second);
     }
     part->archival_meta_stm()
-      ->add_segments(old_segments, std::nullopt, ss::lowres_clock::now() + 1s)
+      ->add_segments(
+        old_segments, std::nullopt, ss::lowres_clock::now() + 1s, never_abort)
       .get();
 
     listen();
@@ -1037,7 +1038,8 @@ static void test_partial_upload_impl(
         all_segments.push_back(s.second);
     }
     part->archival_meta_stm()
-      ->add_segments(all_segments, std::nullopt, ss::lowres_clock::now() + 1s)
+      ->add_segments(
+        all_segments, std::nullopt, ss::lowres_clock::now() + 1s, never_abort)
       .get();
 
     segment_name s2name{

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -554,6 +554,10 @@ ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
     auto applied = co_await wait_no_throw(
       result.value().last_offset, model::no_timeout, as);
     if (!applied) {
+        if (as.has_value() && as.value().get().abort_requested()) {
+            co_return errc::shutting_down;
+        }
+
         if (
           as.has_value() && !as.value().get().abort_requested()
           && _c->is_leader() && _c->term() == current_term) {

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -45,11 +45,11 @@ public:
     command_batch_builder(
       archival_metadata_stm& stm,
       ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      ss::abort_source& as);
     command_batch_builder(const command_batch_builder&) = delete;
     command_batch_builder(command_batch_builder&&) = default;
     command_batch_builder& operator=(const command_batch_builder&) = delete;
-    command_batch_builder& operator=(command_batch_builder&&) = default;
+    // command_batch_builder& operator=(command_batch_builder&&) = default;
     ~command_batch_builder() = default;
     /// Add segments to the batch
     command_batch_builder&
@@ -75,7 +75,7 @@ private:
     std::reference_wrapper<archival_metadata_stm> _stm;
     storage::record_batch_builder _builder;
     ss::lowres_clock::time_point _deadline;
-    std::optional<std::reference_wrapper<ss::abort_source>> _as;
+    ss::abort_source& _as;
     ss::gate::holder _holder;
 };
 
@@ -103,7 +103,7 @@ public:
       std::vector<cloud_storage::segment_meta>,
       std::optional<model::offset> clean_offset,
       ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      ss::abort_source&);
 
     /// Truncate local snapshot by moving start_offset forward
     ///
@@ -114,11 +114,11 @@ public:
     ss::future<std::error_code> truncate(
       model::offset start_rp_offset,
       ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      ss::abort_source&);
     ss::future<std::error_code> truncate(
       kafka::offset start_kafka_offset,
       ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      ss::abort_source&);
 
     /// Truncate local snapshot
     ///
@@ -128,7 +128,7 @@ public:
     ss::future<std::error_code> spillover(
       model::offset start_rp_offset,
       ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      ss::abort_source&);
 
     /// Truncate archive area
     ///
@@ -137,18 +137,17 @@ public:
       model::offset start_rp_offset,
       model::offset_delta delta,
       ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      ss::abort_source&);
 
     /// Removes replaced and truncated segments from the snapshot
-    ss::future<std::error_code> cleanup_metadata(
-      ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+    ss::future<std::error_code>
+    cleanup_metadata(ss::lowres_clock::time_point deadline, ss::abort_source&);
 
     /// Propagates archive_clean_offset forward
     ss::future<std::error_code> cleanup_archive(
       model::offset start_rp_offset,
       ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      ss::abort_source&);
 
     /// Declare that the manifest is clean as of a particular insync_offset:
     /// the insync offset should have been captured before starting the upload,
@@ -200,9 +199,8 @@ public:
 
     /// Create batch builder that can be used to combine and replicate multipe
     /// STM commands together
-    command_batch_builder batch_start(
-      ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+    command_batch_builder
+    batch_start(ss::lowres_clock::time_point deadline, ss::abort_source&);
 
     /// Acquire the lock that prevents modification of the manifest.
     auto acquire_manifest_lock() { return _manifest_lock.get_units(); }
@@ -225,11 +223,10 @@ private:
       std::vector<cloud_storage::segment_meta>,
       std::optional<model::offset> clean_offset,
       ss::lowres_clock::time_point deadline,
-      std::optional<std::reference_wrapper<ss::abort_source>>);
+      ss::abort_source&);
 
-    ss::future<std::error_code> do_replicate_commands(
-      model::record_batch,
-      std::optional<std::reference_wrapper<ss::abort_source>>);
+    ss::future<std::error_code>
+    do_replicate_commands(model::record_batch, ss::abort_source&);
 
     ss::future<> apply(model::record_batch batch) override;
     ss::future<> handle_eviction() override;


### PR DESCRIPTION
The do_replicate_command path in archival metadata stm was dropping out on ntp_archiver's abort source fired, but not returning the property "shutting down" error code.

While looking at this, I noticed that there were optional abort source arguments that should never be omitted in practice, so updated the interfaces to make abort source mandatory (and pass an abort source in from unit tests that previously relied on the optionality).

In the process of that refactor, I noticed a place that ntp_archiver::do_upload_local wasn't passing in an abort source, so added one there

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none