### PR TITLE
[v22.2.x] [recovery_stm] Buffer record_batches using fragmented vector

### DIFF
--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -15,6 +15,7 @@
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "seastarx.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/do_with.hh>
@@ -309,10 +310,17 @@ record_batch_reader make_foreign_memory_record_batch_reader(record_batch);
 record_batch_reader
   make_foreign_memory_record_batch_reader(record_batch_reader::data_t);
 
+record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+  fragmented_vector<model::record_batch>);
+
 record_batch_reader make_generating_record_batch_reader(
   ss::noncopyable_function<ss::future<record_batch_reader::data_t>()>);
 
 ss::future<record_batch_reader::data_t> consume_reader_to_memory(
+  record_batch_reader, timeout_clock::time_point timeout);
+
+ss::future<fragmented_vector<model::record_batch>>
+consume_reader_to_fragmented_memory(
   record_batch_reader, timeout_clock::time_point timeout);
 
 /// \brief wraps a reader into a foreign_ptr<unique_ptr>

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -269,6 +269,9 @@ record_batch_reader make_record_batch_reader(Args&&... args) {
 record_batch_reader
   make_memory_record_batch_reader(record_batch_reader::storage_t);
 
+record_batch_reader make_fragmented_memory_record_batch_reader(
+  fragmented_vector<model::record_batch>);
+
 inline record_batch_reader
 make_memory_record_batch_reader(model::record_batch b) {
     record_batch_reader::data_t batches;

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -26,6 +26,8 @@
 #include "storage/offset_translator_state.h"
 #include "storage/record_batch_builder.h"
 #include "storage/segment_utils.h"
+#include "storage/version.h"
+#include "utils/fragmented_vector.h"
 #include "vassert.h"
 
 #include <seastar/core/abort_source.hh>
@@ -226,6 +228,23 @@ ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
   ss::circular_buffer<model::record_batch>&& batches) {
     ss::circular_buffer<model::record_batch> res;
     res.reserve(batches.size());
+    for (auto& b : batches) {
+        // gap
+        if (b.base_offset() > expected_start) {
+            auto gb = make_ghost_batches(
+              expected_start, prev_offset(b.base_offset()), b.term());
+            std::move(gb.begin(), gb.end(), std::back_inserter(res));
+        }
+        expected_start = next_offset(b.last_offset());
+        res.push_back(std::move(b));
+    }
+    return res;
+}
+
+fragmented_vector<model::record_batch> make_ghost_batches_in_gaps(
+  model::offset expected_start,
+  fragmented_vector<model::record_batch>&& batches) {
+    fragmented_vector<model::record_batch> res;
     for (auto& b : batches) {
         // gap
         if (b.base_offset() > expected_start) {

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -49,6 +49,8 @@ read_bootstrap_state(storage::log, model::offset, ss::abort_source&);
 
 ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
   model::offset, ss::circular_buffer<model::record_batch>&&);
+fragmented_vector<model::record_batch> make_ghost_batches_in_gaps(
+  model::offset, fragmented_vector<model::record_batch>&&);
 
 /// writes snapshot with given data to disk
 ss::future<>

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -221,7 +221,7 @@ recovery_stm::read_range_for_recovery(
 
     // TODO: add timeout of maybe 1minute?
     auto reader = co_await _ptr->_log.make_reader(cfg);
-    auto batches = co_await model::consume_reader_to_memory(
+    auto batches = co_await model::consume_reader_to_fragmented_memory(
       std::move(reader), model::no_timeout);
 
     if (batches.empty()) {
@@ -237,7 +237,7 @@ recovery_stm::read_range_for_recovery(
 
     auto gap_filled_batches = details::make_ghost_batches_in_gaps(
       start_offset, std::move(batches));
-    _base_batch_offset = gap_filled_batches.begin()->base_offset();
+    _base_batch_offset = gap_filled_batches.front().base_offset();
     _last_batch_offset = gap_filled_batches.back().last_offset();
 
     if (is_learner && _ptr->_recovery_throttle) {
@@ -255,7 +255,7 @@ recovery_stm::read_range_for_recovery(
           });
     }
 
-    co_return model::make_foreign_memory_record_batch_reader(
+    co_return model::make_foreign_fragmented_memory_record_batch_reader(
       std::move(gap_filled_batches));
 }
 

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -11,6 +11,7 @@
 
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
@@ -631,14 +632,14 @@ ss::future<> append_entries_request::serde_async_read(
     iobuf_parser in(std::move(tmp));
 
     auto batch_count = read_nested<uint32_t>(in, 0U);
-    auto batches = ss::circular_buffer<model::record_batch>{};
-    batches.reserve(batch_count);
+    auto batches = fragmented_vector<model::record_batch>{};
     for (uint32_t i = 0; i < batch_count; ++i) {
         batches.push_back(reflection::adl<model::record_batch>{}.from(in));
         co_await ss::coroutine::maybe_yield();
     }
 
-    _batches = model::make_memory_record_batch_reader(std::move(batches));
+    _batches = model::make_foreign_fragmented_memory_record_batch_reader(
+      std::move(batches));
     node_id = read_nested<raft::vnode>(in, 0U);
     target_node_id = read_nested<raft::vnode>(in, 0U);
     meta = read_nested<raft::protocol_metadata>(in, 0U);

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -11,6 +11,7 @@
 
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/timeout_clock.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
 #include "raft/group_configuration.h"
@@ -591,19 +592,29 @@ void heartbeat_reply::serde_read(iobuf_parser& src, const serde::header& hdr) {
 }
 
 ss::future<> append_entries_request::serde_async_write(iobuf& dst) {
-    auto mem_batches = co_await model::consume_reader_to_memory(
-      std::move(batches()), model::no_timeout);
-
-    iobuf out;
     using serde::write;
 
-    write(out, static_cast<uint32_t>(mem_batches.size()));
-    for (auto& batch : mem_batches) {
-        // intentionally using reflection here for batches which are not yet
-        // supported with serde, but also have largely solidified.
-        reflection::serialize(out, std::move(batch));
-        co_await ss::coroutine::maybe_yield();
-    }
+    class streaming_writer {
+    public:
+        ss::future<ss::stop_iteration> operator()(model::record_batch b) {
+            reflection::serialize(_out, std::move(b));
+            ++_count;
+            co_return ss::stop_iteration::no;
+        }
+        iobuf end_of_stream() {
+            iobuf header;
+            write(header, static_cast<uint32_t>(_count));
+            _out.prepend(std::move(header));
+            return std::move(_out);
+        }
+
+    private:
+        uint32_t _count = 0;
+        iobuf _out;
+    };
+
+    iobuf out = co_await batches().consume(
+      streaming_writer{}, model::no_timeout);
 
     write(out, node_id);
     write(out, target_node_id);


### PR DESCRIPTION
## Cover letter

Backport of https://github.com/redpanda-data/redpanda/pull/10397

Fixes: #10484

## Backport Required

<!-- Specify which branches this should be backported to, e.g.: -->
- [x] not a bug fix
- [ ] papercut/not impactful enough to backport
- [ ] v22.2.x
- [ ] v22.1.x
- [ ] v21.11.x

## Release notes

* none
