### PR TITLE
cloud_storage: chunk-aware cache trim of indices

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -159,7 +159,8 @@ private:
     /// until it meet a non-empty directory.
     ///
     /// \param key if a path to a file what should be deleted
-    ss::future<> delete_file_and_empty_parents(const std::string_view& key);
+    /// \return true if any parents were deleted
+    ss::future<bool> delete_file_and_empty_parents(const std::string_view& key);
 
     /// This method is called on shard 0 by other shards to report disk
     /// space changes.


### PR DESCRIPTION
Previously, we relied on deleting segment .log files as the trigger for removing related files (indices and transaction manifests).  Now that segments may only put chunks in the cache rather than .log, we
must handle this case and erase the index+tx files when the whole chunks directory is empty.

Fixes https://github.com/redpanda-data/redpanda/issues/9427

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none