### PR TITLE
Filter for version branches

### DIFF
--- a/.github/workflows/scripts/backport-command/backport_on_merge.sh
+++ b/.github/workflows/scripts/backport-command/backport_on_merge.sh
@@ -6,7 +6,7 @@
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/gh_wrapper.sh"
 
-required_backport_branches=$(gh issue view $PR_NUMBER | grep "\[x\]" | sed 's/- \[x\] //')
+required_backport_branches=$(gh issue view $PR_NUMBER | grep "\[x\]" | sed 's/- \[x\] //' | grep "^v")
 
 for branch in $(echo $required_backport_branches); do
   gh pr comment $PR_NUMBER -b "/backport $branch"


### PR DESCRIPTION
Filter for version branches. And filter out all other backport-related notes.



## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none
