### PR TITLE
pandaproxy: Add a client id to SR and PP

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -74,6 +74,7 @@
 #include "model/metadata.h"
 #include "net/server.h"
 #include "pandaproxy/rest/api.h"
+#include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/schema_registry/api.h"
 #include "raft/coordinated_recovery_throttle.h"
 #include "raft/group_manager.h"
@@ -144,6 +145,20 @@ static void set_local_kafka_client_config(
     }
 }
 
+static void set_pp_kafka_client_defaults(
+  pandaproxy::rest::configuration& proxy_config,
+  kafka::client::configuration& client_config) {
+    // override pandaparoxy_client.consumer_session_timeout_ms with
+    // pandaproxy.consumer_instance_timeout_ms
+    client_config.consumer_session_timeout.set_value(
+      proxy_config.consumer_instance_timeout.value());
+
+    if (!client_config.client_identifier.is_overriden()) {
+        client_config.client_identifier.set_value(
+          std::make_optional<ss::sstring>("pandaproxy_client"));
+    }
+}
+
 static void
 set_sr_kafka_client_defaults(kafka::client::configuration& client_config) {
     if (!client_config.produce_batch_delay.is_overriden()) {
@@ -154,6 +169,10 @@ set_sr_kafka_client_defaults(kafka::client::configuration& client_config) {
     }
     if (!client_config.produce_batch_size_bytes.is_overriden()) {
         client_config.produce_batch_size_bytes.set_value(int32_t(0));
+    }
+    if (!client_config.client_identifier.is_overriden()) {
+        client_config.client_identifier.set_value(
+          std::make_optional<ss::sstring>("schema_registry_client"));
     }
 }
 
@@ -650,10 +669,7 @@ void application::hydrate_config(const po::variables_map& cfg) {
         } else {
             set_local_kafka_client_config(_proxy_client_config, config::node());
         }
-        // override pandaparoxy_client.consumer_session_timeout_ms with
-        // pandaproxy.consumer_instance_timeout_ms
-        _proxy_client_config->consumer_session_timeout.set_value(
-          _proxy_config->consumer_instance_timeout.value());
+        set_pp_kafka_client_defaults(*_proxy_config, *_proxy_client_config);
         config_printer("pandaproxy", *_proxy_config);
         config_printer("pandaproxy_client", *_proxy_client_config);
     }


### PR DESCRIPTION
Add a client ID for Rest Proxy and Schema Registry.

The default identifier is `test_client`. Rename them to aid diagnostics when trawling logs.

* Pandaproxy: The client identifier is now `pandaproxy_client`
* Schema Registry: The client identifier is now `schema_registry_client`

I chose the names from the configuration file, other options available, such as from the metrics: `schema_registry` and `rest_proxy`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Improvements

* Pandaproxy: The client identifier is now `pandaproxy_client`
* Schema Registry: The client identifier is now `schema_registry_client`

