### PR TITLE
Prioritized retention / garbage-collection triggered by low-disk alert

### DIFF
--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -50,11 +50,11 @@ local_monitor::local_monitor(
   ss::sstring cache_directory,
   ss::sharded<storage::node_api>& node_api,
   ss::sharded<storage::api>& api)
-  : _free_bytes_alert_threshold(alert_bytes)
-  , _free_percent_alert_threshold(alert_percent)
-  , _min_free_bytes(min_bytes)
-  , _data_directory(data_directory)
-  , _cache_directory(cache_directory)
+  : _free_bytes_alert_threshold(std::move(alert_bytes))
+  , _free_percent_alert_threshold(std::move(alert_percent))
+  , _min_free_bytes(std::move(min_bytes))
+  , _data_directory(std::move(data_directory))
+  , _cache_directory(std::move(cache_directory))
   , _storage_node_api(node_api)
   , _storage_api(api) {
     // Intentionally undocumented environment variable, only for use

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1676,10 +1676,10 @@ void application::wire_up_bootstrap_services() {
         [this](
           uint64_t total_space,
           uint64_t free_space,
-          storage::disk_space_alert) {
+          storage::disk_space_alert alert) {
             return storage.invoke_on_all(
-              [total_space, free_space](storage::api& api) {
-                  api.resources().update_allowance(total_space, free_space);
+              [total_space, free_space, alert](storage::api& api) {
+                  api.handle_disk_notification(total_space, free_space, alert);
               });
         });
     _deferred.emplace_back([this, storage_disk_notification] {

--- a/src/v/storage/api.cc
+++ b/src/v/storage/api.cc
@@ -26,4 +26,9 @@ ss::future<usage_report> api::disk_usage() {
       [](usage_report acc, usage_report update) { return acc + update; });
 }
 
+void api::handle_disk_notification(
+  uint64_t total_space, uint64_t free_space, storage::disk_space_alert) {
+    _resources.update_allowance(total_space, free_space);
+}
+
 } // namespace storage

--- a/src/v/storage/api.cc
+++ b/src/v/storage/api.cc
@@ -27,8 +27,11 @@ ss::future<usage_report> api::disk_usage() {
 }
 
 void api::handle_disk_notification(
-  uint64_t total_space, uint64_t free_space, storage::disk_space_alert) {
+  uint64_t total_space, uint64_t free_space, storage::disk_space_alert alert) {
     _resources.update_allowance(total_space, free_space);
+    if (_log_mgr) {
+        _log_mgr->handle_disk_notification(alert);
+    }
 }
 
 } // namespace storage

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -153,6 +153,14 @@ public:
      */
     ss::future<usage_report> disk_usage();
 
+    /*
+     * Handle a disk notification (e.g. low space)
+     */
+    void handle_disk_notification(
+      uint64_t total_space,
+      uint64_t free_space,
+      storage::disk_space_alert alert);
+
 private:
     storage_resources _resources;
 

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -115,6 +115,7 @@ public:
         return _kvstore->start().then([this] {
             _log_mgr = std::make_unique<log_manager>(
               _log_conf_cb(), kvs(), _resources, _feature_table);
+            return _log_mgr->start();
         });
     }
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1808,6 +1808,9 @@ log make_disk_backed_log(
 }
 
 ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
+    // protect against concurrent log removal with housekeeping loop
+    auto gate = _compaction_housekeeping_gate.hold();
+
     std::optional<model::offset> max_offset;
     if (config().is_collectable()) {
         cfg = apply_overrides(cfg);

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -193,6 +193,7 @@ public:
       ss::noncopyable_function<bool(model::ntp, partition_path::metadata)>
         orphan_filter);
 
+    ss::future<> start();
     ss::future<> stop();
 
     ss::future<ss::lw_shared_ptr<segment>> make_log_segment(
@@ -242,7 +243,6 @@ private:
      * \brief delete old segments and trigger compacted segments
      *        runs inside a seastar thread
      */
-    void trigger_housekeeping();
     ss::future<> housekeeping();
 
     std::optional<batch_cache_index> create_cache(with_cache);
@@ -258,7 +258,6 @@ private:
     storage_resources& _resources;
     ss::sharded<features::feature_table>& _feature_table;
     simple_time_jitter<ss::lowres_clock> _jitter;
-    ss::timer<ss::lowres_clock> _housekeeping_timer;
     logs_type _logs;
     compaction_list_type _logs_list;
     batch_cache _batch_cache;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -244,6 +244,7 @@ private:
      *        runs inside a seastar thread
      */
     ss::future<> housekeeping();
+    ssx::semaphore _housekeeping_sem{0, "log_manager::housekeeping"};
 
     std::optional<batch_cache_index> create_cache(with_cache);
 

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -230,6 +230,8 @@ public:
      */
     ss::future<usage_report> disk_usage();
 
+    void handle_disk_notification(storage::disk_space_alert);
+
 private:
     using logs_type
       = absl::flat_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;
@@ -245,6 +247,7 @@ private:
      */
     ss::future<> housekeeping();
     ssx::semaphore _housekeeping_sem{0, "log_manager::housekeeping"};
+    disk_space_alert _disk_space_alert{disk_space_alert::ok};
 
     std::optional<batch_cache_index> create_cache(with_cache);
 

--- a/tests/rptest/utils/full_disk.py
+++ b/tests/rptest/utils/full_disk.py
@@ -28,8 +28,8 @@ class FullDiskHelper:
         wait_until(lambda: match(key, value), timeout_sec=15)
         self.logger.debug(f"Verified val {value} for {key}.")
 
-    def _set_low_space(self, degraded):
-        victim = random.choice(self.redpanda.nodes)
+    def _set_low_space(self, degraded, *, node=None):
+        victim = node or random.choice(self.redpanda.nodes)
         new_threshold: int = 0
         if degraded:
             new_threshold = 2**60  # arbitrary huge value
@@ -45,8 +45,8 @@ class FullDiskHelper:
         self._wait_for_node_config_value(self.CONF_MIN_FREE_BYTES,
                                          new_threshold)
 
-    def trigger_low_space(self):
-        self._set_low_space(True)
+    def trigger_low_space(self, node=None):
+        self._set_low_space(True, node=node)
 
     def clear_low_space(self):
         self._set_low_space(False)


### PR DESCRIPTION
* On low-disk alert log manager is alerted to immediately begin priority-based application of retention policy to logs in order to reclaim space as fast as possible.
* Current implementation limits GC to normal retention, and doesn't yet include reclaims that violate local retention when data has been uploaded into archival storage.
* Ducktape integration test verifying desired behavior
* Plenty of notes about next steps in code

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features

* Log retention rules applied eagerly in low disk space scenarios.

