### PR TITLE
golang: bump to 1.20.4

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: 1.20.4
 
       - name: Run tests
         working-directory: src/go/rpk/
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: 1.20.4
 
       - name: Create empty release notes
         run: |

--- a/src/go/k8s/Dockerfile
+++ b/src/go/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.20.1 as builder
+FROM public.ecr.aws/docker/library/golang:1.20.4 as builder
 
 ARG TARGETARCH
 

--- a/src/go/rpk/.golangci.yml
+++ b/src/go/rpk/.golangci.yml
@@ -63,7 +63,7 @@ linters-settings:
   #
   # https://github.com/mvdan/gofumpt/issues/137
   gofumpt:
-    lang-version: "1.19.2"
+    lang-version: "1.20.4"
 
   # Revive is yet another metalinter with a lot of useful lints. 
   # The below opts in to all the ones we would like to use.


### PR DESCRIPTION
This fixes an issue with multi-arch images in docker. Also bumps all other references to golang to make it consistent. 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
