### PR TITLE
[backport] [v23.1.x] More detailed partition reconfiguration tracking #10201

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -273,6 +273,29 @@ inline bool has_non_replicable_op_type(const topic_table_delta& d) {
     }
     __builtin_unreachable();
 }
+
+inline std::vector<model::broker_shard> union_replica_sets(
+  const std::vector<model::broker_shard>& lhs,
+  const std::vector<model::broker_shard>& rhs) {
+    std::vector<model::broker_shard> ret;
+    // Inefficient but constant time for small replica sets.
+    std::copy_if(
+      lhs.begin(),
+      lhs.end(),
+      std::back_inserter(ret),
+      [&ret](const model::broker_shard& bs) {
+          return std::find(ret.begin(), ret.end(), bs) == ret.end();
+      });
+    std::copy_if(
+      rhs.begin(),
+      rhs.end(),
+      std::back_inserter(ret),
+      [&ret](const model::broker_shard& bs) {
+          return std::find(ret.begin(), ret.end(), bs) == ret.end();
+      });
+    return ret;
+}
+
 /**
  * Subtracts second replica set from the first one. Result contains only brokers
  * shards that are present in first replica set but not in the second one.

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -25,11 +25,13 @@
 #include "model/metadata.h"
 #include "model/timeout_clock.h"
 #include "rpc/connection_cache.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include <absl/container/node_hash_map.h>
 
@@ -453,6 +455,60 @@ controller_api::shard_for(const raft::group_id& group) const {
 std::optional<ss::shard_id>
 controller_api::shard_for(const model::ntp& ntp) const {
     return _shard_table.local().shard_for(ntp);
+}
+
+ss::future<global_reconciliation_state>
+controller_api::get_global_reconciliation_state(
+  std::vector<model::ntp> ntps, model::timeout_clock::time_point timeout) {
+    // step is to gather per node requests for each of the node
+    absl::node_hash_map<model::node_id, std::vector<model::ntp>> grouped_ntps;
+    const auto ntps_sz = ntps.size();
+
+    for (auto& ntp : ntps) {
+        auto it = _topics.local().updates_in_progress().find(ntp);
+        if (it == _topics.local().updates_in_progress().end()) {
+            // not longer updating
+            continue;
+        }
+        auto all_replicas = union_replica_sets(
+          it->second.get_previous_replicas(), it->second.get_target_replicas());
+        for (const auto& r : all_replicas) {
+            grouped_ntps[r.node_id].push_back(ntp);
+        }
+        co_await ss::coroutine::maybe_yield();
+    }
+
+    using ret_t = result<std::vector<ntp_reconciliation_state>>;
+
+    auto node_results = co_await ssx::parallel_transform(
+      std::move(grouped_ntps), [this, timeout](auto pair) {
+          if (pair.first == _self) {
+              return get_reconciliation_state(std::move(pair.second))
+                .then([id = pair.first](ret_t ret) {
+                    return std::make_pair(id, std::move(ret));
+                });
+          }
+          return get_reconciliation_state(
+                   pair.first, std::move(pair.second), timeout)
+            .then([id = pair.first](ret_t ret) {
+                return std::make_pair(id, std::move(ret));
+            });
+      });
+
+    global_reconciliation_state state;
+    state.ntp_backend_operations.reserve(ntps_sz);
+    for (auto& [node_id, result] : node_results) {
+        if (result.has_error()) {
+            state.node_errors.emplace_back(node_id, result.error());
+            continue;
+        }
+        for (auto& ntp_state : result.value()) {
+            state.ntp_backend_operations[ntp_state.ntp()].emplace_back(
+              node_id, std::move(ntp_state.pending_operations()));
+        }
+        co_await ss::coroutine::maybe_yield();
+    }
+    co_return state;
 }
 
 } // namespace cluster

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -176,6 +176,9 @@ controller_api::get_reconciliation_state(model::ntp ntp) {
                 .source_shard = shard,
                 .p_as = std::move(m.delta.new_assignment),
                 .type = m.delta.type,
+                .current_retry = m.retries,
+                .last_operation_result = m.last_error,
+                .revision_of_operation = model::revision_id(m.delta.offset),
               };
           });
     }

--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -71,6 +71,14 @@ public:
     ss::future<result<std::vector<partition_reconfiguration_state>>>
       get_partitions_reconfiguration_state(
         std::vector<model::ntp>, model::timeout_clock::time_point);
+    /**
+     * Returns state of controller backend from each node in the cluster for
+     * requested list of ntps. A global reconciliation status contains a state
+     * of reconciliation loop execution from every replica that is part of an
+     * ntp replica set.
+     */
+    ss::future<global_reconciliation_state> get_global_reconciliation_state(
+      std::vector<model::ntp>, model::timeout_clock::time_point);
 
     ss::future<result<node_decommission_progress>>
       get_node_decommission_progress(

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/errc.h"
 #include "cluster/fwd.h"
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
@@ -225,6 +226,7 @@ public:
 
         topic_table::delta delta;
         uint64_t retries = 0;
+        cluster::errc last_error = errc::waiting_for_recovery;
         friend std::ostream& operator<<(std::ostream&, const delta_metadata&);
     };
 

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -67,6 +67,7 @@ enum class errc : int16_t {
     cluster_already_exists,
     no_partition_assignments,
     failed_to_create_partition,
+    partition_operation_failed,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -191,6 +192,9 @@ struct errc_category final : public std::error_category {
             return "No replica assignments for the requested partition";
         case errc::failed_to_create_partition:
             return "Failed to create partition replica instance";
+        case errc::partition_operation_failed:
+            return "Generic failure occurred during partition operation "
+                   "execution";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2405,6 +2405,11 @@ public:
     const std::vector<backend_operation>& pending_operations() const {
         return _backend_operations;
     }
+
+    std::vector<backend_operation>& pending_operations() {
+        return _backend_operations;
+    }
+
     reconciliation_status status() const { return _status; }
 
     std::error_code error() const { return make_error_code(_error); }
@@ -2426,6 +2431,31 @@ private:
     std::vector<backend_operation> _backend_operations;
     reconciliation_status _status;
     errc _error;
+};
+
+struct node_backend_operations {
+    node_backend_operations(
+      model::node_id id, std::vector<backend_operation> ops)
+      : node_id(id)
+      , backend_operations(std::move(ops)) {}
+
+    model::node_id node_id;
+    std::vector<backend_operation> backend_operations;
+};
+
+struct node_error {
+    node_error(model::node_id nid, std::error_code err_code)
+      : node_id(nid)
+      , ec(err_code) {}
+
+    model::node_id node_id;
+    std::error_code ec;
+};
+
+struct global_reconciliation_state {
+    absl::node_hash_map<model::ntp, std::vector<node_backend_operations>>
+      ntp_backend_operations;
+    std::vector<node_error> node_errors;
 };
 
 struct reconciliation_state_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2080,16 +2080,29 @@ struct delete_acls_reply
 
 struct backend_operation
   : serde::
-      envelope<backend_operation, serde::version<0>, serde::compat_version<0>> {
+      envelope<backend_operation, serde::version<1>, serde::compat_version<0>> {
     ss::shard_id source_shard;
     partition_assignment p_as;
     topic_table_delta::op_type type;
+
+    uint64_t current_retry;
+    cluster::errc last_operation_result;
+    model::revision_id revision_of_operation;
+
     friend std::ostream& operator<<(std::ostream&, const backend_operation&);
 
     friend bool operator==(const backend_operation&, const backend_operation&)
       = default;
 
-    auto serde_fields() { return std::tie(source_shard, p_as, type); }
+    auto serde_fields() {
+        return std::tie(
+          source_shard,
+          p_as,
+          type,
+          current_retry,
+          last_operation_result,
+          revision_of_operation);
+    }
 };
 
 struct create_data_policy_cmd_data

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -84,6 +84,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::cluster_already_exists:
     case cluster::errc::no_partition_assignments:
     case cluster::errc::failed_to_create_partition:
+    case cluster::errc::partition_operation_failed:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -516,6 +516,75 @@
                 "status": {
                     "type": "string",
                     "description": "Reconfiguration status"
+                },
+                "current_replicas": {
+                    "type": "array",
+                    "items": {
+                        "type": "assignment"
+                    },
+                    "description": "Current replica set"
+                },
+                "bytes_left_to_move": {
+                    "type": "long",
+                    "description": "bytes left to move to new replicas"
+                },
+                "bytes_moved": {
+                    "type": "long",
+                    "description": "bytes already moved to new replicas"
+                },
+                "partition_size": {
+                    "type": "long",
+                    "description": "current size of partition"
+                },
+                "reconciliation_statuses": {
+                    "type": "array",
+                    "items": {
+                        "type": "partition_reconciliation_status"
+                    },
+                    "description": "list of reconciliation statuses per node"
+                }
+            }
+        },
+        "partition_reconciliation_status": {
+            "id": "partition_reconciliation_status",
+            "description": "Partition reconciliation status on a node",
+            "properties": {
+                "node_id": {
+                    "type": "int",
+                    "description": "Id of a node reporting the status"
+                },
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "partition_reconciliation_operation"
+                    },
+                    "description": "list of operations being executed on the node"
+                }
+            }
+        },
+        "partition_reconciliation_operation": {
+            "id": "partition_reconciliation_operation",
+            "description": "Partition reconciliation being executed by a a node on specific shard",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Type of an operation that is currently being executed"
+                },
+                "core": {
+                    "type": "int",
+                    "description": "Core that the status come from"
+                },
+                "retry_number": {
+                    "type": "int",
+                    "description": "Number of currently executed operations retry"
+                },
+                "revision": {
+                    "type": "int",
+                    "description": "Currently executed operation revision"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Result of last operation retry"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -84,6 +84,7 @@
 #include "security/scram_credential.h"
 #include "ssx/future-util.h"
 #include "ssx/metrics.h"
+#include "utils/fragmented_vector.h"
 #include "utils/string_switch.h"
 #include "vlog.h"
 
@@ -99,6 +100,8 @@
 #include <seastar/http/httpd.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/http/request.hh>
+#include <seastar/json/json_elements.hh>
+#include <seastar/util/later.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/variant_utils.hh>
 
@@ -2631,27 +2634,103 @@ ss::future<ss::json::json_return_type>
 admin_server::get_reconfigurations_handler(
   std::unique_ptr<ss::httpd::request>) {
     using reconfiguration = ss::httpd::partition_json::reconfiguration;
-    std::vector<reconfiguration> ret;
+
     auto& in_progress
       = _controller->get_topics_state().local().updates_in_progress();
 
-    ret.reserve(in_progress.size());
-    for (auto& [ntp, status] : in_progress) {
-        reconfiguration r;
-        r.ns = ntp.ns;
-        r.topic = ntp.tp.topic;
-        r.partition = ntp.tp.partition;
-        r.status = fmt::format("{}", status.get_state());
+    std::vector<model::ntp> ntps;
+    ntps.reserve(in_progress.size());
 
-        for (auto& bs : status.get_previous_replicas()) {
-            ss::httpd::partition_json::assignment replica;
-            replica.node_id = bs.node_id;
-            replica.core = bs.shard;
-            r.previous_replicas.push(replica);
-        }
-        ret.push_back(std::move(r));
+    for (auto& [ntp, status] : in_progress) {
+        ntps.push_back(ntp);
     }
-    co_return ss::json::json_return_type(ret);
+
+    auto const deadline = model::timeout_clock::now() + 5s;
+
+    auto [reconfiguration_states, reconciliations]
+      = co_await ss::when_all_succeed(
+        _controller->get_api().local().get_partitions_reconfiguration_state(
+          ntps, deadline),
+        _controller->get_api().local().get_global_reconciliation_state(
+          ntps, deadline));
+
+    if (reconfiguration_states.has_error()) {
+        vlog(
+          logger.info,
+          "unable to get reconfiguration status: {}({})",
+          reconfiguration_states.error().message(),
+          reconfiguration_states.error());
+        throw ss::httpd::base_exception(
+          fmt::format(
+            "unable to get reconfiguration status: {}({})",
+            reconfiguration_states.error().message(),
+            reconfiguration_states.error()),
+          ss::httpd::reply::status_type::service_unavailable);
+    }
+    co_return ss::json::json_return_type(ss::json::stream_range_as_array(
+      std::move(reconfiguration_states.value()),
+      [reconciliations = std::move(reconciliations)](auto& s) {
+          reconfiguration r;
+          r.ns = s.ntp.ns;
+          r.topic = s.ntp.tp.topic;
+          r.partition = s.ntp.tp.partition;
+
+          for (const model::broker_shard& bs : s.current_assignment) {
+              ss::httpd::partition_json::assignment assignment;
+              assignment.core = bs.shard;
+              assignment.node_id = bs.node_id;
+              r.current_replicas.push(assignment);
+          }
+
+          for (const model::broker_shard& bs : s.previous_assignment) {
+              ss::httpd::partition_json::assignment assignment;
+              assignment.core = bs.shard;
+              assignment.node_id = bs.node_id;
+              r.previous_replicas.push(assignment);
+          }
+
+          size_t left_to_move = 0;
+          size_t already_moved = 0;
+          for (auto replica_status : s.already_transferred_bytes) {
+              left_to_move += (s.current_partition_size - replica_status.bytes);
+              already_moved += replica_status.bytes;
+          }
+          r.bytes_left_to_move = left_to_move;
+          r.bytes_moved = already_moved;
+          r.partition_size = s.current_partition_size;
+          // if no information from partitions is present yet, we may indicate
+          // that everything have to be moved
+          if (already_moved == 0 && left_to_move == 0) {
+              r.bytes_left_to_move = s.current_partition_size;
+          }
+
+          auto it = reconciliations.ntp_backend_operations.find(s.ntp);
+          if (it != reconciliations.ntp_backend_operations.end()) {
+              for (auto& node_ops : it->second) {
+                  seastar::httpd::partition_json::
+                    partition_reconciliation_status per_node_status;
+                  per_node_status.node_id = node_ops.node_id;
+
+                  for (auto& op : node_ops.backend_operations) {
+                      auto& current_op = node_ops.backend_operations.front();
+                      seastar::httpd::partition_json::
+                        partition_reconciliation_operation r_op;
+                      r_op.core = op.source_shard;
+                      r_op.retry_number = current_op.current_retry;
+                      r_op.revision = current_op.revision_of_operation;
+                      r_op.status = fmt::format(
+                        "{} ({})",
+                        cluster::error_category().message(
+                          (int)current_op.last_operation_result),
+                        current_op.last_operation_result);
+                      r_op.type = fmt::format("{}", current_op.type);
+                      per_node_status.operations.push(r_op);
+                  }
+                  r.reconciliation_statuses.push(per_node_status);
+              }
+          }
+          return r;
+      }));
 }
 
 ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2628,6 +2628,33 @@ admin_server::mark_transaction_expired_handler(
 }
 
 ss::future<ss::json::json_return_type>
+admin_server::get_reconfigurations_handler(
+  std::unique_ptr<ss::httpd::request>) {
+    using reconfiguration = ss::httpd::partition_json::reconfiguration;
+    std::vector<reconfiguration> ret;
+    auto& in_progress
+      = _controller->get_topics_state().local().updates_in_progress();
+
+    ret.reserve(in_progress.size());
+    for (auto& [ntp, status] : in_progress) {
+        reconfiguration r;
+        r.ns = ntp.ns;
+        r.topic = ntp.tp.topic;
+        r.partition = ntp.tp.partition;
+        r.status = fmt::format("{}", status.get_state());
+
+        for (auto& bs : status.get_previous_replicas()) {
+            ss::httpd::partition_json::assignment replica;
+            replica.node_id = bs.node_id;
+            replica.core = bs.shard;
+            r.previous_replicas.push(replica);
+        }
+        ret.push_back(std::move(r));
+    }
+    co_return ss::json::json_return_type(ret);
+}
+
+ss::future<ss::json::json_return_type>
 admin_server::cancel_partition_reconfig_handler(
   std::unique_ptr<ss::httpd::request> req) {
     const auto ntp = parse_ntp_from_request(req->param);
@@ -3008,29 +3035,8 @@ void admin_server::register_partition_routes() {
 
     register_route<user>(
       ss::httpd::partition_json::get_partition_reconfigurations,
-      [this](std::unique_ptr<ss::httpd::request>) {
-          using reconfiguration = ss::httpd::partition_json::reconfiguration;
-          std::vector<reconfiguration> ret;
-          auto& in_progress
-            = _controller->get_topics_state().local().updates_in_progress();
-
-          ret.reserve(in_progress.size());
-          for (auto& [ntp, status] : in_progress) {
-              reconfiguration r;
-              r.ns = ntp.ns;
-              r.topic = ntp.tp.topic;
-              r.partition = ntp.tp.partition;
-              r.status = fmt::format("{}", status.get_state());
-
-              for (auto& bs : status.get_previous_replicas()) {
-                  ss::httpd::partition_json::assignment replica;
-                  replica.node_id = bs.node_id;
-                  replica.core = bs.shard;
-                  r.previous_replicas.push(replica);
-              }
-              ret.push_back(std::move(r));
-          }
-          return ss::make_ready_future<ss::json::json_return_type>(ret);
+      [this](std::unique_ptr<ss::httpd::request> req) {
+          return get_reconfigurations_handler(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -352,6 +352,9 @@ private:
     ss::future<ss::json::json_return_type>
       trigger_on_demand_rebalance_handler(std::unique_ptr<ss::httpd::request>);
 
+    ss::future<ss::json::json_return_type>
+      get_reconfigurations_handler(std::unique_ptr<ss::httpd::request>);
+
     /// Transaction routes
     ss::future<ss::json::json_return_type>
       get_all_transactions_handler(std::unique_ptr<ss::httpd::request>);

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -761,6 +761,56 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                             consumer_timeout_sec=45,
                             min_records=records)
 
+    @cluster(num_nodes=7)
+    def test_movement_tracking_api(self):
+        """
+        Test verifying correctness of `/reconfigurations` endpoint
+        """
+        throughput, records, _ = self._get_scale_params()
+        partition_count = 5
+        self.start_redpanda(num_nodes=5)
+        admin = Admin(self.redpanda)
+
+        spec = TopicSpec(partition_count=partition_count, replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+        self.start_producer(1, throughput=throughput)
+        self.start_consumer(1)
+        self.await_startup(min_records=throughput * 10, timeout_sec=60)
+        self.redpanda.set_cluster_config({"raft_learner_recovery_rate": 1})
+        brokers = admin.get_brokers()
+        for partition in range(0, partition_count):
+            assignments = self._get_assignments(admin, self.topic, partition)
+            prev_assignments = assignments.copy()
+            replicas = set([r['node_id'] for r in prev_assignments])
+            for b in brokers:
+                if b['node_id'] not in replicas:
+                    assignments[0]['node_id'] = b['node_id']
+                    break
+
+            self.logger.info(
+                f"initial assignments for {self.topic}/{partition}: {prev_assignments}, new assignment: {assignments}"
+            )
+            admin.set_partition_replicas(self.topic, partition, assignments)
+
+        wait_until(
+            lambda: len(admin.list_reconfigurations()) == partition_count, 30)
+        reconfigurations = admin.list_reconfigurations()
+        for r in reconfigurations:
+            assert "previous_replicas" in r
+            assert "current_replicas" in r
+            assert "bytes_left_to_move" in r
+            assert "bytes_moved" in r
+            assert "partition_size" in r
+            assert "reconciliation_statuses" in r
+
+        self.run_validation(enable_idempotence=False,
+                            consumer_timeout_sec=45,
+                            min_records=records)
+        self.redpanda.set_cluster_config(
+            {"raft_learner_recovery_rate": 500 * (2**20)})
+        wait_until(lambda: len(admin.list_reconfigurations()) == 0, 120, 1)
+
 
 class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     """


### PR DESCRIPTION
Enriched `/reconfiguration` API with more information allowing users to track the progress of partition reconciliation. Now the API returns a complete set of information related with partition reconfiguration that is taking place.

The API will now return the following JSON:
```json
{
    "ns": "kafka",
    "topic": "topic-khbikkrzeo",
    "partition": 9,
    "previous_replicas": [
        {
            "node_id": 2,
            "core": 0
        },
        {
            "node_id": 3,
            "core": 0
        },
        {
            "node_id": 1,
            "core": 0
        }
    ],
    "current_replicas": [
        {
            "node_id": 4,
            "core": 0
        },
        {
            "node_id": 3,
            "core": 0
        },
        {
            "node_id": 1,
            "core": 0
        }
    ],
    "bytes_left_to_move": 190,
    "bytes_moved": 0,
    "partition_size": 190,
    "reconciliation_statuses": [
        {
            "node_id": 2,
            "operations": [
                {
                    "type": "update",
                    "core": 0,
                    "retry_number": 7,
                    "revision": 89,
                    "status": "Generic failure occurred during partition operation execution (cluster::errc:52)"
                }
            ]
        },
        {
            "node_id": 1,
            "operations": [
                {
                    "type": "update",
                    "core": 0,
                    "retry_number": 3,
                    "revision": 89,
                    "status": "Current node is not a leader for partition (cluster::errc:17)"
                }
            ]
        },
        {
            "node_id": 4,
            "operations": [
                {
                    "type": "update",
                    "core": 0,
                    "retry_number": 5,
                    "revision": 89,
                    "status": "Current node is not a leader for partition (cluster::errc:17)"
                }
            ]
        },
        {
            "node_id": 3,
            "operations": [
                {
                    "type": "update",
                    "core": 0,
                    "retry_number": 5,
                    "revision": 89,
                    "status": "Current node is not a leader for partition (cluster::errc:17)"
                }
            ]
        }
    ]
}
``` 

Fixes #10434
Backport of https://github.com/redpanda-data/redpanda/pull/10201

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
