### PR TITLE
Minor fixes for public cmake build

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG e538ac0a9c88f597318e97dcaaa82770984c9d6e
+  GIT_TAG 777ad7c4c1e280c63877b80036a5b15fd0a6388a
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   LIST_SEPARATOR |

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -491,7 +491,7 @@ FIXTURE_TEST(rack_aware_assignment_2, partition_allocator_fixture) {
         auto rack_it = std::lower_bound(
           id_rack_ncpu.begin(),
           id_rack_ncpu.end(),
-          std::make_tuple(node_id(), ss::sstring(), 0));
+          std::make_tuple(node_id(), model::rack_id(""), 0));
         BOOST_REQUIRE(rack_it != id_rack_ncpu.end());
         BOOST_REQUIRE(std::get<0>(*rack_it) == node_id());
         auto rack = std::get<1>(*rack_it);

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -5,7 +5,7 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/../api/api-doc/schema_registry.json.h
 )
 
-find_package(protobuf)
+find_package(Protobuf REQUIRED)
 find_package(Avro)
 
 v_cc_library(

--- a/src/v/pandaproxy/schema_registry/protobuf/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/protobuf/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(Protobuf REQUIRED)
-
 set(PROTO_FILES
   confluent/meta.proto
   confluent/types/decimal.proto

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:38
 
 COPY --chown=0:0 install-dependencies.sh /
 


### PR DESCRIPTION
Some small tweaks for the public build. It uses newer compiler and libstdc++ so there are some small code changes too.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
