### PR TITLE
tests: further action injector fixes 

### DIFF
--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -186,11 +186,9 @@ class ActionInjectorThread(Thread):
         self.reverse_action_triggered = False
 
     def run(self):
-        admin = Admin(self.redpanda)
-
         def all_nodes_started(nodes):
-            statuses = [admin.ready(node).get("status") for node in nodes]
-            return all(status == 'ready' for status in statuses)
+            statuses = [self.redpanda.is_node_ready(node) for node in nodes]
+            return all(status is True for status in statuses)
 
         wait_until(lambda: all_nodes_started(self.redpanda.nodes),
                    timeout_sec=self.config.cluster_start_lead_time_sec,
@@ -222,7 +220,7 @@ class ActionInjectorThread(Thread):
         )
         wait_until(lambda: all_nodes_started(self.redpanda.started_nodes()),
                    timeout_sec=self.config.cluster_start_lead_time_sec,
-                   backoff_sec=2,
+                   backoff_sec=0.5,
                    err_msg='Cluster did not recover after failures')
 
     def stop(self):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1698,7 +1698,7 @@ class RedpandaService(RedpandaServiceBase):
             else:
                 yield filename
 
-    def __is_status_ready(self, node):
+    def is_node_ready(self, node):
         """
         Calls Admin API's v1/status/ready endpoint to verify if the node
         is ready
@@ -1773,7 +1773,7 @@ class RedpandaService(RedpandaServiceBase):
                 )
             elif not skip_readiness_check:
                 wait_until(
-                    lambda: self.__is_status_ready(node),
+                    lambda: self.is_node_ready(node),
                     timeout_sec=timeout,
                     backoff_sec=self._startup_poll_interval(first_start),
                     err_msg=
@@ -1815,7 +1815,7 @@ class RedpandaService(RedpandaServiceBase):
                                additional_args, env_vars)
 
             wait_until(
-                lambda: self.__is_status_ready(node),
+                lambda: self.is_node_ready(node),
                 timeout_sec=60,
                 backoff_sec=1,
                 err_msg=


### PR DESCRIPTION
The changes in https://github.com/redpanda-data/redpanda/pull/10196 weren't working properly, and it wasn't obvious because action injector was not propagating exceptions from its main loop when joined.

Fix the status check on teardown, and make it so that exceptions from ActionInjector.run will propagate to callers of join().

Fixes https://github.com/redpanda-data/redpanda/issues/10364

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
