### PR TITLE
tests: wait for recovery rate only on active brokers

### DIFF
--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -399,6 +399,14 @@ def wait_for_recovery_throttle_rate(redpanda, new_rate: int):
                     f"Error getting throttle rate for {node}", exc_info=True)
                 return False
 
-        return all([check_throttle_rate(n) for n in redpanda.started_nodes()])
+        brokers = redpanda._admin.get_brokers(node=redpanda.controller())
+        active_brokers = set([b['node_id'] for b in brokers])
+        assert active_brokers
+        filtered = [
+            n for n in redpanda.started_nodes()
+            if redpanda.node_id(n) in active_brokers
+        ]
+        assert filtered
+        return all([check_throttle_rate(n) for n in filtered])
 
     wait_until(wait_for_throttle_update, timeout_sec=90, backoff_sec=1)


### PR DESCRIPTION
Waiter was trying to poll a configuration update on a decommissioned node and was waiting forever. Patch avoids that by only waiting on active brokers by scraping the brokers end point.

Fixes #10551

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
