### PR TITLE
Backport bot updates

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -179,3 +179,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
         run: $SCRIPT_DIR/post_error.sh
         shell: bash
+
+      - name: Create Issue On Error
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          TARGET_MILESTONE: ${{ steps.create_milestone.outputs.milestone }}
+          ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
+          ORIG_LABELS: ${{ toJson(github.event.client_payload.github.payload.issue.labels) }}
+          ORIG_ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
+          CREATE_ISSUE_ON_ERROR: "true"
+        id: create_issue_on_backport_error
+        run: $SCRIPT_DIR/create_issue.sh
+        shell: bash

--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -14,6 +14,11 @@ if [[ -n $(echo "$ORIG_LABELS" | jq '.[] | select(.name == "kind/backport")') ]]
   backport_failure "$msg"
 fi
 
+additional_body=""
+if [[ ! -z $CREATE_ISSUE_ON_ERROR ]]; then
+  additional_body="Note that this issue was created as a placeholder, since the original PR's commit(s) could not be automatically cherry-picked."
+fi
+
 backport_issue_url=$(gh_issue_url)
 if [[ -z $backport_issue_url ]]; then
   gh issue create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
@@ -21,7 +26,7 @@ if [[ -z $backport_issue_url ]]; then
     --repo "$TARGET_ORG/$TARGET_REPO" \
     --assignee "$ORIG_ASSIGNEES" \
     --milestone "$TARGET_MILESTONE" \
-    --body "Backport $ORIG_ISSUE_URL to branch $BACKPORT_BRANCH"
+    --body "Backport $ORIG_ISSUE_URL to branch $BACKPORT_BRANCH. $additional_body"
 else
   msg="Backport issue already exists: $backport_issue_url"
   echo "BACKPORT_ERROR=$msg" >>"$GITHUB_ENV"


### PR DESCRIPTION
Currently, if the backport bot is unable to automatically create a PR, the associated issue is not created. This makes it easy for backports to be missed. 

This PR changes that, so that an issue is created regardless of whether the PR was created or not. This way, we have an artifact by which we can track the missing backport, making it less likely that a backport will fall through the cracks.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
