### PR TITLE
Check out the repo, and pass the pr number differently.

### DIFF
--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -9,13 +9,16 @@ on:
 
 env:
   SCRIPT_DIR: "${{ github.workspace }}/.github/workflows/scripts/backport-command"
-  PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+  PR_NUMBER: ${{ github.event.number }}
 
 jobs:
   backport-on-merge:
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
       - name: Backport On Merge
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
Checking out the repo should help with this error: `...backport_on_merge.sh: No such file or directory`

Passing the PR number differently should avoid having an empty PR_NUMBER variable (`PR_NUMBER: `)


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none
