### PR TITLE
features: improvements to test-only feature activation

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -504,6 +504,12 @@ const std::optional<security::license>& feature_table::get_license() const {
     return _license;
 }
 
+void feature_table::testing_activate_feature(feature f) {
+    auto& feat = get_state(f);
+    feat.transition_active();
+    on_update();
+}
+
 void feature_table::testing_activate_all() {
     for (auto& s : _feature_state) {
         if (s.spec.available_rule == feature_spec::available_policy::always) {

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -385,6 +385,11 @@ public:
      */
     void testing_activate_all();
 
+    /**
+     * Explicitly activate the given feature.
+     */
+    void testing_activate_feature(feature f);
+
     model::offset get_applied_offset() const { return _applied_offset; }
 
     enum class version_durability : uint8_t {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1877,15 +1877,11 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
         // some of initialization that would usually wait for the controller
         // to commit some state to its log.
         vlog(_log.warn, "Running in unit test mode");
-        if (
-          feature_table.local().get_active_version()
-          == cluster::invalid_version) {
-            vlog(_log.info, "Switching on all features");
-            feature_table
-              .invoke_on_all(
-                [](features::feature_table& ft) { ft.testing_activate_all(); })
-              .get();
-        }
+        vlog(_log.info, "Switching on all features");
+        feature_table
+          .invoke_on_all(
+            [](features::feature_table& ft) { ft.testing_activate_all(); })
+          .get();
     } else {
         // Only populate migrators in non-unit-test mode
         _migrators.push_back(


### PR DESCRIPTION
A couple QOL improvements to test-only feature activation:
* We previously predicated on having an unset version to activate all features. Now that we bootstrap to an actual version, this predicate is removed.
* Added a method to enable specific features, useful for explicit-only features.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
