### PR TITLE
[v23.1.x] cloud_storage: fix reupload of topic manifest

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -621,6 +621,11 @@ ss::future<> partition::update_configuration(topic_properties properties) {
     // Pass the configuration update into the storage layer
     co_await _raft->log().update_configuration(new_ntp_config);
 
+    // Update cached instance of topic properties
+    if (_topic_cfg) {
+        _topic_cfg->properties = std::move(properties);
+    }
+
     // If this partition's cloud storage mode changed, rebuild the archiver.
     // This must happen after raft update, because it reads raft's
     // ntp_config to decide whether to construct an archiver.

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/server/handlers/alter_configs.h"
 
+#include "cluster/metadata_cache.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
@@ -53,7 +54,8 @@ static void parse_and_set_shadow_indexing_mode(
 }
 
 checked<cluster::topic_properties_update, alter_configs_resource_response>
-create_topic_properties_update(alter_configs_resource& resource) {
+create_topic_properties_update(
+  const request_context& ctx, alter_configs_resource& resource) {
     model::topic_namespace tp_ns(
       model::kafka_namespace, model::topic(resource.resource_name));
     cluster::topic_properties_update update(tp_ns);
@@ -65,8 +67,6 @@ create_topic_properties_update(alter_configs_resource& resource) {
      * configuration in topic table, the only difference is the replication
      * factor, if not set in the request explicitly it will not be overriden.
      */
-    update.properties.cleanup_policy_bitflags.op
-      = cluster::incremental_update_operation::set;
     update.properties.compaction_strategy.op
       = cluster::incremental_update_operation::set;
     update.properties.compression.op
@@ -85,6 +85,15 @@ create_topic_properties_update(alter_configs_resource& resource) {
       = cluster::incremental_update_operation::none;
     update.custom_properties.data_policy.op
       = cluster::incremental_update_operation::none;
+
+    /**
+     * Since 'cleanup.policy' is always defaulted to 'delete' at topic creation,
+     * we must special case the handling to preserve this default.
+     */
+    update.properties.cleanup_policy_bitflags.op
+      = cluster::incremental_update_operation::set;
+    update.properties.cleanup_policy_bitflags.value
+      = ctx.metadata_cache().get_default_cleanup_policy_bitflags();
 
     for (auto& cfg : resource.configs) {
         try {
@@ -252,8 +261,11 @@ alter_topic_configuration(
     return do_alter_topics_configuration<
       alter_configs_resource,
       alter_configs_resource_response>(
-      ctx, std::move(resources), validate_only, [](alter_configs_resource& r) {
-          return create_topic_properties_update(r);
+      ctx,
+      std::move(resources),
+      validate_only,
+      [&ctx](alter_configs_resource& r) {
+          return create_topic_properties_update(ctx, r);
       });
 }
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -360,6 +360,20 @@ class CreateSITopicsTest(RedpandaTest):
         for k, v in examples.items():
             kcl.alter_topic_config({k: v}, incremental=False, topic=topic)
 
+        # 'cleanup.policy' is defaulted to 'delete' upon topic creation.
+        # AlterConfigs handling should preserve this default, unless explicitly
+        # overriden.
+        topic_config = rpk.describe_topic_configs(topic)
+        value, src = topic_config["cleanup.policy"]
+        assert value == "delete" and src == "DYNAMIC_TOPIC_CONFIG"
+
+        kcl.alter_topic_config({"cleanup.policy": "compact"},
+                               incremental=False,
+                               topic=topic)
+        topic_config = rpk.describe_topic_configs(topic)
+        value, src = topic_config["cleanup.policy"]
+        assert value == "compact" and src == "DYNAMIC_TOPIC_CONFIG"
+
         # As a control, confirm that if we did pass an invalid property, we would have got an error
         with expect_exception(RuntimeError, lambda e: "invalid" in str(e)):
             kcl.alter_topic_config({"redpanda.invalid.property": 'true'},


### PR DESCRIPTION
Backport of PR #10297

Note: I backported `BucketView` from the tip of dev in the first commit of this PR. Having to re-implement
things for `S3Snapshot` is really annoying. Old tests can now continue using `S3Snapshot`, while new, back-ported, tests
can use`BucketView`. The cherry-picked commits themselves back-ported cleanly.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Bug Fixes
* Fix a bug where recovered topics would use the retention settings specified at creation time (ignoring updates after that point).
* Fix a bug in AlterConfigs which caused cleanup.policy to be un-set unless explicitly overriden. The creation time default is cleanup.policy=delete and AlterConfigs now enforces it.