### PR TITLE
topic_manifest: added operator==

### DIFF
--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -61,6 +61,8 @@ public:
         return _topic_config;
     }
 
+    bool operator==(const topic_manifest& other) const = default;
+
 private:
     /// Update manifest content from json document that supposed to be generated
     /// from manifest.json file

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -132,8 +132,10 @@ struct manifest_topic_configuration {
         std::optional<size_t> segment_size;
         tristate<size_t> retention_bytes{std::nullopt};
         tristate<std::chrono::milliseconds> retention_duration{std::nullopt};
+        bool operator==(const topic_properties& other) const = default;
     };
     topic_properties properties;
+    bool operator==(const manifest_topic_configuration& other) const = default;
 };
 
 struct segment_meta {


### PR DESCRIPTION
this adds topic_manifest::operator==. previously
topic_manfiest inherited base_manifest::operator==, enabling a wrong
equality check.

base_manifest::operator== is removed to prevent similar problems

base_manifest is an empty abstract class that had a defaulted
operator==. being empty, the operator returns always true.

derived classes partition_manfest and tx_range_manifest reimplement
operator== so it's not an issue, but topic_manifest did not and so it
inherits a wrong operation. this operation is used in units tests, so
the results were somewhat falsified.

topic_manfiest::operator== can't be defaulted without a
base_manifest::operator== and requires also manifest_topic_configuration::operator== (defaulted).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
 * none