### PR TITLE
Disk space usage reporting accuracy 

### DIFF
--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -29,7 +29,8 @@
 #include <absl/container/flat_hash_map.h>
 
 namespace cluster {
-class partition_manager {
+class partition_manager
+  : public ss::peering_sharded_service<partition_manager> {
 public:
     using ntp_table_container
       = absl::flat_hash_map<model::ntp, ss::lw_shared_ptr<partition>>;
@@ -180,6 +181,15 @@ public:
     /// Report the aggregate backlog of all archivers for all managed
     /// partitions
     uint64_t upload_backlog_size() const;
+
+    /*
+     * Return disk space usage for for partitions not accounted for by the
+     * underlying logs. Examples include raft snapshots, and other snapshots and
+     * indicies used by any active state machines.
+     *
+     * The results are accumulated for all partitions, across all cores.
+     */
+    ss::future<size_t> non_log_disk_size_bytes() const;
 
 private:
     /// Download log if partition_recovery_manager is initialized.

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -311,6 +311,20 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/local_storage_usage",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get the usage report for local storage",
+                    "type": "long",
+                    "nickname": "get_local_storage_usage",
+                    "produces": [
+                        "application/json"
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -694,6 +708,24 @@
                         "type": "partition_replica_state"
                     },
                     "description": "All replicas of this partition"
+                }
+            }
+        },
+        "local_storage_usage": {
+            "id": "local_storage_usage",
+            "description": "Local storage disk usage",
+            "properties": {
+                "data": {
+                    "type": "long",
+                    "description": "Segment data"
+                },
+                "index": {
+                    "type": "long",
+                    "description": "Segment index"
+                },
+                "compaction": {
+                    "type": "long",
+                    "description": "Compaction index"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -436,6 +436,8 @@ private:
 
     ss::future<ss::json::json_return_type>
       get_partition_state_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      get_local_storage_usage_handler(std::unique_ptr<ss::http::request>);
 
     // Debug routes
     ss::future<ss::json::json_return_type>

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -36,6 +36,7 @@ v_cc_library(
     offset_to_filepos.cc
     fs_utils.cc
     file_sanitizer_types.cc
+    api.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/api.cc
+++ b/src/v/storage/api.cc
@@ -1,0 +1,19 @@
+#include "storage/api.h"
+
+namespace storage {
+
+ss::future<usage_report> api::disk_usage() {
+    co_return co_await container().map_reduce0(
+      [](api& api) {
+          return ss::when_all_succeed(
+                   api._log_mgr->disk_usage(), api._kvstore->disk_usage())
+            .then([](std::tuple<usage_report, usage_report> usage) {
+                const auto& [disk, kvs] = usage;
+                return disk + kvs;
+            });
+      },
+      usage_report{},
+      [](usage_report acc, usage_report update) { return acc + update; });
+}
+
+} // namespace storage

--- a/src/v/storage/api.cc
+++ b/src/v/storage/api.cc
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
 #include "storage/api.h"
 
 namespace storage {

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -99,7 +99,7 @@ private:
 };
 
 // Top-level sharded storage API.
-class api {
+class api : public ss::peering_sharded_service<api> {
 public:
     explicit api(
       std::function<kvstore_config()> kv_conf_cb,
@@ -145,6 +145,12 @@ public:
     kvstore& kvs() { return *_kvstore; }
     log_manager& log_mgr() { return *_log_mgr; }
     storage_resources& resources() { return _resources; }
+
+    /*
+     * Return disk space usage for kvstore and all logs. The information
+     * returned is accumulated from all cores.
+     */
+    ss::future<usage_report> disk_usage();
 
 private:
     storage_resources _resources;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -110,6 +110,8 @@ public:
 
     int64_t compaction_backlog() const final;
 
+    ss::future<usage_report> disk_usage(compaction_config);
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
@@ -184,8 +186,6 @@ private:
     bool is_cloud_retention_active() const;
 
     std::optional<model::offset> retention_offset(compaction_config);
-
-    ss::future<usage_report> disk_usage(compaction_config);
 
 private:
     size_t max_segment_size() const;

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -630,4 +630,18 @@ void kvstore::replay_consumer::print(std::ostream& os) const {
     os << "storage::kvstore";
 }
 
+ss::future<usage_report> kvstore::disk_usage() const {
+    usage_report report{};
+
+    if (_segment) {
+        report.usage = co_await _segment->persistent_size();
+    }
+    report.usage.data += (co_await _snap.size()).value_or(0);
+
+    // kvstore doesn't have on-demand reclaimable data (yet) so the default
+    // reclaim limits of 0 in the report are correct.
+
+    co_return report;
+}
+
 } // namespace storage

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -117,6 +117,14 @@ public:
         return _db.empty();
     }
 
+    /*
+     * Return disk usage information about kvstore. Size information for any
+     * segments are returned in the usage.data field. The kvstore doesn't
+     * currently use indexing, and has no reclaimable space yes, so these fields
+     * will be set to 0.
+     */
+    ss::future<usage_report> disk_usage() const;
+
 private:
     kvstore_config _conf;
     storage_resources& _resources;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -224,6 +224,11 @@ public:
 
     storage_resources& resources() { return _resources; }
 
+    /*
+     * Return disk usage information for all logs managed on the current core.
+     */
+    ss::future<usage_report> disk_usage();
+
 private:
     using logs_type
       = absl::flat_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -473,6 +473,8 @@ ss::future<> do_swap_data_file_handles(
       old_name,
       s->reader().filename());
     co_await ss::rename_file(old_name, s->reader().filename());
+    // the on disk file is changing so clear the size cache
+    s->clear_cached_disk_usage();
 
     auto r = segment_reader(
       s->reader().path(),

--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -318,4 +318,19 @@ ss::future<> snapshot_writer::close() {
     });
 }
 
+ss::future<std::optional<size_t>>
+snapshot_manager::size(ss::sstring filename) const {
+    const auto path = snapshot_path(std::move(filename)).string();
+    try {
+        co_return co_await ss::file_size(path);
+    } catch (...) {
+        vlog(
+          stlog.debug,
+          "Failed to stat snapshot file {}: {}",
+          path,
+          std::current_exception());
+        co_return std::nullopt;
+    }
+}
+
 } // namespace storage

--- a/src/v/storage/snapshot.h
+++ b/src/v/storage/snapshot.h
@@ -120,6 +120,11 @@ public:
 
     ss::future<> remove_snapshot(ss::sstring);
 
+    /*
+     * Return the size of the snapshot on disk.
+     */
+    ss::future<std::optional<size_t>> size(ss::sstring filename) const;
+
 private:
     ss::sstring _partial_prefix;
     std::filesystem::path _dir;
@@ -283,6 +288,13 @@ public:
     }
 
     const ss::sstring& name() { return _filename; }
+
+    /*
+     * Return the size of the snapshot on disk.
+     */
+    ss::future<std::optional<size_t>> size() const {
+        return _snapshot.size(_filename);
+    }
 
 private:
     ss::sstring _filename;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -408,6 +408,13 @@ struct compaction_result {
 struct reclaim_size_limits {
     size_t retention{0};
     size_t available{0};
+
+    friend reclaim_size_limits
+    operator+(reclaim_size_limits lhs, const reclaim_size_limits& rhs) {
+        lhs.retention += rhs.retention;
+        lhs.available += rhs.available;
+        return lhs;
+    }
 };
 
 /*
@@ -441,6 +448,12 @@ struct usage {
 struct usage_report {
     usage usage;
     reclaim_size_limits reclaim;
+
+    friend usage_report operator+(usage_report lhs, const usage_report& rhs) {
+        lhs.usage = lhs.usage + rhs.usage;
+        lhs.reclaim = lhs.reclaim + rhs.reclaim;
+        return lhs;
+    }
 };
 
 } // namespace storage

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -918,3 +918,10 @@ class Admin:
     def get_partition_state(self, namespace, topic, partition, node=None):
         path = f"debug/partition/{namespace}/{topic}/{partition}"
         return self._request("GET", path, node=node).json()
+
+    def get_local_storage_usage(self, node=None):
+        """
+        Get the local storage usage report.
+        """
+        return self._request("get", "debug/local_storage_usage",
+                             node=node).json()

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -90,6 +90,12 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                             redpanda.cloud_storage_diagnostics()
                             raise
 
+                    try:
+                        redpanda.raise_on_storage_usage_inconsistency()
+                    except:
+                        redpanda.cloud_storage_diagnostics()
+                        raise
+
                 if self.redpanda.si_settings is not None:
                     try:
                         self.redpanda.stop_and_scrub_object_storage()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2117,6 +2117,14 @@ class RedpandaService(RedpandaServiceBase):
                 return False
             if file.parents[-2].name == "cloud_storage_cache":
                 return False
+            if "compaction.staging" in file.name:
+                # compaction staging files are temporary and are generally
+                # cleaned up after compaction finishes, or at next round of
+                # compaction if a file was stranded. during shutdown of any
+                # generic test we don't have a good opportunity to force this to
+                # happen without placing a lot of restrictions on shutdown. for
+                # the time being just ignore these.
+                return False
             return True
 
         def inspect_node(node):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2159,7 +2159,8 @@ class RedpandaService(RedpandaServiceBase):
         nodes = []
         max_node, max_diff = retries[0][0], retries[0][1][0]
         for node, deets in retries:
-            nodes.append(self.idx(node))
+            node_name = f"{self.idx(node)}:{node.account.hostname}"
+            nodes.append(node_name)
             pct_diff, reported, reported_total, observed, observed_total = deets
             if pct_diff > max_diff:
                 max_diff = pct_diff
@@ -2167,12 +2168,12 @@ class RedpandaService(RedpandaServiceBase):
             diff = observed_total - reported_total
             for file, size in observed:
                 self.logger.debug(
-                    f"Observed file [{self.idx(node)}]: {size:7} {file}")
+                    f"Observed file [{node_name}]: {size:7} {file}")
             self.logger.warn(
-                f"Storage usage [{self.idx(node)}]: obs {observed_total:7} rep {reported_total:7} diff {diff:7} pct {pct_diff}"
+                f"Storage usage [{node_name}]: obs {observed_total:7} rep {reported_total:7} diff {diff:7} pct {pct_diff}"
             )
 
-        max_node = self.idx(max_node)
+        max_node = f"{self.idx(max_node)}:{max_node.account.hostname}"
         raise RuntimeError(
             f"Storage usage inconsistency on nodes {nodes}: max difference {max_diff} on node {max_node}"
         )


### PR DESCRIPTION
Adds infrastructure for accumulating total space usage. The results are exported through the admin server interface. a Ducktape test that computes the same value out-of-band by examining on disk usage compares to the reported value.

The correctness of this is enforced on every test by checking after each test completes.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
