### PR TITLE
Incremental partition replica allocation API

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -66,17 +66,13 @@ void reassign_replicas(
   partition_allocator& allocator,
   partition_assignment current_assignment,
   members_backend::partition_reallocation& reallocation) {
-    // remove nodes that are going to be reassigned from current assignment.
-    std::erase_if(
-      current_assignment.replicas,
-      [&reallocation](const model::broker_shard& bs) {
-          return reallocation.replicas_to_remove.contains(bs.node_id);
-      });
-
     auto res = allocator.reallocate_partition(
       reallocation.constraints.value(),
       current_assignment,
-      get_allocation_domain(ntp));
+      get_allocation_domain(ntp),
+      std::vector(
+        reallocation.replicas_to_remove.begin(),
+        reallocation.replicas_to_remove.end()));
     if (res.has_value()) {
         reallocation.set_new_replicas(std::move(res.value()));
     } else {

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -48,13 +48,14 @@ public:
     const underlying_t& allocation_nodes() const { return _nodes; }
     int16_t available_nodes() const;
 
-    // Operations on state
-    void deallocate(const model::broker_shard&, partition_allocation_domain);
-    void apply_update(
-      const std::vector<model::broker_shard>&,
-      raft::group_id,
-      partition_allocation_domain);
+    // choose a shard for a replica and add the corresponding allocation.
     result<uint32_t> allocate(model::node_id id, partition_allocation_domain);
+
+    // Operations on state
+    void
+    add_allocation(const model::broker_shard&, partition_allocation_domain);
+    void
+    remove_allocation(const model::broker_shard&, partition_allocation_domain);
 
     void rollback(
       const ss::chunked_fifo<partition_assignment>& pa,
@@ -65,7 +66,9 @@ public:
     // Raft group id
     raft::group_id next_group_id();
     raft::group_id last_group_id() const { return _highest_group; }
-    void set_last_group_id(raft::group_id id) { _highest_group = id; }
+    void update_highest_group_id(raft::group_id id) {
+        _highest_group = std::max(_highest_group, id);
+    }
 
 private:
     /**

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -91,8 +91,7 @@ result<allocated_partition> partition_allocator::allocate_partition(
         return errc::topic_invalid_replication_factor;
     }
 
-    allocated_partition ret{not_changed_replicas, domain};
-
+    allocated_partition ret{not_changed_replicas, domain, *_state};
     for (auto r = 0; r < replicas_to_allocate; ++r) {
         auto effective_constraints = default_constraints(domain);
         effective_constraints.add(p_constraints.constraints);
@@ -103,7 +102,7 @@ result<allocated_partition> partition_allocator::allocate_partition(
         if (!replica) {
             return replica.error();
         }
-        ret.add_replica(replica.value(), *_state);
+        ret.add_replica(replica.value());
     }
     return ret;
 }
@@ -308,7 +307,8 @@ result<allocated_partition> partition_allocator::reallocate_partition(
     if (
       partition_constraints.replication_factor
       == current_assignment.replicas.size()) {
-        return allocated_partition{current_assignment.replicas, domain};
+        return allocated_partition{
+          current_assignment.replicas, domain, *_state};
     }
 
     return allocate_partition(

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -46,11 +46,23 @@ public:
      */
     ss::future<result<allocation_units::pointer>> allocate(allocation_request);
 
-    // Reallocate an already existing partition
+    /// Reallocate an already existing partition
     result<allocated_partition> reallocate_partition(
       partition_constraints,
       const partition_assignment&,
       partition_allocation_domain);
+
+    /// Create allocated_partition object from current replicas for use with the
+    /// allocate_replica method.
+    allocated_partition make_allocated_partition(
+      std::vector<model::broker_shard> replicas,
+      partition_allocation_domain) const;
+
+    /// try to substitute an existing replica with a newly allocated one and add
+    /// it to the allocated_partition object. If the request fails,
+    /// allocated_partition remains unchanged.
+    result<model::broker_shard> reallocate_replica(
+      allocated_partition&, model::node_id previous, allocation_constraints);
 
     // State accessors
 

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -46,11 +46,15 @@ public:
      */
     ss::future<result<allocation_units::pointer>> allocate(allocation_request);
 
-    /// Reallocate an already existing partition
+    /// Reallocate an already existing partition. Existing replicas from
+    /// replicas_to_reallocate will be reallocated, and a number of additional
+    /// replicas to reach the requested replication factor will be allocated
+    /// anew.
     result<allocated_partition> reallocate_partition(
       partition_constraints,
       const partition_assignment&,
-      partition_allocation_domain);
+      partition_allocation_domain,
+      const std::vector<model::node_id>& replicas_to_reallocate = {});
 
     /// Create allocated_partition object from current replicas for use with the
     /// allocate_replica method.
@@ -163,10 +167,13 @@ private:
     std::error_code
     check_cluster_limits(allocation_request const& request) const;
 
-    result<allocated_partition> allocate_partition(
-      partition_constraints,
-      partition_allocation_domain,
-      const std::vector<model::broker_shard>& not_changed_replicas = {});
+    result<allocated_partition> allocate_new_partition(
+      partition_constraints, partition_allocation_domain);
+
+    result<model::broker_shard> do_allocate_replica(
+      allocated_partition&,
+      std::optional<model::node_id> previous,
+      const allocation_constraints&);
 
     allocation_constraints
     default_constraints(const partition_allocation_domain);

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -73,27 +73,22 @@ public:
       const partition_assignment&,
       partition_allocation_domain);
 
-    /// Best effort. Does not throw if we cannot find the replicas.
-    /// Allocation domain must match the one used to allocate the partition.
-    void deallocate(
-      const std::vector<model::broker_shard>&, partition_allocation_domain);
-
-    /// updates the state of allocation, it is used during recovery and
-    /// when processing raft0 committed notifications.
-    /// Allocation domain must match the one used to allocate the partition.
-    void update_allocation_state(
-      const std::vector<model::broker_shard>&,
-      raft::group_id,
-      partition_allocation_domain);
-
+    /// Best effort. Do not throw if we cannot find the replicas.
     void add_allocations(
       const std::vector<model::broker_shard>&, partition_allocation_domain);
     void remove_allocations(
       const std::vector<model::broker_shard>&, partition_allocation_domain);
 
+    void add_allocations_for_new_partition(
+      const std::vector<model::broker_shard>& replicas,
+      raft::group_id group_id,
+      partition_allocation_domain domain) {
+        add_allocations(replicas, domain);
+        _state->update_highest_group_id(group_id);
+    }
+
     bool is_rack_awareness_enabled() const { return _enable_rack_awareness(); }
 
-    allocation_state& state() { return *_state; }
     const allocation_state& state() const { return *_state; }
 
     ss::future<> apply_snapshot(const controller_snapshot&);

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -193,6 +193,21 @@ std::vector<model::broker_shard> allocated_partition::release_new_partition() {
     return std::move(_replicas);
 }
 
+bool allocated_partition::has_changes() const {
+    if (!_original) {
+        return false;
+    }
+    if (_replicas.size() != _original->size()) {
+        return true;
+    }
+    for (const auto& bs : _replicas) {
+        if (!_original->contains(bs)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool allocated_partition::is_original(
   const model::broker_shard& replica) const {
     if (_original) {

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -84,19 +84,14 @@ allocation_units::~allocation_units() {
 }
 
 allocated_partition::allocated_partition(
-  std::vector<model::broker_shard> replicas, partition_allocation_domain domain)
+  std::vector<model::broker_shard> replicas,
+  partition_allocation_domain domain,
+  allocation_state& state)
   : _replicas(std::move(replicas))
-  , _domain(domain) {}
+  , _domain(domain)
+  , _state(state.weak_from_this()) {}
 
-void allocated_partition::add_replica(
-  model::broker_shard replica, allocation_state& state) {
-    if (_state) {
-        vassert(
-          _state.get() == &state, "allocation_state object must be the same");
-    } else {
-        _state = state.weak_from_this();
-    }
-
+void allocated_partition::add_replica(model::broker_shard replica) {
     if (!_original) {
         _original = absl::flat_hash_set<model::broker_shard>(
           _replicas.begin(), _replicas.end());

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -91,13 +91,98 @@ allocated_partition::allocated_partition(
   , _domain(domain)
   , _state(state.weak_from_this()) {}
 
-void allocated_partition::add_replica(model::broker_shard replica) {
+std::optional<allocated_partition::previous_replica>
+allocated_partition::prepare_move(model::node_id prev_node) {
+    previous_replica prev;
+    auto it = std::find_if(
+      _replicas.begin(), _replicas.end(), [prev_node](const auto& bs) {
+          return bs.node_id == prev_node;
+      });
+    if (it == _replicas.end()) {
+        return std::nullopt;
+    }
+    prev.bs = *it;
+    prev.idx = it - _replicas.begin();
+    if (!_original) {
+        _original.emplace(_replicas.begin(), _replicas.end());
+    } else if (!_original->contains(prev.bs)) {
+        // if replica prev.bs is not original, pick an arbitrary original one
+        // that is not present in the current set as the "source" for prev.bs
+        // (they are all interchangeable).
+        //
+        // Example (omitting shard ids for clarity):
+        // _original = [0, 1, 2], _replicas = [2, 3, 4], and we want to move
+        // replica 4 (so prev_node = 4). Because replica 4 is not in _original
+        // (i.e. it was reallocated earlier using the same allocated_partition
+        // object), we need to arbitrarily designate one of nodes 0 and 1 as the
+        // "original" for replica 4 (meaning that the replica on node 4 was
+        // originally on node 0 or 1).
+        for (const auto& bs : *_original) {
+            if (
+              std::find(_replicas.begin(), _replicas.end(), bs)
+              == _replicas.end()) {
+                prev.original = bs;
+                break;
+            }
+        }
+    }
+
+    // remove previous replica and its allocation contribution so that it
+    // doesn't interfere with allocation of the new replica.
+    std::swap(_replicas[prev.idx], _replicas.back());
+    _replicas.pop_back();
+    _state->remove_allocation(prev.bs, _domain);
+    if (prev.original) {
+        _state->remove_allocation(*prev.original, _domain);
+    }
+    return prev;
+}
+
+void allocated_partition::add_replica(
+  model::broker_shard replica, const std::optional<previous_replica>& prev) {
     if (!_original) {
         _original = absl::flat_hash_set<model::broker_shard>(
           _replicas.begin(), _replicas.end());
     }
 
     _replicas.push_back(replica);
+    if (prev) {
+        model::broker_shard original = prev->original.value_or(prev->bs);
+        // previous replica will still be present while partition move is in
+        // progress, so add its contribution back.
+        _state->add_allocation(original, _domain);
+    }
+    if (_original->contains(replica)) {
+        // if the new replica is original its contribution is already
+        // counted, don't do it twice (second time is by the allocation itself).
+        //
+        // Example (omitting shard ids for clarity):
+        // _original = [0, 1, 2], _replicas = [2, 3, 4], prev = 4, replica = 0
+        // (i.e. we are moving replica on node 4 to node 0). Here is how
+        // partition counts will evolve:
+        // * [1, 1, 1, 1, 1] (prior to reallocation)
+        // * [1, 0, 1, 1, 0] (after prepare_move is called, we picked 1 as
+        //   prev->original)
+        // * [2, 0, 1, 1, 0] (after _allocation_strategy.allocate_replica is
+        //   called)
+        // * [2, 1, 1, 1, 0] (after the contribution of prev->original was added
+        //   back)
+        // Here the replica contribution on node 0 was counted twice, so we need
+        // to remove one to bring the counts to the correct value: [1, 1, 1, 0].
+        // Note also that if we had picked 0 as prev->original, we would end up
+        // with correct counts as well.
+        _state->remove_allocation(replica, _domain);
+    }
+}
+
+void allocated_partition::cancel_move(const previous_replica& prev) {
+    // return substituted replica to its place
+    _replicas.push_back(prev.bs);
+    std::swap(_replicas[prev.idx], _replicas.back());
+    _state->add_allocation(prev.bs, _domain);
+    if (prev.original) {
+        _state->add_allocation(*prev.original, _domain);
+    }
 }
 
 std::vector<model::broker_shard> allocated_partition::release_new_partition() {

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -78,7 +78,7 @@ allocation_units::~allocation_units() {
     oncore_debug_verify(_oncore);
     for (auto& pas : _assignments) {
         for (auto& replica : pas.replicas) {
-            _state->deallocate(replica, _domain);
+            _state->remove_allocation(replica, _domain);
         }
     }
 }
@@ -132,7 +132,7 @@ allocated_partition::~allocated_partition() {
 
     for (const auto& bs : _replicas) {
         if (!_original->contains(bs)) {
-            _state->deallocate(bs, _domain);
+            _state->remove_allocation(bs, _domain);
         }
     }
 }

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -233,7 +233,16 @@ private:
       partition_allocation_domain,
       allocation_state&);
 
-    void add_replica(model::broker_shard);
+    struct previous_replica {
+        model::broker_shard bs;
+        size_t idx;
+        std::optional<model::broker_shard> original;
+    };
+
+    std::optional<previous_replica> prepare_move(model::node_id previous);
+    void
+    add_replica(model::broker_shard, const std::optional<previous_replica>&);
+    void cancel_move(const previous_replica&);
 
     // used to move the allocation to allocation_units
     std::vector<model::broker_shard> release_new_partition();

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -213,10 +213,6 @@ private:
 
 class allocated_partition {
 public:
-    // construct an object from an original assignment
-    allocated_partition(
-      std::vector<model::broker_shard>, partition_allocation_domain);
-
     const std::vector<model::broker_shard>& replicas() const {
         return _replicas;
     }
@@ -230,7 +226,15 @@ public:
 
 private:
     friend class partition_allocator;
-    void add_replica(model::broker_shard, allocation_state&);
+
+    // construct an object from an original assignment
+    allocated_partition(
+      std::vector<model::broker_shard>,
+      partition_allocation_domain,
+      allocation_state&);
+
+    void add_replica(model::broker_shard);
+
     // used to move the allocation to allocation_units
     std::vector<model::broker_shard> release_new_partition();
 

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -216,6 +216,9 @@ public:
     const std::vector<model::broker_shard>& replicas() const {
         return _replicas;
     }
+
+    bool has_changes() const;
+
     bool is_original(const model::broker_shard&) const;
 
     allocated_partition& operator=(allocated_partition&&) = default;

--- a/src/v/cluster/tests/allocation_bench.cc
+++ b/src/v/cluster/tests/allocation_bench.cc
@@ -43,14 +43,14 @@ PERF_TEST_F(partition_allocator_fixture, deallocation_3) {
         {
             auto units = std::move(r.value());
             replicas = units->get_assignments().front().replicas;
-            allocator.update_allocation_state(
+            allocator.add_allocations_for_new_partition(
               units->get_assignments().front().replicas,
               units->get_assignments().front().group,
               cluster::partition_allocation_domains::common);
         }
         perf_tests::do_not_optimize(replicas);
         perf_tests::start_measuring_time();
-        allocator.deallocate(
+        allocator.remove_allocations(
           replicas, cluster::partition_allocation_domains::common);
         perf_tests::stop_measuring_time();
     });
@@ -69,7 +69,7 @@ PERF_TEST_F(partition_allocator_fixture, recovery) {
     }
 
     perf_tests::start_measuring_time();
-    allocator.update_allocation_state(
+    allocator.add_allocations_for_new_partition(
       replicas,
       raft::group_id(replicas.size() / 3),
       cluster::partition_allocation_domains::common);

--- a/src/v/cluster/tests/backend_reallocation_strategy_test.cc
+++ b/src/v/cluster/tests/backend_reallocation_strategy_test.cc
@@ -89,7 +89,7 @@ struct strategy_test_fixture {
         auto units = std::move(res.value());
 
         for (auto& p_as : units->get_assignments()) {
-            allocator.update_allocation_state(
+            allocator.add_allocations_for_new_partition(
               p_as.replicas,
               p_as.group,
               cluster::partition_allocation_domains::common);

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -78,7 +78,7 @@ struct partition_allocator_fixture {
                        .get();
 
         for (auto& pas : units.value()->get_assignments()) {
-            allocator.state().apply_update(
+            allocator.add_allocations_for_new_partition(
               pas.replicas,
               pas.group,
               cluster::partition_allocation_domains::common);

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -232,10 +232,8 @@ FIXTURE_TEST(recovery_test, partition_allocator_fixture) {
     };
     // 100 topics with 12 partitions each replicated on 3 nodes each
     auto replicas = create_replicas(100, 12);
-    allocator.update_allocation_state(
-      replicas,
-      raft::group_id(0),
-      cluster::partition_allocation_domains::common);
+    allocator.add_allocations(
+      replicas, cluster::partition_allocation_domains::common);
     // each node in the cluster holds one replica for each partition,
     // so it has to have topics * partitions shards allocated
     cluster::allocation_node::allocation_capacity allocated_shards{100 * 12};
@@ -360,7 +358,7 @@ FIXTURE_TEST(allocator_exception_safety_test, partition_allocator_fixture) {
             if (res) {
                 capacity--;
                 for (auto& as : res.value()->get_assignments()) {
-                    allocator.update_allocation_state(
+                    allocator.add_allocations_for_new_partition(
                       as.replicas,
                       as.group,
                       cluster::partition_allocation_domains::common);
@@ -385,7 +383,7 @@ FIXTURE_TEST(updating_nodes_properties, partition_allocator_fixture) {
         auto res = allocator.allocate(std::move(req)).get();
         if (res) {
             for (auto& as : res.value()->get_assignments()) {
-                allocator.update_allocation_state(
+                allocator.add_allocations_for_new_partition(
                   as.replicas,
                   as.group,
                   cluster::partition_allocation_domains::common);

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -107,7 +107,8 @@ private:
     ss::future<>
     update_leaders_with_estimates(ss::chunked_fifo<ntp_leader> leaders);
     template<typename T>
-    void update_allocations(const T&, partition_allocation_domain);
+    void
+    add_allocations_for_new_partitions(const T&, partition_allocation_domain);
 
     void deallocate_topic(
       const model::topic_namespace&,


### PR DESCRIPTION
Add a `partition_allocator` method that allows the client to move replicas for a partition one-by-one (maybe even reverting previously scheduled replica moves) instead of reallocating the entire replica group at once.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none