### PR TITLE
tests: fix CloudRetentionTest

### DIFF
--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -141,7 +141,7 @@ class CloudRetentionTest(PreallocNodesTest):
             total_of_hwms = 0
             for p in range(0, num_partitions):
                 try:
-                    manifest = s3_snapshot.manifest_for_ntp(self.topic_name, 0)
+                    manifest = s3_snapshot.manifest_for_ntp(self.topic_name, p)
                 except:
                     return False
 


### PR DESCRIPTION
Commit d3fa44ee251cb7772e8ed41cd1596d7f66c7cb55 had a typo where we were always querying partition 0's manifest instead of each partition.

This wasn't noticeable on docker tests that only use 1 partition, but makes the test unreliable on dedicated nodes.

Fixes #10469

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none