### PR TITLE
Feat/cstore/partition manifest serde

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -674,12 +674,9 @@ ntp_archiver::download_manifest() {
       _conf->cloud_storage_initial_backoff,
       &_rtcnode);
     cloud_storage::partition_manifest tmp(_ntp, _rev);
-    auto path = tmp.get_manifest_path();
-    auto key = cloud_storage::remote_manifest_path(
-      std::filesystem::path(std::move(path)));
     vlog(_rtclog.debug, "Downloading manifest");
-    auto result = co_await _remote.download_manifest(
-      get_bucket_name(), key, tmp, fib);
+    auto [result, _] = co_await _remote.try_download_partition_manifest(
+      get_bucket_name(), tmp, fib);
 
     // It's OK if the manifest is not found for a newly created topic. The
     // condition in if statement is not guaranteed to cover all cases for new

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -322,8 +322,8 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
 
     {
         std::stringstream s1, s2;
-        m.serialize(s1);
-        archival_stm.manifest().serialize(s2);
+        m.serialize_json(s1);
+        archival_stm.manifest().serialize_json(s2);
         vlog(logger.info, "original manifest: {}", s1.str());
         vlog(logger.info, "restored manifest: {}", s2.str());
     }

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -28,7 +28,7 @@ static const auto manifest_ntp = model::ntp(
   manifest_namespace, manifest_topic, manifest_partition);
 static const auto manifest_revision = model::initial_revision_id(0);
 static const ss::sstring manifest_url = ssx::sformat(
-  "/10000000/meta/{}_{}/manifest.json",
+  "/10000000/meta/{}_{}/manifest.bin",
   manifest_ntp.path(),
   manifest_revision());
 
@@ -281,7 +281,10 @@ public:
         i.append(json.data(), json.size());
         cloud_storage::partition_manifest m;
 
-        m.update(make_iobuf_input_stream(std::move(i))).get();
+        m.update(
+           cloud_storage::manifest_format::json,
+           make_iobuf_input_stream(std::move(i)))
+          .get();
 
         stm._manifest = ss::make_shared<cloud_storage::partition_manifest>(
           std::move(m));
@@ -447,7 +450,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     std::stringstream st;
-    stm_manifest.serialize(st);
+    stm_manifest.serialize_json(st);
     vlog(test_log.debug, "manifest: {}", st.str());
     verify_segment_request("500-1-v1.log", stm_manifest);
 

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -49,7 +49,7 @@ static const auto manifest_ntp = model::ntp(                    // NOLINT
   manifest_partition);
 static const auto manifest_revision = model::initial_revision_id(0); // NOLINT
 static const ss::sstring manifest_url = ssx::sformat(                // NOLINT
-  "/10000000/meta/{}_{}/manifest.json",
+  "/10000000/meta/{}_{}/manifest.bin",
   manifest_ntp.path(),
   manifest_revision());
 

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -91,7 +91,9 @@ static constexpr ss::lowres_clock::duration segment_lock_timeout{60s};
 
 SEASTAR_THREAD_TEST_CASE(test_segment_collection) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -124,7 +126,9 @@ SEASTAR_THREAD_TEST_CASE(test_segment_collection) {
 
 SEASTAR_THREAD_TEST_CASE(test_start_ahead_of_manifest) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -183,7 +187,9 @@ SEASTAR_THREAD_TEST_CASE(test_empty_manifest) {
 
 SEASTAR_THREAD_TEST_CASE(test_short_compacted_segment_inside_manifest_segment) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -216,7 +222,9 @@ SEASTAR_THREAD_TEST_CASE(test_short_compacted_segment_inside_manifest_segment) {
 
 SEASTAR_THREAD_TEST_CASE(test_compacted_segment_aligned_with_manifest_segment) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -250,7 +258,9 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_aligned_with_manifest_segment) {
 SEASTAR_THREAD_TEST_CASE(
   test_short_compacted_segment_aligned_with_manifest_segment) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -286,7 +296,9 @@ SEASTAR_THREAD_TEST_CASE(
 SEASTAR_THREAD_TEST_CASE(
   test_many_compacted_segments_make_up_to_manifest_segment) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -319,7 +331,9 @@ SEASTAR_THREAD_TEST_CASE(
 
 SEASTAR_THREAD_TEST_CASE(test_compacted_segment_larger_than_manifest_segment) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -355,7 +369,9 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_larger_than_manifest_segment) {
 
 SEASTAR_THREAD_TEST_CASE(test_collect_capped_by_size) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -402,7 +418,9 @@ SEASTAR_THREAD_TEST_CASE(test_collect_capped_by_size) {
 
 SEASTAR_THREAD_TEST_CASE(test_no_compacted_segments) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -430,7 +448,9 @@ SEASTAR_THREAD_TEST_CASE(test_no_compacted_segments) {
 
 SEASTAR_THREAD_TEST_CASE(test_segment_name_adjustment) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -457,7 +477,9 @@ SEASTAR_THREAD_TEST_CASE(test_segment_name_adjustment) {
 
 SEASTAR_THREAD_TEST_CASE(test_segment_name_no_adjustment) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -484,7 +506,10 @@ SEASTAR_THREAD_TEST_CASE(test_segment_name_no_adjustment) {
 
 SEASTAR_THREAD_TEST_CASE(test_collected_segments_completely_cover_gap) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest_with_gaps)).get();
+    m.update(
+       cloud_storage::manifest_format::json,
+       make_manifest_stream(manifest_with_gaps))
+      .get();
 
     using namespace storage;
 
@@ -581,7 +606,10 @@ SEASTAR_THREAD_TEST_CASE(test_collected_segments_completely_cover_gap) {
 
 SEASTAR_THREAD_TEST_CASE(test_collection_starts_in_gap) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest_with_gaps)).get();
+    m.update(
+       cloud_storage::manifest_format::json,
+       make_manifest_stream(manifest_with_gaps))
+      .get();
 
     using namespace storage;
 
@@ -613,7 +641,10 @@ SEASTAR_THREAD_TEST_CASE(test_collection_starts_in_gap) {
 
 SEASTAR_THREAD_TEST_CASE(test_collection_ends_in_gap) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest_with_gaps)).get();
+    m.update(
+       cloud_storage::manifest_format::json,
+       make_manifest_stream(manifest_with_gaps))
+      .get();
 
     using namespace storage;
 
@@ -645,7 +676,9 @@ SEASTAR_THREAD_TEST_CASE(test_collection_ends_in_gap) {
 
 SEASTAR_THREAD_TEST_CASE(test_compacted_segment_after_manifest_start) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     using namespace storage;
 
@@ -677,7 +710,9 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_after_manifest_start) {
 
 SEASTAR_THREAD_TEST_CASE(test_upload_candidate_generation) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -749,7 +784,9 @@ SEASTAR_THREAD_TEST_CASE(test_upload_candidate_generation) {
 
 SEASTAR_THREAD_TEST_CASE(test_upload_aligned_to_non_existent_offset) {
     cloud_storage::partition_manifest m;
-    m.update(make_manifest_stream(manifest)).get();
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
 
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -2,6 +2,7 @@
 v_cc_library(
   NAME cloud_storage
   SRCS
+    base_manifest.cc
     cache_service.cc
     access_time_tracker.cc
     cache_probe.cc

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -1,3 +1,12 @@
+v_cc_library(
+  NAME segment_meta_cstore
+  SRCS
+    segment_meta_cstore.cc
+  DEPS
+    v::bytes
+    v::model
+    absl::btree
+)
 
 v_cc_library(
   NAME cloud_storage
@@ -33,6 +42,7 @@ v_cc_library(
     v::model
     v::rphashing
     v::cloud_roles
+    v::segment_meta_cstore
     # NOTE: do not add v::cloud as a dependency
 )
 add_subdirectory(tests)

--- a/src/v/cloud_storage/base_manifest.cc
+++ b/src/v/cloud_storage/base_manifest.cc
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/base_manifest.h"
+
+namespace cloud_storage {
+
+base_manifest::~base_manifest() = default;
+} // namespace cloud_storage

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1373,7 +1373,7 @@ struct partition_manifest_handler
     }
 };
 
-ss::future<> partition_manifest::update(iobuf buf) {
+ss::future<> partition_manifest::update_with_json(iobuf buf) {
     iobuf_istreambuf ibuf(buf);
     std::istream stream(&ibuf);
     json::IStreamWrapper wrapper(stream);
@@ -1381,7 +1381,7 @@ ss::future<> partition_manifest::update(iobuf buf) {
     partition_manifest_handler handler(_mem_tracker);
 
     if (reader.Parse(wrapper, handler)) {
-        partition_manifest::update(std::move(handler));
+        partition_manifest::do_update(std::move(handler));
     } else {
         rapidjson::ParseErrorCode e = reader.GetParseErrorCode();
         size_t o = reader.GetErrorOffset();
@@ -1400,10 +1400,10 @@ ss::future<> partition_manifest::update(ss::input_stream<char> is) {
     iobuf result;
     auto os = make_iobuf_ref_output_stream(result);
     co_await ss::copy(is, os);
-    co_return co_await update(std::move(result));
+    co_return co_await update_with_json(std::move(result));
 }
 
-void partition_manifest::update(partition_manifest_handler&& handler) {
+void partition_manifest::do_update(partition_manifest_handler&& handler) {
     if (handler._version != static_cast<int>(manifest_version::v1)) {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
@@ -1489,7 +1489,7 @@ struct partition_manifest::serialization_cursor {
     bool epilogue_done{false};
 };
 
-ss::future<serialized_json_stream> partition_manifest::serialize() const {
+ss::future<serialized_data_stream> partition_manifest::serialize() const {
     auto iso = _insync_offset;
     iobuf serialized;
     iobuf_ostreambuf obuf(serialized);
@@ -1517,7 +1517,7 @@ ss::future<serialized_json_stream> partition_manifest::serialize() const {
           get_manifest_path()));
     }
     size_t size_bytes = serialized.size_bytes();
-    co_return serialized_json_stream{
+    co_return serialized_data_stream{
       .stream = make_iobuf_input_stream(std::move(serialized)),
       .size_bytes = size_bytes};
 }

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1046,6 +1046,8 @@ struct partition_manifest_handler
                 _archive_start_offset_delta = model::offset_delta(u);
             } else if (_manifest_key == "archive_clean_offset") {
                 _archive_clean_offset = model::offset(u);
+            } else if (_manifest_key == "start_kafka_offset") {
+                _start_kafka_offset = kafka::offset(u);
             } else {
                 return false;
             }
@@ -1275,6 +1277,7 @@ struct partition_manifest_handler
     std::optional<model::offset> _archive_start_offset;
     std::optional<model::offset_delta> _archive_start_offset_delta;
     std::optional<model::offset> _archive_clean_offset;
+    std::optional<kafka::offset> _start_kafka_offset;
 
     // required segment meta fields
     std::optional<bool> _is_compacted;
@@ -1450,6 +1453,8 @@ void partition_manifest::update(partition_manifest_handler&& handler) {
     } else {
         _cloud_log_size_bytes = compute_cloud_log_size();
     }
+
+    _start_kafka_offset = handler._start_kafka_offset.value_or(kafka::offset{});
 }
 
 // This object is supposed to track state of the asynchronous
@@ -1587,6 +1592,11 @@ void partition_manifest::serialize_begin(
     if (_archive_clean_offset != model::offset{}) {
         w.Key("archive_clean_offset");
         w.Int64(_archive_clean_offset());
+    }
+
+    if (_start_kafka_offset != kafka::offset{}) {
+        w.Key("start_kafka_offset");
+        w.Int64(_start_kafka_offset());
     }
     cursor->prologue_done = true;
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -304,7 +304,7 @@ public:
     const_iterator find(model::offset o) const;
 
     /// Update manifest file from iobuf
-    ss::future<> update(iobuf buf);
+    ss::future<> update_with_json(iobuf buf);
 
     /// Update manifest file from input_stream (remote set)
     ss::future<> update(ss::input_stream<char> is) override;
@@ -312,7 +312,7 @@ public:
     /// Serialize manifest object
     ///
     /// \return asynchronous input_stream with the serialized json
-    ss::future<serialized_json_stream> serialize() const override;
+    ss::future<serialized_data_stream> serialize() const override;
 
     /// Serialize manifest object
     ///
@@ -419,7 +419,7 @@ private:
 
     /// Update manifest content from json document that supposed to be generated
     /// from manifest.json file
-    void update(partition_manifest_handler&& handler);
+    void do_update(partition_manifest_handler&& handler);
 
     /// Copy segments from _segments to _replaced
     /// Returns the total size in bytes of the replaced segments, or nullopt if

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -68,8 +68,8 @@ remote_segment_path generate_remote_segment_path(
 /// Generate correct S3 segment name based on term and base offset
 segment_name generate_local_segment_name(model::offset o, model::term_id t);
 
-remote_manifest_path
-generate_partition_manifest_path(const model::ntp&, model::initial_revision_id);
+remote_manifest_path generate_partition_manifest_path(
+  const model::ntp&, model::initial_revision_id, manifest_format);
 
 // This structure can be impelenented
 // to allow access to private fields of the manifest.
@@ -188,7 +188,25 @@ public:
     }
 
     /// Manifest object name in S3
-    remote_manifest_path get_manifest_path() const override;
+    std::pair<manifest_format, remote_manifest_path>
+    get_manifest_format_and_path() const override;
+
+    remote_manifest_path get_manifest_path(manifest_format fmt) const {
+        switch (fmt) {
+        case manifest_format::json:
+            return get_legacy_manifest_format_and_path().second;
+        case manifest_format::serde:
+            return get_manifest_format_and_path().second;
+        }
+    }
+
+    remote_manifest_path get_manifest_path() const override {
+        return get_manifest_format_and_path().second;
+    }
+
+    /// Manifest object name before feature::cloud_storage_manifest_format_v2
+    std::pair<manifest_format, remote_manifest_path>
+    get_legacy_manifest_format_and_path() const;
 
     /// Get NTP
     const model::ntp& get_ntp() const;
@@ -307,7 +325,12 @@ public:
     ss::future<> update_with_json(iobuf buf);
 
     /// Update manifest file from input_stream (remote set)
-    ss::future<> update(ss::input_stream<char> is) override;
+    ss::future<> update(
+      manifest_format serialization_format, ss::input_stream<char> is) override;
+
+    ss::future<> update(ss::input_stream<char> is) override {
+        return update(manifest_format::serde, std::move(is));
+    }
 
     /// Serialize manifest object
     ///
@@ -317,14 +340,14 @@ public:
     /// Serialize manifest object
     ///
     /// \param out output stream that should be used to output the json
-    void serialize(std::ostream& out) const;
+    void serialize_json(std::ostream& out) const;
 
     // Serialize the manifest to an ss::output_stream in JSON format
     /// \param out output stream to serialize into; must be kept alive
     /// by the caller until the returned future completes.
     ///
     /// \return a future that completes after serialization is done
-    ss::future<> serialize(ss::output_stream<char>& out) const;
+    ss::future<> serialize_json(ss::output_stream<char>& out) const;
 
     manifest_type get_manifest_type() const override {
         return manifest_type::partition;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -16,9 +16,11 @@
 #include "model/metadata.h"
 #include "model/timestamp.h"
 #include "segment_meta_cstore.h"
+#include "serde/envelope.h"
 #include "serde/serde.h"
 #include "utils/tracking_allocator.h"
 
+#include <seastar/core/iostream.hh>
 #include <seastar/core/shared_ptr.hh>
 
 #include <deque>
@@ -82,7 +84,11 @@ public:
 
     /// Compact representation of the segment_meta
     /// that can be used to generate a segment path in S3
-    struct lw_segment_meta {
+    struct lw_segment_meta
+      : serde::envelope<
+          lw_segment_meta,
+          serde::version<0>,
+          serde::compat_version<0>> {
         model::initial_revision_id ntp_revision;
         model::offset base_offset;
         model::offset committed_offset;
@@ -320,22 +326,6 @@ public:
     /// \return a future that completes after serialization is done
     ss::future<> serialize(ss::output_stream<char>& out) const;
 
-    /// Compare two manifests for equality. Don't compare the mem_tracker.
-    bool operator==(const partition_manifest& other) const {
-        return _ntp == other._ntp && _rev == other._rev
-               && _segments == other._segments
-               && _last_offset == other._last_offset
-               && _start_offset == other._start_offset
-               && _last_uploaded_compacted_offset
-                    == other._last_uploaded_compacted_offset
-               && _insync_offset == other._insync_offset
-               && _replaced == other._replaced
-               && _archive_clean_offset == other._archive_clean_offset
-               && _archive_start_offset == other._archive_start_offset
-               && _archive_start_offset_delta
-                    == other._archive_start_offset_delta;
-    }
-
     manifest_type get_manifest_type() const override {
         return manifest_type::partition;
     };
@@ -374,6 +364,50 @@ public:
       model::offset start_rp_offset, model::offset_delta start_delta);
     void set_archive_clean_offset(model::offset start_rp_offset);
     kafka::offset get_start_kafka_offset_override() const;
+
+    auto serde_fields() {
+        // this list excludes _mem_tracker, which is not serialized
+        return std::tie(
+          _ntp,
+          _rev,
+          _segments,
+          _replaced,
+          _last_offset,
+          _start_offset,
+          _last_uploaded_compacted_offset,
+          _insync_offset,
+          _cloud_log_size_bytes,
+          _archive_start_offset,
+          _archive_start_offset_delta,
+          _archive_clean_offset,
+          _start_kafka_offset);
+    }
+    auto serde_fields() const {
+        // this list excludes _mem_tracker, which is not serialized
+        return std::tie(
+          _ntp,
+          _rev,
+          _segments,
+          _replaced,
+          _last_offset,
+          _start_offset,
+          _last_uploaded_compacted_offset,
+          _insync_offset,
+          _cloud_log_size_bytes,
+          _archive_start_offset,
+          _archive_start_offset_delta,
+          _archive_clean_offset,
+          _start_kafka_offset);
+    }
+
+    /// Compare two manifests for equality. Don't compare the mem_tracker.
+    bool operator==(const partition_manifest& other) const {
+        return serde_fields() == other.serde_fields();
+    }
+
+    void from_iobuf(iobuf in);
+
+    iobuf to_iobuf() const;
 
 private:
     void subtract_from_cloud_log_size(size_t to_subtract);

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -188,6 +188,13 @@ public:
     /// \return future that returns success code
     ss::future<download_result> download_manifest(
       const cloud_storage_clients::bucket_name& bucket,
+      const std::pair<manifest_format, remote_manifest_path>& format_key,
+      base_manifest& manifest,
+      retry_chain_node& parent);
+
+    /// compatibility version of download_manifest for json format
+    ss::future<download_result> download_manifest(
+      const cloud_storage_clients::bucket_name& bucket,
       const remote_manifest_path& key,
       base_manifest& manifest,
       retry_chain_node& parent);
@@ -207,9 +214,28 @@ public:
     /// \return future that returns success code
     ss::future<download_result> maybe_download_manifest(
       const cloud_storage_clients::bucket_name& bucket,
+      const std::pair<manifest_format, remote_manifest_path>& format_key,
+      base_manifest& manifest,
+      retry_chain_node& parent);
+
+    /// compatibility version of maybe_download_manifest for json format
+    ss::future<download_result> maybe_download_manifest(
+      const cloud_storage_clients::bucket_name& bucket,
       const remote_manifest_path& key,
       base_manifest& manifest,
       retry_chain_node& parent);
+
+    /// \brief Try downloading partition_manifest. the function tries first the
+    /// manifest_format::serde path, and then manifest_format::json path. it's
+    /// expected that manifest is constructed with the approprieate npt and
+    /// revision_id, as it will be used to generate the paths return type is
+    /// download_result and index of path that generated the result
+    ss::future<std::pair<download_result, manifest_format>>
+    try_download_partition_manifest(
+      const cloud_storage_clients::bucket_name& bucket,
+      partition_manifest& manifest,
+      retry_chain_node& parent,
+      bool expect_missing = false);
 
     /// \brief Upload manifest to the pre-defined S3 location
     ///
@@ -338,7 +364,7 @@ public:
 
     ss::future<download_result> do_download_manifest(
       const cloud_storage_clients::bucket_name& bucket,
-      const remote_manifest_path& key,
+      const std::pair<manifest_format, remote_manifest_path>& format_key,
       base_manifest& manifest,
       retry_chain_node& parent,
       bool expect_missing = false);

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -127,8 +127,11 @@ remote_partition::borrow_result_t remote_partition::borrow_next_reader(
             if (mit->delta_offset_end == model::offset_delta{}) {
                 break;
             }
+
+            // If a segment contains kafka data batches, its next offset will
+            // be greater than its base offset.
             auto b = mit->base_kafka_offset();
-            auto end = mit->next_kafka_offset() - kafka::offset(1);
+            auto end = mit->next_kafka_offset();
             if (b != end) {
                 break;
             }

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -520,7 +520,7 @@ private:
             _partition->evict_reader(std::move(_reader));
             vlog(
               _ctxlog.debug,
-              "initializing new segment reader {}, next offset",
+              "initializing new segment reader {}, next offset {}",
               config.start_offset,
               _next_segment_base_offset);
             if (_next_segment_base_offset != model::offset{}) {

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -117,8 +117,8 @@ public:
     // Serialize the manifest to an ss::output_stream in JSON format.
     // Note that the caller must hold the archival_metadat_stm::_manifest_lock
     // and keep the stream alive until the future completes.
-    ss::future<>
-    serialize_manifest_to_output_stream(ss::output_stream<char>& output) const;
+    ss::future<> serialize_json_manifest_to_output_stream(
+      ss::output_stream<char>& output) const;
 
     // returns term last kafka offset
     std::optional<kafka::offset> get_term_last_offset(model::term_id) const;

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -1038,7 +1038,12 @@ void segment_meta_cstore::from_iobuf(iobuf in) {
     *_impl = serde::from_iobuf<segment_meta_cstore::impl>(std::move(in));
 }
 
-iobuf segment_meta_cstore::to_iobuf() {
-    return serde::to_iobuf(std::exchange(*_impl, {}));
+iobuf segment_meta_cstore::to_iobuf() const {
+    impl tmp;
+    for (auto s : *this) {
+        tmp.append(s);
+    }
+
+    return serde::to_iobuf(std::move(tmp));
 }
 } // namespace cloud_storage

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -360,23 +360,39 @@ public:
 
         // extract the end iterator for hints, to cover only the frames that
         // will be cloned
-        auto end_hints = [&] {
+        auto last_hint_tosave = [&] {
             auto frame_it = _base_offset.get_frame_iterator_by_element_index(
               first_replacement_index);
             if (frame_it == _base_offset._frames.begin()) {
                 // no hint will be saved
-                return _hints.begin();
+                return _hints.end();
             }
             --frame_it; // go back to last frame that will be cloned
-            auto frame_max_offset = frame_it->last_value();
-            return _hints.upper_bound(
-              frame_max_offset.value_or(model::offset::min()()));
+            for (; frame_it != _base_offset._frames.begin(); --frame_it) {
+                // go back until we have a non-empty frame. this should be just
+                // an iteration
+                if (auto frame_max_offset = frame_it->last_value()) {
+                    auto to_clone_hint = _hints.lower_bound(
+                      frame_max_offset.value());
+                    vassert(
+                      to_clone_hint == _hints.end()
+                        || to_clone_hint->first <= frame_max_offset.value(),
+                      "to_clone_hint out of range: hint-{} frame_max_offset-{}",
+                      to_clone_hint->first,
+                      frame_max_offset.value());
+                    return to_clone_hint;
+                }
+            }
+            return _hints.end();
         }();
 
         // this column_store is initialized with the run of segments that are
         // not changed
         auto replacement_store = column_store{
-          share_frame, std::move(to_clone_frames), _hints.begin(), end_hints};
+          share_frame,
+          std::move(to_clone_frames),
+          last_hint_tosave,
+          _hints.end()};
 
         auto unchanged_committed_offset
           = replacement_store.last_committed_offset().value_or(

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -921,7 +921,7 @@ public:
 
     void from_iobuf(iobuf in);
 
-    iobuf to_iobuf();
+    iobuf to_iobuf() const;
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -78,3 +78,16 @@ rp_test(
   LIBRARIES Seastar::seastar_perf_testing v::cloud_storage v::storage
   LABELS cloud_storage
 )
+
+# Fuzz test for segment_meta_cstore
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  add_executable(segment_meta_cstore_fuzz_rpfixture segment_meta_cstore_fuzz.cc)
+  target_compile_options(segment_meta_cstore_fuzz_rpfixture PRIVATE -Og -fsanitize=address,fuzzer)
+  target_link_libraries(segment_meta_cstore_fuzz_rpfixture v::segment_meta_cstore fmt::fmt -fsanitize=address,undefined,fuzzer)
+  add_test (
+    NAME segment_meta_cstore_fuzz_rpfixture
+    COMMAND $<TARGET_FILE:segment_meta_cstore_fuzz_rpfixture> -max_total_time=30 -rss_limit_mb=8192
+  )
+endif()
+endif()

--- a/src/v/cloud_storage/tests/common_def.h
+++ b/src/v/cloud_storage/tests/common_def.h
@@ -10,7 +10,9 @@
 
 #pragma once
 #include "bytes/iobuf.h"
+#include "cloud_storage/base_manifest.h"
 #include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/types.h"
 #include "model/fundamental.h"
 #include "model/record_batch_types.h"
 #include "model/tests/random_batch.h"
@@ -34,6 +36,15 @@ static const ss::sstring manifest_url = ssx::sformat( // NOLINT
   "20000000/meta/{}_{}/manifest.json",
   manifest_ntp.path(),
   manifest_revision());
+static const ss::sstring manifest_serde_url = ssx::sformat(
+  "20000000/meta/{}_{}/manifest.bin", manifest_ntp.path(), manifest_revision());
+
+static const auto json_manifest_format_path = std::pair{
+  manifest_format::json,
+  remote_manifest_path(std::filesystem::path(manifest_url))};
+static const auto serde_manifest_format_path = std::pair{
+  manifest_format::serde,
+  remote_manifest_path(std::filesystem::path(manifest_serde_url))};
 
 inline iobuf iobuf_deep_copy(const iobuf& i) {
     iobuf res;

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -17,6 +17,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
+#include "random/generators.h"
 #include "seastarx.h"
 #include "serde/serde.h"
 #include "utils/tracking_allocator.h"
@@ -2303,4 +2304,45 @@ SEASTAR_THREAD_TEST_CASE(test_archive_offsets_serialization) {
     BOOST_REQUIRE_EQUAL(
       restored.get_archive_start_offset(), model::offset(100));
     BOOST_REQUIRE_EQUAL(restored.get_archive_clean_offset(), model::offset(50));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_partition_manifest_outofbound_trigger) {
+    BOOST_TEST_INFO(
+      fmt::format("random_seed: [{}]", random_generators::internal::gen));
+    auto m = partition_manifest{manifest_ntp, model::initial_revision_id(0)};
+    BOOST_REQUIRE(m.get_start_offset() == std::nullopt);
+    auto max_committed_offset = random_generators::get_int(0, 100000);
+    auto all_bo = std::vector<model::offset>{};
+    for (int i = 0; i < max_committed_offset;) {
+        auto co = random_generators::get_int(1, 100);
+        m.add(partition_manifest::segment_meta{
+          .base_offset = model::offset{i},
+          .committed_offset = model::offset{i + co},
+        });
+        i += co;
+        all_bo.emplace_back(model::offset{i});
+    }
+    for (auto o : all_bo) {
+        auto b = m.begin();
+        auto e = m.end();
+        m.truncate(o);
+        vlog(
+          test_log.debug,
+          "Truncating from {}, iterating from {}",
+          o,
+          b->base_offset);
+        model::offset sum{0};
+        size_t size_sum{0};
+        for (; b != e; ++b) {
+            auto t = *b;
+            sum = sum + t.base_offset;
+            size_sum += m.size();
+        }
+        vlog(
+          test_log.debug,
+          "Scanned from {}, sum {}, size_sum{}",
+          o,
+          sum,
+          size_sum);
+    }
 }

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -11,6 +11,7 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
+#include "cloud_storage/base_manifest.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
@@ -23,6 +24,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 
+#include <boost/test/tools/context.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -298,7 +300,11 @@ ss::logger test_log("partition_manifest_test");
 partition_manifest
 manifest_for(std::vector<std::pair<model::offset, kafka::offset>> o) {
     partition_manifest manifest;
-    manifest.update(make_manifest_stream(empty_manifest_json)).get();
+    manifest
+      .update(
+        cloud_storage::manifest_format::json,
+        make_manifest_stream(empty_manifest_json))
+      .get();
     for (int i = 0; i < o.size() - 1; i++) {
         segment_meta seg{
           .is_compacted = false,
@@ -425,7 +431,8 @@ SEASTAR_THREAD_TEST_CASE(test_segment_contains_by_kafka_offset) {
 
 SEASTAR_THREAD_TEST_CASE(test_segment_contains) {
     partition_manifest m;
-    m.update(make_manifest_stream(manifest_with_gaps)).get();
+    m.update(manifest_format::json, make_manifest_stream(manifest_with_gaps))
+      .get();
     BOOST_REQUIRE(m.segment_containing(model::offset{9}) == m.end());
     BOOST_REQUIRE(m.segment_containing(model::offset{90}) == m.end());
     BOOST_REQUIRE(
@@ -451,7 +458,9 @@ SEASTAR_THREAD_TEST_CASE(test_segment_contains) {
 // Test for the partition manifest tracked memory.
 SEASTAR_THREAD_TEST_CASE(test_manifest_mem_tracking) {
     partition_manifest empty_manifest;
-    empty_manifest.update(make_manifest_stream(empty_manifest_json)).get();
+    empty_manifest
+      .update(manifest_format::json, make_manifest_stream(empty_manifest_json))
+      .get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_type) {
@@ -533,15 +542,16 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_path) {
     partition_manifest m(manifest_ntp, model::initial_revision_id(0));
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
-      path, "20000000/meta/test-ns/test-topic/42_0/manifest.json");
+      path, "20000000/meta/test-ns/test-topic/42_0/manifest.bin");
 }
 
 SEASTAR_THREAD_TEST_CASE(test_empty_manifest_update) {
     partition_manifest m;
-    m.update(make_manifest_stream(empty_manifest_json)).get();
+    m.update(manifest_format::json, make_manifest_stream(empty_manifest_json))
+      .get();
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
-      path, "20000000/meta/test-ns/test-topic/42_0/manifest.json");
+      path, "20000000/meta/test-ns/test-topic/42_0/manifest.bin");
 }
 
 void require_equal_segment_meta(
@@ -563,10 +573,12 @@ void require_equal_segment_meta(
 
 SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
     partition_manifest m;
-    m.update(make_manifest_stream(complete_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(complete_manifest_json))
+      .get();
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
-      path, "60000000/meta/test-ns/test-topic/42_1/manifest.json");
+      path, "60000000/meta/test-ns/test-topic/42_1/manifest.bin");
     BOOST_REQUIRE_EQUAL(m.size(), 5);
     std::map<ss::sstring, partition_manifest::segment_meta> expected = {
       {"10-1-v1.log",
@@ -654,10 +666,13 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
 
 SEASTAR_THREAD_TEST_CASE(test_max_segment_meta_update) {
     partition_manifest m;
-    m.update(make_manifest_stream(max_segment_meta_manifest_json)).get();
+    m.update(
+       manifest_format::json,
+       make_manifest_stream(max_segment_meta_manifest_json))
+      .get();
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
-      path, "60000000/meta/test-ns/test-topic/42_1/manifest.json");
+      path, "60000000/meta/test-ns/test-topic/42_1/manifest.bin");
     BOOST_REQUIRE_EQUAL(m.size(), 1);
     std::map<ss::sstring, partition_manifest::segment_meta> expected = {
       {"10-1-v1.log",
@@ -686,7 +701,10 @@ SEASTAR_THREAD_TEST_CASE(test_max_segment_meta_update) {
 SEASTAR_THREAD_TEST_CASE(test_no_size_bytes_segment_meta) {
     partition_manifest m;
     BOOST_REQUIRE_EXCEPTION(
-      m.update(make_manifest_stream(no_size_bytes_segment_meta)).get(),
+      m.update(
+         manifest_format::json,
+         make_manifest_stream(no_size_bytes_segment_meta))
+        .get(),
       std::runtime_error,
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
@@ -700,7 +718,9 @@ SEASTAR_THREAD_TEST_CASE(test_no_size_bytes_segment_meta) {
  */
 SEASTAR_THREAD_TEST_CASE(test_timestamps_segment_meta) {
     partition_manifest m;
-    m.update(make_manifest_stream(no_timestamps_segment_meta)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(no_timestamps_segment_meta))
+      .get();
     std::map<ss::sstring, partition_manifest::segment_meta> expected = {
       {"10-1-v1.log",
        partition_manifest::segment_meta{
@@ -715,11 +735,13 @@ SEASTAR_THREAD_TEST_CASE(test_timestamps_segment_meta) {
 
 SEASTAR_THREAD_TEST_CASE(test_metas_get_smaller) {
     partition_manifest m;
-    m.update(make_manifest_stream(segment_meta_gets_smaller_manifest_json))
+    m.update(
+       manifest_format::json,
+       make_manifest_stream(segment_meta_gets_smaller_manifest_json))
       .get();
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
-      path, "60000000/meta/test-ns/test-topic/42_1/manifest.json");
+      path, "60000000/meta/test-ns/test-topic/42_1/manifest.bin");
     BOOST_REQUIRE_EQUAL(m.size(), 2);
     std::map<ss::sstring, partition_manifest::segment_meta> expected = {
       {"10-1-v1.log",
@@ -759,7 +781,10 @@ SEASTAR_THREAD_TEST_CASE(test_metas_get_smaller) {
 SEASTAR_THREAD_TEST_CASE(test_no_closing_bracket_meta) {
     partition_manifest m;
     BOOST_REQUIRE_EXCEPTION(
-      m.update(make_manifest_stream(no_closing_bracket_segment_meta)).get(),
+      m.update(
+         manifest_format::json,
+         make_manifest_stream(no_closing_bracket_segment_meta))
+        .get(),
       std::runtime_error,
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
@@ -773,10 +798,12 @@ SEASTAR_THREAD_TEST_CASE(test_no_closing_bracket_meta) {
 
 SEASTAR_THREAD_TEST_CASE(test_fields_after_segments) {
     partition_manifest m;
-    m.update(make_manifest_stream(fields_after_segments_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(fields_after_segments_json))
+      .get();
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
-      path, "60000000/meta/test-ns/test-topic/42_1/manifest.json");
+      path, "60000000/meta/test-ns/test-topic/42_1/manifest.bin");
     BOOST_REQUIRE_EQUAL(m.size(), 1);
     std::map<ss::sstring, partition_manifest::segment_meta> expected = {
       {"10-1-v1.log",
@@ -799,7 +826,10 @@ SEASTAR_THREAD_TEST_CASE(test_fields_after_segments) {
 SEASTAR_THREAD_TEST_CASE(test_missing_manifest_field) {
     partition_manifest m;
     BOOST_REQUIRE_EXCEPTION(
-      m.update(make_manifest_stream(missing_last_offset_manifest_json)).get(),
+      m.update(
+         manifest_format::json,
+         make_manifest_stream(missing_last_offset_manifest_json))
+        .get(),
       std::runtime_error,
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
@@ -992,12 +1022,12 @@ SEASTAR_THREAD_TEST_CASE(test_replaced_sname_format_version) {
       });
 
     std::stringstream sstr;
-    m.serialize(sstr);
+    m.serialize_json(sstr);
 
     vlog(test_log.info, "serialized: {}", sstr.str());
 
     partition_manifest m2;
-    m2.update(make_manifest_stream(sstr.str())).get();
+    m2.update(manifest_format::json, make_manifest_stream(sstr.str())).get();
     auto replaced = m2.replaced_segments();
     BOOST_REQUIRE_EQUAL(replaced.size(), 4);
     // size 0, inferred as v1
@@ -1703,7 +1733,9 @@ void scan_ts_segments(partition_manifest const& m) {
  */
 SEASTAR_THREAD_TEST_CASE(test_timequery_complete) {
     partition_manifest m;
-    m.update(make_manifest_stream(complete_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(complete_manifest_json))
+      .get();
 
     scan_ts_segments(m);
 }
@@ -1713,14 +1745,18 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_complete) {
  */
 SEASTAR_THREAD_TEST_CASE(test_timequery_single_segment) {
     partition_manifest m;
-    m.update(make_manifest_stream(max_segment_meta_manifest_json)).get();
+    m.update(
+       manifest_format::json,
+       make_manifest_stream(max_segment_meta_manifest_json))
+      .get();
 
     scan_ts_segments(m);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_timequery_gaps) {
     partition_manifest m;
-    m.update(make_manifest_stream(manifest_with_gaps)).get();
+    m.update(manifest_format::json, make_manifest_stream(manifest_with_gaps))
+      .get();
 
     // Timestamps within the segments and off the ends
     scan_ts_segments(m);
@@ -1779,7 +1815,8 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_wide_range) {
 })json";
 
     partition_manifest m;
-    m.update(make_manifest_stream(wide_timestamps)).get();
+    m.update(manifest_format::json, make_manifest_stream(wide_timestamps))
+      .get();
 
     scan_ts_segments(m);
 }
@@ -1839,7 +1876,9 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_overlaps) {
     })json";
 
     partition_manifest m;
-    m.update(make_manifest_stream(overlapping_timestamps)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(overlapping_timestamps))
+      .get();
 
     scan_ts_segments_general(m);
 }
@@ -1895,7 +1934,7 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_out_of_order) {
     })json";
 
     partition_manifest m;
-    m.update(make_manifest_stream(raw)).get();
+    m.update(manifest_format::json, make_manifest_stream(raw)).get();
 
     // Before range: should get first segment
     expect_ts_segment(
@@ -1916,10 +1955,12 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_out_of_order) {
 
 SEASTAR_THREAD_TEST_CASE(test_reset_manifest) {
     partition_manifest m;
-    m.update(make_manifest_stream(complete_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(complete_manifest_json))
+      .get();
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
-      path, "60000000/meta/test-ns/test-topic/42_1/manifest.json");
+      path, "60000000/meta/test-ns/test-topic/42_1/manifest.bin");
     BOOST_REQUIRE_EQUAL(m.size(), 5);
 
     partition_manifest expected{
@@ -1927,6 +1968,33 @@ SEASTAR_THREAD_TEST_CASE(test_reset_manifest) {
 
     m.unsafe_reset();
     BOOST_REQUIRE(m == expected);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_partition_manifest_v2_json) {
+    // manifest_version::v2 gets generated by converting manifest.bin (serde) to
+    // an equivalent json. the differences with v1 are only in the version
+    // number. (2, to distinguish from v1 that is generated by old redpanda)
+    constexpr static std::string_view v2_json = R"json(
+{
+  "version": 2,
+  "namespace": "kafka",
+  "topic": "panda-topic",
+  "partition": 0,
+  "revision": 21,
+  "last_offset": 22159,
+  "segments": {},
+  "replaced": {},
+  "insync_offset": 25554,
+  "last_uploaded_compacted_offset": 9223372036854776000,
+  "start_offset": 0
+}
+  )json";
+    partition_manifest m;
+    auto buf = iobuf{};
+    buf.append(v2_json.data(), v2_json.size());
+    m.update_with_json(std::move(buf)).get();
+    BOOST_CHECK_EQUAL(m.size(), 0);
+    BOOST_CHECK_EQUAL(m.replaced_segments_count(), 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
@@ -1984,7 +2052,7 @@ SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
     })json";
 
     partition_manifest m;
-    m.update(make_manifest_stream(raw)).get();
+    m.update(manifest_format::json, make_manifest_stream(raw)).get();
 
     {
         // old format with archival term
@@ -2037,7 +2105,9 @@ SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
 
 SEASTAR_THREAD_TEST_CASE(test_cloud_log_size_updates) {
     partition_manifest manifest;
-    manifest.update(make_manifest_stream(empty_manifest_json)).get();
+    manifest
+      .update(manifest_format::json, make_manifest_stream(empty_manifest_json))
+      .get();
 
     BOOST_REQUIRE_EQUAL(manifest.cloud_log_size(), 0);
 
@@ -2104,7 +2174,10 @@ SEASTAR_THREAD_TEST_CASE(test_cloud_log_size_truncate_twice) {
     // even further.
 
     partition_manifest manifest;
-    manifest.update(make_manifest_stream(complete_manifest_json)).get();
+    manifest
+      .update(
+        manifest_format::json, make_manifest_stream(complete_manifest_json))
+      .get();
 
     BOOST_REQUIRE_EQUAL(manifest.cloud_log_size(), 15360);
 
@@ -2170,7 +2243,9 @@ SEASTAR_THREAD_TEST_CASE(test_deserialize_v1_manifest) {
 })json";
 
     partition_manifest manifest;
-    manifest.update(make_manifest_stream(v1_manifest_json)).get();
+    manifest
+      .update(manifest_format::json, make_manifest_stream(v1_manifest_json))
+      .get();
 
     BOOST_REQUIRE_EQUAL(manifest.cloud_log_size(), 11264);
 }

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -304,8 +304,8 @@ FIXTURE_TEST(test_scan_by_kafka_offset_repeats, cloud_storage_fixture) {
       *this, model::offset(0), model::offset_delta(0), batch_types);
     print_segments(segments);
     for (int i = 0; i <= 3; i++) {
-        BOOST_REQUIRE(check_scan(*this, kafka::offset(i), 4 - i));
-        BOOST_REQUIRE(check_fetch(*this, kafka::offset(i), true));
+        BOOST_CHECK(check_scan(*this, kafka::offset(i), 4 - i));
+        BOOST_CHECK(check_fetch(*this, kafka::offset(i), true));
     }
     BOOST_REQUIRE(check_scan(*this, kafka::offset(4), 0));
     BOOST_REQUIRE(check_fetch(*this, kafka::offset(4), false));

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -240,7 +240,13 @@ FIXTURE_TEST(test_overlapping_segments, cloud_storage_fixture) {
     cloud_storage::partition_manifest manifest(manifest_ntp, manifest_revision);
 
     auto expectations = make_imposter_expectations(
-      manifest, segments, false, model::offset_delta(0));
+      manifest,
+      segments,
+      false,
+      model::offset_delta(0),
+      // Use v1 format because it only includes the base offset, not the
+      // committed offset.  We will modify the committed offset.
+      segment_name_format::v1);
 
     std::stringstream sstr;
     manifest.serialize_json(sstr);

--- a/src/v/cloud_storage/tests/segment_meta_cstore_fuzz.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_fuzz.cc
@@ -1,0 +1,525 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License included in
+ * the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with the Business
+ * Source License, use of this software will be governed by the Apache License,
+ * Version 2.0
+ *
+ * Coverage
+ * ========
+ *
+ * llvm-profdata merge -sparse default.profraw -o default.profdata
+ *
+ * llvm-cov show segment_meta_cstore_fuzz_rpfixture
+ * -instr-profile=default.profdata -format=html ../src/v/bytes/iobuf.h
+ * ../src/v/bytes/iobuf.cc > cov.html
+ */
+
+#include "cloud_storage/segment_meta_cstore.h"
+#include "cloud_storage/types.h"
+#include "model/fundamental.h"
+#include "reflection/to_tuple.h"
+#include "serde/type_str.h"
+
+#include <absl/container/btree_map.h>
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+#include <utility>
+#include <variant>
+
+class cstore_ops {
+    cloud_storage::segment_meta_cstore cstore{};
+    absl::btree_map<model::offset, cloud_storage::segment_meta> reference{};
+
+    cloud_storage::segment_meta_cstore::const_iterator reader_it = cstore.end();
+    cloud_storage::segment_meta_cstore::const_iterator reader_end
+      = cstore.end();
+
+public:
+    void moves() {
+        auto tmp = cloud_storage::segment_meta_cstore{
+          std::move(cstore)};    // move constructor
+        cstore = std::move(tmp); // move assignment
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+        cstore = std::move(cstore); // self-move assignment
+#pragma clang diagnostic pop
+    }
+
+    void reset_reader(size_t index) {
+        reader_end = cstore.end();
+        reader_it = std::next(cstore.begin(), std::min(index, cstore.size()));
+    }
+
+    void reset_reader(model::offset off) {
+        reader_end = cstore.end();
+        reader_it = cstore.lower_bound(off);
+    }
+
+    void consume_reader(size_t quantity) {
+        for (; quantity != 0 && reader_it != reader_end;
+             ++reader_it, --quantity) {
+            auto value = *reader_it;
+            (void)value;
+        }
+    }
+
+    void append_segment(cloud_storage::segment_meta smeta) {
+        auto opt_last = cstore.last_segment();
+        if (opt_last) {
+            // ensure segment will be last
+            auto delta = smeta.committed_offset - smeta.base_offset;
+            smeta.base_offset = opt_last->committed_offset + model::offset{1};
+            smeta.committed_offset = smeta.base_offset + delta;
+        }
+
+        if (reference.contains(smeta.base_offset)) {
+            throw std::runtime_error{
+              fmt::format("base_offset {} already exists", smeta.base_offset)};
+        }
+
+        cstore.insert(smeta);
+        reference[smeta.base_offset] = smeta;
+    }
+
+    // clean version is for smeta that is correctly aligned with pre-existing
+    // base and committed offsets
+    void replace_segment_clean(
+      cloud_storage::segment_meta smeta,
+      uint16_t index,
+      uint16_t num_of_replacements) {
+        if (index >= reference.size()) {
+            // just append
+            append_segment(smeta);
+            return;
+        }
+        // side step a degenerate cases
+        num_of_replacements = std::max(num_of_replacements, uint16_t(1));
+        auto end_index = size_t(index + num_of_replacements);
+        end_index = std::min(end_index, reference.size());
+
+        if (index == end_index) {
+            // this can happen in a degenerate case
+            return;
+        }
+
+        // extract range to be replaced
+        auto repl_beg = std::next(reference.begin(), index);
+        auto repl_end = std::next(reference.begin(), end_index);
+
+        // make smeta a replacement for range
+        smeta.base_offset = repl_beg->second.base_offset;
+        smeta.committed_offset = std::prev(repl_end)->second.committed_offset;
+
+        // replace
+        cstore.insert(smeta);
+        reference.erase(repl_beg, repl_end);
+        reference[smeta.base_offset] = smeta;
+    }
+
+    void prepend_segment(cloud_storage::segment_meta smeta) {
+        if (reference.empty()) {
+            append_segment(smeta);
+            return;
+        }
+
+        // adapt smeta
+        auto delta = smeta.committed_offset - smeta.base_offset;
+        smeta.committed_offset = reference.begin()->second.base_offset
+                                 - model::offset{1};
+        smeta.base_offset = smeta.committed_offset - delta;
+
+        reference[smeta.base_offset] = smeta;
+        cstore.insert(smeta);
+    }
+
+    // insert a replacement that will have a base offset before the first one in
+    // the store
+    void replace_segment_clean_in_front(
+      cloud_storage::segment_meta smeta, size_t num_of_replacements) {
+        if (reference.empty() || num_of_replacements == 0) {
+            prepend_segment(smeta);
+            return;
+        }
+        // num_of_replacements is at least 1
+        num_of_replacements = std::min(num_of_replacements, reference.size());
+        auto repl_end = std::next(reference.begin(), num_of_replacements);
+
+        // adapt smeta
+        auto delta = smeta.committed_offset - smeta.base_offset;
+        smeta.committed_offset = reference.begin()->second.base_offset
+                                 - model::offset{1};
+        smeta.base_offset = smeta.committed_offset - delta;
+        smeta.committed_offset = std::prev(repl_end)->second.committed_offset;
+
+        // replace them
+        cstore.insert(smeta);
+        reference.erase(reference.begin(), repl_end);
+        reference[smeta.base_offset] = smeta;
+    }
+
+    void clear() {
+        cstore = cloud_storage::segment_meta_cstore{};
+        reference.clear();
+    }
+
+    void truncate(model::offset new_start_offset) {
+        auto new_start = std::find_if(
+          reference.begin(), reference.end(), [new_start_offset](auto& kv) {
+              return kv.second.base_offset >= new_start_offset;
+          });
+        reference.erase(reference.begin(), new_start);
+        cstore.prefix_truncate(new_start_offset);
+    }
+
+    void serialize() {
+        auto buf = cstore.to_iobuf();
+        auto tmp = cloud_storage::segment_meta_cstore{};
+        tmp.from_iobuf(std::move(buf));
+
+        if (cstore != tmp) {
+            throw std::runtime_error{
+              fmt::format("cstore != tmp after serialization")};
+        }
+    }
+
+public:
+    /*
+     * Check consistency of cstore with reference.
+     */
+    void check() const {
+        if (reference.size() != cstore.size()) {
+            throw std::runtime_error{fmt::format(
+              "reference size {} != cstore size {}",
+              reference.size(),
+              cstore.size())};
+            ;
+        }
+
+        // if you squint, you'll see std::mismatch (but cstore_it is not
+        // copyable)
+        auto ref_it = reference.begin();
+        auto cstore_it = cstore.begin();
+        for (; ref_it != reference.end(); ++ref_it, ++cstore_it) {
+            if (ref_it->second != *cstore_it) {
+                throw std::runtime_error{fmt::format(
+                  "reference {} != cstore {} @ index {}",
+                  ref_it->second,
+                  *cstore_it,
+                  cstore_it.index())};
+            }
+        }
+
+        if (reader_it != reader_end) {
+            // this is just a nudge to check for up in the materialize() path
+            auto _ = *reader_it;
+            (void)_;
+        }
+    }
+};
+
+class Tape {
+    std::string_view program_;
+    std::string_view::const_iterator pc_;
+
+public:
+    // signal that the program should terminate normally
+    class end_of_program : std::exception {};
+
+    explicit Tape(std::string_view program)
+      : program_(program)
+      , pc_(program.cbegin()) {}
+
+    template<typename T>
+    T read() {
+        std::array<char, sizeof(T)> buf;
+        if (std::distance(pc_, program_.cend()) < buf.size()) {
+            throw end_of_program();
+        }
+        std::copy_n(pc_, buf.size(), buf.begin());
+        auto ret = std::bit_cast<T>(buf);
+        std::advance(pc_, sizeof(T));
+        return ret;
+    }
+
+    // This produces a segment meta that do not respect invariants in
+    // redpanda. the only invariant is base_offset < committed_offset
+    // furthermore, base_offset is always the same, just a placeholer
+    auto read_generic_segment_meta() -> cloud_storage::segment_meta {
+        constexpr static auto base_offset = model::offset{10};
+        return {
+          .is_compacted = read<uint8_t>() != 0,
+          .size_bytes = read<size_t>(),
+          .base_offset = base_offset,
+          .committed_offset
+          = base_offset
+            + std::max(model::offset{read<uint16_t>()}, model::offset{0})
+            + model::offset{1},
+          .base_timestamp = read<model::timestamp>(),
+          .max_timestamp = read<model::timestamp>(),
+          .delta_offset = read<model::offset_delta>(),
+          .ntp_revision = read<model::initial_revision_id>(),
+          .archiver_term = read<model::term_id>(),
+          .segment_term = read<model::term_id>(),
+          .delta_offset_end = read<model::offset_delta>(),
+          .sname_format = read<cloud_storage::segment_name_format>(),
+          .metadata_size_hint = read<uint64_t>(),
+        };
+    }
+
+    auto read_simplified_segment_meta() -> cloud_storage::segment_meta {
+        constexpr static auto base_offset = model::offset{10};
+        return {
+          .is_compacted = false,
+          .size_bytes = 1024u,
+          .base_offset = base_offset,
+          .committed_offset
+          = base_offset
+            + std::max(model::offset{read<uint16_t>()}, model::offset{0})
+            + model::offset{1},
+          .base_timestamp = {},
+          .max_timestamp = {},
+          .delta_offset = {},
+          .ntp_revision = {},
+          .archiver_term = {},
+          .segment_term = {},
+          .delta_offset_end = {},
+          .sname_format = {},
+          .metadata_size_hint = {},
+        };
+    }
+};
+
+struct noop {
+    auto operator()(cstore_ops& ops) const {}
+};
+struct move_op {
+    auto operator()(cstore_ops& ops) const { ops.moves(); }
+};
+
+struct append_segment_op {
+    cloud_storage::segment_meta smeta{};
+    void setup(Tape& tape) { smeta = tape.read_generic_segment_meta(); }
+    auto operator()(cstore_ops& ops) const { ops.append_segment(smeta); }
+};
+
+struct replace_segment_clean_op {
+    cloud_storage::segment_meta smeta{};
+    uint16_t index{};
+    uint16_t num_of_replacements{};
+    void setup(Tape& tape) {
+        smeta = tape.read_generic_segment_meta();
+        index = tape.read<uint16_t>();
+        num_of_replacements = tape.read<uint16_t>();
+    }
+    auto operator()(cstore_ops& ops) const {
+        ops.replace_segment_clean(smeta, index, num_of_replacements);
+    }
+};
+
+struct prepend_segment_op {
+    cloud_storage::segment_meta smeta{};
+    void setup(Tape& tape) { smeta = tape.read_generic_segment_meta(); }
+    auto operator()(cstore_ops& ops) const { ops.prepend_segment(smeta); }
+};
+
+struct replace_segment_clean_in_front_op {
+    cloud_storage::segment_meta smeta{};
+    size_t num_of_replacements{};
+    void setup(Tape& tape) {
+        smeta = tape.read_generic_segment_meta();
+        num_of_replacements = tape.read<size_t>();
+    }
+    auto operator()(cstore_ops& ops) const {
+        ops.replace_segment_clean_in_front(smeta, num_of_replacements);
+    }
+};
+
+struct clear_op {
+    auto operator()(cstore_ops& ops) const { ops.clear(); }
+};
+
+struct truncate_op {
+    model::offset new_start_offset{};
+    void setup(Tape& tape) { new_start_offset = tape.read<model::offset>(); }
+    auto operator()(cstore_ops& ops) const { ops.truncate(new_start_offset); }
+};
+
+struct serialize_op {
+    auto operator()(cstore_ops& ops) const { ops.serialize(); }
+};
+
+struct reset_reader_op {
+    model::offset start_offset{};
+    void setup(Tape& tape) { start_offset = tape.read<model::offset>(); }
+    auto operator()(cstore_ops& ops) const { ops.reset_reader(start_offset); }
+};
+
+struct consume_reader_op {
+    size_t quantity{};
+    void setup(Tape& tape) { quantity = tape.read<size_t>(); }
+    auto operator()(cstore_ops& ops) const { ops.consume_reader(quantity); }
+};
+
+using cstore_operation = std::variant<
+  noop,
+  move_op,
+  append_segment_op,
+  replace_segment_clean_op,
+  replace_segment_clean_in_front_op,
+  prepend_segment_op,
+  clear_op,
+  truncate_op,
+  serialize_op,
+  reset_reader_op,
+  consume_reader_op>;
+
+// SIN SECTION
+// this is a sections of ODR sins to appease the daemons of the linker
+
+auto cloud_storage::operator<<(std::ostream& os, segment_meta const& s)
+  -> std::ostream& {
+    return os << fmt::format(
+             "{{is_compacted: {}, size_bytes: {}, base_offset: {}, "
+             "committed_offset: "
+             "{}, base_timestamp: {}, max_timestamp: {}, delta_offset: {}, "
+             "ntp_revision: {}, archiver_term: {}, segment_term: {}, "
+             "delta_offset_end: {}, sname_format: {}, metadata_size_hint: {}}}",
+             s.is_compacted,
+             s.size_bytes,
+             s.base_offset,
+             s.committed_offset,
+             s.base_timestamp,
+             s.max_timestamp,
+             s.delta_offset,
+             s.ntp_revision,
+             s.archiver_term,
+             s.segment_term,
+             s.delta_offset_end,
+             s.sname_format,
+             s.metadata_size_hint);
+}
+
+auto cloud_storage::operator<<(std::ostream& os, segment_name_format const& sn)
+  -> std::ostream& {
+    return os << fmt::format("{}", unsigned(sn));
+}
+
+// END OF SIN SECTION
+
+template<>
+struct fmt::formatter<cstore_operation>
+  : public fmt::formatter<std::string_view> {
+    auto format(cstore_operation const& op, auto& ctx) const {
+        auto f = [&] {
+            return std::visit<std::string>(
+              []<typename OP>(OP const& op) {
+                  if constexpr (reflection::arity<OP>() == 0) {
+                      return fmt::format("{}", serde::type_str<OP>());
+                  } else {
+                      return fmt::format(
+                        "{}{}",
+                        serde::type_str<OP>(),
+                        reflection::to_tuple(op));
+                  }
+              },
+              op);
+        };
+        return formatter<std::string_view>::format(f(), ctx);
+    }
+};
+
+/*
+ * a program is a series of bytes. the structure of a program is:
+ *
+ *   [{op_code[, operands...]}*]
+ *
+ * where the set of operands are dependent on the op_code. the program
+ * ends when the end of the program is reached. if the operands for the
+ * final op_code are truncated then the program should terminate
+ * normally.
+ */
+class driver {
+    Tape tape;
+    cstore_ops m_{};
+    std::vector<cstore_operation> trace_{};
+
+public:
+    explicit driver(std::string_view program)
+      : tape{program} {}
+    void print_trace() const {
+        // this could be a fmt::print + fmt::join if we had ranges
+        fmt::print("TRACE:\n");
+        for (auto i = 0u; i < trace_.size(); ++i) {
+            fmt::print("\t{:>4} {}\n", i, trace_[i]);
+        }
+    }
+
+    bool operator()() {
+        // default op
+        auto next_op = cstore_operation{noop{}};
+        try {
+            // try to construct the next op, this could fail if there are not
+            // enough bytes
+            auto next_op_idx = tape.read<uint8_t>()
+                               % std::variant_size_v<cstore_operation>;
+            [&]<size_t... Is>(std::index_sequence<Is...>) {
+                ([&] {
+                    if (next_op_idx == Is) {
+                        next_op = cstore_operation{std::in_place_index<Is>};
+                        if constexpr (requires(
+                                        std::variant_alternative_t<
+                                          Is,
+                                          cstore_operation> op,
+                                        Tape t) { op.setup(t); }) {
+                            // call setup if op has it
+                            std::get<Is>(next_op).setup(tape);
+                        }
+
+                        return true;
+                    }
+                    return false;
+                }()
+                 || ...);
+            }
+            (std::make_index_sequence<std::variant_size_v<cstore_operation>>{});
+        } catch (const Tape::end_of_program&) {
+            return false;
+        }
+        trace_.push_back(next_op);
+        std::visit([&](auto& op) { op(m_); }, next_op);
+        return true;
+    }
+
+    void check() const { m_.check(); }
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    // NOLINTNEXTLINE
+    std::string_view d(reinterpret_cast<const char*>(data), size);
+    auto p = driver{d};
+
+    try {
+        while (p()) {
+            p.check();
+        }
+    } catch (...) {
+        p.print_trace();
+        throw;
+    }
+
+    return 0;
+}

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -863,9 +863,10 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_serde_roundtrip) {
     }
     {
         auto [inflated_sz, actual_sz] = store.inflated_actual_size();
+        auto pre_serde_size = store.size();
         auto iobuf = store.to_iobuf();
         auto serialized_sz = iobuf.size_bytes();
-        BOOST_REQUIRE(store.empty());
+        BOOST_REQUIRE_EQUAL(store.size(), pre_serde_size);
         store.from_iobuf(std::move(iobuf));
         vlog(
           test.info,

--- a/src/v/cloud_storage/tests/util.h
+++ b/src/v/cloud_storage/tests/util.h
@@ -651,9 +651,6 @@ std::vector<model::record_batch_header> scan_remote_partition_incrementally(
         config::shard_local_cfg().cloud_storage_max_readers_per_shard(
           maybe_max_readers);
     }
-    auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
-      manifest_ntp, manifest_revision);
-
     auto manifest = hydrate_manifest(imposter.api.local(), bucket);
     auto partition = ss::make_shared<remote_partition>(
       manifest, imposter.api.local(), imposter.cache.local(), bucket);
@@ -727,8 +724,6 @@ std::vector<model::record_batch_header> scan_remote_partition(
         config::shard_local_cfg().cloud_storage_max_readers_per_shard(
           maybe_max_readers);
     }
-    auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
-      manifest_ntp, manifest_revision);
     storage::log_reader_config reader_config(
       base, max, ss::default_priority_class());
 

--- a/src/v/cloud_storage/tests/util.h
+++ b/src/v/cloud_storage/tests/util.h
@@ -502,7 +502,8 @@ std::vector<cloud_storage_fixture::expectation> make_imposter_expectations(
   cloud_storage::partition_manifest& m,
   const std::vector<in_memory_segment>& segments,
   bool truncate_segments = false,
-  model::offset_delta delta = model::offset_delta(0)) {
+  model::offset_delta delta = model::offset_delta(0),
+  segment_name_format sname_format = segment_name_format::v2) {
     std::vector<cloud_storage_fixture::expectation> results;
 
     for (const auto& s : segments) {
@@ -530,8 +531,7 @@ std::vector<cloud_storage_fixture::expectation> make_imposter_expectations(
           .delta_offset = segment_delta,
           .ntp_revision = m.get_revision_id(),
           .delta_offset_end = model::offset_delta(delta)
-                              + model::offset_delta(s.num_config_records),
-        };
+                              + model::offset_delta(s.num_config_records)};
 
         m.add(s.sname, meta);
         delta = delta

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -173,7 +173,7 @@ topic_manifest::topic_manifest(
 topic_manifest::topic_manifest()
   : _topic_config(std::nullopt) {}
 
-void topic_manifest::update(const topic_manifest_handler& handler) {
+void topic_manifest::do_update(const topic_manifest_handler& handler) {
     if (handler._version != topic_manifest_version) {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
@@ -286,7 +286,7 @@ ss::future<> topic_manifest::update(ss::input_stream<char> is) {
     topic_manifest_handler handler;
     if (reader.Parse(wrapper, handler)) {
         vlog(cst_log.debug, "Parsed successfully!");
-        topic_manifest::update(handler);
+        topic_manifest::do_update(handler);
     } else {
         rapidjson::ParseErrorCode e = reader.GetParseErrorCode();
         size_t o = reader.GetErrorOffset();
@@ -309,7 +309,7 @@ ss::future<> topic_manifest::update(ss::input_stream<char> is) {
     co_return;
 }
 
-ss::future<serialized_json_stream> topic_manifest::serialize() const {
+ss::future<serialized_data_stream> topic_manifest::serialize() const {
     iobuf serialized;
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
@@ -321,7 +321,7 @@ ss::future<serialized_json_stream> topic_manifest::serialize() const {
           get_manifest_path()));
     }
     size_t size_bytes = serialized.size_bytes();
-    co_return serialized_json_stream{
+    co_return serialized_data_stream{
       .stream = make_iobuf_input_stream(std::move(serialized)),
       .size_bytes = size_bytes};
 }

--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -34,7 +34,7 @@ public:
     /// Serialize manifest object
     ///
     /// \return asynchronous input_stream with the serialized json
-    ss::future<serialized_json_stream> serialize() const override;
+    ss::future<serialized_data_stream> serialize() const override;
 
     /// Manifest object name in S3
     remote_manifest_path get_manifest_path() const override;
@@ -61,12 +61,15 @@ public:
         return _topic_config;
     }
 
-    bool operator==(const topic_manifest& other) const = default;
+    bool operator==(const topic_manifest& other) const {
+        return std::tie(_topic_config, _rev)
+               == std::tie(other._topic_config, other._rev);
+    };
 
 private:
     /// Update manifest content from json document that supposed to be generated
     /// from manifest.json file
-    void update(const topic_manifest_handler& handler);
+    void do_update(const topic_manifest_handler& handler);
 
     std::optional<manifest_topic_configuration> _topic_config;
     model::initial_revision_id _rev;

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -51,10 +51,10 @@ ss::future<> tx_range_manifest::update(ss::input_stream<char> is) {
     Document m;
     IStreamWrapper wrapper(stream);
     m.ParseStream(wrapper);
-    update(m);
+    do_update(m);
 }
 
-void tx_range_manifest::update(const rapidjson::Document& doc) {
+void tx_range_manifest::do_update(const rapidjson::Document& doc) {
     _ranges = fragmented_vector<model::tx_range>();
     auto version = doc["version"].GetInt();
     auto compat_version = doc["compat_version"].GetInt();
@@ -83,7 +83,7 @@ void tx_range_manifest::update(const rapidjson::Document& doc) {
     _ranges.shrink_to_fit();
 }
 
-ss::future<serialized_json_stream> tx_range_manifest::serialize() const {
+ss::future<serialized_data_stream> tx_range_manifest::serialize() const {
     iobuf serialized;
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
@@ -95,7 +95,7 @@ ss::future<serialized_json_stream> tx_range_manifest::serialize() const {
           get_manifest_path()));
     }
     size_t size_bytes = serialized.size_bytes();
-    co_return serialized_json_stream{
+    co_return serialized_data_stream{
       .stream = make_iobuf_input_stream(std::move(serialized)),
       .size_bytes = size_bytes};
 }

--- a/src/v/cloud_storage/tx_range_manifest.h
+++ b/src/v/cloud_storage/tx_range_manifest.h
@@ -41,12 +41,11 @@ public:
 
     /// Update manifest file from input_stream (remote set)
     ss::future<> update(ss::input_stream<char> is) override;
-    void update(const rapidjson::Document& is);
 
     /// Serialize manifest object
     ///
     /// \return asynchronous input_stream with the serialized json
-    ss::future<serialized_json_stream> serialize() const override;
+    ss::future<serialized_data_stream> serialize() const override;
 
     /// Manifest object name in S3
     remote_manifest_path get_manifest_path() const override;
@@ -65,6 +64,8 @@ public:
     }
 
 private:
+    void do_update(const rapidjson::Document& is);
+
     remote_segment_path _path;
     fragmented_vector<model::tx_range> _ranges;
 };

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -77,6 +77,7 @@ enum class upload_result : int32_t {
 
 enum class manifest_version : int32_t {
     v1 = 1,
+    v2 = 2,
 };
 
 enum class tx_range_manifest_version : int32_t {

--- a/src/v/cluster/cloud_metadata/cluster_manifest.cc
+++ b/src/v/cluster/cloud_metadata/cluster_manifest.cc
@@ -88,7 +88,7 @@ void cluster_metadata_manifest::load_from_json(const rapidjson::Document& doc) {
     }
 }
 
-ss::future<cloud_storage::serialized_json_stream>
+ss::future<cloud_storage::serialized_data_stream>
 cluster_metadata_manifest::serialize() const {
     iobuf serialized;
     iobuf_ostreambuf obuf(serialized);
@@ -101,7 +101,7 @@ cluster_metadata_manifest::serialize() const {
           get_manifest_path()));
     }
     size_t size_bytes = serialized.size_bytes();
-    co_return cloud_storage::serialized_json_stream{
+    co_return cloud_storage::serialized_data_stream{
       .stream = make_iobuf_input_stream(std::move(serialized)),
       .size_bytes = size_bytes};
 }

--- a/src/v/cluster/cloud_metadata/cluster_manifest.h
+++ b/src/v/cluster/cloud_metadata/cluster_manifest.h
@@ -62,14 +62,27 @@ struct cluster_metadata_manifest
     ss::sstring controller_snapshot_path;
 
     ss::future<> update(ss::input_stream<char> is) override;
-    ss::future<cloud_storage::serialized_json_stream>
+    ss::future<cloud_storage::serialized_data_stream>
     serialize() const override;
     cloud_storage::remote_manifest_path get_manifest_path() const override;
     cloud_storage::manifest_type get_manifest_type() const override {
         return cloud_storage::manifest_type::cluster_metadata;
     }
 
-    bool operator==(const cluster_metadata_manifest& other) const = default;
+    bool operator==(const cluster_metadata_manifest& other) const {
+        return std::tie(
+                 upload_time_since_epoch,
+                 cluster_uuid,
+                 metadata_id,
+                 controller_snapshot_offset,
+                 controller_snapshot_path)
+               == std::tie(
+                 other.upload_time_since_epoch,
+                 other.cluster_uuid,
+                 other.metadata_id,
+                 other.controller_snapshot_offset,
+                 other.controller_snapshot_path);
+    }
 
 private:
     void load_from_json(const rapidjson::Document& doc);

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -16,6 +16,7 @@
 #include "cluster/tm_stm_cache_manager.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -850,6 +851,16 @@ static ss::future<bool> should_finalize(
 }
 
 ss::future<> partition::remove_remote_persistent_state(ss::abort_source& as) {
+    if (!_feature_table.local().is_active(
+          features::feature::cloud_storage_manifest_format_v2)) {
+        // this is meant to prevent uploading manifests with new format while
+        // the cluster is in a mixed state
+        vlog(
+          clusterlog.info,
+          "skipping erasing tiered storage objects for partition {}",
+          ntp());
+        co_return;
+    }
     // Backward compatibility: even if remote.delete is true, only do
     // deletion if the partition is in full tiered storage mode (this
     // excludes read replica clusters from deleting data in S3)
@@ -920,7 +931,7 @@ void partition::set_topic_config(
     }
 }
 
-ss::future<> partition::serialize_manifest_to_output_stream(
+ss::future<> partition::serialize_json_manifest_to_output_stream(
   ss::output_stream<char>& output) {
     if (!_archival_meta_stm || !_cloud_storage_partition) {
         throw std::runtime_error(fmt::format(
@@ -933,7 +944,8 @@ ss::future<> partition::serialize_manifest_to_output_stream(
     // of time the manifest lock is held for.
     co_await ss::with_timeout(
       model::timeout_clock::now() + manifest_serialization_timeout,
-      _cloud_storage_partition->serialize_manifest_to_output_stream(output));
+      _cloud_storage_partition->serialize_json_manifest_to_output_stream(
+        output));
 }
 
 ss::future<std::error_code>

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1024,7 +1024,7 @@ ss::future<> partition::unsafe_reset_remote_partition_manifest(iobuf buf) {
     // Deserialise provided manifest
     cloud_storage::partition_manifest req_m{
       _raft->ntp(), _raft->log_config().get_initial_revision()};
-    co_await req_m.update(std::move(buf));
+    co_await req_m.update_with_json(std::move(buf));
 
     // A generous timeout of 60 seconds is used as it applies
     // for the replication multiple batches.

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -345,7 +345,7 @@ public:
     // completes.
     static constexpr std::chrono::seconds manifest_serialization_timeout{3s};
     ss::future<>
-    serialize_manifest_to_output_stream(ss::output_stream<char>& output);
+    serialize_json_manifest_to_output_stream(ss::output_stream<char>& output);
 
     std::optional<std::reference_wrapper<cluster::topic_configuration>>
     get_topic_config() {

--- a/src/v/cluster/partition_recovery_manager.cc
+++ b/src/v/cluster/partition_recovery_manager.cc
@@ -310,7 +310,7 @@ ss::future<log_recovery_result> partition_downloader::download_log() {
     auto mat = co_await find_recovery_material();
     if (cst_log.is_enabled(ss::log_level::debug)) {
         std::stringstream ostr;
-        mat.partition_manifest.serialize(ostr);
+        mat.partition_manifest.serialize_json(ostr);
         vlog(
           _ctxlog.debug,
           "Partition manifest used for recovery: {}",
@@ -606,15 +606,15 @@ partition_downloader::find_recovery_material() {
       _ctxlog.info,
       "Downloading partition manifest {}",
       tmp.get_manifest_path());
-    auto res = co_await _remote->download_manifest(
-      _bucket, tmp.get_manifest_path(), tmp, _rtcnode);
+    auto [res, res_fmt] = co_await _remote->try_download_partition_manifest(
+      _bucket, tmp, _rtcnode);
     if (res == download_result::success) {
         recovery_mat.partition_manifest = std::move(tmp);
         co_return recovery_mat;
     }
     if (res == download_result::notfound) {
         // Manifest is not available in the cloud
-        throw missing_partition_exception(tmp.get_manifest_path());
+        throw missing_partition_exception(tmp.get_manifest_path(res_fmt));
     }
     // Some other, possibly transient error
     throw std::runtime_error(

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4398,7 +4398,7 @@ ss::future<ss::json::json_return_type> admin_server::sync_local_state_handler(
         vlog(logger.info, "Requested bucket syncup completed");
         if (result) {
             std::stringstream sts;
-            result->serialize(sts);
+            result->serialize_json(sts);
             vlog(logger.info, "Requested bucket syncup result {}", sts.str());
         } else {
             vlog(logger.info, "Requested bucket syncup result empty");
@@ -4698,7 +4698,8 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::get_manifest(
                         std::move(os),
                         std::move(part),
                         [](auto& os, auto& part) mutable {
-                            return part->serialize_manifest_to_output_stream(os)
+                            return part
+                              ->serialize_json_manifest_to_output_stream(os)
                               .finally([&os] { return os.close(); });
                         });
                   });

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -119,7 +119,7 @@ function install_rust_tools() {
 
   git clone https://github.com/jcsp/segment_toy.git
   pushd segment_toy
-  git reset --hard c863c1a
+  git reset --hard 0acf2f8f06db94c0c72c13369d9ff1effb799d2d
   cargo build --release
   cp target/release/rp-storage-tool /usr/local/bin
   popd

--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -119,9 +119,9 @@ function install_rust_tools() {
 
   git clone https://github.com/jcsp/segment_toy.git
   pushd segment_toy
-  git reset --hard 3a4b8b37bf1fddd5ff767a13c13e3947476485a8
+  git reset --hard c863c1a
   cargo build --release
-  cp target/release/segments /usr/local/bin
+  cp target/release/rp-storage-tool /usr/local/bin
   popd
   rm -rf segment_toy
 

--- a/tests/rptest/clients/rp_storage_tool.py
+++ b/tests/rptest/clients/rp_storage_tool.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import tempfile
+import subprocess
+import json
+
+
+class RpStorageTool:
+    def __init__(self, logger):
+        self.logger = logger
+
+    def decode_partition_manifest(self, binary_data, logger) -> dict:
+        # Decode to JSON using external tool
+        with tempfile.NamedTemporaryFile(mode='wb') as tmp:
+            tmp.write(binary_data)
+            tmp.flush()
+            cmd = [
+                "rp-storage-tool", "decode-partition-manifest",
+                f"--path={tmp.name}"
+            ]
+            self.logger.debug(
+                f"Decoding {len(binary_data)} byte binary manifest: {cmd}")
+            p = subprocess.run(cmd, capture_output=True)
+            if p.returncode != 0:
+                self.logger.error(p.stderr)
+                self.logger.error(f"Binary at: {tmp.name}")
+
+                # XXX TODO
+                import time
+                time.sleep(3600)
+
+                raise RuntimeError(f"Manifest decode failed: {p.stderr}")
+            else:
+                json_bytes = p.stdout
+                try:
+                    return json.loads(json_bytes)
+                except Exception as e:
+                    self.logger.error(
+                        f"Error loading JSON decoded from binary manifest: {e}"
+                    )
+                    self.logger.error(f"Decoded json: {json_bytes}")
+                    raise

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -865,7 +865,7 @@ class RedpandaServiceBase(Service):
         metrics_endpoint = ("/metrics" if metrics_endpoint
                             == MetricsEndpoint.METRICS else "/public_metrics")
         url = f"http://{node.account.hostname}:9644{metrics_endpoint}"
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=10)
         assert resp.status_code == 200
         return text_string_to_metric_families(resp.text)
 

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -126,7 +126,8 @@ class CloudRetentionTest(PreallocNodesTest):
             s3_snapshot = BucketView(self.redpanda, topics=topics)
             try:
                 manifest = s3_snapshot.manifest_for_ntp(self.topic_name, 0)
-            except:
+            except Exception as e:
+                self.logger.debug(f"Failed to get manifest: {e}")
                 return False
 
             if "segments" not in manifest:
@@ -142,7 +143,8 @@ class CloudRetentionTest(PreallocNodesTest):
             for p in range(0, num_partitions):
                 try:
                     manifest = s3_snapshot.manifest_for_ntp(self.topic_name, p)
-                except:
+                except Exception as e:
+                    self.logger.debug(f"Failed to get manifest: {e}")
                     return False
 
                 kafka_last_offset = BucketView.kafka_last_offset(manifest)
@@ -273,7 +275,7 @@ class CloudRetentionTest(PreallocNodesTest):
                         f"Partition {partition} doesn't have last_offset")
                     return False
 
-                if not "segments" not in manifest:
+                if "segments" in manifest and len(manifest['segments']):
                     self.logger.info(
                         f"Partition {partition} still has segments")
                     return False

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -149,7 +149,8 @@ class BucketScrubSelfTest(RedpandaTest):
 
     @skip_debug_mode  # We wait for a decent amount of traffic
     @cluster(num_nodes=4)
-    @matrix(cloud_storage_type=get_cloud_storage_type())
+    #@matrix(cloud_storage_type=get_cloud_storage_type())
+    @matrix(cloud_storage_type=[CloudStorageType.S3])
     def test_missing_segment(self, cloud_storage_type):
         topic = 'test'
 


### PR DESCRIPTION
This pr introduces serde serialization for partition_manifest. The files are now manifest.binary instead of manifest.json (file suffix is open for discussion).

partition_manifests::update can be used with either manifest.json and manifest.binary, but the format must be manually specified. serialize produces manifest.serde only. 

To not mess during an upgrade, uploading is stopped until the cluster is upgraded. 

To support both files, it's introduced remote::try_download_manifests. It accepts a vector of paths to try to download one after the other

The new manifest.bin has serde::version<2> (manifest_version::v2). this is done so as to be compatible with manifest.json. this is useful in the scenario where a manifest.bin is converted to a json representation through rp-storage-tool and then feed back to redpanda, like EndToEndShadowIndexingTest.test_reset does 

Fixes #9895 

some commits are cherry picked from https://github.com/redpanda-data/redpanda/pull/10782, https://github.com/redpanda-data/redpanda/pull/10704, https://github.com/redpanda-data/redpanda/pull/10696 and https://github.com/redpanda-data/redpanda/pull/10463

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Partition-manifest is now encoded via serde and the file on cloud will be manifest.binary instead of manifest.json
