### PR TITLE
tests: make Segment.offset integer type

### DIFF
--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -26,7 +26,7 @@ class Segment:
 
         m = re.match(r"^(\d+)\-\d+\-v\d+$", name)
         assert m, f"Unexpected segment name {name}"
-        self.offset = m.group(1)
+        self.offset = int(m.group(1))
 
     def add_file(self, fn, ext):
         assert fn


### PR DESCRIPTION
wait_for_local_storage_truncate() takes the oldest segment's value, as determined by its base offset. Finding the oldest segment used Segment.offset, which has a return type of string.

It doesn't look like there are other callers, so I updated the offsets member rather than the call site.

Fixes https://github.com/redpanda-data/redpanda/issues/10400

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none