### PR TITLE
Operator: add timeout option for console finalizers

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/common_types_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/common_types_test.go
@@ -1,0 +1,72 @@
+package v1alpha1_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFinalizerTimeout(t *testing.T) {
+	tcs := []struct {
+		annotation *string
+		deletion   time.Time
+		expired    bool
+		error      bool
+	}{
+		{
+			annotation: nil,
+			expired:    false,
+		},
+		{
+			annotation: asRef(""),
+			expired:    false,
+		},
+		{
+			annotation: asRef("5m"),
+			expired:    false,
+		},
+		{
+			annotation: asRef("10m"),
+			deletion:   time.Now().Add(-6 * time.Minute),
+			expired:    false,
+		},
+		{
+			annotation: asRef("5m"),
+			deletion:   time.Now().Add(-6 * time.Minute),
+			expired:    true,
+		},
+		{
+			annotation: asRef("5xm"),
+			error:      true,
+		},
+	}
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("test-%d", idx), func(t *testing.T) {
+			c := redpandav1alpha1.Console{}
+			if tc.annotation != nil {
+				c.ObjectMeta.Annotations = map[string]string{
+					redpandav1alpha1.FinalizersTimeoutAnnotation: *tc.annotation,
+				}
+			}
+			if !tc.deletion.IsZero() {
+				c.DeletionTimestamp = &metav1.Time{Time: tc.deletion}
+			}
+			ex, err := redpandav1alpha1.FinalizersExpired(&c)
+			if tc.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expired, ex)
+			}
+		})
+	}
+}
+
+func asRef(s string) *string {
+	return &s
+}

--- a/src/go/k8s/tests/e2e/console-finalizers/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/00-assert.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: console

--- a/src/go/k8s/tests/e2e/console-finalizers/00-create-ns.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/00-create-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: console

--- a/src/go/k8s/tests/e2e/console-finalizers/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/01-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster
+  namespace: console
+status:
+  replicas: 1
+  restarting: false
+  conditions:
+    - type: ClusterConfigured
+      status: "True"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: ../../../hack/get-redpanda-info.sh console

--- a/src/go/k8s/tests/e2e/console-finalizers/01-cluster.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/01-cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster
+  namespace: console
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 500Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+    schemaRegistry:
+      port: 8081
+    pandaproxyApi:
+     - port: 8082
+    developerMode: true

--- a/src/go/k8s/tests/e2e/console-finalizers/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/02-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console
+  namespace: console
+status:
+  readyReplicas: 1
+---
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Console
+metadata:
+  name: console
+  namespace: console
+  finalizers:
+    - consoles.redpanda.vectorized.io/service-account
+    - consoles.redpanda.vectorized.io/acl
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda-console
+  tail: -1
+- command: ../../../hack/get-redpanda-info.sh

--- a/src/go/k8s/tests/e2e/console-finalizers/02-console.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/02-console.yaml
@@ -1,0 +1,20 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Console
+metadata:
+  name: console
+  namespace: console
+  annotations:
+    operator.redpanda.com/finalizers-timeout: 10s
+spec:
+  server:
+    listenPort: 8080
+  schema:
+    enabled: true
+  clusterRef:
+    name: cluster
+    namespace: console
+  deployment:
+    image: vectorized/console:v2.1.1
+  connect:
+    enabled: false
+

--- a/src/go/k8s/tests/e2e/console-finalizers/03-unmanage-cluster.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/03-unmanage-cluster.yaml
@@ -1,0 +1,7 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster
+  namespace: console
+  annotations:
+    redpanda.vectorized.io/managed: "false"

--- a/src/go/k8s/tests/e2e/console-finalizers/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/04-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cluster
+  namespace: console
+status:
+  availableReplicas: 0

--- a/src/go/k8s/tests/e2e/console-finalizers/04-shutdown-cluster.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/04-shutdown-cluster.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cluster
+  namespace: console
+spec:
+  replicas: 0

--- a/src/go/k8s/tests/e2e/console-finalizers/05-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/05-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda-console
+  tail: -1
+- command: ../../../hack/get-redpanda-info.sh

--- a/src/go/k8s/tests/e2e/console-finalizers/05-delete-console.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/05-delete-console.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: redpanda.vectorized.io/v1alpha1
+  kind: Console
+  name: console
+  namespace: console

--- a/src/go/k8s/tests/e2e/console-finalizers/06-cleanup.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/06-cleanup.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: redpanda.vectorized.io/v1alpha1
+  kind: Cluster
+  name: cluster
+  namespace: console
+- apiVersion: v1
+  kind: Namespace
+  name: console


### PR DESCRIPTION
This adds an option to delete console even when the Redpanda cluster is unavailable (e.g. corrupted). Console stores into redpanda a service account and related ACLs that are used to perform operations on the cluster. When deleting the Console, the ACLs and service account need to be deleted as well, so there are finalizers that are removed only when the cluster has been cleaned up.

There are cases where the main Cluster is unavailable and we want to delete both the Console and the Cluster, but we can't: the Console deletion never finishes because the operator tries indefinitely to remove the service account and ACLs.

With this change, we can mark a Console with a timeout for the deletion operation (annotation e.g. `operator.redpanda.com/finalizers-timeout=5m`), to be used in those cases where the deletion of the console is often associated with the deletion of the cluster, so it does not really matter if we delete the service account or not, because the cluster is going to be destroyed as well.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes



### Improvements

* Console supports the annotation operator.redpanda.com/finalizers-timeout to indicate a timeout for finalizers to be removed
