### PR TITLE
Server side schema id validation

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -304,6 +304,25 @@ std::optional<std::chrono::milliseconds>
 metadata_cache::get_default_segment_ms() const {
     return config::shard_local_cfg().log_segment_ms();
 }
+
+bool metadata_cache::get_default_record_key_schema_id_validation() const {
+    return false;
+}
+
+pandaproxy::schema_registry::subject_name_strategy
+metadata_cache::get_default_record_key_subject_name_strategy() const {
+    return pandaproxy::schema_registry::subject_name_strategy::topic_name;
+}
+
+bool metadata_cache::get_default_record_value_schema_id_validation() const {
+    return false;
+}
+
+pandaproxy::schema_registry::subject_name_strategy
+metadata_cache::get_default_record_value_subject_name_strategy() const {
+    return pandaproxy::schema_registry::subject_name_strategy::topic_name;
+}
+
 topic_properties metadata_cache::get_default_properties() const {
     topic_properties tp;
     tp.compression = {get_default_compression()};

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -19,6 +19,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "seastarx.h"
 #include "utils/expiring_promise.h"
 
@@ -184,6 +185,13 @@ public:
     model::shadow_indexing_mode get_default_shadow_indexing_mode() const;
     uint32_t get_default_batch_max_bytes() const;
     std::optional<std::chrono::milliseconds> get_default_segment_ms() const;
+    bool get_default_record_key_schema_id_validation() const;
+    pandaproxy::schema_registry::subject_name_strategy
+    get_default_record_key_subject_name_strategy() const;
+    bool get_default_record_value_schema_id_validation() const;
+    pandaproxy::schema_registry::subject_name_strategy
+    get_default_record_value_subject_name_strategy() const;
+
     topic_properties get_default_properties() const;
     std::optional<partition_assignment>
     get_partition_assignment(const model::ntp& ntp) const;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -819,6 +819,30 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
       overrides.remote_delete,
       storage::ntp_config::default_remote_delete);
     incremental_update(properties.segment_ms, overrides.segment_ms);
+    incremental_update(
+      properties.record_key_schema_id_validation,
+      overrides.record_key_schema_id_validation);
+    incremental_update(
+      properties.record_key_schema_id_validation_compat,
+      overrides.record_key_schema_id_validation_compat);
+    incremental_update(
+      properties.record_key_subject_name_strategy,
+      overrides.record_key_subject_name_strategy);
+    incremental_update(
+      properties.record_key_subject_name_strategy_compat,
+      overrides.record_key_subject_name_strategy_compat);
+    incremental_update(
+      properties.record_value_schema_id_validation,
+      overrides.record_value_schema_id_validation);
+    incremental_update(
+      properties.record_value_schema_id_validation_compat,
+      overrides.record_value_schema_id_validation_compat);
+    incremental_update(
+      properties.record_value_subject_name_strategy,
+      overrides.record_value_subject_name_strategy);
+    incremental_update(
+      properties.record_value_subject_name_strategy_compat,
+      overrides.record_value_subject_name_strategy_compat);
     // no configuration change, no need to generate delta
     if (properties == properties_snapshot) {
         co_return errc::success;

--- a/src/v/cluster/topic_validators.h
+++ b/src/v/cluster/topic_validators.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/types.h"
+
+namespace cluster {
+
+struct schema_id_validation_validator {
+    static constexpr const char* error_message
+      = "Mismatch between redpanda.* and confluent.* schema id validation "
+        "properties ";
+    static constexpr errc ec = errc::topic_invalid_config;
+
+    template<typename T>
+    static bool
+    compatible(std::optional<T> const& lhs, std::optional<T> const& rhs) {
+        return !lhs.has_value() || lhs == rhs;
+    }
+
+    static bool is_valid(cluster::topic_properties& p) {
+        return compatible(
+                 p.record_key_schema_id_validation,
+                 p.record_key_schema_id_validation_compat)
+               && compatible(
+                 p.record_key_subject_name_strategy,
+                 p.record_key_subject_name_strategy_compat)
+               && compatible(
+                 p.record_value_schema_id_validation,
+                 p.record_value_schema_id_validation_compat)
+               && compatible(
+                 p.record_value_subject_name_strategy,
+                 p.record_value_subject_name_strategy_compat);
+    }
+};
+
+} // namespace cluster

--- a/src/v/cluster/topic_validators.h
+++ b/src/v/cluster/topic_validators.h
@@ -23,7 +23,8 @@ struct schema_id_validation_validator {
     template<typename T>
     static bool
     compatible(std::optional<T> const& lhs, std::optional<T> const& rhs) {
-        return !lhs.has_value() || lhs == rhs;
+        // If both are specified, they must match
+        return !lhs || !rhs || lhs == rhs;
     }
 
     static bool is_valid(cluster::topic_properties& p) {

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -329,6 +329,14 @@ struct compat_check<cluster::topic_properties> {
         json_write(retention_local_target_ms);
         json_write(remote_delete);
         json_write(segment_ms);
+        json_write(record_key_schema_id_validation);
+        json_write(record_key_schema_id_validation_compat);
+        json_write(record_key_subject_name_strategy);
+        json_write(record_key_subject_name_strategy_compat);
+        json_write(record_value_schema_id_validation);
+        json_write(record_value_schema_id_validation_compat);
+        json_write(record_value_subject_name_strategy);
+        json_write(record_value_subject_name_strategy_compat);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -350,6 +358,14 @@ struct compat_check<cluster::topic_properties> {
         json_read(retention_local_target_ms);
         json_read(remote_delete);
         json_read(segment_ms);
+        json_read(record_key_schema_id_validation);
+        json_read(record_key_schema_id_validation_compat);
+        json_read(record_key_subject_name_strategy);
+        json_read(record_key_subject_name_strategy_compat);
+        json_read(record_value_schema_id_validation);
+        json_read(record_value_schema_id_validation_compat);
+        json_read(record_value_subject_name_strategy);
+        json_read(record_value_subject_name_strategy_compat);
         return obj;
     }
 

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -676,7 +676,15 @@ struct instance_generator<cluster::topic_properties> {
           // Remote delete always false to enable ADL roundtrip (ADL
           // always decodes to false for legacy topics)
           false,
-          tests::random_tristate([] { return tests::random_duration_ms(); })};
+          tests::random_tristate([] { return tests::random_duration_ms(); }),
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2036,7 +2036,13 @@ configuration::configuration()
       "Interval, in seconds, of how often a message informing the operator "
       "that unsafe strings are permitted",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      300s) {}
+      300s)
+  , kafka_schema_id_validation_cache_capacity(
+      *this,
+      "kafka_schema_id_validation_cache_capacity",
+      "Per-shard capacity of the cache for validating schema IDs.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      128) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -414,6 +414,9 @@ struct configuration final : public config_store {
     property<bool> legacy_permit_unsafe_log_operation;
     property<std::chrono::seconds> legacy_unsafe_log_warning_interval_sec;
 
+    // schema id validation
+    config::property<size_t> kafka_schema_id_validation_cache_capacity;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -15,6 +15,7 @@
 #include "config/rjson_serialization.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "reflection/type_traits.h"
 #include "utils/intrusive_list_helpers.h"
 #include "utils/to_string.h"
@@ -614,6 +615,11 @@ consteval std::string_view property_type_name() {
     } else if constexpr (std::is_same_v<
                            type,
                            model::cloud_storage_chunk_eviction_strategy>) {
+        return "string";
+    } else if constexpr (std::is_same_v<
+                           type,
+                           pandaproxy::schema_registry::
+                             subject_name_strategy>) {
         return "string";
     } else {
         static_assert(dependent_false<T>::value, "Type name not defined");

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -166,4 +166,10 @@ void rjson_serialize(
     stringize(w, v);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const pandaproxy::schema_registry::subject_name_strategy& v) {
+    stringize(w, v);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -19,6 +19,7 @@
 #include "json/json.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -77,5 +78,9 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const model::cloud_storage_chunk_eviction_strategy& v);
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const pandaproxy::schema_registry::subject_name_strategy& v);
 
 } // namespace json

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -69,6 +69,8 @@ std::string_view to_string_view(feature f) {
         return "transaction_partitioning";
     case feature::force_partition_reconfiguration:
         return "force_partition_reconfiguration";
+    case feature::schema_id_validation:
+        return "schema_id_validation";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -58,6 +58,7 @@ enum class feature : std::uint64_t {
     cloud_storage_manifest_format_v2 = 1ULL << 24U,
     transaction_partitioning = 1ULL << 25U,
     force_partition_reconfiguration = 1ULL << 26U,
+    schema_id_validation = 1ULL << 27U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -262,6 +263,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{10},
     "force_partition_reconfiguration",
     feature::force_partition_reconfiguration,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{10},
+    "schema_id_validation",
+    feature::schema_id_validation,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -57,6 +57,7 @@ v_cc_library(
     v::cluster
     v::kafka_protocol
     v::security
+    v::pandaproxy_schema_registry
     absl::flat_hash_map
     absl::flat_hash_set
 )

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -29,28 +29,37 @@
 
 #include <fmt/ostream.h>
 
+#include <array>
 #include <chrono>
 #include <string_view>
 
 namespace kafka {
 
-static constexpr std::array<std::string_view, 16> supported_configs{
-  topic_property_compression,
-  topic_property_cleanup_policy,
-  topic_property_timestamp_type,
-  topic_property_segment_size,
-  topic_property_compaction_strategy,
-  topic_property_retention_bytes,
-  topic_property_retention_duration,
-  topic_property_recovery,
-  topic_property_remote_write,
-  topic_property_remote_read,
-  topic_property_remote_delete,
-  topic_property_read_replica,
-  topic_property_max_message_bytes,
-  topic_property_retention_local_target_bytes,
-  topic_property_retention_local_target_ms,
-  topic_property_segment_ms};
+static constexpr auto supported_configs = std::to_array(
+  {topic_property_compression,
+   topic_property_cleanup_policy,
+   topic_property_timestamp_type,
+   topic_property_segment_size,
+   topic_property_compaction_strategy,
+   topic_property_retention_bytes,
+   topic_property_retention_duration,
+   topic_property_recovery,
+   topic_property_remote_write,
+   topic_property_remote_read,
+   topic_property_remote_delete,
+   topic_property_read_replica,
+   topic_property_max_message_bytes,
+   topic_property_retention_local_target_bytes,
+   topic_property_retention_local_target_ms,
+   topic_property_segment_ms,
+   topic_property_record_key_schema_id_validation,
+   topic_property_record_key_schema_id_validation_compat,
+   topic_property_record_key_subject_name_strategy,
+   topic_property_record_key_subject_name_strategy_compat,
+   topic_property_record_value_schema_id_validation,
+   topic_property_record_value_schema_id_validation_compat,
+   topic_property_record_value_subject_name_strategy,
+   topic_property_record_value_subject_name_strategy_compat});
 
 bool is_supported(std::string_view name) {
     return std::any_of(
@@ -71,7 +80,8 @@ using validators = make_validator_types<
   timestamp_type_validator,
   cleanup_policy_validator,
   remote_read_and_write_are_not_supported_for_read_replica,
-  batch_max_bytes_limits>;
+  batch_max_bytes_limits,
+  subject_name_strategy_validator>;
 
 static std::vector<creatable_topic_configs>
 properties_to_result_configs(config_map_t config_map) {

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -22,7 +22,9 @@
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/record_batch_reader.h"
+#include "model/timeout_clock.h"
 #include "model/timestamp.h"
+#include "pandaproxy/schema_registry/validation.h"
 #include "raft/errc.h"
 #include "raft/types.h"
 #include "ssx/future-util.h"
@@ -285,6 +287,9 @@ static partition_produce_stages produce_topic_partition(
     auto batch_size = batch.size_bytes();
     auto num_records = batch.record_count();
     auto reader = reader_from_lcore_batch(std::move(batch));
+    auto validator
+      = pandaproxy::schema_registry::maybe_make_schema_id_validator(
+        octx.rctx.schema_registry(), topic.name, topic_cfg->properties);
     auto start = std::chrono::steady_clock::now();
 
     auto dispatch = std::make_unique<ss::promise<>>();
@@ -296,6 +301,7 @@ static partition_produce_stages produce_topic_partition(
             *shard,
             octx.ssg,
             [reader = std::move(reader),
+             validator = std::move(validator),
              ntp = std::move(ntp),
              dispatch = std::move(dispatch),
              num_records,
@@ -336,12 +342,31 @@ static partition_produce_stages produce_topic_partition(
                       ntp,
                       source_shard);
                 }
+
+                return pandaproxy::schema_registry::maybe_validate_schema_id(
+                         std::move(validator), std::move(reader))
+                  .then([ntp{std::move(ntp)},
+                         partition{std::move(partition)},
+                         dispatch = std::move(dispatch),
+                         bid,
+                         acks,
+                         source_shard,
+                         num_records,
+                         batch_size,
+                         timeout](auto reader) mutable {
+                      if (reader.has_error()) {
+                          return finalize_request_with_error_code(
+                            reader.assume_error(),
+                            std::move(dispatch),
+                            ntp,
+                            source_shard);
+                      }
                 auto stages = partition_append(
                   ntp.tp.partition,
                   ss::make_lw_shared<replicated_partition>(
                     std::move(partition)),
                   bid,
-                  std::move(reader),
+                  std::move(reader).assume_value(),
                   acks,
                   num_records,
                   batch_size,
@@ -368,6 +393,7 @@ static partition_produce_stages produce_topic_partition(
                   })
                   .then([f = std::move(stages.produced)]() mutable {
                       return std::move(f);
+                  });
                   });
             })
           .then([&octx, start, m = std::move(m)](

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -11,10 +11,12 @@
 
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "kafka/server/handlers/configs/config_utils.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "model/timestamp.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "units.h"
 #include "utils/string_switch.h"
 
@@ -185,6 +187,14 @@ to_cluster_type(const creatable_topic& t) {
     cfg.properties.segment_ms = get_tristate_value<std::chrono::milliseconds>(
       config_entries, topic_property_segment_ms);
 
+    schema_id_validation_config_parser schema_id_validation_config_parser{
+      cfg.properties};
+
+    for (auto& p : t.configs) {
+        schema_id_validation_config_parser(
+          p, kafka::config_resource_operation::set);
+    }
+
     /// Final topic_property not decoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
 
@@ -301,6 +311,43 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
         config_entries[topic_property_segment_ms] = from_config_type(
           properties.segment_ms.value());
     }
+
+    if (properties.record_key_schema_id_validation) {
+        config_entries[topic_property_record_key_schema_id_validation]
+          = from_config_type(properties.record_key_schema_id_validation);
+    }
+    if (properties.record_key_schema_id_validation_compat) {
+        config_entries[topic_property_record_key_schema_id_validation_compat]
+          = from_config_type(properties.record_key_schema_id_validation_compat);
+    }
+    if (properties.record_key_subject_name_strategy) {
+        config_entries[topic_property_record_key_subject_name_strategy]
+          = from_config_type(properties.record_key_subject_name_strategy);
+    }
+    if (properties.record_key_subject_name_strategy_compat) {
+        config_entries[topic_property_record_key_subject_name_strategy_compat]
+          = from_config_type(
+            properties.record_key_subject_name_strategy_compat);
+    }
+    if (properties.record_value_schema_id_validation) {
+        config_entries[topic_property_record_value_schema_id_validation]
+          = from_config_type(properties.record_value_schema_id_validation);
+    }
+    if (properties.record_value_schema_id_validation_compat) {
+        config_entries[topic_property_record_value_schema_id_validation_compat]
+          = from_config_type(
+            properties.record_value_schema_id_validation_compat);
+    }
+    if (properties.record_value_subject_name_strategy) {
+        config_entries[topic_property_record_value_subject_name_strategy]
+          = from_config_type(properties.record_value_subject_name_strategy);
+    }
+    if (properties.record_value_subject_name_strategy_compat) {
+        config_entries[topic_property_record_value_subject_name_strategy_compat]
+          = from_config_type(
+            properties.record_value_subject_name_strategy_compat);
+    }
+
     /// Final topic_property not encoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
     return config_entries;

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -67,6 +67,33 @@ static constexpr std::string_view topic_property_remote_delete
   = "redpanda.remote.delete";
 static constexpr std::string_view topic_property_segment_ms = "segment.ms";
 
+// Server side schema id validation
+static constexpr std::string_view topic_property_record_key_schema_id_validation
+  = "redpanda.key.schema.id.validation";
+static constexpr std::string_view
+  topic_property_record_key_subject_name_strategy
+  = "redpanda.key.subject.name.strategy";
+static constexpr std::string_view
+  topic_property_record_value_schema_id_validation
+  = "redpanda.value.schema.id.validation";
+static constexpr std::string_view
+  topic_property_record_value_subject_name_strategy
+  = "redpanda.value.subject.name.strategy";
+
+// Server side schema id validation (compat names)
+static constexpr std::string_view
+  topic_property_record_key_schema_id_validation_compat
+  = "confluent.key.schema.validation";
+static constexpr std::string_view
+  topic_property_record_key_subject_name_strategy_compat
+  = "confluent.key.subject.name.strategy";
+static constexpr std::string_view
+  topic_property_record_value_schema_id_validation_compat
+  = "confluent.value.schema.validation";
+static constexpr std::string_view
+  topic_property_record_value_subject_name_strategy_compat
+  = "confluent.value.subject.name.strategy";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 static constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -24,6 +24,7 @@
 #include "kafka/server/server.h"
 #include "kafka/server/usage_manager.h"
 #include "kafka/types.h"
+#include "pandaproxy/schema_registry/fwd.h"
 #include "seastarx.h"
 #include "security/fwd.h"
 #include "vlog.h"
@@ -133,6 +134,11 @@ public:
 
     cluster::tx_gateway_frontend& tx_gateway_frontend() const {
         return _conn->server().tx_gateway_frontend();
+    }
+
+    const std::unique_ptr<pandaproxy::schema_registry::api>&
+    schema_registry() const {
+        return _conn->server().schema_registry();
     }
 
     std::chrono::milliseconds throttle_delay_ms() const {

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -100,7 +100,8 @@ server::server(
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
   ss::sharded<cluster::tx_registry_frontend>& tx_registry_frontend,
   std::optional<qdc_monitor::config> qdc_config,
-  ssx::thread_worker& tw) noexcept
+  ssx::thread_worker& tw,
+  const std::unique_ptr<pandaproxy::schema_registry::api>& sr) noexcept
   : net::server(cfg, klog)
   , _smp_group(smp)
   , _fetch_scheduling_group(fetch_sg)
@@ -134,7 +135,8 @@ server::server(
   , _krb_configurator(config::shard_local_cfg().sasl_kerberos_config.bind())
   , _thread_worker(tw)
   , _replica_selector(
-      std::make_unique<rack_aware_replica_selector>(_metadata_cache.local())) {
+      std::make_unique<rack_aware_replica_selector>(_metadata_cache.local()))
+  , _schema_registry(sr) {
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);
     }

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -23,6 +23,7 @@
 #include "kafka/server/handlers/handler_probe.h"
 #include "kafka/server/queue_depth_monitor.h"
 #include "net/server.h"
+#include "pandaproxy/schema_registry/fwd.h"
 #include "security/fwd.h"
 #include "security/gssapi_principal_mapper.h"
 #include "security/krb5_configurator.h"
@@ -61,7 +62,8 @@ public:
       ss::sharded<cluster::tx_gateway_frontend>&,
       ss::sharded<cluster::tx_registry_frontend>&,
       std::optional<qdc_monitor::config>,
-      ssx::thread_worker&) noexcept;
+      ssx::thread_worker&,
+      const std::unique_ptr<pandaproxy::schema_registry::api>&) noexcept;
 
     ~server() noexcept override = default;
     server(const server&) = delete;
@@ -158,6 +160,10 @@ public:
 
     ssx::thread_worker& thread_worker() { return _thread_worker; }
 
+    const std::unique_ptr<pandaproxy::schema_registry::api>& schema_registry() {
+        return _schema_registry;
+    }
+
     /**
      * \param api_names list of Kafka API names
      * \return std::vector<bool> always sized to index the entire Kafka API key
@@ -209,6 +215,7 @@ private:
     class latency_probe _probe;
     ssx::thread_worker& _thread_worker;
     std::unique_ptr<replica_selector> _replica_selector;
+    const std::unique_ptr<pandaproxy::schema_registry::api>& _schema_registry;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ rp_test(
     topic_utils_test.cc
     handler_interface_test.cc
     quota_managers_test.cc
+    validator_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka v::coproc
   LABELS kafka

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -346,7 +346,15 @@ FIXTURE_TEST(
       "retention.local.target.bytes",
       "retention.local.target.ms",
       "redpanda.remote.delete",
-      "segment.ms"};
+      "segment.ms",
+      "redpanda.key.schema.id.validation",
+      "confluent.key.schema.validation",
+      "redpanda.key.subject.name.strategy",
+      "confluent.key.subject.name.strategy",
+      "redpanda.value.schema.id.validation",
+      "confluent.value.schema.validation",
+      "redpanda.value.subject.name.strategy",
+      "confluent.value.subject.name.strategy"};
 
     // All properties_request
     auto all_describe_resp = describe_configs(test_tp);

--- a/src/v/kafka/server/tests/validator_tests.cc
+++ b/src/v/kafka/server/tests/validator_tests.cc
@@ -1,0 +1,80 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/protocol/schemata/create_topics_request.h"
+#include "kafka/server/handlers/topics/types.h"
+#include "kafka/server/handlers/topics/validators.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+
+namespace bdata = boost::unit_test::data;
+using namespace pandaproxy::schema_registry;
+using namespace kafka;
+
+struct test_validator_data {
+    std::vector<createable_topic_config> configs;
+    bool is_valid;
+    friend std::ostream&
+    operator<<(std::ostream& os, test_validator_data const& d) {
+        fmt::print(os, "configs: {}, expect valid: {}", d.configs, d.is_valid);
+        return os;
+    }
+};
+
+std::ostream& operator<<(std::ostream& os, subject_name_strategy sns) {
+    return os << to_string_view(sns);
+}
+
+static const auto sns_data = std::to_array(
+  {// Correct keys and values: - expect success
+   test_validator_data{
+     {{.name = ss::sstring{topic_property_record_key_subject_name_strategy},
+       .value = ss::sstring{to_string_view(
+         subject_name_strategy::topic_name)}}},
+     true},
+   {{{.name
+      = ss::sstring{topic_property_record_key_subject_name_strategy_compat},
+      .value = ss::sstring{to_string_view_compat(
+        subject_name_strategy::topic_name)}}},
+    true},
+   {{{.name = ss::sstring{topic_property_record_value_subject_name_strategy},
+      .value = ss::sstring{to_string_view(subject_name_strategy::topic_name)}}},
+    true},
+   {{{.name
+      = ss::sstring{topic_property_record_value_subject_name_strategy_compat},
+      .value = ss::sstring{to_string_view_compat(
+        subject_name_strategy::topic_name)}}},
+    true}, // Correct key, null value: expect success
+   {{{.name = ss::sstring{topic_property_record_value_subject_name_strategy},
+      .value = std::nullopt}},
+    true},
+   // Incorrect key: - expect success
+   {{{.name = ss::sstring{topic_property_remote_read},
+      .value = ss::sstring{to_string_view_compat(
+        subject_name_strategy::topic_name)}}},
+    true},
+   // Correct key, invalid sns: - expect failure
+   {{{.name = ss::sstring{topic_property_record_value_subject_name_strategy},
+      .value = ss::sstring{"InvalidNameStrategy"}}},
+    false}});
+
+BOOST_DATA_TEST_CASE(
+  test_subject_name_strategy_validator, bdata::make(sns_data), data) {
+    creatable_topic no_options = {
+      .name = model::topic_view{"test_tp"},
+      .num_partitions = 1,
+      .replication_factor = 1,
+      .configs = data.configs};
+    BOOST_REQUIRE_EQUAL(
+      subject_name_strategy_validator::is_valid(no_options), data.is_valid);
+}

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -729,7 +729,7 @@ public:
 private:
     record_batch_header _header;
     iobuf _records;
-    bool _compressed;
+    bool _compressed{false};
 
     record_batch(record_batch_header header, iobuf&& records, bool compressed)
       : _header(header)

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -11,8 +11,8 @@ v_cc_library(
     v::pandaproxy_parsing
     v::pandaproxy_json
     v::kafka_client
+    v::kafka_protocol
     v::syschecks
-    v::kafka
     v::ssx
     v::utils
   )

--- a/src/v/pandaproxy/rest/CMakeLists.txt
+++ b/src/v/pandaproxy/rest/CMakeLists.txt
@@ -17,8 +17,8 @@ v_cc_library(
     v::pandaproxy_parsing
     v::pandaproxy_json
     v::kafka_client
+    v::kafka_protocol
     v::syschecks
-    v::kafka
     v::ssx
     v::utils
   )

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -26,7 +26,7 @@ v_cc_library(
     v::pandaproxy_parsing
     v::pandaproxy_json
     v::kafka_client
-    v::kafka
+    v::kafka_protocol
     v::ssx
     v::utils
     v::pandaproxy_schema_registry_protobuf

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -21,6 +21,7 @@ v_cc_library(
     types.cc
     avro.cc
     protobuf.cc
+    validation.cc
   DEPS
     v::pandaproxy_common
     v::pandaproxy_parsing

--- a/src/v/pandaproxy/schema_registry/api.h
+++ b/src/v/pandaproxy/schema_registry/api.h
@@ -45,6 +45,7 @@ public:
     ss::future<> restart();
 
 private:
+    friend class schema_id_validator;
     model::node_id _node_id;
     ss::smp_service_group _sg;
     size_t _max_memory;

--- a/src/v/pandaproxy/schema_registry/api.h
+++ b/src/v/pandaproxy/schema_registry/api.h
@@ -55,6 +55,7 @@ private:
 
     ss::sharded<kafka::client::client> _client;
     std::unique_ptr<pandaproxy::schema_registry::sharded_store> _store;
+    ss::sharded<schema_id_validation_probe> _schema_id_validation_probe;
     ss::sharded<schema_id_cache> _schema_id_cache;
     ss::sharded<pandaproxy::schema_registry::service> _service;
     ss::sharded<pandaproxy::schema_registry::seq_writer> _sequencer;

--- a/src/v/pandaproxy/schema_registry/api.h
+++ b/src/v/pandaproxy/schema_registry/api.h
@@ -54,6 +54,7 @@ private:
 
     ss::sharded<kafka::client::client> _client;
     std::unique_ptr<pandaproxy::schema_registry::sharded_store> _store;
+    ss::sharded<schema_id_cache> _schema_id_cache;
     ss::sharded<pandaproxy::schema_registry::service> _service;
     ss::sharded<pandaproxy::schema_registry::seq_writer> _sequencer;
 };

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -342,6 +342,10 @@ canonical_schema_definition::raw_string avro_schema_definition::raw() const {
     return canonical_schema_definition::raw_string{_impl.toJson(false)};
 }
 
+ss::sstring avro_schema_definition::name() const {
+    return _impl.root()->name().fullname();
+};
+
 class collected_schema {
 public:
     bool contains(const ss::sstring& name) const {

--- a/src/v/pandaproxy/schema_registry/fwd.h
+++ b/src/v/pandaproxy/schema_registry/fwd.h
@@ -15,6 +15,7 @@ namespace pandaproxy::schema_registry {
 
 class api;
 struct configuration;
+class schema_id_cache;
 class seq_writer;
 class service;
 class sharded_store;

--- a/src/v/pandaproxy/schema_registry/fwd.h
+++ b/src/v/pandaproxy/schema_registry/fwd.h
@@ -16,6 +16,7 @@ namespace pandaproxy::schema_registry {
 class api;
 struct configuration;
 class schema_id_cache;
+class schema_id_validation_probe;
 class seq_writer;
 class service;
 class sharded_store;

--- a/src/v/pandaproxy/schema_registry/schema_id_cache.h
+++ b/src/v/pandaproxy/schema_registry/schema_id_cache.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "config/property.h"
+#include "model/fundamental.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "seastarx.h"
+
+#include <boost/multi_index/indexed_by.hpp>
+#include <boost/multi_index/key.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <iterator>
+#include <utility>
+
+namespace pandaproxy::schema_registry {
+
+///\brief An MRU cache of valid schemas for a given topic.
+class schema_id_cache {
+public:
+    enum class field : uint8_t { key, val };
+    using offsets_t = std::optional<std::vector<int32_t>>;
+
+    explicit schema_id_cache(config::binding<size_t> cap)
+      : _capacity{std::move(cap)} {
+        _capacity.watch([this]() { shrink_to_capacity(); });
+    }
+
+    bool has(
+      model::topic_view topic,
+      field field,
+      subject_name_strategy sns,
+      schema_id s_id,
+      offsets_t const& offsets) {
+        auto& map = _cache.get<underlying_map>();
+        auto it = map.find(entry::view_t(topic, field, sns, s_id, offsets));
+        bool has = it != map.end();
+        if (has) {
+            auto& list = _cache.get<underlying_list>();
+            list.relocate(list.begin(), _cache.project<underlying_list>(it));
+        }
+        return has;
+    };
+
+    void put(
+      model::topic_view topic,
+      field field,
+      subject_name_strategy sns,
+      schema_id s_id,
+      offsets_t offsets) {
+        auto& list = _cache.get<underlying_list>();
+        auto [it, i] = list.emplace_front(
+          topic, field, sns, s_id, std::move(offsets));
+        if (i) {
+            shrink_to_capacity();
+        }
+    }
+
+    size_t invalidate(model::topic_view topic) {
+        auto& map = _cache.get<underlying_map>();
+        auto [b, e] = map.equal_range(topic, entry::topic_less{});
+        auto count = std::distance(b, e);
+        map.erase(b, e);
+        return count;
+    }
+
+private:
+    // Truncate the cache from the back of the sequence
+    void shrink_to_capacity() {
+        auto& list = _cache.get<underlying_list>();
+        if (list.size() > _capacity()) {
+            list.resize(_capacity());
+        }
+    }
+
+    struct entry {
+        entry() = default;
+        entry(
+          model::topic_view tp,
+          field f,
+          subject_name_strategy sns,
+          schema_id s_id,
+          offsets_t offsets = std::nullopt)
+          : topic{tp}
+          , s_id{s_id}
+          , offsets{std::move(offsets)}
+          , f{f}
+          , sns{sns} {}
+
+        model::topic topic;
+        schema_id s_id{invalid_schema_id};
+        std::optional<std::vector<int32_t>> offsets;
+        field f{};
+        subject_name_strategy sns{};
+
+        using view_t = std::tuple<
+          model::topic_view,
+          field,
+          subject_name_strategy,
+          schema_id,
+          offsets_t const&>;
+        view_t view() const { return {topic, f, sns, s_id, offsets}; }
+
+        // Full comparison of entry
+        struct less {
+            using is_transparent = void;
+            bool operator()(entry const& lhs, entry const& rhs) const {
+                return lhs.view() < rhs.view();
+            }
+            bool operator()(view_t lhs, entry const& rhs) const {
+                return lhs < rhs.view();
+            }
+            bool operator()(entry const& lhs, view_t rhs) const {
+                return lhs.view() < rhs;
+            }
+        };
+
+        // Compare only the topic
+        struct topic_less {
+            using is_transparent = void;
+            bool operator()(model::topic_view lhs, entry const& rhs) const {
+                return lhs < model::topic_view(rhs.topic);
+            }
+            bool operator()(entry const& lhs, model::topic_view rhs) const {
+                return model::topic_view(lhs.topic) < rhs;
+            }
+        };
+    };
+
+    struct underlying_list {};
+    struct underlying_map {};
+    using underlying_t = boost::multi_index::multi_index_container<
+      entry,
+      boost::multi_index::indexed_by<
+        // Sequenced list of entries
+        boost::multi_index::sequenced<boost::multi_index::tag<underlying_list>>,
+        // Set of entries by topic, field, sns, prefix
+        boost::multi_index::ordered_unique<
+          boost::multi_index::tag<underlying_map>,
+          boost::multi_index::identity<entry>,
+          entry::less>>>;
+
+    underlying_t _cache;
+    config::binding<size_t> _capacity;
+};
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -173,7 +173,6 @@ ss::future<> service::do_start() {
     }
     auto guard = gate_guard(_gate);
     try {
-        co_await configure();
         co_await create_internal_topic();
         vlog(plog.info, "Schema registry successfully initialized");
     } catch (...) {
@@ -364,9 +363,10 @@ service::service(
       controller.get()} {}
 
 ss::future<> service::start() {
+    co_await configure();
     static std::vector<model::broker_endpoint> not_advertised{};
     _server.routes(get_schema_registry_routes(_gate, _ensure_started));
-    return _server.start(
+    co_return co_await _server.start(
       _config.schema_registry_api(),
       _config.schema_registry_api_tls(),
       not_advertised);

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -598,4 +598,14 @@ ss::future<bool> sharded_store::is_compatible(
     co_return is_compat;
 }
 
+ss::future<bool> sharded_store::has_version(
+  const subject& sub, schema_id id, include_deleted i) {
+    auto sub_shard{shard_for(sub)};
+    auto has_id = co_await _store.invoke_on(
+      sub_shard, _smp_opts, [id, sub, i](class store& s) mutable {
+          return s.has_version(sub, id, i);
+      });
+    co_return has_id.has_value() && has_id.assume_value();
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -125,6 +125,8 @@ public:
     ss::future<bool>
     is_compatible(schema_version version, canonical_schema new_schema);
 
+    ss::future<bool> has_version(const subject&, schema_id, include_deleted);
+
 private:
     ss::future<bool>
     upsert_schema(schema_id id, canonical_schema_definition def);

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -297,6 +297,17 @@ public:
         return sub_it->second.versions;
     }
 
+    ///\brief Return whether this subject has a version that references the
+    /// schema_id.
+    result<bool> has_version(
+      const subject& sub, schema_id id, include_deleted inc_del) const {
+        auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
+        const auto& vs = sub_it->second.versions;
+        return std::any_of(vs.cbegin(), vs.cend(), [id](const auto& entry) {
+            return entry.id == id;
+        });
+    }
+
     bool is_referenced(const subject& sub, schema_version ver) {
         return std::any_of(
           _subjects.begin(), _subjects.end(), [&sub, ver](const auto& s) {

--- a/src/v/pandaproxy/schema_registry/subject_name_strategy.h
+++ b/src/v/pandaproxy/schema_registry/subject_name_strategy.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/schema_registry/types.h"
+#include "utils/string_switch.h"
+
+namespace pandaproxy::schema_registry {
+
+enum class subject_name_strategy : uint8_t {
+    topic_name,
+    record_name,
+    topic_record_name,
+};
+
+inline constexpr std::string_view to_string_view(subject_name_strategy e) {
+    switch (e) {
+    case subject_name_strategy::topic_name:
+        return "io.confluent.kafka.serializers.subject.TopicNameStrategy";
+    case subject_name_strategy::record_name:
+        return "io.confluent.kafka.serializers.subject.RecordNameStrategy";
+    case subject_name_strategy::topic_record_name:
+        return "io.confluent.kafka.serializers.subject.TopicRecordNameStrategy";
+    }
+    return "{invalid}";
+}
+
+inline constexpr std::ostream&
+operator<<(std::ostream& os, subject_name_strategy e) {
+    return os << to_string_view(e);
+}
+
+inline std::istream& operator>>(std::istream& i, subject_name_strategy& e) {
+    ss::sstring s;
+    i >> s;
+    e = string_switch<subject_name_strategy>(s)
+          .match(
+            to_string_view(subject_name_strategy::topic_name),
+            subject_name_strategy::topic_name)
+          .match(
+            to_string_view(subject_name_strategy::record_name),
+            subject_name_strategy::record_name)
+          .match(
+            to_string_view(subject_name_strategy::topic_record_name),
+            subject_name_strategy::topic_record_name);
+    return i;
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/subject_name_strategy.h
+++ b/src/v/pandaproxy/schema_registry/subject_name_strategy.h
@@ -25,6 +25,19 @@ enum class subject_name_strategy : uint8_t {
 inline constexpr std::string_view to_string_view(subject_name_strategy e) {
     switch (e) {
     case subject_name_strategy::topic_name:
+        return "TopicNameStrategy";
+    case subject_name_strategy::record_name:
+        return "RecordNameStrategy";
+    case subject_name_strategy::topic_record_name:
+        return "TopicRecordNameStrategy";
+    }
+    return "{invalid}";
+}
+
+inline constexpr std::string_view
+to_string_view_compat(subject_name_strategy e) {
+    switch (e) {
+    case subject_name_strategy::topic_name:
         return "io.confluent.kafka.serializers.subject.TopicNameStrategy";
     case subject_name_strategy::record_name:
         return "io.confluent.kafka.serializers.subject.RecordNameStrategy";
@@ -43,14 +56,17 @@ inline std::istream& operator>>(std::istream& i, subject_name_strategy& e) {
     ss::sstring s;
     i >> s;
     e = string_switch<subject_name_strategy>(s)
-          .match(
+          .match_all(
             to_string_view(subject_name_strategy::topic_name),
+            to_string_view_compat(subject_name_strategy::topic_name),
             subject_name_strategy::topic_name)
-          .match(
+          .match_all(
             to_string_view(subject_name_strategy::record_name),
+            to_string_view_compat(subject_name_strategy::record_name),
             subject_name_strategy::record_name)
-          .match(
+          .match_all(
             to_string_view(subject_name_strategy::topic_record_name),
+            to_string_view_compat(subject_name_strategy::topic_record_name),
             subject_name_strategy::topic_record_name);
     return i;
 }

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -6,6 +6,7 @@ rp_test(
     util.cc
     storage.cc
     store.cc
+    schema_id_cache.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v_pandaproxy_schema_registry
   LABELS pandaproxy

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -249,6 +249,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition) {
       "schema2 is an avro_schema_definition");
     pps::canonical_schema_definition avro_conversion{valid};
     BOOST_CHECK_EQUAL(expected, avro_conversion);
+    BOOST_CHECK_EQUAL(valid.name(), "myrecord");
 }
 
 SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition_custom_attributes) {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -83,6 +83,19 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
     store.insert(schema1, pps::schema_version{1});
     auto valid_simple
       = pps::make_protobuf_schema_definition(store.store, schema1).get();
+    BOOST_REQUIRE_EQUAL(valid_simple.name({0}).value(), "Simple");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_nested) {
+    simple_sharded_store store;
+
+    auto schema1 = pps::canonical_schema{pps::subject{"nested"}, nested};
+    store.insert(schema1, pps::schema_version{1});
+    auto valid_nested
+      = pps::make_protobuf_schema_definition(store.store, schema1).get();
+    BOOST_REQUIRE_EQUAL(valid_nested.name({0}).value(), "A0");
+    BOOST_REQUIRE_EQUAL(valid_nested.name({1, 0, 2}).value(), "A1.B0.C2");
+    BOOST_REQUIRE_EQUAL(valid_nested.name({1, 0, 4}).value(), "A1.B0.C4");
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
@@ -56,3 +56,20 @@ message Test3 {
   Test2 id =  1;
 })",
   pps::schema_type::protobuf};
+
+const auto nested = pps::canonical_schema_definition{
+  R"(
+syntax = "proto3";
+
+message A0 {}
+
+message A1 {
+  message B0 {
+     message C0 {}
+     message C1 {}
+     message C2 {}
+     message C3 {}
+     message C4 {}
+  }
+})",
+  pps::schema_type::protobuf};

--- a/src/v/pandaproxy/schema_registry/test/schema_id_cache.cc
+++ b/src/v/pandaproxy/schema_registry/test/schema_id_cache.cc
@@ -1,0 +1,114 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/schema_id_cache.h"
+
+#include "config/config_store.h"
+
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+namespace pps = pandaproxy::schema_registry;
+
+constexpr auto key = pps::schema_id_cache::field::key;
+constexpr auto val = pps::schema_id_cache::field::val;
+
+constexpr auto topic_name = pps::subject_name_strategy::topic_name;
+constexpr auto record_name = pps::subject_name_strategy::record_name;
+constexpr auto topic_record_name
+  = pps::subject_name_strategy::topic_record_name;
+
+const model::topic_view tp1{"tp1"};
+const model::topic_view tp2{"tp2"};
+const model::topic_view tp3{"tp3"};
+
+const pps::schema_id s_id1{1};
+const pps::schema_id s_id2{2};
+const pps::schema_id s_id3{3};
+
+BOOST_AUTO_TEST_CASE(test_schema_id_cache_basic_retrieval) {
+    pps::schema_id_cache c{config::mock_binding(size_t(2))};
+
+    c.put(tp1, key, topic_name, s_id1, std::nullopt);
+    c.put(tp2, key, topic_name, s_id2, {{3, 4, 5}});
+
+    // Match
+    BOOST_REQUIRE(c.has(tp1, key, topic_name, s_id1, std::nullopt));
+    BOOST_REQUIRE(c.has(tp2, key, topic_name, s_id2, {{3, 4, 5}}));
+
+    // Missing offsets
+    BOOST_REQUIRE(!c.has(tp2, key, topic_name, s_id2, std::nullopt));
+    // Empty offsets
+    BOOST_REQUIRE(!c.has(tp2, key, topic_name, s_id2, {{}}));
+    // Incorrect offsets
+    BOOST_REQUIRE(!c.has(tp2, key, topic_name, s_id2, {{3, 4}}));
+
+    // Wrong field
+    BOOST_REQUIRE(!c.has(tp1, val, topic_name, s_id1, std::nullopt));
+
+    // Wrong sns
+    BOOST_REQUIRE(!c.has(tp1, key, record_name, s_id1, std::nullopt));
+
+    // Wrong sns
+    BOOST_REQUIRE(!c.has(tp1, key, topic_record_name, s_id1, std::nullopt));
+}
+
+BOOST_AUTO_TEST_CASE(test_schema_id_cache_capacity) {
+    config::config_store store;
+
+    config::property<size_t> p{
+      store, "capacity", "", {.needs_restart = config::needs_restart::no}};
+    auto reset_p = ss::defer([&p]() { p.reset(); });
+    p.set_value(size_t{2});
+    pps::schema_id_cache c{p.bind()};
+
+    c.put(tp1, key, topic_name, s_id1, {});
+    c.put(tp2, key, topic_name, s_id2, {});
+
+    // Should evict tp1
+    c.put(tp3, key, topic_name, s_id3, {});
+
+    BOOST_REQUIRE(!c.has(tp1, key, topic_name, s_id1, {}));
+    BOOST_REQUIRE(c.has(tp2, key, topic_name, s_id2, {}));
+    BOOST_REQUIRE(c.has(tp3, key, topic_name, s_id3, {}));
+
+    // should evict tp2
+    p.set_value(size_t{1});
+
+    BOOST_REQUIRE(!c.has(tp1, key, topic_name, s_id1, {}));
+    BOOST_REQUIRE(!c.has(tp2, key, topic_name, s_id2, {}));
+    BOOST_REQUIRE(c.has(tp3, key, topic_name, s_id3, {}));
+}
+
+BOOST_AUTO_TEST_CASE(test_schema_id_cache_invalidate) {
+    pps::schema_id_cache c{config::mock_binding(size_t(16))};
+
+    c.put(tp1, key, topic_name, s_id1, {});
+    c.put(tp1, key, record_name, s_id2, {});
+    c.put(tp1, key, topic_record_name, s_id3, {});
+    c.put(tp2, key, topic_name, s_id1, {});
+    c.put(tp2, key, record_name, s_id2, {});
+    c.put(tp2, key, topic_record_name, s_id3, {});
+    c.put(tp3, key, topic_name, s_id1, {});
+    c.put(tp3, key, record_name, s_id2, {});
+    c.put(tp3, key, topic_record_name, s_id3, {});
+
+    BOOST_REQUIRE_EQUAL(c.invalidate(tp2), 3);
+
+    BOOST_REQUIRE(c.has(tp1, key, topic_name, s_id1, {}));
+    BOOST_REQUIRE(c.has(tp1, key, record_name, s_id2, {}));
+    BOOST_REQUIRE(c.has(tp1, key, topic_record_name, s_id3, {}));
+    BOOST_REQUIRE(!c.has(tp2, key, topic_name, s_id1, {}));
+    BOOST_REQUIRE(!c.has(tp2, key, record_name, s_id2, {}));
+    BOOST_REQUIRE(!c.has(tp2, key, topic_record_name, s_id3, {}));
+    BOOST_REQUIRE(c.has(tp3, key, topic_name, s_id1, {}));
+    BOOST_REQUIRE(c.has(tp3, key, record_name, s_id2, {}));
+    BOOST_REQUIRE(c.has(tp3, key, topic_record_name, s_id3, {}));
+}

--- a/src/v/pandaproxy/schema_registry/test/validation.cc
+++ b/src/v/pandaproxy/schema_registry/test/validation.cc
@@ -1,0 +1,66 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/protobuf.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/test/compatibility_avro.h"
+#include "pandaproxy/schema_registry/test/compatibility_protobuf.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+SEASTAR_THREAD_TEST_CASE(test_validation) {
+    pps::sharded_store store;
+    store.start(ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    const pps::schema_version ver1{1};
+
+    // Insert simple
+    auto referenced_schema = pps::canonical_schema{
+      pps::subject{"simple.proto"}, simple};
+    store
+      .upsert(
+        pps::seq_marker{
+          std::nullopt, std::nullopt, ver1, pps::seq_marker_key_type::schema},
+        referenced_schema,
+        pps::schema_id{1},
+        ver1,
+        pps::is_deleted::no)
+      .get();
+
+    // Insert referenced
+    auto importing_schema = pps::canonical_schema{
+      pps::subject{"imported.proto"},
+      imported,
+      {{"simple", pps::subject{"simple.proto"}, ver1}}};
+
+    store
+      .upsert(
+        pps::seq_marker{
+          std::nullopt, std::nullopt, ver1, pps::seq_marker_key_type::schema},
+        importing_schema,
+        pps::schema_id{2},
+        ver1,
+        pps::is_deleted::no)
+      .get();
+
+    auto referenced_by
+      = store.referenced_by(referenced_schema.sub(), ver1).get();
+
+    BOOST_REQUIRE_EQUAL(referenced_by.size(), 1);
+    BOOST_REQUIRE_EQUAL(referenced_by[0], pps::schema_id{2});
+}

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -12,7 +12,9 @@
 #pragma once
 
 #include "avro/ValidSchema.hh"
+#include "kafka/protocol/errors.h"
 #include "model/metadata.h"
+#include "outcome.h"
 #include "seastarx.h"
 #include "utils/named_type.h"
 #include "utils/string_switch.h"
@@ -131,6 +133,8 @@ public:
         return {raw(), type()};
     }
 
+    ss::sstring name() const;
+
 private:
     avro::ValidSchema _impl;
 };
@@ -159,6 +163,9 @@ public:
     explicit operator canonical_schema_definition() const {
         return {raw(), type()};
     }
+
+    ::result<ss::sstring, kafka::error_code>
+    name(std::vector<int> const& fields) const;
 
 private:
     pimpl _impl;

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "pandaproxy/schema_registry/validation.h"
+
+#include "bytes/bytes.h"
+#include "bytes/iobuf_parser.h"
+#include "cluster/controller.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "features/feature_table.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/timeout_clock.h"
+#include "pandaproxy/logger.h"
+#include "pandaproxy/schema_registry/avro.h"
+#include "pandaproxy/schema_registry/errors.h"
+#include "pandaproxy/schema_registry/protobuf.h"
+#include "pandaproxy/schema_registry/schema_id_cache.h"
+#include "pandaproxy/schema_registry/seq_writer.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "storage/parser_utils.h"
+#include "utils/vint.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/coroutine/exception.hh>
+
+#include <absl/algorithm/container.h>
+
+#include <iterator>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+
+namespace pandaproxy::schema_registry {
+
+namespace {
+
+using field = schema_id_cache::field;
+
+auto to_string_view(field f) {
+    switch (f) {
+    case field::key:
+        return "key";
+    case field::val:
+        return "value";
+    }
+};
+
+auto make_subject(
+  subject_name_strategy sns,
+  const model::topic& t,
+  field f,
+  std::string_view record_name) {
+    switch (sns) {
+    case subject_name_strategy::topic_name:
+        return subject{ssx::sformat("{}-{}", t(), to_string_view(f))};
+    case subject_name_strategy::record_name:
+        return subject{record_name};
+    case subject_name_strategy::topic_record_name:
+        return subject{ssx::sformat("{}-{}", t(), record_name)};
+    }
+};
+
+std::vector<int32_t> get_proto_offsets(iobuf_parser& p) {
+    // The encoding is a length, followed by indexes into the file or message.
+    // Each number is a zigzag encoded integer.
+    std::vector<int32_t> offsets;
+    auto [offset_count, bytes_read] = p.read_varlong();
+    if (!bytes_read) {
+        return {};
+    }
+    // Reject more offsets than bytes remaining; it's not possible
+    if (static_cast<size_t>(offset_count) > p.bytes_left()) {
+        return {};
+    }
+    offsets.resize(offset_count);
+    for (auto& o : offsets) {
+        std::tie(o, bytes_read) = p.read_varlong();
+        if (!bytes_read) {
+            return {};
+        }
+    }
+    if (offsets.empty()) {
+        // If the decoded length is 0, then assume the optimised encoding for
+        // using the first message in the file
+        offsets.push_back(0);
+    }
+    return offsets;
+}
+
+ss::future<std::optional<ss::sstring>> get_record_name(
+  pandaproxy::schema_registry::sharded_store& store,
+  field field,
+  const model::topic& topic,
+  subject_name_strategy sns,
+  const canonical_schema_definition& schema,
+  std::optional<std::vector<int32_t>>& offsets) {
+    if (sns == subject_name_strategy::topic_name) {
+        // Result is succesfully nothing
+        co_return "";
+    }
+
+    switch (schema.type()) {
+    case schema_type::avro: {
+        auto s = co_await make_avro_schema_definition(
+          store, {subject("r"), {schema.raw(), schema.type()}});
+        co_return s().root()->name().fullname();
+    } break;
+    case schema_type::protobuf: {
+        if (!offsets) {
+            co_return std::nullopt;
+        }
+        auto s = co_await make_protobuf_schema_definition(
+          store, {subject("r"), {schema.raw(), schema.type()}});
+        auto r = s.name(*offsets);
+        if (!r) {
+            co_return std::nullopt;
+        }
+        co_return std::move(r).assume_value();
+    } break;
+    case schema_type::json:
+        break;
+    }
+    co_return std::nullopt;
+}
+
+} // namespace
+
+class schema_id_validator::impl {
+public:
+    using data_t = model::record_batch_reader::data_t;
+    using foreign_data_t = model::record_batch_reader::foreign_data_t;
+    using storage_t = model::record_batch_reader::storage_t;
+
+    impl(
+      const std::unique_ptr<api>& api,
+      model::topic topic,
+      const cluster::topic_properties& props)
+      : _api{api}
+      , _topic{std::move(topic)}
+      , _record_key_schema_id_validation{props.record_key_schema_id_validation
+                                           .value_or(
+                                             props
+                                               .record_key_schema_id_validation_compat
+                                               .value_or(false))}
+      , _record_key_subject_name_strategy{props.record_key_subject_name_strategy
+                                            .value_or(
+                                              props
+                                                .record_key_subject_name_strategy_compat
+                                                .value_or(
+                                                  subject_name_strategy::
+                                                    topic_name))}
+      , _record_value_schema_id_validation{props
+                                             .record_value_schema_id_validation
+                                             .value_or(
+                                               props
+                                                 .record_value_schema_id_validation_compat
+                                                 .value_or(false))}
+      , _record_value_subject_name_strategy{
+          props.record_value_subject_name_strategy.value_or(
+            props.record_value_subject_name_strategy_compat.value_or(
+              subject_name_strategy::topic_name))} {}
+
+    auto validate_field(
+      field field, model::topic topic, subject_name_strategy sns, iobuf buf)
+      -> ss::future<bool> {
+        iobuf_parser parser(std::move(buf));
+
+        if (parser.bytes_left() < 5) {
+            vlog(
+              plog.debug,
+              "validating: topic: {}, field: {}, not enough bytes: {}",
+              topic(),
+              to_string_view(field),
+              parser.bytes_left());
+            co_return false;
+        }
+
+        auto magic = parser.consume_type<int8_t>();
+        if (magic != 0) {
+            vlog(
+              plog.debug,
+              "validating: topic: {}, field: {}, invalid magic: {}",
+              topic(),
+              to_string_view(field),
+              magic);
+            co_return false;
+        }
+
+        auto id = schema_id{parser.consume_be_type<int32_t>()};
+
+        // Optimistically check the cache in case just the id matches
+        // This is true for Avro with TopicNameStrategy
+        if (_api->_schema_id_cache.local().has(
+              topic, field, sns, id, std::nullopt)) {
+            vlog(
+              plog.debug,
+              "validating: topic: {}, field: {}, cache hit",
+              topic(),
+              to_string_view(field));
+            co_return true;
+        }
+
+        // Determine the schema type
+        std::optional<canonical_schema_definition> schema;
+        try {
+            schema.emplace(co_await _api->_store->get_schema_definition(id));
+        } catch (const exception& ex) {
+            vlog(
+              plog.debug,
+              "validating: topic: {}, field: {}, schema not found: {}",
+              topic(),
+              to_string_view(field),
+              ex.message());
+            co_return false;
+        }
+
+        std::optional<std::vector<int32_t>> proto_offsets;
+        if (schema->type() == schema_type::protobuf) {
+            auto offsets = get_proto_offsets(parser);
+            if (offsets.empty()) {
+                vlog(
+                  plog.debug,
+                  "validating: topic: {}, field: {}, invalid protobuf offsets",
+                  topic(),
+                  to_string_view(field));
+                co_return false;
+            }
+
+            if (_api->_schema_id_cache.local().has(
+                  topic, field, sns, id, offsets)) {
+                vlog(
+                  plog.debug,
+                  "validating: topic: {}, field: {}, cache hit",
+                  topic(),
+                  to_string_view(field));
+                co_return true;
+            }
+
+            proto_offsets.emplace(std::move(offsets));
+        }
+
+        auto record_name = co_await get_record_name(
+          *_api->_store, field, topic, sns, *schema, proto_offsets);
+        if (!record_name) {
+            vlog(
+              plog.debug,
+              "validating: topic: {}, field: {}, unable to extract record_name",
+              topic(),
+              to_string_view(field));
+            co_return false;
+        }
+
+        auto sub = make_subject(sns, topic, field, *record_name);
+
+        auto has_id = co_await _api->_store->has_version(
+          sub, id, include_deleted::yes);
+        if (!has_id) {
+            vlog(
+              plog.debug,
+              "validating: sub: {}, id: {}, has_id: {}",
+              sub,
+              id,
+              has_id);
+            co_return false;
+        }
+
+        _api->_schema_id_cache.local().put(
+          topic, field, sns, id, std::move(proto_offsets));
+        co_return true;
+    };
+
+    ss::future<bool> validate(const model::record_batch& batch) {
+        if (
+          !_record_key_schema_id_validation
+          && !_record_value_schema_id_validation) {
+            co_return true;
+        }
+
+        auto key_is_valid =
+          [this](const model::record& record) -> ss::future<bool> {
+            if (!_record_key_schema_id_validation) {
+                return ss::make_ready_future<bool>(true);
+            }
+            return validate_field(
+              field::key,
+              _topic,
+              _record_key_subject_name_strategy,
+              record.key().copy());
+        };
+
+        auto value_is_valid =
+          [this](const model::record& record) -> ss::future<bool> {
+            if (!_record_value_schema_id_validation) {
+                return ss::make_ready_future<bool>(true);
+            }
+            return validate_field(
+              field::val,
+              _topic,
+              _record_value_subject_name_strategy,
+              record.value().copy());
+        };
+
+        const model::record_batch& b = batch;
+        std::optional<const model::record_batch> u;
+        bool compressed = batch.compressed();
+        if (compressed) {
+            u.emplace(
+              co_await storage::internal::decompress_batch(batch.copy()));
+        }
+
+        bool valid{true};
+        co_await model::for_each_record(
+          compressed ? u.value() : b,
+          [&valid, k{std::move(key_is_valid)}, v{std::move(value_is_valid)}](
+            const model::record& r) {
+              return k(r)
+                .then([&r, v{std::move(v)}](bool k) {
+                    return k ? v(r) : ss::make_ready_future<bool>(false);
+                })
+                .then([&valid](bool v) { valid = v; });
+          });
+        co_return valid;
+    }
+
+    ss::future<bool> validate(const data_t& data) {
+        for (const auto& b : data) {
+            if (!co_await validate(b)) {
+                co_return false;
+            }
+        }
+        co_return true;
+    }
+
+    auto validate(const foreign_data_t& data) { return validate(*data.buffer); }
+
+    ss::future<result> operator()(model::record_batch_reader&& rbr) {
+        if (!_api->_controller->get_feature_table().local().is_active(
+              features::feature::schema_id_validation)) {
+            co_return std::move(rbr);
+        }
+        if (!_api) {
+            // If Schema Registry is not enabled, the safe default is to reject
+            co_return kafka::error_code::invalid_record;
+        }
+
+        auto impl = std::move(rbr).release();
+        auto slice = co_await impl->do_load_slice(model::no_timeout);
+        vassert(
+          impl->is_end_of_stream(),
+          "Attempt to validate schema id on a record_batch_reader with "
+          "multiple slices");
+
+        auto valid = co_await ss::visit(
+          slice, [this](const auto& d) { return validate(d); });
+
+        if (!valid) {
+            // It's possible that the schema registry doesn't have a newly
+            // written schema, update and retry.
+            co_await _api->_sequencer.local().read_sync();
+            valid = co_await ss::visit(
+              slice, [this](const auto& d) { return validate(d); });
+        }
+
+        if (!valid) {
+            vlog(
+              plog.debug,
+              "validating: _topic: {}, _record_key_schema_id_validation: {}, "
+              "_record_key_subject_name_strategy: {}, "
+              "_record_value_schema_id_validation: {}, "
+              "_record_value_subject_name_strategy: {}",
+              _topic,
+              _record_key_schema_id_validation,
+              _record_key_subject_name_strategy,
+              _record_value_schema_id_validation,
+              _record_value_subject_name_strategy);
+            co_return kafka::error_code::invalid_record;
+        }
+
+        co_return model::make_memory_record_batch_reader(std::move(slice));
+    }
+
+private:
+    const std::unique_ptr<api>& _api;
+    model::topic _topic;
+    bool _record_key_schema_id_validation;
+    pandaproxy::schema_registry::subject_name_strategy
+      _record_key_subject_name_strategy;
+    bool _record_value_schema_id_validation;
+    pandaproxy::schema_registry::subject_name_strategy
+      _record_value_subject_name_strategy;
+};
+
+schema_id_validator::schema_id_validator(
+  const std::unique_ptr<api>& api,
+  const model::topic& topic,
+  const cluster::topic_properties& props)
+  : _impl{std::make_unique<impl>(api, topic, props)} {}
+
+schema_id_validator::schema_id_validator(schema_id_validator&&) noexcept
+  = default;
+schema_id_validator::~schema_id_validator() noexcept = default;
+
+bool should_validate_schema_id(const cluster::topic_properties& props) {
+    return props.record_key_schema_id_validation.value_or(
+             props.record_key_schema_id_validation_compat.value_or(false))
+           || props.record_value_schema_id_validation.value_or(
+             props.record_value_schema_id_validation_compat.value_or(false));
+}
+
+std::optional<schema_id_validator> maybe_make_schema_id_validator(
+  const std::unique_ptr<api>& api,
+  const model::topic& topic,
+  const cluster::topic_properties& props) {
+    return api != nullptr && should_validate_schema_id(props)
+             ? std::make_optional<schema_id_validator>(api, topic, props)
+             : std::nullopt;
+}
+
+ss::future<schema_id_validator::result>
+schema_id_validator::operator()(model::record_batch_reader&& rbr) {
+    return (*_impl)(std::move(rbr));
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -28,11 +28,13 @@
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "pandaproxy/schema_registry/validation_metrics.h"
 #include "storage/parser_utils.h"
 #include "utils/vint.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/coroutine/exception.hh>
 
@@ -210,6 +212,7 @@ public:
               "validating: topic: {}, field: {}, cache hit",
               topic(),
               to_string_view(field));
+            _api->_schema_id_validation_probe.local().hit();
             co_return true;
         }
 
@@ -246,6 +249,7 @@ public:
                   "validating: topic: {}, field: {}, cache hit",
                   topic(),
                   to_string_view(field));
+                _api->_schema_id_validation_probe.local().hit();
                 co_return true;
             }
 
@@ -279,6 +283,7 @@ public:
 
         _api->_schema_id_cache.local().put(
           topic, field, sns, id, std::move(proto_offsets));
+        _api->_schema_id_validation_probe.local().miss();
         co_return true;
     };
 

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -324,6 +324,7 @@ public:
         if (compressed) {
             u.emplace(
               co_await storage::internal::decompress_batch(batch.copy()));
+            _api->_schema_id_validation_probe.local().decompressed();
         }
 
         bool valid{true};

--- a/src/v/pandaproxy/schema_registry/validation.h
+++ b/src/v/pandaproxy/schema_registry/validation.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "kafka/protocol/errors.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "outcome.h"
+#include "pandaproxy/schema_registry/api.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+namespace pandaproxy::schema_registry {
+
+class schema_id_validator {
+public:
+    class impl;
+    schema_id_validator(
+      const std::unique_ptr<api>& api,
+      const model::topic& topic,
+      const cluster::topic_properties& props);
+    schema_id_validator(schema_id_validator&&) noexcept;
+    schema_id_validator(const schema_id_validator&) = delete;
+    schema_id_validator& operator=(schema_id_validator&&) = delete;
+    schema_id_validator& operator=(const schema_id_validator&) = delete;
+    ~schema_id_validator() noexcept;
+
+    using result = ::result<model::record_batch_reader, kafka::error_code>;
+    ss::future<result> operator()(model::record_batch_reader&&);
+
+private:
+    std::unique_ptr<impl> _impl;
+};
+
+std::optional<schema_id_validator> maybe_make_schema_id_validator(
+  const std::unique_ptr<api>& api,
+  const model::topic& topic,
+  const cluster::topic_properties& props);
+
+ss::future<schema_id_validator::result> inline maybe_validate_schema_id(
+  std::optional<schema_id_validator> validator,
+  model::record_batch_reader rbr) {
+    if (validator) {
+        co_return co_await (*validator)(std::move(rbr));
+    }
+    co_return std::move(rbr);
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/validation_metrics.h
+++ b/src/v/pandaproxy/schema_registry/validation_metrics.h
@@ -47,16 +47,25 @@ public:
                              "schema ID validation cache (see cluster config: "
                              "kafka_schema_id_validation_cache_capacity)"),
              {})
+             .aggregate(aggregate_labels),
+           sm::make_counter(
+             "batches_decompressed",
+             [this]() { return _batches_decompressed; },
+             sm::description("Total number of batches decompressed for "
+                             "server-side schema ID validation"),
+             {})
              .aggregate(aggregate_labels)});
     }
 
     void hit() { ++_hits; }
     void miss() { ++_misses; }
+    void decompressed() { ++_batches_decompressed; }
 
 private:
     ss::metrics::metric_groups _metrics;
     int64_t _hits;
     int64_t _misses;
+    int64_t _batches_decompressed;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/validation_metrics.h
+++ b/src/v/pandaproxy/schema_registry/validation_metrics.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "config/configuration.h"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_registration.hh>
+
+namespace pandaproxy::schema_registry {
+
+class schema_id_validation_probe {
+public:
+    void setup_metrics() {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_metrics()) {
+            return;
+        }
+
+        auto aggregate_labels = config::shard_local_cfg().aggregate_metrics()
+                                  ? std::vector<sm::label>{sm::shard_label}
+                                  : std::vector<sm::label>{};
+
+        _metrics.add_group(
+          "kafka_schema_id_cache",
+          {sm::make_counter(
+             "hits",
+             [this]() { return _hits; },
+             sm::description("Total number of hits for the server-side schema "
+                             "ID validation cache (see cluster config: "
+                             "kafka_schema_id_validation_cache_capacity)"),
+             {})
+             .aggregate(aggregate_labels),
+           sm::make_counter(
+             "misses",
+             [this]() { return _misses; },
+             sm::description("Total number of misses for the server-side "
+                             "schema ID validation cache (see cluster config: "
+                             "kafka_schema_id_validation_cache_capacity)"),
+             {})
+             .aggregate(aggregate_labels)});
+    }
+
+    void hit() { ++_hits; }
+    void miss() { ++_misses; }
+
+private:
+    ss::metrics::metric_groups _metrics;
+    int64_t _hits;
+    int64_t _misses;
+};
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1621,7 +1621,8 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         std::ref(tx_gateway_frontend),
         std::ref(tx_registry_frontend),
         qdc_config,
-        std::ref(*thread_worker))
+        std::ref(*thread_worker),
+        std::ref(_schema_registry))
       .get();
     construct_service(
       _compaction_controller,

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -144,6 +144,10 @@ public:
 
     std::unique_ptr<ssx::thread_worker> thread_worker;
 
+    const std::unique_ptr<pandaproxy::schema_registry::api>& schema_registry() {
+        return _schema_registry;
+    }
+
 private:
     using deferred_actions
       = std::deque<ss::deferred_action<std::function<void()>>>;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -147,7 +147,8 @@ public:
           app.tx_gateway_frontend,
           app.tx_registry_frontend,
           std::nullopt,
-          *app.thread_worker);
+          *app.thread_worker,
+          app.schema_registry());
 
         configs.stop().get();
     }

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ rp_test(
     license_test.cc
     gssapi_principal_mapper_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES Boost::unit_test_framework v::kafka
+  LIBRARIES Boost::unit_test_framework v::kafka_protocol v::storage
   LABELS kafka
 )
 

--- a/tests/protobuf/payload.proto
+++ b/tests/protobuf/payload.proto
@@ -22,3 +22,34 @@ message Payload {
     int32 val = 1;
     google.protobuf.Timestamp timestamp = 2;
 }
+
+message A {
+    message B {
+        message C {
+            message D {
+                message M00 {}
+                message M01 {}
+                message M02 {}
+                message M03 {}
+                message M04 {}
+                message M05 {}
+                message M06 {}
+                message M07 {}
+                message M08 {}
+                message M09 {}
+                message M10 {}
+                message M11 {}
+                message M12 {}
+                message M13 {}
+                message M14 {}
+                message M15 {}
+                message M16 {}
+                message M17 {}
+                message NestedPayload {
+                    int32 val = 1;
+                    google.protobuf.Timestamp timestamp = 2;
+                }
+            }
+        }
+    }
+}

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -6,6 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+from enum import Enum
 import random
 import string
 
@@ -46,6 +47,26 @@ class TopicSpec:
     TIMESTAMP_CREATE_TIME = "CreateTime"
     TIMESTAMP_LOG_APPEND_TIME = "LogAppendTime"
 
+    class SubjectNameStrategy(str, Enum):
+        TOPIC_NAME = "TopicNameStrategy"
+        RECORD_NAME = "RecordNameStrategy"
+        TOPIC_RECORD_NAME = "TopicRecordNameStrategy"
+
+    PROPERTY_RECORD_KEY_SCHEMA_ID_VALIDATION = "redpanda.key.schema.id.validation"
+    PROPERTY_RECORD_KEY_SUBJECT_NAME_STRATEGY = "redpanda.key.subject.name.strategy"
+    PROPERTY_RECORD_VALUE_SCHEMA_ID_VALIDATION = "redpanda.value.schema.id.validation"
+    PROPERTY_RECORD_VALUE_SUBJECT_NAME_STRATEGY = "redpanda.value.subject.name.strategy"
+
+    class SubjectNameStrategyCompat(str, Enum):
+        TOPIC_NAME = "io.confluent.kafka.serializers.subject.TopicNameStrategy"
+        RECORD_NAME = "io.confluent.kafka.serializers.subject.RecordNameStrategy"
+        TOPIC_RECORD_NAME = "io.confluent.kafka.serializers.subject.TopicRecordNameStrategy"
+
+    PROPERTY_RECORD_KEY_SCHEMA_ID_VALIDATION_COMPAT = "confluent.key.schema.validation"
+    PROPERTY_RECORD_KEY_SUBJECT_NAME_STRATEGY_COMPAT = "confluent.key.subject.name.strategy"
+    PROPERTY_RECORD_VALUE_SCHEMA_ID_VALIDATION_COMPAT = "confluent.value.schema.validation"
+    PROPERTY_RECORD_VALUE_SUBJECT_NAME_STRATEGY_COMPAT = "confluent.value.subject.name.strategy"
+
     def __init__(self,
                  *,
                  name=None,
@@ -62,7 +83,15 @@ class TopicSpec:
                  redpanda_remote_write=None,
                  redpanda_remote_delete=None,
                  segment_ms=None,
-                 max_message_bytes=None):
+                 max_message_bytes=None,
+                 record_key_schema_id_validation=None,
+                 record_key_schema_id_validation_compat=None,
+                 record_key_subject_name_strategy=None,
+                 record_key_subject_name_strategy_compat=None,
+                 record_value_schema_id_validation=None,
+                 record_value_schema_id_validation_compat=None,
+                 record_value_subject_name_strategy=None,
+                 record_value_subject_name_strategy_compat=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -78,6 +107,14 @@ class TopicSpec:
         self.redpanda_remote_delete = redpanda_remote_delete
         self.segment_ms = segment_ms
         self.max_message_bytes = max_message_bytes
+        self.record_key_schema_id_validation = record_key_schema_id_validation
+        self.record_key_schema_id_validation_compat = record_key_schema_id_validation_compat
+        self.record_key_subject_name_strategy = record_key_subject_name_strategy
+        self.record_key_subject_name_strategy_compat = record_key_subject_name_strategy_compat
+        self.record_value_schema_id_validation = record_value_schema_id_validation
+        self.record_value_schema_id_validation_compat = record_value_schema_id_validation_compat
+        self.record_value_subject_name_strategy = record_value_subject_name_strategy
+        self.record_value_subject_name_strategy_compat = record_value_subject_name_strategy_compat
 
     def __str__(self):
         return self.name

--- a/tests/rptest/remote_scripts/payload_pb2.py
+++ b/tests/rptest/remote_scripts/payload_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rpayload.proto\x12\x0c\x63om.redpanda\x1a\x1fgoogle/protobuf/timestamp.proto\"E\n\x07Payload\x12\x0b\n\x03val\x18\x01 \x01(\x05\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.TimestampB\x0bP\x01Z\x07./;mainb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rpayload.proto\x12\x0c\x63om.redpanda\x1a\x1fgoogle/protobuf/timestamp.proto\"E\n\x07Payload\x12\x0b\n\x03val\x18\x01 \x01(\x05\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xe0\x01\n\x01\x41\x1a\xda\x01\n\x01\x42\x1a\xd4\x01\n\x01\x43\x1a\xce\x01\n\x01\x44\x1a\x05\n\x03M00\x1a\x05\n\x03M01\x1a\x05\n\x03M02\x1a\x05\n\x03M03\x1a\x05\n\x03M04\x1a\x05\n\x03M05\x1a\x05\n\x03M06\x1a\x05\n\x03M07\x1a\x05\n\x03M08\x1a\x05\n\x03M09\x1a\x05\n\x03M10\x1a\x05\n\x03M11\x1a\x05\n\x03M12\x1a\x05\n\x03M13\x1a\x05\n\x03M14\x1a\x05\n\x03M15\x1a\x05\n\x03M16\x1a\x05\n\x03M17\x1aK\n\rNestedPayload\x12\x0b\n\x03val\x18\x01 \x01(\x05\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.TimestampB\x0bP\x01Z\x07./;mainb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'payload_pb2', globals())
@@ -24,4 +24,50 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._serialized_options = b'P\001Z\007./;main'
   _PAYLOAD._serialized_start=64
   _PAYLOAD._serialized_end=133
+  _A._serialized_start=136
+  _A._serialized_end=360
+  _A_B._serialized_start=142
+  _A_B._serialized_end=360
+  _A_B_C._serialized_start=148
+  _A_B_C._serialized_end=360
+  _A_B_C_D._serialized_start=154
+  _A_B_C_D._serialized_end=360
+  _A_B_C_D_M00._serialized_start=159
+  _A_B_C_D_M00._serialized_end=164
+  _A_B_C_D_M01._serialized_start=166
+  _A_B_C_D_M01._serialized_end=171
+  _A_B_C_D_M02._serialized_start=173
+  _A_B_C_D_M02._serialized_end=178
+  _A_B_C_D_M03._serialized_start=180
+  _A_B_C_D_M03._serialized_end=185
+  _A_B_C_D_M04._serialized_start=187
+  _A_B_C_D_M04._serialized_end=192
+  _A_B_C_D_M05._serialized_start=194
+  _A_B_C_D_M05._serialized_end=199
+  _A_B_C_D_M06._serialized_start=201
+  _A_B_C_D_M06._serialized_end=206
+  _A_B_C_D_M07._serialized_start=208
+  _A_B_C_D_M07._serialized_end=213
+  _A_B_C_D_M08._serialized_start=215
+  _A_B_C_D_M08._serialized_end=220
+  _A_B_C_D_M09._serialized_start=222
+  _A_B_C_D_M09._serialized_end=227
+  _A_B_C_D_M10._serialized_start=229
+  _A_B_C_D_M10._serialized_end=234
+  _A_B_C_D_M11._serialized_start=236
+  _A_B_C_D_M11._serialized_end=241
+  _A_B_C_D_M12._serialized_start=243
+  _A_B_C_D_M12._serialized_end=248
+  _A_B_C_D_M13._serialized_start=250
+  _A_B_C_D_M13._serialized_end=255
+  _A_B_C_D_M14._serialized_start=257
+  _A_B_C_D_M14._serialized_end=262
+  _A_B_C_D_M15._serialized_start=264
+  _A_B_C_D_M15._serialized_end=269
+  _A_B_C_D_M16._serialized_start=271
+  _A_B_C_D_M16._serialized_end=276
+  _A_B_C_D_M17._serialized_start=278
+  _A_B_C_D_M17._serialized_end=283
+  _A_B_C_D_NESTEDPAYLOAD._serialized_start=285
+  _A_B_C_D_NESTEDPAYLOAD._serialized_end=360
 # @@protoc_insertion_point(module_scope)

--- a/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
+++ b/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
@@ -32,7 +32,10 @@ class SchemaType(IntEnum):
     PROTOBUF = 2
 
 
-ProtobuPayloadClasses = {"com.redpanda.Payload": payload_pb2.Payload}
+ProtobuPayloadClasses = {
+    "com.redpanda.Payload": payload_pb2.Payload,
+    "com.redpanda.A.B.C.D.NestedPayload": payload_pb2.A.B.C.D.NestedPayload
+}
 
 
 class AvroPayload(OrderedDict):
@@ -55,7 +58,20 @@ AVRO_SCHEMA_PAYLOAD = '''{
 }
 '''
 
-AvroSchemas = {"com.redpanda.Payload": AVRO_SCHEMA_PAYLOAD}
+AVRO_SCHEMA_NESTED_PAYLOAD = '''{
+"type": "record",
+"name": "NestedPayload",
+"namespace": "com.redpanda.A.B.C.D",
+  "fields": [
+    {"name": "val", "type": "int"}
+  ]
+}
+'''
+
+AvroSchemas = {
+    "com.redpanda.Payload": AVRO_SCHEMA_PAYLOAD,
+    "com.redpanda.A.B.C.D.NestedPayload": AVRO_SCHEMA_NESTED_PAYLOAD
+}
 
 
 def make_protobuf_payload(payload_class, val: int):

--- a/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
+++ b/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
@@ -86,19 +86,26 @@ class SerdeClient:
         self.acked = 0
         self.consumed = 0
 
-        self.serde_config = {'use.deprecated.format': False}
+        serde_config = {}
+
+        self.avro_serde_config = serde_config.copy()
+
+        self.proto_serde_config = serde_config.copy()
+        self.proto_serde_config['use.deprecated.format'] = False
         if skip_known_types is not None:
-            self.serde_config.update({'skip.known.types': skip_known_types})
+            self.proto_serde_config['skip.known.types'] = skip_known_types
 
         self.security_config = security_config
 
     def _make_serializer(self):
         return {
             SchemaType.AVRO:
-            AvroSerializer(self.sr_client, AVRO_SCHEMA),
+            AvroSerializer(self.sr_client,
+                           AVRO_SCHEMA,
+                           conf=self.avro_serde_config),
             SchemaType.PROTOBUF:
             ProtobufSerializer(ProtobufPayloadClass, self.sr_client,
-                               self.serde_config)
+                               self.proto_serde_config)
         }[self.schema_type]
 
     def _make_deserializer(self):

--- a/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
+++ b/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
@@ -24,12 +24,15 @@ from confluent_kafka.schema_registry import SchemaRegistryClient, topic_subject_
 from confluent_kafka.schema_registry.avro import AvroDeserializer, AvroSerializer
 from confluent_kafka.schema_registry.protobuf import ProtobufDeserializer, ProtobufSerializer
 
-from payload_pb2 import Payload as ProtobufPayloadClass
+import payload_pb2
 
 
 class SchemaType(IntEnum):
     AVRO = 1
     PROTOBUF = 2
+
+
+ProtobuPayloadClasses = {"com.redpanda.Payload": payload_pb2.Payload}
 
 
 class AvroPayload(OrderedDict):
@@ -42,18 +45,21 @@ class AvroPayload(OrderedDict):
         return self['val']
 
 
-AVRO_SCHEMA = '''{
+AVRO_SCHEMA_PAYLOAD = '''{
 "type": "record",
-"name": "payload",
+"name": "Payload",
+"namespace": "com.redpanda",
   "fields": [
     {"name": "val", "type": "int"}
   ]
 }
 '''
 
+AvroSchemas = {"com.redpanda.Payload": AVRO_SCHEMA_PAYLOAD}
 
-def make_protobuf_payload(val: int):
-    p = ProtobufPayloadClass()
+
+def make_protobuf_payload(payload_class, val: int):
+    p = payload_class()
     p.val = val
     p.timestamp.FromDatetime(datetime.now())
     return p
@@ -85,13 +91,16 @@ class SerdeClient:
                  logger=logging.getLogger("SerdeClient"),
                  security_config: dict = None,
                  skip_known_types: Optional[bool] = None,
-                 subject_name_strategy: Optional[str] = None):
+                 subject_name_strategy: Optional[str] = None,
+                 payload_class: str = "com.redpanda.Payload"):
         self.logger = logger
         self.brokers = brokers
         self.sr_client = SchemaRegistryClient({'url': schema_registry_url})
         self.schema_type = schema_type
         self.topic = topic
         self.group = group
+        self.protobuf_payload_class = ProtobuPayloadClasses[payload_class]
+        self.avro_schema = AvroSchemas[payload_class]
 
         self.produced = 0
         self.acked = 0
@@ -115,10 +124,10 @@ class SerdeClient:
         return {
             SchemaType.AVRO:
             AvroSerializer(self.sr_client,
-                           AVRO_SCHEMA,
+                           self.avro_schema,
                            conf=self.avro_serde_config),
             SchemaType.PROTOBUF:
-            ProtobufSerializer(ProtobufPayloadClass, self.sr_client,
+            ProtobufSerializer(self.protobuf_payload_class, self.sr_client,
                                self.proto_serde_config)
         }[self.schema_type]
 
@@ -126,17 +135,19 @@ class SerdeClient:
         return {
             SchemaType.AVRO:
             AvroDeserializer(self.sr_client,
-                             AVRO_SCHEMA,
+                             self.avro_schema,
                              from_dict=lambda d, _: AvroPayload(d['val'])),
             SchemaType.PROTOBUF:
-            ProtobufDeserializer(ProtobufPayloadClass,
+            ProtobufDeserializer(self.protobuf_payload_class,
                                  {'use.deprecated.format': False})
         }[self.schema_type]
 
     def _make_payload(self, val: int):
         return {
-            SchemaType.AVRO: AvroPayload(val),
-            SchemaType.PROTOBUF: make_protobuf_payload(val)
+            SchemaType.AVRO:
+            AvroPayload(val),
+            SchemaType.PROTOBUF:
+            make_protobuf_payload(self.protobuf_payload_class, val)
         }[self.schema_type]
 
     def _get_security_options(self):
@@ -239,7 +250,8 @@ def main(args):
                     logger=logger,
                     security_config=security_dict,
                     skip_known_types=args.skip_known_types,
-                    subject_name_strategy=args.subject_name_strategy)
+                    subject_name_strategy=args.subject_name_strategy,
+                    payload_class=args.payload_class)
     p.run(args.count)
 
 
@@ -259,7 +271,7 @@ if __name__ == '__main__':
                         '--protocol',
                         dest="protocol",
                         default=SchemaType.AVRO.name,
-                        choices=SchemaType._member_names_,
+                        choices=[v.name for v in SchemaType],
                         help="Topic name")
     parser.add_argument('-t',
                         '--topic',
@@ -284,6 +296,11 @@ if __name__ == '__main__':
                         dest="skip_known_types",
                         action='store_true',
                         help="Optional bool")
+    parser.add_argument('--payload-class',
+                        dest="payload_class",
+                        default='com.redpanda.Payload',
+                        choices=list(ProtobuPayloadClasses.keys()),
+                        help="Which class to use as a payload")
     parser.add_argument(
         '--subject-name-strategy',
         default='io.confluent.kafka.serializers.subject.TopicNameStrategy',

--- a/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
+++ b/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
@@ -122,6 +122,7 @@ class SerdeClient:
 
         self.produced = 0
         self.acked = 0
+        self.first_ack = None
         self.consumed = 0
 
         serde_config = {}
@@ -185,7 +186,9 @@ class SerdeClient:
                 self.logger.error(f"Produce err: {err}")
                 sys.exit(err.code())
             assert msg is not None
-            assert msg.offset() == self.acked
+            if self.first_ack is None:
+                self.first_ack = msg.offset()
+            assert msg.offset() == self.first_ack + self.acked
             self.logger.debug("Acked offset %d", msg.offset())
             self.acked += 1
 

--- a/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
+++ b/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
@@ -216,7 +216,8 @@ def main(args):
                     topic=args.topic,
                     group=args.group,
                     logger=logger,
-                    security_config=security_dict)
+                    security_config=security_dict,
+                    skip_known_types=args.skip_known_types)
     p.run(args.count)
 
 

--- a/tests/rptest/services/serde_client.py
+++ b/tests/rptest/services/serde_client.py
@@ -110,3 +110,13 @@ class SerdeClient(BackgroundThreadService):
 
         for line in ssh_output:
             self.logger.debug(line)
+
+    def __enter__(self):
+        self.run()
+
+    def __exit__(self, *args):
+        self.reset()
+
+    def reset(self):
+        self.worker_errors.clear()
+        self.errors = ''

--- a/tests/rptest/services/serde_client.py
+++ b/tests/rptest/services/serde_client.py
@@ -48,7 +48,8 @@ class SerdeClient(BackgroundThreadService):
                  group=str(uuid4()),
                  security_config: Optional[dict] = None,
                  skip_known_types: Optional[bool] = None,
-                 subject_name_strategy: Optional[str] = None):
+                 subject_name_strategy: Optional[str] = None,
+                 payload_class: Optional[str] = None):
 
         if num_nodes is None and nodes is None:
             num_nodes = 1
@@ -77,6 +78,10 @@ class SerdeClient(BackgroundThreadService):
         if subject_name_strategy is not None:
             assert self._serde_client_type == SerdeClientType.Python
             self._cmd_args += f" --subject-name-strategy {subject_name_strategy}"
+
+        if payload_class is not None:
+            assert self._serde_client_type == SerdeClientType.Python
+            self._cmd_args += f" --payload-class {payload_class}"
 
         if self._serde_client_type == SerdeClientType.Golang:
             self._cmd_args += f" --debug"

--- a/tests/rptest/services/serde_client.py
+++ b/tests/rptest/services/serde_client.py
@@ -47,7 +47,8 @@ class SerdeClient(BackgroundThreadService):
                  topic=str(uuid4()),
                  group=str(uuid4()),
                  security_config: Optional[dict] = None,
-                 skip_known_types: Optional[bool] = None):
+                 skip_known_types: Optional[bool] = None,
+                 subject_name_strategy: Optional[str] = None):
 
         if num_nodes is None and nodes is None:
             num_nodes = 1
@@ -72,6 +73,10 @@ class SerdeClient(BackgroundThreadService):
                 self._cmd_args += " --skip-known-types"
             else:
                 assert False
+
+        if subject_name_strategy is not None:
+            assert self._serde_client_type == SerdeClientType.Python
+            self._cmd_args += f" --subject-name-strategy {subject_name_strategy}"
 
         if self._serde_client_type == SerdeClientType.Golang:
             self._cmd_args += f" --debug"

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -9,6 +9,7 @@
 import json
 import logging
 import pprint
+import random
 import re
 import tempfile
 import time
@@ -618,6 +619,10 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # Enabling this property requires a file be manually added
                 # to RP's data dir for it to start
                 continue
+
+            if name == 'record_key_subject_name_strategy' or name == 'record_value_subject_name_strategy':
+                valid_value = random.choice(
+                    [e for e in p['enum_values'] if e != initial_value])
 
             updates[name] = valid_value
 

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -148,6 +148,60 @@ class DescribeTopicsTest(RedpandaTest):
                 value="1209600000",  # 2 weeks in ms
                 doc_string=
                 "Default log segment lifetime in ms for topics which do not set segment.ms"
+            ),
+            "redpanda.key.schema.id.validation":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="false",
+                doc_string=
+                "Enable validation of the schema id for keys on a record"),
+            "redpanda.key.subject.name.strategy":
+            ConfigProperty(
+                config_type="STRING",
+                value="TopicNameStrategy",
+                doc_string=
+                "The subject name strategy for keys if redpanda.key.schema.id.validation is enabled"
+            ),
+            "redpanda.value.schema.id.validation":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="false",
+                doc_string=
+                "Enable validation of the schema id for values on a record"),
+            "redpanda.value.subject.name.strategy":
+            ConfigProperty(
+                config_type="STRING",
+                value="TopicNameStrategy",
+                doc_string=
+                "The subject name strategy for values if redpanda.value.schema.id.validation is enabled"
+            ),
+            "confluent.key.schema.validation":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="false",
+                doc_string=
+                "Enable validation of the schema id for keys on a record"),
+            "confluent.key.subject.name.strategy":
+            ConfigProperty(
+                config_type="STRING",
+                value=
+                "io.confluent.kafka.serializers.subject.TopicNameStrategy",
+                doc_string=
+                "The subject name strategy for keys if confluent.key.schema.validation is enabled"
+            ),
+            "confluent.value.schema.validation":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="false",
+                doc_string=
+                "Enable validation of the schema id for values on a record"),
+            "confluent.value.subject.name.strategy":
+            ConfigProperty(
+                config_type="STRING",
+                value=
+                "io.confluent.kafka.serializers.subject.TopicNameStrategy",
+                doc_string=
+                "The subject name strategy for values if confluent.value.schema.validation is enabled"
             )
         }
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -172,7 +172,8 @@ class SchemaRegistryEndpoints(RedpandaTest):
                           topic: str,
                           count: int,
                           skip_known_types: Optional[bool] = None,
-                          subject_name_strategy: Optional[str] = None):
+                          subject_name_strategy: Optional[str] = None,
+                          payload_class: Optional[str] = None):
         schema_reg = self.redpanda.schema_reg().split(',', 1)[0]
         sasl_enabled = self.redpanda.sasl_enabled()
         sec_cfg = self.redpanda.security_config() if sasl_enabled else None
@@ -186,7 +187,8 @@ class SchemaRegistryEndpoints(RedpandaTest):
                            topic=topic,
                            security_config=sec_cfg,
                            skip_known_types=skip_known_types,
-                           subject_name_strategy=subject_name_strategy)
+                           subject_name_strategy=subject_name_strategy,
+                           payload_class=payload_class)
 
     def _get_topics(self):
         return requests.get(

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -224,6 +224,21 @@ class SchemaRegistryEndpoints(RedpandaTest):
 
         return topic
 
+    def _alter_topic_config(self, topic, set_key, set_value):
+        rpk = self._get_rpk_tools()
+        rpk.alter_topic_config(topic=topic,
+                               set_key=set_key,
+                               set_value=set_value)
+
+        def has_config():
+            configs = rpk.describe_topic_configs(topic=topic)
+            self.logger.warn(f"CONFIGS: {configs}")
+            config = configs.get(set_key, None)
+            self.logger.warn(f"CONFIG: {config[0]}")
+            return config[0] == set_value
+
+        wait_until(has_config, 5)
+
     def _get_config(self, headers=HTTP_GET_HEADERS, **kwargs):
         return self._request("GET", "config", headers=headers, **kwargs)
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -171,7 +171,8 @@ class SchemaRegistryEndpoints(RedpandaTest):
                           client_type: SerdeClientType,
                           topic: str,
                           count: int,
-                          skip_known_types: Optional[bool] = None):
+                          skip_known_types: Optional[bool] = None,
+                          subject_name_strategy: Optional[str] = None):
         schema_reg = self.redpanda.schema_reg().split(',', 1)[0]
         sasl_enabled = self.redpanda.sasl_enabled()
         sec_cfg = self.redpanda.security_config() if sasl_enabled else None
@@ -184,7 +185,8 @@ class SchemaRegistryEndpoints(RedpandaTest):
                            count,
                            topic=topic,
                            security_config=sec_cfg,
-                           skip_known_types=skip_known_types)
+                           skip_known_types=skip_known_types,
+                           subject_name_strategy=subject_name_strategy)
 
     def _get_topics(self):
         return requests.get(

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -193,6 +193,14 @@ class CreateTopicsTest(RedpandaTest):
         lambda: "true" if random.randint(0, 1) else "false",
         'segment.ms':
         lambda: random.choice([-1, random.randint(10000, 10000000)]),
+        TopicSpec.PROPERTY_RECORD_KEY_SCHEMA_ID_VALIDATION:
+        lambda: "true" if random.randint(0, 1) else "false",
+        TopicSpec.PROPERTY_RECORD_KEY_SUBJECT_NAME_STRATEGY:
+        lambda: random.choice(list(TopicSpec.SubjectNameStrategy)).value,
+        TopicSpec.PROPERTY_RECORD_VALUE_SCHEMA_ID_VALIDATION:
+        lambda: "true" if random.randint(0, 1) else "false",
+        TopicSpec.PROPERTY_RECORD_VALUE_SUBJECT_NAME_STRATEGY:
+        lambda: random.choice(list(TopicSpec.SubjectNameStrategy)).value
     }
 
     def __init__(self, test_context):

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -59,6 +59,39 @@ def read_topic_properties_serde(rdr: Reader, version):
         topic_properties |= {
             'segment_ms': rdr.read_tristate(Reader.read_uint64)
         }
+    if version >= 5:
+        topic_properties |= {
+            'record_key_schema_id_validation':
+            rdr.read_optional(Reader.read_bool)
+        }
+        topic_properties |= {
+            'record_key_schema_id_validation_compat':
+            rdr.read_optional(Reader.read_bool)
+        }
+        topic_properties |= {
+            'record_key_subject_name_strategy':
+            rdr.read_optional(Reader.read_serde_enum)
+        }
+        topic_properties |= {
+            'record_key_subject_name_strategy_compat':
+            rdr.read_optional(Reader.read_serde_enum)
+        }
+        topic_properties |= {
+            'record_value_schema_id_validation':
+            rdr.read_optional(Reader.read_bool)
+        }
+        topic_properties |= {
+            'record_value_schema_id_validation_compat':
+            rdr.read_optional(Reader.read_bool)
+        }
+        topic_properties |= {
+            'record_value_subject_name_strategy':
+            rdr.read_optional(Reader.read_serde_enum)
+        }
+        topic_properties |= {
+            'record_value_subject_name_strategy_compat':
+            rdr.read_optional(Reader.read_serde_enum)
+        }
 
     return topic_properties
 
@@ -79,7 +112,7 @@ def read_topic_configuration_assignment_serde(rdr: Reader):
                     rdr.read_int16(),
                     'properties':
                     rdr.read_envelope(read_topic_properties_serde,
-                                      max_version=4),
+                                      max_version=5),
                 }, 1),
             'assignments':
             rdr.read_serde_vector(lambda r: r.read_envelope(
@@ -160,10 +193,43 @@ def read_incremental_topic_update_serde(rdr: Reader):
                 read_property_update_serde(
                     rdr, lambda r: r.read_tristate(Reader.read_uint64))
             }
+        if version >= 4:
+            incr_obj |= {
+                'record_key_schema_id_validation':
+                rdr.read_optional(Reader.read_bool)
+            }
+            incr_obj |= {
+                'record_key_schema_id_validation_compat':
+                rdr.read_optional(Reader.read_bool)
+            }
+            incr_obj |= {
+                'record_key_subject_name_strategy':
+                rdr.read_optional(Reader.read_serde_enum)
+            }
+            incr_obj |= {
+                'record_key_subject_name_strategy_compat':
+                rdr.read_optional(Reader.read_serde_enum)
+            }
+            incr_obj |= {
+                'record_value_schema_id_validation':
+                rdr.read_optional(Reader.read_bool)
+            }
+            incr_obj |= {
+                'record_value_schema_id_validation_compat':
+                rdr.read_optional(Reader.read_bool)
+            }
+            incr_obj |= {
+                'record_value_subject_name_strategy':
+                rdr.read_optional(Reader.read_serde_enum)
+            }
+            incr_obj |= {
+                'record_value_subject_name_strategy_compat':
+                rdr.read_optional(Reader.read_serde_enum)
+            }
 
         return incr_obj
 
-    return rdr.read_envelope(incr_topic_upd, max_version=3)
+    return rdr.read_envelope(incr_topic_upd, max_version=4)
 
 
 def read_create_partitions_serde(rdr: Reader):


### PR DESCRIPTION
# Server-side Schema ID Validation

**Note:** This is an enterprise feature governed by the [RCL](https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md)

Records produced to a topic may use a serde client library that supports encoding the payload (key or value) according to a schema registered in the Schema Registry.

The client libraries can be configured with a Subject Name Strategy that maps the topic and schema onto a Subject within the Schema Registry.

Since this configuration is not enforced anywhere, it is possible for it to be misconfigured on the producer, resulting in invalid data arriving on the topic.

Server-side Schema ID Validation mitigates this possibility by inspecting the Schema ID encoded into the header of the record payload according to properties configure on the topic, and rejecting any batch that does not satisfy the configuration. **Note:** it does **not** check the payload is encoded according to the Schema.

## Configuration

### Topic configuration parameters


| Name | Description |
| ---- | ----------- |
| `redpanda.key.schema.id.validation` | Enable validation of the schema id for keys on record in the topic |
| `redpanda.key.subject.name.strategy` | The Subject Name Strategy for keys on record in the topic |
| `redpanda.value.schema.id.validation` | Enable validation of the schema id for values on record in the topic |
| `redpanda.value.subject.name.strategy` | The Subject Name Strategy for values on record in the topic |

### Topic configuration parameters (compatibility)

| Name | Description |
| ---- | ----------- |
| `confluent.key.schema.validation` | Enable validation of the schema id for keys on record in the topic |
| `confluent.key.subject.name.strategy` | The Subject Name Strategy for keys on record in the topic |
| `confluent.value.schema.validation` | Enable validation of the schema id for values on record in the topic |
| `confluent.value.subject.name.strategy` | The Subject Name Strategy for values on record in the topic |

### Subject Name Strategy

Available Subject Name Strategies.

| Name | Description |
| ---- | ----------- |
| `TopicNameStrategy` | The mapped Subject is the topic name and field: `<topic>-[key\|value]` |
| `RecordNameStrategy` | The mapped Subject is the fully qualified name of the record in the Schema: `<record>` |
| `TopicRecordNameStrategy` | The mapped Subject is topic name and the fully qualified name of the record in the Schema: `<topic>-<record>` |

### Subject Name Strategy (compatibility)

Available Subject Name Strategies.

| Name | Description |
| ---- | ----------- |
| `io.confluent.kafka.serializers.subject.TopicNameStrategy` | The mapped Subject is the topic name and field: `<topic>-[key\|value]` |
| `io.confluent.kafka.serializers.subject.RecordNameStrategy` | The mapped Subject is the fully qualified name of the record in the Schema: `<record>` |
| `io.confluent.kafka.serializers.subject.TopicRecordNameStrategy` | The mapped Subject is topic name and the fully qualified name of the record in the Schema: `<topic>-<record>` |

## Practical considerations

Enabling Schema ID validation on a compressed topic requires decompressing each batch before it is accepted for produce.

## TODO
* Licence
* Metrics
  * Rejected per topic

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features

* Redpanda: Server-side validation of Schema IDs encoded into the header of a record encoded by a serde client library.