### PR TITLE
c/partition_allocator: introduce `allocated_partition`

### DIFF
--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -35,17 +35,16 @@ public:
           : constraints(partition_constraints(p_id, replication_factor)) {}
 
         partition_reallocation() = default;
-        void set_new_replicas(allocation_units units) {
-            allocation_units = std::move(units);
-            new_replica_set
-              = allocation_units->get_assignments().front().replicas;
+        void set_new_replicas(allocated_partition units) {
+            allocated = std::move(units);
+            new_replica_set = allocated->replicas();
         }
 
-        void release_assignment_units() { allocation_units.reset(); }
+        void release_allocated() { allocated.reset(); }
 
         std::optional<partition_constraints> constraints;
         absl::node_hash_set<model::node_id> replicas_to_remove;
-        std::optional<allocation_units> allocation_units;
+        std::optional<allocated_partition> allocated;
         std::vector<model::broker_shard> new_replica_set;
         std::vector<model::broker_shard> current_replica_set;
         reallocation_state state = reallocation_state::initial;

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -220,11 +220,11 @@ ss::future<> partition_balancer_backend::do_tick() {
     co_await ss::max_concurrent_for_each(
       plan_data.reassignments,
       32,
-      [this, current_term](ntp_reassignments& reassignment) {
+      [this, current_term](ntp_reassignment& reassignment) {
           return _topics_frontend
             .move_partition_replicas(
               reassignment.ntp,
-              reassignment.allocation_units.get_assignments().front().replicas,
+              reassignment.allocated.replicas(),
               model::timeout_clock::now() + add_move_cmd_timeout,
               current_term)
             .then([reassignment = std::move(reassignment)](auto errc) {

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -19,9 +19,9 @@
 
 namespace cluster {
 
-struct ntp_reassignments {
+struct ntp_reassignment {
     model::ntp ntp;
-    allocation_units allocation_units;
+    allocated_partition allocated;
 };
 
 struct planner_config {
@@ -55,7 +55,7 @@ public:
 
     struct plan_data {
         partition_balancer_violations violations;
-        std::vector<ntp_reassignments> reassignments;
+        std::vector<ntp_reassignment> reassignments;
         std::vector<model::ntp> cancellations;
         size_t failed_reassignments_count = 0;
         status status = status::empty;
@@ -63,7 +63,7 @@ public:
         void add_reassignment(
           model::ntp,
           const std::vector<model::broker_shard>& orig_replicas,
-          allocation_units,
+          allocated_partition,
           std::string_view reason);
     };
 
@@ -92,7 +92,7 @@ private:
       double max_disk_usage_ratio,
       reallocation_request_state&) const;
 
-    result<allocation_units> get_reallocation(
+    result<allocated_partition> get_reallocation(
       const model::ntp&,
       const partition_assignment&,
       size_t partition_size,

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -20,7 +20,9 @@ void allocation_state::rollback(
   const partition_allocation_domain domain) {
     verify_shard();
     for (auto& as : v) {
-        rollback(as.replicas, domain);
+        for (auto& bs : as.replicas) {
+            deallocate(bs, domain);
+        }
         // rollback for each assignment as the groups are distinct
         _highest_group = raft::group_id(_highest_group() - 1);
     }

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -60,15 +60,6 @@ public:
       const ss::chunked_fifo<partition_assignment>& pa,
       partition_allocation_domain);
 
-    template<typename Replicas>
-    void
-    rollback(const Replicas& replicas, partition_allocation_domain domain) {
-        verify_shard();
-        for (auto& bs : replicas) {
-            deallocate(bs, domain);
-        }
-    }
-
     bool validate_shard(model::node_id node, uint32_t shard) const;
 
     // Raft group id

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -67,7 +67,8 @@ public:
      */
     ss::future<result<allocation_units::pointer>> allocate(allocation_request);
 
-    result<allocation_units> reallocate_partition(
+    // Reallocate an already existing partition
+    result<allocated_partition> reallocate_partition(
       partition_constraints,
       const partition_assignment&,
       partition_allocation_domain);
@@ -146,11 +147,6 @@ private:
       partition_constraints,
       partition_allocation_domain,
       const std::vector<model::broker_shard>& not_changed_replicas = {});
-
-    result<std::vector<model::broker_shard>> do_reallocate_partition(
-      partition_constraints,
-      partition_allocation_domain,
-      const std::vector<model::broker_shard>&);
 
     allocation_constraints
     default_constraints(const partition_allocation_domain);

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -99,7 +99,7 @@ public:
     ss::future<> apply_snapshot(const controller_snapshot&);
 
 private:
-    template<typename T>
+    // reverts not only allocations but group_ids as well
     class intermediate_allocation {
     public:
         intermediate_allocation(
@@ -110,15 +110,18 @@ private:
           , _domain(domain) {
             _partial.reserve(res);
         }
-        void push_back(T t) { _partial.push_back(std::move(t)); }
 
         template<typename... Args>
         void emplace_back(Args&&... args) {
             _partial.emplace_back(std::forward<Args>(args)...);
         }
 
-        const ss::chunked_fifo<T>& get() const { return _partial; }
-        ss::chunked_fifo<T> finish() && { return std::exchange(_partial, {}); }
+        const ss::chunked_fifo<partition_assignment>& get() const {
+            return _partial;
+        }
+        ss::chunked_fifo<partition_assignment> finish() && {
+            return std::exchange(_partial, {});
+        }
         intermediate_allocation(intermediate_allocation&&) noexcept = default;
 
         intermediate_allocation(
@@ -135,7 +138,7 @@ private:
         }
 
     private:
-        ss::chunked_fifo<T> _partial;
+        ss::chunked_fifo<partition_assignment> _partial;
         ss::weak_ptr<allocation_state> _state;
         partition_allocation_domain _domain;
     };
@@ -143,7 +146,7 @@ private:
     std::error_code
     check_cluster_limits(allocation_request const& request) const;
 
-    result<std::vector<model::broker_shard>> allocate_partition(
+    result<allocated_partition> allocate_partition(
       partition_constraints,
       partition_allocation_domain,
       const std::vector<model::broker_shard>& not_changed_replicas = {});

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -105,6 +105,14 @@ void allocated_partition::add_replica(
     _replicas.push_back(replica);
 }
 
+std::vector<model::broker_shard> allocated_partition::release_new_partition() {
+    vassert(
+      _original && _original->empty(),
+      "new partition shouldn't have previous replicas");
+    _state = nullptr;
+    return std::move(_replicas);
+}
+
 bool allocated_partition::is_original(
   const model::broker_shard& replica) const {
     if (_original) {

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -74,27 +74,11 @@ allocation_units::allocation_units(
   , _state(state.weak_from_this())
   , _domain(domain) {}
 
-allocation_units::allocation_units(
-  ss::chunked_fifo<partition_assignment> assignments,
-  std::vector<model::broker_shard> previous_allocations,
-  allocation_state& state,
-  const partition_allocation_domain domain)
-  : _assignments(std::move(assignments))
-  , _state(state.weak_from_this())
-  , _domain(domain) {
-    _previous.reserve(previous_allocations.size());
-    for (auto& prev : previous_allocations) {
-        _previous.emplace(prev);
-    }
-}
-
 allocation_units::~allocation_units() {
     oncore_debug_verify(_oncore);
     for (auto& pas : _assignments) {
         for (auto& replica : pas.replicas) {
-            if (!_previous.contains(replica) && _state) {
-                _state->deallocate(replica, _domain);
-            }
+            _state->deallocate(replica, _domain);
         }
     }
 }

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -231,6 +231,8 @@ public:
 private:
     friend class partition_allocator;
     void add_replica(model::broker_shard, allocation_state&);
+    // used to move the allocation to allocation_units
+    std::vector<model::broker_shard> release_new_partition();
 
 private:
     std::vector<model::broker_shard> _replicas;

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -219,6 +219,36 @@ private:
     [[no_unique_address]] oncore _oncore;
 };
 
+class allocated_partition {
+public:
+    // construct an object from an original assignment
+    allocated_partition(
+      std::vector<model::broker_shard>, partition_allocation_domain);
+
+    const std::vector<model::broker_shard>& replicas() const {
+        return _replicas;
+    }
+    bool is_original(const model::broker_shard&) const;
+
+    allocated_partition& operator=(allocated_partition&&) = default;
+    allocated_partition& operator=(const allocated_partition&) = delete;
+    allocated_partition(const allocated_partition&) = delete;
+    allocated_partition(allocated_partition&&) = default;
+    ~allocated_partition();
+
+private:
+    friend class partition_allocator;
+    void add_replica(model::broker_shard, allocation_state&);
+
+private:
+    std::vector<model::broker_shard> _replicas;
+    std::optional<absl::flat_hash_set<model::broker_shard>> _original;
+    partition_allocation_domain _domain;
+    ss::weak_ptr<allocation_state> _state;
+    // oncore checker to ensure destruction happens on the same core
+    [[no_unique_address]] oncore _oncore;
+};
+
 /**
  * Configuration used to request manual allocation configuration for topic.
  * Custom allocation only designate nodes where partition should be placed but

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -183,11 +183,6 @@ struct allocation_units {
       ss::chunked_fifo<partition_assignment>,
       allocation_state&,
       partition_allocation_domain);
-    allocation_units(
-      ss::chunked_fifo<partition_assignment>,
-      std::vector<model::broker_shard>,
-      allocation_state&,
-      partition_allocation_domain);
     allocation_units& operator=(allocation_units&&) = default;
     allocation_units& operator=(const allocation_units&) = delete;
     allocation_units(const allocation_units&) = delete;
@@ -209,9 +204,6 @@ struct allocation_units {
 
 private:
     ss::chunked_fifo<partition_assignment> _assignments;
-    // set of previous replicas, they will not be reverted when allocation units
-    // goes out of scope
-    absl::node_hash_set<model::broker_shard> _previous;
     // keep the pointer to make this type movable
     ss::weak_ptr<allocation_state> _state;
     partition_allocation_domain _domain;

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -232,10 +232,9 @@ struct partition_balancer_planner_fixture {
         move_partition_replicas(std::move(ntp), std::move(new_replicas));
     }
 
-    void move_partition_replicas(cluster::ntp_reassignments& reassignment) {
+    void move_partition_replicas(cluster::ntp_reassignment& reassignment) {
         move_partition_replicas(
-          reassignment.ntp,
-          reassignment.allocation_units.get_assignments().front().replicas);
+          reassignment.ntp, reassignment.allocated.replicas());
     }
 
     void cancel_partition_move(model::ntp ntp) {

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -109,10 +109,7 @@ FIXTURE_TEST(test_node_down, partition_balancer_planner_fixture) {
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(1), model::node_id(2), model::node_id(3)});
 
-    auto new_replicas = plan_data.reassignments.front()
-                          .allocation_units.get_assignments()
-                          .front()
-                          .replicas;
+    auto new_replicas = plan_data.reassignments.front().allocated.replicas();
     check_expected_assignments(new_replicas, expected_nodes);
 }
 
@@ -182,10 +179,7 @@ FIXTURE_TEST(
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(1), model::node_id(2), model::node_id(4)});
 
-    auto new_replicas = plan_data.reassignments.front()
-                          .allocation_units.get_assignments()
-                          .front()
-                          .replicas;
+    auto new_replicas = plan_data.reassignments.front().allocated.replicas();
     check_expected_assignments(new_replicas, expected_nodes);
 }
 /*
@@ -222,10 +216,7 @@ FIXTURE_TEST(
 
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(1), model::node_id(2), model::node_id(3)});
-    auto new_replicas = plan_data.reassignments.front()
-                          .allocation_units.get_assignments()
-                          .front()
-                          .replicas;
+    auto new_replicas = plan_data.reassignments.front().allocated.replicas();
     check_expected_assignments(new_replicas, expected_nodes);
 }
 
@@ -295,10 +286,7 @@ FIXTURE_TEST(test_move_from_full_node, partition_balancer_planner_fixture) {
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(1), model::node_id(2), model::node_id(3)});
 
-    auto new_replicas = plan_data.reassignments.front()
-                          .allocation_units.get_assignments()
-                          .front()
-                          .replicas;
+    auto new_replicas = plan_data.reassignments.front().allocated.replicas();
     check_expected_assignments(new_replicas, expected_nodes);
 }
 
@@ -339,12 +327,10 @@ FIXTURE_TEST(
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(1), model::node_id(2), model::node_id(3)});
 
-    auto new_replicas_1
-      = reassignments[0].allocation_units.get_assignments().front().replicas;
+    auto new_replicas_1 = reassignments[0].allocated.replicas();
     check_expected_assignments(new_replicas_1, expected_nodes);
 
-    auto new_replicas_2
-      = reassignments[1].allocation_units.get_assignments().front().replicas;
+    auto new_replicas_2 = reassignments[1].allocated.replicas();
     check_expected_assignments(new_replicas_2, expected_nodes);
 }
 
@@ -387,13 +373,11 @@ FIXTURE_TEST(
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(3), model::node_id(4), model::node_id(5)});
 
-    auto new_replicas_1
-      = reassignments[0].allocation_units.get_assignments().front().replicas;
+    auto new_replicas_1 = reassignments[0].allocated.replicas();
     BOOST_REQUIRE_EQUAL(new_replicas_1.size(), expected_nodes.size());
     check_expected_assignments(new_replicas_1, expected_nodes);
 
-    auto new_replicas_2
-      = reassignments[1].allocation_units.get_assignments().front().replicas;
+    auto new_replicas_2 = reassignments[1].allocated.replicas();
     check_expected_assignments(new_replicas_2, expected_nodes);
 }
 
@@ -432,8 +416,7 @@ FIXTURE_TEST(
     const auto& reassignments = plan_data.reassignments;
     BOOST_REQUIRE_EQUAL(reassignments.size(), 1);
 
-    auto new_replicas
-      = reassignments[0].allocation_units.get_assignments().front().replicas;
+    auto new_replicas = reassignments[0].allocated.replicas();
     std::unordered_set<model::node_id> new_replicas_set;
     for (const auto& bs : new_replicas) {
         new_replicas_set.insert(bs.node_id);
@@ -490,8 +473,7 @@ FIXTURE_TEST(test_move_part_of_replicas, partition_balancer_planner_fixture) {
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(0), model::node_id(3), model::node_id(4)});
 
-    auto new_replicas
-      = reassignments[0].allocation_units.get_assignments().front().replicas;
+    auto new_replicas = reassignments[0].allocated.replicas();
     check_expected_assignments(new_replicas, expected_nodes);
 }
 
@@ -545,16 +527,14 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 2);
     std::unordered_set<model::node_id> expected_nodes({model::node_id(2)});
 
-    auto new_replicas_1
-      = reassignments[0].allocation_units.get_assignments().front().replicas;
+    auto new_replicas_1 = reassignments[0].allocated.replicas();
 
     check_expected_assignments(new_replicas_1, expected_nodes);
     // First move less size node
     BOOST_REQUIRE_EQUAL(reassignments[0].ntp.tp.topic, "topic-1");
     BOOST_REQUIRE_EQUAL(reassignments[0].ntp.tp.partition, 2);
 
-    auto new_replicas_2
-      = reassignments[1].allocation_units.get_assignments().front().replicas;
+    auto new_replicas_2 = reassignments[1].allocated.replicas();
     check_expected_assignments(new_replicas_2, expected_nodes);
     BOOST_REQUIRE_EQUAL(reassignments[1].ntp.tp.topic, "topic-1");
     BOOST_REQUIRE_EQUAL(reassignments[1].ntp.tp.partition, 1);
@@ -610,8 +590,7 @@ FIXTURE_TEST(test_lot_of_partitions, partition_balancer_planner_fixture) {
     size_t node_4_counter = 0;
 
     for (auto& reassignment : reassignments) {
-        auto new_replicas
-          = reassignment.allocation_units.get_assignments().front().replicas;
+        auto new_replicas = reassignment.allocated.replicas();
         BOOST_REQUIRE(new_replicas.size() == 3);
         for (const auto r : new_replicas) {
             BOOST_REQUIRE(expected_nodes.contains(r.node_id));
@@ -662,10 +641,8 @@ FIXTURE_TEST(test_node_cancelation, partition_balancer_planner_fixture) {
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(1), model::node_id(2), model::node_id(3)});
 
-    auto new_replicas = planner_result.reassignments.front()
-                          .allocation_units.get_assignments()
-                          .front()
-                          .replicas;
+    auto new_replicas
+      = planner_result.reassignments.front().allocated.replicas();
     check_expected_assignments(new_replicas, expected_nodes);
 
     for (auto& reassignment : planner_result.reassignments) {
@@ -724,10 +701,7 @@ FIXTURE_TEST(test_rack_awareness, partition_balancer_planner_fixture) {
     std::unordered_set<model::node_id> expected_nodes(
       {model::node_id(1), model::node_id(2), model::node_id(4)});
 
-    auto new_replicas = plan_data.reassignments.front()
-                          .allocation_units.get_assignments()
-                          .front()
-                          .replicas;
+    auto new_replicas = plan_data.reassignments.front().allocated.replicas();
     check_expected_assignments(new_replicas, expected_nodes);
 }
 
@@ -886,8 +860,7 @@ FIXTURE_TEST(test_rack_awareness_repair, partition_balancer_planner_fixture) {
     check_violations(plan_data, {}, {});
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 2);
     for (const auto& ras : plan_data.reassignments) {
-        const auto& new_replicas
-          = ras.allocation_units.get_assignments().front().replicas;
+        const auto& new_replicas = ras.allocated.replicas();
         BOOST_REQUIRE_EQUAL(new_replicas.size(), 3);
         absl::node_hash_set<model::rack_id> racks;
         for (const auto& bs : new_replicas) {

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1186,7 +1186,7 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
 
     // units shold exist during replicate_and_wait call
     using units_from_allocator
-      = ss::foreign_ptr<std::unique_ptr<allocation_units>>;
+      = ss::foreign_ptr<std::unique_ptr<allocated_partition>>;
     std::vector<units_from_allocator> units;
     units.reserve(partition_count);
 
@@ -1246,7 +1246,7 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
                     get_allocation_domain(ntp));
               })
             .then([&error, &units, &new_assignments, topic, p_id](
-                    result<allocation_units> reallocation) {
+                    result<allocated_partition> reallocation) {
                 if (!reallocation) {
                     vlog(
                       clusterlog.warn,
@@ -1259,13 +1259,13 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
                     return;
                 }
 
-                units_from_allocator ptr = std::make_unique<allocation_units>(
-                  std::move(reallocation.value()));
+                units_from_allocator ptr
+                  = std::make_unique<allocated_partition>(
+                    std::move(reallocation.value()));
 
                 units.emplace_back(std::move(ptr));
 
-                new_assignments.emplace_back(
-                  p_id, units.back()->get_assignments().front().replicas);
+                new_assignments.emplace_back(p_id, units.back()->replicas());
             });
       });
 


### PR DESCRIPTION
Historically, `partition_allocator` API mixed the case of allocating new partitions (where the result is several partitions) and reallocating existing ones (where the result is a single partition). E.g. `allocation_units` struct is supposed to hold several partitions, but can only rollback a single one. Fix this by introducing the `allocated_partition` struct that will hold a result of (re)allocating a single partition.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
