### PR TITLE
tests: check bad_offsets at end of kgo-verifier produce

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -619,6 +619,14 @@ class KgoVerifierProducer(KgoVerifierService):
 
         self._status_thread.raise_on_error()
 
+        if self._status.bad_offsets != 0:
+            # This either means that the test sent multiple producers' traffic to
+            # the same topic, or that Redpanda showed a buggy behavior with
+            # idempotency: producer records should always land at the next offset
+            # after the last record they wrote.
+            raise RuntimeError(
+                f"{self.who_am_i()} possible idempotency bug: {self._status}")
+
         return super().wait_node(node, timeout_sec=timeout_sec)
 
     def wait_for_acks(self, count, timeout_sec, backoff_sec):


### PR DESCRIPTION
This check acts as a reproducer for https://github.com/redpanda-data/redpanda/pull/10232 and more generally as a pervasive sanity check of our offset handling and idempotency.

This does rely on tests calling wait() on producers, but that is already required to get any meaningful error detection (if kgo-verifier fails to start, you don't find out until you call wait())

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none