### PR TITLE
cloud_metadata: flesh out uploader implementation for controller snapshots

### DIFF
--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -122,6 +122,12 @@ ss::future<> upload_housekeeping_service::bg_idle_loop() {
         case cloud_storage::api_activity_notification::segment_download:
             weight = 1;
             break;
+        // Controller snapshot IO is independent of housekeeping.
+        case cloud_storage::api_activity_notification::
+          controller_snapshot_download:
+        case cloud_storage::api_activity_notification::
+          controller_snapshot_upload:
+            break;
         };
 
         _api_utilization->update(weight, ss::lowres_clock::now());

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -21,6 +21,7 @@ v_cc_library(
     partition_manifest.cc
     recursive_directory_walker.cc
     remote.cc
+    remote_file.cc
     offset_translation_layer.cc
     remote_probe.cc
     read_path_probes.cc

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -16,6 +16,7 @@ v_cc_library(
     cache_service.cc
     access_time_tracker.cc
     cache_probe.cc
+    download_exception.cc
     topic_manifest.cc
     partition_manifest.cc
     recursive_directory_walker.cc

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -184,6 +184,11 @@ public:
       std::optional<uint64_t> size_limit_override,
       std::optional<size_t> object_limit_override);
 
+    std::filesystem::path
+    get_local_path(const std::filesystem::path& key) const {
+        return _cache_dir / key;
+    }
+
 private:
     /// Load access time tracker from file
     ss::future<> load_access_time_tracker();

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -34,6 +34,15 @@ namespace cloud_storage {
 static constexpr size_t default_write_buffer_size = 128_KiB;
 static constexpr unsigned default_writebehind = 10;
 
+// These timeout/backoff settings are for S3 requests
+using namespace std::chrono_literals;
+static const ss::lowres_clock::duration cache_hydration_timeout = 60s;
+static const ss::lowres_clock::duration cache_hydration_backoff = 250ms;
+
+// This backoff is for failure of the local cache to retain recently
+// promoted data (i.e. highly stressed cache)
+static const ss::lowres_clock::duration cache_thrash_backoff = 5000ms;
+
 class cache_test_fixture;
 
 struct [[nodiscard]] cache_item {

--- a/src/v/cloud_storage/download_exception.cc
+++ b/src/v/cloud_storage/download_exception.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/download_exception.h"
+
+#include "vassert.h"
+
+namespace cloud_storage {
+
+download_exception::download_exception(
+  download_result r, std::filesystem::path p)
+  : result(r)
+  , path(std::move(p)) {
+    vassert(
+      r != download_result::success,
+      "Exception created with successful error code");
+}
+
+const char* download_exception::what() const noexcept {
+    switch (result) {
+    case download_result::failed:
+        return "Failed";
+    case download_result::notfound:
+        return "NotFound";
+    case download_result::timedout:
+        return "TimedOut";
+    case download_result::success:
+        vassert(false, "Successful result can't be used as an error");
+    }
+    __builtin_unreachable();
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/download_exception.h
+++ b/src/v/cloud_storage/download_exception.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_storage/types.h"
+
+namespace cloud_storage {
+
+class download_exception : public std::exception {
+public:
+    explicit download_exception(download_result r, std::filesystem::path p);
+
+    const char* what() const noexcept override;
+
+    const download_result result;
+    std::filesystem::path path;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -614,6 +614,26 @@ ss::future<upload_result> remote::upload_segment(
       [this] { _probe.upload_backoff(); });
 }
 
+ss::future<download_result> remote::download_stream(
+  const cloud_storage_clients::bucket_name& bucket,
+  const remote_segment_path& path,
+  const try_consume_stream& cons_str,
+  retry_chain_node& parent,
+  const std::string_view stream_label,
+  const download_metrics& metrics,
+  std::optional<cloud_storage_clients::http_byte_range> byte_range) {
+    return download_stream(
+      bucket,
+      path,
+      cons_str,
+      parent,
+      stream_label,
+      [&metrics] { return metrics.download_latency_measurement(); },
+      [&metrics] { metrics.failed_download_metric(); },
+      [&metrics] { metrics.download_backoff_metric(); },
+      byte_range);
+}
+
 ss::future<download_result> remote::download_segment(
   const cloud_storage_clients::bucket_name& bucket,
   const remote_segment_path& segment_path,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -457,6 +457,22 @@ private:
       SuccessfulUploadMetricFn successful_upload_metric,
       UploadBackoffMetricFn upload_backoff_metric);
 
+    template<
+      typename DownloadLatencyMeasurementFn,
+      typename FailedDownloadMetricFn,
+      typename DownloadBackoffMetricFn>
+    ss::future<download_result> download_stream(
+      const cloud_storage_clients::bucket_name& bucket,
+      const remote_segment_path& path,
+      const try_consume_stream& cons_str,
+      retry_chain_node& parent,
+      const std::string_view stream_label,
+      DownloadLatencyMeasurementFn download_latency_measurement,
+      FailedDownloadMetricFn failed_download_metric,
+      DownloadBackoffMetricFn download_backoff_metric,
+      std::optional<cloud_storage_clients::http_byte_range> byte_range
+      = std::nullopt);
+
     ss::future<upload_result> delete_objects_sequentially(
       const cloud_storage_clients::bucket_name& bucket,
       std::vector<cloud_storage_clients::object_key> keys,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -105,6 +105,8 @@ enum class api_activity_notification {
     segment_delete,
     manifest_upload,
     manifest_download,
+    controller_snapshot_upload,
+    controller_snapshot_download,
 };
 
 /// \brief Represents remote endpoint

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -425,6 +425,23 @@ public:
     ss::abort_source& as() { return _as; }
 
 private:
+    template<
+      typename FailedUploadMetricFn,
+      typename SuccessfulUploadMetricFn,
+      typename UploadBackoffMetricFn>
+    ss::future<upload_result> upload_stream(
+      const cloud_storage_clients::bucket_name& bucket,
+      const remote_segment_path& segment_path,
+      uint64_t content_length,
+      const reset_input_stream& reset_str,
+      retry_chain_node& parent,
+      lazy_abort_source& lazy_abort_source,
+      const std::string_view stream_label,
+      api_activity_notification event_type,
+      FailedUploadMetricFn failed_upload_metric,
+      SuccessfulUploadMetricFn successful_upload_metric,
+      UploadBackoffMetricFn upload_backoff_metric);
+
     ss::future<upload_result> delete_objects_sequentially(
       const cloud_storage_clients::bucket_name& bucket,
       std::vector<cloud_storage_clients::object_key> keys,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -272,6 +272,21 @@ public:
       std::optional<cloud_storage_clients::http_byte_range> byte_range
       = std::nullopt);
 
+    /// \brief Upload a controller snapshot file to S3
+    ///
+    /// The method uploads the snapshot while tolerating some errors. It can
+    /// retry after some errors.
+    /// \param remote_path is a snapshot's name in S3
+    /// \param file is a controller snapshot file
+    /// \param parent is used for logging and retries
+    /// \param lazy_abort_source is used to stop further upload attempts
+    ss::future<upload_result> upload_controller_snapshot(
+      const cloud_storage_clients::bucket_name& bucket,
+      const remote_segment_path& remote_path,
+      const ss::file& file,
+      retry_chain_node& parent,
+      lazy_abort_source& lazy_abort_source);
+
     /// \brief Download segment index from S3
     /// \param ix is the index which will be populated from data from the object
     /// store

--- a/src/v/cloud_storage/remote_file.cc
+++ b/src/v/cloud_storage/remote_file.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_storage/remote_file.h"
+
+#include "cloud_storage/cache_service.h"
+#include "cloud_storage/download_exception.h"
+#include "cloud_storage/logger.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/types.h"
+#include "cloud_storage_clients/types.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/gate.hh>
+
+namespace cloud_storage {
+
+remote_file::remote_file(
+  remote& r,
+  cache& cache,
+  cloud_storage_clients::bucket_name bucket,
+  remote_segment_path remote_path,
+  retry_chain_node& retry_parent,
+  ss::sstring log_prefix,
+  remote::download_metrics metrics)
+  : _remote(r)
+  , _cache(cache)
+  , _bucket(std::move(bucket))
+  , _remote_path(std::move(remote_path))
+  , _rtc(&retry_parent)
+  , _ctxlog(cst_log, _rtc, std::move(log_prefix))
+  , _metrics(std::move(metrics))
+  , _cache_backoff_jitter(cache_thrash_backoff){};
+
+ss::future<ss::file> remote_file::hydrate_readable_file() {
+    ss::gate::holder g(_gate);
+    while (!_gate.is_closed()) {
+        // If the file is in cache, return immediately.
+        auto maybe_file = co_await _cache.get(_remote_path);
+        if (maybe_file.has_value()) {
+            co_return maybe_file->body;
+        }
+        // Otherwise, go to remote storage and put it in the cache.
+        auto res = co_await _remote.download_stream(
+          _bucket,
+          _remote_path,
+          [this](uint64_t size_bytes, ss::input_stream<char> s) {
+              return put_in_cache(size_bytes, std::move(s));
+          },
+          _rtc,
+          "file",
+          _metrics);
+
+        if (res != download_result::success) {
+            throw download_exception(res, _remote_path);
+        }
+        maybe_file = co_await _cache.get(_remote_path);
+        if (!maybe_file.has_value()) {
+            // The file was evicted immediately after the put. Try again.
+            co_await ss::sleep(_cache_backoff_jitter.next_duration());
+            continue;
+        }
+        co_return maybe_file->body;
+    }
+    throw ss::gate_closed_exception();
+}
+
+ss::future<uint64_t>
+remote_file::put_in_cache(uint64_t size_bytes, ss::input_stream<char> s) {
+    try {
+        auto reservation = co_await _cache.reserve_space(size_bytes, 1);
+        co_await _cache.put(_remote_path, s, reservation).finally([&s] {
+            return s.close();
+        });
+    } catch (...) {
+        auto put_exception = std::current_exception();
+        vlog(
+          _ctxlog.warn,
+          "Failed to write a segment file to cache, error: {}",
+          put_exception);
+        std::rethrow_exception(put_exception);
+    }
+    co_return size_bytes;
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/remote_file.h
+++ b/src/v/cloud_storage/remote_file.h
@@ -42,6 +42,10 @@ public:
     // Throws an exception if there was an issue downloading or caching.
     ss::future<ss::file> hydrate_readable_file();
 
+    std::filesystem::path local_path() const {
+        return _cache.get_local_path(_remote_path);
+    }
+
 private:
     // Puts the given stream into the cache. Expected to be used as a
     // remote::try_consume_stream.

--- a/src/v/cloud_storage/remote_file.h
+++ b/src/v/cloud_storage/remote_file.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_storage/cache_service.h"
+#include "cloud_storage/logger.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage_clients/types.h"
+#include "utils/retry_chain_node.h"
+
+namespace cloud_storage {
+
+// Encapsulates and exposes a file to be downloaded from remote storage and
+// backed by the cloud cache.
+class remote_file {
+public:
+    remote_file(
+      remote& r,
+      cache& cache,
+      cloud_storage_clients::bucket_name bucket,
+      remote_segment_path remote_path,
+      retry_chain_node& retry_parent,
+      ss::sstring log_prefix,
+      remote::download_metrics metrics = {});
+    remote_file(const remote_segment&) = delete;
+    remote_file(remote_segment&&) = delete;
+    remote_file& operator=(const remote_segment&) = delete;
+    remote_file& operator=(remote_segment&&) = delete;
+    ~remote_file() = default;
+
+    // Hydrates the file of the remote path, fetching from the cache or
+    // downloading from remote storage if it doesn't exist. Returns a file that
+    // has been opened with read flags.
+    //
+    // Throws an exception if there was an issue downloading or caching.
+    ss::future<ss::file> hydrate_readable_file();
+
+private:
+    // Puts the given stream into the cache. Expected to be used as a
+    // remote::try_consume_stream.
+    //
+    // Throws an exception if there was a problem inserting into the cache.
+    ss::future<uint64_t>
+    put_in_cache(uint64_t size_bytes, ss::input_stream<char> s);
+
+    remote& _remote;
+    cache& _cache;
+    cloud_storage_clients::bucket_name _bucket;
+    remote_segment_path _remote_path;
+    retry_chain_node _rtc;
+    retry_chain_logger _ctxlog;
+    const remote::download_metrics _metrics;
+    simple_time_jitter<ss::lowres_clock> _cache_backoff_jitter;
+
+    ss::gate _gate;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/remote_probe.cc
+++ b/src/v/cloud_storage/remote_probe.cc
@@ -129,6 +129,20 @@ remote_probe::remote_probe(
               "spillover_manifest_downloads",
               [this] { return get_spillover_manifest_downloads(); },
               sm::description("Number of spillover manifest downloads")),
+            sm::make_counter(
+              "controller_snapshot_successful_uploads",
+              [this] { return get_controller_snapshot_successful_uploads(); },
+              sm::description(
+                "Number of completed controller snapshot uploads")),
+            sm::make_counter(
+              "controller_snapshot_failed_uploads",
+              [this] { return get_controller_snapshot_failed_uploads(); },
+              sm::description("Number of failed controller snapshot uploads")),
+            sm::make_counter(
+              "controller_snapshot_upload_backoff",
+              [this] { return get_controller_snapshot_upload_backoffs(); },
+              sm::description("Number of times backoff was applied during "
+                              "controller snapshot uploads")),
             sm::make_histogram(
               "client_acquisition_latency",
               [this] {

--- a/src/v/cloud_storage/remote_probe.h
+++ b/src/v/cloud_storage/remote_probe.h
@@ -217,6 +217,25 @@ public:
 
     auto segment_download() { return _segment_download_latency.auto_measure(); }
 
+    void controller_snapshot_successful_upload() {
+        _cnt_controller_snapshot_successful_uploads++;
+    }
+    void controller_snapshot_failed_upload() {
+        _cnt_controller_snapshot_failed_uploads++;
+    }
+    void controller_snapshot_upload_backoff() {
+        _cnt_controller_snapshot_upload_backoffs++;
+    }
+    uint64_t get_controller_snapshot_successful_uploads() const {
+        return _cnt_controller_snapshot_successful_uploads;
+    }
+    uint64_t get_controller_snapshot_failed_uploads() const {
+        return _cnt_controller_snapshot_failed_uploads;
+    }
+    uint64_t get_controller_snapshot_upload_backoffs() const {
+        return _cnt_controller_snapshot_upload_backoffs;
+    }
+
 private:
     /// Number of topic manifest uploads
     uint64_t _cnt_topic_manifest_uploads{0};
@@ -250,6 +269,12 @@ private:
     uint64_t _cnt_upload_backoff{0};
     /// Number of times backoff  was applied during log-segment downloads
     uint64_t _cnt_download_backoff{0};
+    /// Number of completed controller snapshot uploads.
+    uint64_t _cnt_controller_snapshot_successful_uploads;
+    /// Number of failed controller snapshot uploads.
+    uint64_t _cnt_controller_snapshot_failed_uploads;
+    /// Number of times backoff was applied during controller snapshot uploads.
+    uint64_t _cnt_controller_snapshot_upload_backoffs;
     /// Number of bytes being successfully sent to S3
     uint64_t _cnt_bytes_sent{0};
     /// Number of bytes being successfully received from S3

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -54,16 +54,6 @@ generate_index_path(const cloud_storage::remote_segment_path& p);
 
 static constexpr size_t remote_segment_sampling_step_bytes = 64_KiB;
 
-class download_exception : public std::exception {
-public:
-    explicit download_exception(download_result r, std::filesystem::path p);
-
-    const char* what() const noexcept override;
-
-    const download_result result;
-    std::filesystem::path path;
-};
-
 class remote_segment_exception : public std::runtime_error {
 public:
     explicit remote_segment_exception(const std::string& m)

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ rp_test(
     util.cc
     s3_imposter.cc
     remote_test.cc
+    remote_file_test.cc
     remote_segment_test.cc
     remote_partition_test.cc
     topic_recovery_service_test.cc

--- a/src/v/cloud_storage/tests/remote_file_test.cc
+++ b/src/v/cloud_storage/tests/remote_file_test.cc
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iostream.h"
+#include "cloud_storage/cache_service.h"
+#include "cloud_storage/download_exception.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/remote_file.h"
+#include "cloud_storage/tests/cache_test_fixture.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/seastar.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+const cloud_storage_clients::bucket_name bucket{"bucket"};
+ss::abort_source never_abort;
+cloud_storage::lazy_abort_source always_continue{[]() { return std::nullopt; }};
+constexpr model::cloud_credentials_source config_file{
+  model::cloud_credentials_source::config_file};
+
+iobuf make_iobuf_from_string(std::string_view s) {
+    iobuf b;
+    b.append(s.data(), s.size());
+    return b;
+}
+
+} // namespace
+using namespace cloud_storage;
+
+class remote_file_fixture
+  : public s3_imposter_fixture
+  , public cache_test_fixture {
+public:
+    remote_file_fixture()
+      : data_dir("data_dir") {
+        ss::recursive_touch_directory(data_dir.get_path().string()).get();
+        auto conf = get_configuration();
+        pool
+          .start(
+            10, ss::sharded_parameter([this] { return get_configuration(); }))
+          .get();
+        remote
+          .start(
+            std::ref(pool),
+            ss::sharded_parameter([this] { return get_configuration(); }),
+            ss::sharded_parameter([] { return config_file; }))
+          .get();
+        set_expectations_and_listen({});
+    }
+
+    std::filesystem::path test_path(const ss::sstring& name) {
+        return std::filesystem::path{
+          data_dir.get_path() / std::filesystem::path(name)};
+    }
+
+    void write_local_file(
+      const std::filesystem::path& filepath, const ss::sstring& body) {
+        ss::open_flags flags = ss::open_flags::rw | ss::open_flags::create;
+        auto f = ss::open_file_dma(
+                   filepath.string(), flags, ss::file_open_options{})
+                   .get();
+
+        ss::file_output_stream_options w_opts;
+        auto os = ss::make_file_output_stream(std::move(f), w_opts).get();
+        auto close = ss::defer([&os] { os.close().get(); });
+        write_iobuf_to_output_stream(make_iobuf_from_string(body), os).get();
+    }
+
+    upload_result upload_local_file(
+      const std::filesystem::path& file_path,
+      const remote_segment_path& remote_path,
+      retry_chain_node& retry_node) {
+        ss::open_flags flags = ss::open_flags::ro;
+        ss::file f = ss::open_file_dma(file_path.string(), flags).get();
+        return remote.local()
+          .upload_controller_snapshot(
+            bucket, remote_path, f, retry_node, always_continue)
+          .get();
+    }
+
+    ~remote_file_fixture() {
+        data_dir.remove().get();
+        pool.local().shutdown_connections();
+        remote.stop().get();
+        pool.stop().get();
+    }
+
+    temporary_dir data_dir;
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    ss::sharded<remote> remote;
+};
+
+FIXTURE_TEST(test_cached_file, remote_file_fixture) {
+    const ss::sstring local_path = "file";
+    const ss::sstring body = "body";
+    const auto file_path = test_path(local_path);
+
+    // Write a local file and then upload.
+    write_local_file(file_path, body);
+    const remote_segment_path remote_path{"remote_path"};
+    retry_chain_node retry_node(never_abort, 10s, 20ms);
+    auto upl_res = upload_local_file(file_path, remote_path, retry_node);
+    BOOST_REQUIRE(upl_res == upload_result::success);
+    BOOST_REQUIRE_EQUAL(1, get_requests().size());
+
+    // Download the file and ensure it matches the expected body. Repeated
+    // attempts should fetch from cache rather than from the remote.
+    remote_file rfile(
+      remote.local(),
+      sharded_cache.local(),
+      bucket,
+      remote_path,
+      retry_node,
+      ss::sstring("log_prefix"));
+    for (int i = 0; i < 3; i++) {
+        auto hydrated_file = rfile.hydrate_readable_file().get();
+        auto cached_size = hydrated_file.size().get();
+        auto buf = hydrated_file.dma_read_bulk<char>(0, cached_size).get();
+        auto cached_body = ss::to_sstring(std::move(buf));
+        BOOST_REQUIRE_EQUAL(cached_body, body);
+        BOOST_REQUIRE_EQUAL(2, get_requests().size());
+    }
+
+    // Now invalidate the cache and try again.
+    sharded_cache.local()
+      .invalidate(std::filesystem::path{remote_path()})
+      .get();
+    auto hydrated_file = rfile.hydrate_readable_file().get();
+    auto cached_size = hydrated_file.size().get();
+    auto buf = hydrated_file.dma_read_bulk<char>(0, cached_size).get();
+    auto cached_body = ss::to_sstring(std::move(buf));
+    BOOST_REQUIRE_EQUAL(cached_body, body);
+    BOOST_REQUIRE_EQUAL(3, get_requests().size());
+}
+
+FIXTURE_TEST(test_missing_file, remote_file_fixture) {
+    retry_chain_node retry_node(never_abort, 100ms, 20ms);
+    const remote_segment_path remote_path{"remote_path"};
+    remote_file rfile(
+      remote.local(),
+      sharded_cache.local(),
+      bucket,
+      remote_path,
+      retry_node,
+      ss::sstring("log_prefix"));
+    BOOST_REQUIRE_EXCEPTION(
+      rfile.hydrate_readable_file().get(), download_exception, [](auto& e) {
+          ss::sstring what{e.what()};
+          return what.find("NotFound") != what.npos;
+      });
+}

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -10,6 +10,7 @@
  */
 
 #include "cloud_storage/async_manifest_view.h"
+#include "cloud_storage/download_exception.h"
 #include "cloud_storage/tests/cloud_storage_fixture.h"
 #include "cloud_storage/tests/s3_imposter.h"
 #include "cloud_storage/tests/util.h"

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -11,6 +11,7 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
+#include "cloud_storage/download_exception.h"
 #include "cloud_storage/materialized_resources.h"
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/partition_manifest.h"

--- a/src/v/cluster/cloud_metadata/key_utils.cc
+++ b/src/v/cluster/cloud_metadata/key_utils.cc
@@ -9,6 +9,7 @@
  */
 #include "cluster/cloud_metadata/key_utils.h"
 
+#include "cloud_storage/remote_segment.h"
 #include "cluster/cloud_metadata/types.h"
 #include "model/fundamental.h"
 #include "utils/uuid.h"
@@ -31,6 +32,14 @@ cloud_storage::remote_manifest_path cluster_manifest_key(
       "{}/{}/cluster_manifest.json",
       cluster_manifests_prefix(cluster_uuid),
       meta_id()));
+}
+
+cloud_storage::remote_segment_path controller_snapshot_key(
+  const model::cluster_uuid& cluster_uuid, const model::offset& offset) {
+    return cloud_storage::remote_segment_path(fmt::format(
+      "{}/{}/controller.snapshot",
+      cluster_uuid_prefix(cluster_uuid),
+      offset()));
 }
 
 ss::sstring cluster_metadata_prefix(

--- a/src/v/cluster/cloud_metadata/key_utils.h
+++ b/src/v/cluster/cloud_metadata/key_utils.h
@@ -24,9 +24,15 @@ ss::sstring cluster_uuid_prefix(const model::cluster_uuid&);
 // E.g. /cluster_metadata/<cluster_uuid>/manifests
 ss::sstring cluster_manifests_prefix(const model::cluster_uuid&);
 
+// E.g. /cluster_metadata/<cluster_uuid>/manifests/cluster_manifest.json
 cloud_storage::remote_manifest_path
 cluster_manifest_key(const model::cluster_uuid&, const cluster_metadata_id&);
 
+// E.g. /cluster_metadata/<cluster_uuid>/<offset>/controller.snapshot
+cloud_storage::remote_segment_path
+controller_snapshot_key(const model::cluster_uuid&, const model::offset&);
+
+// E.g. /cluster_metadata/<cluster_uuid>/<meta_id>
 ss::sstring
 cluster_metadata_prefix(const model::cluster_uuid&, const cluster_metadata_id&);
 

--- a/src/v/cluster/cloud_metadata/manifest_downloads.h
+++ b/src/v/cluster/cloud_metadata/manifest_downloads.h
@@ -39,4 +39,13 @@ ss::future<cluster_manifest_result> download_highest_manifest_for_cluster(
   const cloud_storage_clients::bucket_name& bucket,
   retry_chain_node& retry_node);
 
+// Returns keys with the cluster UUID prefix aren't referenced by the manifest
+// and can be safely deleted.
+ss::future<std::list<ss::sstring>> list_orphaned_by_manifest(
+  cloud_storage::remote& remote,
+  const model::cluster_uuid& cluster_uuid,
+  const cloud_storage_clients::bucket_name& bucket,
+  const cluster_metadata_manifest& manifest,
+  retry_chain_node& retry_node);
+
 } // namespace cluster::cloud_metadata

--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -10,15 +10,20 @@
 
 #include "archival/ntp_archiver_service.h"
 #include "cloud_storage/remote.h"
+#include "cloud_storage/remote_file.h"
 #include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/types.h"
 #include "cluster/cloud_metadata/cluster_manifest.h"
 #include "cluster/cloud_metadata/key_utils.h"
 #include "cluster/cloud_metadata/manifest_downloads.h"
 #include "cluster/cloud_metadata/uploader.h"
+#include "cluster/config_frontend.h"
+#include "cluster/controller_snapshot.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "redpanda/application.h"
 #include "redpanda/tests/fixture.h"
+#include "storage/snapshot.h"
 
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -38,6 +43,7 @@ public:
       : redpanda_thread_fixture(
         redpanda_thread_fixture::init_cloud_storage_tag{}, httpd_port_number())
       , raft0(app.partition_manager.local().get(model::controller_ntp)->raft())
+      , controller_stm(app.controller->get_controller_stm().local())
       , remote(app.cloud_storage_api.local())
       , bucket(cloud_storage_clients::bucket_name("test-bucket")) {
         set_expectations_and_listen({});
@@ -69,6 +75,7 @@ public:
 
 protected:
     cluster::consensus_ptr raft0;
+    cluster::controller_stm& controller_stm;
     cloud_storage::remote& remote;
     const cloud_storage_clients::bucket_name bucket;
     model::cluster_uuid cluster_uuid;
@@ -140,8 +147,12 @@ FIXTURE_TEST(test_upload_next_metadata, cluster_metadata_uploader_fixture) {
     auto& manifest = down_res.value();
     BOOST_REQUIRE_EQUAL(manifest.metadata_id, cluster_metadata_id{});
 
+    tests::cooperative_spin_wait_with_timeout(5s, [this] {
+        return controller_stm.maybe_write_snapshot();
+    }).get();
     // Uploading the first time should set the metadata ID to 0, and we should
     // increment from there.
+    ss::sstring first_controller_snapshot_path;
     for (int i = 0; i < 3; i++) {
         auto err = uploader
                      .upload_next_metadata(
@@ -149,8 +160,45 @@ FIXTURE_TEST(test_upload_next_metadata, cluster_metadata_uploader_fixture) {
                      .get();
         BOOST_REQUIRE_EQUAL(err, error_outcome::success);
         BOOST_REQUIRE_EQUAL(manifest.metadata_id, cluster_metadata_id(i));
+        if (first_controller_snapshot_path.empty()) {
+            first_controller_snapshot_path = manifest.controller_snapshot_path;
+        } else {
+            // After the first upload, the subsequent controller snapshots
+            // won't be changed, since no controller updates will have
+            // happened.
+            BOOST_REQUIRE_EQUAL(
+              manifest.controller_snapshot_path,
+              first_controller_snapshot_path);
+        }
     }
     BOOST_REQUIRE_EQUAL(manifest.metadata_id, cluster_metadata_id(2));
+
+    // Do a sanity check that we can read the controller.
+    BOOST_REQUIRE(!first_controller_snapshot_path.empty());
+    cloud_storage::remote_file remote_file(
+      remote,
+      app.shadow_index_cache.local(),
+      bucket,
+      cloud_storage::remote_segment_path(first_controller_snapshot_path),
+      retry_node,
+      "controller");
+
+    auto f = remote_file.hydrate_readable_file().get();
+    ss::file_input_stream_options options;
+    auto input = ss::make_file_input_stream(f, options);
+    storage::snapshot_reader reader(
+      std::move(f), std::move(input), remote_file.local_path());
+    auto close = ss::defer([&reader] { reader.close().get(); });
+
+    auto snap_metadata_buf = reader.read_metadata().get();
+    auto snap_metadata_parser = iobuf_parser(std::move(snap_metadata_buf));
+    auto snap_metadata = reflection::adl<raft::snapshot_metadata>{}.from(
+      snap_metadata_parser);
+    const size_t snap_size = reader.get_snapshot_size().get();
+    auto snap_buf_parser = iobuf_parser{
+      read_iobuf_exactly(reader.input(), snap_size).get()};
+    auto snapshot = serde::read<cluster::controller_snapshot>(snap_buf_parser);
+    BOOST_REQUIRE_EQUAL(snapshot.bootstrap.cluster_uuid, cluster_uuid);
 
     // We should see timeouts when appropriate; errors should still increment.
     retry_chain_node bad_retry_node(
@@ -176,6 +224,18 @@ FIXTURE_TEST(test_upload_next_metadata, cluster_metadata_uploader_fixture) {
 // Test that the upload fiber uploads monotonically increasing metadata, and
 // that the fiber stop when leadership changes.
 FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
+    tests::cooperative_spin_wait_with_timeout(5s, [this] {
+        return controller_stm.maybe_write_snapshot();
+    }).get();
+    const auto get_local_snap_offset = [&] {
+        auto snap = raft0->open_snapshot().get();
+        BOOST_REQUIRE(snap.has_value());
+        auto ret = snap->metadata.last_included_index;
+        snap->close().get();
+        return ret;
+    };
+    const auto snap_offset = get_local_snap_offset();
+
     config::shard_local_cfg()
       .cloud_storage_cluster_metadata_upload_interval_ms.set_value(1000ms);
     cluster::cloud_metadata::uploader uploader(
@@ -185,39 +245,65 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
     // Checks that metadata is uploaded a new term, stepping down in between
     // calls, and ensuring that subsequent calls yield manifests with higher
     // metadata IDs and the expected snapshot offset.
-    const auto check_uploads_in_term_and_stepdown = [&]() {
-        // Wait to become leader before uploading.
-        tests::cooperative_spin_wait_with_timeout(5s, [this] {
-            return raft0->is_leader();
-        }).get();
+    const auto check_uploads_in_term_and_stepdown =
+      [&](model::offset expected_snap_offset) {
+          // Wait to become leader before uploading.
+          tests::cooperative_spin_wait_with_timeout(5s, [this] {
+              return raft0->is_leader();
+          }).get();
 
-        // Start uploading in this term.
-        auto upload_in_term = uploader.upload_until_term_change();
-        auto defer = ss::defer([&] {
-            uploader.stop_and_wait().get();
-            upload_in_term.get();
-        });
+          // Start uploading in this term.
+          auto upload_in_term = uploader.upload_until_term_change();
+          auto defer = ss::defer([&] {
+              uploader.stop_and_wait().get();
+              try {
+                  upload_in_term.get();
+              } catch (...) {
+              }
+          });
 
-        // Keep checking the latest manifest for whether the metadata ID is
-        // some non-zero value (indicating we've uploaded multiple manifests);
-        auto initial_meta_id = highest_meta_id;
-        cluster::cloud_metadata::cluster_metadata_manifest manifest;
-        tests::cooperative_spin_wait_with_timeout(
-          10s,
-          [&]() -> ss::future<bool> {
-              return downloaded_manifest_has_higher_id(
-                initial_meta_id, &manifest);
-          })
-          .get();
-        BOOST_REQUIRE_GT(manifest.metadata_id, highest_meta_id);
-        highest_meta_id = manifest.metadata_id;
+          // Keep checking the latest manifest for whether the metadata ID is
+          // some non-zero value (indicating we've uploaded multiple manifests);
+          auto initial_meta_id = highest_meta_id;
+          cluster::cloud_metadata::cluster_metadata_manifest manifest;
+          tests::cooperative_spin_wait_with_timeout(
+            10s,
+            [&]() -> ss::future<bool> {
+                return downloaded_manifest_has_higher_id(
+                  initial_meta_id, &manifest);
+            })
+            .get();
+          BOOST_REQUIRE_GT(manifest.metadata_id, highest_meta_id);
+          highest_meta_id = manifest.metadata_id;
 
-        // Stop the upload loop and continue in a new term.
-        raft0->step_down("forced stepdown").get();
-        upload_in_term.get();
-        defer.cancel();
-    };
+          BOOST_REQUIRE_EQUAL(
+            manifest.controller_snapshot_offset, expected_snap_offset);
+
+          // Stop the upload loop and continue in a new term.
+          raft0->step_down("forced stepdown").get();
+          upload_in_term.get();
+          defer.cancel();
+      };
     for (int i = 0; i < 3; ++i) {
-        check_uploads_in_term_and_stepdown();
+        check_uploads_in_term_and_stepdown(snap_offset);
     }
+
+    // Now do some action and write a new snapshot.
+    tests::cooperative_spin_wait_with_timeout(5s, [this] {
+        return raft0->is_leader();
+    }).get();
+    auto result = app.controller->get_config_frontend()
+                    .local()
+                    .do_patch(
+                      cluster::config_update_request{
+                        .upsert = {{"cluster_id", "foo"}}},
+                      model::timeout_clock::now() + 5s)
+                    .get();
+    BOOST_REQUIRE(!result.errc);
+    tests::cooperative_spin_wait_with_timeout(5s, [this] {
+        return controller_stm.maybe_write_snapshot();
+    }).get();
+    const auto new_snap_offset = get_local_snap_offset();
+    BOOST_REQUIRE_NE(new_snap_offset, snap_offset);
+    check_uploads_in_term_and_stepdown(new_snap_offset);
 }

--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -24,6 +24,7 @@
 #include "redpanda/application.h"
 #include "redpanda/tests/fixture.h"
 #include "storage/snapshot.h"
+#include "test_utils/async.h"
 
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -169,18 +170,15 @@ FIXTURE_TEST(test_upload_next_metadata, cluster_metadata_uploader_fixture) {
       cluster_uuid, bucket, remote, raft0);
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::max(), 10ms);
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return raft0->is_leader();
-    }).get();
+    boost_require_eventually(5s, [this] { return raft0->is_leader(); });
     auto down_res
       = uploader.download_highest_manifest_or_create(retry_node).get();
     BOOST_REQUIRE(down_res.has_value());
     auto& manifest = down_res.value();
     BOOST_REQUIRE_EQUAL(manifest.metadata_id, cluster_metadata_id{});
 
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return controller_stm.maybe_write_snapshot();
-    }).get();
+    boost_require_eventually(
+      5s, [this] { return controller_stm.maybe_write_snapshot(); });
     // Uploading the first time should set the metadata ID to 0, and we should
     // increment from there.
     ss::sstring first_controller_snapshot_path;
@@ -255,9 +253,8 @@ FIXTURE_TEST(test_upload_next_metadata, cluster_metadata_uploader_fixture) {
 // Test that the upload fiber uploads monotonically increasing metadata, and
 // that the fiber stop when leadership changes.
 FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return controller_stm.maybe_write_snapshot();
-    }).get();
+    boost_require_eventually(
+      5s, [this] { return controller_stm.maybe_write_snapshot(); });
     const auto get_local_snap_offset = [&] {
         auto snap = raft0->open_snapshot().get();
         BOOST_REQUIRE(snap.has_value());
@@ -279,9 +276,7 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
     const auto check_uploads_in_term_and_stepdown =
       [&](model::offset expected_snap_offset) {
           // Wait to become leader before uploading.
-          tests::cooperative_spin_wait_with_timeout(5s, [this] {
-              return raft0->is_leader();
-          }).get();
+          boost_require_eventually(5s, [this] { return raft0->is_leader(); });
 
           // Start uploading in this term.
           auto upload_in_term = uploader.upload_until_term_change();
@@ -297,13 +292,10 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
           // some non-zero value (indicating we've uploaded multiple manifests);
           auto initial_meta_id = highest_meta_id;
           cluster::cloud_metadata::cluster_metadata_manifest manifest;
-          tests::cooperative_spin_wait_with_timeout(
-            10s,
-            [&]() -> ss::future<bool> {
-                return downloaded_manifest_has_higher_id(
-                  initial_meta_id, &manifest);
-            })
-            .get();
+          boost_require_eventually(10s, [&]() -> ss::future<bool> {
+              return downloaded_manifest_has_higher_id(
+                initial_meta_id, &manifest);
+          });
           BOOST_REQUIRE_GT(manifest.metadata_id, highest_meta_id);
           highest_meta_id = manifest.metadata_id;
 
@@ -320,9 +312,7 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
     }
 
     // Now do some action and write a new snapshot.
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return raft0->is_leader();
-    }).get();
+    boost_require_eventually(5s, [this] { return raft0->is_leader(); });
     auto result = app.controller->get_config_frontend()
                     .local()
                     .do_patch(
@@ -331,9 +321,8 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
                       model::timeout_clock::now() + 5s)
                     .get();
     BOOST_REQUIRE(!result.errc);
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return controller_stm.maybe_write_snapshot();
-    }).get();
+    boost_require_eventually(
+      5s, [this] { return controller_stm.maybe_write_snapshot(); });
     const auto new_snap_offset = get_local_snap_offset();
     BOOST_REQUIRE_NE(new_snap_offset, snap_offset);
     check_uploads_in_term_and_stepdown(new_snap_offset);
@@ -342,16 +331,13 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
 FIXTURE_TEST(
   test_upload_loop_deletes_orphans, cluster_metadata_uploader_fixture) {
     // Write a snapshot and begin the upload loop.
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return controller_stm.maybe_write_snapshot();
-    }).get();
+    boost_require_eventually(
+      5s, [this] { return controller_stm.maybe_write_snapshot(); });
     config::shard_local_cfg()
       .cloud_storage_cluster_metadata_upload_interval_ms.set_value(1000ms);
     cluster::cloud_metadata::uploader uploader(
       cluster_uuid, bucket, remote, raft0);
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return raft0->is_leader();
-    }).get();
+    boost_require_eventually(5s, [this] { return raft0->is_leader(); });
 
     auto upload_in_term = uploader.upload_until_term_change();
     auto defer = ss::defer([&] {
@@ -363,13 +349,13 @@ FIXTURE_TEST(
     });
     // Wait for some valid metadata to show up.
     cluster::cloud_metadata::cluster_metadata_manifest manifest;
-    tests::cooperative_spin_wait_with_timeout(5s, [this, &manifest] {
+    boost_require_eventually(5s, [this, &manifest] {
         return downloaded_manifest_has_higher_id(
           cluster::cloud_metadata::cluster_metadata_id{-1}, &manifest);
-    }).get();
-    tests::cooperative_spin_wait_with_timeout(5s, [this, &manifest] {
+    });
+    boost_require_eventually(5s, [this, &manifest] {
         return list_contains_manifest_contents(manifest);
-    }).get();
+    });
     // Now do something to trigger another controller snapshot.
     auto result = app.controller->get_config_frontend()
                     .local()
@@ -379,12 +365,11 @@ FIXTURE_TEST(
                       model::timeout_clock::now() + 5s)
                     .get();
     BOOST_REQUIRE(!result.errc);
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
-        return controller_stm.maybe_write_snapshot();
-    }).get();
+    boost_require_eventually(
+      5s, [this] { return controller_stm.maybe_write_snapshot(); });
 
     // The uploader should delete the stale manifest and snapshot.
-    tests::cooperative_spin_wait_with_timeout(5s, [this] {
+    boost_require_eventually(5s, [this] {
         auto& s3_reqs = get_requests();
         int num_deletes = 0;
         for (const auto& r : s3_reqs) {
@@ -393,5 +378,5 @@ FIXTURE_TEST(
             }
         }
         return num_deletes >= 2;
-    }).get();
+    });
 }

--- a/src/v/cluster/cloud_metadata/uploader.cc
+++ b/src/v/cluster/cloud_metadata/uploader.cc
@@ -21,6 +21,7 @@
 #include "raft/types.h"
 #include "ssx/future-util.h"
 #include "ssx/sleep_abortable.h"
+#include "storage/snapshot.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/fstream.hh>
@@ -92,7 +93,26 @@ ss::future<error_outcome> uploader::upload_next_metadata(
     } else {
         manifest.metadata_id = cluster_metadata_id(manifest.metadata_id() + 1);
     }
-    // TODO: upload cluster metadata.
+    // Set up an abort source for if there is a leadership change while
+    // we're uploading.
+    auto lazy_as = cloud_storage::lazy_abort_source{
+      [&, synced_term]() -> std::optional<ss::sstring> {
+          if (synced_term == _raft0->term()) {
+              return std::nullopt;
+          }
+          return std::make_optional(fmt::format(
+            "lost leadership or term changed: synced term {} vs "
+            "current term {}",
+            synced_term,
+            _raft0->term()));
+      },
+    };
+
+    auto upload_controller_errc = co_await maybe_upload_controller_snapshot(
+      manifest, lazy_as, retry_node);
+    if (upload_controller_errc != error_outcome::success) {
+        co_return upload_controller_errc;
+    }
 
     if (co_await term_has_changed(synced_term)) {
         co_return error_outcome::term_has_changed;
@@ -108,6 +128,94 @@ ss::future<error_outcome> uploader::upload_next_metadata(
           "Failed to upload cluster metadata manifest in term {}: {}",
           synced_term,
           upload_result);
+        co_return error_outcome::upload_failed;
+    }
+    co_return error_outcome::success;
+}
+
+ss::future<error_outcome> uploader::maybe_upload_controller_snapshot(
+  cluster_metadata_manifest& manifest,
+  cloud_storage::lazy_abort_source& lazy_as,
+  retry_chain_node& retry_node) {
+    auto controller_snap_file = co_await _raft0->open_snapshot_file();
+    if (!controller_snap_file.has_value()) {
+        // Nothing to upload; continue.
+        co_return error_outcome::success;
+    }
+    vlog(
+      clusterlog.trace,
+      "Local controller snapshot found at {}",
+      _raft0->get_snapshot_path());
+    auto reader = storage::snapshot_reader(
+      controller_snap_file.value(),
+      ss::make_file_input_stream(
+        *controller_snap_file, 0, co_await controller_snap_file->size()),
+      _raft0->get_snapshot_path());
+    model::offset local_last_included_offset;
+    std::exception_ptr err;
+    try {
+        auto snap_metadata_buf = co_await reader.read_metadata();
+        auto snap_parser = iobuf_parser(std::move(snap_metadata_buf));
+        auto snap_metadata = reflection::adl<raft::snapshot_metadata>{}.from(
+          snap_parser);
+        local_last_included_offset = snap_metadata.last_included_index;
+        vassert(
+          snap_metadata.last_included_index != model::offset{},
+          "Invalid offset for snapshot {}",
+          _raft0->get_snapshot_path());
+        vlog(
+          clusterlog.debug,
+          "Local controller snapshot at {} has last offset {}, current "
+          "snapshot offset in manifest {}",
+          _raft0->get_snapshot_path(),
+          local_last_included_offset,
+          manifest.controller_snapshot_offset);
+
+        if (
+          manifest.controller_snapshot_offset != model::offset{}
+          && local_last_included_offset
+               <= manifest.controller_snapshot_offset) {
+            // The cluster metadata manifest already contains a higher snapshot
+            // than what's local (e.g. uploaded by another controller replica).
+            // No need to do anything.
+            co_await reader.close();
+            co_return error_outcome::success;
+        }
+
+        // If we haven't uploaded a snapshot or the local snapshot is
+        // new, upload it.
+        cloud_storage::remote_segment_path remote_controller_snapshot_path{
+          controller_snapshot_key(_cluster_uuid, local_last_included_offset)};
+        auto upl_res = co_await _remote.upload_controller_snapshot(
+          _bucket,
+          remote_controller_snapshot_path,
+          controller_snap_file.value(),
+          retry_node,
+          lazy_as);
+        if (upl_res != cloud_storage::upload_result::success) {
+            vlog(
+              clusterlog.warn,
+              "Upload of controller snapshot failed: {}",
+              upl_res);
+            co_await reader.close();
+            co_return error_outcome::upload_failed;
+        }
+        manifest.controller_snapshot_path
+          = remote_controller_snapshot_path().string();
+        manifest.controller_snapshot_offset = local_last_included_offset;
+    } catch (...) {
+        err = std::current_exception();
+    }
+    co_await reader.close();
+    if (err) {
+        try {
+            std::rethrow_exception(err);
+        } catch (const std::exception& e) {
+            vlog(
+              clusterlog.warn,
+              "Upload of controller snapshot failed with exception: {}",
+              e.what());
+        }
         co_return error_outcome::upload_failed;
     }
     co_return error_outcome::success;

--- a/src/v/cluster/cloud_metadata/uploader.h
+++ b/src/v/cluster/cloud_metadata/uploader.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include "cloud_storage/remote.h"
 #include "cloud_storage_clients/types.h"
 #include "cluster/cloud_metadata/cluster_manifest.h"
 #include "cluster/types.h"
@@ -80,6 +81,17 @@ public:
     ss::future<error_outcome> upload_next_metadata(
       model::term_id synced_term,
       cluster_metadata_manifest& manifest,
+      retry_chain_node& retry_node);
+
+    // Uploads the controller snapshot if the local snapshot has a higher
+    // offset than that referenced by the manifest.
+    //
+    // Possible error results:
+    // - upload_failed: there was a physical error uploading to remote storage,
+    //   callers may retry with the resulting manifest in the same term.
+    ss::future<error_outcome> maybe_upload_controller_snapshot(
+      cluster_metadata_manifest& manifest,
+      cloud_storage::lazy_abort_source& lazy_as,
       retry_chain_node& retry_node);
 
 private:

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -120,6 +120,7 @@ public:
     ss::sharded<members_backend>& get_members_backend() {
         return _members_backend;
     }
+    ss::sharded<controller_stm>& get_controller_stm() { return _stm; }
 
     bool is_raft0_leader() const {
         vassert(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2377,6 +2377,10 @@ consensus::open_snapshot() {
     };
 }
 
+ss::future<std::optional<ss::file>> consensus::open_snapshot_file() const {
+    return _snapshot_mgr.open_snapshot_file();
+}
+
 ss::future<std::error_code> consensus::replicate_configuration(
   ssx::semaphore_units u, group_configuration cfg) {
     // under the _op_sem lock

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -217,6 +217,7 @@ public:
 
     // Open the current snapshot for reading (if present)
     ss::future<std::optional<opened_snapshot>> open_snapshot();
+    ss::future<std::optional<ss::file>> open_snapshot_file() const;
 
     std::filesystem::path get_snapshot_path() const {
         return _snapshot_mgr.snapshot_path();

--- a/src/v/storage/snapshot.h
+++ b/src/v/storage/snapshot.h
@@ -107,6 +107,8 @@ public:
       , _io_prio(io_prio) {}
 
     ss::future<std::optional<snapshot_reader>> open_snapshot(ss::sstring);
+    ss::future<std::optional<ss::file>>
+    open_snapshot_file(const ss::sstring&) const;
     ss::future<uint64_t> get_snapshot_size(ss::sstring);
 
     ss::future<snapshot_writer> start_snapshot(ss::sstring);
@@ -262,6 +264,10 @@ public:
 
     ss::future<std::optional<snapshot_reader>> open_snapshot() {
         return _snapshot.open_snapshot(_filename);
+    }
+
+    ss::future<std::optional<ss::file>> open_snapshot_file() const {
+        return _snapshot.open_snapshot_file(_filename);
     }
 
     ss::future<uint64_t> get_snapshot_size() {


### PR DESCRIPTION
This PR improves the metadata upload loop in a couple ways:
* We now upload the latest controller snapshot as a part of the loop. Some utilities are added to capture the the ss::file of the underlying snapshot, and upload ss::files to remote storage rather than going through segment or manifest APIs.
* We now clean up objects that are not referenced by the manifest. This allows us to ensure that over time, we don't accumulate a large number of snapshot files. As this is a destructive operation, this is gated by a linearizable barrier.

Along the way, this PR includes some ancillary changes:
- adds a couple APIs for interacting with the controller snapshot file
- templatizes the upload/download_segment methods to be reusable for non-segments
- adds a wrapper around a remote cacheable file, currently used in tests, but will be used in subsequent work when downloading controller snapshots

Related [#9552](https://github.com/redpanda-data/redpanda/issues/9552)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
