### PR TITLE
[recovery_stm] Buffer record_batches using fragmented vector

### DIFF
--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -15,6 +15,7 @@
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "seastarx.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/do_with.hh>
@@ -310,10 +311,17 @@ record_batch_reader make_foreign_memory_record_batch_reader(record_batch);
 record_batch_reader
   make_foreign_memory_record_batch_reader(record_batch_reader::data_t);
 
+record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+  fragmented_vector<model::record_batch>);
+
 record_batch_reader make_generating_record_batch_reader(
   ss::noncopyable_function<ss::future<record_batch_reader::data_t>()>);
 
 ss::future<record_batch_reader::data_t> consume_reader_to_memory(
+  record_batch_reader, timeout_clock::time_point timeout);
+
+ss::future<fragmented_vector<model::record_batch>>
+consume_reader_to_fragmented_memory(
   record_batch_reader, timeout_clock::time_point timeout);
 
 /// \brief wraps a reader into a foreign_ptr<unique_ptr>

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -270,6 +270,9 @@ record_batch_reader make_record_batch_reader(Args&&... args) {
 record_batch_reader
   make_memory_record_batch_reader(record_batch_reader::storage_t);
 
+record_batch_reader make_fragmented_memory_record_batch_reader(
+  fragmented_vector<model::record_batch>);
+
 inline record_batch_reader
 make_memory_record_batch_reader(model::record_batch b) {
     record_batch_reader::data_t batches;

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -49,6 +49,8 @@ read_bootstrap_state(storage::log, model::offset, ss::abort_source&);
 
 ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
   model::offset, ss::circular_buffer<model::record_batch>&&);
+fragmented_vector<model::record_batch> make_ghost_batches_in_gaps(
+  model::offset, fragmented_vector<model::record_batch>&&);
 
 /// writes snapshot with given data to disk
 ss::future<>

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -11,6 +11,7 @@
 
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
@@ -631,14 +632,14 @@ ss::future<> append_entries_request::serde_async_read(
     iobuf_parser in(std::move(tmp));
 
     auto batch_count = read_nested<uint32_t>(in, 0U);
-    auto batches = ss::circular_buffer<model::record_batch>{};
-    batches.reserve(batch_count);
+    auto batches = fragmented_vector<model::record_batch>{};
     for (uint32_t i = 0; i < batch_count; ++i) {
         batches.push_back(reflection::adl<model::record_batch>{}.from(in));
         co_await ss::coroutine::maybe_yield();
     }
 
-    _batches = model::make_memory_record_batch_reader(std::move(batches));
+    _batches = model::make_foreign_fragmented_memory_record_batch_reader(
+      std::move(batches));
     node_id = read_nested<raft::vnode>(in, 0U);
     target_node_id = read_nested<raft::vnode>(in, 0U);
     meta = read_nested<raft::protocol_metadata>(in, 0U);

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -11,6 +11,7 @@
 
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/timeout_clock.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
 #include "raft/group_configuration.h"
@@ -591,19 +592,29 @@ void heartbeat_reply::serde_read(iobuf_parser& src, const serde::header& hdr) {
 }
 
 ss::future<> append_entries_request::serde_async_write(iobuf& dst) {
-    auto mem_batches = co_await model::consume_reader_to_memory(
-      std::move(batches()), model::no_timeout);
-
-    iobuf out;
     using serde::write;
 
-    write(out, static_cast<uint32_t>(mem_batches.size()));
-    for (auto& batch : mem_batches) {
-        // intentionally using reflection here for batches which are not yet
-        // supported with serde, but also have largely solidified.
-        reflection::serialize(out, std::move(batch));
-        co_await ss::coroutine::maybe_yield();
-    }
+    class streaming_writer {
+    public:
+        ss::future<ss::stop_iteration> operator()(model::record_batch b) {
+            reflection::serialize(_out, std::move(b));
+            ++_count;
+            co_return ss::stop_iteration::no;
+        }
+        iobuf end_of_stream() {
+            iobuf header;
+            write(header, static_cast<uint32_t>(_count));
+            _out.prepend(std::move(header));
+            return std::move(_out);
+        }
+
+    private:
+        uint32_t _count = 0;
+        iobuf _out;
+    };
+
+    iobuf out = co_await batches().consume(
+      streaming_writer{}, model::no_timeout);
 
     write(out, node_id);
     write(out, target_node_id);


### PR DESCRIPTION
During recovery we read all batches into a single `ss::circular_buffer`.
Read these into a fragmented vector to prevent large contiguous allocations.

It seems possible that we want to use a different data structure than `ss::circular_buffer` for reading record_batches, but that seemed like a very invasive change. This at least fixes the only case of potentially large amounts of record_batches being read into memory at once based on the current usages of `consume_into_memory`

Fixes: #10298
Fixes: #10303
Fixes: #10301

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none
