### PR TITLE
c/backend: s/parallel_for_each/max_concurrent_for_each

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -542,9 +542,10 @@ bool is_finishing_operation(
 } // namespace
 
 ss::future<> controller_backend::do_bootstrap() {
-    return ss::parallel_for_each(
+    return ss::max_concurrent_for_each(
       _topic_deltas.begin(),
       _topic_deltas.end(),
+      1024,
       [this](underlying_t::value_type& ntp_deltas) {
           return bootstrap_ntp(ntp_deltas.first, ntp_deltas.second);
       });
@@ -923,9 +924,10 @@ ss::future<> controller_backend::reconcile_topics() {
             return ss::now();
         }
         // reconcile NTPs in parallel
-        return ss::parallel_for_each(
+        return ss::max_concurrent_for_each(
                  _topic_deltas.begin(),
                  _topic_deltas.end(),
+                 1024,
                  [this](underlying_t::value_type& ntp_deltas) {
                      return reconcile_ntp(ntp_deltas.second);
                  })


### PR DESCRIPTION
It appears the contiguous allocation is from a vector of futures in the state maintained by parallel_for_each.. and max_concurrent_for_each doesn't have that limitation due to it's implementation.

Fixes #10348

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
