### PR TITLE
Force NIC tuner to use mq exclusively

### DIFF
--- a/src/go/rpk/pkg/tuners/irq/device_info.go
+++ b/src/go/rpk/pkg/tuners/irq/device_info.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -99,6 +100,9 @@ func (deviceInfo *deviceInfo) GetIRQs(
 			}
 		}
 	}
+
+	sort.Ints(irqs)
+
 	zap.L().Sugar().Debugf("DeviceInfo '%s' IRQs '%v'", irqConfigDir, irqs)
 	return irqs, nil
 }

--- a/src/go/rpk/pkg/utils/files.go
+++ b/src/go/rpk/pkg/utils/files.go
@@ -15,6 +15,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -61,6 +62,7 @@ func ListFilesInPath(fs afero.Fs, path string) []string {
 	for _, fileInfo := range files {
 		names = append(names, fileInfo.Name())
 	}
+	sort.Strings(names)
 	return names
 }
 


### PR DESCRIPTION
This series makes the NIC IRQ tuner always select "mq" mode.

Currently we try to choose among sq[-split] and mq modes for assigning
NIC IRQ affinity. However the idea behind sq and sq-split modes is that
a core is *dedicated* to IRQs (i.e., Redpanda core does not run on that
core or lcore). Nnow, we don't currently support propagating a cpuset to
Redpanda, so RP will run on the IRQ core, causing it to be the first
bottleneck, at least for high packet count loads which stress softirqs.

We change the tuner to use mq mode exclusively for now, regardless of
the number of cores or lcores. In the future we may investigate the use
of the sq modes again, if we can propagate a cpuset to Redpanda.

MQ mode was being selected on many/most relevant instance types already
because of the condition `numPU == rxQueues` (logical core count equals
the number of NIC queues): if this condition was met, we chose mq mode.
However, on some instance types this condition was not met, e.g., most/all
GCP instances when hyperthreading was turned off, or large instance types
like GCP instances with 32 cores or more (and probably some AWS types),
because the total number of NIC queues is limited and eventually we 
exceed that number.

Users may still select `sq` or `sq-split` modes explicitly.

Fixes issue #10444.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Fixed an issue where sq or sq-split mode may be chosen for NIC IRQ affinity in the redpanda tuner, resulting in core/shard 0 becoming a bottleneck for some high packet-per-second loads.
