### PR TITLE
[v23.1.x] cloud_storage: handle transport errors during manifest download

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -245,7 +245,9 @@ ss::future<> ntp_archiver::sync_manifest_until_abort() {
               e);
         } catch (...) {
             vlog(
-              _rtclog.error, "upload loop error: {}", std::current_exception());
+              _rtclog.error,
+              "sync manifest loop error: {}",
+              std::current_exception());
         }
     }
 }

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -15,6 +15,7 @@
 #include "cloud_storage/materialized_segments.h"
 #include "cloud_storage/remote_segment.h"
 #include "cloud_storage/types.h"
+#include "cloud_storage_clients/util.h"
 #include "model/metadata.h"
 #include "net/connection.h"
 #include "ssx/sformat.h"
@@ -186,19 +187,28 @@ ss::future<download_result> remote::do_download_manifest(
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
-            co_await manifest.update(resp.value()->as_input_stream());
-            switch (manifest.get_manifest_type()) {
-            case manifest_type::partition:
-                _probe.partition_manifest_download();
-                break;
-            case manifest_type::topic:
-                _probe.topic_manifest_download();
-                break;
-            case manifest_type::tx_range:
-                _probe.txrange_manifest_download();
-                break;
+            try {
+                co_await manifest.update(resp.value()->as_input_stream());
+
+                switch (manifest.get_manifest_type()) {
+                case manifest_type::partition:
+                    _probe.partition_manifest_download();
+                    break;
+                case manifest_type::topic:
+                    _probe.topic_manifest_download();
+                    break;
+                case manifest_type::tx_range:
+                    _probe.txrange_manifest_download();
+                    break;
+                }
+                co_return download_result::success;
+            } catch (...) {
+                // Draining the response stream may throw I/O errors: convert
+                // those into an error outcome.
+                resp
+                  = cloud_storage_clients::util::handle_client_transport_error(
+                    std::current_exception(), cst_log);
             }
-            co_return download_result::success;
         }
 
         lease.client->shutdown();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10324
Fixes https://github.com/redpanda-data/redpanda/issues/10045,