### PR TITLE
[v22.3.x] ducktape: NodeOpsExecutor ensure node not empty before DE_RECOMMISSION

### DIFF
--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -404,6 +404,9 @@ class NodeOpsExecutor():
             if operation.wait_for_finish:
                 self.wait_for_rebalanced(operation.node)
         elif operation.type == OperationType.DE_RECOMMISSION:
+            # If node is empty decommission will finish immediately and we won't
+            # be able to recommission it
+            self.wait_for_rebalanced(operation.node)
             self.decommission(operation.node)
 
             self.recommission(operation.node)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8503
Fixes https://github.com/redpanda-data/redpanda/issues/10639,