### PR TITLE
cluster: faster initialization of metrics reporter + `cluster_id`

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -283,7 +283,7 @@ ss::future<> metrics_reporter::try_initialize_cluster_info() {
     // a UUID.  No timeout: we cannot generate any reports until this
     // happens.
     if (_raft0->committed_offset() < model::offset{2}) {
-        vlog(clusterlog.info, "Waiting to initialize cluster UUID...");
+        vlog(clusterlog.info, "Waiting to initialize cluster metrics ID...");
         co_await _controller_stm.local().wait(
           model::offset{2},
           model::timeout_clock::time_point::max(),
@@ -326,7 +326,8 @@ ss::future<> metrics_reporter::try_initialize_cluster_info() {
     boost::uuids::random_generator_mt19937 uuid_gen(mersenne_twister);
 
     _cluster_info.uuid = fmt::format("{}", uuid_gen());
-    vlog(clusterlog.info, "Generated cluster UUID {}", _cluster_info.uuid);
+    vlog(
+      clusterlog.info, "Generated cluster metrics ID {}", _cluster_info.uuid);
 }
 
 /**

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -110,6 +110,7 @@ metrics_reporter::metrics_reporter(
   ss::sharded<ss::abort_source>& as)
   : _raft0(std::move(raft0))
   , _cluster_info(controller_stm.local().get_metrics_reporter_cluster_info())
+  , _controller_stm(controller_stm)
   , _members_table(members_table)
   , _topics(topic_table)
   , _health_monitor(health_monitor)
@@ -124,12 +125,17 @@ ss::future<> metrics_reporter::start() {
       config::shard_local_cfg().metrics_reporter_url());
     _tick_timer.set_callback([this] { report_metrics(); });
 
-    const auto initial_delay = 10s;
+    _last_success = model::timeout_clock::now();
 
-    // A shorter initial wait than the tick interval, so that we
-    // give the cluster state a chance to stabilize, but also send
-    // a report reasonably promptly.
-    _tick_timer.arm(initial_delay);
+    // Immediately enter the report loop, as on a fresh cluster this will
+    // be what initializes the cluster UUId.  It will not actually transmit
+    // a report on the first call, because the interval has not yet elapsed
+    // since the _last_success we just set to now().
+    // It is important to do this promptly and not wait here, because the
+    // controller cannot generate snapshots until the cluster UUID
+    // is initialized.
+    report_metrics();
+
     co_return;
 }
 
@@ -273,17 +279,20 @@ ss::future<> metrics_reporter::try_initialize_cluster_info() {
         co_return;
     }
 
+    // Wait until the controller log has seen enough batches to generate
+    // a UUID.  No timeout: we cannot generate any reports until this
+    // happens.
+    if (_raft0->committed_offset() < model::offset{2}) {
+        vlog(clusterlog.info, "Waiting to initialize cluster UUID...");
+        co_await _controller_stm.local().wait(
+          model::offset{2},
+          model::timeout_clock::time_point::max(),
+          std::ref(_as.local()));
+    }
+
     if (_raft0->start_offset() > model::offset{0}) {
         // Controller log already snapshotted, wait until cluster info gets
         // initialized from the snapshot.
-        co_return;
-    }
-
-    /**
-     * In order to seed the UUID generator we use a hash over first two batches
-     * timestamps and initial raft-0 configuration
-     */
-    if (_raft0->committed_offset() < model::offset{2}) {
         co_return;
     }
 
@@ -317,6 +326,7 @@ ss::future<> metrics_reporter::try_initialize_cluster_info() {
     boost::uuids::random_generator_mt19937 uuid_gen(mersenne_twister);
 
     _cluster_info.uuid = fmt::format("{}", uuid_gen());
+    vlog(clusterlog.info, "Generated cluster UUID {}", _cluster_info.uuid);
 }
 
 /**

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -106,6 +106,7 @@ private:
 
     consensus_ptr _raft0;
     metrics_reporter_cluster_info& _cluster_info; // owned by controller_stm
+    ss::sharded<controller_stm>& _controller_stm;
     ss::sharded<members_table>& _members_table;
     ss::sharded<topic_table>& _topics;
     ss::sharded<health_monitor_frontend>& _health_monitor;


### PR DESCRIPTION
This is pulled out of https://github.com/redpanda-data/redpanda/pull/10287 because it's useful in its own right.

Clients issue warnings like this when run against a freshly started  redpanda:
```
lineno:107]: %4|1682528724.188|CLUSTERID|rdkafka#consumer-2| [thrd:main]: Broker GroupCoordinator/3 reports different ClusterId "redpanda.2d339cd9-b540-484d-80da-16cd0650e49b" than previously known "redpanda.initializing": a client must not be simultaneously connected to multiple clusters
```

It's because we were lazily initializing cluster id about 10 seconds after starting for the first time.

In this PR:
- Initialize the cluster ID as soon as there is something in the cluster log
- Block starting the kafka API listener until the cluster ID is set.

Blocking the API startup is potentially fragile if we ever changed cluster bootstrap to not generate a few messages as a side effect of startup up for the first time (a raft config, a bootstrap_cmd, one config write, one config status write), but if that ever happened, I expect it would be pretty obvious.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Redpanda no longer uses a temporary `redpanda.initializing` cluster ID in Kafka API responses sent very soon after creating a cluster for the first time: a UUID cluster ID is now generated before responding to any Kafka requests.
