### PR TITLE
Add a widget that finds the PR on github push action.

### DIFF
--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -19,6 +19,17 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      # Find the PR associated with this push, if there is one.
+      - uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          # Can be "open", "closed", or "all".  Defaults to "open".
+          state: closed
+      - run: $PR_NUMBER=${PR}"
+        if: success() && steps.findPr.outputs.number
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
+
       - name: Backport On Merge
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none
