### PR TITLE
[v23.1.x] archival: avoid lock inversion in segment merger

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1461,18 +1461,21 @@ ntp_archiver::get_housekeeping_jobs() {
     return res;
 }
 
-ss::future<std::optional<upload_candidate_with_locks>>
+ss::future<std::pair<
+  std::optional<ssx::semaphore_units>,
+  std::optional<upload_candidate_with_locks>>>
 ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
     if (!may_begin_uploads()) {
-        co_return std::nullopt;
+        co_return std::make_pair(std::nullopt, std::nullopt);
     }
     auto run = scanner(_parent.start_offset(), manifest());
     if (!run.has_value()) {
         vlog(_rtclog.debug, "Scan didn't resulted in upload candidate");
-        co_return std::nullopt;
+        co_return std::make_pair(std::nullopt, std::nullopt);
     } else {
         vlog(_rtclog.debug, "Scan result: {}", run);
     }
+    auto units = co_await ss::get_units(_mutex, 1, _as);
     if (run->meta.base_offset >= _parent.start_offset()) {
         auto log_generic = _parent.log();
         auto& log = dynamic_cast<storage::disk_log_impl&>(
@@ -1489,7 +1492,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
           _conf->upload_io_priority, _conf->segment_upload_timeout);
         if (candidate.candidate.exposed_name().empty()) {
             vlog(_rtclog.warn, "Failed to make upload candidate");
-            co_return std::nullopt;
+            co_return std::make_pair(std::nullopt, std::nullopt);
         }
         if (candidate.candidate.content_length != run->meta.size_bytes) {
             vlog(
@@ -1498,9 +1501,9 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
               "actual {}",
               candidate.candidate,
               run->meta);
-            co_return std::nullopt;
+            co_return std::make_pair(std::nullopt, std::nullopt);
         }
-        co_return candidate;
+        co_return std::make_pair(std::move(units), std::move(candidate));
     }
     // segment_name exposed_name;
     upload_candidate candidate = {};
@@ -1517,12 +1520,16 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
       = cloud_storage::partition_manifest::generate_remote_segment_name(
         run->meta);
     // Create a remote upload candidate
-    co_return upload_candidate_with_locks{std::move(candidate)};
+    co_return std::make_pair(
+      std::move(units), upload_candidate_with_locks{std::move(candidate)});
 }
 
 ss::future<bool> ntp_archiver::upload(
+  ssx::semaphore_units archiver_units,
   upload_candidate_with_locks upload_locks,
   std::optional<std::reference_wrapper<retry_chain_node>> source_rtc) {
+    ss::gate::holder holder(_gate);
+    auto units = std::move(archiver_units);
     if (upload_locks.candidate.sources.size() > 0) {
         return do_upload_local(std::move(upload_locks), source_rtc);
     }
@@ -1559,8 +1566,6 @@ ss::future<bool> ntp_archiver::do_upload_local(
           upload.exposed_name);
         co_return false;
     }
-
-    auto units = co_await ss::get_units(_mutex, 1, _as);
 
     auto offset = upload.final_offset;
     auto base = upload.starting_offset;


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/10319

CONFLICT:
- v23.1.x didn't hold a gate in upload

The main archival loop currently takes locks in the order 1) ntp_archiver_service::_mutex, 2) segment locks. The segment merging housekeeping job takes locks in the opposite order.

This could result in a deadlock when attempting to take a lock on the same segment if the segment merger attempts to merge a partially uploaded segment, and concurrently the archival loop attempts to do another partial segment upload of that segment.

This commit extends the ntp_archiver_service interface to force callers of ntp_archival_service::upload() to already have a lock, rather than acquiring the lock therein.

Fixes #10085

(cherry picked from commit 589d07c734de647641a9f32d154c581c9c573792)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Fixed a lock ordering inversion that could lead the upload loop to occasionally timeout.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
