### PR TITLE
tests: bump Dockerfile to latest kinetic-20230412

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM public.ecr.aws/docker/library/ubuntu:kinetic-20220830
+FROM public.ecr.aws/docker/library/ubuntu:kinetic-20230412
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Instead of PR #7787 which bumps to the next ubuntu-23.04 (lunar), this PR conservatively updates to the latest docker image of ubunu-22.10 [kinetic](https://hub.docker.com/_/ubuntu/tags?page=1&name=kinetic) to pull in the latest bug fixes.

Need to backport to v23.1.x because that branch is [also on kinetic](https://github.com/redpanda-data/redpanda/blob/7230400b13d6b17d11e2eb118dd28d57bbf0b15a/tests/docker/Dockerfile).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none