### PR TITLE
k8s: remove --platform flag from operator images' dockerfile

### DIFF
--- a/src/go/k8s/Dockerfile
+++ b/src/go/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.20.1 as builder
+FROM public.ecr.aws/docker/library/golang:1.20.1 as builder
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Assume arch options are handled by the image builder (e.g. buildx)

## Backports Required


- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
