### PR TITLE
tests: ducktape redpanda service for cloud

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -14,12 +14,13 @@ class KubectlTool:
     """
     Wrapper around kubectl.
     """
-    def __init__(self, redpanda, namespace='redpanda'):
+    def __init__(self, redpanda, cmd_prefix=[], namespace='redpanda'):
         self._redpanda = redpanda
+        self._cmd_prefix = cmd_prefix
         self._namespace = namespace
 
     def exec(self, remote_cmd):
-        cmd = [
+        cmd = self._cmd_prefix + [
             'kubectl', 'exec', '-n', self._namespace, 'redpanda-0', '--',
             'bash', '-c'
         ] + [remote_cmd]
@@ -32,7 +33,7 @@ class KubectlTool:
         return res
 
     def exists(self, remote_path):
-        cmd = [
+        cmd = self._cmd_prefix + [
             'kubectl', 'exec', '-n', self._namespace, 'redpanda-0', '--',
             'stat'
         ] + [remote_path]

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -63,7 +63,7 @@ class KubectlTool:
     def exec(self, remote_cmd):
         self._install()
         cmd = self._cmd_prefix + [
-            'kubectl', 'exec', '-n', self._namespace,
+            'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
             f'rp-{self._cluster_id}-0', '--', 'bash', '-c'
         ] + ['"' + remote_cmd + '"']
         try:
@@ -78,7 +78,7 @@ class KubectlTool:
     def exists(self, remote_path):
         self._install()
         cmd = self._cmd_prefix + [
-            'kubectl', 'exec', '-n', self._namespace,
+            'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
             f'rp-{self._cluster_id}-0', '--', 'stat'
         ] + [remote_path]
         try:

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -12,8 +12,11 @@ import subprocess
 
 class KubectlTool:
     """
-    Wrapper around kubectl.
+    Wrapper around kubectl for operating on a redpanda cluster.
     """
+
+    KUBECTL_VERSION = '1.24.10'
+
     def __init__(self,
                  redpanda,
                  cmd_prefix=[],
@@ -23,8 +26,42 @@ class KubectlTool:
         self._cmd_prefix = cmd_prefix
         self._namespace = namespace
         self._cluster_id = cluster_id
+        self._kubectl_installed = False
+
+    def _install(self):
+        if not self._kubectl_installed:
+            download_cmd = self._cmd_prefix + [
+                'wget', '-q',
+                f'https://dl.k8s.io/release/v{self.KUBECTL_VERSION}/bin/linux/amd64/kubectl',
+                '-O', '/tmp/kubectl'
+            ]
+            install_cmd = self._cmd_prefix + [
+                'sudo', 'install', '-m', '0755', '/tmp/kubectl',
+                '/usr/local/bin/kubectl'
+            ]
+            cleanup_cmd = self._cmd_prefix + ['rm', '-f', '/tmp/kubectl']
+            config_cmd = self._cmd_prefix + [
+                'awscli2', 'eks', 'update-kubeconfig', '--name',
+                f'redpanda-{self._cluster_id}', '--region', 'us-west-2'
+            ]
+            try:
+                self._redpanda.logger.info(download_cmd)
+                res = subprocess.check_output(download_cmd)
+                self._redpanda.logger.info(install_cmd)
+                res = subprocess.check_output(install_cmd)
+                self._redpanda.logger.info(cleanup_cmd)
+                res = subprocess.check_output(cleanup_cmd)
+                self._redpanda.logger.info(config_cmd)
+                res = subprocess.check_output(config_cmd)
+            except subprocess.CalledProcessError as e:
+                self._redpanda.logger.info("kubectl error {}: {}".format(
+                    e.returncode, e.output))
+                exit(1)
+            self._kubectl_installed = True
+        return
 
     def exec(self, remote_cmd):
+        self._install()
         cmd = self._cmd_prefix + [
             'kubectl', 'exec', '-n', self._namespace,
             f'rp-{self._cluster_id}-0', '--', 'bash', '-c'
@@ -39,6 +76,7 @@ class KubectlTool:
         return res
 
     def exists(self, remote_path):
+        self._install()
         cmd = self._cmd_prefix + [
             'kubectl', 'exec', '-n', self._namespace,
             f'rp-{self._cluster_id}-0', '--', 'stat'

--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -13,7 +13,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, RedpandaService, MetricsEndpoint, SISettings, get_cloud_storage_type
+from rptest.services.redpanda import CloudStorageType, make_redpanda_service, MetricsEndpoint, SISettings, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import wait_until
 from ducktape.mark import matrix
@@ -90,11 +90,11 @@ class CloudStorageCompactionTest(EndToEndTest):
             self.configuration["max_compacted_log_segment_size"],
         })
 
-        self.redpanda = RedpandaService(context=self.test_context,
-                                        num_brokers=3,
-                                        si_settings=self.si_settings,
-                                        extra_rp_conf=extra_rp_conf,
-                                        environment=environment)
+        self.redpanda = make_redpanda_service(context=self.test_context,
+                                              num_brokers=3,
+                                              si_settings=self.si_settings,
+                                              extra_rp_conf=extra_rp_conf,
+                                              environment=environment)
 
     def setUp(self):
         assert self.redpanda
@@ -136,9 +136,8 @@ class CloudStorageCompactionTest(EndToEndTest):
             cloud_storage_segment_max_upload_interval_sec=self.
             configuration["cloud_storage_segment_max_upload_interval_sec"])
         self.rr_si_settings.load_context(self.logger, self.test_context)
-        self.rr_cluster = RedpandaService(self.test_context,
-                                          num_brokers=3,
-                                          si_settings=self.rr_si_settings)
+        self.rr_cluster = make_redpanda_service(
+            self.test_context, num_brokers=3, si_settings=self.rr_si_settings)
 
     def _create_read_repica_topic_success(self):
         try:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3703,6 +3703,9 @@ class RedpandaService(RedpandaServiceBase):
                 )
 
 
-def make_redpanda_service(environment):
+def make_redpanda_service(context, num_brokers, **kwargs):
     """Factory function for instatiating the appropriate RedpandaServiceBase subclass."""
-    pass
+    if RedpandaServiceCloud.GLOBAL_CLOUD_API_URL in context.globals:
+        return RedpandaServiceCloud(context, num_brokers, **kwargs)
+    else:
+        return RedpandaService(context, num_brokers, **kwargs)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -37,6 +37,7 @@ from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.utils.local_filesystem_utils import mkdir_p
 from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster import ClusterNode
+from ducktape.cluster.cluster_spec import ClusterSpec
 from prometheus_client.parser import text_string_to_metric_families
 from ducktape.errors import TimeoutError
 from ducktape.tests.test import TestContext
@@ -764,13 +765,15 @@ class RedpandaServiceBase(Service):
                  context,
                  num_brokers,
                  *,
+                 cluster_spec=None,
                  extra_rp_conf=None,
                  resource_settings: Optional[ResourceSettings] = None,
                  si_settings: Optional[SISettings] = None,
                  superuser: Optional[SaslCredentials] = None,
                  disable_cloud_storage_diagnostics=True):
         super(RedpandaServiceBase, self).__init__(context,
-                                                  num_nodes=num_brokers)
+                                                  num_nodes=num_brokers,
+                                                  cluster_spec=cluster_spec)
         self._context = context
         self._extra_rp_conf = extra_rp_conf or dict()
 
@@ -1050,8 +1053,10 @@ class RedpandaServiceBase(Service):
 
 
 class RedpandaServiceK8s(RedpandaServiceBase):
-    def __init__(self, context, num_brokers):
-        super(RedpandaServiceK8s, self).__init__(context, num_brokers)
+    def __init__(self, context, num_brokers, cluster_spec=None):
+        super(RedpandaServiceK8s, self).__init__(context,
+                                                 num_brokers,
+                                                 cluster_spec=cluster_spec)
         self._trim_logs = False
         self._helm = HelmTool(self)
         self._kubectl = KubectlTool(self)
@@ -1129,6 +1134,333 @@ class RedpandaServiceK8s(RedpandaServiceBase):
         Updates the values of the helm release
         """
         self._helm.upgrade_config_cluster(values)
+
+
+class RedpandaServiceCloud(RedpandaServiceK8s):
+    """
+    Service class for running tests against Redpanda Cloud.
+
+    Use the `make_redpanda_service` factory function to instantiate. Set
+    the GLOBAL_CLOUD_* values in the global json file to have the factory
+    use `RedpandaServiceCloud`.
+    """
+
+    GLOBAL_CLOUD_OAUTH_URL = 'cloud_oauth_url'
+    GLOBAL_CLOUD_OAUTH_CLIENT_ID = 'cloud_oauth_client_id'
+    GLOBAL_CLOUD_OAUTH_CLIENT_SECRET = 'cloud_oauth_client_secret'
+    GLOBAL_CLOUD_OAUTH_AUDIENCE = 'cloud_oauth_audience'
+    GLOBAL_CLOUD_API_URL = 'cloud_api_url'
+    GLOBAL_CLOUD_CLUSTER_ID = 'cloud_cluster_id'
+    GLOBAL_CLOUD_DELETE_CLUSTER = 'cloud_delete_cluster'
+
+    class CloudCluster():
+        """
+        Operations on a Redpanda Cloud cluster via the swagger API.
+
+        Creates and deletes a cluster. Will also create a new namespace for
+        that cluster.
+        """
+
+        CHECK_TIMEOUT_SEC = 3600
+        CHECK_BACKOFF_SEC = 60.0
+        DEFAULT_PRODUCT_ID = 'cgrdrd9jiflmsknn2nl0'
+
+        def __init__(self,
+                     logger,
+                     oauth_url,
+                     oauth_client_id,
+                     oauth_client_secret,
+                     oauth_audience,
+                     api_url,
+                     cluster_id=None,
+                     delete_namespace=False):
+            """
+            Initializes the object, but does not create clusters. Use
+            `create` method to create a cluster.
+
+
+            :param logger: logging object
+            :param oauth_url: full url of the oauth endpoint to get a token
+            :param oauth_client_id: client id from redpanda cloud ui page for clients
+            :param oauth_client_secret: client secret from redpanda cloud ui page for clients
+            :param oauth_audience: oauth audience
+            :param api_url: url of hostname for swagger api without trailing slash char
+            :param cluster_id: if not None, will skip creating a new cluster
+            :param delete_namespace: if False, will skip namespace deletion step after tests are run
+            """
+
+            self._logger = logger
+            self._oauth_url = oauth_url
+            self._oauth_client_id = oauth_client_id
+            self._oauth_client_secret = oauth_client_secret
+            self._oauth_audience = oauth_audience
+            self._api_url = api_url
+            self._cluster_id = cluster_id
+            self._delete_namespace = delete_namespace
+            self._token = None
+
+            # unique 8-char identifier to be used when creating names of things for this cluster
+            self._unique_id = str(uuid.uuid1())[:8]
+
+        @property
+        def cluster_id(self):
+            """
+            The clusterId of the created cluster.
+            """
+
+            return self._cluster_id
+
+        def _get_token(self):
+            """
+            Returns access token to be used in subsequent api calls to cloud api.
+
+            To save on repeated token generation, this function will cache it in a local variable.
+            Assumes the token has an expiration that will last throughout the usage of this cluster.
+
+            :return: access token as a string
+            """
+
+            if self._token is None:
+                headers = {'Content-Type': "application/x-www-form-urlencoded"}
+                data = {
+                    'grant_type': 'client_credentials',
+                    'client_id': f'{self._oauth_client_id}',
+                    'client_secret': f'{self._oauth_client_secret}',
+                    'audience': f'{self._oauth_audience}'
+                }
+                resp = requests.post(f'{self._oauth_url}',
+                                     headers=headers,
+                                     data=data)
+                resp.raise_for_status()
+                j = resp.json()
+                self._token = j['access_token']
+            return self._token
+
+        def _http_get(self, endpoint, **kwargs):
+            token = self._get_token()
+            headers = {
+                'Authorization': f'Bearer {token}',
+                'Accept': 'application/json'
+            }
+            resp = requests.get(f'{self._api_url}{endpoint}',
+                                headers=headers,
+                                **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+
+        def _http_post(self, endpoint, **kwargs):
+            token = self._get_token()
+            headers = {
+                'Authorization': f'Bearer {token}',
+                'Accept': 'application/json'
+            }
+            resp = requests.post(f'{self._api_url}{endpoint}',
+                                 headers=headers,
+                                 **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+
+        def _http_delete(self, endpoint, **kwargs):
+            token = self._get_token()
+            headers = {
+                'Authorization': f'Bearer {token}',
+                'Accept': 'application/json'
+            }
+            resp = requests.delete(f'{self._api_url}{endpoint}',
+                                   headers=headers,
+                                   **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+
+        def _create_namespace(self):
+            name = f'rp-ducktape-ns-{self._unique_id}'  # e.g. rp-ducktape-ns-3b36f516
+            self._logger.debug(f'creating namespace name {name}')
+            body = {'name': name}
+            r = self._http_post('/api/v1/namespaces', json=body)
+            self._logger.debug(f'created namespaceUuid {r["id"]}')
+            return r['id']
+
+        def _cluster_ready(self, namespace_uuid, name):
+            self._logger.debug(f'checking readiness of cluster {name}')
+            params = {'namespaceUuid': namespace_uuid}
+            clusters = self._http_get('/api/v1/clusters', params=params)
+            for c in clusters:
+                if c['name'] == name:
+                    if c['state'] == 'ready':
+                        return True
+            return False
+
+        def _get_cluster_id(self, namespace_uuid, name):
+            """
+            Get clusterId.
+
+            :param namespace_uuid: namespaceUuid the cluster is contained in
+            :param name: name of the cluster
+            :return: clusterId as a string or None if not found
+            """
+
+            params = {'namespaceUuid': namespace_uuid}
+            clusters = self._http_get('/api/v1/clusters', params=params)
+            for c in clusters:
+                if c['name'] == name:
+                    return c['id']
+            return None
+
+        def create(self, product_id=None):
+            """
+            Create a cloud cluster and a new namespace; block until cluster is finished creating.
+
+            Returns the clusterId.
+            """
+
+            if product_id is None:
+                product_id = self.DEFAULT_PRODUCT_ID
+
+            if self.cluster_id is not None:
+                self._logger.warn(
+                    f'will not create cluster; already have cluster_id {self.cluster_id}'
+                )
+                return self.cluster_id
+
+            namespace_uuid = self._create_namespace()
+
+            name = f'rp-ducktape-cluster-{self._unique_id}'  # e.g. rp-ducktape-cluster-3b36f516
+            self._logger.debug(f'creating cluster name {name}')
+            body = {
+                "namespaceUuid": namespace_uuid,
+                "connectionType": "public",
+                "network": {
+                    "displayName": f"public-network-{name}",
+                    "spec": {
+                        "deploymentType": "FMC",
+                        "provider": "AWS",
+                        "regionId": "ccpfuvec6lhdao925q10",
+                        "zones": ["usw2-az1"],
+                        "installPackVersion": "23.1.20230502184729",
+                        "cidr": "10.0.0.0/16"
+                    }
+                },
+                "cluster": {
+                    "name": name,
+                    "productId": product_id,
+                    "spec": {
+                        "clusterType": "FMC",
+                        "provider": "AWS",
+                        "region": "us-west-2",
+                        "isMultiAz": False,
+                        "zones": ["usw2-az1"],
+                        "installPackVersion": "23.1.20230502184729",
+                        "connectors": {
+                            "enabled": True
+                        },
+                        "networkId": ""
+                    }
+                }
+            }
+
+            self._logger.debug(f'body: {json.dumps(body)}')
+
+            r = self._http_post('/api/v1/workflows/network-cluster', json=body)
+
+            self._logger.info(
+                f'waiting for creation of cluster {name} namespaceUuid {r["namespaceUuid"]}, checking every {self.CHECK_BACKOFF_SEC} seconds'
+            )
+
+            wait_until(
+                lambda: self._cluster_ready(namespace_uuid, name),
+                timeout_sec=self.CHECK_TIMEOUT_SEC,
+                backoff_sec=self.CHECK_BACKOFF_SEC,
+                err_msg=
+                f'Unable to deterimine readiness of cloud cluster {name}')
+            self._cluster_id = self._get_cluster_id(namespace_uuid, name)
+
+            return self._cluster_id
+
+        def delete(self):
+            """
+            Deletes a cloud cluster and the namespace it belongs to.
+            """
+
+            if self._cluster_id is None:
+                self._logger.warn(
+                    f'cluster_id is None, unable to delete cluster')
+                return
+
+            resp = self._http_get(f'/api/v1/clusters/{self.cluster_id}')
+            namespace_uuid = resp['namespaceUuid']
+
+            resp = self._http_delete(f'/api/v1/clusters/{self.cluster_id}')
+            self._logger.debug(f'resp: {json.dumps(resp)}')
+            self._cluster_id = None
+
+            # skip namespace deletion to avoid error because cluster delete not complete yet
+            if self._delete_namespace:
+                resp = self._http_delete(
+                    f'/api/v1/namespaces/{namespace_uuid}')
+                self._logger.debug(f'resp: {json.dumps(resp)}')
+
+    def __init__(self, context, num_brokers):
+        """
+        Initialize a RedpandaServiceCloud object.
+
+        :param context: test context object
+        :param num_brokers: ignored because Redpanda Cloud will launch the number of brokers necessary to satisfy the product needs
+        """
+
+        super(RedpandaServiceCloud,
+              self).__init__(context, None, cluster_spec=ClusterSpec.empty())
+        self.logger.info(
+            f'num_brokers is {num_brokers}, but setting to None for cloud')
+
+        self._trim_logs = False
+
+        self._cloud_oauth_url = context.globals.get(
+            self.GLOBAL_CLOUD_OAUTH_URL, None)
+        self._cloud_oauth_client_id = context.globals.get(
+            self.GLOBAL_CLOUD_OAUTH_CLIENT_ID, None)
+        self._cloud_oauth_client_secret = context.globals.get(
+            self.GLOBAL_CLOUD_OAUTH_CLIENT_SECRET, None)
+        self._cloud_oauth_audience = context.globals.get(
+            self.GLOBAL_CLOUD_OAUTH_AUDIENCE, None)
+        self._cloud_api_url = context.globals.get(self.GLOBAL_CLOUD_API_URL,
+                                                  None)
+        self._cloud_cluster_id = context.globals.get(
+            self.GLOBAL_CLOUD_CLUSTER_ID, None)
+        self._cloud_delete_cluster = context.globals.get(
+            self.GLOBAL_CLOUD_DELETE_CLUSTER, True)
+        self.logger.debug(f'initial cluster_id: {self._cloud_cluster_id}')
+
+        self._cloud_cluster = self.CloudCluster(
+            self.logger, self._cloud_oauth_url, self._cloud_oauth_client_id,
+            self._cloud_oauth_client_secret, self._cloud_oauth_audience,
+            self._cloud_api_url, self._cloud_cluster_id)
+        self._kubectl = None
+
+    def start_node(self, node, **kwargs):
+        pass
+
+    def start(self, **kwargs):
+        cluster_id = self._cloud_cluster.create()
+        target = f'redpanda@{cluster_id}-agent'
+        self._kubectl = KubectlTool(self,
+                                    cmd_prefix=['tsh', 'ssh', target],
+                                    cluster_id=self._cloud_cluster.cluster_id)
+
+    def stop_node(self, node, **kwargs):
+        pass
+
+    def stop(self, **kwargs):
+        if self._cloud_delete_cluster:
+            self._cloud_cluster.delete()
+        else:
+            self.logger.info(
+                f'skipping delete of cluster {self._cloud_cluster.cluster_id}')
+
+    def clean_node(self, node, **kwargs):
+        pass
+
+    def node_id(self, node, force_refresh=False, timeout_sec=30):
+        pass
 
 
 class RedpandaService(RedpandaServiceBase):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1042,6 +1042,9 @@ class RedpandaServiceBase(Service):
     def cloud_storage_diagnostics(self):
         pass
 
+    def raise_on_storage_usage_inconsistency(self):
+        pass
+
 
 class RedpandaServiceK8s(RedpandaServiceBase):
     def __init__(self, context, num_brokers):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1045,6 +1045,9 @@ class RedpandaServiceBase(Service):
     def raise_on_storage_usage_inconsistency(self):
         pass
 
+    def validate_controller_log(self):
+        pass
+
 
 class RedpandaServiceK8s(RedpandaServiceBase):
     def __init__(self, context, num_brokers):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -760,16 +760,15 @@ class RedpandaServiceBase(Service):
         }
     }
 
-    def __init__(
-        self,
-        context,
-        num_brokers,
-        *,
-        extra_rp_conf=None,
-        resource_settings: Optional[ResourceSettings] = None,
-        si_settings: Optional[SISettings] = None,
-        superuser: Optional[SaslCredentials] = None,
-    ):
+    def __init__(self,
+                 context,
+                 num_brokers,
+                 *,
+                 extra_rp_conf=None,
+                 resource_settings: Optional[ResourceSettings] = None,
+                 si_settings: Optional[SISettings] = None,
+                 superuser: Optional[SaslCredentials] = None,
+                 disable_cloud_storage_diagnostics=True):
         super(RedpandaServiceBase, self).__init__(context,
                                                   num_nodes=num_brokers)
         self._context = context
@@ -797,6 +796,11 @@ class RedpandaServiceBase(Service):
         if resource_settings is None:
             resource_settings = ResourceSettings()
         self._resource_settings = resource_settings
+
+        # Disable saving cloud storage diagnostics. This may be useful for
+        # tests that generate millions of objecst, as collecting diagnostics
+        # may take a significant amount of time.
+        self._disable_cloud_storage_diagnostics = disable_cloud_storage_diagnostics
 
         self._trim_logs = self._context.globals.get(self.TRIM_LOGS_KEY, True)
 
@@ -1035,6 +1039,9 @@ class RedpandaServiceBase(Service):
         self._node_id_by_idx[idx] = node_id
         return node_id
 
+    def cloud_storage_diagnostics(self):
+        pass
+
 
 class RedpandaServiceK8s(RedpandaServiceBase):
     def __init__(self, context, num_brokers):
@@ -1144,6 +1151,7 @@ class RedpandaService(RedpandaServiceBase):
             resource_settings=resource_settings,
             si_settings=si_settings,
             superuser=superuser,
+            disable_cloud_storage_diagnostics=disable_cloud_storage_diagnostics
         )
         self._security = security
         self._installer: RedpandaInstaller = RedpandaInstaller(self)
@@ -1183,11 +1191,6 @@ class RedpandaService(RedpandaServiceBase):
 
         self.logger.info(
             f"ResourceSettings: dedicated_nodes={self._dedicated_nodes}")
-
-        # Disable saving cloud storage diagnostics. This may be useful for
-        # tests that generate millions of objecst, as collecting diagnostics
-        # may take a significant amount of time.
-        self._disable_cloud_storage_diagnostics = disable_cloud_storage_diagnostics
 
         self.cloud_storage_client: Optional[S3Client] = None
 

--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -13,7 +13,7 @@ from rptest.clients.default import DefaultClient
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.services.failure_injector import FailureSpec
-from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import make_redpanda_service, CHAOS_LOG_ALLOW_LIST
 from rptest.tests.e2e_finjector import EndToEndFinjectorTest
 
 
@@ -35,7 +35,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
 
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_availability_when_one_node_failed(self):
-        self.redpanda = RedpandaService(
+        self.redpanda = make_redpanda_service(
             self.test_context,
             3,
             extra_rp_conf={
@@ -66,7 +66,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
     @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_recovery_after_catastrophic_failure(self):
 
-        self.redpanda = RedpandaService(
+        self.redpanda = make_redpanda_service(
             self.test_context,
             3,
             extra_rp_conf={

--- a/tests/rptest/tests/cluster_view_test.py
+++ b/tests/rptest/tests/cluster_view_test.py
@@ -12,14 +12,14 @@ import json
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import make_redpanda_service
 from rptest.tests.end_to_end import EndToEndTest
 
 
 class ClusterViewTest(EndToEndTest):
     @cluster(num_nodes=3)
     def test_view_changes_on_add(self):
-        self.redpanda = RedpandaService(self.test_context, 3)
+        self.redpanda = make_redpanda_service(self.test_context, 3)
         # start single node cluster
         self.redpanda.start(nodes=[self.redpanda.nodes[0]])
 

--- a/tests/rptest/tests/controller_upgrade_test.py
+++ b/tests/rptest/tests/controller_upgrade_test.py
@@ -15,7 +15,7 @@ from rptest.clients.default import DefaultClient
 from rptest.services.admin import Admin
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer, RedpandaAdminOperation
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, make_redpanda_service
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.tests.end_to_end import EndToEndTest
 
@@ -46,7 +46,7 @@ class ControllerUpgradeTest(EndToEndTest):
         Validates that cluster is operational when upgrading controller log
         '''
 
-        self.redpanda = RedpandaService(self.test_context, 5)
+        self.redpanda = make_redpanda_service(self.test_context, 5)
         installer = self.redpanda._installer
         prev_version = installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD)

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -24,7 +24,7 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierRandomConsumer, KgoVerifierSeqConsumer
 from rptest.services.metrics_check import MetricCheck
-from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import make_redpanda_service, CHAOS_LOG_ALLOW_LIST
 from rptest.services.redpanda import SISettings, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.prealloc_nodes import PreallocNodesTest
@@ -71,11 +71,11 @@ class EndToEndShadowIndexingBase(EndToEndTest):
         self.si_settings.load_context(self.logger, test_context)
         self.scale = Scale(test_context)
 
-        self.redpanda = RedpandaService(context=self.test_context,
-                                        num_brokers=self.num_brokers,
-                                        si_settings=self.si_settings,
-                                        extra_rp_conf=extra_rp_conf,
-                                        environment=environment)
+        self.redpanda = make_redpanda_service(context=self.test_context,
+                                              num_brokers=self.num_brokers,
+                                              si_settings=self.si_settings,
+                                              extra_rp_conf=extra_rp_conf,
+                                              environment=environment)
         self.kafka_tools = KafkaCliTools(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
 

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -24,7 +24,7 @@ import os
 from typing import Optional
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, make_redpanda_service
 from rptest.services.redpanda_installer import InstallOptions
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.clients.default import DefaultClient
@@ -97,12 +97,13 @@ class EndToEndTest(Test):
             self._extra_rp_conf = {**self._extra_rp_conf, **extra_rp_conf}
         assert self.redpanda is None
 
-        self.redpanda = RedpandaService(self.test_context,
-                                        num_nodes,
-                                        extra_rp_conf=self._extra_rp_conf,
-                                        extra_node_conf=self._extra_node_conf,
-                                        si_settings=self.si_settings,
-                                        environment=environment)
+        self.redpanda = make_redpanda_service(
+            self.test_context,
+            num_nodes,
+            extra_rp_conf=self._extra_rp_conf,
+            extra_node_conf=self._extra_node_conf,
+            si_settings=self.si_settings,
+            environment=environment)
         if new_bootstrap:
             seeds = [
                 self.redpanda.nodes[i]

--- a/tests/rptest/tests/mirror_maker_test.py
+++ b/tests/rptest/tests/mirror_maker_test.py
@@ -20,7 +20,7 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.services.kafka import KafkaServiceAdapter
 from rptest.services.mirror_maker2 import MirrorMaker2
 
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import make_redpanda_service
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
 from rptest.services.verifiable_consumer import VerifiableConsumer
@@ -68,8 +68,8 @@ class MirrorMakerService(EndToEndTest):
 
     def start_brokers(self, source_type=kafka_source):
         if source_type == TestMirrorMakerService.redpanda_source:
-            self.source_broker = RedpandaService(self.test_context,
-                                                 num_brokers=3)
+            self.source_broker = make_redpanda_service(self.test_context,
+                                                       num_brokers=3)
         else:
             self.source_broker = KafkaServiceAdapter(
                 self.test_context,
@@ -78,7 +78,7 @@ class MirrorMakerService(EndToEndTest):
                              zk=self.zk,
                              version=V_3_0_0))
 
-        self.redpanda = RedpandaService(self.test_context, num_brokers=3)
+        self.redpanda = make_redpanda_service(self.test_context, num_brokers=3)
         self.source_broker.start()
         self.redpanda.start()
 

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -23,7 +23,7 @@ from ducktape.mark import parametrize
 from rptest.clients.types import TopicSpec
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
-from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RESTART_LOG_ALLOW_LIST, RedpandaService
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RESTART_LOG_ALLOW_LIST, RedpandaService, make_redpanda_service
 from rptest.utils.node_operations import NodeDecommissionWaiter
 
 
@@ -514,7 +514,7 @@ class NodesDecommissioningTest(EndToEndTest):
     @parametrize(shutdown_decommissioned=False)
     def test_decommissioning_rebalancing_node(self, shutdown_decommissioned):
         # start redpanda with disabled rebalancing
-        self.redpanda = RedpandaService(
+        self.redpanda = make_redpanda_service(
             self.test_context,
             4,
             extra_rp_conf={"partition_autobalancing_mode": "node_add"})

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -16,7 +16,7 @@ from rptest.services.admin import Admin
 from rptest.util import wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.clients.default import DefaultClient
-from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
+from rptest.services.redpanda import make_redpanda_service, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
 from rptest.services.failure_injector import FailureInjector, FailureSpec
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
@@ -457,9 +457,9 @@ class PartitionBalancerTest(PartitionBalancerService):
     @cluster(num_nodes=8, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_rack_awareness(self):
         extra_rp_conf = self._extra_rp_conf | {"enable_rack_awareness": True}
-        self.redpanda = RedpandaService(self.test_context,
-                                        num_brokers=6,
-                                        extra_rp_conf=extra_rp_conf)
+        self.redpanda = make_redpanda_service(self.test_context,
+                                              num_brokers=6,
+                                              extra_rp_conf=extra_rp_conf)
 
         rack_layout = "AABBCC"
         for ix, node in enumerate(self.redpanda.nodes):
@@ -502,9 +502,9 @@ class PartitionBalancerTest(PartitionBalancerService):
         """
 
         extra_rp_conf = self._extra_rp_conf | {"enable_rack_awareness": True}
-        self.redpanda = RedpandaService(self.test_context,
-                                        num_brokers=5,
-                                        extra_rp_conf=extra_rp_conf)
+        self.redpanda = make_redpanda_service(self.test_context,
+                                              num_brokers=5,
+                                              extra_rp_conf=extra_rp_conf)
 
         rack_layout = "ABBCC"
         for ix, node in enumerate(self.redpanda.nodes):
@@ -641,7 +641,7 @@ class PartitionBalancerTest(PartitionBalancerService):
         if skip_reason:
             self.logger.warn("skipping test: " + skip_reason)
             # avoid the "Test requested 6 nodes, used only 0" error
-            self.redpanda = RedpandaService(self.test_context, 0)
+            self.redpanda = make_redpanda_service(self.test_context, 0)
             self.test_context.cluster.alloc(ClusterSpec.simple_linux(6))
             return
 

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -18,7 +18,7 @@ from rptest.util import expect_exception
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 
-from rptest.services.redpanda import CloudStorageType, RedpandaService, get_cloud_storage_type
+from rptest.services.redpanda import CloudStorageType, RedpandaService, get_cloud_storage_type, make_redpanda_service
 from rptest.services.redpanda_installer import InstallOptions, RedpandaInstaller
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.utils.expect_rate import ExpectRate, RateTarget
@@ -124,9 +124,8 @@ class TestReadReplicaService(EndToEndTest):
         self.second_cluster = None
 
     def start_second_cluster(self) -> None:
-        self.second_cluster = RedpandaService(self.test_context,
-                                              num_brokers=3,
-                                              si_settings=self.rr_settings)
+        self.second_cluster = make_redpanda_service(
+            self.test_context, num_brokers=3, si_settings=self.rr_settings)
         self.second_cluster.start(start_si=False)
 
     def create_read_replica_topic(self) -> None:
@@ -386,9 +385,8 @@ class ReadReplicasUpgradeTest(EndToEndTest):
                        30)
         self.producer.stop()
 
-        self.second_cluster = RedpandaService(self.test_context,
-                                              num_brokers=3,
-                                              si_settings=self.rr_settings)
+        self.second_cluster = make_redpanda_service(
+            self.test_context, num_brokers=3, si_settings=self.rr_settings)
         previous_version = self.second_cluster._installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD)
         self.second_cluster._installer.install(self.second_cluster.nodes,

--- a/tests/rptest/tests/redpanda_binary_test.py
+++ b/tests/rptest/tests/redpanda_binary_test.py
@@ -11,7 +11,7 @@ import re
 
 from ducktape.tests.test import Test
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import make_redpanda_service
 
 
 class RedpandaBinaryTest(Test):
@@ -21,7 +21,7 @@ class RedpandaBinaryTest(Test):
     """
     def __init__(self, test_context):
         super(RedpandaBinaryTest, self).__init__(test_context=test_context)
-        self.redpanda = RedpandaService(self.test_context, 1)
+        self.redpanda = make_redpanda_service(self.test_context, 1)
 
     @cluster(num_nodes=1, check_allowed_error_logs=False)
     def test_version(self):

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -11,7 +11,7 @@ import os
 from typing import Sequence
 
 from ducktape.tests.test import Test
-from rptest.services.redpanda import RedpandaService, CloudStorageType
+from rptest.services.redpanda import make_redpanda_service, CloudStorageType
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.default import DefaultClient
 from rptest.util import Scale
@@ -54,11 +54,11 @@ class RedpandaTest(Test):
             else:
                 num_brokers = 1
 
-        self.redpanda = RedpandaService(test_context,
-                                        num_brokers,
-                                        extra_rp_conf=extra_rp_conf,
-                                        si_settings=self.si_settings,
-                                        **kwargs)
+        self.redpanda = make_redpanda_service(test_context,
+                                              num_brokers,
+                                              extra_rp_conf=extra_rp_conf,
+                                              si_settings=self.si_settings,
+                                              **kwargs)
         self._client = DefaultClient(self.redpanda)
 
     def early_exit_hook(self):

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -16,7 +16,7 @@ from ducktape.mark import matrix
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import make_redpanda_service
 from rptest.tests.end_to_end import EndToEndTest
 
 
@@ -134,14 +134,13 @@ class ScalingUpTest(EndToEndTest):
     @cluster(num_nodes=5)
     @matrix(partition_count=[1, 20])
     def test_adding_nodes_to_cluster(self, partition_count):
-        self.redpanda = RedpandaService(self.test_context,
-                                        3,
-                                        extra_rp_conf={
-                                            "group_topic_partitions":
-                                            self.group_topic_partitions,
-                                            "partition_autobalancing_mode":
-                                            "node_add"
-                                        })
+        self.redpanda = make_redpanda_service(
+            self.test_context,
+            3,
+            extra_rp_conf={
+                "group_topic_partitions": self.group_topic_partitions,
+                "partition_autobalancing_mode": "node_add"
+            })
         # start single node cluster
         self.redpanda.start(nodes=[self.redpanda.nodes[0]])
         # create some topics
@@ -168,14 +167,13 @@ class ScalingUpTest(EndToEndTest):
     @matrix(partition_count=[1, 20])
     def test_adding_multiple_nodes_to_the_cluster(self, partition_count):
 
-        self.redpanda = RedpandaService(self.test_context,
-                                        6,
-                                        extra_rp_conf={
-                                            "partition_autobalancing_mode":
-                                            "node_add",
-                                            "group_topic_partitions":
-                                            self.group_topic_partitions
-                                        })
+        self.redpanda = make_redpanda_service(
+            self.test_context,
+            6,
+            extra_rp_conf={
+                "partition_autobalancing_mode": "node_add",
+                "group_topic_partitions": self.group_topic_partitions
+            })
         # start single node cluster
         self.redpanda.start(nodes=self.redpanda.nodes[0:3])
         # create some topics
@@ -201,14 +199,13 @@ class ScalingUpTest(EndToEndTest):
     @matrix(partition_count=[1, 20])
     def test_on_demand_rebalancing(self, partition_count):
         # start redpanda with disabled rebalancing
-        self.redpanda = RedpandaService(self.test_context,
-                                        6,
-                                        extra_rp_conf={
-                                            "partition_autobalancing_mode":
-                                            "off",
-                                            "group_topic_partitions":
-                                            self.group_topic_partitions
-                                        })
+        self.redpanda = make_redpanda_service(
+            self.test_context,
+            6,
+            extra_rp_conf={
+                "partition_autobalancing_mode": "off",
+                "group_topic_partitions": self.group_topic_partitions
+            })
         # start single node cluster
         self.redpanda.start(nodes=self.redpanda.nodes[0:3])
         # create some topics
@@ -242,14 +239,13 @@ class ScalingUpTest(EndToEndTest):
 
     @cluster(num_nodes=7)
     def test_topic_hot_spots(self):
-        self.redpanda = RedpandaService(self.test_context,
-                                        5,
-                                        extra_rp_conf={
-                                            "group_topic_partitions":
-                                            self.group_topic_partitions,
-                                            "partition_autobalancing_mode":
-                                            "node_add"
-                                        })
+        self.redpanda = make_redpanda_service(
+            self.test_context,
+            5,
+            extra_rp_conf={
+                "group_topic_partitions": self.group_topic_partitions,
+                "partition_autobalancing_mode": "node_add"
+            })
         # start 3 nodes cluster
         self.redpanda.start(nodes=self.redpanda.nodes[0:3])
         # create some topics

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -3,7 +3,7 @@ import pprint
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings, RedpandaService, LoggingConfig, get_cloud_storage_type
+from rptest.services.redpanda import CloudStorageType, SISettings, make_redpanda_service, LoggingConfig, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import wait_until_segments, wait_for_removal_of_n_segments
 from rptest.utils.si_utils import BucketView
@@ -30,10 +30,10 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
             group_initial_rebalance_delay=300,
             compacted_log_segment_size=self.segment_size,
         )
-        self.redpanda = RedpandaService(context=self.test_context,
-                                        num_brokers=self.num_brokers,
-                                        si_settings=self.si_settings,
-                                        extra_rp_conf=extra_rp_conf)
+        self.redpanda = make_redpanda_service(context=self.test_context,
+                                              num_brokers=self.num_brokers,
+                                              si_settings=self.si_settings,
+                                              extra_rp_conf=extra_rp_conf)
         self.topic = self.topics[0].name
         self._rpk_client = RpkTool(self.redpanda)
 

--- a/tests/rptest/tests/timely_shutdown_test.py
+++ b/tests/rptest/tests/timely_shutdown_test.py
@@ -13,7 +13,7 @@ from ducktape.utils.util import wait_until
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.tests.end_to_end import EndToEndTest
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, make_redpanda_service
 from rptest.services.admin import Admin
 from rptest.services.failure_injector import FailureInjector, FailureSpec
 from rptest.util import wait_until_result
@@ -42,9 +42,9 @@ class ShutdownTest(EndToEndTest):
             'enable_leader_balancer': False,
             'auto_create_topics_enabled': True
         }
-        self.redpanda = RedpandaService(self.test_context,
-                                        3,
-                                        extra_rp_conf=rp_conf)
+        self.redpanda = make_redpanda_service(self.test_context,
+                                              3,
+                                              extra_rp_conf=rp_conf)
         admin = Admin(self.redpanda)
 
         def checked_get_leader():

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -14,7 +14,7 @@ import threading
 
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import RedpandaService, SISettings
+from rptest.services.redpanda import RedpandaService, SISettings, make_redpanda_service
 from rptest.services.metrics_check import MetricCheck
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
@@ -459,9 +459,9 @@ class TestReadReplicaTimeQuery(RedpandaTest):
         self.rr_cluster = None
 
     def start_read_replica_cluster(self, num_brokers) -> None:
-        self.rr_cluster = RedpandaService(self.test_context,
-                                          num_brokers=num_brokers,
-                                          si_settings=self.rr_settings)
+        self.rr_cluster = make_redpanda_service(self.test_context,
+                                                num_brokers=num_brokers,
+                                                si_settings=self.rr_settings)
         self.rr_cluster.start(start_si=False)
 
     def create_read_replica_topic(self) -> None:

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -19,7 +19,7 @@ import random
 from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, make_redpanda_service
 from rptest.clients.default import DefaultClient
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 import confluent_kafka as ck
@@ -720,7 +720,7 @@ class GATransaction_MixedVersionsTest(RedpandaTest):
 
     @cluster(num_nodes=2, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def check_parsing_test(self):
-        self.redpanda = RedpandaService(
+        self.redpanda = make_redpanda_service(
             self.test_context,
             1,
             extra_rp_conf={


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/cloudv2/issues/5893, Fixes #10346, Fixes https://github.com/redpanda-data/devprod/issues/670

This PR adds a new `ducktape` class `RedpandaServiceCloud` which enables tests to run against redpanda cloud. The new class uses inner class `RedpandaServiceCloud.CloudCluster` to connect with the redpanda cloud swagger API to provision and delete clusters. There are some hard-coded values passed to the swagger API that will need to be cleaned up in a future PR because the swagger API is v0.1.0.

Client ID and secrets from redpanda cloud UI are needed to connect to the api. Set these settings in `ducktape --globals` for the new classes to work:
```json
{
    "cloud_oauth_url": "https://auth.example.com/oauth/token",
    "cloud_oauth_client_id": "your-client-id",
    "cloud_oauth_client_secret": "your-client-secret",
    "cloud_oauth_audience": "your-audience",
    "cloud_api_url": "https://your-api.cloud.redpanda.com"
}
```

A simple test class ~`CloudSelfTest`~ `SimpleSelfTest` is created in `tests/rptest/tests/services_self_test.py` to run a few operations that connect to the k8s pods of redpanda cloud. The creation and deletion of a cluster will take over 30 min so you need to bump the test runner timeout:
```console
ducktape \
  --debug \
  --globals=/path/to/ducktape_globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/path/to/ducktape_cluster.json \
  --test-runner-timeout=3600000 \
  tests/rptest/tests/services_self_test.py::CloudSelfTest
```

To skip creation and deletion of a cluster, you can set these additional `ducktape --globals` values:
```json
{
    "cloud_cluster_id": "chns4udibsvmbjmrtjm0",
    "cloud_delete_cluster": false
}
```

Output of a ~`CloudSelfTest`~ `SimpleSelfTest` test run using an existing cluster:
```console
test_id:    rptest.tests.services_self_test.CloudSelfTest.test_cloud
status:     PASS
run time:   25.479 seconds
------------------------------------------------------------------------------
==============================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-05-26--016
run time:         25.493 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
==============================================================================
```

Output of a ~`CloudSelfTest`~ `SimpleSelfTest` test run creating and deleting a cluster:
```console
...
[INFO  - 2023-05-26 12:33:44,599 - redpanda - create - lineno:1365]: waiting for creation of cluster rp-ducktape-cluster-8c90c19c namespaceUuid 178a5705-47da-4bef-a938-c0e371839870, checking every 60.0 seconds
[DEBUG - 2023-05-26 12:33:44,599 - redpanda - _cluster_ready - lineno:1284]: checking readiness of cluster rp-ducktape-cluster-8c90c19c
[DEBUG - 2023-05-26 12:34:45,475 - redpanda - _cluster_ready - lineno:1284]: checking readiness of cluster rp-ducktape-cluster-8c90c19c
[DEBUG - 2023-05-26 12:35:46,243 - redpanda - _cluster_ready - lineno:1284]: checking readiness of cluster rp-ducktape-cluster-8c90c19c
...
[INFO:2023-05-26 13:09:35,611]: RunnerClient: rptest.tests.services_self_test.CloudSelfTest.test_cloud: Tearing down...
[DEBUG - 2023-05-26 13:09:36,464 - redpanda - delete - lineno:1393]: resp: {"id": "choagahmsn17ttei3f0g", "name": "rp-ducktape-cluster-8c90c19c"...
...
test_id:    rptest.tests.services_self_test.CloudSelfTest.test_cloud
status:     PASS
run time:   35 minutes 54.077 seconds
-------------------------------------------------------------------------------
===============================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-05-26--018
run time:         35 minutes 54.101 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
===============================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none