### PR TITLE
cloud_storage: Fix typo in partition_manifest

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1071,7 +1071,7 @@ struct partition_manifest_handler
                 _delta_offset_end = model::offset_delta(u);
             } else if ("sname_format" == _segment_meta_key) {
                 _meta_sname_format = segment_name_format(u);
-            } else if ("metadata_size_hint") {
+            } else if ("metadata_size_hint" == _segment_meta_key) {
                 _metadata_size_hint = static_cast<size_t>(u);
             }
             if (_state == state::expect_segment_meta_value) {


### PR DESCRIPTION
Fix typo in the `partition_manifest` deserialization code.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none