### PR TITLE
storage: storage failure injection within ducktape tests

### DIFF
--- a/src/v/storage/file_sanitizer_types.cc
+++ b/src/v/storage/file_sanitizer_types.cc
@@ -96,20 +96,24 @@ from_json(const json::Value& key, const json::Value& value) {
     if (auto it = value.FindMember("delay_probability");
         it != value.MemberEnd()) {
         op_config.delay_probability = it->value.GetDouble();
-    }
 
-    if (auto it = value.FindMember("min_delay_ms"); it != value.MemberEnd()) {
-        op_config.min_delay_ms = it->value.GetInt();
-    } else {
-        throw std::runtime_error("JSON failure injection config specifies "
-                                 "'delay_probability', but no 'min_delay_ms'");
-    }
+        if (auto it = value.FindMember("min_delay_ms");
+            it != value.MemberEnd()) {
+            op_config.min_delay_ms = it->value.GetInt();
+        } else {
+            throw std::runtime_error(
+              "JSON failure injection config specifies "
+              "'delay_probability', but no 'min_delay_ms'");
+        }
 
-    if (auto it = value.FindMember("max_delay_ms"); it != value.MemberEnd()) {
-        op_config.max_delay_ms = it->value.GetInt();
-    } else {
-        throw std::runtime_error("JSON failure injection config specifies "
-                                 "'delay_probability', but no 'max_delay_ms'");
+        if (auto it = value.FindMember("max_delay_ms");
+            it != value.MemberEnd()) {
+            op_config.max_delay_ms = it->value.GetInt();
+        } else {
+            throw std::runtime_error(
+              "JSON failure injection config specifies "
+              "'delay_probability', but no 'max_delay_ms'");
+        }
     }
 
     return op_config;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -925,3 +925,10 @@ class Admin:
         """
         return self._request("get", "debug/local_storage_usage",
                              node=node).json()
+
+    def set_storage_failure_injection(self, node, value: bool):
+        str_value = "true" if value else "false"
+        return self._request(
+            "PUT",
+            f"debug/set_storage_failure_injection_enabled?value={str_value}",
+            node=node)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -106,6 +106,14 @@ RESTART_LOG_ALLOW_LIST = [
     re.compile("Error \"raft::errc:19\" on replicating"),
 ]
 
+FAILURE_INJECTION_LOG_ALLOW_LIST = [
+    re.compile(
+        "Assert failure: .* filesystem error: Injected Failure: Input/output error"
+    ),
+    re.compile("assert - Backtrace below:"),
+    re.compile("finject - .* flush called concurrently with other operations")
+]
+
 # Log errors that are expected in chaos-style tests that e.g.
 # stop redpanda nodes uncleanly
 CHAOS_LOG_ALLOW_LIST = [
@@ -711,6 +719,8 @@ class RedpandaServiceBase(Service):
 
     # Where we put a compressed binary if saving it after failure
     EXECUTABLE_SAVE_PATH = "/tmp/redpanda.gz"
+
+    FAILURE_INJECTION_CONFIG_PATH = "/etc/redpanda/failure_injection_config.json"
 
     # When configuring multiple listeners for testing, a secondary port to use
     # instead of the default.

--- a/tests/rptest/services/redpanda_monitor.py
+++ b/tests/rptest/services/redpanda_monitor.py
@@ -1,0 +1,69 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import threading
+
+from rptest.services.redpanda import RedpandaService
+
+from ducktape.services.background_thread import BackgroundThreadService
+
+
+class RedpandaMonitor(BackgroundThreadService):
+    def __init__(self, context, redpanda: RedpandaService):
+        super(RedpandaMonitor, self).__init__(context, num_nodes=1)
+        self.redpanda = redpanda
+        self.stopping = threading.Event()
+        self.interval = 2  # seconds
+
+    def _worker(self, idx, node):
+        self.stopping.clear()
+
+        self.redpanda.logger.info(
+            f"Started RedpandaMonitor on {node.account.hostname}")
+
+        while not self.stopping.is_set():
+            started_dead_nodes = []
+            for n in self.redpanda.started_nodes():
+                try:
+                    pid = self.redpanda.redpanda_pid(n, timeout=3)
+                    if pid is None:
+                        started_dead_nodes.append(n)
+
+                except Exception as e:
+                    self.redpanda.logger.warn(
+                        f"Failed to fetch PID for node {n.account.hostname}")
+
+            for n in started_dead_nodes:
+                self.redpanda.remove_from_started_nodes(n)
+
+            for n in started_dead_nodes:
+                try:
+                    self.redpanda.logger.info(
+                        f"RedpandaMonitor restarting {n.account.hostname}")
+                    self.redpanda.start_node(node=n,
+                                             write_config=False,
+                                             timeout=60)
+                except Exception as e:
+                    self.redpanda.logger.error(
+                        f"RedpandaMonitor failed to restart {n.account.hostname}: {e}"
+                    )
+
+            time.sleep(self.interval)
+
+        self.redpanda.logger.info(
+            f"Stopped RedpandaMonitor on {node.account.hostname}")
+
+    def stop_node(self, node):
+        self.redpanda.logger.info(
+            f"Stopping RedpandaMonitor on {node.account.hostname}")
+        self.stopping.set()
+
+    def clean_node(self, nodes):
+        pass

--- a/tests/rptest/services/storage_failure_injection.py
+++ b/tests/rptest/services/storage_failure_injection.py
@@ -1,0 +1,120 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+
+from collections import ChainMap
+from enum import Enum
+from dataclasses import dataclass
+from typing import Optional
+from functools import reduce
+
+
+class BatchType(str, Enum):
+    raft_data = "batch_type::raft_data"
+    raft_configuration = "batch_type::raft_configuration"
+    controller = "batch_type::controller"
+    kvstore = "batch_type::kvstore"
+    checkpoint = "batch_type::checkpoint"
+    topic_management_cmd = "batch_type::topic_management_cmd"
+    ghost_batch = "batch_type::ghost_batch"
+    id_allocator = "batch_type::id_allocator"
+    tx_prepare = "batch_type::tx_prepare"
+    tx_fence = "batch_type::tx_fence"
+    tm_update = "batch_type::tm_update"
+    user_management_cmd = "batch_type::user_management_cmd"
+    acl_management_cmd = "batch_type::acl_management_cmd"
+    group_prepare_tx = "batch_type::group_prepare_tx"
+    group_commit_tx = "batch_type::group_commit_tx"
+    group_abort_tx = "batch_type::group_abort_tx"
+    node_management_cmd = "batch_type::node_management_cmd"
+    data_policy_management_cmd = "batch_type::data_policy_management_cmd"
+    archival_metadata = "batch_type::archival_metadata"
+    cluster_config_cmd = "batch_type::cluster_config_cmd"
+    feature_update = "batch_type::feature_update"
+    cluster_bootstrap_cmd = "batch_type::cluster_boostrap_cmd"
+    version_fence = "batch_type::version_fence"
+
+
+class Operation(str, Enum):
+    write = "write"
+    falloc = "falloc"
+    flush = "flush"
+    truncate = "truncate"
+    close = "close"
+
+
+@dataclass
+class NTP:
+    topic: str
+    partition: int
+    namespace: str = "kafka"
+
+
+@dataclass
+class FailureConfig:
+    operation: Operation
+    batch_type: Optional[BatchType] = None
+    failure_probability: Optional[float] = None
+    delay_probability: Optional[float] = None
+    min_delay_ms: Optional[int] = None
+    max_delay_ms: Optional[int] = None
+
+    def to_dict(self):
+        op_config = dict()
+        if self.batch_type:
+            op_config["batch_type"] = self.batch_type.value
+        if self.failure_probability:
+            op_config["failure_probability"] = self.failure_probability
+        if self.delay_probability:
+            op_config["delay_probability"] = self.delay_probability
+        if self.min_delay_ms:
+            op_config["min_delay_ms"] = self.min_delay_ms
+        if self.max_delay_ms:
+            op_config["max_delay_ms"] = self.max_delay_ms
+
+        return {self.operation.value: op_config}
+
+
+@dataclass
+class NTPFailureInjectionConfig:
+    ntp: NTP
+    failure_configs: list[FailureConfig]
+
+    def to_dict(self):
+        return {
+            "namespace":
+            self.ntp.namespace,
+            "topic":
+            self.ntp.topic,
+            "partition":
+            self.ntp.partition,
+            "failure_configs":
+            reduce(lambda a, b: {
+                **a,
+                **b
+            }, [cfg.to_dict() for cfg in self.failure_configs])
+        }
+
+
+@dataclass
+class FailureInjectionConfig:
+    seed: int
+    ntp_failure_configs: list[NTPFailureInjectionConfig]
+
+    def to_dict(self):
+        return {
+            "seed": self.seed,
+            "ntps":
+            [ntp_cfg.to_dict() for ntp_cfg in self.ntp_failure_configs]
+        }
+
+    def write_to_file(self, path):
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f)

--- a/tools/offline_log_viewer/storage.py
+++ b/tools/offline_log_viewer/storage.py
@@ -136,6 +136,7 @@ class BatchType(Enum):
     cluster_config_cmd = 20
     feature_update = 21
     cluster_bootstrap_cmd = 22
+    version_fence = 23
     unknown = -1
 
     @classmethod


### PR DESCRIPTION
This PR introduces the ducktape infra required to run tests with failure injection
enabled. Currently, only one test makes use of this functionality: `KgoVerifierTest.test_with_all_type_of_loads_with_failures`, but more will follow.

Currently based on: https://github.com/redpanda-data/redpanda/pull/10229

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

