### PR TITLE
Partially mitigating unsafe usage subprocess.Popen()

### DIFF
--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -318,6 +318,7 @@ class TestRunner():
         env["LSAN_OPTIONS"] = f"suppressions={lsan_suppressions}"
 
         # We only capture stderr because that's where backtraces go
+        # FIXME: avoid usage of the unsafe shell=True if possible, or sanitized the cmd input
         p = subprocess.Popen(cmd,
                              env=env,
                              shell=True,


### PR DESCRIPTION
Two of the custom python test scripts in `./tools/` needed improvement due to the unsafe usage of `subprocess.Popen(shell=True)` ([actual-meaning-of-shell-true-in-subprocess](https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess))

This PR adds sanitization only for the `./tools/coverage_dash.py` destination argument that can be submitted with a env variable, and it was prone to code execution due to [this](https://stackoverflow.com/questions/21009416/python-subprocess-security). 

Furthermore, it leaves a note for future improvement of the same issue within `./tools/cmake_test.py`. However the purpose of this test script is to execute commands, so in this case is a feature not a bug.

## Backports Required

no

## Release Notes

none

### Bug Fixes

no

### Features

no

### Improvements

* The PR add input sanitization for python test scripts that are using unsafe `subproces.Popen()`
