### PR TITLE
[v23.1.x] Limit memory used while fetching many partitions

### DIFF
--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -12,6 +12,8 @@
 #include "config/base_property.h"
 #include "config/property.h"
 
+#include <optional>
+
 namespace config {
 
 /**
@@ -24,10 +26,21 @@ namespace detail {
  * Traits required for a type to be usable with `numeric_bounds`
  */
 template<typename T>
-concept numeric = requires(const T& x) {
-    {x % x};
-    { x < x } -> std::same_as<bool>;
-    { x > x } -> std::same_as<bool>;
+concept numeric = requires(const T& x, const T& y) {
+    x - y;
+    x + y;
+    x / 2;
+    { x < y } -> std::same_as<bool>;
+    { x > y } -> std::same_as<bool>;
+};
+
+/**
+ * Traits required for a type to be usable with `numeric_integral_bounds`
+ */
+template<typename T>
+concept numeric_integral = requires(const T& x, const T& y) {
+    requires numeric<T>;
+    x % y;
 };
 
 /**
@@ -58,20 +71,36 @@ struct inner_type<T> {
     using inner = typename T::value_type;
 };
 
+/**
+ * Traits for the bounds types
+ */
+template<typename T>
+concept bounds = requires(T bounds, const typename T::underlying_t& value) {
+    {
+        bounds.min
+        } -> std::convertible_to<std::optional<typename T::underlying_t>>;
+    {
+        bounds.max
+        } -> std::convertible_to<std::optional<typename T::underlying_t>>;
+    { bounds.validate(value) } -> std::same_as<std::optional<ss::sstring>>;
+    { bounds.clamp(value) } -> std::same_as<typename T::underlying_t>;
+};
+
 } // namespace detail
 
 /**
- * Define valid bounds for a numeric configuration property.
+ * Define valid bounds for an integral numeric configuration property.
  */
 template<typename T>
-requires detail::numeric<T>
-struct numeric_bounds {
+requires detail::numeric_integral<T>
+struct numeric_integral_bounds {
+    using underlying_t = T;
     std::optional<T> min = std::nullopt;
     std::optional<T> max = std::nullopt;
     std::optional<T> align = std::nullopt;
     std::optional<odd_even_constraint> oddeven = std::nullopt;
 
-    T clamp(T& original) {
+    T clamp(const T& original) const {
         T result = original;
 
         if (align.has_value()) {
@@ -90,7 +119,7 @@ struct numeric_bounds {
         return result;
     }
 
-    std::optional<ss::sstring> validate(T& value) {
+    std::optional<ss::sstring> validate(const T& value) const {
         if (min.has_value() && value < min.value()) {
             return fmt::format("too small, must be at least {}", min.value());
         } else if (max.has_value() && value > max.value()) {
@@ -111,7 +140,48 @@ struct numeric_bounds {
     }
 };
 
-template<typename T, typename I = typename detail::inner_type<T>::inner>
+/**
+ * Define valid bounds for any numeric configuration property.
+ */
+template<detail::numeric T>
+struct numeric_bounds {
+    using underlying_t = T;
+    std::optional<T> min = std::nullopt;
+    std::optional<T> max = std::nullopt;
+
+    T clamp(T value) const {
+        if (min.has_value()) {
+            value = std::max(min.value(), value);
+        }
+        if (max.has_value()) {
+            value = std::min(max.value(), value);
+        }
+        return value;
+    }
+
+    std::optional<ss::sstring> validate(const T& value) const {
+        if (min.has_value() && value < min.value()) {
+            return fmt::format("too small, must be at least {}", min.value());
+        } else if (max.has_value() && value > max.value()) {
+            return fmt::format("too large, must be at most {}", max.value());
+        }
+        return std::nullopt;
+    }
+};
+
+/**
+ * A property that validates its value against the constraints defined by \p B
+ *
+ * \tparam T Underlying property value type
+ * \tparam B Bounds class, like \ref numeric_integral_bounds or
+ *      \ref numeric_bounds, or user defined that satisfies \ref detail::bounds
+ * \tparam I Always default
+ */
+template<
+  typename T,
+  template<typename> typename B = numeric_integral_bounds,
+  typename I = typename detail::inner_type<T>::inner>
+requires detail::bounds<B<I>>
 class bounded_property : public property<T> {
 public:
     bounded_property(
@@ -120,7 +190,7 @@ public:
       std::string_view desc,
       base_property::metadata meta,
       T def,
-      numeric_bounds<I> bounds)
+      B<I> bounds)
       : property<T>(
         conf,
         name,
@@ -193,11 +263,9 @@ private:
 
         if (_bounds.min.has_value() && _bounds.max.has_value()) {
             // Take midpoint of min/max and align it.
-            guess = _bounds.min.value()
-                    + (_bounds.max.value() - _bounds.min.value()) / 2;
-            if (_bounds.align.has_value()) {
-                guess -= guess % _bounds.align.value();
-            }
+            guess = _bounds.clamp(
+              _bounds.min.value()
+              + (_bounds.max.value() - _bounds.min.value()) / 2);
         } else {
             if constexpr (reflection::is_std_optional<T>) {
                 if (property<T>::_default.has_value()) {
@@ -214,7 +282,7 @@ private:
         return fmt::format("{}", guess);
     }
 
-    numeric_bounds<I> _bounds;
+    B<I> _bounds;
 
     // The example value is stored rather than generated on the fly, to
     // satisfy the example() interface that wants a string_view: it

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1930,7 +1930,15 @@ configuration::configuration()
       "considering itself to be isolated",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       3000,
-      {.min = 100, .max = 10000}) {}
+      {.min = 100, .max = 10000})
+  , kafka_memory_share_for_fetch(
+      *this,
+      "kafka_memory_share_for_fetch",
+      "The share of kafka subsystem memory that can be used for fetch read "
+      "buffers, as a fraction of kafka subsystem memory amount",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      0.3,
+      {.min = 0.0, .max = 1.0}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1937,8 +1937,17 @@ configuration::configuration()
       "The share of kafka subsystem memory that can be used for fetch read "
       "buffers, as a fraction of kafka subsystem memory amount",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      0.3,
-      {.min = 0.0, .max = 1.0}) {}
+      0.5,
+      {.min = 0.0, .max = 1.0})
+  , kafka_memory_batch_size_estimate_for_fetch(
+      *this,
+      "kafka_memory_batch_size_estimate_for_fetch",
+      "The size of the batch used to estimate memory consumption for Fetch "
+      "requests, in bytes. Smaller sizes allow more concurrent fetch requests "
+      "per shard, larger sizes prevent running out of memory because of too "
+      "many concurrent fetch requests.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      1_MiB) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -397,6 +397,7 @@ struct configuration final : public config_store {
     bounded_property<int64_t> node_isolation_heartbeat_timeout;
 
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
+    property<size_t> kafka_memory_batch_size_estimate_for_fetch;
 
     configuration();
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -396,6 +396,8 @@ struct configuration final : public config_store {
 
     bounded_property<int64_t> node_isolation_heartbeat_timeout;
 
+    bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -305,8 +305,10 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
         total_max_bytes += c.cfg.max_bytes;
     }
 
-    auto max_bytes_per_fetch
-      = config::shard_local_cfg().kafka_max_bytes_per_fetch();
+    // bytes_left comes from the fetch plan and also accounts for the max_bytes
+    // field in the fetch request
+    const size_t max_bytes_per_fetch = std::min<size_t>(
+      config::shard_local_cfg().kafka_max_bytes_per_fetch(), octx.bytes_left);
     if (total_max_bytes > max_bytes_per_fetch) {
         auto per_partition = max_bytes_per_fetch / ntp_fetch_configs.size();
         vlog(
@@ -362,7 +364,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
         return ss::now();
     }
 
-    bool foreign_read = shard != ss::this_shard_id();
+    const bool foreign_read = shard != ss::this_shard_id();
 
     // dispatch to remote core
     return octx.rctx.partition_manager()

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -49,6 +49,7 @@
 
 namespace kafka {
 static constexpr std::chrono::milliseconds default_fetch_timeout = 5s;
+
 /**
  * Make a partition response error.
  */
@@ -806,6 +807,15 @@ void op_context::response_placeholder::set(
             _it->partition_response->has_to_be_included = has_to_be_included;
         }
     }
+}
+
+size_t fetch_memory_estimator(
+  const size_t request_size, connection_context& /*conn_ctx*/) {
+    return request_size
+             * 3 // appx memory for fetch plans, fetch configs, read results
+           + config::shard_local_cfg()
+               .kafka_memory_batch_size_estimate_for_fetch();
+    // at least one batch of the data will be read
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -30,6 +30,7 @@
 #include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "resource_mgmt/io_priority.h"
+#include "ssx/semaphore.h"
 #include "storage/parser_utils.h"
 #include "utils/to_string.h"
 
@@ -143,6 +144,113 @@ static ss::future<read_result> read_from_partition(
 }
 
 /**
+ * Consume proper amounts of units from memory semaphores and return them as
+ * semaphore_units. Fetch semaphore units returned are the indication of
+ * available resources: if none, there is no memory for the operation;
+ * if less than \p max_bytes, the fetch should be capped to that size.
+ *
+ * \param max_bytes The limit of how much data is going to be fetched
+ * \param obligatory_batch_read Set to true for the first ntp in the fetch
+ *   fetch request, at least one batch must be fetched for that ntp. Also it
+ *   is assumed that a batch size has already been consumed from kafka
+ *   memory semaphore for it.
+ */
+read_result::memory_units_t reserve_memory_units(
+  const request_context& rctx,
+  const size_t max_bytes,
+  const bool obligatory_batch_read) {
+    read_result::memory_units_t memory_units;
+    const size_t memory_kafka_now = rctx.memory_sem().current();
+    const size_t memory_fetch = rctx.memory_fetch_sem().current();
+    const size_t batch_size_estimate
+      = config::shard_local_cfg().kafka_memory_batch_size_estimate_for_fetch();
+
+    if (obligatory_batch_read) {
+        // `batch_size_estimate` units has already been consumed from
+        // memory_sem in the very beginning of request handling
+        // (see \ref fetch_memory_estimator,
+        // \ref connection_context::reserve_request_units). Since
+        // `obligatory_batch_read` only appear once per \ref
+        // fetch_ntps_in_parallel call, it is used to avoid taking that
+        // amount from memory_sem twice.
+        // Note on changing `kafka_memory_batch_size_estimate_for_fetch`
+        // property at runtime: it is possible that when the property is
+        // changed, the value for `batch_size_estimate` will be different in
+        // `fetch_memory_estimator()` and here, and the `memory_kafka_before`
+        // value will be off. However this will be a one time event that should
+        // not cause dramatic consequences. An alternative would be to store a
+        // copy of the value in each request context which will not be necessary
+        // at least 99.99% of times.
+        const size_t memory_kafka_before = memory_kafka_now
+                                           + batch_size_estimate;
+        // don't reserve more than available, unless it's less than a batch
+        const size_t fetch_size = std::max(
+          batch_size_estimate,
+          std::min({max_bytes, memory_kafka_before, memory_fetch}));
+        memory_units.fetch = ss::consume_units(
+          rctx.memory_fetch_sem(), fetch_size);
+        // remember: a batch has been reserved upfront
+        memory_units.kafka = ss::consume_units(
+          rctx.memory_sem(), fetch_size - batch_size_estimate);
+    } else {
+        // don't try to reserve less than a batch
+        const size_t requested_fetch_size = std::max(
+          max_bytes, batch_size_estimate);
+        // but don't reserve more than available
+        const size_t fetch_size = std::min(
+          {requested_fetch_size, memory_kafka_now, memory_fetch});
+        // if not enough memory is available, nothing is reserved
+        if (fetch_size >= batch_size_estimate) {
+            memory_units.fetch = ss::consume_units(
+              rctx.memory_fetch_sem(), fetch_size);
+            memory_units.kafka = ss::consume_units(
+              rctx.memory_sem(), fetch_size);
+        }
+    }
+
+    return memory_units;
+}
+
+/**
+ * Make the \p units hold exactly \p target_bytes, by consuming more units
+ * from \p sem or by returning extra units back.
+ */
+static void adjust_semaphore_units(
+  ssx::semaphore& sem, ssx::semaphore_units& units, const size_t target_bytes) {
+    if (target_bytes < units.count()) {
+        units.return_units(units.count() - target_bytes);
+    }
+    if (target_bytes > units.count()) {
+        units.adopt(ss::consume_units(sem, target_bytes - units.count()));
+    }
+}
+
+/**
+ * Memory units have been reserved before the read op based on an estimation.
+ * Now when we know how much data has actually been read, return any extra
+ * amount.
+ */
+static void adjust_memory_units(
+  const request_context& rctx,
+  read_result::memory_units_t& memory_units,
+  const size_t read_bytes,
+  const bool obligatory_read) {
+    const size_t batch_size_estimate
+      = config::shard_local_cfg().kafka_memory_batch_size_estimate_for_fetch();
+    // for kafka memsemaphore, account for the pre-allocated amount that is not
+    // in the units counter
+    const size_t read_after_obligatory = obligatory_read
+                                           ? std::max(
+                                               read_bytes, batch_size_estimate)
+                                               - batch_size_estimate
+                                           : read_bytes;
+    adjust_semaphore_units(
+      rctx.memory_fetch_sem(), memory_units.fetch, read_bytes);
+    adjust_semaphore_units(
+      rctx.memory_sem(), memory_units.kafka, read_after_obligatory);
+}
+
+/**
  * Entry point for reading from an ntp. This is executed on NTP home core and
  * build error responses if anything goes wrong.
  */
@@ -150,7 +258,20 @@ static ss::future<read_result> do_read_from_ntp(
   cluster::partition_manager& cluster_pm,
   op_context& octx,
   ntp_fetch_config ntp_config,
-  bool foreign_read) {
+  bool foreign_read,
+  const bool obligatory_batch_read) {
+    // control available memory
+    read_result::memory_units_t memory_units;
+    if (!ntp_config.cfg.skip_read) {
+        memory_units = reserve_memory_units(
+          octx.rctx, ntp_config.cfg.max_bytes, obligatory_batch_read);
+        if (!memory_units.fetch) {
+            ntp_config.cfg.skip_read = true;
+        } else if (ntp_config.cfg.max_bytes > memory_units.fetch.count()) {
+            ntp_config.cfg.max_bytes = memory_units.fetch.count();
+        }
+    }
+
     /*
      * lookup the ntp's partition
      */
@@ -202,8 +323,13 @@ static ss::future<read_result> do_read_from_ntp(
           offset_ec);
         co_return read_result(offset_ec);
     }
-    co_return co_await read_from_partition(
+    read_result result = co_await read_from_partition(
       std::move(*kafka_partition), ntp_config.cfg, foreign_read, octx.deadline);
+
+    adjust_memory_units(
+      octx.rctx, memory_units, result.data_size_bytes(), obligatory_batch_read);
+    result.memory_units = std::move(memory_units);
+    co_return result;
 }
 
 static ntp_fetch_config
@@ -216,9 +342,14 @@ ss::future<read_result> read_from_ntp(
   op_context& octx,
   const model::ntp& ntp,
   fetch_config config,
-  bool foreign_read) {
+  bool foreign_read,
+  const bool obligatory_batch_read) {
     return do_read_from_ntp(
-      cluster_pm, octx, make_ntp_fetch_config(ntp, config), foreign_read);
+      cluster_pm,
+      octx,
+      make_ntp_fetch_config(ntp, config),
+      foreign_read,
+      obligatory_batch_read);
 }
 
 static void fill_fetch_responses(
@@ -324,11 +455,14 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
         }
     }
 
+    const auto first_p_id = ntp_fetch_configs.front().ntp().tp.partition;
     auto results = co_await ssx::parallel_transform(
       std::move(ntp_fetch_configs),
-      [&cluster_pm, &octx, foreign_read](const ntp_fetch_config& ntp_cfg) {
-          auto p_id = ntp_cfg.ntp().tp.partition;
-          return do_read_from_ntp(cluster_pm, octx, ntp_cfg, foreign_read)
+      [&cluster_pm, &octx, foreign_read, first_p_id](
+        const ntp_fetch_config& ntp_cfg) {
+          const auto p_id = ntp_cfg.ntp().tp.partition;
+          return do_read_from_ntp(
+                   cluster_pm, octx, ntp_cfg, foreign_read, first_p_id == p_id)
             .then([p_id](read_result res) {
                 res.partition = p_id;
                 return res;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -147,15 +147,16 @@ static ss::future<read_result> read_from_partition(
  */
 static ss::future<read_result> do_read_from_ntp(
   cluster::partition_manager& cluster_pm,
-  coproc::partition_manager& coproc_pm,
+  op_context& octx,
   ntp_fetch_config ntp_config,
-  bool foreign_read,
-  std::optional<model::timeout_clock::time_point> deadline) {
+  bool foreign_read) {
     /*
      * lookup the ntp's partition
      */
     auto kafka_partition = make_partition_proxy(
-      ntp_config.ntp(), cluster_pm, coproc_pm);
+      ntp_config.ntp(),
+      cluster_pm,
+      octx.rctx.coproc_partition_manager().local());
     if (unlikely(!kafka_partition)) {
         co_return read_result(error_code::unknown_topic_or_partition);
     }
@@ -201,7 +202,7 @@ static ss::future<read_result> do_read_from_ntp(
         co_return read_result(offset_ec);
     }
     co_return co_await read_from_partition(
-      std::move(*kafka_partition), ntp_config.cfg, foreign_read, deadline);
+      std::move(*kafka_partition), ntp_config.cfg, foreign_read, octx.deadline);
 }
 
 static ntp_fetch_config
@@ -211,17 +212,12 @@ make_ntp_fetch_config(const model::ntp& ntp, const fetch_config& fetch_cfg) {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager& cluster_pm,
-  coproc::partition_manager& coproc_pm,
+  op_context& octx,
   const model::ntp& ntp,
   fetch_config config,
-  bool foreign_read,
-  std::optional<model::timeout_clock::time_point> deadline) {
+  bool foreign_read) {
     return do_read_from_ntp(
-      cluster_pm,
-      coproc_pm,
-      make_ntp_fetch_config(ntp, config),
-      foreign_read,
-      deadline);
+      cluster_pm, octx, make_ntp_fetch_config(ntp, config), foreign_read);
 }
 
 static void fill_fetch_responses(
@@ -329,12 +325,7 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
       std::move(ntp_fetch_configs),
       [&cluster_pm, &octx, foreign_read](const ntp_fetch_config& ntp_cfg) {
           auto p_id = ntp_cfg.ntp().tp.partition;
-          return do_read_from_ntp(
-                   cluster_pm,
-                   octx.rctx.coproc_partition_manager().local(),
-                   ntp_cfg,
-                   foreign_read,
-                   octx.deadline)
+          return do_read_from_ntp(cluster_pm, octx, ntp_cfg, foreign_read)
             .then([p_id](read_result res) {
                 res.partition = p_id;
                 return res;

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -349,6 +349,10 @@ struct fetch_plan {
     }
 };
 
+/*
+ * Unit Tests Exposure
+ */
+
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
   op_context&,
@@ -356,5 +360,8 @@ ss::future<read_result> read_from_ntp(
   fetch_config,
   bool,
   bool obligatory_batch_read);
+
+read_result::memory_units_t reserve_memory_units(
+  const request_context& rctx, size_t max_bytes, bool obligatory_batch_read);
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -219,6 +219,11 @@ struct read_result {
     using foreign_data_t = ss::foreign_ptr<std::unique_ptr<iobuf>>;
     using data_t = std::unique_ptr<iobuf>;
     using variant_t = std::variant<data_t, foreign_data_t>;
+    struct memory_units_t {
+        ssx::semaphore_units kafka;
+        ssx::semaphore_units fetch;
+    };
+
     explicit read_result(error_code e)
       : error(e) {}
 
@@ -283,6 +288,7 @@ struct read_result {
     error_code error;
     model::partition_id partition;
     std::vector<cluster::rm_stm::tx_range> aborted_transactions;
+    memory_units_t memory_units;
 };
 // struct aggregating fetch requests and corresponding response iterators for
 // the same shard
@@ -348,6 +354,7 @@ ss::future<read_result> read_from_ntp(
   op_context&,
   const model::ntp&,
   fetch_config,
-  bool);
+  bool,
+  bool obligatory_batch_read);
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -17,7 +17,19 @@
 
 namespace kafka {
 
-using fetch_handler = single_stage_handler<fetch_api, 4, 11>;
+/**
+ * Estimate the minimum size of memory required for a fetch request.
+ *
+ * Fetch request processing is adaptive to the amount of memory available,
+ * controlled by kafka::server::memory_fetch_sem(). It can decide to read
+ * from less partitions than requested. However it is required to read from
+ * at least a single partition, and the amount of memory required for that
+ * is accounted for upfront by this estimator.
+ */
+memory_estimate_fn fetch_memory_estimator;
+
+using fetch_handler
+  = single_stage_handler<fetch_api, 4, 11, fetch_memory_estimator>;
 
 /*
  * Fetch operation context

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -333,10 +333,9 @@ struct fetch_plan {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
-  coproc::partition_manager&,
+  op_context&,
   const model::ntp&,
   fetch_config,
-  bool,
-  std::optional<model::timeout_clock::time_point>);
+  bool);
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -235,6 +235,14 @@ public:
         return _conn->server().controller_api();
     }
 
+    ssx::semaphore& memory_sem() const noexcept {
+        return _conn->server().memory();
+    }
+
+    ssx::semaphore& memory_fetch_sem() const noexcept {
+        return _conn->server().memory_fetch_sem();
+    }
+
 private:
     template<typename ResponseType>
     void update_usage_stats(const ResponseType& r, size_t response_size) {

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -167,7 +167,11 @@ public:
     static std::vector<bool>
     convert_api_names_to_key_bitmap(const std::vector<ss::sstring>& api_names);
 
+    ssx::semaphore& memory_fetch_sem() noexcept { return _memory_fetch_sem; }
+
 private:
+    void setup_metrics();
+
     ss::smp_service_group _smp_group;
     ss::scheduling_group _fetch_scheduling_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
@@ -195,8 +199,10 @@ private:
     security::tls::principal_mapper _mtls_principal_mapper;
     security::gssapi_principal_mapper _gssapi_principal_mapper;
     security::krb5::configurator _krb_configurator;
+    ssx::semaphore _memory_fetch_sem;
 
     class latency_probe _probe;
+    ss::metrics::metric_groups _metrics;
     ssx::thread_worker& _thread_worker;
 };
 

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -174,7 +174,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
           .invoke_on(
             shard,
             [&octx, ntp, config](cluster::partition_manager& pm) {
-                return kafka::read_from_ntp(pm, octx, ntp, config, true);
+                return kafka::read_from_ntp(pm, octx, ntp, config, true, false);
             })
           .get0();
     };

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -18,10 +18,12 @@
 
 #include <seastar/core/smp.hh>
 
+#include <boost/test/tools/interface.hpp>
 #include <fmt/ostream.h>
 
 #include <chrono>
 #include <limits>
+#include <ostream>
 
 using namespace std::chrono_literals;
 
@@ -655,4 +657,141 @@ FIXTURE_TEST(fetch_request_max_bytes, redpanda_thread_fixture) {
     BOOST_REQUIRE(fetch_one_byte.data.topics[0].partitions[0].records);
     BOOST_REQUIRE(
       fetch_one_byte.data.topics[0].partitions[0].records->size_bytes() > 0);
+}
+
+struct reserve_memory_units_fixture : redpanda_thread_fixture {
+    kafka::request_context rctx = make_request_context();
+
+    struct r {
+        size_t kafka, fetch;
+        r(size_t kafka_, size_t fetch_)
+          : kafka(kafka_)
+          , fetch(fetch_) {}
+        friend bool operator==(const r&, const r&) = default;
+        friend std::ostream& operator<<(std::ostream& s, const r& v) {
+            return s << "{kafka: " << v.kafka << ", fetch: " << v.fetch << "}";
+        }
+    };
+
+    // reserve memory units, return how many memory units have been reserved
+    // from each memory semaphore
+    r test_case(size_t max_bytes, bool obligatory_batch_read) const {
+        auto mu = kafka::reserve_memory_units(
+          rctx, max_bytes, obligatory_batch_read);
+        return {mu.kafka.count(), mu.fetch.count()};
+    }
+};
+
+FIXTURE_TEST(reserve_memory_units_test, reserve_memory_units_fixture) {
+    using namespace kafka;
+    using namespace std::chrono_literals;
+    // same as in fetch.cc
+    static constexpr size_t batch_size = 1_MiB;
+
+    // below are test prerequisites, tests are done based on these assumptions
+    // if these are not valid, the test needs a change
+    size_t kafka_mem = rctx.memory_sem().available_units();
+    size_t fetch_mem = rctx.memory_fetch_sem().available_units();
+    BOOST_TEST_REQUIRE(fetch_mem > batch_size * 3);
+    BOOST_TEST_REQUIRE(kafka_mem > fetch_mem);
+    BOOST_TEST_REQUIRE(batch_size > 100);
+
+    // *** plenty of memory cases
+    // kafka_mem > fetch_mem > batch_size
+    BOOST_TEST(test_case(batch_size / 100, false) == r(batch_size, batch_size));
+    BOOST_TEST(test_case(batch_size / 100, true) == r(0, batch_size));
+    BOOST_TEST(test_case(batch_size, false) == r(batch_size, batch_size));
+    BOOST_TEST(test_case(batch_size, true) == r(0, batch_size));
+    BOOST_TEST(
+      test_case(batch_size * 3, false) == r(batch_size * 3, batch_size * 3));
+    BOOST_TEST(
+      test_case(batch_size * 3, true) == r(batch_size * 2, batch_size * 3));
+    BOOST_TEST(test_case(fetch_mem, false) == r(fetch_mem, fetch_mem));
+    BOOST_TEST(
+      test_case(fetch_mem, true) == r(fetch_mem - batch_size, fetch_mem));
+    BOOST_TEST(test_case(fetch_mem + 1, false) == r(fetch_mem, fetch_mem));
+    BOOST_TEST(
+      test_case(fetch_mem + 1, true) == r(fetch_mem - batch_size, fetch_mem));
+    BOOST_TEST(test_case(kafka_mem, false) == r(fetch_mem, fetch_mem));
+    BOOST_TEST(
+      test_case(kafka_mem, true) == r(fetch_mem - batch_size, fetch_mem));
+
+    // *** still a lot of mem but kafka mem somewhat used:
+    // fetch_mem > kafka_mem > batch_size (fetch_mem - kafka_mem < batch_size)
+    auto memsemunits = ss::consume_units(
+      rctx.memory_sem(), kafka_mem - fetch_mem + 1000);
+    kafka_mem = rctx.memory_sem().available_units();
+    BOOST_TEST_REQUIRE(kafka_mem < fetch_mem);
+    BOOST_TEST_REQUIRE(kafka_mem > batch_size + 1000);
+
+    BOOST_TEST(test_case(batch_size, false) == r(batch_size, batch_size));
+    BOOST_TEST(test_case(batch_size, true) == r(0, batch_size));
+    BOOST_TEST(
+      test_case(kafka_mem - 100, false) == r(kafka_mem - 100, kafka_mem - 100));
+    BOOST_TEST(
+      test_case(kafka_mem - 100, true)
+      == r(kafka_mem - 100 - batch_size, kafka_mem - 100));
+    BOOST_TEST(test_case(kafka_mem + 100, false) == r(kafka_mem, kafka_mem));
+    // in this test, the reserved amount is bigger than kafka_mem because
+    // a part of it have been reseved from kafka memsemaphore before,
+    // and the actual amount used from kafka memsemaphore now is less than
+    // what is requested by batch_size
+    BOOST_TEST(
+      test_case(kafka_mem + 100, true)
+      == r(kafka_mem + 100 - batch_size, kafka_mem + 100));
+    BOOST_TEST(test_case(fetch_mem + 100, false) == r(kafka_mem, kafka_mem));
+    BOOST_TEST(
+      test_case(fetch_mem + 100, true) == r(fetch_mem - batch_size, fetch_mem));
+
+    memsemunits.return_all();
+    kafka_mem = rctx.memory_sem().available_units();
+
+    // *** low on fetch memory tests
+    // kafka_mem > batch_size > fetch_mem
+    // Under this condition, unless obligatory_batch_read, we cannot reserve
+    // memory as it's not enough for at least a single batch.
+    // If obligatory_batch_read, the reserved amount will always be a single
+    // batch.
+    memsemunits = ss::consume_units(
+      rctx.memory_fetch_sem(), fetch_mem - batch_size + 1000);
+    fetch_mem = rctx.memory_fetch_sem().available_units();
+    BOOST_TEST_REQUIRE(kafka_mem > batch_size);
+    BOOST_TEST_REQUIRE(fetch_mem < batch_size);
+
+    BOOST_TEST(test_case(fetch_mem - 100, false) == r(0, 0));
+    BOOST_TEST(test_case(fetch_mem - 100, true) == r(0, batch_size));
+    BOOST_TEST(test_case(batch_size - 100, false) == r(0, 0));
+    BOOST_TEST(test_case(batch_size - 100, true) == r(0, batch_size));
+    BOOST_TEST(test_case(kafka_mem - 100, false) == r(0, 0));
+    BOOST_TEST(test_case(kafka_mem - 100, true) == r(0, batch_size));
+    BOOST_TEST(test_case(kafka_mem + 100, false) == r(0, 0));
+    BOOST_TEST(test_case(kafka_mem + 100, true) == r(0, batch_size));
+
+    memsemunits.return_all();
+    fetch_mem = rctx.memory_fetch_sem().available_units();
+
+    // *** low on kafka memory tests
+    // fetch_mem > batch_size > kafka_mem
+    // Essentially the same behaviour as in low fetch memory cases
+    memsemunits = ss::consume_units(
+      rctx.memory_sem(), kafka_mem - batch_size + 1000);
+    kafka_mem = rctx.memory_sem().available_units();
+    BOOST_TEST_REQUIRE(kafka_mem < batch_size);
+    BOOST_TEST_REQUIRE(fetch_mem > batch_size);
+
+    BOOST_TEST(test_case(kafka_mem - 100, false) == r(0, 0));
+    BOOST_TEST(test_case(kafka_mem - 100, true) == r(0, batch_size));
+    BOOST_TEST(test_case(batch_size - 100, false) == r(0, 0));
+    BOOST_TEST(test_case(batch_size - 100, true) == r(0, batch_size));
+    BOOST_TEST(test_case(batch_size + 100, false) == r(0, 0));
+    BOOST_TEST(test_case(batch_size + 100, true) == r(100, batch_size + 100));
+    BOOST_TEST(test_case(fetch_mem - 100, false) == r(0, 0));
+    BOOST_TEST(
+      test_case(fetch_mem - 100, true) == r(kafka_mem, kafka_mem + batch_size));
+    BOOST_TEST(test_case(fetch_mem + 100, false) == r(0, 0));
+    BOOST_TEST(
+      test_case(fetch_mem + 100, true) == r(kafka_mem, kafka_mem + batch_size));
+
+    memsemunits.return_all();
+    kafka_mem = rctx.memory_sem().available_units();
 }

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -73,7 +73,7 @@ struct config_connection_rate_bindings {
 
 struct server_configuration {
     std::vector<server_endpoint> addrs;
-    int64_t max_service_memory_per_core;
+    int64_t max_service_memory_per_core = 0;
     std::optional<int> listen_backlog;
     std::optional<int> tcp_recv_buf;
     std::optional<int> tcp_send_buf;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -111,6 +111,8 @@ public:
         app.wire_up_and_start(*app_signal, true);
 
         configs.start(ss::sstring("fixture_config")).get();
+        configs.local().max_service_memory_per_core
+          = memory_groups::rpc_total_memory();
 
         // used by request context builder
         proto = std::make_unique<kafka::server>(


### PR DESCRIPTION
Backport of PR #10371
Fixes #10641

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
