### PR TITLE
Per-handler kafka request metrics

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -24,6 +24,7 @@ set(handlers_srcs
   server/handlers/topics/topic_utils.cc
   server/handlers/describe_producers.cc
   server/handlers/describe_transactions.cc
+  server/handlers/handler_probe.cc
 )
 
 v_cc_library(

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -433,35 +433,35 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                                     return maybe_process_responses();
                                 });
                             })
-                            .handle_exception([self, sres](std::exception_ptr e) {
-                                // ssx::spawn_with_gate already caught
-                                // shutdown-like exceptions, so we should only
-                                // be taking this path for real errors.  That
-                                // also means that on shutdown we don't bother
-                                // to call shutdown_input on the connection, so
-                                // rely on any future reader to check the abort
-                                // source before considering reading the
-                                // connection.
+                            .handle_exception(
+                              [self, sres](std::exception_ptr e) {
+                                  // ssx::spawn_with_gate already caught
+                                  // shutdown-like exceptions, so we should only
+                                  // be taking this path for real errors.  That
+                                  // also means that on shutdown we don't bother
+                                  // to call shutdown_input on the connection,
+                                  // so rely on any future reader to check the
+                                  // abort source before considering reading the
+                                  // connection.
+                                  auto disconnected
+                                    = net::is_disconnect_exception(e);
+                                  if (disconnected) {
+                                      vlog(
+                                        klog.info,
+                                        "Disconnected {} ({})",
+                                        self->conn->addr,
+                                        disconnected.value());
+                                  } else {
+                                      vlog(
+                                        klog.warn,
+                                        "Error processing request: {}",
+                                        e);
+                                  }
 
-                                auto disconnected
-                                  = net::is_disconnect_exception(e);
-                                if (disconnected) {
-                                    vlog(
-                                      klog.info,
-                                      "Disconnected {} ({})",
-                                      self->conn->addr,
-                                      disconnected.value());
-                                } else {
-                                    vlog(
-                                      klog.warn,
-                                      "Error processing request: {}",
-                                      e);
-                                }
-
-                                sres->tracker->mark_errored();
-                                self->_server.probe().service_error();
-                                self->conn->shutdown_input();
-                            });
+                                  sres->tracker->mark_errored();
+                                  self->_server.probe().service_error();
+                                  self->conn->shutdown_input();
+                              });
                       return d;
                   })
                   .handle_exception([self, sres](std::exception_ptr e) {

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -406,7 +406,6 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                             })
                             .finally([self, d = std::move(d), sres]() mutable {
                                 sres->tracker->mark_errored();
-                                self->_server.probe().service_error();
                                 return std::move(d);
                             });
                       }
@@ -459,7 +458,6 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                                   }
 
                                   sres->tracker->mark_errored();
-                                  self->_server.probe().service_error();
                                   self->conn->shutdown_input();
                               });
                       return d;

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -407,7 +407,6 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                             .finally([self, d = std::move(d), sres]() mutable {
                                 sres->tracker->mark_errored();
                                 self->_server.probe().service_error();
-                                self->_server.probe().request_completed();
                                 return std::move(d);
                             });
                       }

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "config/property.h"
+#include "kafka/server/handlers/handler_probe.h"
 #include "kafka/server/response.h"
 #include "kafka/server/server.h"
 #include "kafka/types.h"
@@ -52,19 +53,33 @@ class request_context;
 // used to track number of pending requests
 class request_tracker {
 public:
-    explicit request_tracker(net::server_probe& probe) noexcept
-      : _probe(probe) {
+    explicit request_tracker(
+      net::server_probe& probe, handler_probe& h_probe) noexcept
+      : _probe(probe)
+      , _h_probe(h_probe) {
         _probe.request_received();
+        _h_probe.request_started();
     }
     request_tracker(const request_tracker&) = delete;
     request_tracker(request_tracker&&) = delete;
     request_tracker& operator=(const request_tracker&) = delete;
     request_tracker& operator=(request_tracker&&) = delete;
 
-    ~request_tracker() noexcept { _probe.request_completed(); }
+    void mark_errored() { _errored = true; }
+
+    ~request_tracker() noexcept {
+        _probe.request_completed();
+        if (_errored) {
+            _h_probe.request_errored();
+        } else {
+            _h_probe.request_completed();
+        }
+    }
 
 private:
     net::server_probe& _probe;
+    handler_probe& _h_probe;
+    bool _errored{false};
 };
 
 struct request_data {

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -71,6 +71,7 @@ public:
         _probe.request_completed();
         if (_errored) {
             _h_probe.request_errored();
+            _probe.service_error();
         } else {
             _h_probe.request_completed();
         }

--- a/src/v/kafka/server/handlers/handler_probe.cc
+++ b/src/v/kafka/server/handlers/handler_probe.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/handlers/handler_probe.h"
+
+#include "config/configuration.h"
+#include "kafka/server/handlers/handler_interface.h"
+#include "kafka/server/logger.h"
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_registration.hh>
+
+#include <chrono>
+#include <memory>
+
+namespace kafka {
+
+handler_probe_manager::handler_probe_manager()
+  : _metrics()
+  , _probes(max_api_key() + 2) {
+    const auto unknown_handler_key = max_api_key() + 1;
+    for (size_t i = 0; i < _probes.size(); i++) {
+        auto key = api_key{i};
+
+        if (handler_for_key(key) || i == unknown_handler_key) {
+            _probes[i].setup_metrics(_metrics, key);
+        }
+    }
+}
+
+handler_probe& handler_probe_manager::get_probe(api_key key) {
+    if (!handler_for_key(key)) {
+        return _probes.back();
+    }
+
+    return _probes[key];
+}
+
+handler_probe::handler_probe()
+  : _last_recorded_in_progress(ss::lowres_clock::now()) {}
+
+void handler_probe::setup_metrics(
+  ss::metrics::metric_groups& metrics, api_key key) {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    const char* handler_name;
+    if (auto handler = handler_for_key(key)) {
+        handler_name = handler.value()->name();
+    } else {
+        handler_name = "unknown_handler";
+    }
+
+    std::vector<sm::label_instance> labels{sm::label("handler")(handler_name)};
+    auto aggregate_labels = config::shard_local_cfg().aggregate_metrics()
+                              ? std::vector<sm::label>{sm::shard_label}
+                              : std::vector<sm::label>{};
+
+    metrics.add_group(
+      prometheus_sanitize::metrics_name("kafka_handler"),
+      {
+        sm::make_counter(
+          "requests_completed_total",
+          [this] { return _requests_completed; },
+          sm::description("Number of kafka requests completed"),
+          labels)
+          .aggregate(aggregate_labels),
+        sm::make_counter(
+          "requests_errored_total",
+          [this] { return _requests_errored; },
+          sm::description("Number of kafka requests errored"),
+          labels)
+          .aggregate(aggregate_labels),
+        sm::make_counter(
+          "requests_in_progress_total",
+          [this] { return _requests_in_progress_every_ns / 1'000'000'000; },
+          sm::description("A running total of kafka requests in progress"),
+          labels)
+          .aggregate(aggregate_labels),
+      });
+}
+
+/*
+ * This roughly approximates an integral of `_requests_in_progress`.
+ * By providing Prometheus with a counter of the integral rather than
+ * a gauge for `_requests_in_progress` we avoid any bias in the value
+ * that Prometheus's sampling rate could introduce.
+ */
+void handler_probe::sample_in_progress() {
+    auto now = ss::lowres_clock::now();
+    auto s_diff = (now - _last_recorded_in_progress)
+                  / std::chrono::nanoseconds(1);
+
+    _requests_in_progress_every_ns += _requests_in_progress * s_diff;
+    _last_recorded_in_progress = now;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/handler_probe.cc
+++ b/src/v/kafka/server/handlers/handler_probe.cc
@@ -90,6 +90,18 @@ void handler_probe::setup_metrics(
           sm::description("A running total of kafka requests in progress"),
           labels)
           .aggregate(aggregate_labels),
+        sm::make_counter(
+          "received_bytes_total",
+          [this] { return _bytes_received; },
+          sm::description("Number of bytes received from kafka requests"),
+          labels)
+          .aggregate(aggregate_labels),
+        sm::make_counter(
+          "sent_bytes_total",
+          [this] { return _bytes_sent; },
+          sm::description("Number of bytes sent in kafka replies"),
+          labels)
+          .aggregate(aggregate_labels),
       });
 }
 

--- a/src/v/kafka/server/handlers/handler_probe.h
+++ b/src/v/kafka/server/handlers/handler_probe.h
@@ -39,6 +39,10 @@ public:
         _requests_in_progress++;
     }
 
+    void add_bytes_received(size_t bytes) { _bytes_received += bytes; }
+
+    void add_bytes_sent(size_t bytes) { _bytes_sent += bytes; }
+
 private:
     uint64_t _requests_completed{0};
     uint64_t _requests_errored{0};
@@ -47,6 +51,9 @@ private:
     uint64_t _requests_in_progress_every_ns{0};
 
     ss::lowres_clock::time_point _last_recorded_in_progress;
+
+    uint64_t _bytes_received{0};
+    uint64_t _bytes_sent{0};
 };
 
 /**

--- a/src/v/kafka/server/handlers/handler_probe.h
+++ b/src/v/kafka/server/handlers/handler_probe.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/types.h"
+#include "ssx/metrics.h"
+
+namespace kafka {
+
+/**
+ * Stores per-handler metrics for kafka requests.
+ * And exposes them to the internal metrics endpoint.
+ */
+class handler_probe {
+public:
+    explicit handler_probe();
+    void setup_metrics(ss::metrics::metric_groups&, api_key);
+
+    void sample_in_progress();
+    void request_completed() {
+        sample_in_progress();
+
+        _requests_completed++;
+        _requests_in_progress--;
+    }
+    void request_errored() { _requests_errored++; }
+    void request_started() {
+        sample_in_progress();
+
+        _requests_in_progress++;
+    }
+
+private:
+    uint64_t _requests_completed{0};
+    uint64_t _requests_errored{0};
+
+    uint64_t _requests_in_progress{0};
+    uint64_t _requests_in_progress_every_ns{0};
+
+    ss::lowres_clock::time_point _last_recorded_in_progress;
+};
+
+/**
+ * Maps Kafka api keys to the `handler_probe` instance
+ * specific to that key.
+ */
+class handler_probe_manager {
+public:
+    handler_probe_manager();
+    /**
+     * Maps an `api_key` to the metrics probe it's associate with.
+     * If the `api_key` isn't valid a probe to an `unknown_handler`
+     * is returned instead.
+     */
+    handler_probe& get_probe(api_key key);
+
+private:
+    ss::metrics::metric_groups _metrics;
+    std::vector<handler_probe> _probes;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -15,10 +15,12 @@
 #include "config/configuration.h"
 #include "features/feature_table.h"
 #include "kafka/latency_probe.h"
+#include "kafka/protocol/types.h"
 #include "kafka/server/fetch_metadata_cache.hh"
 #include "kafka/server/fetch_session_cache.h"
 #include "kafka/server/fwd.h"
 #include "kafka/server/handlers/fetch/replica_selector.h"
+#include "kafka/server/handlers/handler_probe.h"
 #include "kafka/server/queue_depth_monitor.h"
 #include "net/server.h"
 #include "security/fwd.h"
@@ -169,6 +171,10 @@ public:
         return *_replica_selector;
     }
 
+    handler_probe& handler_probe(api_key key) {
+        return _handler_probes.get_probe(key);
+    }
+
 private:
     ss::smp_service_group _smp_group;
     ss::scheduling_group _fetch_scheduling_group;
@@ -197,6 +203,9 @@ private:
     security::tls::principal_mapper _mtls_principal_mapper;
     security::gssapi_principal_mapper _gssapi_principal_mapper;
     security::krb5::configurator _krb_configurator;
+
+    handler_probe_manager _handler_probes;
+
     class latency_probe _probe;
     ssx::thread_worker& _thread_worker;
     std::unique_ptr<replica_selector> _replica_selector;


### PR DESCRIPTION
Adds usage metrics to each Kafka request handler. I.e,
![image](https://user-images.githubusercontent.com/3487600/236968844-70fb9051-aa55-4a2c-9b04-220ba26b2223.png)
![image](https://user-images.githubusercontent.com/3487600/236968860-26c80561-cf42-447a-a49e-f5b174b8e05c.png)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features
* adds usage metrics to each Kafka request handler