### PR TITLE
Split log::compat into compaction and gc primitives

### DIFF
--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -240,7 +240,7 @@ struct reupload_fixture : public archiver_fixture {
         auto size_before = seg_set.size();
 
         disk_log_impl()
-          ->compact(storage::compaction_config{
+          ->housekeeping(storage::housekeeping_config{
             model::timestamp::max(),
             std::nullopt,
             model::offset::max(),

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -631,7 +631,7 @@ FIXTURE_TEST(
 
     ss::abort_source as{};
     log
-      ->compact(storage::compaction_config(
+      ->housekeeping(storage::housekeeping_config(
         model::timestamp::now(),
         std::nullopt,
         model::offset::max(),

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -80,13 +80,13 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
 
     // Compact the local log to GC to the collectible offset.
     ss::abort_source as;
-    storage::compaction_config compaction_conf(
+    storage::housekeeping_config housekeeping_conf(
       model::timestamp::min(),
       1,
       log->stm_manager()->max_collectible_offset(),
       ss::default_priority_class(),
       as);
-    partition->log().compact(compaction_conf).get();
+    partition->log().housekeeping(housekeeping_conf).get();
     // NOTE: the storage layer only initially requests eviction; it relies on
     // Raft to write a snapshot and subsequently truncate.
     tests::cooperative_spin_wait_with_timeout(3s, [log] {

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -115,7 +115,7 @@ public:
         log->flush().get0();
         log->force_roll(ss::default_priority_class()).get0();
         ss::abort_source as{};
-        storage::compaction_config ccfg(
+        storage::housekeeping_config ccfg(
           model::timestamp::min(),
           std::nullopt,
           model::offset::max(),
@@ -124,7 +124,7 @@ public:
         // Compacts until a single sealed segment remains, other than the
         // currently active one.
         tests::cooperative_spin_wait_with_timeout(30s, [log, ccfg]() {
-            return log->compact(ccfg).then(
+            return log->housekeeping(ccfg).then(
               [log]() { return log->segment_count() == 2; });
         }).get();
 

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -537,7 +537,7 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
     info("Compacting log of node: {}", leader_id);
     retry_with_leader(gr, 5, 2s, [first_ts, &as](raft_node& n) {
         return n.log
-          ->compact(storage::compaction_config(
+          ->housekeeping(storage::housekeeping_config(
             first_ts,
             100_MiB,
             model::offset::max(),

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -58,7 +58,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
           [this] {
               for (auto& [_, n] : gr.get_members()) {
                   n.log
-                    ->compact(storage::compaction_config(
+                    ->housekeeping(storage::housekeeping_config(
                       retention_timestamp,
                       100_MiB,
                       model::offset::max(),

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -737,7 +737,7 @@ gc_config disk_log_impl::apply_overrides(gc_config defaults) const {
     return override_retention_config(ret);
 }
 
-ss::future<> disk_log_impl::compact(compaction_config cfg) {
+ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
     ss::gate::holder holder{_compaction_housekeeping_gate};
     vlog(
       gclog.trace,
@@ -752,7 +752,7 @@ ss::future<> disk_log_impl::compact(compaction_config cfg) {
     }
 
     if (config().is_compacted() && !_segs.empty()) {
-        co_await do_compact(cfg, new_start_offset);
+        co_await do_compact(cfg.compact, new_start_offset);
     }
 
     _probe.set_compaction_ratio(_compaction_ratio.get());

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1115,7 +1115,7 @@ ss::future<> disk_log_impl::maybe_roll(
     }
 }
 
-ss::future<> disk_log_impl::do_housekeeping() {
+ss::future<> disk_log_impl::apply_segment_ms() {
     auto gate = _compaction_housekeeping_gate.hold();
     // do_housekeeping races with maybe_roll to use new_segment.
     // take a lock to prevent problems

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1780,11 +1780,11 @@ log make_disk_backed_log(
     return log(ptr);
 }
 
-ss::future<usage_report> disk_log_impl::disk_usage(compaction_config cfg) {
+ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
     std::optional<model::offset> max_offset;
     if (config().is_collectable()) {
-        cfg.gc = apply_overrides(cfg.gc);
-        max_offset = retention_offset(cfg.gc);
+        cfg = apply_overrides(cfg);
+        max_offset = retention_offset(cfg);
     }
 
     /*

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -110,7 +110,7 @@ public:
 
     int64_t compaction_backlog() const final;
 
-    ss::future<usage_report> disk_usage(compaction_config);
+    ss::future<usage_report> disk_usage(gc_config);
 
 private:
     friend class disk_log_appender; // for multi-term appends

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -175,13 +175,13 @@ private:
     ss::future<>
     retention_adjust_timestamps(std::chrono::seconds ignore_in_future);
 
-    compaction_config apply_overrides(compaction_config) const;
+    gc_config apply_overrides(gc_config) const;
 
     storage_resources& resources();
 
     void wrote_stm_bytes(size_t);
 
-    compaction_config override_retention_config(compaction_config cfg) const;
+    gc_config override_retention_config(gc_config) const;
 
     bool is_cloud_retention_active() const;
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -136,7 +136,7 @@ private:
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_compaction_range(const compaction_config&);
-    ss::future<std::optional<model::offset>> gc(compaction_config);
+    ss::future<std::optional<model::offset>> gc(gc_config);
 
     ss::future<> remove_empty_segments();
 
@@ -167,8 +167,8 @@ private:
     // These methods search the log for the offset to evict at such that
     // the retention policy is satisfied. If no such offset is found
     // std::nullopt is returned.
-    std::optional<model::offset> size_based_gc_max_offset(compaction_config);
-    std::optional<model::offset> time_based_gc_max_offset(compaction_config);
+    std::optional<model::offset> size_based_gc_max_offset(gc_config);
+    std::optional<model::offset> time_based_gc_max_offset(gc_config);
 
     /// Conditionally adjust retention timestamp on any segment that appears
     /// to have invalid timestamps, to ensure retention can proceed.
@@ -185,7 +185,7 @@ private:
 
     bool is_cloud_retention_active() const;
 
-    std::optional<model::offset> retention_offset(compaction_config);
+    std::optional<model::offset> retention_offset(gc_config);
 
 private:
     size_t max_segment_size() const;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -73,6 +73,7 @@ public:
     ss::future<> truncate_prefix(truncate_prefix_config) final;
     ss::future<> housekeeping(housekeeping_config) final;
     ss::future<> apply_segment_ms() final;
+    ss::future<> gc(gc_config) final;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;
 
@@ -136,7 +137,7 @@ private:
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_compaction_range(const compaction_config&);
-    ss::future<std::optional<model::offset>> gc(gc_config);
+    ss::future<std::optional<model::offset>> do_gc(gc_config);
 
     ss::future<> remove_empty_segments();
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -71,7 +71,7 @@ public:
     ss::future<> flush() final;
     ss::future<> truncate(truncate_config) final;
     ss::future<> truncate_prefix(truncate_prefix_config) final;
-    ss::future<> compact(compaction_config) final;
+    ss::future<> housekeeping(housekeeping_config) final;
     ss::future<> apply_segment_ms() final;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -72,7 +72,7 @@ public:
     ss::future<> truncate(truncate_config) final;
     ss::future<> truncate_prefix(truncate_prefix_config) final;
     ss::future<> compact(compaction_config) final;
-    ss::future<> do_housekeeping() final override;
+    ss::future<> apply_segment_ms() final;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;
 

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -55,7 +55,7 @@ public:
 
         // TODO should compact be merged in this?
         // run housekeeping task, like rolling segments
-        virtual ss::future<> do_housekeeping() = 0;
+        virtual ss::future<> apply_segment_ms() = 0;
 
         virtual ss::future<model::record_batch_reader>
           make_reader(log_reader_config) = 0;
@@ -176,7 +176,7 @@ public:
 
     ss::future<> compact(compaction_config cfg) { return _impl->compact(cfg); }
 
-    ss::future<> housekeeping() { return _impl->do_housekeeping(); }
+    ss::future<> apply_segment_ms() { return _impl->apply_segment_ms(); }
     /**
      * \brief Returns a future that resolves when log eviction is scheduled
      *

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -52,6 +52,7 @@ public:
         virtual ss::future<> housekeeping(housekeeping_config) = 0;
         virtual ss::future<> truncate(truncate_config) = 0;
         virtual ss::future<> truncate_prefix(truncate_prefix_config) = 0;
+        virtual ss::future<> gc(gc_config) = 0;
 
         // TODO should compact be merged in this?
         // run housekeeping task, like rolling segments
@@ -177,6 +178,8 @@ public:
     ss::future<> housekeeping(housekeeping_config cfg) {
         return _impl->housekeeping(cfg);
     }
+
+    ss::future<> gc(gc_config cfg) { return _impl->gc(cfg); }
 
     ss::future<> apply_segment_ms() { return _impl->apply_segment_ms(); }
     /**

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -49,7 +49,7 @@ public:
 
         // it shouldn't block for a long time as it will block other logs
         // eviction
-        virtual ss::future<> compact(compaction_config) = 0;
+        virtual ss::future<> housekeeping(housekeeping_config) = 0;
         virtual ss::future<> truncate(truncate_config) = 0;
         virtual ss::future<> truncate_prefix(truncate_prefix_config) = 0;
 
@@ -174,7 +174,9 @@ public:
         return _impl->timequery(cfg);
     }
 
-    ss::future<> compact(compaction_config cfg) { return _impl->compact(cfg); }
+    ss::future<> housekeeping(housekeeping_config cfg) {
+        return _impl->housekeeping(cfg);
+    }
 
     ss::future<> apply_segment_ms() { return _impl->apply_segment_ms(); }
     /**

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -210,12 +210,19 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         co_return;
     }
 
-    // TODO handle this after compaction?
-    // handle segment.ms sequentially, since compaction is already sequential
-    // when this will be unified with compaction, the whole task could be made
-    // concurrent
+    /*
+     * Apply segment ms will roll the active segment if it is old enough. This
+     * is best done prior to running gc or compaction because it ensures that
+     * an inactive partition eventually makes data in its most recent segment
+     * eligible for these housekeeping processes.
+     *
+     * TODO:
+     *   handle this after compaction? handle segment.ms sequentially, since
+     *   compaction is already sequential when this will be unified with
+     *   compaction, the whole task could be made concurrent
+     */
     for (auto& log_meta : _logs_list) {
-        co_await log_meta.handle.housekeeping();
+        co_await log_meta.handle.apply_segment_ms();
     }
 
     for (auto& log_meta : _logs_list) {

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -636,12 +636,8 @@ ss::future<usage_report> log_manager::disk_usage() {
       logs.end(),
       [this, collection_threshold](log l) {
           auto log = dynamic_cast<disk_log_impl*>(l.get_impl());
-          return log->disk_usage(compaction_config(
-            collection_threshold,
-            _config.retention_bytes(),
-            l.stm_manager()->max_collectible_offset(),
-            _config.compaction_priority,
-            _abort_source));
+          return log->disk_usage(
+            gc_config(collection_threshold, _config.retention_bytes()));
       },
       usage_report{},
       [](usage_report acc, usage_report update) { return acc + update; });

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -244,7 +244,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
 
         auto ntp_sanitizer_cfg = _config.maybe_get_ntp_sanitizer_config(
           current_log.handle.config().ntp());
-        co_await current_log.handle.compact(compaction_config(
+        co_await current_log.handle.housekeeping(housekeeping_config(
           collection_threshold,
           _config.retention_bytes(),
           current_log.handle.stm_manager()->max_collectible_offset(),

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -503,7 +503,7 @@ struct compact_op final : opfuzz::op {
     ~compact_op() noexcept override = default;
     const char* name() const final { return "compact_op"; }
     ss::future<> invoke(opfuzz::op_context ctx) final {
-        compaction_config cfg(
+        housekeeping_config cfg(
           model::timestamp::max(),
           std::nullopt,
           model::offset::max(),
@@ -520,7 +520,7 @@ struct compact_op final : opfuzz::op {
           ctx.log->config().ntp(),
           cfg,
           *ctx.log);
-        return ctx.log->compact(cfg);
+        return ctx.log->housekeeping(cfg);
     }
 };
 

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -511,8 +511,8 @@ struct compact_op final : opfuzz::op {
           *(ctx._as),
           storage::ntp_sanitizer_config{.sanitize_only = true});
         if (random_generators::get_int(0, 100) > 70) {
-            cfg.eviction_time = model::timestamp::now();
-            cfg.max_bytes = 10_MiB;
+            cfg.gc.eviction_time = model::timestamp::now();
+            cfg.gc.max_bytes = 10_MiB;
         }
         vlog(
           fuzzlogger.info,

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -356,7 +356,7 @@ FIXTURE_TEST(
     // garbadge collect first append series
     ss::abort_source as;
     log
-      .compact(compaction_config(
+      .housekeeping(housekeeping_config(
         ts,
         std::nullopt,
         model::offset::max(),
@@ -536,7 +536,7 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     // for the log eviction stm with an offset until which
     // to evict. The test does not listen for the notification,
     // so this call is basically a no-op.
-    auto f1 = log.compact(compaction_config(
+    auto f1 = log.housekeeping(housekeeping_config(
       ts,
       std::nullopt,
       model::offset::max(),

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -71,11 +71,11 @@ void validate_offsets(
 }
 
 void compact_and_prefix_truncate(
-  storage::disk_log_impl& log, storage::compaction_config cfg) {
+  storage::disk_log_impl& log, storage::housekeeping_config cfg) {
     ss::abort_source as;
     auto eviction_future = log.monitor_eviction(as);
 
-    log.compact(cfg).get();
+    log.housekeeping(cfg).get();
 
     if (eviction_future.available()) {
         auto evict_until = eviction_future.get();
@@ -528,19 +528,19 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
      * [100..110][200..230][231..261]
      */
 
-    storage::compaction_config ccfg_no_compact(
+    storage::housekeeping_config ccfg_no_compact(
       model::timestamp(200),
       std::nullopt,
       model::offset::min(), // should prevent compaction
       ss::default_priority_class(),
       as);
     auto before = log.offsets();
-    log.compact(ccfg_no_compact).get0();
+    log.housekeeping(ccfg_no_compact).get0();
     auto after = log.offsets();
     BOOST_REQUIRE_EQUAL(after.start_offset, before.start_offset);
 
     auto make_compaction_cfg = [&as](int timestamp) {
-        return storage::compaction_config(
+        return storage::housekeeping_config(
           model::timestamp(timestamp),
           std::nullopt,
           model::offset::max(),
@@ -612,7 +612,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
 
     // Set the max number of bytes to the total size of the log.
     // This will prevent compaction.
-    storage::compaction_config ccfg_no_compact(
+    storage::housekeeping_config ccfg_no_compact(
       model::timestamp::min(),
       total_size + first_size,
       model::offset::max(),
@@ -641,7 +641,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
         last_offset = seg->offsets().dirty_offset;
     }
 
-    storage::compaction_config ccfg(
+    storage::housekeeping_config ccfg(
       model::timestamp::min(),
       max_size,
       model::offset::max(),
@@ -708,22 +708,22 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       10,
       model::term_id(0),
       custom_ts_batch_generator(model::timestamp(gc_ts() + 10)));
-    storage::compaction_config ccfg(
+    storage::housekeeping_config ccfg(
       gc_ts,
       std::nullopt,
       model::offset::max(),
       ss::default_priority_class(),
       as);
 
-    log.compact(ccfg).get0();
+    log.housekeeping(ccfg).get0();
 
     auto offset = last_evicted_offset.get_future().get0();
-    log.compact(ccfg).get0();
+    log.housekeeping(ccfg).get0();
     auto lstats_after = log.offsets();
 
     BOOST_REQUIRE_EQUAL(lstats_before.start_offset, lstats_after.start_offset);
     // wait for compaction
-    log.compact(ccfg).get0();
+    log.housekeeping(ccfg).get0();
     log
       .truncate_prefix(storage::truncate_prefix_config{
         model::next_offset(offset), ss::default_priority_class()})
@@ -817,13 +817,13 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
     int appends = 100;
     int batches_per_append = 5;
     auto compact = [log, &as]() mutable {
-        storage::compaction_config ccfg(
+        storage::housekeeping_config ccfg(
           model::timestamp::min(),
           1000,
           model::offset::max(),
           ss::default_priority_class(),
           as);
-        return log.compact(ccfg);
+        return log.housekeeping(ccfg);
     };
 
     auto append =
@@ -998,7 +998,7 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
     storage::ntp_config ntp_cfg(
       ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov));
 
-    storage::compaction_config compaction_cfg(
+    storage::housekeeping_config compaction_cfg(
       model::timestamp::min(),
       1,
       model::offset::max(),
@@ -1009,7 +1009,7 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
     auto offsets_after_recovery = log.offsets();
     info("After recovery: {}", log);
     // trigger compaction
-    log.compact(compaction_cfg).get0();
+    log.housekeeping(compaction_cfg).get0();
     auto offsets_after_compact = log.offsets();
     info("After compaction, offsets: {}, {}", offsets_after_compact, log);
 
@@ -1159,7 +1159,7 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
         // append some batches to first segment (all batches have the same key)
         append_single_record_batch(log, 14, model::term_id(1));
 
-        storage::compaction_config c_cfg(
+        storage::housekeeping_config c_cfg(
           model::timestamp::min(),
           std::nullopt,
           model::offset::max(),
@@ -1179,7 +1179,7 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
         // roll segment
         append_single_record_batch(log, 1, model::term_id(8));
         // compact log
-        log.compact(c_cfg).get0();
+        log.housekeeping(c_cfg).get0();
     }
 
     // force recovery
@@ -1224,7 +1224,7 @@ FIXTURE_TEST(
     // append some batches to first segment (all batches have the same key)
     append_single_record_batch(log, 14, model::term_id(1));
 
-    storage::compaction_config c_cfg(
+    storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
@@ -1243,7 +1243,7 @@ FIXTURE_TEST(
 
     // segment should be rolled after truncation
     BOOST_REQUIRE_EQUAL(log.segment_count(), 2);
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
 
     auto read = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read.begin()->base_offset(), model::offset(6));
@@ -1411,7 +1411,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
       lstats_before.committed_offset, model::offset{input_batch_count - 1});
     BOOST_REQUIRE_EQUAL(lstats_before.start_offset, model::offset{0});
 
-    storage::compaction_config ccfg(
+    storage::housekeeping_config ccfg(
       model::timestamp::min(),
       50_KiB,
       model::offset::max(),
@@ -1520,37 +1520,37 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
-    storage::compaction_config c_cfg(
+    storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
       ss::default_priority_class(),
       as);
 
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     // Self compactions complete.
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
     // Check if it honors max_compactible offset by resetting it to the base
     // offset of first segment. Nothing should be compacted.
     const auto first_segment_offsets = disk_log->segments().front()->offsets();
-    c_cfg.max_collectible_offset = first_segment_offsets.base_offset;
-    log.compact(c_cfg).get0();
+    c_cfg.compact.max_collectible_offset = first_segment_offsets.base_offset;
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
     // reset
-    c_cfg.max_collectible_offset = model::offset::max();
+    c_cfg.compact.max_collectible_offset = model::offset::max();
 
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 
     // no change since we can't combine with appender segment
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 }
 
@@ -1588,30 +1588,30 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
-    storage::compaction_config c_cfg(
+    storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
       ss::default_priority_class(),
       as);
 
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
     // the two segments with term 2 can be combined
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     // no more pairs with the same term
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     for (int i = 0; i < 5; i++) {
@@ -1665,7 +1665,7 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
-    storage::compaction_config c_cfg(
+    storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
@@ -1673,28 +1673,28 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
       as);
 
     // self compaction steps
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
     // the first two segments are combined 2+2=4 < 6 MB
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     // the new first and second are too big 4+5 > 6 MB but the second and third
     // can be combined 5 + 15KB < 6 MB
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
     // then the next 16 KB can be folded in
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 
     // that's all that can be done. the next seg is an appender
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 }
 
@@ -1865,7 +1865,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
-    storage::compaction_config c_cfg(
+    storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
@@ -1887,10 +1887,10 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
         + 2 * segments[2]->size_bytes() + segments[3]->size_bytes()
         + self_seg_compaction_sz);
     // self compaction steps
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
     auto new_backlog_size = log.compaction_backlog();
@@ -2175,7 +2175,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 
-    storage::compaction_config c_cfg(
+    storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
@@ -2183,8 +2183,8 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
       as);
 
     // self compaction steps
-    log.compact(c_cfg).get0();
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
 
     // read all batches
     auto first_read = read_and_validate_all_batches(log);
@@ -2404,7 +2404,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 
-    storage::compaction_config c_cfg(
+    storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
@@ -2414,7 +2414,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(before_compaction.size(), 3);
     // compact
-    log.compact(c_cfg).get0();
+    log.housekeeping(c_cfg).get0();
     auto after_compaction = compact_in_memory(log);
 
     BOOST_REQUIRE(before_compaction == after_compaction);
@@ -2632,7 +2632,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                      [&] { return done; },
                      [&log, &as] {
                          return log
-                           .compact(storage::compaction_config(
+                           .housekeeping(storage::housekeeping_config(
                              model::timestamp::min(),
                              std::nullopt,
                              model::offset::max(),
@@ -2726,7 +2726,7 @@ FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
             .get();
 
           log
-            .compact(storage::compaction_config(
+            .housekeeping(storage::housekeeping_config(
               model::timestamp::min(),
               std::nullopt,
               model::offset::max(),
@@ -2859,13 +2859,13 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
     auto pre_compact_gaps = analyze(*disk_log);
     disk_log->force_roll(ss::default_priority_class()).get();
     auto max_compact_offset = first_stats.committed_offset;
-    storage::compaction_config ccfg(
+    storage::housekeeping_config ccfg(
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       max_compact_offset,
       ss::default_priority_class(),
       as);
-    log.compact(ccfg).get0();
+    log.housekeeping(ccfg).get0();
     auto final_stats = log.offsets();
     auto post_compact_gaps = analyze(*disk_log);
 
@@ -2923,7 +2923,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
     log.flush().get0();
 
     disk_log->force_roll(ss::default_priority_class()).get();
-    storage::compaction_config ccfg(
+    storage::housekeeping_config ccfg(
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       model::offset::max(),
@@ -2934,7 +2934,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
                     ->offset_data_stream(
                       model::offset(0), ss::default_priority_class())
                     .get();
-    log.compact(std::move(ccfg)).get();
+    log.housekeeping(std::move(ccfg)).get();
     stream.close().get();
 };
 
@@ -2977,14 +2977,14 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
                == linear_int_kv_batch_generator::records_per_batch;
     }));
 
-    storage::compaction_config ccfg(
+    storage::housekeeping_config ccfg(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
       ss::default_priority_class(),
       as);
 
-    log.compact(ccfg).get();
+    log.housekeeping(ccfg).get();
 
     batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(
@@ -3062,13 +3062,13 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     BOOST_REQUIRE_EQUAL(pre_gaps.num_gaps, 0);
     tlog.info("pre-compact stats: {}, analysis: {}", pre_stats, pre_gaps);
 
-    storage::compaction_config ccfg(
+    storage::housekeeping_config ccfg(
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       model::offset(args.max_compact_offs),
       ss::default_priority_class(),
       as);
-    log.compact(ccfg).get0();
+    log.housekeeping(ccfg).get0();
     auto final_stats = log.offsets();
     auto final_gaps = analyze(*disk_log);
     tlog.info("post-compact stats: {}, analysis: {}", final_stats, final_gaps);
@@ -3308,7 +3308,7 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
 
         compact_and_prefix_truncate(
           *disk_log,
-          storage::compaction_config(
+          storage::housekeeping_config(
             model::timestamp::min(),
             cfg.retention_bytes(),
             model::offset::max(),
@@ -3486,7 +3486,7 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
 
     BOOST_REQUIRE_EQUAL(log.segment_count(), 2);
 
-    compaction_config cfg{
+    housekeeping_config cfg{
       model::timestamp::max(),
       1,
       model::offset::max(),
@@ -3512,7 +3512,7 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
     auto& first_seg = log.segments().front();
     BOOST_REQUIRE_EQUAL(first_seg->finished_self_compaction(), false);
 
-    b.apply_compaction(cfg, *new_start_offset).get();
+    b.apply_compaction(cfg.compact, *new_start_offset).get();
 
     BOOST_REQUIRE_EQUAL(first_seg->finished_self_compaction(), false);
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3496,7 +3496,7 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
     // Call into `disk_log_impl::gc` and listen for the eviction
     // notification being created.
     auto eviction_future = log.monitor_eviction(abs);
-    auto new_start_offset = b.apply_retention(cfg).get();
+    auto new_start_offset = b.apply_retention(cfg.gc).get();
     BOOST_REQUIRE(new_start_offset);
 
     BOOST_REQUIRE_EQUAL(log.segment_count(), 2);

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -140,12 +140,8 @@ ss::future<> disk_log_builder::gc(
 ss::future<usage_report> disk_log_builder::disk_usage(
   model::timestamp collection_upper_bound,
   std::optional<size_t> max_partition_retention_size) {
-    return get_disk_log_impl().disk_usage(compaction_config(
-      collection_upper_bound,
-      max_partition_retention_size,
-      model::offset::max(),
-      ss::default_priority_class(),
-      _abort_source));
+    return get_disk_log_impl().disk_usage(
+      gc_config(collection_upper_bound, max_partition_retention_size));
 }
 
 ss::future<std::optional<model::offset>>

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -146,7 +146,7 @@ ss::future<usage_report> disk_log_builder::disk_usage(
 
 ss::future<std::optional<model::offset>>
 disk_log_builder::apply_retention(gc_config cfg) {
-    return get_disk_log_impl().gc(cfg);
+    return get_disk_log_impl().do_gc(cfg);
 }
 
 ss::future<> disk_log_builder::apply_compaction(

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -145,8 +145,8 @@ ss::future<usage_report> disk_log_builder::disk_usage(
 }
 
 ss::future<std::optional<model::offset>>
-disk_log_builder::apply_retention(compaction_config cfg) {
-    return get_disk_log_impl().gc(cfg.gc);
+disk_log_builder::apply_retention(gc_config cfg) {
+    return get_disk_log_impl().gc(cfg);
 }
 
 ss::future<> disk_log_builder::apply_compaction(

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -117,7 +117,7 @@ ss::future<> disk_log_builder::gc(
     auto eviction_future = get_log().monitor_eviction(as);
 
     get_log()
-      .compact(compaction_config(
+      .housekeeping(housekeeping_config(
         collection_upper_bound,
         max_partition_retention_size,
         model::offset::max(),

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -150,7 +150,7 @@ ss::future<usage_report> disk_log_builder::disk_usage(
 
 ss::future<std::optional<model::offset>>
 disk_log_builder::apply_retention(compaction_config cfg) {
-    return get_disk_log_impl().gc(cfg);
+    return get_disk_log_impl().gc(cfg.gc);
 }
 
 ss::future<> disk_log_builder::apply_compaction(

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -306,8 +306,7 @@ public:
     ss::future<usage_report> disk_usage(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);
-    ss::future<std::optional<model::offset>>
-    apply_retention(compaction_config cfg);
+    ss::future<std::optional<model::offset>> apply_retention(gc_config cfg);
     ss::future<> apply_compaction(
       compaction_config cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -165,12 +165,16 @@ std::ostream& operator<<(std::ostream& os, const gc_config& cfg) {
 std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
     fmt::print(
       o,
-      "{{gc:{}, max_collectible_offset:{}, "
+      "{{max_collectible_offset:{}, "
       "should_sanitize:{}}}",
-      c.gc,
       c.max_collectible_offset,
       c.sanitizer_config);
     return o;
+}
+
+std::ostream& operator<<(std::ostream& os, const housekeeping_config& cfg) {
+    fmt::print(os, "{{compact:{}, gc:{}}}", cfg.compact, cfg.gc);
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& o, const compaction_result& r) {

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -153,13 +153,21 @@ std::ostream& operator<<(std::ostream& o, const offset_stats& s) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& os, const gc_config& cfg) {
+    fmt::print(
+      os,
+      "{{eviction_time:{}, max_bytes:{}}}",
+      cfg.eviction_time,
+      cfg.max_bytes.value_or(-1));
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
     fmt::print(
       o,
-      "{{evicition_time:{}, max_bytes:{}, max_collectible_offset:{}, "
+      "{{gc:{}, max_collectible_offset:{}, "
       "should_sanitize:{}}}",
-      c.eviction_time,
-      c.max_bytes.value_or(-1),
+      c.gc,
       c.max_collectible_offset,
       c.sanitizer_config);
     return o;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -339,6 +339,10 @@ struct log_reader_config {
 };
 
 struct gc_config {
+    gc_config(model::timestamp upper, std::optional<size_t> max_bytes_in_log)
+      : eviction_time(upper)
+      , max_bytes(max_bytes_in_log) {}
+
     // remove everything below eviction time
     model::timestamp eviction_time;
     // remove one segment if log is > max_bytes
@@ -355,10 +359,7 @@ struct compaction_config {
       ss::io_priority_class p,
       ss::abort_source& as,
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt)
-      : gc({
-        .eviction_time = upper,
-        .max_bytes = max_bytes_in_log,
-      })
+      : gc(upper, max_bytes_in_log)
       , max_collectible_offset(max_collect_offset)
       , iopc(p)
       , sanitizer_config(std::move(san_cfg))


### PR DESCRIPTION
This is a non-functional refactor that renames log::compat -> log::housekeeping, which is a combination of compaction and gc/retention processes. The PR then exposes the gc/retention primitive as a public interface that allows it to be invoked separately from compaction in the case of low-disk space situations in which quickly reclaiming space is important.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

