### PR TITLE
[v23.1.x] tests: bump Dockerfile to latest kinetic-20230412

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM public.ecr.aws/docker/library/ubuntu:kinetic-20220830
+FROM public.ecr.aws/docker/library/ubuntu:kinetic-20230412
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10636
