### PR TITLE
[v22.2.x] Fix overallocation in `cluster::get_leadership_reply`

### DIFF
--- a/src/v/cluster/metadata_dissemination_handler.cc
+++ b/src/v/cluster/metadata_dissemination_handler.cc
@@ -84,13 +84,15 @@ metadata_dissemination_handler::do_update_leadership(
 
 static get_leadership_reply
 make_get_leadership_reply(const partition_leaders_table& leaders) {
-    std::vector<ntp_leader> ret;
+    fragmented_vector<ntp_leader> ret;
+
     leaders.for_each_leader([&ret](
                               model::topic_namespace_view tp_ns,
                               model::partition_id pid,
                               std::optional<model::node_id> leader,
                               model::term_id term) mutable {
-        ret.emplace_back(model::ntp(tp_ns.ns, tp_ns.tp, pid), term, leader);
+        ret.push_back(
+          ntp_leader{model::ntp(tp_ns.ns, tp_ns.tp, pid), term, leader});
     });
 
     return get_leadership_reply{std::move(ret)};

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -252,13 +252,17 @@ ss::future<> metadata_dissemination_service::process_get_update_reply(
         return ss::make_ready_future<>();
     }
     // Update all NTP leaders
-    return _leaders
-      .invoke_on_all([reply = std::move(reply_result.value())](
-                       partition_leaders_table& leaders) mutable {
-          for (auto& l : reply.leaders) {
-              leaders.update_partition_leader(l.ntp, l.term, l.leader_id);
-          }
-      })
+    return ss::do_with(
+             std::move(reply_result.value().leaders),
+             [this](auto& reply) {
+                 return _leaders.invoke_on_all(
+                   [&reply](partition_leaders_table& leaders) {
+                       for (const auto& l : reply) {
+                           leaders.update_partition_leader(
+                             l.ntp, l.term, l.leader_id);
+                       }
+                   });
+             })
       .then([&meta] { meta.success = true; });
 }
 

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -165,11 +165,11 @@ struct get_leadership_request
 
 struct get_leadership_reply
   : serde::envelope<get_leadership_reply, serde::version<0>> {
-    std::vector<ntp_leader> leaders;
+    fragmented_vector<ntp_leader> leaders;
 
     get_leadership_reply() noexcept = default;
 
-    explicit get_leadership_reply(std::vector<ntp_leader> leaders)
+    explicit get_leadership_reply(fragmented_vector<ntp_leader> leaders)
       : leaders(std::move(leaders)) {}
 
     friend bool
@@ -183,6 +183,13 @@ struct get_leadership_reply
     }
 
     auto serde_fields() { return std::tie(leaders); }
+
+    /*
+     * Support for serde compat check
+     */
+    get_leadership_reply copy() const {
+        return get_leadership_reply{leaders.copy()};
+    }
 };
 
 } // namespace cluster
@@ -194,7 +201,7 @@ struct adl<cluster::get_leadership_reply> {
         serialize(out, r.leaders);
     }
     cluster::get_leadership_reply from(iobuf_parser& in) {
-        auto leaders = adl<std::vector<cluster::ntp_leader>>{}.from(in);
+        auto leaders = adl<fragmented_vector<cluster::ntp_leader>>{}.from(in);
         return cluster::get_leadership_reply(std::move(leaders));
     }
 };

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -12,6 +12,7 @@
 #include "cluster/metadata_dissemination_types.h"
 #include "cluster/tests/utils.h"
 #include "cluster/types.h"
+#include "compat/check.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -530,8 +531,9 @@ SEASTAR_THREAD_TEST_CASE(partition_status_serialization_old_version) {
 }
 
 template<typename T>
-void serde_roundtrip_test(const T original) {
-    auto serde_in = original;
+void serde_roundtrip_test(T a) {
+    using compat::compat_copy;
+    auto [serde_in, original] = compat_copy(std::move(a));
     auto serde_out = serde::to_iobuf(std::move(serde_in));
     auto from_serde = serde::from_iobuf<T>(std::move(serde_out));
 
@@ -539,8 +541,9 @@ void serde_roundtrip_test(const T original) {
 }
 
 template<typename T>
-void adl_roundtrip_test(const T original) {
-    auto adl_in = original;
+void adl_roundtrip_test(T a) {
+    using compat::compat_copy;
+    auto [adl_in, original] = compat_copy(std::move(a));
     auto adl_out = reflection::to_iobuf(std::move(adl_in));
     auto from_adl = reflection::from_iobuf<T>(std::move(adl_out));
 
@@ -548,9 +551,11 @@ void adl_roundtrip_test(const T original) {
 }
 
 template<typename T>
-void roundtrip_test(const T original) {
-    serde_roundtrip_test(original);
-    adl_roundtrip_test(original);
+void roundtrip_test(T a) {
+    using compat::compat_copy;
+    auto [original_a, original_b] = compat_copy(std::move(a));
+    serde_roundtrip_test(std::move(original_a));
+    adl_roundtrip_test(std::move(original_b));
 }
 
 template<typename T>
@@ -886,12 +891,12 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
     roundtrip_test(cluster::get_leadership_request());
 
-    roundtrip_test(cluster::get_leadership_reply({
-      cluster::ntp_leader(
-        model::random_ntp(),
-        tests::random_named_int<model::term_id>(),
-        tests::random_named_int<model::node_id>()),
-    }));
+    fragmented_vector<cluster::ntp_leader> leaders;
+    leaders.push_back(cluster::ntp_leader{
+      model::random_ntp(),
+      tests::random_named_int<model::term_id>(),
+      tests::random_named_int<model::node_id>()});
+    roundtrip_test(cluster::get_leadership_reply(std::move(leaders)));
 
     roundtrip_test(
       cluster::allocate_id_request(random_timeout_clock_duration()));

--- a/src/v/compat/check.h
+++ b/src/v/compat/check.h
@@ -74,6 +74,16 @@ std::pair<T, T> compat_copy(T t) {
     return {t, t};
 }
 
+template<typename T>
+concept ExplicitCopyable = requires(T a) {
+    { a.copy() } -> std::same_as<T>;
+};
+
+template<ExplicitCopyable T>
+std::pair<T, T> compat_copy(T t) {
+    return {t.copy(), std::move(t)};
+}
+
 /*
  * Holder for binary serialization of a data structure along with the name of
  * the protocol used (e.g. adl, serde).

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -110,6 +110,15 @@ void read_value(json::Value const& v, std::vector<T>& target) {
 }
 
 template<typename T>
+void read_value(json::Value const& v, fragmented_vector<T>& target) {
+    for (auto const& e : v.GetArray()) {
+        auto t = T{};
+        read_value(e, t);
+        target.push_back(t);
+    }
+}
+
+template<typename T>
 void read_value(json::Value const& v, std::optional<T>& target) {
     if (v.IsNull()) {
         target = std::nullopt;
@@ -163,7 +172,7 @@ requires(!std::is_enum_v<T>) void read_member(
     if (it != v.MemberEnd()) {
         read_value(it->value, target);
     } else {
-        target = {};
+        target = T{};
         std::cout << "key " << key << " not found, default initializing"
                   << std::endl;
     }

--- a/src/v/compat/metadata_dissemination_compat.h
+++ b/src/v/compat/metadata_dissemination_compat.h
@@ -118,10 +118,10 @@ struct compat_check<cluster::get_leadership_reply> {
     }
     static std::vector<compat_binary>
     to_binary(cluster::get_leadership_reply obj) {
-        return compat_binary::serde_and_adl(obj);
+        return compat_binary::serde_and_adl(std::move(obj));
     }
     static void check(cluster::get_leadership_reply obj, compat_binary test) {
-        verify_adl_or_serde(obj, std::move(test));
+        verify_adl_or_serde(std::move(obj), std::move(test));
     }
 };
 

--- a/src/v/compat/metadata_dissemination_generator.h
+++ b/src/v/compat/metadata_dissemination_generator.h
@@ -58,12 +58,12 @@ EMPTY_COMPAT_GENERATOR(cluster::get_leadership_request);
 template<>
 struct instance_generator<cluster::get_leadership_reply> {
     static cluster::get_leadership_reply random() {
-        return cluster::get_leadership_reply({
-          cluster::ntp_leader(
-            model::random_ntp(),
-            tests::random_named_int<model::term_id>(),
-            tests::random_named_int<model::node_id>()),
-        });
+        fragmented_vector<cluster::ntp_leader> leaders;
+        leaders.push_back(cluster::ntp_leader{
+          model::random_ntp(),
+          tests::random_named_int<model::term_id>(),
+          tests::random_named_int<model::node_id>()});
+        return cluster::get_leadership_reply(std::move(leaders));
     }
 
     static std::vector<cluster::get_leadership_reply> limits() { return {}; }

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -91,6 +91,17 @@ void rjson_serialize(
     w.EndArray();
 }
 
+template<typename T, size_t max_fragment_size>
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const fragmented_vector<T, max_fragment_size>& v) {
+    w.StartArray();
+    for (const auto& e : v) {
+        rjson_serialize(w, e);
+    }
+    w.EndArray();
+}
+
 template<typename T, typename A>
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const ss::circular_buffer<T, A>& v) {


### PR DESCRIPTION
Backport of PR #10585 
Fixes #10613 

Force push `0a9102a`:

* removed line that was accidentally added