### PR TITLE
topic_recovery: avoid listing with no prefix

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_cloud_storage.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage.go
@@ -17,8 +17,8 @@ import (
 // RecoveryRequestParams represents the request body schema for the automated recovery API endpoint.
 type RecoveryRequestParams struct {
 	TopicNamesPattern string `json:"topic_names_pattern"`
-	RetentionBytes    int    `json:"retention_bytes"`
-	RetentionMs       int    `json:"retention_ms"`
+	RetentionBytes    *int   `json:"retention_bytes,omitempty"`
+	RetentionMs       *int   `json:"retention_ms,omitempty"`
 }
 
 type RecoveryStartResponse struct {

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
@@ -76,10 +76,14 @@ recovery process until it's finished.`,
 				out.MaybeDie(err, "failed to poll automated recovery status: %v", err)
 
 				pending := false
-				for _, topicDownload := range status.TopicDownloads {
-					if topicDownload.PendingDownloads > 0 {
-						pending = true
-						break
+				if status.State != "inactive" {
+					pending = true
+				} else {
+					for _, topicDownload := range status.TopicDownloads {
+						if topicDownload.PendingDownloads > 0 {
+							pending = true
+							break
+						}
 					}
 				}
 

--- a/src/v/cloud_storage/recovery_request.cc
+++ b/src/v/cloud_storage/recovery_request.cc
@@ -98,8 +98,10 @@ void recovery_request::parse_request_body(const ss::http::request& request) {
             json::StringBuffer sbuf;
             json::Writer<json::StringBuffer> w{sbuf};
             validator.schema_validator.GetError().Accept(w);
-            throw bad_request{
-              fmt::format("invalid request body: {}", sbuf.GetString())};
+            throw bad_request{fmt::format(
+              "invalid request body '{}': {}",
+              request.content.data(),
+              sbuf.GetString())};
         }
 
         if (document.HasMember("topic_names_pattern")) {

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -75,7 +75,7 @@ public:
 
     cloud_storage_clients::s3_configuration get_configuration();
 
-    void disable_search_on_get_list() { _search_on_get_list = false; }
+    void set_search_on_get_list(bool should) { _search_on_get_list = should; }
 
 private:
     void set_routes(

--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -25,12 +25,6 @@ namespace {
 const ss::sstring no_manifests = R"XML(
     <ListBucketResult>
       <IsTruncated>false</IsTruncated>
-      <Contents>
-          <Key>a</Key>
-      </Contents>
-      <Contents>
-          <Key>b</Key>
-      </Contents>
       <NextContinuationToken>n</NextContinuationToken>
     </ListBucketResult>
     )XML";
@@ -98,6 +92,30 @@ const s3_imposter_fixture::expectation recovery_state{
   .body = recovery_results,
 };
 
+// Generates expectations such that listing on a manifest prefix will result in
+// a response that contains no manifests.
+std::vector<s3_imposter_fixture::expectation>
+generate_no_manifests_expectations(
+  std::vector<s3_imposter_fixture::expectation> additional_expectations) {
+    std::vector<uint64_t> prefixes;
+    prefixes.reserve(16);
+    for (uint64_t i = 0x00000000; i <= 0xF0000000; i += 0x10000000) {
+        prefixes.emplace_back(i);
+    }
+    std::vector<s3_imposter_fixture::expectation> expectations;
+    expectations.reserve(prefixes.size());
+    for (const auto& prefix_bitmask : prefixes) {
+        expectations.emplace_back(s3_imposter_fixture::expectation{
+          .url = fmt::format("/?list-type=2&prefix={:08x}/", prefix_bitmask),
+          .body = no_manifests,
+        });
+    }
+    for (auto& e : additional_expectations) {
+        expectations.emplace_back(std::move(e));
+    }
+    return expectations;
+}
+
 } // namespace
 
 class fixture
@@ -110,7 +128,7 @@ public:
         redpanda_thread_fixture::init_cloud_storage_tag{},
         httpd_port_number()) {
         // This test will manually set expectations for list requests.
-        disable_search_on_get_list();
+        set_search_on_get_list(false);
     }
 
     void wait_for_topic(model::topic_namespace tp_ns) {
@@ -165,8 +183,8 @@ FIXTURE_TEST(start_with_good_request, fixture) {
 }
 
 FIXTURE_TEST(recovery_with_no_topics_exits_early, fixture) {
-    set_expectations_and_listen(
-      {{.url = root_level.url, .body = no_manifests}});
+    set_search_on_get_list(true);
+    set_expectations_and_listen({});
 
     auto& service = app.topic_recovery_service;
     auto result = service.local().start_recovery({});
@@ -178,10 +196,10 @@ FIXTURE_TEST(recovery_with_no_topics_exits_early, fixture) {
     BOOST_REQUIRE_EQUAL(result, expected);
 
     // Wait until one request is received, to list bucket for manifest files
-    wait_for_n_requests(1, equals::yes);
+    wait_for_n_requests(16, equals::yes);
 
     const auto& list_topics_req = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req.url, root_level.url);
+    BOOST_REQUIRE_EQUAL(list_topics_req.url, "/?list-type=2&prefix=00000000/");
 
     // Wait until recovery exits after finding no topics to create
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
@@ -189,7 +207,7 @@ FIXTURE_TEST(recovery_with_no_topics_exits_early, fixture) {
     }).get();
 
     // No other calls were made
-    BOOST_REQUIRE_EQUAL(get_requests().size(), 1);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 16);
 }
 
 void do_test(fixture& f) {
@@ -203,18 +221,11 @@ void do_test(fixture& f) {
     BOOST_REQUIRE_EQUAL(result, expected);
 
     // Wait until three requests are received:
-    // 1. to list bucket for topic meta prefixes
-    // 2. to list the topic meta prefix itself
-    // 3. to download manifest
-    f.wait_for_n_requests(3, fixture::equals::yes);
+    // 1..16. to list bucket for topic meta prefixes
+    // 17. to download manifest
+    f.wait_for_n_requests(17, fixture::equals::yes);
 
-    const auto& list_topics_req = f.get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req.url, root_level.url);
-
-    const auto& list_prefix_req = f.get_requests()[1];
-    BOOST_REQUIRE_EQUAL(list_prefix_req.url, meta_level.url);
-
-    const auto& get_manifest_req = f.get_requests()[2];
+    const auto& get_manifest_req = f.get_requests()[16];
     BOOST_REQUIRE_EQUAL(get_manifest_req.url, manifest.url);
 
     // Wait until recovery exits after finding no topics to create
@@ -222,20 +233,19 @@ void do_test(fixture& f) {
         return service.local().is_active() == false;
     }).get();
 
-    BOOST_REQUIRE_EQUAL(f.get_requests().size(), 3);
+    BOOST_REQUIRE_EQUAL(f.get_requests().size(), 17);
 }
 
 FIXTURE_TEST(recovery_with_unparseable_topic_manifest, fixture) {
-    set_expectations_and_listen(
-      {root_level, meta_level, {.url = manifest.url, .body = "bad json"}});
+    set_expectations_and_listen(generate_no_manifests_expectations(
+      {meta_level, {.url = manifest.url, .body = "bad json"}}));
     do_test(*this);
 }
 
 FIXTURE_TEST(recovery_with_missing_topic_manifest, fixture) {
-    set_expectations_and_listen({
-      root_level,
+    set_expectations_and_listen(generate_no_manifests_expectations({
       meta_level,
-    });
+    }));
     do_test(*this);
 }
 
@@ -249,7 +259,8 @@ FIXTURE_TEST(recovery_with_existing_topic, fixture) {
                                  .create_topics(topic_cfg, model::no_timeout)
                                  .get();
     wait_for_topics(std::move(topic_create_result)).get();
-    set_expectations_and_listen({root_level, meta_level});
+    set_expectations_and_listen(
+      generate_no_manifests_expectations({meta_level}));
 
     auto& service = app.topic_recovery_service;
     auto result = service.local().start_recovery({});
@@ -259,24 +270,18 @@ FIXTURE_TEST(recovery_with_existing_topic, fixture) {
       .message = "recovery started"};
 
     BOOST_REQUIRE_EQUAL(result, expected);
-    wait_for_n_requests(2, equals::yes);
-
-    const auto& list_topics_req = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req.url, root_level.url);
-
-    const auto& prefix_req = get_requests()[1];
-    BOOST_REQUIRE_EQUAL(prefix_req.url, meta_level.url);
+    wait_for_n_requests(16, equals::yes);
 
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
         return service.local().is_active() == false;
     }).get();
 
-    BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 16);
 }
 
 FIXTURE_TEST(recovery_where_topic_is_created, fixture) {
-    set_expectations_and_listen(
-      {root_level, meta_level, manifest, recovery_state});
+    set_expectations_and_listen(generate_no_manifests_expectations(
+      {meta_level, manifest, recovery_state}));
 
     auto& service = app.topic_recovery_service;
     auto result = service.local().start_recovery({});
@@ -286,16 +291,7 @@ FIXTURE_TEST(recovery_where_topic_is_created, fixture) {
       .message = "recovery started"};
 
     BOOST_REQUIRE_EQUAL(result, expected);
-    wait_for_n_requests(3);
-
-    const auto& list_topics_req = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req.url, root_level.url);
-
-    const auto& prefix_req = get_requests()[1];
-    BOOST_REQUIRE_EQUAL(prefix_req.url, meta_level.url);
-
-    const auto& get_manifest = get_requests()[2];
-    BOOST_REQUIRE_EQUAL(get_manifest.url, manifest.url);
+    wait_for_n_requests(16);
 
     // Wait for the topic to appear
     wait_for_topic(tp_ns);
@@ -324,25 +320,27 @@ FIXTURE_TEST(recovery_where_topic_is_created, fixture) {
     // 2. list prefix content
     // 3. download manifest
     // 4. try to clear recovery results from previous runs
-    BOOST_REQUIRE_GE(get_requests().size(), 4);
+    BOOST_REQUIRE_GE(get_requests().size(), 18);
 }
 
 FIXTURE_TEST(recovery_result_clear_before_start, fixture) {
-    set_expectations_and_listen(
-      {root_level, meta_level, manifest, recovery_state});
+    set_expectations_and_listen(generate_no_manifests_expectations(
+      {meta_level, manifest, recovery_state}));
 
     auto& service = app.topic_recovery_service;
     service.local().start_recovery({});
-    wait_for_n_requests(5);
+    wait_for_n_requests(22);
 
-    const auto& delete_request = get_requests()[4];
+    // 16 to check each manifest prefix, 1 to download the topic manifest, 1 to
+    // check recovery results, 1 to delete.
+    const auto& delete_request = get_requests()[18];
     BOOST_REQUIRE_EQUAL(delete_request.url, "/?delete");
     BOOST_REQUIRE_EQUAL(delete_request.method, "POST");
 }
 
 FIXTURE_TEST(recovery_download_tracking, fixture) {
-    set_expectations_and_listen(
-      {root_level, meta_level, manifest, recovery_state});
+    set_expectations_and_listen(generate_no_manifests_expectations(
+      {meta_level, manifest, recovery_state}));
 
     auto& service = app.topic_recovery_service;
     service.local().start_recovery({});
@@ -364,10 +362,9 @@ FIXTURE_TEST(recovery_download_tracking, fixture) {
 }
 
 FIXTURE_TEST(recovery_with_topic_name_pattern_without_match, fixture) {
-    set_expectations_and_listen({
-      root_level,
+    set_expectations_and_listen(generate_no_manifests_expectations({
       meta_level,
-    });
+    }));
 
     ss::http::request r;
     r._headers = {{"Content-Type", "application/json"}};
@@ -376,18 +373,18 @@ FIXTURE_TEST(recovery_with_topic_name_pattern_without_match, fixture) {
     auto& service = app.topic_recovery_service;
     service.local().start_recovery(r);
 
-    wait_for_n_requests(2, equals::yes);
+    wait_for_n_requests(16, equals::yes);
 
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
         return !service.local().is_active();
     }).get();
 
-    BOOST_REQUIRE_EQUAL(get_requests().size(), 2);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 16);
 }
 
 FIXTURE_TEST(recovery_with_topic_name_pattern_with_match, fixture) {
-    set_expectations_and_listen(
-      {root_level, meta_level, manifest, recovery_state});
+    set_expectations_and_listen(generate_no_manifests_expectations(
+      {meta_level, manifest, recovery_state}));
 
     ss::http::request r;
     r._headers = {{"Content-Type", "application/json"}};
@@ -396,13 +393,13 @@ FIXTURE_TEST(recovery_with_topic_name_pattern_with_match, fixture) {
     auto& service = app.topic_recovery_service;
     service.local().start_recovery(r);
 
-    wait_for_n_requests(5);
+    wait_for_n_requests(19);
     wait_for_topic(tp_ns);
 }
 
 FIXTURE_TEST(recovery_with_retention_ms_override, fixture) {
-    set_expectations_and_listen(
-      {root_level, meta_level, manifest, recovery_state});
+    set_expectations_and_listen(generate_no_manifests_expectations(
+      {meta_level, manifest, recovery_state}));
 
     ss::http::request r;
     r._headers = {{"Content-Type", "application/json"}};
@@ -412,7 +409,7 @@ FIXTURE_TEST(recovery_with_retention_ms_override, fixture) {
     auto& service = app.topic_recovery_service;
     service.local().start_recovery(r);
 
-    wait_for_n_requests(5);
+    wait_for_n_requests(19);
     wait_for_topic(tp_ns);
     auto topic = app.controller->get_topics_state().local().get_topic_cfg(
       tp_ns);
@@ -424,9 +421,8 @@ FIXTURE_TEST(recovery_with_retention_ms_override, fixture) {
 }
 
 FIXTURE_TEST(recovery_with_retention_bytes_override, fixture) {
-    set_expectations_and_listen(
-      {root_level, meta_level, manifest, recovery_state});
-
+    set_expectations_and_listen(generate_no_manifests_expectations(
+      {meta_level, manifest, recovery_state}));
     ss::http::request r;
     r._headers = {{"Content-Type", "application/json"}};
     r.content_length = 1;
@@ -447,8 +443,8 @@ FIXTURE_TEST(recovery_with_retention_bytes_override, fixture) {
 }
 
 FIXTURE_TEST(recovery_status, fixture) {
-    set_expectations_and_listen(
-      {root_level, meta_level, manifest, recovery_state});
+    set_expectations_and_listen(generate_no_manifests_expectations(
+      {meta_level, manifest, recovery_state}));
 
     ss::http::request r;
     r._headers = {{"Content-Type", "application/json"}};

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -227,38 +227,14 @@ collect_manifest_paths(
     const auto& bucket = cfg.bucket;
     auto rtc = make_rtc(as, cfg);
 
-    // List only the items at the top of the bucket hierarchy. The delimiter
-    // ensures that any "directories" will be collected into the common_prefixes
-    // field of the result.
-    auto top_level = co_await remote.list_objects(
-      bucket, rtc, std::nullopt, '/');
-    if (top_level.has_error()) {
-        vlog(
-          cst_log.error,
-          "Failed to list top level items: {}",
-          top_level.error());
-        co_return recovery_error_ctx::make("failed to list top level items");
+    // Look under each manifest prefix for topic manifests.
+    std::array<uint64_t, 16> prefixes;
+    for (int i = 0; i < 16; ++i) {
+        prefixes.at(i) = 0x10000000 * static_cast<uint64_t>(i);
     }
-
-    auto prefixes = top_level.value().common_prefixes;
-    for (const auto& prefix : prefixes) {
-        vlog(cst_log.trace, "found top level prefix: {}", prefix);
-    }
-
-    // Filter out prefixes which do not match the prefix expression that topic
-    // manifests use
-    auto it = std::remove_if(
-      prefixes.begin(), prefixes.end(), [](const auto& prefix) {
-          return !std::regex_match(prefix.cbegin(), prefix.cend(), prefix_expr);
-      });
-    prefixes.erase(it, prefixes.end());
-
-    for (auto& prefix : prefixes) {
-        vlog(cst_log.trace, "found possible topic meta prefix: {}", prefix);
-    }
-
     std::vector<remote_segment_path> paths;
-    for (const auto& prefix : prefixes) {
+    for (const auto& prefix_bitmask : prefixes) {
+        const auto prefix = fmt::format("{:08x}/", prefix_bitmask);
         auto rtc = make_rtc(as, cfg);
 
         // This request is restricted to prefix, it should only return the

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -157,6 +157,7 @@ topic_recovery_service::start_recovery(const ss::http::request& req) {
         }
 
         recovery_request request(req);
+        _state = state::starting;
         ssx::spawn_with_gate(_gate, [this, r = std::move(request)]() mutable {
             return start_bg_recovery_task(std::move(r)).then([](auto result) {
                 if (result.has_error()) {
@@ -257,19 +258,7 @@ collect_manifest_paths(
 
 ss::future<result<void, recovery_error_ctx>>
 topic_recovery_service::start_bg_recovery_task(recovery_request request) {
-    if (is_active()) {
-        vlog(cst_log.warn, "A recovery is already active");
-        co_return recovery_error_ctx::make(
-          "A recovery is already active",
-          recovery_error_code::recovery_already_running);
-    }
-
     vlog(cst_log.info, "Starting recovery task with request: {}", request);
-    // Setting this state here ensures that another request coming in soon after
-    // on the same shard is rejected. If we set this state after the RPC call,
-    // it is possible that two requests sent back to back on the controller
-    // leader assume that no other recovery is running.
-    _state = state::starting;
     if (_pending_status_timer.cancel()) {
         vlog(
           cst_log.warn,

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -682,6 +682,18 @@ class RpkTool:
         ]
         return self._execute(cmd)
 
+    def cluster_recovery_start(self, wait: bool = True, polling_interval='5s'):
+        cmd = [
+            self._rpk_binary(), '--api-urls',
+            self._admin_host(), 'cluster', 'storage', 'recovery', 'start'
+        ]
+        if wait:
+            cmd.append('--wait')
+            if polling_interval:
+                cmd.append('--polling-interval')
+                cmd.append(polling_interval)
+        return self._execute(cmd)
+
     def self_test_start(self,
                         disk_duration_ms=None,
                         network_duration_ms=None,

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -465,6 +465,7 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
                 "cloud_storage_enable_segment_merging": False,
                 'log_segment_size_min': 1024,
             },
+            environment={'__REDPANDA_TOPIC_REC_DL_CHECK_MILLIS': 5000},
             si_settings=si_settings)
         self.kafka_tools = KafkaCliTools(self.redpanda)
 
@@ -508,6 +509,45 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
         seq_consumer.start(clean=False)
         seq_consumer.wait()
         self.redpanda.stop_node(self.redpanda.nodes[0])
+
+    @skip_debug_mode
+    @cluster(num_nodes=2)
+    def test_many_partitions_recovery(self):
+        """
+        Test that reproduces an OOM when doing recovery with a large dataset in
+        the bucket.
+        """
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=1024,
+                                       msg_count=1000 * 1000,
+                                       custom_node=self.preallocated_nodes)
+        producer.start()
+        try:
+            wait_until(
+                lambda: nodes_report_cloud_segments(self.redpanda, 100 * 200),
+                timeout_sec=180,
+                backoff_sec=3)
+        finally:
+            producer.stop()
+            producer.wait()
+
+        node = self.redpanda.nodes[0]
+        self.redpanda.stop()
+        self.redpanda.remove_local_data(node)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda._admin.await_stable_leader("controller",
+                                                 partition=0,
+                                                 namespace='redpanda',
+                                                 timeout_s=60,
+                                                 backoff_s=2)
+
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_recovery_start(wait=True)
+        wait_until(lambda: len(set(rpk.list_topics())) == 1,
+                   timeout_sec=120,
+                   backoff_sec=3)
 
 
 class ShadowIndexingWhileBusyTest(PreallocNodesTest):

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -49,7 +49,10 @@ class EndToEndShadowIndexingBase(EndToEndTest):
         replication_factor=3,
     ), )
 
-    def __init__(self, test_context, extra_rp_conf=None, environment=None):
+    def __init__(self,
+                 test_context,
+                 extra_rp_conf=None,
+                 environment={'__REDPANDA_TOPIC_REC_DL_CHECK_MILLIS': 5000}):
         super(EndToEndShadowIndexingBase,
               self).__init__(test_context=test_context)
 
@@ -158,6 +161,50 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
                     index_segment_pair[match[1]] += 1
             for file, count in index_segment_pair.items():
                 assert count == 2, f'expected one index and one log for {file}, found {count}'
+
+    @skip_debug_mode
+    @cluster(num_nodes=4)
+    def test_recover(self):
+        # Recovery will leave behind results files, which aren't tracked.
+        # TODO: remove when recovery is controller-driven instead of using
+        # results objects.
+        self.start_producer()
+        produce_until_segments(
+            redpanda=self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+        original_snapshot = self.redpanda.storage(
+            all_nodes=True).segments_by_node("kafka", self.topic, 0)
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.segment_size,
+            },
+        )
+
+        wait_for_removal_of_n_segments(redpanda=self.redpanda,
+                                       topic=self.topic,
+                                       partition_idx=0,
+                                       n=6,
+                                       original_snapshot=original_snapshot)
+
+        self.redpanda.stop()
+        self.redpanda.remove_local_data(self.redpanda.nodes[0])
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda._admin.await_stable_leader("controller",
+                                                 partition=0,
+                                                 namespace='redpanda',
+                                                 timeout_s=60,
+                                                 backoff_s=2)
+
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_recovery_start(wait=True)
+        wait_until(lambda: len(set(rpk.list_topics())) == 1,
+                   timeout_sec=30,
+                   backoff_sec=1)
 
 
 class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -182,7 +182,7 @@ class SIAdminApiTest(RedpandaTest):
                     payload=payload)
             except requests.exceptions.HTTPError as e:
                 assert e.response.status_code == requests.status_codes.codes[
-                    'bad_request'], f'unexpected status code: {response} for {payload}'
+                    'bad_request'], f'unexpected status code: {e.response} for {payload}'
 
     @cluster(num_nodes=3)
     def test_topic_recovery_status_to_non_controller(self):


### PR DESCRIPTION
We currently look for topic/partition manifests by scanning the bucket with no prefix and a '/' delimiter. This is wasteful since there are only 16 prefixes we expect.

Instead of searching remote storage for prefixes to use, this commit changes topic recovery to look at all 16 prefixes that match /[0-f0-9]0000000/, which is likely to be the result of the search anyway.

Along the way, this adds some to other topic recovery improvements:
- Adds topic recovery via `RpkTool` in ducktape.
- Updates RPK to not pass the retention arguments by default (currently they're not exposed publicly anyway).
- Improves logging on schema validation error for bad requests.
- Fixes a race between rpk's polling and redpanda's starting of recovery.
- Adds a small test for the `RpkTool`-driven recovery.
- Adds a many-partitions variant that runs in CI (i.e. not a full-blown scale test).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements
* Automated topic recovery will be faster when operating on buckets with a large number of objects.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
