### PR TITLE
rptest: skip debug mode for timing stress test

### DIFF
--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -247,11 +247,6 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
         self.admin = Admin(self.redpanda)
         self.checks = []
 
-        # Fine tune the allowed overshoot for debug builds as they are
-        # significantly slower.
-        if self.debug_mode:
-            self.allow_runtime_overshoot_by = 2.5
-
     def _create_producer(self) -> KgoVerifierProducer:
         bps = self.produce_byte_rate_per_ntp * self.topics[0].partition_count
         bytes_count = bps * self.target_runtime
@@ -445,6 +440,7 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             self.logger.info(f"All checks completed successfuly")
 
     @cluster(num_nodes=5)
+    @skip_debug_mode
     def test_cloud_storage(self):
         """
         This is the baseline test. It runs the workload and performs the checks


### PR DESCRIPTION
This commit skips debug mode tests for CloudStorageTimingStressTest(s). In rare instances, the debug build cannot upload fast enough and fails to finish in the expected runtime. This has started happening after the debug build was changed to use shared libs, but the issues probably could have occurred before.

Fixes https://github.com/redpanda-data/redpanda/issues/10361

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
