### PR TITLE
rptest: loosen runtime for debug cloud timing test

### DIFF
--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -247,6 +247,11 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
         self.admin = Admin(self.redpanda)
         self.checks = []
 
+        # Fine tune the allowed overshoot for debug builds as they are
+        # significantly slower.
+        if self.debug_mode:
+            self.allow_runtime_overshoot_by = 2.5
+
     def _create_producer(self) -> KgoVerifierProducer:
         bps = self.produce_byte_rate_per_ntp * self.topics[0].partition_count
         bytes_count = bps * self.target_runtime


### PR DESCRIPTION
We have seen a number of cases where runs of
`CloudStorageTimingStressTest` time out on debug builds. Looking into the logs for those failures, it transpired that they finish the workload within a few seconds of begin interrupted.

This commit tweaks the allowed overshoot when using debug builds.

Fixes #10361

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
