### PR TITLE
storage: adapt to non-copyable iterator

### DIFF
--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -176,12 +176,14 @@ model::offset segment_collector::find_replacement_boundary() const {
     // _begin_inclusive (in gap): 22.
     if (it == _manifest.end()) {
         // first segment after gap: 25-29
-        it = std::find_if(
-          _manifest.begin(), _manifest.end(), [this](const auto& entry) {
-              return entry.base_offset > _begin_inclusive;
-          });
-
+        for (it = _manifest.begin(); it != _manifest.end(); ++it) {
+            const auto& entry = *it;
+            if (entry.base_offset > _begin_inclusive) {
+                break;
+            }
+        }
         // The collection is valid if it can reach the end of the gap: 24
+        vassert(it != _manifest.end(), "Trying to dereference end iterator");
         replace_boundary = it->base_offset - model::offset{1};
     } else {
         replace_boundary = it->committed_offset;


### PR DESCRIPTION
std::find_if requires copyable iterators, but
segment_meta_materializing_iterator is not copyable (contains a unique_ptr). this is apparently not a problem in libc++ because it forwards the r-value reference, but libstdc++ does make a copy.

```
    In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/algorithm:61:
    /usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/stl_algo.h:3923:29: error: call to deleted constructor of 'cloud_storage::segment_meta_materializing_iterator'
          return std::__find_if(__first, __last,
                                ^~~~~~~
    /home/nwatkins/src/redpanda-osbuild/src/v/archival/segment_reupload.cc:185:20: note: in instantiation of function template specialization 'std::find_if<cloud_storage::segment_meta_materializing_iterator, (lambda at /home/nwatkins/src/redpanda-osbuild/src/v/archival/segment_reupload.cc:186:48)>' requested here
             it = std::find_if(
```

Fix by adding a few hand-coded searches to replace calls to std::find_if.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
