### PR TITLE
fix: segment_meta_cstore::insert_entries bug 

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -360,23 +360,39 @@ public:
 
         // extract the end iterator for hints, to cover only the frames that
         // will be cloned
-        auto end_hints = [&] {
+        auto last_hint_tosave = [&] {
             auto frame_it = _base_offset.get_frame_iterator_by_element_index(
               first_replacement_index);
             if (frame_it == _base_offset._frames.begin()) {
                 // no hint will be saved
-                return _hints.begin();
+                return _hints.end();
             }
             --frame_it; // go back to last frame that will be cloned
-            auto frame_max_offset = frame_it->last_value();
-            return _hints.upper_bound(
-              frame_max_offset.value_or(model::offset::min()()));
+            for (; frame_it != _base_offset._frames.begin(); --frame_it) {
+                // go back until we have a non-empty frame. this should be just
+                // an iteration
+                if (auto frame_max_offset = frame_it->last_value()) {
+                    auto to_clone_hint = _hints.lower_bound(
+                      frame_max_offset.value());
+                    vassert(
+                      to_clone_hint == _hints.end()
+                        || to_clone_hint->first <= frame_max_offset.value(),
+                      "to_clone_hint out of range: hint-{} frame_max_offset-{}",
+                      to_clone_hint->first,
+                      frame_max_offset.value());
+                    return to_clone_hint;
+                }
+            }
+            return _hints.end();
         }();
 
         // this column_store is initialized with the run of segments that are
         // not changed
         auto replacement_store = column_store{
-          share_frame, std::move(to_clone_frames), _hints.begin(), end_hints};
+          share_frame,
+          std::move(to_clone_frames),
+          last_hint_tosave,
+          _hints.end()};
 
         auto unchanged_committed_offset
           = replacement_store.last_committed_offset().value_or(

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -16,6 +16,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
+#include "random/generators.h"
 #include "seastarx.h"
 #include "utils/tracking_allocator.h"
 
@@ -2189,4 +2190,46 @@ SEASTAR_THREAD_TEST_CASE(test_archive_offsets_serialization) {
     BOOST_REQUIRE_EQUAL(
       restored.get_archive_start_offset(), model::offset(100));
     BOOST_REQUIRE_EQUAL(restored.get_archive_clean_offset(), model::offset(50));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_partition_manifest_outofbound_trigger) {
+    // std::istringstream{"2071065989"} >> random_generators::internal::gen;
+    BOOST_TEST_INFO(
+      fmt::format("random_seed: [{}]", random_generators::internal::gen));
+    auto m = partition_manifest{manifest_ntp, model::initial_revision_id(0)};
+    BOOST_REQUIRE(m.get_start_offset() == std::nullopt);
+    auto max_committed_offset = random_generators::get_int(0, 100000);
+    auto all_bo = std::vector<model::offset>{};
+    for (int i = 0; i < max_committed_offset;) {
+        auto co = random_generators::get_int(1, 100);
+        m.add(partition_manifest::segment_meta{
+          .base_offset = model::offset{i},
+          .committed_offset = model::offset{i + co},
+        });
+        i += co;
+        all_bo.emplace_back(model::offset{i});
+    }
+    for (auto o : all_bo) {
+        auto b = m.begin();
+        auto e = m.end();
+        m.truncate(o);
+        vlog(
+          test_log.debug,
+          "Truncating from {}, iterating from {}",
+          o,
+          b->base_offset);
+        model::offset sum{0};
+        size_t size_sum{0};
+        for (; b != e; ++b) {
+            auto t = *b;
+            sum = sum + t.base_offset;
+            size_sum += m.size();
+        }
+        vlog(
+          test_log.debug,
+          "Scanned from {}, sum {}, size_sum{}",
+          o,
+          sum,
+          size_sum);
+    }
 }


### PR DESCRIPTION
segment_meta_store::insert_entries was implemented as if _hints was ordered with std::lower. this is incorrect and could lead to _hints referring to frames that have been modified or directly out of bound.

related to #10435 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
