### PR TITLE
cloud_storage: fix deletion of `replaced`, disable adjacent segment merging in test

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -839,8 +839,8 @@ remote_partition::finalize(ss::abort_source& as) {
     if (manifest_get_result != download_result::success) {
         vlog(
           _ctxlog.debug,
-          "Failed to fetch manifest during finalize(), maybe another node"
-          "already completed deletino. Error: {}",
+          "Failed to fetch manifest during finalize(), maybe another node "
+          "already completed deletion. Error: {}",
           manifest_get_result);
         co_return finalize_result{.get_status = manifest_get_result};
     }

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -374,7 +374,10 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                 # We rely on the scrubber to delete topic manifests, and to eventually
                 # delete data if cloud storage was unavailable during initial delete.  To
                 # control test runtimes, set a short interval.
-                'cloud_storage_housekeeping_interval_ms': 5000
+                'cloud_storage_housekeeping_interval_ms': 5000,
+
+                # Segment merging confuses these tests, because it looks like segments getting deleted
+                'cloud_storage_enable_segment_merging': False,
             },
             si_settings=self.si_settings)
 


### PR DESCRIPTION
This test recently had the housekeeping interval reduced in order to get the scrubber to run promptly.  However this also caused adjacent segment merging to happen more frequently, upsetting tests that expect no segments to be deleted, and exposing an issue where recently-merged segments in the `replaced` list are not cleaned up during deletion.

Fixes https://github.com/redpanda-data/redpanda/issues/10655
Fixes https://github.com/redpanda-data/redpanda/issues/10609

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
