### PR TITLE
storage: switch to node_hash_map for kvstore

### DIFF
--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -25,7 +25,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/timer.hh>
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 namespace storage {
 
@@ -151,7 +151,7 @@ private:
     ssx::semaphore _sem{0, "s/kvstore"};
     ss::lw_shared_ptr<segment> _segment;
     model::offset _next_offset;
-    absl::flat_hash_map<bytes, iobuf, bytes_type_hash, bytes_type_eq> _db;
+    absl::node_hash_map<bytes, iobuf, bytes_type_hash, bytes_type_eq> _db;
 
     ss::future<> put(key_space ks, bytes key, std::optional<iobuf> value);
     void apply_op(bytes key, std::optional<iobuf> value);


### PR DESCRIPTION
The flat_hash_map has been seen to produce oversized allocations with even only a few hundred partitions per core.

While our keys are not huge, the `bytes` type has size 32 due to inlining, the number of partitions per core can be in the thousands, and each partitions stores more than one kvstore entry for distinct storage, raft purposes.

Fixes https://github.com/redpanda-data/redpanda/issues/10304

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none