### PR TITLE
cluster: Switch partition_leaders_table to use absl::node_hash_map

### DIFF
--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -20,7 +20,6 @@
 
 #include <seastar/core/sharded.hh>
 
-#include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_map.h>
 
 #include <optional>
@@ -203,7 +202,7 @@ private:
     std::optional<leader_meta>
       find_leader_meta(model::topic_namespace_view, model::partition_id) const;
 
-    absl::flat_hash_map<leader_key, leader_meta, leader_key_hash, leader_key_eq>
+    absl::node_hash_map<leader_key, leader_meta, leader_key_hash, leader_key_eq>
       _leaders;
 
     // per-ntp notifications for leadership election. note that the


### PR DESCRIPTION
Fixes #10349

Another instance of large allocations caused by `absl::flat_hash_map`.

Switch to using `node::node_hash_map` which should result in smaller contiguous allocations.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x // skipping this as less important for clusters on that version due to general perf issues with that

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.



Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
