### PR TITLE
Backport on merge

### DIFF
--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -1,0 +1,24 @@
+# Invoke the backport bot whenever we merge into dev.
+
+name: backport-on-merge
+
+on:
+  push:
+    branches:
+      - dev
+
+env:
+  SCRIPT_DIR: "${{ github.workspace }}/.github/workflows/scripts/backport-command"
+  PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+
+jobs:
+  backport-on-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Backport On Merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+        id: extract_required_backports_from_pr_body
+        run: $SCRIPT_DIR/backport_on_merge.sh
+        shell: bash

--- a/.github/workflows/scripts/backport-command/backport_on_merge.sh
+++ b/.github/workflows/scripts/backport-command/backport_on_merge.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# type-branch job
+# Extract Required Backports from PR Body step
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/gh_wrapper.sh"
+
+required_backport_branches=$(gh issue view $PR_NUMBER | grep "\[x\]" | sed 's/- \[x\] //')
+
+for branch in `echo $required_backport_branches`
+do
+	gh pr comment $PR_NUMBER -b "/backport $branch"
+done

--- a/.github/workflows/scripts/backport-command/backport_on_merge.sh
+++ b/.github/workflows/scripts/backport-command/backport_on_merge.sh
@@ -8,7 +8,6 @@ source "$SCRIPT_DIR/gh_wrapper.sh"
 
 required_backport_branches=$(gh issue view $PR_NUMBER | grep "\[x\]" | sed 's/- \[x\] //')
 
-for branch in `echo $required_backport_branches`
-do
-	gh pr comment $PR_NUMBER -b "/backport $branch"
+for branch in $(echo $required_backport_branches); do
+  gh pr comment $PR_NUMBER -b "/backport $branch"
 done


### PR DESCRIPTION
Creates a new github action that gets invoked whenever we merge into dev. The action will call the backport_on_merge.sh script, which will find the branches that we need to backport to, and will then invoke the backport bot.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
