### PR TITLE
[v22.3.x] config: validate that strings are non-empty

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -272,7 +272,8 @@ configuration::configuration()
       "cluster_id",
       "Cluster identifier",
       {.needs_restart = needs_restart::no},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , disable_metrics(
       *this,
       "disable_metrics",
@@ -990,31 +991,36 @@ configuration::configuration()
       "cloud_storage_access_key",
       "AWS access key",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_secret_key(
       *this,
       "cloud_storage_secret_key",
       "AWS secret key",
       {.visibility = visibility::user, .secret = is_secret::yes},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_region(
       *this,
       "cloud_storage_region",
       "AWS region that houses the bucket used for storage",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_bucket(
       *this,
       "cloud_storage_bucket",
       "AWS bucket that should be used to store data",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_api_endpoint(
       *this,
       "cloud_storage_api_endpoint",
       "Optional API endpoint",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_credentials_source(
       *this,
       "cloud_storage_credentials_source",
@@ -1078,7 +1084,8 @@ configuration::configuration()
       "Path to certificate that should be used to validate server certificate "
       "during TLS handshake",
       {.visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_initial_backoff_ms(
       *this,
       "cloud_storage_initial_backoff_ms",
@@ -1151,7 +1158,8 @@ configuration::configuration()
       "Derived from cloud_storage_credentials_source if not set. Only required "
       "when using IAM role based access.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
-      std::nullopt)
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -67,4 +67,22 @@ validate_connection_rate(const std::vector<ss::sstring>& ips_with_limit) {
     return std::nullopt;
 }
 
+std::optional<ss::sstring>
+validate_non_empty_string_vec(const std::vector<ss::sstring>& vs) {
+    for (const auto& s : vs) {
+        if (s.empty()) {
+            return "Empty strings are not valid in this collection";
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<ss::sstring>
+validate_non_empty_string_opt(const std::optional<ss::sstring>& os) {
+    if (os.has_value() && os.value().empty()) {
+        return "Empty string is not valid";
+    } else {
+        return std::nullopt;
+    }
+}
 }; // namespace config

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -25,4 +25,10 @@ parse_connection_rate_override(const ss::sstring& raw_option);
 std::optional<ss::sstring>
 validate_connection_rate(const std::vector<ss::sstring>& ips_with_limit);
 
+std::optional<ss::sstring>
+validate_non_empty_string_vec(const std::vector<ss::sstring>&);
+
+std::optional<ss::sstring>
+validate_non_empty_string_opt(const std::optional<ss::sstring>&);
+
 }; // namespace config


### PR DESCRIPTION
Folks coming from Go may infer that "" is equivalent to null, but in our type system "" and std::nullopt are different.

To reduce risk of confusion, validate away empty strings for all the nullable and array string properties where an empty string doesn't make sense (like URIs)

This indirectly addresses cases where tiered storage configuration could get confused when incompatible backend settings were set (but set to empty strings)

Related https://github.com/redpanda-data/redpanda/issues/9592

(cherry picked from commit 8775152fa0ba77dd61487b8ff5139e0a242b869b)

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
