### PR TITLE
archival: Disable adjacent segment merging when not a leader

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -151,8 +151,12 @@ ss::future<> ntp_archiver::start() {
 }
 
 void ntp_archiver::notify_leadership(std::optional<model::node_id> leader_id) {
-    if (leader_id && *leader_id == _parent.raft()->self().id()) {
+    bool is_leader = leader_id && *leader_id == _parent.raft()->self().id();
+    if (is_leader) {
         _leader_cond.signal();
+    }
+    if (_local_segment_merger) {
+        _local_segment_merger->set_enabled(is_leader);
     }
 }
 


### PR DESCRIPTION
Currently, the adjacent segment merger is not disabled when partition loses leadership. It can't cause any problems because the job checks leadership before proceeding with re-uploads. This PR adds extra safety layer by enabling/disabling the adjacent segment merger when leadership changes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Disable adjacent segment merging when the partition is not a leader