### PR TITLE
application: syncfs on storage during startup

### DIFF
--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -70,6 +70,7 @@ class application {
 public:
     int run(int, char**);
 
+    ss::future<> sync_disks();
     void initialize(
       std::optional<YAML::Node> proxy_cfg = std::nullopt,
       std::optional<YAML::Node> proxy_client_cfg = std::nullopt,

--- a/src/v/utils/file_sanitizer.h
+++ b/src/v/utils/file_sanitizer.h
@@ -134,6 +134,13 @@ public:
           get_file_impl(_file)->flush());
     }
 
+    ss::future<> syncfs() final {
+        assert_file_not_closed();
+        return with_op(
+          ssx::sformat("ss::future<> syncfs(void)"),
+          get_file_impl(_file)->syncfs());
+    }
+
     ss::future<struct stat> stat() final {
         assert_file_not_closed();
         return with_op(


### PR DESCRIPTION
This depends on:
- https://github.com/redpanda-data/seastar/pull/47
- A vtools change to pull in https://github.com/redpanda-data/seastar/pull/47

If Redpanda crashes during storage writes, there
may be non-persistent metadata left visible in
the filesystem.

To provide the guarantee that everything the storage layer sees on disk during recovery is persistent,
call syncfs during startup.

The strength of this guarantee depends on the underlying filesystem, as some filesystems may lie about persistence if there has previously been an I/O error on a device, by marking pages clean even though they were not
successfully flushed.

This does not help in all cases, but it is a cheap thing to do that may help us reason about storage
consistency issues across crash/restart cycles if
they are seen in the field.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none