### PR TITLE
[v22.3.x] storage: switch to node_hash_map for kvstore

### DIFF
--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -25,7 +25,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/timer.hh>
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 namespace storage {
 
@@ -146,7 +146,7 @@ private:
     ssx::semaphore _sem{0, "s/kvstore"};
     ss::lw_shared_ptr<segment> _segment;
     model::offset _next_offset;
-    absl::flat_hash_map<bytes, iobuf, bytes_type_hash, bytes_type_eq> _db;
+    absl::node_hash_map<bytes, iobuf, bytes_type_hash, bytes_type_eq> _db;
 
     ss::future<> put(key_space ks, bytes key, std::optional<iobuf> value);
     void apply_op(bytes key, std::optional<iobuf> value);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10340
Fixes https://github.com/redpanda-data/redpanda/issues/10413,