### PR TITLE
Removed large contiguous allocations from the topic creation path 

### DIFF
--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -95,7 +95,7 @@ ss::future<bool> health_manager::ensure_partition_replication(model::ntp ntp) {
         co_return false;
     }
 
-    auto new_assignments = allocation.value().get_assignments();
+    auto new_assignments = allocation.value().copy_assignments();
 
     auto it = std::find_if(
       new_assignments.cbegin(),

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -16,22 +16,13 @@
 namespace cluster {
 
 void allocation_state::rollback(
-  const std::vector<partition_assignment>& v,
+  const ss::chunked_fifo<partition_assignment>& v,
   const partition_allocation_domain domain) {
     verify_shard();
     for (auto& as : v) {
         rollback(as.replicas, domain);
         // rollback for each assignment as the groups are distinct
         _highest_group = raft::group_id(_highest_group() - 1);
-    }
-}
-
-void allocation_state::rollback(
-  const std::vector<model::broker_shard>& v,
-  const partition_allocation_domain domain) {
-    verify_shard();
-    for (auto& bs : v) {
-        deallocate(bs, domain);
     }
 }
 
@@ -71,7 +62,7 @@ void allocation_state::apply_update(
             continue;
         }
 
-            it->second->allocate_on(bs.shard, domain);
+        it->second->allocate_on(bs.shard, domain);
     }
 }
 

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -57,9 +57,17 @@ public:
     result<uint32_t> allocate(model::node_id id, partition_allocation_domain);
 
     void rollback(
-      const std::vector<partition_assignment>& pa, partition_allocation_domain);
-    void rollback(
-      const std::vector<model::broker_shard>& v, partition_allocation_domain);
+      const ss::chunked_fifo<partition_assignment>& pa,
+      partition_allocation_domain);
+
+    template<typename Replicas>
+    void
+    rollback(const Replicas& replicas, partition_allocation_domain domain) {
+        verify_shard();
+        for (auto& bs : replicas) {
+            deallocate(bs, domain);
+        }
+    }
 
     bool validate_shard(model::node_id node, uint32_t shard) const;
 

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -51,7 +51,7 @@ public:
     // Operations on state
     void deallocate(const model::broker_shard&, partition_allocation_domain);
     void apply_update(
-      std::vector<model::broker_shard>,
+      const std::vector<model::broker_shard>&,
       raft::group_id,
       partition_allocation_domain);
     result<uint32_t> allocate(model::node_id id, partition_allocation_domain);

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -22,6 +22,7 @@
 #include "units.h"
 #include "utils/human.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -110,8 +111,12 @@ partition_allocator::allocate_partition(
         replicas.push_back(replica.value());
         all_replicas.push_back(replica.value());
     }
-
-    return std::move(replicas).finish();
+    auto replicas_fifo = std::move(replicas).finish();
+    std::vector<model::broker_shard> ret;
+    ret.reserve(replicas_fifo.size());
+    std::move(
+      replicas_fifo.begin(), replicas_fifo.end(), std::back_inserter(ret));
+    return ret;
 }
 
 /**
@@ -343,9 +348,10 @@ result<allocation_units> partition_allocator::reallocate_partition(
       current_assignment.id,
       std::move(replicas.value()),
     };
-
+    ss::chunked_fifo<partition_assignment> p_as;
+    p_as.push_back(std::move(assignment));
     return allocation_units(
-      {std::move(assignment)}, current_assignment.replicas, *_state, domain);
+      std::move(p_as), current_assignment.replicas, *_state, domain);
 }
 
 void partition_allocator::deallocate(

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -116,8 +116,8 @@ private:
             _partial.emplace_back(std::forward<Args>(args)...);
         }
 
-        const std::vector<T>& get() const { return _partial; }
-        std::vector<T> finish() && { return std::exchange(_partial, {}); }
+        const ss::chunked_fifo<T>& get() const { return _partial; }
+        ss::chunked_fifo<T> finish() && { return std::exchange(_partial, {}); }
         intermediate_allocation(intermediate_allocation&&) noexcept = default;
 
         intermediate_allocation(
@@ -134,7 +134,7 @@ private:
         }
 
     private:
-        std::vector<T> _partial;
+        ss::chunked_fifo<T> _partial;
         ss::weak_ptr<allocation_state> _state;
         partition_allocation_domain _domain;
     };

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -13,6 +13,7 @@
 
 #include "cluster/logger.h"
 #include "cluster/scheduling/allocation_state.h"
+#include "utils/to_string.h"
 
 #include <fmt/ostream.h>
 
@@ -66,7 +67,7 @@ void allocation_constraints::add(allocation_constraints other) {
 }
 
 allocation_units::allocation_units(
-  std::vector<partition_assignment> assignments,
+  ss::chunked_fifo<partition_assignment> assignments,
   allocation_state& state,
   const partition_allocation_domain domain)
   : _assignments(std::move(assignments))
@@ -74,7 +75,7 @@ allocation_units::allocation_units(
   , _domain(domain) {}
 
 allocation_units::allocation_units(
-  std::vector<partition_assignment> assignments,
+  ss::chunked_fifo<partition_assignment> assignments,
   std::vector<model::broker_shard> previous_allocations,
   allocation_state& state,
   const partition_allocation_domain domain)

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -16,6 +16,7 @@
 #include "model/fundamental.h"
 #include "vassert.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/util/noncopyable_function.hh>
 
@@ -179,11 +180,11 @@ struct allocation_units {
     using pointer = ss::foreign_ptr<std::unique_ptr<allocation_units>>;
 
     allocation_units(
-      std::vector<partition_assignment>,
+      ss::chunked_fifo<partition_assignment>,
       allocation_state&,
       partition_allocation_domain);
     allocation_units(
-      std::vector<partition_assignment>,
+      ss::chunked_fifo<partition_assignment>,
       std::vector<model::broker_shard>,
       allocation_state&,
       partition_allocation_domain);
@@ -194,12 +195,20 @@ struct allocation_units {
 
     ~allocation_units();
 
-    const std::vector<partition_assignment>& get_assignments() const {
+    const ss::chunked_fifo<partition_assignment>& get_assignments() const {
         return _assignments;
     }
 
+    ss::chunked_fifo<partition_assignment> copy_assignments() {
+        ss::chunked_fifo<partition_assignment> p_as;
+        p_as.reserve(_assignments.size());
+        std::copy(
+          _assignments.begin(), _assignments.end(), std::back_inserter(p_as));
+        return p_as;
+    }
+
 private:
-    std::vector<partition_assignment> _assignments;
+    ss::chunked_fifo<partition_assignment> _assignments;
     // set of previous replicas, they will not be reverted when allocation units
     // goes out of scope
     absl::node_hash_set<model::broker_shard> _previous;
@@ -239,7 +248,7 @@ struct allocation_request {
     allocation_request& operator=(allocation_request&&) = default;
     ~allocation_request() = default;
 
-    std::vector<partition_constraints> partitions;
+    ss::chunked_fifo<partition_constraints> partitions;
     partition_allocation_domain domain;
 
     friend std::ostream& operator<<(std::ostream&, const allocation_request&);

--- a/src/v/cluster/tests/backend_reallocation_strategy_test.cc
+++ b/src/v/cluster/tests/backend_reallocation_strategy_test.cc
@@ -97,7 +97,7 @@ struct strategy_test_fixture {
 
         cluster::topic_configuration_assignment t_cfg;
 
-        t_cfg.assignments = units->get_assignments();
+        t_cfg.assignments = units->copy_assignments();
         t_cfg.cfg.tp_ns = model::topic_namespace(
           model::kafka_namespace,
           model::topic(fmt::format("test-topic-{}", rev_offset())));

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -20,6 +20,7 @@
 #include "units.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
@@ -100,7 +101,7 @@ struct cmd_test_fixture {
         return model::topic_namespace(test_ns, model::topic(tp));
     }
 
-    std::vector<cluster::partition_assignment>
+    ss::chunked_fifo<cluster::partition_assignment>
     allocate(const cluster::topic_configuration& cfg) {
         std::vector<cluster::partition_assignment> ret;
         ret.reserve(cfg.partition_count);

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -24,6 +24,8 @@
 #include "random/generators.h"
 #include "units.h"
 
+#include <seastar/core/chunked_fifo.hh>
+
 struct partition_allocator_fixture {
     static constexpr uint32_t partitions_per_shard = 1000;
     static constexpr uint32_t partitions_reserve_shard0 = 2;
@@ -84,7 +86,7 @@ struct partition_allocator_fixture {
     }
 
     uint allocated_nodes_count(
-      const std::vector<cluster::partition_assignment>& allocs) {
+      const ss::chunked_fifo<cluster::partition_assignment>& allocs) {
         return std::accumulate(
           allocs.begin(),
           allocs.end(),

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -23,6 +23,8 @@
 #include "test_utils/fixture.h"
 #include "units.h"
 
+#include <seastar/core/chunked_fifo.hh>
+
 #include <chrono>
 #include <optional>
 
@@ -111,7 +113,7 @@ struct partition_balancer_planner_fixture {
                      .allocate(std::move(req))
                      .get()
                      .value()
-                     ->get_assignments();
+                     ->copy_assignments();
 
         return {cfg, std::move(pas)};
     }
@@ -147,7 +149,7 @@ struct partition_balancer_planner_fixture {
           partition_nodes.size(),
           replication_factor);
 
-        std::vector<cluster::partition_assignment> assignments;
+        ss::chunked_fifo<cluster::partition_assignment> assignments;
         for (size_t i = 0; i < partition_nodes.size(); ++i) {
             const auto& nodes = partition_nodes[i];
             BOOST_REQUIRE_EQUAL(nodes.size(), replication_factor);
@@ -161,7 +163,7 @@ struct partition_balancer_planner_fixture {
         }
         cluster::create_topic_cmd cmd{
           make_tp_ns(name),
-          cluster::topic_configuration_assignment{cfg, std::move(assignments)}};
+          cluster::topic_configuration_assignment(cfg, std::move(assignments))};
 
         dispatch_command(std::move(cmd));
     }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -29,6 +29,7 @@
 #include "units.h"
 #include "v8_engine/data_policy.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/testing/thread_test_case.hh>
 
@@ -548,8 +549,8 @@ cluster::topic_properties random_topic_properties() {
     return properties;
 }
 
-std::vector<cluster::partition_assignment> random_partition_assignments() {
-    std::vector<cluster::partition_assignment> ret;
+ss::chunked_fifo<cluster::partition_assignment> random_partition_assignments() {
+    ss::chunked_fifo<cluster::partition_assignment> ret;
 
     for (auto a = 0, ma = random_generators::get_int(1, 10); a < ma; a++) {
         cluster::partition_assignment p_as;

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -98,7 +98,7 @@ struct topic_table_fixture {
                      .allocate(std::move(req))
                      .get()
                      .value()
-                     ->get_assignments();
+                     ->copy_assignments();
 
         return cluster::topic_configuration_assignment(cfg, std::move(pas));
     }

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -18,6 +18,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/types.h"
+#include "ssx/future-util.h"
 
 #include <absl/container/node_hash_map.h>
 #include <fmt/ranges.h>
@@ -451,30 +452,18 @@ ss::future<std::error_code> do_apply(
 template<typename Cmd>
 ss::future<std::error_code>
 topic_updates_dispatcher::dispatch_updates_to_cores(Cmd cmd, model::offset o) {
-    using ret_t = std::vector<std::error_code>;
-    return ss::do_with(
-      ret_t{}, [this, cmd = std::move(cmd), o](ret_t& ret) mutable {
-          ret.reserve(ss::smp::count);
-          return ss::parallel_for_each(
-                   boost::irange(0, (int)ss::smp::count),
-                   [this, &ret, cmd = std::move(cmd), o](int shard) mutable {
-                       return do_apply(shard, cmd, _topic_table, o)
-                         .then([&ret](std::error_code r) { ret.push_back(r); });
-                   })
-            .then([&ret] { return std::move(ret); })
-            .then([](std::vector<std::error_code> results) mutable {
-                auto ret = results.front();
-                for (auto& r : results) {
-                    vassert(
-                      ret == r,
-                      "State inconsistency across shards detected, expected "
-                      "result: {}, have: {}",
-                      ret,
-                      r);
-                }
-                return ret;
-            });
+    auto results = co_await ssx::parallel_transform(
+      boost::irange<ss::shard_id>(0, ss::smp::count),
+      [this, cmd = std::move(cmd), o](ss::shard_id shard) mutable {
+          return do_apply(shard, cmd, _topic_table, o);
       });
+
+    vassert(
+      std::equal(std::next(results.begin()), results.end(), results.begin()),
+      "State inconsistency across shards detected results: {}",
+      results);
+
+    co_return results.front();
 }
 
 void topic_updates_dispatcher::deallocate_topic(

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -20,6 +20,8 @@
 #include "raft/types.h"
 #include "ssx/future-util.h"
 
+#include <seastar/coroutine/maybe_yield.hh>
+
 #include <absl/container/node_hash_map.h>
 #include <fmt/ranges.h>
 
@@ -51,35 +53,33 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
 
 ss::future<std::error_code> topic_updates_dispatcher::apply(
   create_topic_cmd command, model::offset offset) {
-    return dispatch_updates_to_cores(command, offset)
-      .then([this, command](std::error_code ec) {
-          if (ec == errc::success) {
-              const auto& tp_ns = command.key;
-              update_allocations(
-                command.value.assignments, get_allocation_domain(tp_ns));
+    auto tp_ns = command.key;
+    ss::chunked_fifo<partition_assignment> assignments;
 
-              for (const auto& p_as : command.value.assignments) {
-                  _partition_balancer_state.local().handle_ntp_update(
-                    tp_ns.ns, tp_ns.tp, p_as.id, {}, p_as.replicas);
-              }
-          }
-          return ec;
-      })
+    std::copy(
+      command.value.assignments.begin(),
+      command.value.assignments.end(),
+      std::back_inserter(assignments));
 
-      .then([this, command](std::error_code ec) {
-          if (ec == errc::success) {
-              std::vector<ntp_leader> leaders;
-              const auto& tp_ns = command.value.cfg.tp_ns;
-              for (auto& p_as : command.value.assignments) {
-                  leaders.emplace_back(
-                    model::ntp(tp_ns.ns, tp_ns.tp, p_as.id),
-                    p_as.replicas.begin()->node_id);
-              }
-              return update_leaders_with_estimates(leaders).then(
-                [ec]() { return ss::make_ready_future<std::error_code>(ec); });
-          }
-          return ss::make_ready_future<std::error_code>(ec);
-      });
+    auto ec = co_await dispatch_updates_to_cores(std::move(command), offset);
+
+    if (ec == errc::success) {
+        update_allocations(assignments, get_allocation_domain(tp_ns));
+        ss::chunked_fifo<ntp_leader> leaders;
+        for (const auto& p_as : assignments) {
+            _partition_balancer_state.local().handle_ntp_update(
+              tp_ns.ns, tp_ns.tp, p_as.id, {}, p_as.replicas);
+            leaders.emplace_back(
+              model::ntp(tp_ns.ns, tp_ns.tp, p_as.id),
+              p_as.replicas.begin()->node_id);
+            co_await ss::coroutine::maybe_yield();
+        }
+        co_await update_leaders_with_estimates(std::move(leaders));
+
+        co_return errc::success;
+    }
+
+    co_return ec;
 }
 ss::future<std::error_code>
 topic_updates_dispatcher::apply(delete_topic_cmd cmd, model::offset offset) {
@@ -255,20 +255,24 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
 
 ss::future<std::error_code> topic_updates_dispatcher::apply(
   create_partition_cmd cmd, model::offset offset) {
-    return dispatch_updates_to_cores(cmd, offset)
-      .then([this, cmd](std::error_code ec) {
-          if (ec == errc::success) {
-              const auto& tp_ns = cmd.key;
-              update_allocations(
-                cmd.value.assignments, get_allocation_domain(tp_ns));
+    auto tp_ns = cmd.key;
+    ss::chunked_fifo<partition_assignment> assignments;
 
-              for (const auto& p_as : cmd.value.assignments) {
-                  _partition_balancer_state.local().handle_ntp_update(
-                    tp_ns.ns, tp_ns.tp, p_as.id, {}, p_as.replicas);
-              }
-          }
-          return ec;
-      });
+    std::copy(
+      cmd.value.assignments.begin(),
+      cmd.value.assignments.end(),
+      std::back_inserter(assignments));
+    auto ec = co_await dispatch_updates_to_cores(std::move(cmd), offset);
+
+    if (ec == errc::success) {
+        update_allocations(assignments, get_allocation_domain(tp_ns));
+
+        for (const auto& p_as : assignments) {
+            _partition_balancer_state.local().handle_ntp_update(
+              tp_ns.ns, tp_ns.tp, p_as.id, {}, p_as.replicas);
+        }
+    }
+    co_return ec;
 }
 ss::future<std::error_code> topic_updates_dispatcher::apply(
   create_non_replicable_topic_cmd cmd, model::offset offset) {
@@ -287,7 +291,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
                 assignments->begin(),
                 assignments->end(),
                 std::back_inserter(p_as));
-              update_allocations(std::move(p_as), allocation_domain);
+              update_allocations(p_as, allocation_domain);
           }
           return ec;
       });
@@ -417,19 +421,17 @@ topic_updates_dispatcher::collect_in_progress(
 }
 
 ss::future<> topic_updates_dispatcher::update_leaders_with_estimates(
-  std::vector<ntp_leader> leaders) {
-    for (const auto& i : leaders) {
-        vlog(
-          clusterlog.debug,
-          "update_leaders_with_estimates: new NTP {} leader {}",
-          i.first,
-          i.second);
-    }
+  ss::chunked_fifo<ntp_leader> leaders) {
     return ss::do_with(
-      std::move(leaders), [this](std::vector<ntp_leader>& leaders) {
+      std::move(leaders), [this](ss::chunked_fifo<ntp_leader>& leaders) {
           return ss::parallel_for_each(leaders, [this](ntp_leader& leader) {
+              vlog(
+                clusterlog.debug,
+                "update_leaders_with_estimates: new NTP {} leader {}",
+                leader.first,
+                leader.second);
               return _partition_leaders_table.invoke_on_all(
-                [leader](partition_leaders_table& l) {
+                [leader = std::move(leader)](partition_leaders_table& l) {
                     return l.update_partition_leader(
                       leader.first, model::term_id(1), leader.second);
                 });
@@ -491,21 +493,13 @@ void topic_updates_dispatcher::deallocate_topic(
         }
     }
 }
-
+template<typename T>
 void topic_updates_dispatcher::update_allocations(
-  const std::vector<partition_assignment>& assignments,
-  const partition_allocation_domain domain) {
-    // for create topics we update allocation state
-    std::vector<model::broker_shard> shards;
-    raft::group_id max_group_id = raft::group_id(0);
+  const T& assignments, const partition_allocation_domain domain) {
     for (const auto& pas : assignments) {
-        max_group_id = std::max(max_group_id, pas.group);
-        std::move(
-          pas.replicas.begin(), pas.replicas.end(), std::back_inserter(shards));
+        _partition_allocator.local().update_allocation_state(
+          pas.replicas, pas.group, domain);
     }
-
-    _partition_allocator.local().update_allocation_state(
-      shards, max_group_id, domain);
 }
 
 ss::future<>

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -40,376 +40,351 @@ topic_updates_dispatcher::topic_updates_dispatcher(
 
 ss::future<std::error_code>
 topic_updates_dispatcher::apply_update(model::record_batch b) {
-    auto base_offset = b.base_offset();
-    return deserialize(std::move(b), commands)
-      .then([this, base_offset](auto cmd) {
-          return ss::visit(
-            std::move(cmd),
-            [this, base_offset](delete_topic_cmd del_cmd) {
-                auto topic_assignments
-                  = _topic_table.local().get_topic_assignments(del_cmd.value);
-                in_progress_map in_progress;
+    auto offset = b.base_offset();
+    auto cmd = co_await deserialize(std::move(b), commands);
 
-                if (topic_assignments) {
-                    in_progress = collect_in_progress(
-                      del_cmd.key, *topic_assignments);
-                }
-                return dispatch_updates_to_cores(del_cmd, base_offset)
-                  .then(
-                    [this,
-                     tp_ns = std::move(del_cmd.key),
-                     topic_assignments = std::move(topic_assignments),
-                     in_progress = std::move(in_progress)](std::error_code ec) {
-                        if (ec == errc::success) {
-                            vassert(
-                              topic_assignments.has_value(),
-                              "Topic had to exist before successful delete");
-                            vlog(
-                              clusterlog.trace,
-                              "Deallocating ntp: {},  in_progress ops: {}",
-                              tp_ns,
-                              in_progress);
-                            deallocate_topic(
-                              tp_ns,
-                              *topic_assignments,
-                              in_progress,
-                              get_allocation_domain(tp_ns));
+    co_return co_await std::visit(
+      [this, offset](auto cmd) { return apply(std::move(cmd), offset); },
+      std::move(cmd));
+}
 
-                            for (const auto& p_as : *topic_assignments) {
-                                _partition_balancer_state.local()
-                                  .handle_ntp_update(
-                                    tp_ns.ns,
-                                    tp_ns.tp,
-                                    p_as.id,
-                                    p_as.replicas,
-                                    {});
-                            }
-                        }
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  create_topic_cmd command, model::offset offset) {
+    return dispatch_updates_to_cores(command, offset)
+      .then([this, command](std::error_code ec) {
+          if (ec == errc::success) {
+              const auto& tp_ns = command.key;
+              update_allocations(
+                command.value.assignments, get_allocation_domain(tp_ns));
 
-                        return ec;
-                    });
-            },
-            [this, base_offset](create_topic_cmd create_cmd) {
-                return dispatch_updates_to_cores(create_cmd, base_offset)
-                  .then([this, create_cmd](std::error_code ec) {
-                      if (ec == errc::success) {
-                          const auto& tp_ns = create_cmd.key;
-                          update_allocations(
-                            create_cmd.value.assignments,
-                            get_allocation_domain(tp_ns));
+              for (const auto& p_as : command.value.assignments) {
+                  _partition_balancer_state.local().handle_ntp_update(
+                    tp_ns.ns, tp_ns.tp, p_as.id, {}, p_as.replicas);
+              }
+          }
+          return ec;
+      })
 
-                          for (const auto& p_as :
-                               create_cmd.value.assignments) {
-                              _partition_balancer_state.local()
-                                .handle_ntp_update(
-                                  tp_ns.ns,
-                                  tp_ns.tp,
-                                  p_as.id,
-                                  {},
-                                  p_as.replicas);
-                          }
-                      }
-                      return ec;
-                  })
-
-                  .then([this, create_cmd](std::error_code ec) {
-                      if (ec == errc::success) {
-                          std::vector<ntp_leader> leaders;
-                          const auto& tp_ns = create_cmd.value.cfg.tp_ns;
-                          for (auto& p_as : create_cmd.value.assignments) {
-                              leaders.emplace_back(
-                                model::ntp(tp_ns.ns, tp_ns.tp, p_as.id),
-                                p_as.replicas.begin()->node_id);
-                          }
-                          return update_leaders_with_estimates(leaders).then(
-                            [ec]() {
-                                return ss::make_ready_future<std::error_code>(
-                                  ec);
-                            });
-                      }
-                      return ss::make_ready_future<std::error_code>(ec);
-                  });
-            },
-            [this, base_offset](move_partition_replicas_cmd cmd) {
-                auto p_as = _topic_table.local().get_partition_assignment(
-                  cmd.key);
-                return dispatch_updates_to_cores(cmd, base_offset)
-                  .then([this, p_as = std::move(p_as), cmd = std::move(cmd)](
-                          std::error_code ec) {
-                      if (!ec) {
-                          const auto& ntp = cmd.key;
-                          vassert(
-                            p_as.has_value(),
-                            "Partition {} have to exist before successful "
-                            "partition reallocation",
-                            ntp);
-                          auto to_add = subtract_replica_sets(
-                            cmd.value, p_as->replicas);
-                          _partition_allocator.local().add_allocations(
-                            to_add, get_allocation_domain(ntp));
-
-                          _partition_balancer_state.local().handle_ntp_update(
-                            ntp.ns,
-                            ntp.tp.topic,
-                            ntp.tp.partition,
-                            p_as->replicas,
-                            cmd.value);
-                      }
-                      return ec;
-                  });
-            },
-            [this, base_offset](cancel_moving_partition_replicas_cmd cmd) {
-                auto current_assignment
-                  = _topic_table.local().get_partition_assignment(cmd.key);
-                auto new_target_replicas
-                  = _topic_table.local().get_previous_replica_set(cmd.key);
-                auto ntp = cmd.key;
-                return dispatch_updates_to_cores(std::move(cmd), base_offset)
-                  .then([this,
-                         ntp = std::move(ntp),
-                         current_assignment = std::move(current_assignment),
-                         new_target_replicas = std::move(new_target_replicas)](
-                          std::error_code ec) {
-                      if (ec) {
-                          return ec;
-                      }
-                      vassert(
-                        current_assignment.has_value()
-                          && new_target_replicas.has_value(),
-                        "Previous replicas for NTP {} must exists as finish "
-                        "update can only be applied to partition that is "
-                        "currently being updated",
-                        ntp);
-
-                      _partition_balancer_state.local().handle_ntp_update(
-                        ntp.ns,
-                        ntp.tp.topic,
-                        ntp.tp.partition,
-                        current_assignment->replicas,
-                        *new_target_replicas);
-                      return ec;
-                  });
-            },
-            [this, base_offset](finish_moving_partition_replicas_cmd cmd) {
-                // initial replica set of the move command (not changed when
-                // operation is cancelled)
-                auto previous_replicas
-                  = _topic_table.local().get_previous_replica_set(cmd.key);
-                // requested/target replica set of original move command(not
-                // changed when move is cancelled)
-                auto target_replicas
-                  = _topic_table.local().get_target_replica_set(cmd.key);
-                /**
-                 * Finish moving command may be related either with cancellation
-                 * or with finish of an original move
-                 *
-                 * For original move the direction of data transfer is:
-                 *
-                 *  previous_replica -> target_replicas
-                 *
-                 * for cancelled move it is:
-                 *
-                 *  target_replicas -> previous_replicas
-                 *
-                 * Finish command contains the final replica set it will be
-                 * target_replicas for finished move and previous_replicas for
-                 * finished cancellation
-                 */
-                return dispatch_updates_to_cores(cmd, base_offset)
-                  .then([this,
-                         ntp = std::move(cmd.key),
-                         previous_replicas = std::move(previous_replicas),
-                         target_replicas = std::move(target_replicas),
-                         command_replicas = std::move(cmd.value)](
-                          std::error_code ec) {
-                      if (ec) {
-                          return ec;
-                      }
-                      vassert(
-                        previous_replicas.has_value(),
-                        "Previous replicas for NTP {} must exists as finish "
-                        "update can only be applied to partition that is "
-                        "currently being updated",
-                        ntp);
-                      vassert(
-                        target_replicas.has_value(),
-                        "Target replicas for NTP {} must exists as finish "
-                        "update can only be applied to partition that is "
-                        "currently being updated",
-                        ntp);
-                      std::vector<model::broker_shard> to_delete;
-                      // move was successful, not cancelled
-                      if (target_replicas == command_replicas) {
-                          to_delete = subtract_replica_sets(
-                            *previous_replicas, command_replicas);
-                      } else {
-                          vassert(
-                            previous_replicas == command_replicas,
-                            "When finishing cancelled move of partition {} the "
-                            "finish command replica set {} must be equal to "
-                            "previous_replicas {} from topic table in progress "
-                            "update tracker",
-                            ntp,
-                            command_replicas,
-                            previous_replicas);
-                          to_delete = subtract_replica_sets(
-                            *target_replicas, command_replicas);
-                      }
-                      _partition_allocator.local().remove_allocations(
-                        to_delete, get_allocation_domain(ntp));
-
-                      return ec;
-                  });
-            },
-            [this, base_offset](revert_cancel_partition_move_cmd cmd) {
-                /**
-                 * In this case partition underlying raft group reconfiguration
-                 * already finished when it is attempted to be cancelled.
-                 *
-                 * In the case where original move was scheduled
-                 * to happen from replica set A to B:
-                 *
-                 *      A->B
-                 *
-                 * Cancellation would result in reconfiguration:
-                 *
-                 *      B->A
-                 * But since the move A->B finished we update the topic table
-                 * back to the state from before the cancellation
-                 *
-                 */
-
-                // Replica set that the original move was requested from (A from
-                // an example above)
-                auto previous_replicas
-                  = _topic_table.local().get_previous_replica_set(
-                    cmd.value.ntp);
-                auto target_replicas
-                  = _topic_table.local().get_target_replica_set(cmd.value.ntp);
-                return dispatch_updates_to_cores(cmd, base_offset)
-                  .then([this,
-                         ntp = std::move(cmd.value.ntp),
-                         previous_replicas = std::move(previous_replicas),
-                         target_replicas = std::move(target_replicas)](
-                          std::error_code ec) {
-                      if (ec) {
-                          return ec;
-                      }
-
-                      vassert(
-                        previous_replicas.has_value(),
-                        "Previous replicas for NTP {} must exists as revert "
-                        "update can only be applied to partition that move is "
-                        "currently being cancelled",
-                        ntp);
-                      vassert(
-                        target_replicas.has_value(),
-                        "Target replicas for NTP {} must exists as revert "
-                        "update can only be applied to partition that move is "
-                        "currently being cancelled",
-                        ntp);
-
-                      auto to_delete = subtract_replica_sets(
-                        *previous_replicas, *target_replicas);
-                      _partition_allocator.local().remove_allocations(
-                        to_delete, get_allocation_domain(ntp));
-
-                      _partition_balancer_state.local().handle_ntp_update(
-                        ntp.ns,
-                        ntp.tp.topic,
-                        ntp.tp.partition,
-                        *previous_replicas,
-                        *target_replicas);
-                      return ec;
-                  });
-            },
-            [this, base_offset](update_topic_properties_cmd cmd) {
-                return dispatch_updates_to_cores(std::move(cmd), base_offset);
-            },
-            [this, base_offset](create_partition_cmd cmd) {
-                return dispatch_updates_to_cores(cmd, base_offset)
-                  .then([this, cmd](std::error_code ec) {
-                      if (ec == errc::success) {
-                          const auto& tp_ns = cmd.key;
-                          update_allocations(
-                            cmd.value.assignments,
-                            get_allocation_domain(tp_ns));
-
-                          for (const auto& p_as : cmd.value.assignments) {
-                              _partition_balancer_state.local()
-                                .handle_ntp_update(
-                                  tp_ns.ns,
-                                  tp_ns.tp,
-                                  p_as.id,
-                                  {},
-                                  p_as.replicas);
-                          }
-                      }
-                      return ec;
-                  });
-            },
-            [this, base_offset](create_non_replicable_topic_cmd cmd) {
-                auto assignments = _topic_table.local().get_topic_assignments(
-                  cmd.key.source);
-                return dispatch_updates_to_cores(cmd, base_offset)
-                  .then([this,
-                         assignments = std::move(assignments),
-                         allocation_domain = get_allocation_domain(
-                           cmd.key.name)](std::error_code ec) {
-                      if (ec == errc::success) {
-                          vassert(
-                            assignments.has_value(), "null topic_metadata");
-                          std::vector<partition_assignment> p_as;
-                          p_as.reserve(assignments->size());
-                          std::move(
-                            assignments->begin(),
-                            assignments->end(),
-                            std::back_inserter(p_as));
-                          update_allocations(
-                            std::move(p_as), allocation_domain);
-                      }
-                      return ec;
-                  });
-            },
-            [this, base_offset](move_topic_replicas_cmd cmd) {
-                auto assignments = _topic_table.local().get_topic_assignments(
-                  cmd.key);
-                return dispatch_updates_to_cores(cmd, base_offset)
-                  .then([this,
-                         assignments = std::move(assignments),
-                         cmd = std::move(cmd)](std::error_code ec) {
-                      if (!assignments.has_value()) {
-                          return std::error_code(errc::topic_not_exists);
-                      }
-                      if (ec == errc::success) {
-                          for (const auto& [partition_id, replicas] :
-                               cmd.value) {
-                              auto assigment_it = assignments.value().find(
-                                partition_id);
-                              auto ntp = model::ntp(
-                                cmd.key.ns, cmd.key.tp, partition_id);
-                              if (assigment_it == assignments.value().end()) {
-                                  return std::error_code(
-                                    errc::partition_not_exists);
-                              }
-                              auto to_add = subtract_replica_sets(
-                                replicas, assigment_it->replicas);
-                              _partition_allocator.local().add_allocations(
-                                to_add, get_allocation_domain(ntp));
-                              _partition_balancer_state.local()
-                                .handle_ntp_update(
-                                  ntp.ns,
-                                  ntp.tp.topic,
-                                  ntp.tp.partition,
-                                  assigment_it->replicas,
-                                  replicas);
-                          }
-                      }
-                      return ec;
-                  });
-            });
+      .then([this, command](std::error_code ec) {
+          if (ec == errc::success) {
+              std::vector<ntp_leader> leaders;
+              const auto& tp_ns = command.value.cfg.tp_ns;
+              for (auto& p_as : command.value.assignments) {
+                  leaders.emplace_back(
+                    model::ntp(tp_ns.ns, tp_ns.tp, p_as.id),
+                    p_as.replicas.begin()->node_id);
+              }
+              return update_leaders_with_estimates(leaders).then(
+                [ec]() { return ss::make_ready_future<std::error_code>(ec); });
+          }
+          return ss::make_ready_future<std::error_code>(ec);
       });
 }
+ss::future<std::error_code>
+topic_updates_dispatcher::apply(delete_topic_cmd cmd, model::offset offset) {
+    auto topic_assignments = _topic_table.local().get_topic_assignments(
+      cmd.value);
+    in_progress_map in_progress;
+
+    if (topic_assignments) {
+        in_progress = collect_in_progress(cmd.key, *topic_assignments);
+    }
+    return dispatch_updates_to_cores(cmd, offset)
+      .then([this,
+             tp_ns = std::move(cmd.key),
+             topic_assignments = std::move(topic_assignments),
+             in_progress = std::move(in_progress)](std::error_code ec) {
+          if (ec == errc::success) {
+              vassert(
+                topic_assignments.has_value(),
+                "Topic had to exist before successful delete");
+              vlog(
+                clusterlog.trace,
+                "Deallocating ntp: {},  in_progress ops: {}",
+                tp_ns,
+                in_progress);
+              deallocate_topic(
+                tp_ns,
+                *topic_assignments,
+                in_progress,
+                get_allocation_domain(tp_ns));
+
+              for (const auto& p_as : *topic_assignments) {
+                  _partition_balancer_state.local().handle_ntp_update(
+                    tp_ns.ns, tp_ns.tp, p_as.id, p_as.replicas, {});
+              }
+          }
+
+          return ec;
+      });
+}
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  move_partition_replicas_cmd cmd, model::offset offset) {
+    auto p_as = _topic_table.local().get_partition_assignment(cmd.key);
+    return dispatch_updates_to_cores(cmd, offset)
+      .then([this, p_as = std::move(p_as), cmd = std::move(cmd)](
+              std::error_code ec) {
+          if (!ec) {
+              const auto& ntp = cmd.key;
+              vassert(
+                p_as.has_value(),
+                "Partition {} have to exist before successful "
+                "partition reallocation",
+                ntp);
+              auto to_add = subtract_replica_sets(cmd.value, p_as->replicas);
+              _partition_allocator.local().add_allocations(
+                to_add, get_allocation_domain(ntp));
+
+              _partition_balancer_state.local().handle_ntp_update(
+                ntp.ns,
+                ntp.tp.topic,
+                ntp.tp.partition,
+                p_as->replicas,
+                cmd.value);
+          }
+          return ec;
+      });
+}
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  cancel_moving_partition_replicas_cmd cmd, model::offset offset) {
+    auto current_assignment = _topic_table.local().get_partition_assignment(
+      cmd.key);
+    auto new_target_replicas = _topic_table.local().get_previous_replica_set(
+      cmd.key);
+    auto ntp = cmd.key;
+    return dispatch_updates_to_cores(std::move(cmd), offset)
+      .then([this,
+             ntp = std::move(ntp),
+             current_assignment = std::move(current_assignment),
+             new_target_replicas = std::move(new_target_replicas)](
+              std::error_code ec) {
+          if (ec) {
+              return ec;
+          }
+          vassert(
+            current_assignment.has_value() && new_target_replicas.has_value(),
+            "Previous replicas for NTP {} must exists as finish "
+            "update can only be applied to partition that is "
+            "currently being updated",
+            ntp);
+
+          _partition_balancer_state.local().handle_ntp_update(
+            ntp.ns,
+            ntp.tp.topic,
+            ntp.tp.partition,
+            current_assignment->replicas,
+            *new_target_replicas);
+          return ec;
+      });
+}
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  finish_moving_partition_replicas_cmd cmd, model::offset offset) {
+    // initial replica set of the move command (not changed when
+    // operation is cancelled)
+    auto previous_replicas = _topic_table.local().get_previous_replica_set(
+      cmd.key);
+    // requested/target replica set of original move command(not
+    // changed when move is cancelled)
+    auto target_replicas = _topic_table.local().get_target_replica_set(cmd.key);
+    /**
+     * Finish moving command may be related either with cancellation
+     * or with finish of an original move
+     *
+     * For original move the direction of data transfer is:
+     *
+     *  previous_replica -> target_replicas
+     *
+     * for cancelled move it is:
+     *
+     *  target_replicas -> previous_replicas
+     *
+     * Finish command contains the final replica set it will be
+     * target_replicas for finished move and previous_replicas for
+     * finished cancellation
+     */
+    return dispatch_updates_to_cores(cmd, offset)
+      .then([this,
+             ntp = std::move(cmd.key),
+             previous_replicas = std::move(previous_replicas),
+             target_replicas = std::move(target_replicas),
+             command_replicas = std::move(cmd.value)](std::error_code ec) {
+          if (ec) {
+              return ec;
+          }
+          vassert(
+            previous_replicas.has_value(),
+            "Previous replicas for NTP {} must exists as finish "
+            "update can only be applied to partition that is "
+            "currently being updated",
+            ntp);
+          vassert(
+            target_replicas.has_value(),
+            "Target replicas for NTP {} must exists as finish "
+            "update can only be applied to partition that is "
+            "currently being updated",
+            ntp);
+          std::vector<model::broker_shard> to_delete;
+          // move was successful, not cancelled
+          if (target_replicas == command_replicas) {
+              to_delete = subtract_replica_sets(
+                *previous_replicas, command_replicas);
+          } else {
+              vassert(
+                previous_replicas == command_replicas,
+                "When finishing cancelled move of partition {} the "
+                "finish command replica set {} must be equal to "
+                "previous_replicas {} from topic table in progress "
+                "update tracker",
+                ntp,
+                command_replicas,
+                previous_replicas);
+              to_delete = subtract_replica_sets(
+                *target_replicas, command_replicas);
+          }
+          _partition_allocator.local().remove_allocations(
+            to_delete, get_allocation_domain(ntp));
+
+          return ec;
+      });
+}
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  update_topic_properties_cmd cmd, model::offset offset) {
+    return dispatch_updates_to_cores(std::move(cmd), offset);
+}
+
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  create_partition_cmd cmd, model::offset offset) {
+    return dispatch_updates_to_cores(cmd, offset)
+      .then([this, cmd](std::error_code ec) {
+          if (ec == errc::success) {
+              const auto& tp_ns = cmd.key;
+              update_allocations(
+                cmd.value.assignments, get_allocation_domain(tp_ns));
+
+              for (const auto& p_as : cmd.value.assignments) {
+                  _partition_balancer_state.local().handle_ntp_update(
+                    tp_ns.ns, tp_ns.tp, p_as.id, {}, p_as.replicas);
+              }
+          }
+          return ec;
+      });
+}
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  create_non_replicable_topic_cmd cmd, model::offset offset) {
+    auto assignments = _topic_table.local().get_topic_assignments(
+      cmd.key.source);
+    return dispatch_updates_to_cores(cmd, offset)
+      .then([this,
+             assignments = std::move(assignments),
+             allocation_domain = get_allocation_domain(cmd.key.name)](
+              std::error_code ec) {
+          if (ec == errc::success) {
+              vassert(assignments.has_value(), "null topic_metadata");
+              std::vector<partition_assignment> p_as;
+              p_as.reserve(assignments->size());
+              std::move(
+                assignments->begin(),
+                assignments->end(),
+                std::back_inserter(p_as));
+              update_allocations(std::move(p_as), allocation_domain);
+          }
+          return ec;
+      });
+}
+
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  move_topic_replicas_cmd cmd, model::offset offset) {
+    auto assignments = _topic_table.local().get_topic_assignments(cmd.key);
+    return dispatch_updates_to_cores(cmd, offset)
+      .then([this, assignments = std::move(assignments), cmd = std::move(cmd)](
+              std::error_code ec) {
+          if (!assignments.has_value()) {
+              return std::error_code(errc::topic_not_exists);
+          }
+          if (ec == errc::success) {
+              for (const auto& [partition_id, replicas] : cmd.value) {
+                  auto assigment_it = assignments.value().find(partition_id);
+                  auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, partition_id);
+                  if (assigment_it == assignments.value().end()) {
+                      return std::error_code(errc::partition_not_exists);
+                  }
+                  auto to_add = subtract_replica_sets(
+                    replicas, assigment_it->replicas);
+                  _partition_allocator.local().add_allocations(
+                    to_add, get_allocation_domain(ntp));
+                  _partition_balancer_state.local().handle_ntp_update(
+                    ntp.ns,
+                    ntp.tp.topic,
+                    ntp.tp.partition,
+                    assigment_it->replicas,
+                    replicas);
+              }
+          }
+          return ec;
+      });
+}
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  revert_cancel_partition_move_cmd cmd, model::offset offset) {
+    /**
+     * In this case partition underlying raft group reconfiguration
+     * already finished when it is attempted to be cancelled.
+     *
+     * In the case where original move was scheduled
+     * to happen from replica set A to B:
+     *
+     *      A->B
+     *
+     * Cancellation would result in reconfiguration:
+     *
+     *      B->A
+     * But since the move A->B finished we update the topic table
+     * back to the state from before the cancellation
+     *
+     */
+
+    // Replica set that the original move was requested from (A from
+    // an example above)
+    auto previous_replicas = _topic_table.local().get_previous_replica_set(
+      cmd.value.ntp);
+    auto target_replicas = _topic_table.local().get_target_replica_set(
+      cmd.value.ntp);
+    return dispatch_updates_to_cores(cmd, offset)
+      .then([this,
+             ntp = std::move(cmd.value.ntp),
+             previous_replicas = std::move(previous_replicas),
+             target_replicas = std::move(target_replicas)](std::error_code ec) {
+          if (ec) {
+              return ec;
+          }
+
+          vassert(
+            previous_replicas.has_value(),
+            "Previous replicas for NTP {} must exists as revert "
+            "update can only be applied to partition that move is "
+            "currently being cancelled",
+            ntp);
+          vassert(
+            target_replicas.has_value(),
+            "Target replicas for NTP {} must exists as revert "
+            "update can only be applied to partition that move is "
+            "currently being cancelled",
+            ntp);
+
+          auto to_delete = subtract_replica_sets(
+            *previous_replicas, *target_replicas);
+          _partition_allocator.local().remove_allocations(
+            to_delete, get_allocation_domain(ntp));
+
+          _partition_balancer_state.local().handle_ntp_update(
+            ntp.ns,
+            ntp.tp.topic,
+            ntp.tp.partition,
+            *previous_replicas,
+            *target_replicas);
+          return ec;
+      });
+}
+
 topic_updates_dispatcher::in_progress_map
 topic_updates_dispatcher::collect_in_progress(
   const model::topic_namespace& tp_ns,

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -504,12 +504,12 @@ void topic_updates_dispatcher::deallocate_topic(
 }
 
 void topic_updates_dispatcher::update_allocations(
-  std::vector<partition_assignment> assignments,
+  const std::vector<partition_assignment>& assignments,
   const partition_allocation_domain domain) {
     // for create topics we update allocation state
     std::vector<model::broker_shard> shards;
     raft::group_id max_group_id = raft::group_id(0);
-    for (auto& pas : assignments) {
+    for (const auto& pas : assignments) {
         max_group_id = std::max(max_group_id, pas.group);
         std::move(
           pas.replicas.begin(), pas.replicas.end(), std::back_inserter(shards));

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -105,7 +105,7 @@ private:
 
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader> leaders);
     void update_allocations(
-      std::vector<partition_assignment>, partition_allocation_domain);
+      const std::vector<partition_assignment>&, partition_allocation_domain);
 
     void deallocate_topic(
       const model::topic_namespace&,

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -18,6 +18,7 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 
 namespace cluster {
@@ -103,9 +104,10 @@ private:
 
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
-    ss::future<> update_leaders_with_estimates(std::vector<ntp_leader> leaders);
-    void update_allocations(
-      const std::vector<partition_assignment>&, partition_allocation_domain);
+    ss::future<>
+    update_leaders_with_estimates(ss::chunked_fifo<ntp_leader> leaders);
+    template<typename T>
+    void update_allocations(const T&, partition_allocation_domain);
 
     void deallocate_topic(
       const model::topic_namespace&,

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -84,6 +84,23 @@ private:
     template<typename Cmd>
     ss::future<std::error_code> dispatch_updates_to_cores(Cmd, model::offset);
 
+    ss::future<std::error_code> apply(create_topic_cmd, model::offset);
+    ss::future<std::error_code> apply(delete_topic_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(move_partition_replicas_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(finish_moving_partition_replicas_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(update_topic_properties_cmd, model::offset);
+    ss::future<std::error_code> apply(create_partition_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(create_non_replicable_topic_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(cancel_moving_partition_replicas_cmd, model::offset);
+    ss::future<std::error_code> apply(move_topic_replicas_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(revert_cancel_partition_move_cmd, model::offset);
+
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader> leaders);

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -559,7 +559,8 @@ ss::future<topic_result> topics_frontend::replicate_create_topic(
     auto tp_ns = cfg.tp_ns;
     create_topic_cmd cmd(
       tp_ns,
-      topic_configuration_assignment(std::move(cfg), units->get_assignments()));
+      topic_configuration_assignment(
+        std::move(cfg), units->copy_assignments()));
 
     for (auto& p_as : cmd.value.assignments) {
         std::shuffle(
@@ -935,7 +936,7 @@ ss::future<topic_result> topics_frontend::do_create_partition(
 
     auto tp_ns = p_cfg.tp_ns;
     create_partitions_configuration_assignment payload(
-      std::move(p_cfg), units.value()->get_assignments());
+      std::move(p_cfg), units.value()->copy_assignments());
     create_partition_cmd cmd = create_partition_cmd(tp_ns, std::move(payload));
 
     try {
@@ -1340,7 +1341,7 @@ allocation_request make_allocation_request(
     return req;
 }
 
-ss::future<result<std::vector<partition_assignment>>>
+ss::future<result<ss::chunked_fifo<partition_assignment>>>
 topics_frontend::generate_reassignments(
   model::ntp ntp, std::vector<model::node_id> new_replicas) {
     auto tp_metadata = _topics.local().get_topic_metadata_ref(
@@ -1364,7 +1365,7 @@ topics_frontend::generate_reassignments(
         co_return units.error();
     }
 
-    auto assignments = units.value()->get_assignments();
+    auto assignments = units.value()->copy_assignments();
     if (assignments.empty()) {
         co_return errc::no_partition_assignments;
     }

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -26,6 +26,7 @@
 #include "partition_balancer_types.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 
 #include <absl/container/flat_hash_map.h>
@@ -220,7 +221,7 @@ private:
       model::topic_namespace topic, int32_t partition_count) const;
 
     // Generates a new partition assignment for a single partition
-    ss::future<result<std::vector<partition_assignment>>>
+    ss::future<result<ss::chunked_fifo<partition_assignment>>>
     generate_reassignments(
       model::ntp, std::vector<model::node_id> new_replicas);
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -743,13 +743,6 @@ operator<<(std::ostream& o, const create_partitions_configuration& cfg) {
     return o;
 }
 
-std::ostream& operator<<(
-  std::ostream& o, const create_partitions_configuration_assignment& cpca) {
-    fmt::print(
-      o, "{{configuration: {}, assignments: {}}}", cpca.cfg, cpca.assignments);
-    return o;
-}
-
 std::ostream&
 operator<<(std::ostream& o, const custom_assignable_topic_configuration& catc) {
     fmt::print(
@@ -1250,21 +1243,6 @@ adl<cluster::create_topics_reply>::from(iobuf_parser& in) {
       std::move(results), std::move(md), std::move(cfg)};
 }
 
-void adl<cluster::topic_configuration_assignment>::to(
-  iobuf& b, cluster::topic_configuration_assignment&& assigned_cfg) {
-    reflection::serialize(
-      b, std::move(assigned_cfg.cfg), std::move(assigned_cfg.assignments));
-}
-
-cluster::topic_configuration_assignment
-adl<cluster::topic_configuration_assignment>::from(iobuf_parser& in) {
-    auto cfg = adl<cluster::topic_configuration>{}.from(in);
-    auto assignments = adl<std::vector<cluster::partition_assignment>>{}.from(
-      in);
-    return cluster::topic_configuration_assignment(
-      std::move(cfg), std::move(assignments));
-}
-
 void adl<cluster::configuration_invariants>::to(
   iobuf& out, cluster::configuration_invariants&& r) {
     reflection::serialize(out, r.version, r.node_id, r.core_count);
@@ -1625,21 +1603,6 @@ adl<cluster::create_partitions_configuration>::from(iobuf_parser& in) {
     ret.custom_assignments = std::move(custom_assignment);
     return ret;
 }
-
-void adl<cluster::create_partitions_configuration_assignment>::to(
-  iobuf& out, cluster::create_partitions_configuration_assignment&& ca) {
-    return serialize(out, std::move(ca.cfg), std::move(ca.assignments));
-}
-
-cluster::create_partitions_configuration_assignment
-adl<cluster::create_partitions_configuration_assignment>::from(
-  iobuf_parser& in) {
-    auto cfg = adl<cluster::create_partitions_configuration>{}.from(in);
-    auto p_as = adl<std::vector<cluster::partition_assignment>>{}.from(in);
-
-    return cluster::create_partitions_configuration_assignment(
-      std::move(cfg), std::move(p_as));
-};
 
 void adl<cluster::create_data_policy_cmd_data>::to(
   iobuf& out, cluster::create_data_policy_cmd_data&& dp_cmd_data) {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -20,6 +20,7 @@
 #include "tristate.h"
 #include "utils/to_string.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sstring.hh>
 
 #include <fmt/ostream.h>
@@ -615,7 +616,7 @@ operator<<(std::ostream& o, const incremental_topic_custom_updates& i) {
 
 namespace {
 cluster::assignments_set to_assignments_map(
-  std::vector<cluster::partition_assignment> assignment_vector) {
+  ss::chunked_fifo<cluster::partition_assignment> assignment_vector) {
     cluster::assignments_set ret;
     for (auto& p_as : assignment_vector) {
         ret.emplace(std::move(p_as));

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -197,20 +197,6 @@ storage::ntp_config topic_configuration::make_ntp_config(
       init_rev};
 }
 
-model::topic_metadata topic_configuration_assignment::get_metadata() const {
-    model::topic_metadata ret(cfg.tp_ns);
-    ret.partitions.reserve(assignments.size());
-    std::transform(
-      std::cbegin(assignments),
-      std::cend(assignments),
-      std::back_inserter(ret.partitions),
-      [](const partition_assignment& pd) {
-          return pd.create_partition_metadata();
-      });
-
-    return ret;
-}
-
 topic_table_delta::topic_table_delta(
   model::ntp ntp,
   cluster::partition_assignment new_assignment,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1683,8 +1683,6 @@ struct topic_configuration_assignment
     topic_configuration cfg;
     std::vector<partition_assignment> assignments;
 
-    model::topic_metadata get_metadata() const;
-
     auto serde_fields() { return std::tie(cfg, assignments); }
 
     friend bool operator==(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1668,54 +1668,39 @@ struct create_partitions_configuration
     operator<<(std::ostream&, const create_partitions_configuration&);
 };
 
-struct topic_configuration_assignment
+template<typename T>
+struct configuration_with_assignment
   : serde::envelope<
-      topic_configuration_assignment,
+      configuration_with_assignment<T>,
       serde::version<0>,
       serde::compat_version<0>> {
-    topic_configuration_assignment() = default;
+    configuration_with_assignment() = default;
 
-    topic_configuration_assignment(
-      topic_configuration cfg, std::vector<partition_assignment> pas)
-      : cfg(std::move(cfg))
+    configuration_with_assignment(
+      T value, std::vector<partition_assignment> pas)
+      : cfg(std::move(value))
       , assignments(std::move(pas)) {}
 
-    topic_configuration cfg;
+    T cfg;
     std::vector<partition_assignment> assignments;
 
     auto serde_fields() { return std::tie(cfg, assignments); }
 
     friend bool operator==(
-      const topic_configuration_assignment&,
-      const topic_configuration_assignment&)
+      const configuration_with_assignment<T>&,
+      const configuration_with_assignment<T>&)
       = default;
+
+    template<typename V>
+    friend std::ostream&
+    operator<<(std::ostream&, const configuration_with_assignment<V>&);
 };
 
-struct create_partitions_configuration_assignment
-  : serde::envelope<
-      create_partitions_configuration_assignment,
-      serde::version<0>,
-      serde::compat_version<0>> {
-    create_partitions_configuration_assignment() = default;
-    create_partitions_configuration_assignment(
-      create_partitions_configuration cfg,
-      std::vector<partition_assignment> pas)
-      : cfg(std::move(cfg))
-      , assignments(std::move(pas)) {}
+using create_partitions_configuration_assignment
+  = configuration_with_assignment<create_partitions_configuration>;
 
-    create_partitions_configuration cfg;
-    std::vector<partition_assignment> assignments;
-
-    auto serde_fields() { return std::tie(cfg, assignments); }
-
-    friend std::ostream& operator<<(
-      std::ostream&, const create_partitions_configuration_assignment&);
-
-    friend bool operator==(
-      const create_partitions_configuration_assignment&,
-      const create_partitions_configuration_assignment&)
-      = default;
-};
+using topic_configuration_assignment
+  = configuration_with_assignment<topic_configuration>;
 
 struct topic_result
   : serde::envelope<topic_result, serde::version<0>, serde::compat_version<0>> {
@@ -3529,6 +3514,16 @@ struct metrics_reporter_cluster_info
     auto serde_fields() { return std::tie(uuid, creation_timestamp); }
 };
 
+template<typename V>
+std::ostream& operator<<(
+  std::ostream& o, const configuration_with_assignment<V>& with_assignment) {
+    fmt::print(
+      o,
+      "{{configuration: {}, assignments: {}}}",
+      with_assignment.cfg,
+      with_assignment.assignments);
+    return o;
+}
 } // namespace cluster
 namespace std {
 template<>
@@ -3609,10 +3604,22 @@ struct adl<cluster::create_topics_reply> {
     cluster::create_topics_reply from(iobuf);
     cluster::create_topics_reply from(iobuf_parser&);
 };
-template<>
-struct adl<cluster::topic_configuration_assignment> {
-    void to(iobuf&, cluster::topic_configuration_assignment&&);
-    cluster::topic_configuration_assignment from(iobuf_parser&);
+template<typename T>
+struct adl<cluster::configuration_with_assignment<T>> {
+    void
+    to(iobuf& b, cluster::configuration_with_assignment<T>&& with_assignment) {
+        reflection::serialize(
+          b,
+          std::move(with_assignment.cfg),
+          std::move(with_assignment.assignments));
+    }
+
+    cluster::configuration_with_assignment<T> from(iobuf_parser& in) {
+        auto cfg = adl<T>{}.from(in);
+        auto assignments
+          = adl<std::vector<cluster::partition_assignment>>{}.from(in);
+        return {std::move(cfg), std::move(assignments)};
+    }
 };
 
 template<>
@@ -3654,12 +3661,6 @@ template<>
 struct adl<cluster::create_partitions_configuration> {
     void to(iobuf&, cluster::create_partitions_configuration&&);
     cluster::create_partitions_configuration from(iobuf_parser&);
-};
-
-template<>
-struct adl<cluster::create_partitions_configuration_assignment> {
-    void to(iobuf&, cluster::create_partitions_configuration_assignment&&);
-    cluster::create_partitions_configuration_assignment from(iobuf_parser&);
 };
 
 template<>

--- a/src/v/reflection/adl.h
+++ b/src/v/reflection/adl.h
@@ -94,7 +94,7 @@ struct adl {
         } else if constexpr (is_fragmented_vector || is_chunked_fifo) {
             using value_type = typename type::value_type;
             int32_t n = in.template consume_type<int32_t>();
-            fragmented_vector<value_type> ret;
+            type ret;
             while (n-- > 0) {
                 ret.push_back(adl<value_type>{}.from(in));
             }


### PR DESCRIPTION
When dealing with a topic that has a lot of partitions all the
partition allocations are gathered in a single collection. Previously
the allocations were stored in a `std::vector` this lead to a situation
in which a vector was large enough to trigger oversized allocation
warning. Replaced a vector with `ss::chunked_fifo` to prevent large
allocations.

Fixes: #10350
Fixes: #10351

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements
- reduced memory pressure with large partition counts 