### PR TITLE
Send Describe ACL requests to the controller

### DIFF
--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -140,6 +140,11 @@
             "name": "get_partition_state",
             "input_type": "partition_state_request",
             "output_type": "partition_state_reply"
+        },
+        {
+            "name": "describe_acls",
+            "input_type": "describe_acls_request",
+            "output_type": "describe_acls_reply"
         }
     ]
 }

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -54,6 +54,10 @@ public:
       std::vector<security::acl_binding_filter>,
       model::timeout_clock::duration);
 
+    ss::future<describe_acls_reply> describe_acls(
+      security::acl_binding_filter filter,
+      model::timeout_clock::duration timeout);
+
     /**
      * For use during cluster creation, if RP_BOOTSTRAP_USER is set
      * then returns the user creds specified in it
@@ -77,9 +81,17 @@ private:
       std::vector<security::acl_binding_filter>,
       model::timeout_clock::duration);
 
+    std::vector<acl_resource>
+    do_describe_acls(const security::acl_binding_filter& filter);
+
     ss::future<std::vector<delete_acls_result>> dispatch_delete_acls_to_leader(
       model::node_id,
       std::vector<security::acl_binding_filter>,
+      model::timeout_clock::duration);
+
+    ss::future<describe_acls_reply> dispatch_describe_acls_to_leader(
+      model::node_id,
+      security::acl_binding_filter,
       model::timeout_clock::duration);
 
     model::node_id _self;

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -777,4 +777,13 @@ service::do_get_partition_state(partition_state_request req) {
       });
 }
 
+ss::future<describe_acls_reply>
+service::describe_acls(describe_acls_request&& req, rpc::streaming_context&) {
+    return ss::with_scheduling_group(
+      get_scheduling_group(), [this, req]() mutable {
+          return _security_frontend.local().describe_acls(
+            std::move(req.filter), req.timeout);
+      });
+}
+
 } // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -121,6 +121,9 @@ public:
     ss::future<partition_state_reply> get_partition_state(
       partition_state_request&&, rpc::streaming_context&) final;
 
+    ss::future<describe_acls_reply>
+    describe_acls(describe_acls_request&&, rpc::streaming_context&) final;
+
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
     std::

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3551,6 +3551,60 @@ std::ostream& operator<<(
       with_assignment.assignments);
     return o;
 }
+
+struct acl_description
+  : serde::
+      envelope<acl_description, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    security::acl_principal principal;
+    security::acl_host host;
+    security::acl_operation operation;
+    security::acl_permission permission_type;
+
+    auto serde_fields() {
+        return std::tie(principal, host, operation, permission_type);
+    }
+};
+
+struct acl_resource
+  : serde::envelope<acl_resource, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    security::resource_type type;
+    ss::sstring name;
+    security::pattern_type pattern_type;
+    std::vector<acl_description> acls;
+
+    auto serde_fields() { return std::tie(type, name, pattern_type, acls); }
+};
+
+struct describe_acls_request
+  : serde::envelope<
+      describe_acls_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    security::acl_binding_filter filter;
+    model::timeout_clock::duration timeout;
+
+    auto serde_fields() { return std::tie(filter, timeout); }
+};
+
+struct describe_acls_reply
+  : serde::envelope<
+      describe_acls_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    errc error{errc::success};
+    std::vector<acl_resource> acl_resources;
+
+    auto serde_fields() { return std::tie(error, acl_resources); }
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/kafka/server/handlers/describe_acls.cc
+++ b/src/v/kafka/server/handlers/describe_acls.cc
@@ -10,7 +10,9 @@
  */
 #include "kafka/server/handlers/describe_acls.h"
 
+#include "cluster/topics_frontend.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/server/errors.h"
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
@@ -25,54 +27,39 @@
 namespace kafka {
 
 static void fill_response(
-  request_context& ctx,
-  security::acl_binding_filter& filter,
-  describe_acls_response_data& response) {
-    /*
-     * collapse common acls by pattern
-     */
-    absl::flat_hash_map<
-      security::resource_pattern,
-      std::vector<security::acl_entry>>
-      entries;
-
-    auto bindings = ctx.authorizer().acls(filter);
-
-    for (const auto& binding : bindings) {
-        entries[binding.pattern()].push_back(binding.entry());
-    }
-
+  const std::vector<cluster::acl_resource>& entries,
+  describe_acls_response_data& data) {
     for (const auto& entry : entries) {
         describe_acls_resource resource;
-
-        // resource pattern
-        resource.type = details::to_kafka_resource_type(entry.first.resource());
-        resource.name = entry.first.name();
+        resource.type = details::to_kafka_resource_type(entry.type);
+        resource.name = entry.name;
         resource.pattern_type = details::to_kafka_pattern_type(
-          entry.first.pattern());
+          entry.pattern_type);
 
         // acl entries
-        for (auto& acl : entry.second) {
+        for (const auto& acl : entry.acls) {
             // ignore ephemeral_users
             auto ephemeral_user = security::principal_type::ephemeral_user;
-            if (acl.principal().type() == ephemeral_user) {
+            if (acl.principal.type() == ephemeral_user) {
                 continue;
             }
             acl_description desc{
-              .principal = details::to_kafka_principal(acl.principal()),
-              .host = details::to_kafka_host(acl.host()),
-              .operation = details::to_kafka_operation(acl.operation()),
-              .permission_type = details::to_kafka_permission(acl.permission()),
+              .principal = details::to_kafka_principal(acl.principal),
+              .host = details::to_kafka_host(acl.host),
+              .operation = details::to_kafka_operation(acl.operation),
+              .permission_type = details::to_kafka_permission(
+                acl.permission_type),
             };
             resource.acls.push_back(std::move(desc));
         }
-        response.resources.push_back(std::move(resource));
+        data.resources.push_back(std::move(resource));
     }
 }
 
 template<>
 ss::future<response_ptr> describe_acls_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+    static const auto default_describe_acls_timeout = 3s;
     describe_acls_request request;
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
@@ -88,7 +75,14 @@ ss::future<response_ptr> describe_acls_handler::handle(
 
     try {
         auto filter = details::to_acl_binding_filter(request.data);
-        fill_response(ctx, filter, data);
+        auto result = co_await ctx.security_frontend().describe_acls(
+          filter, default_describe_acls_timeout);
+        if (result.error != cluster::errc::success) {
+            vlog(klog.debug, "Error describing ACLs: {}", result.error);
+            data.error_code = map_topic_error_code(result.error);
+        } else {
+            fill_response(result.acl_resources, data);
+        }
     } catch (const details::acl_conversion_error& e) {
         vlog(klog.debug, "Error describing ACLs: {}", e.what());
         data.error_code = error_code::invalid_request;


### PR DESCRIPTION
Send Describle ACL requests to the controller node so clients do not observe stale state

Fixes: https://github.com/redpanda-data/redpanda/issues/9266

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Describe ACL requests will be forwarded to the controller node so that the most up-to-date state is available.
