### PR TITLE
Correctly pass the PR author upon cherry-pick failure.

### DIFF
--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -15,8 +15,11 @@ if [[ -n $(echo "$ORIG_LABELS" | jq '.[] | select(.name == "kind/backport")') ]]
 fi
 
 additional_body=""
-if [[ ! -z $CREATE_ISSUE_ON_ERROR ]]; then
+orig_assignees=$ORIG_ASSIGNEES
+
+if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
   additional_body="Note that this issue was created as a placeholder, since the original PR's commit(s) could not be automatically cherry-picked."
+  orig_assignees=$(gh issue view $PR_NUMBER --json author --jq .author.login)
 fi
 
 backport_issue_url=$(gh_issue_url)
@@ -24,7 +27,7 @@ if [[ -z $backport_issue_url ]]; then
   gh issue create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
     --label "kind/backport" \
     --repo "$TARGET_ORG/$TARGET_REPO" \
-    --assignee "$ORIG_ASSIGNEES" \
+    --assignee "$orig_assignees" \
     --milestone "$TARGET_MILESTONE" \
     --body "Backport $ORIG_ISSUE_URL to branch $BACKPORT_BRANCH. $additional_body"
 else


### PR DESCRIPTION
This PR deals with the scenario when the backport bot is unable to create a PR. This work gets it to create a tracking issue. In the previous commit, the author was not correctly passed, which resulted in unassigned issues being created. This PR should fix that. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

