### PR TITLE
Small kafka server clean-ups

### DIFF
--- a/src/v/coproc/tests/utils/event_publisher_utils.h
+++ b/src/v/coproc/tests/utils/event_publisher_utils.h
@@ -9,6 +9,7 @@
  */
 
 #pragma once
+#include "coproc/fwd.h"
 #include "coproc/types.h"
 #include "kafka/client/client.h"
 #include "model/record_batch_reader.h"

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -153,8 +153,7 @@ static ss::future<read_result> do_read_from_ntp(
     /*
      * lookup the ntp's partition
      */
-    auto kafka_partition = make_partition_proxy(
-      ntp_config.ntp(), cluster_pm);
+    auto kafka_partition = make_partition_proxy(ntp_config.ntp(), cluster_pm);
     if (unlikely(!kafka_partition)) {
         co_return read_result(error_code::unknown_topic_or_partition);
     }
@@ -215,10 +214,7 @@ ss::future<read_result> read_from_ntp(
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
     return do_read_from_ntp(
-      cluster_pm,
-      make_ntp_fetch_config(ntp, config),
-      foreign_read,
-      deadline);
+      cluster_pm, make_ntp_fetch_config(ntp, config), foreign_read, deadline);
 }
 
 static void fill_fetch_responses(
@@ -324,11 +320,9 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
 
     auto results = co_await ssx::parallel_transform(
       std::move(ntp_fetch_configs),
-      [&cluster_pm, deadline, foreign_read](
-        const ntp_fetch_config& ntp_cfg) {
+      [&cluster_pm, deadline, foreign_read](const ntp_fetch_config& ntp_cfg) {
           auto p_id = ntp_cfg.ntp().tp.partition;
-          return do_read_from_ntp(
-                   cluster_pm, ntp_cfg, foreign_read, deadline)
+          return do_read_from_ntp(cluster_pm, ntp_cfg, foreign_read, deadline)
             .then([p_id](read_result res) {
                 res.partition = p_id;
                 return res;
@@ -377,10 +371,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
          configs = std::move(fetch.requests)](
           cluster::partition_manager& mgr) mutable {
             return fetch_ntps_in_parallel(
-              mgr,
-              std::move(configs),
-              foreign_read,
-              deadline);
+              mgr, std::move(configs), foreign_read, deadline);
         })
       .then([responses = std::move(fetch.responses),
              metrics = std::move(fetch.metrics),

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -147,7 +147,6 @@ static ss::future<read_result> read_from_partition(
  */
 static ss::future<read_result> do_read_from_ntp(
   cluster::partition_manager& cluster_pm,
-  coproc::partition_manager& coproc_pm,
   ntp_fetch_config ntp_config,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
@@ -155,7 +154,7 @@ static ss::future<read_result> do_read_from_ntp(
      * lookup the ntp's partition
      */
     auto kafka_partition = make_partition_proxy(
-      ntp_config.ntp(), cluster_pm, coproc_pm);
+      ntp_config.ntp(), cluster_pm);
     if (unlikely(!kafka_partition)) {
         co_return read_result(error_code::unknown_topic_or_partition);
     }
@@ -211,14 +210,12 @@ make_ntp_fetch_config(const model::ntp& ntp, const fetch_config& fetch_cfg) {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager& cluster_pm,
-  coproc::partition_manager& coproc_pm,
   const model::ntp& ntp,
   fetch_config config,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
     return do_read_from_ntp(
       cluster_pm,
-      coproc_pm,
       make_ntp_fetch_config(ntp, config),
       foreign_read,
       deadline);
@@ -301,7 +298,6 @@ static void fill_fetch_responses(
 
 static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
   cluster::partition_manager& cluster_pm,
-  coproc::partition_manager& coproc_pm,
   std::vector<ntp_fetch_config> ntp_fetch_configs,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
@@ -328,11 +324,11 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
 
     auto results = co_await ssx::parallel_transform(
       std::move(ntp_fetch_configs),
-      [&cluster_pm, &coproc_pm, deadline, foreign_read](
+      [&cluster_pm, deadline, foreign_read](
         const ntp_fetch_config& ntp_cfg) {
           auto p_id = ntp_cfg.ntp().tp.partition;
           return do_read_from_ntp(
-                   cluster_pm, coproc_pm, ntp_cfg, foreign_read, deadline)
+                   cluster_pm, ntp_cfg, foreign_read, deadline)
             .then([p_id](read_result res) {
                 res.partition = p_id;
                 return res;
@@ -377,13 +373,11 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
         shard,
         octx.ssg,
         [foreign_read,
-         &octx,
          deadline = octx.deadline,
          configs = std::move(fetch.requests)](
           cluster::partition_manager& mgr) mutable {
             return fetch_ntps_in_parallel(
               mgr,
-              octx.rctx.coproc_partition_manager().local(),
               std::move(configs),
               foreign_read,
               deadline);

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -333,7 +333,6 @@ struct fetch_plan {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
-  coproc::partition_manager&,
   const model::ntp&,
   fetch_config,
   bool,

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -67,8 +67,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
   model::isolation_level isolation_lvl,
   kafka::leader_epoch current_leader_epoch,
   cluster::partition_manager& mgr) {
-    auto kafka_partition = make_partition_proxy(
-      ntp, mgr);
+    auto kafka_partition = make_partition_proxy(ntp, mgr);
     if (!kafka_partition) {
         co_return list_offsets_response::make_partition(
           ntp.tp.partition, error_code::unknown_topic_or_partition);

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -68,7 +68,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
   kafka::leader_epoch current_leader_epoch,
   cluster::partition_manager& mgr) {
     auto kafka_partition = make_partition_proxy(
-      ntp, mgr, octx.rctx.coproc_partition_manager().local());
+      ntp, mgr);
     if (!kafka_partition) {
         co_return list_offsets_response::make_partition(
           ntp.tp.partition, error_code::unknown_topic_or_partition);

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -64,8 +64,7 @@ static ss::future<std::vector<epoch_end_offset>> fetch_offsets_from_shard(
         ret.reserve(requests.size());
         for (auto& r : requests) {
             auto p = make_partition_proxy(
-              r.ntp,
-              ctx.partition_manager().local());
+              r.ntp, ctx.partition_manager().local());
             // offsets_for_leader_epoch request should only be answered by
             // leader
             if (!p || !p->is_leader()) {

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -65,8 +65,7 @@ static ss::future<std::vector<epoch_end_offset>> fetch_offsets_from_shard(
         for (auto& r : requests) {
             auto p = make_partition_proxy(
               r.ntp,
-              ctx.partition_manager().local(),
-              ctx.coproc_partition_manager().local());
+              ctx.partition_manager().local());
             // offsets_for_leader_epoch request should only be answered by
             // leader
             if (!p || !p->is_leader()) {

--- a/src/v/kafka/server/partition_proxy.cc
+++ b/src/v/kafka/server/partition_proxy.cc
@@ -19,8 +19,7 @@
 namespace kafka {
 
 std::optional<partition_proxy> make_partition_proxy(
-  const model::ntp& ntp,
-  cluster::partition_manager& cluster_pm) {
+  const model::ntp& ntp, cluster::partition_manager& cluster_pm) {
     auto partition = cluster_pm.get(ntp);
     if (partition) {
         return make_partition_proxy<replicated_partition>(partition);

--- a/src/v/kafka/server/partition_proxy.cc
+++ b/src/v/kafka/server/partition_proxy.cc
@@ -20,15 +20,10 @@ namespace kafka {
 
 std::optional<partition_proxy> make_partition_proxy(
   const model::ntp& ntp,
-  cluster::partition_manager& cluster_pm,
-  coproc::partition_manager& coproc_pm) {
+  cluster::partition_manager& cluster_pm) {
     auto partition = cluster_pm.get(ntp);
     if (partition) {
         return make_partition_proxy<replicated_partition>(partition);
-    }
-    auto cp_partition = coproc_pm.get(ntp);
-    if (cp_partition) {
-        return make_partition_proxy<materialized_partition>(cp_partition);
     }
     return std::nullopt;
 }

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -123,7 +123,7 @@ partition_proxy make_partition_proxy(Args&&... args) {
     return partition_proxy(std::make_unique<Impl>(std::forward<Args>(args)...));
 }
 
-std::optional<partition_proxy> make_partition_proxy(
-  const model::ntp&, cluster::partition_manager&);
+std::optional<partition_proxy>
+make_partition_proxy(const model::ntp&, cluster::partition_manager&);
 
 } // namespace kafka

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -124,6 +124,6 @@ partition_proxy make_partition_proxy(Args&&... args) {
 }
 
 std::optional<partition_proxy> make_partition_proxy(
-  const model::ntp&, cluster::partition_manager&, coproc::partition_manager&);
+  const model::ntp&, cluster::partition_manager&);
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -143,10 +143,6 @@ public:
 
     cluster::shard_table& shards() { return _conn->server().shard_table(); }
 
-    ss::sharded<coproc::partition_manager>& coproc_partition_manager() {
-        return _conn->server().coproc_partition_manager();
-    }
-
     ss::sharded<cluster::partition_manager>& partition_manager() {
         return _conn->server().partition_manager();
     }

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -97,7 +97,6 @@ server::server(
   ss::sharded<cluster::security_frontend>& sec_fe,
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
-  ss::sharded<coproc::partition_manager>& coproc_partition_manager,
   std::optional<qdc_monitor::config> qdc_config,
   ssx::thread_worker& tw) noexcept
   : net::server(cfg, klog)
@@ -125,7 +124,6 @@ server::server(
   , _security_frontend(sec_fe)
   , _controller_api(controller_api)
   , _tx_gateway_frontend(tx_gateway_frontend)
-  , _coproc_partition_manager(coproc_partition_manager)
   , _mtls_principal_mapper(
       config::shard_local_cfg().kafka_mtls_principal_mapping_rules.bind())
   , _gssapi_principal_mapper(

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -91,7 +91,6 @@ server::server(
   ss::sharded<kafka::usage_manager>& usage_manager,
   ss::sharded<cluster::shard_table>& tbl,
   ss::sharded<cluster::partition_manager>& pm,
-  ss::sharded<fetch_session_cache>& session_cache,
   ss::sharded<cluster::id_allocator_frontend>& id_allocator_frontend,
   ss::sharded<security::credential_store>& credentials,
   ss::sharded<security::authorizer>& authorizer,
@@ -114,7 +113,8 @@ server::server(
   , _usage_manager(usage_manager)
   , _shard_table(tbl)
   , _partition_manager(pm)
-  , _fetch_session_cache(session_cache)
+  , _fetch_session_cache(
+      config::shard_local_cfg().fetch_session_eviction_timeout_ms())
   , _id_allocator_frontend(id_allocator_frontend)
   , _is_idempotence_enabled(
       config::shard_local_cfg().enable_idempotence.value())

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -17,6 +17,7 @@
 #include "features/feature_table.h"
 #include "kafka/latency_probe.h"
 #include "kafka/server/fetch_metadata_cache.hh"
+#include "kafka/server/fetch_session_cache.h"
 #include "kafka/server/fwd.h"
 #include "kafka/server/queue_depth_monitor.h"
 #include "net/server.h"
@@ -50,7 +51,6 @@ public:
       ss::sharded<kafka::usage_manager>&,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::partition_manager>&,
-      ss::sharded<fetch_session_cache>&,
       ss::sharded<cluster::id_allocator_frontend>&,
       ss::sharded<security::credential_store>&,
       ss::sharded<security::authorizer>&,
@@ -111,9 +111,7 @@ public:
     }
     coordinator_ntp_mapper& coordinator_mapper();
 
-    fetch_session_cache& fetch_sessions_cache() {
-        return _fetch_session_cache.local();
-    }
+    fetch_session_cache& fetch_sessions_cache() { return _fetch_session_cache; }
     quota_manager& quota_mgr() { return _quota_mgr.local(); }
     usage_manager& usage_mgr() { return _usage_manager.local(); }
     snc_quota_manager& snc_quota_mgr() { return _snc_quota_mgr.local(); }
@@ -180,7 +178,7 @@ private:
     ss::sharded<kafka::usage_manager>& _usage_manager;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::partition_manager>& _partition_manager;
-    ss::sharded<kafka::fetch_session_cache>& _fetch_session_cache;
+    kafka::fetch_session_cache _fetch_session_cache;
     ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
     bool _is_idempotence_enabled{false};
     bool _are_transactions_enabled{false};

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -13,7 +13,6 @@
 
 #include "cluster/fwd.h"
 #include "config/configuration.h"
-#include "coproc/fwd.h"
 #include "features/feature_table.h"
 #include "kafka/latency_probe.h"
 #include "kafka/server/fetch_metadata_cache.hh"
@@ -57,7 +56,6 @@ public:
       ss::sharded<cluster::security_frontend>&,
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
-      ss::sharded<coproc::partition_manager>&,
       std::optional<qdc_monitor::config>,
       ssx::thread_worker&) noexcept;
 
@@ -103,9 +101,6 @@ public:
     }
     kafka::group_router& group_router() { return _group_router.local(); }
     cluster::shard_table& shard_table() { return _shard_table.local(); }
-    ss::sharded<coproc::partition_manager>& coproc_partition_manager() {
-        return _coproc_partition_manager;
-    }
     ss::sharded<cluster::partition_manager>& partition_manager() {
         return _partition_manager;
     }
@@ -187,7 +182,6 @@ private:
     ss::sharded<cluster::security_frontend>& _security_frontend;
     ss::sharded<cluster::controller_api>& _controller_api;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
-    ss::sharded<coproc::partition_manager>& _coproc_partition_manager;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;
     security::tls::principal_mapper _mtls_principal_mapper;

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -171,10 +171,9 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
         return octx.rctx.partition_manager()
           .invoke_on(
             shard,
-            [&octx, ntp, config](cluster::partition_manager& pm) {
+            [ntp, config](cluster::partition_manager& pm) {
                 return kafka::read_from_ntp(
                   pm,
-                  octx.rctx.coproc_partition_manager().local(),
                   ntp,
                   config,
                   true,

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -173,11 +173,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
             shard,
             [ntp, config](cluster::partition_manager& pm) {
                 return kafka::read_from_ntp(
-                  pm,
-                  ntp,
-                  config,
-                  true,
-                  model::no_timeout);
+                  pm, ntp, config, true, model::no_timeout);
             })
           .get0();
     };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1530,7 +1530,6 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         std::ref(controller->get_security_frontend()),
         std::ref(controller->get_api()),
         std::ref(tx_gateway_frontend),
-        std::ref(cp_partition_manager),
         qdc_config,
         std::ref(*thread_worker))
       .get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -61,7 +61,6 @@
 #include "features/fwd.h"
 #include "kafka/client/configuration.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
-#include "kafka/server/fetch_session_cache.h"
 #include "kafka/server/group_manager.h"
 #include "kafka/server/group_router.h"
 #include "kafka/server/queue_depth_monitor.h"
@@ -1525,7 +1524,6 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         std::ref(usage_manager),
         std::ref(shard_table),
         std::ref(partition_manager),
-        std::ref(fetch_session_cache),
         std::ref(id_allocator_frontend),
         std::ref(controller->get_credential_store()),
         std::ref(controller->get_authorizer()),
@@ -1535,10 +1533,6 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         std::ref(cp_partition_manager),
         qdc_config,
         std::ref(*thread_worker))
-      .get();
-    construct_service(
-      fetch_session_cache,
-      config::shard_local_cfg().fetch_session_eviction_timeout_ms())
       .get();
     construct_service(
       _compaction_controller,

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -124,7 +124,6 @@ public:
     ss::sharded<features::feature_table> feature_table;
 
     ss::sharded<kafka::coordinator_ntp_mapper> coordinator_ntp_mapper;
-    ss::sharded<kafka::fetch_session_cache> fetch_session_cache;
     ss::sharded<kafka::group_router> group_router;
     ss::sharded<kafka::quota_manager> quota_mgr;
     ss::sharded<kafka::snc_quota_manager> snc_quota_mgr;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -130,7 +130,6 @@ public:
           app.usage_manager,
           app.shard_table,
           app.partition_manager,
-          app.fetch_session_cache,
           app.id_allocator_frontend,
           app.controller->get_credential_store(),
           app.controller->get_authorizer(),

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -136,7 +136,6 @@ public:
           app.controller->get_security_frontend(),
           app.controller->get_api(),
           app.tx_gateway_frontend,
-          app.cp_partition_manager,
           std::nullopt,
           *app.thread_worker);
 


### PR DESCRIPTION
Small clean-up:

* Moves the fetch session cache out of the application layer and into the kafka server itself, the only user of the cache.
* Removes coproc partition manager reference from the kafka server.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

