### PR TITLE
schema_registry: Return the latest schema_version

### DIFF
--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -123,10 +123,14 @@ public:
 
         if (!version.has_value()) {
             auto const& versions = sub_it->second.versions;
-            if (versions.empty() || (!inc_del && versions.back().deleted)) {
+            auto it = std::find_if(
+              versions.rbegin(), versions.rend(), [inc_del](const auto& ver) {
+                  return inc_del || !ver.deleted;
+              });
+            if (it == versions.rend()) {
                 return not_found(sub);
             }
-            return *std::prev(versions.end());
+            return *it;
         }
 
         auto v_it = BOOST_OUTCOME_TRYX(


### PR DESCRIPTION
Requesting the latest version should return the most recent version, according to the include_deleted flag.

Change the logic to search backwards through the versions with the correct predicate.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* Schema Registry: Fix a bug in `GET /subjects/<subject>/versions/latest` that would previously not find the latest non-deleted version.