### PR TITLE
[v23.1.x] schema_registry: Return the latest schema_version

### DIFF
--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -123,10 +123,14 @@ public:
 
         if (!version.has_value()) {
             auto const& versions = sub_it->second.versions;
-            if (versions.empty() || (!inc_del && versions.back().deleted)) {
+            auto it = std::find_if(
+              versions.rbegin(), versions.rend(), [inc_del](const auto& ver) {
+                  return inc_del || !ver.deleted;
+              });
+            if (it == versions.rend()) {
                 return not_found(sub);
             }
-            return *std::prev(versions.end());
+            return *it;
         }
 
         auto v_it = BOOST_OUTCOME_TRYX(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10543
