### PR TITLE
[v22.3.x] k/client: auto-retry on consumer offsets commit and fetch

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -499,8 +499,10 @@ ss::future<offset_fetch_response> client::consumer_offset_fetch(
   const member_id& name,
   std::vector<offset_fetch_request_topic> topics) {
     return get_consumer(g_id, name)
-      .then([topics{std::move(topics)}](shared_consumer_t c) mutable {
-          return c->offset_fetch(std::move(topics));
+      .then([this, topics{std::move(topics)}](shared_consumer_t c) mutable {
+          return gated_retry_with_mitigation([c, topics{std::move(topics)}]() {
+              return c->offset_fetch(topics);
+          });
       });
 }
 
@@ -509,8 +511,10 @@ ss::future<offset_commit_response> client::consumer_offset_commit(
   const member_id& name,
   std::vector<offset_commit_request_topic> topics) {
     return get_consumer(g_id, name)
-      .then([topics{std::move(topics)}](shared_consumer_t c) mutable {
-          return c->offset_commit(std::move(topics));
+      .then([this, topics{std::move(topics)}](shared_consumer_t c) mutable {
+          return gated_retry_with_mitigation([c, topics{std::move(topics)}]() {
+              return c->offset_commit(topics);
+          });
       });
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/9809
Fixes https://github.com/redpanda-data/redpanda/issues/10390,