### PR TITLE
offline_log_viewer: update for topic_lifecycle_transition

### DIFF
--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -206,6 +206,23 @@ def decode_topic_command_serde(k_rdr: Reader, rdr: Reader):
         cmd['topic'] = rdr.read_string()
         k_rdr.read_string()
         k_rdr.read_string()
+    elif cmd['type'] == 10:
+        # This command replaces delete_topic in Redpanda 23.2
+        cmd['type_string'] = 'topic_lifecycle_transition'
+        cmd['namespace'] = k_rdr.read_string()
+        cmd['topic'] = k_rdr.read_string()
+        cmd['transition'] = rdr.read_envelope(
+            lambda rdr, _v: {
+                'nt':
+                rdr.read_envelope(
+                    lambda rdr, _v: {
+                        'namespace': rdr.read_string(),
+                        'topic': rdr.read_string(),
+                        'initial_revision_id': rdr.read_int64()
+                    }),
+                'mode':
+                rdr.read_serde_enum(),
+            })
     elif cmd['type'] == 2:
         cmd['type_string'] = 'update_partitions'
         cmd['namespace'] = k_rdr.read_string()


### PR DESCRIPTION
This command type merged yesterday, update the tool to understand it.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none