### PR TITLE
Support chunk based readers in tiered storage read path

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -23,6 +23,7 @@ v_cc_library(
     recovery_request.cc
     recovery_utils.cc
     segment_meta_cstore.cc
+    segment_chunk.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -24,6 +24,8 @@ v_cc_library(
     recovery_utils.cc
     segment_meta_cstore.cc
     segment_chunk.cc
+    segment_chunk_api.cc
+    segment_chunk_data_source.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -924,7 +924,7 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
             batch_keys.emplace_back(segment_path);
             tx_batch_keys.emplace_back(
               tx_range_manifest(segment_path).get_manifest_path());
-            index_keys.emplace_back(generate_remote_index_path(segment_path));
+            index_keys.emplace_back(generate_index_path(segment_path));
         }
 
         vlog(

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -16,6 +16,7 @@
 #include "cloud_storage/partition_probe.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_segment_index.h"
+#include "cloud_storage/segment_chunk_api.h"
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/types.h"
 #include "model/fundamental.h"
@@ -36,7 +37,7 @@
 namespace cloud_storage {
 
 std::filesystem::path
-generate_remote_index_path(const cloud_storage::remote_segment_path& p);
+generate_index_path(const cloud_storage::remote_segment_path& p);
 
 static constexpr size_t remote_segment_sampling_step_bytes = 64_KiB;
 
@@ -104,16 +105,37 @@ public:
     /// create an input stream _sharing_ the underlying file handle
     /// starting at position @pos
     ss::future<input_stream_with_offsets> offset_data_stream(
-      kafka::offset kafka_offset,
+      kafka::offset start,
+      kafka::offset end,
       std::optional<model::timestamp>,
       ss::io_priority_class);
 
-    /// Hydrate the segment
+    /// Hydrate the segment for segment meta version v2 or lower. For v3 or
+    /// higher, only hydrate the index. If the index hydration fails, fall back
+    /// to old mode where the full segment is hydrated. For v3 or higher
+    /// versions, the actual segment data is hydrated by the data source
+    /// implementation, but the index is still required to be present first.
     ss::future<> hydrate();
+
+    /// Hydrate a part of a segment, identified by the given start and end
+    /// offsets. If the end offset is std::nullopt, the last offset in the file
+    /// is used as the end offset.
+    ss::future<> hydrate_chunk(
+      chunk_start_offset_t start, std::optional<chunk_start_offset_t> end);
+
+    /// Loads the segment chunk file from cache into an open file handle. If the
+    /// file is not present in cache, the returned file handle is unopened.
+    ss::future<ss::file> materialize_chunk(chunk_start_offset_t);
 
     retry_chain_node* get_retry_chain_node() { return &_rtc; }
 
-    bool download_in_progress() const noexcept { return !_wait_list.empty(); }
+    bool download_in_progress() const noexcept {
+        if (is_legacy_mode_engaged()) {
+            return !_wait_list.empty();
+        } else {
+            return _chunks_api->downloads_in_progress();
+        }
+    }
 
     /// Return aborted transactions metadata associated with the segment
     ///
@@ -127,6 +149,22 @@ public:
     }
 
     bool is_stopped() const { return _stopped; }
+
+    uint64_t max_hydrated_chunks() const;
+
+    /// Given a kafka offset, determines the starting offset of the chunk it
+    /// lies in. The precondition is that coarse index must have been hydrated.
+    /// The returned start offset is guaranteed to be the start of a batch. If
+    /// the coarse index is empty (which may happen when the remote segment is
+    /// smaller than chunk size), offset 0 is returned.
+    chunk_start_offset_t
+    get_chunk_start_for_kafka_offset(kafka::offset koff) const;
+
+    const offset_index::coarse_index_t& get_coarse_index() const;
+
+    bool is_fallback_engaged() const {
+        return _fallback_mode == fallback_mode::yes;
+    }
 
 private:
     /// get a file offset for the corresponding kafka offset
@@ -154,6 +192,11 @@ private:
 
     ss::future<uint64_t> put_segment_in_cache(uint64_t, ss::input_stream<char>);
 
+    /// Stores a segment chunk in cache. The chunk is stored in a path derived
+    /// from the segment path: <segment_path>_chunks/chunk_start_file_offset.
+    ss::future<uint64_t> put_chunk_in_cache(
+      uint64_t, ss::input_stream<char>, chunk_start_offset_t chunk_start);
+
     /// Hydrate tx manifest. Method downloads the manifest file to the cache
     /// dir.
     ss::future<> do_hydrate_txrange();
@@ -169,12 +212,31 @@ private:
     /// Load segment index from file (if available)
     ss::future<bool> maybe_materialize_index();
 
+    std::filesystem::path
+    get_path_to_chunk(chunk_start_offset_t chunk_start) const {
+        return _chunk_root / fmt::format("{}", chunk_start);
+    }
+
+    /// Decides if the remote segment should download the full segment as part
+    /// of the hydration process. This is true if we are working with a segment
+    /// format older than v3 or we are in fallback mode. In newer formats we
+    /// download chunks of the segment instead of the entire segment file.
+    bool is_legacy_mode_engaged() const;
+
+    /// Is the remote segment state materialized, IE do we need to hydrate or
+    /// not. For segment format v0, v1 and v2, the data file handle should be
+    /// opened. For newer formats, v3 or later, the index should be
+    /// materialized.
+    bool is_state_materialized() const;
+
     ss::gate _gate;
     remote& _api;
     cache& _cache;
     cloud_storage_clients::bucket_name _bucket;
     const model::ntp& _ntp;
     remote_segment_path _path;
+    std::filesystem::path _index_path;
+    std::filesystem::path _chunk_root;
 
     model::term_id _term;
     model::offset _base_rp_offset;
@@ -207,6 +269,16 @@ private:
     bool _stopped{false};
 
     segment_name_format _sname_format;
+
+    using fallback_mode = ss::bool_class<struct fallback_mode_tag>;
+    fallback_mode _fallback_mode{fallback_mode::no};
+
+    uint64_t _max_hydrated_chunks{0};
+    uint64_t _chunk_size{0};
+    uint64_t _chunks_in_segment{1};
+
+    std::optional<segment_chunks> _chunks_api;
+    std::optional<offset_index::coarse_index_t> _coarse_index;
 };
 
 class remote_segment_batch_consumer;
@@ -354,6 +426,8 @@ struct hydration_loop_state {
       hydrate_action_t h,
       materialize_action_t m,
       hydration_request::kind path_kind);
+
+    void remove_request(const std::filesystem::path& p);
 
     ss::future<> update_current_path_states();
 

--- a/src/v/cloud_storage/remote_segment_index.cc
+++ b/src/v/cloud_storage/remote_segment_index.cc
@@ -10,10 +10,10 @@
 
 #include "cloud_storage/remote_segment_index.h"
 
+#include "cloud_storage/logger.h"
 #include "model/record_batch_types.h"
 #include "serde/envelope.h"
 #include "serde/serde.h"
-#include "vlog.h"
 
 namespace cloud_storage {
 
@@ -203,6 +203,13 @@ offset_index::build_coarse_index(uint64_t step_size) const {
             auto curr_fpos = *it;
             auto crossed_step_sz = curr_fpos % step_size;
             if (crossed_step_sz < curr_mod_step_sz) {
+                vlog(
+                  cst_log.trace,
+                  "adding entry to coarse index, current file pos: {}, step "
+                  "size: {}, curr mod step size: {}",
+                  curr_fpos,
+                  step_size,
+                  curr_mod_step_sz);
                 index[kafka::offset{*kit}] = curr_fpos;
             }
             curr_mod_step_sz = crossed_step_sz;

--- a/src/v/cloud_storage/segment_chunk.cc
+++ b/src/v/cloud_storage/segment_chunk.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/segment_chunk.h"
+
+namespace cloud_storage {
+
+std::strong_ordering
+segment_chunk::operator<=>(const segment_chunk& chunk) const {
+    const auto cmp = required_by_readers_in_future
+                     <=> chunk.required_by_readers_in_future;
+    if (cmp != std::strong_ordering::equal) {
+        return cmp;
+    }
+
+    // A low required_after_n_chunks means the chunk is required sooner than the
+    // other chunk. However the default value of required_after_n_chunks is 0
+    // which can erroneously win in sorting by appearing lowest, so if one of
+    // the two compared numbers is 0 and the other is not, the non zero number
+    // must win.
+
+    const auto required_this = required_after_n_chunks > 0
+                                 ? required_after_n_chunks
+                                 : std::numeric_limits<uint64_t>::max();
+    const auto required_that = chunk.required_after_n_chunks > 0
+                                 ? chunk.required_after_n_chunks
+                                 : std::numeric_limits<uint64_t>::max();
+    return required_that <=> required_this;
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/segment_chunk.h
+++ b/src/v/cloud_storage/segment_chunk.h
@@ -1,0 +1,69 @@
+
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/expiring_fifo.hh>
+#include <seastar/core/file.hh>
+
+namespace storage {
+struct log_reader_config;
+}
+
+namespace cloud_storage {
+
+using chunk_start_offset_t = uint64_t;
+
+enum class chunk_state {
+    not_available,
+    download_in_progress,
+    hydrated,
+};
+
+struct segment_chunk {
+    chunk_state current_state;
+
+    // Handle to chunk data file. Shared among all readers. Put behind an
+    // optional to preserve safety when evicting a chunk. When a chunk is no
+    // longer used by any reader and has a low enough score to evict, its
+    // handle is first removed from the struct before closing, so that any new
+    // readers asking to hydrate the chunk at the same time do not get a closed
+    // file handle due to race.
+    using handle_t = ss::lw_shared_ptr<ss::file>;
+    std::optional<handle_t> handle;
+
+    // Keeps track of the number of readers which will require the chunk in
+    // future, after they have read their current chunk. For example if a
+    // reader's fetch config spans chunks [4,10], then while it is reading chunk
+    // 4, it should increment this count for all the readers [5,10]. This helps
+    // the eviction process decide which chunks are not required soon.
+    uint64_t required_by_readers_in_future{0};
+
+    // How soon does a reader require this chunk after it is done reading the
+    // current chunk. For example given a reader with fetch config [4,10] it
+    // requires chunk 5 first and chunk 10 last after it is done reading
+    // chunk 4. So it sets incrementing required_after_n_chunks values into each
+    // chunk [5,10]. Helps to break ties if two chunks have the same number of
+    // required_by_readers_in_future, the chunk with this field lower is more
+    // urgently required.
+    uint64_t required_after_n_chunks{0};
+
+    // List of readers waiting to hydrate this chunk. The first reader starts
+    // hydration and the others wait for the hydration to finish.
+    using expiry_handler = std::function<void(ss::promise<handle_t>&)>;
+    ss::expiring_fifo<ss::promise<handle_t>, expiry_handler> waiters;
+
+    std::strong_ordering operator<=>(const segment_chunk&) const;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/segment_chunk_api.h"
+
+#include "cloud_storage/logger.h"
+#include "cloud_storage/remote_segment.h"
+#include "utils/gate_guard.h"
+
+namespace {
+constexpr auto cache_backoff_duration = 5s;
+constexpr auto eviction_duration = 10s;
+
+ss::future<cloud_storage::segment_chunk::handle_t> add_waiter_to_chunk(
+  cloud_storage::chunk_start_offset_t chunk_start,
+  cloud_storage::segment_chunk& chunk) {
+    ss::promise<cloud_storage::segment_chunk::handle_t> p;
+    auto f = p.get_future();
+    chunk.waiters.push_back(std::move(p), ss::lowres_clock::time_point::max());
+
+    using cloud_storage::cst_log;
+    vlog(
+      cst_log.trace,
+      "hydrate request added to waiters for chunk id {}, current waiter "
+      "size: {}",
+      chunk_start,
+      chunk.waiters.size());
+    return f;
+}
+
+} // namespace
+
+namespace cloud_storage {
+
+void expiry_handler_impl(ss::promise<segment_chunk::handle_t>& pr) {
+    pr.set_exception(ss::timed_out_error());
+}
+
+segment_chunks::segment_chunks(
+  remote_segment& segment, uint64_t max_hydrated_chunks)
+  : _segment(segment)
+  , _cache_backoff_jitter(cache_backoff_duration)
+  , _eviction_jitter(eviction_duration)
+  , _rtc{_as}
+  , _ctxlog(cst_log, _rtc, _segment.get_segment_path()().native())
+  , _max_hydrated_chunks{max_hydrated_chunks} {}
+
+ss::future<> segment_chunks::start() {
+    if (_started) {
+        return ss::now();
+    }
+
+    _started = true;
+
+    const auto& ix = _segment.get_coarse_index();
+
+    // The first chunk starts at offset 0, whereas the first entry in the coarse
+    // index will be after that. Adding the first chunk independently covers
+    // corner cases such as where segment is smaller than chunk. Since chunk 0
+    // is always populated, in these cases it covers the full segment, and
+    // hydrating it hydrates the entire segment file.
+    _chunks[0] = segment_chunk{
+      .current_state = chunk_state::not_available,
+      .handle = std::nullopt,
+      .required_by_readers_in_future = 0,
+      .required_after_n_chunks = 0,
+      .waiters = {expiry_handler_impl}};
+
+    for (const auto& [koff, file_offset] : ix) {
+        vlog(
+          _ctxlog.trace,
+          "adding chunk metadata at file offset: {} [kafka offset {}]",
+          file_offset,
+          koff);
+        _chunks[file_offset] = segment_chunk{
+          .current_state = chunk_state::not_available,
+          .handle = std::nullopt,
+          .required_by_readers_in_future = 0,
+          .required_after_n_chunks = 0,
+          .waiters = {expiry_handler_impl}};
+    }
+
+    _eviction_timer.set_callback(
+      [this] { ssx::background = trim_chunk_files(); });
+    _eviction_timer.rearm(_eviction_jitter());
+    return ss::now();
+}
+
+ss::future<> segment_chunks::stop() {
+    vlog(_ctxlog.debug, "stopping segment_chunks");
+    _eviction_timer.cancel();
+    if (!_as.abort_requested()) {
+        _as.request_abort();
+    }
+
+    co_await _gate.close();
+    vlog(_ctxlog.debug, "stopped segment_chunks");
+}
+
+bool segment_chunks::downloads_in_progress() const {
+    return std::any_of(_chunks.begin(), _chunks.end(), [](const auto& entry) {
+        return entry.second.current_state == chunk_state::download_in_progress;
+    });
+}
+
+ss::future<ss::file>
+segment_chunks::do_hydrate_and_materialize(chunk_start_offset_t chunk_start) {
+    gate_guard g{_gate};
+    vassert(_started, "chunk API is not started");
+
+    auto it = _chunks.find(chunk_start);
+    std::optional<chunk_start_offset_t> chunk_end = std::nullopt;
+    if (auto next = std::next(it); next != _chunks.end()) {
+        chunk_end = next->first - 1;
+    }
+
+    co_await _segment.hydrate_chunk(chunk_start, chunk_end);
+    co_return co_await _segment.materialize_chunk(chunk_start);
+}
+
+ss::future<segment_chunk::handle_t>
+segment_chunks::hydrate_chunk(chunk_start_offset_t chunk_start) {
+    gate_guard g{_gate};
+    vassert(_started, "chunk API is not started");
+
+    vassert(
+      _chunks.contains(chunk_start),
+      "No chunk starting at offset {}, cannot hydrate",
+      chunk_start);
+
+    auto& chunk = _chunks[chunk_start];
+    auto curr_state = chunk.current_state;
+    if (curr_state == chunk_state::hydrated) {
+        vassert(
+          chunk.handle,
+          "chunk state is hydrated without data file for id {}",
+          chunk_start);
+        co_return chunk.handle.value();
+    }
+
+    // If a download is already in progress, subsequent callers to hydrate are
+    // added to a wait list, and notified when the download finishes.
+    if (curr_state == chunk_state::download_in_progress) {
+        co_return co_await add_waiter_to_chunk(chunk_start, chunk);
+    }
+
+    // Download is not in progress. Set the flag and begin download attempt.
+    try {
+        chunk.current_state = chunk_state::download_in_progress;
+
+        // Keep retrying if materialization fails.
+        bool done = false;
+        while (!done) {
+            auto handle = co_await do_hydrate_and_materialize(chunk_start);
+            if (handle) {
+                done = true;
+                chunk.handle = ss::make_lw_shared(std::move(handle));
+            } else {
+                vlog(
+                  _ctxlog.trace,
+                  "do_hydrate_and_materialize failed for chunk start offset {}",
+                  chunk_start);
+                co_await ss::sleep_abortable(
+                  _cache_backoff_jitter.next_jitter_duration(), _as);
+            }
+        }
+    } catch (const std::exception& ex) {
+        chunk.current_state = chunk_state::not_available;
+        while (!chunk.waiters.empty()) {
+            chunk.waiters.front().set_to_current_exception();
+            chunk.waiters.pop_front();
+        }
+        throw;
+    }
+
+    vassert(
+      chunk.handle.has_value(),
+      "hydrate loop ended without materializing chunk handle for id {}",
+      chunk_start);
+    auto handle = chunk.handle.value();
+    chunk.current_state = chunk_state::hydrated;
+
+    while (!chunk.waiters.empty()) {
+        chunk.waiters.front().set_value(handle);
+        chunk.waiters.pop_front();
+    }
+
+    co_return handle;
+}
+
+ss::future<> segment_chunks::trim_chunk_files() {
+    gate_guard g{_gate};
+    vassert(_started, "chunk API is not started");
+
+    vlog(_ctxlog.trace, "starting chunk trim");
+
+    std::vector<chunk_map_t::iterator> to_release;
+    uint64_t hydrated_chunks = 0;
+    for (auto it = _chunks.begin(); it != _chunks.end(); ++it) {
+        const auto& metadata = it->second;
+        if (metadata.current_state == chunk_state::hydrated) {
+            hydrated_chunks += 1;
+            if (metadata.handle.has_value() && metadata.handle->owned()) {
+                to_release.push_back(it);
+            }
+        }
+    }
+
+    bool need_trim = hydrated_chunks > _max_hydrated_chunks;
+    vlog(
+      _ctxlog.trace,
+      "{} hydrated chunks, need trim: {}",
+      hydrated_chunks,
+      need_trim);
+    if (!need_trim) {
+        co_return;
+    }
+
+    std::sort(
+      to_release.begin(),
+      to_release.end(),
+      [](const auto& it_a, const auto& it_b) {
+          return it_a->second <=> it_b->second == std::strong_ordering::less;
+      });
+
+    std::vector<ss::lw_shared_ptr<ss::file>> files_to_close;
+    files_to_close.reserve(to_release.size());
+
+    // The files to close are first moved out of chunks and into a vector. This
+    // is necessary to make sure that the chunks are no longer able to use the
+    // file handle about to be closed before a scheduling point. If the file
+    // handles are closed in this loop, because the close operation is
+    // a scheduling point, it is possible that a chunk may get its file handle
+    // acquired by a reader while it is waiting to be closed.
+    for (auto& it : to_release) {
+        if (hydrated_chunks <= _max_hydrated_chunks) {
+            break;
+        }
+
+        vlog(
+          _ctxlog.trace,
+          "marking chunk starting at offset {} for release, pending for "
+          "release: {} chunks",
+          it->first,
+          hydrated_chunks - _max_hydrated_chunks);
+        files_to_close.push_back(std::move(it->second.handle.value()));
+        it->second.handle = std::nullopt;
+        it->second.current_state = chunk_state::not_available;
+        hydrated_chunks -= 1;
+    }
+
+    std::vector<ss::future<>> fs;
+    fs.reserve(files_to_close.size());
+
+    for (auto& f : files_to_close) {
+        fs.push_back(f->close());
+    }
+
+    auto close_results = co_await ss::when_all(fs.begin(), fs.end());
+    for (const auto& result : close_results) {
+        if (result.failed()) {
+            vlog(
+              _ctxlog.warn,
+              "failed to close a chunk file handle during eviction");
+        }
+    }
+
+    _eviction_timer.rearm(_eviction_jitter());
+}
+
+void segment_chunks::register_readers(
+  chunk_start_offset_t first, chunk_start_offset_t last) {
+    vassert(_started, "chunk API is not started");
+
+    if (last <= first) {
+        // If working with a single chunk, there are no future readers.
+        return;
+    }
+
+    auto start = _chunks.find(first);
+    vassert(
+      start != _chunks.end(), "No chunk found starting at first: {}", first);
+
+    auto end = _chunks.find(last);
+    vassert(end != _chunks.end(), "No chunk found starting at last: {}", last);
+
+    auto required_after = 1;
+    end = std::next(end);
+    for (auto it = start; it != end; ++required_after, ++it) {
+        auto& chunk = it->second;
+        chunk.required_by_readers_in_future += 1;
+        chunk.required_after_n_chunks += required_after;
+    }
+}
+
+void segment_chunks::mark_acquired_and_update_stats(
+  chunk_start_offset_t first, chunk_start_offset_t last) {
+    vassert(_started, "chunk API is not started");
+
+    auto start = _chunks.find(first);
+    auto end = _chunks.find(last);
+
+    vassert(
+      start != _chunks.end(), "No chunk found starting at first: {}", first);
+    vassert(end != _chunks.end(), "No chunk found starting at last: {}", last);
+
+    start->second.required_by_readers_in_future -= 1;
+
+    end = std::next(end);
+    for (auto it = start; it != end; ++it) {
+        it->second.required_after_n_chunks -= 1;
+    }
+}
+
+segment_chunk& segment_chunks::get(chunk_start_offset_t chunk_start) {
+    vassert(_started, "chunk API is not started");
+
+    vassert(
+      _chunks.contains(chunk_start),
+      "chunk start {} is not present in metadata",
+      chunk_start);
+    return _chunks[chunk_start];
+}
+
+chunk_start_offset_t
+segment_chunks::get_next_chunk_start(chunk_start_offset_t f) const {
+    vassert(_chunks.contains(f), "No chunk found starting at {}", f);
+    auto it = _chunks.find(f);
+    auto next = std::next(it);
+    vassert(next != _chunks.end(), "No chunk found after {}", f);
+    return next->first;
+}
+
+segment_chunks::iterator_t segment_chunks::begin() { return _chunks.begin(); }
+
+segment_chunks::iterator_t segment_chunks::end() { return _chunks.end(); }
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/segment_chunk.h"
+#include "random/simple_time_jitter.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/gate.hh>
+
+#include <absl/container/btree_map.h>
+
+namespace cloud_storage {
+
+class remote_segment;
+
+class segment_chunks {
+    using chunk_map_t = absl::btree_map<chunk_start_offset_t, segment_chunk>;
+
+public:
+    explicit segment_chunks(
+      remote_segment& segment, uint64_t max_hydrated_chunks);
+
+    segment_chunks(const segment_chunks&) = delete;
+    segment_chunks& operator=(const segment_chunks&) = delete;
+    segment_chunks(segment_chunks&&) = delete;
+    segment_chunks& operator=(segment_chunks&&) = delete;
+    virtual ~segment_chunks() = default;
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    bool downloads_in_progress() const;
+
+    // Hydrates the given chunk id. The remote segment object is used for
+    // hydration. The waiters are managed per chunk in `segment_chunk::waiters`.
+    // The first reader to request hydration queues the download. The next
+    // readers are added to wait list.
+    ss::future<segment_chunk::handle_t>
+    hydrate_chunk(chunk_start_offset_t chunk_start);
+
+    // For all chunks between first and last, increment the
+    // required_by_readers_in_future value by one, and increment the
+    // required_after_n_chunks values with progressively larger values to denote
+    // how far in future the chunk will be required.
+    void
+    register_readers(chunk_start_offset_t first, chunk_start_offset_t last);
+
+    // Mark the first chunk id as acquired by decrementing its
+    // required_by_readers_in_future count, and decrement the
+    // required_after_n_chunks counts for everything from [first, last] by one.
+    // A chunk with required_by_readers_in_future count 0 which does not share
+    // its handle with any data source is eligible for trimming.
+    void mark_acquired_and_update_stats(
+      chunk_start_offset_t first, chunk_start_offset_t last);
+
+    // Returns reference to metadata for chunk for given chunk id
+    segment_chunk& get(chunk_start_offset_t);
+
+    chunk_start_offset_t get_next_chunk_start(chunk_start_offset_t f) const;
+
+    using iterator_t = chunk_map_t::iterator;
+    iterator_t begin();
+    iterator_t end();
+
+private:
+    // Attempts to download chunk into cache and return the file handle for
+    // segment_chunk. Should be retried if there is a failure due to cache
+    // eviction between download and opening the file handle.
+    ss::future<ss::file>
+    do_hydrate_and_materialize(chunk_start_offset_t chunk_start);
+
+    // Periodically closes chunk file handles for the space to be reclaimable by
+    // cache eviction. The chunks are evicted when they are no longer opened for
+    // reading by any readers. We also take into account any readers that may
+    // need a chunk soon when evicting, by sorting on
+    // `segment_chunk::required_by_readers_in_future` and
+    // `segment_chunk::required_after_n_chunks` values.
+    ss::future<> trim_chunk_files();
+
+    chunk_map_t _chunks;
+    remote_segment& _segment;
+
+    simple_time_jitter<ss::lowres_clock> _cache_backoff_jitter;
+
+    simple_time_jitter<ss::lowres_clock> _eviction_jitter;
+    ss::timer<ss::lowres_clock> _eviction_timer;
+
+    ss::abort_source _as;
+    ss::gate _gate;
+
+    bool _started{false};
+
+    retry_chain_node _rtc;
+    retry_chain_logger _ctxlog;
+
+    uint64_t _max_hydrated_chunks;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/segment_chunk_data_source.cc
+++ b/src/v/cloud_storage/segment_chunk_data_source.cc
@@ -1,0 +1,135 @@
+
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/segment_chunk_data_source.h"
+
+#include "cloud_storage/remote_segment.h"
+#include "utils/gate_guard.h"
+
+namespace cloud_storage {
+
+chunk_data_source_impl::chunk_data_source_impl(
+  segment_chunks& chunks,
+  remote_segment& segment,
+  kafka::offset start,
+  kafka::offset end,
+  int64_t begin_stream_at,
+  ss::file_input_stream_options stream_options)
+  : _chunks(chunks)
+  , _segment(segment)
+  , _first_chunk_start(_segment.get_chunk_start_for_kafka_offset(start))
+  , _last_chunk_start(_segment.get_chunk_start_for_kafka_offset(end))
+  , _begin_stream_at{begin_stream_at - _first_chunk_start}
+  , _current_chunk_start(_first_chunk_start)
+  , _stream_options(std::move(stream_options))
+  , _rtc{_as}
+  , _ctxlog{cst_log, _rtc, _segment.get_segment_path()().native()} {
+    vlog(
+      _ctxlog.trace,
+      "chunk data source initialized with file position {} to {}",
+      _first_chunk_start,
+      _last_chunk_start);
+    _chunks.register_readers(_current_chunk_start, _last_chunk_start);
+}
+
+chunk_data_source_impl::~chunk_data_source_impl() {
+    vassert(
+      !_current_stream.has_value(),
+      "stream not closed before destroying data source");
+    vlog(_ctxlog.debug, "chunk data source destroyed");
+}
+
+ss::future<ss::temporary_buffer<char>> chunk_data_source_impl::get() {
+    gate_guard g{_gate};
+
+    if (!_current_stream) {
+        co_await load_stream_for_chunk(_current_chunk_start);
+        vassert(
+          _current_stream.has_value(),
+          "cannot read without stream for segment {}, current chunk id: {}",
+          _segment.get_segment_path(),
+          _current_chunk_start);
+    }
+
+    auto buf = co_await _current_stream->read();
+    while (buf.empty() && _current_chunk_start < _last_chunk_start) {
+        _current_chunk_start = _chunks.get_next_chunk_start(
+          _current_chunk_start);
+        co_await load_stream_for_chunk(_current_chunk_start);
+        buf = co_await _current_stream->read();
+    }
+
+    co_return buf;
+}
+
+ss::future<> chunk_data_source_impl::load_stream_for_chunk(
+  chunk_start_offset_t chunk_start) {
+    vlog(_ctxlog.debug, "loading stream for chunk starting at {}", chunk_start);
+
+    _current_data_file
+      = co_await _chunks.hydrate_chunk(chunk_start)
+          .handle_exception([this, chunk_start](const std::exception_ptr& ex) {
+              vlog(
+                _ctxlog.error,
+                "failed to hydrate chunk starting at {}, error: {}",
+                chunk_start,
+                ex);
+
+              auto maybe_close_stream = ss::now();
+              if (_current_stream) {
+                  maybe_close_stream = _current_stream->close().then(
+                    [this] { _current_stream = std::nullopt; });
+              }
+
+              return maybe_close_stream.then([ex] {
+                  return ss::make_exception_future<segment_chunk::handle_t>(ex);
+              });
+          });
+
+    // Decrement the required_by_readers_in_future count by 1, we have acquired
+    // the file handle here. Once we are done with this handle, if it is not
+    // shared with any other data source, it should be eligible for trimming.
+    _chunks.mark_acquired_and_update_stats(
+      _current_chunk_start, _last_chunk_start);
+
+    if (_current_stream) {
+        co_await _current_stream->close();
+    }
+
+    // The first read of the data source begins at _begin_stream_at. This is
+    // necessary because the remote segment reader which uses this data source
+    // sets a delta before reading, and the remote segment consumer which
+    // consumes data from this source expects all offsets to be below the delta.
+    // Setting the appropriate start offset on the file stream makes sure that
+    // we do not break that assertion.
+    uint64_t begin = 0;
+    if (_current_chunk_start == _first_chunk_start) {
+        begin = _begin_stream_at;
+    }
+    vlog(
+      _ctxlog.trace,
+      "creating stream for chunk at {}, begin at {}",
+      _current_chunk_start,
+      begin);
+
+    _current_stream = ss::make_file_input_stream(
+      *_current_data_file, begin, _stream_options);
+}
+
+ss::future<> chunk_data_source_impl::close() {
+    co_await _gate.close();
+    if (_current_stream) {
+        co_await _current_stream->close();
+        _current_stream = std::nullopt;
+    }
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -1,0 +1,70 @@
+
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/segment_chunk_api.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/fstream.hh>
+#include <seastar/core/iostream.hh>
+
+namespace cloud_storage {
+
+class chunk_data_source_impl final : public ss::data_source_impl {
+public:
+    chunk_data_source_impl(
+      segment_chunks& chunks,
+      remote_segment& segment,
+      kafka::offset start,
+      kafka::offset end,
+      int64_t begin_stream_at,
+      ss::file_input_stream_options stream_options);
+
+    chunk_data_source_impl(const chunk_data_source_impl&) = delete;
+    chunk_data_source_impl& operator=(const chunk_data_source_impl&) = delete;
+    chunk_data_source_impl(chunk_data_source_impl&&) = delete;
+    chunk_data_source_impl& operator=(chunk_data_source_impl&&) = delete;
+
+    ~chunk_data_source_impl() override;
+
+    ss::future<ss::temporary_buffer<char>> get() override;
+
+    ss::future<> close() override;
+
+private:
+    // Acquires the file handle for the given chunk, then opens a file stream
+    // into it. The stream for the first chunk starts at the reader config start
+    // offset, and the stream for the last chunk ends at the reader config last
+    // offset.
+    ss::future<> load_stream_for_chunk(chunk_start_offset_t chunk_start);
+
+    segment_chunks& _chunks;
+    remote_segment& _segment;
+
+    chunk_start_offset_t _first_chunk_start;
+    chunk_start_offset_t _last_chunk_start;
+    uint64_t _begin_stream_at;
+
+    chunk_start_offset_t _current_chunk_start;
+    std::optional<ss::input_stream<char>> _current_stream{};
+
+    ss::lw_shared_ptr<ss::file> _current_data_file;
+    ss::file_input_stream_options _stream_options;
+
+    ss::gate _gate;
+
+    ss::abort_source _as;
+    retry_chain_node _rtc;
+    retry_chain_logger _ctxlog;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -10,7 +10,8 @@ rp_test(
     tx_range_manifest_test.cc
     remote_segment_index_test.cc
     recovery_request_test.cc
-    segment_meta_cstore_test.cc 
+    segment_meta_cstore_test.cc
+    segment_chunk_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cloud_storage v::storage_test_utils v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -393,7 +393,11 @@ FIXTURE_TEST(test_download_segment_range, remote_fixture) {
     iobuf_parser p(std::move(downloaded));
     auto actual = p.read_string(p.bytes_left());
 
-    BOOST_REQUIRE_EQUAL(actual, manifest_payload);
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      actual.begin(),
+      actual.end(),
+      manifest_payload.begin(),
+      manifest_payload.begin() + 2);
     BOOST_REQUIRE(subscription.available());
     BOOST_REQUIRE(
       subscription.get() == api_activity_notification::segment_upload);

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/base_manifest.h"
+#include "cloud_storage_clients/client.h"
 #include "config/configuration.h"
 #include "http/tests/registered_urls.h"
 
@@ -106,3 +107,5 @@ public:
         config::shard_local_cfg().cloud_storage_enabled.set_value(false);
     }
 };
+
+cloud_storage_clients::http_byte_range parse_byte_header(std::string_view s);

--- a/src/v/cloud_storage/tests/segment_chunk_test.cc
+++ b/src/v/cloud_storage/tests/segment_chunk_test.cc
@@ -9,11 +9,18 @@
  */
 
 #include "cloud_storage/segment_chunk.h"
+#include "cloud_storage/segment_chunk_api.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
+using namespace cloud_storage;
+
+namespace {
+ss::logger test_log("test");
+}
+
 SEASTAR_THREAD_TEST_CASE(test_chunk_ordering) {
-    std::vector<cloud_storage::segment_chunk> chunks{};
+    std::vector<segment_chunk> chunks{};
 
     // Primary ordering is on readers waiting, higher values are more important.
     chunks.push_back(
@@ -61,4 +68,142 @@ SEASTAR_THREAD_TEST_CASE(test_chunk_ordering) {
         BOOST_REQUIRE_EQUAL(expected, chunk.required_after_n_chunks);
         expected -= 1;
     }
+}
+
+auto make_chunks(size_t n = 10) {
+    segment_chunks::chunk_map_t chunks;
+    auto handle = ss::make_lw_shared(ss::file{});
+    for (auto i = 0; i < n; ++i) {
+        chunks.insert({i, segment_chunk{.handle = handle}});
+    }
+    return chunks;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_eager_chunk_eviction) {
+    class eager_chunk_eviction_strategy_test final
+      : public eager_chunk_eviction_strategy {
+    public:
+        size_t evicted;
+
+    protected:
+        ss::future<> close_files(
+          std::vector<ss::lw_shared_ptr<ss::file>> files_to_close,
+          retry_chain_logger& rtc) override {
+            evicted = files_to_close.size();
+            co_return;
+        }
+    };
+
+    auto chunks = make_chunks();
+    std::vector<segment_chunks::chunk_map_t::iterator> to_evict;
+    for (auto it = chunks.begin(); it != chunks.end(); ++it) {
+        to_evict.push_back(it);
+    }
+
+    auto st = eager_chunk_eviction_strategy_test{};
+    ss::abort_source as;
+    retry_chain_node rtc{as};
+    retry_chain_logger l{test_log, rtc};
+    st.evict(to_evict, l).get();
+    BOOST_REQUIRE_EQUAL(st.evicted, chunks.size());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_capped_chunk_eviction) {
+    class capped_chunk_eviction_strategy_test final
+      : public capped_chunk_eviction_strategy {
+    public:
+        capped_chunk_eviction_strategy_test(
+          uint64_t max_chunks, uint64_t hydrated)
+          : capped_chunk_eviction_strategy{max_chunks, hydrated} {}
+        size_t evicted;
+
+    protected:
+        ss::future<> close_files(
+          std::vector<ss::lw_shared_ptr<ss::file>> files_to_close,
+          retry_chain_logger& rtc) override {
+            evicted = files_to_close.size();
+            co_return;
+        }
+    };
+
+    auto chunks = make_chunks();
+    std::vector<segment_chunks::chunk_map_t::iterator> to_evict;
+    for (auto it = chunks.begin(); it != chunks.end(); ++it) {
+        to_evict.push_back(it);
+    }
+
+    size_t max = 5;
+    size_t hydrated = 9;
+    auto st = capped_chunk_eviction_strategy_test{max, hydrated};
+    ss::abort_source as;
+    retry_chain_node rtc{as};
+    retry_chain_logger l{test_log, rtc};
+    st.evict(to_evict, l).get();
+    BOOST_REQUIRE_EQUAL(st.evicted, hydrated - max);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_predictive_chunk_eviction) {
+    class predictive_chunk_eviction_strategy_test final
+      : public predictive_chunk_eviction_strategy {
+    public:
+        predictive_chunk_eviction_strategy_test(
+          uint64_t max_chunks, uint64_t hydrated)
+          : predictive_chunk_eviction_strategy{max_chunks, hydrated} {}
+        size_t evicted;
+
+    protected:
+        ss::future<> close_files(
+          std::vector<ss::lw_shared_ptr<ss::file>> files_to_close,
+          retry_chain_logger& rtc) override {
+            evicted = files_to_close.size();
+            co_return;
+        }
+    };
+
+    segment_chunks::chunk_map_t chunks;
+    auto handle = ss::make_lw_shared(ss::file{});
+    chunks.insert(
+      {0,
+       segment_chunk{
+         .current_state = chunk_state::hydrated,
+         .handle = handle,
+         .required_by_readers_in_future = 0,
+         .required_after_n_chunks = 0}});
+    chunks.insert(
+      {1,
+       segment_chunk{
+         .current_state = chunk_state::hydrated,
+         .handle = handle,
+         .required_by_readers_in_future = 1,
+         .required_after_n_chunks = 0}});
+    chunks.insert(
+      {2,
+       segment_chunk{
+         .current_state = chunk_state::hydrated,
+         .handle = handle,
+         .required_by_readers_in_future = 2,
+         .required_after_n_chunks = 0}});
+
+    std::vector<segment_chunks::chunk_map_t::iterator> to_evict;
+    for (auto it = chunks.begin(); it != chunks.end(); ++it) {
+        to_evict.push_back(it);
+    }
+
+    size_t max = 1;
+    size_t hydrated = 3;
+    auto st = predictive_chunk_eviction_strategy_test{max, hydrated};
+    ss::abort_source as;
+    retry_chain_node rtc{as};
+    retry_chain_logger l{test_log, rtc};
+
+    st.evict(to_evict, l).get();
+
+    BOOST_REQUIRE(!chunks[0].handle.has_value());
+    BOOST_REQUIRE(chunks[0].current_state == chunk_state::not_available);
+
+    BOOST_REQUIRE(!chunks[1].handle.has_value());
+    BOOST_REQUIRE(chunks[1].current_state == chunk_state::not_available);
+
+    BOOST_REQUIRE(chunks[2].handle.has_value());
+    BOOST_REQUIRE(chunks[2].current_state == chunk_state::hydrated);
 }

--- a/src/v/cloud_storage/tests/segment_chunk_test.cc
+++ b/src/v/cloud_storage/tests/segment_chunk_test.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/segment_chunk.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+SEASTAR_THREAD_TEST_CASE(test_chunk_ordering) {
+    std::vector<cloud_storage::segment_chunk> chunks{};
+
+    // Primary ordering is on readers waiting, higher values are more important.
+    chunks.push_back(
+      {.required_by_readers_in_future = 10, .required_after_n_chunks = 1});
+    chunks.push_back(
+      {.required_by_readers_in_future = 11, .required_after_n_chunks = 100});
+    chunks.push_back(
+      {.required_by_readers_in_future = 12, .required_after_n_chunks = 121});
+    chunks.push_back(
+      {.required_by_readers_in_future = 13, .required_after_n_chunks = 1221});
+
+    std::sort(chunks.begin(), chunks.end());
+    auto expected = 10;
+    for (const auto& chunk : chunks) {
+        BOOST_REQUIRE_EQUAL(expected, chunk.required_by_readers_in_future);
+        expected += 1;
+    }
+
+    chunks.clear();
+
+    // Secondary ordering is on required_after_n_chunks, lower values are more
+    // important. A lower required_after_n_chunks means that a chunk is required
+    // soon.
+    chunks.push_back(
+      {.required_by_readers_in_future = 10, .required_after_n_chunks = 1});
+    chunks.push_back(
+      {.required_by_readers_in_future = 10, .required_after_n_chunks = 2});
+    chunks.push_back(
+      {.required_by_readers_in_future = 10, .required_after_n_chunks = 3});
+    chunks.push_back(
+      {.required_by_readers_in_future = 10, .required_after_n_chunks = 4});
+    // Chunk with 0 value of required_after_n_chunks will appear first in
+    // ascending sort. Since 0 is the default, a value of 0 means that a chunk
+    // is not required by any readers. A value of 1 means that the chunks is
+    // next to be read for some data source.
+    chunks.push_back(
+      {.required_by_readers_in_future = 10, .required_after_n_chunks = 0});
+
+    std::sort(chunks.begin(), chunks.end());
+    BOOST_REQUIRE_EQUAL(chunks.begin()->required_after_n_chunks, 0);
+    chunks.erase(chunks.begin());
+
+    expected = 4;
+    for (const auto& chunk : chunks) {
+        BOOST_REQUIRE_EQUAL(expected, chunk.required_after_n_chunks);
+        expected -= 1;
+    }
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1556,6 +1556,17 @@ configuration::configuration()
       "are downloaded.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , cloud_storage_chunk_eviction_strategy(
+      *this,
+      "cloud_storage_chunk_eviction_strategy",
+      "Selects a strategy for evicting unused cache chunks.",
+      {.needs_restart = needs_restart::no,
+       .example = "eager",
+       .visibility = visibility::tunable},
+      model::cloud_storage_chunk_eviction_strategy::eager,
+      {model::cloud_storage_chunk_eviction_strategy::eager,
+       model::cloud_storage_chunk_eviction_strategy::capped,
+       model::cloud_storage_chunk_eviction_strategy::predictive})
   , superusers(
       *this,
       "superusers",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1527,6 +1527,35 @@ configuration::configuration()
       "value of `topic_partitions_per_shard` multiplied by 2 is used.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
+  , cloud_storage_cache_chunk_size(
+      *this,
+      "cloud_storage_cache_chunk_size",
+      "Size of chunks of segments downloaded into cloud storage cache. Reduces "
+      "space usage by only downloading the necessary chunk from a segment.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      16_MiB)
+  , cloud_storage_hydrated_chunks_per_segment_ratio(
+      *this,
+      "cloud_storage_hydrated_chunks_per_segment_ratio",
+      "The maximum number of chunks per segment that can be hydrated at a "
+      "time. Above this number, unused chunks will be trimmed.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.7)
+  , cloud_storage_min_chunks_per_segment_threshold(
+      *this,
+      "cloud_storage_min_chunks_per_segment_threshold",
+      "The minimum number of chunks per segment for trimming to be enabled. If "
+      "the number of chunks in a segment is below this threshold, the segment "
+      "is small enough that all chunks in it can be hydrated at any given time",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5)
+  , cloud_storage_disable_chunk_reads(
+      *this,
+      "cloud_storage_disable_chunk_reads",
+      "Disable chunk reads and switch back to legacy mode where full segments "
+      "are downloaded.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , superusers(
       *this,
       "superusers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -310,6 +310,8 @@ struct configuration final : public config_store {
     property<double> cloud_storage_hydrated_chunks_per_segment_ratio;
     property<uint64_t> cloud_storage_min_chunks_per_segment_threshold;
     property<bool> cloud_storage_disable_chunk_reads;
+    enum_property<model::cloud_storage_chunk_eviction_strategy>
+      cloud_storage_chunk_eviction_strategy;
 
     one_or_many_property<ss::sstring> superusers;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -306,6 +306,10 @@ struct configuration final : public config_store {
     property<std::optional<uint32_t>> cloud_storage_max_readers_per_shard;
     property<std::optional<uint32_t>>
       cloud_storage_max_materialized_segments_per_shard;
+    property<uint64_t> cloud_storage_cache_chunk_size;
+    property<double> cloud_storage_hydrated_chunks_per_segment_ratio;
+    property<uint64_t> cloud_storage_min_chunks_per_segment_threshold;
+    property<bool> cloud_storage_disable_chunk_reads;
 
     one_or_many_property<ss::sstring> superusers;
 

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -407,4 +407,35 @@ struct convert<std::filesystem::path> {
     }
 };
 
+template<>
+struct convert<model::cloud_storage_chunk_eviction_strategy> {
+    using type = model::cloud_storage_chunk_eviction_strategy;
+
+    static constexpr auto acceptable_values = std::to_array(
+      {"eager", "capped", "predictive"});
+
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+
+        if (
+          std::find(acceptable_values.begin(), acceptable_values.end(), value)
+          == acceptable_values.end()) {
+            return false;
+        }
+
+        rhs = string_switch<type>(std::string_view{value})
+                .match(
+                  "eager", model::cloud_storage_chunk_eviction_strategy::eager)
+                .match(
+                  "capped",
+                  model::cloud_storage_chunk_eviction_strategy::capped)
+                .match(
+                  "predictive",
+                  model::cloud_storage_chunk_eviction_strategy::predictive);
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -613,6 +613,10 @@ consteval std::string_view property_type_name() {
         return "string";
     } else if constexpr (std::is_same_v<type, std::filesystem::path>) {
         return "string";
+    } else if constexpr (std::is_same_v<
+                           type,
+                           model::cloud_storage_chunk_eviction_strategy>) {
+        return "string";
     } else {
         static_assert(dependent_false<T>::value, "Type name not defined");
     }

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -160,4 +160,10 @@ void rjson_serialize(
     stringize(w, v);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const model::cloud_storage_chunk_eviction_strategy& v) {
+    stringize(w, v);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -74,4 +74,8 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::leader_balancer_mode& v);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const model::cloud_storage_chunk_eviction_strategy& v);
+
 } // namespace json

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -468,6 +468,24 @@ leader_balancer_mode_to_string(leader_balancer_mode mode) {
 std::ostream& operator<<(std::ostream&, leader_balancer_mode);
 std::istream& operator>>(std::istream&, leader_balancer_mode&);
 
+enum class cloud_storage_chunk_eviction_strategy {
+    eager = 0,
+    capped = 1,
+    predictive = 2,
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, cloud_storage_chunk_eviction_strategy st) {
+    switch (st) {
+    case cloud_storage_chunk_eviction_strategy::eager:
+        return os << "eager";
+    case cloud_storage_chunk_eviction_strategy::capped:
+        return os << "capped";
+    case cloud_storage_chunk_eviction_strategy::predictive:
+        return os << "predictive";
+    }
+}
+
 namespace internal {
 /*
  * Old version for use in backwards compatibility serialization /

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -40,7 +40,8 @@ class CloudRetentionTest(PreallocNodesTest):
         # test run.
         pass
 
-    @cluster(num_nodes=4)
+    @cluster(num_nodes=4,
+             log_allow_list=[r"failed to hydrate chunk.*NotFound"])
     @matrix(max_consume_rate_mb=[20, None],
             cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode

--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -1,0 +1,240 @@
+import pprint
+
+from ducktape.utils.util import wait_until
+
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
+from rptest.services.kgo_verifier_services import KgoVerifierRandomConsumer
+from rptest.services.redpanda import SISettings
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.util import Scale, wait_for_local_storage_truncate
+from rptest.utils.si_utils import nodes_report_cloud_segments
+
+
+class CloudStorageChunkReadTest(PreallocNodesTest):
+    def __init__(self, test_context):
+        self.log_segment_size = 1048576 * 5
+        self.test_context = test_context
+        self.si_settings = SISettings(
+            test_context=test_context,
+            log_segment_size=self.log_segment_size,
+            fast_uploads=True,
+        )
+        self.si_settings.load_context(self.logger, test_context=test_context)
+
+        super().__init__(
+            test_context=test_context,
+            node_prealloc_count=1,
+            num_brokers=3,
+            si_settings=self.si_settings,
+            extra_rp_conf={'cloud_storage_cache_chunk_size': 1024 * 256})
+
+        self.scale = Scale(test_context)
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.topics = (TopicSpec(name='panda-topic',
+                                 partition_count=1,
+                                 replication_factor=3,
+                                 segment_bytes=self.log_segment_size), )
+
+        self.extra_rp_conf = {'cloud_storage_cache_chunk_size': 1024 * 256}
+        if not self.redpanda.dedicated_nodes:
+            self.extra_rp_conf.update(
+                {'cloud_storage_max_readers_per_shard': 10})
+        self.redpanda.set_extra_rp_conf(self.extra_rp_conf)
+
+    def setup(self):
+        # Do not start redpanda here, let the tests start with custom config options
+        pass
+
+    def teardown(self):
+        self.redpanda.cloud_storage_client.empty_bucket(
+            self.si_settings.cloud_storage_bucket)
+
+    def _set_params_and_start_redpanda(self, **kwargs):
+        if kwargs:
+            self.extra_rp_conf.update(kwargs)
+            self.redpanda.set_extra_rp_conf(self.extra_rp_conf)
+        self.redpanda.start()
+        self._create_initial_topics()
+
+    def _produce_baseline(self, n_segments=20, msg_count=200000):
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=1024,
+                                       msg_count=msg_count,
+                                       custom_node=self.preallocated_nodes)
+        producer.start()
+        wait_until(
+            lambda: nodes_report_cloud_segments(self.redpanda, n_segments),
+            timeout_sec=180,
+            backoff_sec=3)
+        producer.stop()
+        producer.wait()
+
+        for t in self.topics:
+            self.client().alter_topic_config(
+                t.name, TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,
+                self.log_segment_size)
+
+        # Wait for half of the segments to be removed, to exercise the read path
+        # when using the sequential consumer later on.
+        wait_for_local_storage_truncate(self.redpanda,
+                                        self.topic,
+                                        partition_idx=0,
+                                        target_bytes=(n_segments // 2) *
+                                        self.log_segment_size)
+
+        return producer
+
+    def _remove_indices_from_cloud(self):
+        for obj in self.cloud_storage_client.list_objects(
+                self.si_settings.cloud_storage_bucket, self.topic):
+            if obj.key.endswith('.index'):
+                self.cloud_storage_client.delete_object(
+                    self.si_settings.cloud_storage_bucket, obj.key)
+
+    def _assert_files_in_cache(self, expr: str, must_be_absent=False):
+        """
+        Asserts that files matching a pattern are present in the cache directory on _any one_ of the started nodes.
+        If must_be_absent is True, then the files should be absent on every started node.
+        """
+        found_files = []
+        for node in self.redpanda.started_nodes():
+            files = [
+                l.strip() for l in node.account.ssh_capture(
+                    f"""find {self.redpanda.DATA_DIR}/cloud_storage_cache""")
+            ]
+            self.redpanda.logger.debug(f'files in cache: {files}')
+
+            found_files += [
+                l.strip() for l in node.account.ssh_capture(
+                    f"""find {self.redpanda.DATA_DIR}/cloud_storage_cache -regex '{expr}'"""
+                )
+            ]
+
+        if must_be_absent:
+            assert not found_files, 'unexpected files in cache dir: ' \
+                                    f'{pprint.pformat(found_files)} ' \
+                                    f'matching expression {expr}'
+        else:
+            assert found_files, f'no files in cache dir matching expression {expr}'
+
+    @cluster(num_nodes=4)
+    def test_read_chunks(self):
+        self._set_params_and_start_redpanda(
+            cloud_storage_cache_chunk_size=1048576 * 8)
+
+        self._produce_baseline()
+
+        rand_cons = KgoVerifierRandomConsumer(self.test_context,
+                                              self.redpanda,
+                                              self.topic,
+                                              0,
+                                              50,
+                                              10,
+                                              nodes=self.preallocated_nodes)
+        rand_cons.start()
+        rand_cons.wait(timeout_sec=300)
+
+        # There should be no log files in cache
+        self._assert_files_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$',
+                                    must_be_absent=True)
+        # There should be some chunk files in cache
+        self._assert_files_in_cache(f'.*kafka/{self.topic}/.*_chunks/[0-9]+')
+
+        consumer = KgoVerifierSeqConsumer(self.test_context,
+                                          self.redpanda,
+                                          self.topic,
+                                          0,
+                                          nodes=self.preallocated_nodes)
+        consumer.start()
+        consumer.wait(timeout_sec=120)
+        self._assert_files_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$',
+                                    must_be_absent=True)
+
+    @cluster(num_nodes=4)
+    def test_fallback_mode(self):
+        """
+        In fallback mode, redpanda is not able to download the index from cloud storage.
+        This should result in fallback mode being engaged, which instructs the leader to
+        start downloading full segments. Additionally, the index is generated on the fly
+        during download.
+        """
+        self._set_params_and_start_redpanda()
+
+        self._produce_baseline(n_segments=5)
+        self._remove_indices_from_cloud()
+
+        self._consume_baseline()
+
+        # There should be no chunk files in cache in fallback mode
+        self._assert_files_in_cache(f'kafka/{self.topic}/.*_chunks/[0-9]+$',
+                                    must_be_absent=True)
+
+        # There should be some log files in cache in fallback mode
+        self._assert_files_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$')
+
+        # Index files should have been generated during full segment download.
+        self._assert_files_in_cache(f'.*kafka/{self.topic}/.*index$')
+
+    def _consume_baseline(self, timeout=60):
+        consumer = KgoVerifierSeqConsumer(self.test_context,
+                                          self.redpanda,
+                                          self.topic,
+                                          0,
+                                          nodes=self.preallocated_nodes)
+        consumer.start()
+        consumer.wait(timeout_sec=timeout)
+
+    @cluster(num_nodes=4)
+    def test_read_when_chunk_api_disabled(self):
+        self._set_params_and_start_redpanda(
+            cloud_storage_disable_chunk_reads=True)
+        self._produce_baseline(n_segments=5)
+        self._consume_baseline()
+
+        self._assert_files_in_cache(f'kafka/{self.topic}/.*_chunks/[0-9]+$',
+                                    must_be_absent=True)
+
+        self._assert_files_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$')
+        self._assert_files_in_cache(f'.*kafka/{self.topic}/.*index$')
+
+    @cluster(num_nodes=4)
+    def test_read_when_cache_smaller_than_segment_size(self):
+        self.si_settings.cloud_storage_cache_size = 1048576 * 4
+        self.redpanda.set_si_settings(self.si_settings)
+        self._set_params_and_start_redpanda(
+            cloud_storage_cache_chunk_size=1048576)
+
+        self._produce_baseline(n_segments=6, msg_count=50000)
+        self._consume_baseline(timeout=180)
+
+        self._assert_files_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$',
+                                    must_be_absent=True)
+        self._assert_files_in_cache(f'.*kafka/{self.topic}/.*_chunks/[0-9]+')
+
+    @cluster(num_nodes=4)
+    def test_read_when_segment_size_smaller_than_chunk_size(self):
+        self.topics[0].segment_bytes = 512 * 1024
+        self._set_params_and_start_redpanda(cloud_storage_cache_chunk_size=16 *
+                                            1024 * 1024)
+
+        self._produce_baseline(n_segments=20)
+        rand_cons = KgoVerifierRandomConsumer(self.test_context,
+                                              self.redpanda,
+                                              self.topic,
+                                              msg_size=0,
+                                              rand_read_msgs=50,
+                                              parallel=50,
+                                              nodes=self.preallocated_nodes)
+        rand_cons.start()
+        rand_cons.wait(timeout_sec=300)
+
+        self._consume_baseline()
+
+        self._assert_files_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$',
+                                    must_be_absent=True)
+        self._assert_files_in_cache(f'.*kafka/{self.topic}/.*_chunks/[0-9]+')

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -385,7 +385,7 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
         self.consumer.wait()
 
         self.redpanda.metric_sum(
-            "redpanda_cloud_storage_delete_segments",
+            "redpanda_cloud_storage_deleted_segments",
             metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS) > 0
 
         self.redpanda.metric_sum(
@@ -454,9 +454,12 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
 
         self.epilogue()
 
-    @cluster(
-        num_nodes=5,
-        log_allow_list=[r"Error in hydraton loop: .*Connection reset by peer"])
+    @cluster(num_nodes=5,
+             log_allow_list=[
+                 r"Error in hydraton loop: .*Connection reset by peer",
+                 r"failed to hydrate chunk.*Connection reset by peer",
+                 r"failed to hydrate chunk.*NotFound"
+             ])
     @skip_debug_mode
     def test_cloud_storage_with_partition_moves(self):
         """

--- a/tests/rptest/tests/test_si_cache_space_leak.py
+++ b/tests/rptest/tests/test_si_cache_space_leak.py
@@ -90,7 +90,8 @@ class ShadowIndexingCacheSpaceLeakTest(RedpandaTest):
                    backoff_sec=10)
         self.test_context.cluster.free_single(self._verifier_node)
 
-    @cluster(num_nodes=4)
+    @cluster(num_nodes=4,
+             log_allow_list=[r'failed to hydrate chunk.*NotFound'])
     @matrix(message_size=[10000], num_messages=[100000], concurrency=[2])
     def test_si_cache(self, message_size, num_messages, concurrency):
         if self.debug_mode:


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/9426

The tiered storage read path can now download small parts of a segment to service fetch requests. This reduces cache space usage and allows for eviction of chunks which are not in use. The changes in this PR introduce the following entities:

* segment chunk: Stores metadata about a part of a segment in cloud storage. The metadata is an optional file handle, readers waiting for the chunk to be hydrated, state and statistics.
* segment chunk API: Created once per remote segment, handles trimming of unused chunks, wraps chunk hydration (via remote segment) into retries, and stores a map of chunk start offset to metadata.
* segment chunk data source: A data source implementation which is initialized with a range of chunks and iterates over them to service fetch requests. Hydrates chunks as needed lazily.

The remote segment now only downloads and materializes the index and the tx manifest. The log segment is not downloaded. The segment also maintains a coarse index of kafka offset to file offset, with resolution roughly equal to chunk size, which is used to decide which chunks can service a fetch request. The offset data stream created for a remote segment which is used by the remote segment batch reader uses the segment chunk data source, so that chunks are hydrated as the reader progresses through the fetch request.

#### Fallback mode
In certain cases where the segment is either old enough not to have an index or where the index is not downloadable, the remote segment switches to fallback mode. In this case the chunk abstractions are not used and the full segment is always downloaded and an index is generated on the fly. The fallback mode is irreversible and is set for the duration that the remote segment is present. In theory once the index is generated it could be re-uploaded and fallback mode could be disengaged, but this requires handling several corner cases such as closing the existing segment file handle and waiting for current readers to finish, and is left out of this PR.

#### Chunk eviction/trimming
A chunk once hydrated keeps its file handle open so that even if the cache service removes the file, the readers reading from the chunk are not affected. Periodically, the chunk API trims chunks not in use. The criteria for a chunk to be trimmed are:

1. The chunk file handle is not shared with any data sources
2. The number of hydrated chunks in segment is higher than the max hydrated chunks for the segment.
3. The number of readers waiting for the chunk as part of their fetch requests are lower than those for other chunks.

The last criterion is evaluated by sorting chunks by the stats managed per chunk, which tell us how many readers are going to use a chunk after they are done with their current chunk, and how soon they are going to use it.

#### New properties

 1. `cloud_storage_cache_chunk_size` - determines the chunk size. Requires restart
 2. `cloud_storage_default_hydrated_chunks_ratio`: determines what maximum ratio of chunks can be maintained per remote segment, dependent on segment size. Determines the number of chunks after which trimming will be required. Defaults to 0.7. Does not require restart. Changes affect new materialized segments.
 3. `cloud_storage_min_chunks_in_segment_threshold`: A threshold below which the segment is considered to be small enough that all chunks in it can be materialized at once. Defaults to 10. Does not require restart. Changes affect new materialized segments.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* Adds support for downloading chunks of segments instead of full segment in tiered storage read path. This allows for more controlled consumption of cache space as well as easier eviction of unused chunks.


### Features

* The chunk read feature is enabled by default for new segments. 

### Improvements

* A broker can now download small sections of a log segment, instead of downloading the entire file. This reduces cache space consumption.
