### PR TITLE
[v22.3.x] k/alter_configs: use default for cleanup policy

### DIFF
--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -356,6 +356,20 @@ class CreateSITopicsTest(RedpandaTest):
         for k, v in examples.items():
             kcl.alter_topic_config({k: v}, incremental=False, topic=topic)
 
+        # 'cleanup.policy' is defaulted to 'delete' upon topic creation.
+        # AlterConfigs handling should preserve this default, unless explicitly
+        # overriden.
+        topic_config = rpk.describe_topic_configs(topic)
+        value, src = topic_config["cleanup.policy"]
+        assert value == "delete" and src == "DYNAMIC_TOPIC_CONFIG"
+
+        kcl.alter_topic_config({"cleanup.policy": "compact"},
+                               incremental=False,
+                               topic=topic)
+        topic_config = rpk.describe_topic_configs(topic)
+        value, src = topic_config["cleanup.policy"]
+        assert value == "compact" and src == "DYNAMIC_TOPIC_CONFIG"
+
         # As a control, confirm that if we did pass an invalid property, we would have got an error
         with expect_exception(RuntimeError, lambda e: "invalid" in str(e)):
             kcl.alter_topic_config({"redpanda.invalid.property": 'true'},


### PR DESCRIPTION
Previously, AlterConfigs handling would un-set the cleanup-policy unless it was specified. This is problematic because we always override the cleanup-policy to `delete` on topic creation.

This patch change AlterConfigs handling to preserve the creation time default.

(cherry picked from commit 261dc934933318171522ef3b0b11a18b3284d9dd)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Bug Fixes

* Fix a bug in `AlterConfigs` which caused `cleanup.policy` to be un-set unless explicitly overriden. The creation time default is `cleanup.policy=delete` and `AlterConfigs` now enforces it.