### PR TITLE
add alias for version in rpk

### DIFF
--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -65,9 +65,10 @@ func Execute() {
 		zap.ReplaceGlobals(p.Logger())
 	})
 	root := &cobra.Command{
-		Use:   "rpk",
-		Short: "rpk is the Redpanda CLI & toolbox",
-		Long:  "",
+		Use:     "rpk",
+		Short:   "rpk is the Redpanda CLI & toolbox",
+		Long:    "",
+		Version: version.Pretty(),
 
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 	}


### PR DESCRIPTION
Adds an alias for version as a convenience for people used to --version.

Fixes #4802


<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features

* none 

### Improvements

* adds --version flag to the top level rpk command to print the rpk version



