### PR TITLE
Fix txn atomicity issue

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1801,20 +1801,23 @@ group::begin_tx(cluster::begin_group_tx_request r) {
     if (_partition->term() != _term) {
         vlog(
           _ctx_txlog.trace,
-          "processing name:begin_tx pid:{} tx_seq:{} timeout:{} => stale "
-          "leader",
+          "processing name:begin_tx pid:{} tx_seq:{} timeout:{} coordinator:{} "
+          "=> stale leader",
           r.pid,
           r.tx_seq,
-          r.timeout);
+          r.timeout,
+          r.tm_partition);
         co_return make_begin_tx_reply(cluster::tx_errc::stale);
     }
 
     vlog(
       _ctx_txlog.trace,
-      "processing name:begin_tx pid:{} tx_seq:{} timeout:{} in term:{}",
+      "processing name:begin_tx pid:{} tx_seq:{} timeout:{} coordinator:{} in "
+      "term:{}",
       r.pid,
       r.tx_seq,
       r.timeout,
+      r.tm_partition,
       _term);
     auto fence_it = _fence_pid_epoch.find(r.pid.get_id());
     if (fence_it == _fence_pid_epoch.end()) {

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -612,7 +612,7 @@ public:
         }
         auto [ongoing_it, _] = _tx_data.try_emplace(
           id.get_id(), tx_data{txseq, tm_partition});
-        if (ongoing_it->second.tx_seq < txseq) {
+        if (ongoing_it->second.tx_seq <= txseq) {
             ongoing_it->second.tx_seq = txseq;
             ongoing_it->second.tm_partition = tm_partition;
         }

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -556,6 +556,8 @@ ss::future<> group_manager::inject_noop(
 
 ss::future<>
 group_manager::gc_partition_state(ss::lw_shared_ptr<attached_partition> p) {
+    vlog(klog.trace, "Removing groups of {}", p->partition->ntp());
+
     /**
      * since this operation is destructive for partitions group we hold a
      * catchup write lock
@@ -569,6 +571,7 @@ group_manager::gc_partition_state(ss::lw_shared_ptr<attached_partition> p) {
     for (auto it = _groups.begin(); it != _groups.end();) {
         if (it->second->partition()->ntp() == p->partition->ntp()) {
             groups_for_shutdown.push_back(it->second);
+            vlog(klog.trace, "Removed group {}", it->second);
             _groups.erase(it++);
             continue;
         }
@@ -607,6 +610,8 @@ ss::future<> group_manager::handle_partition_leader_change(
         p->loading = false;
         return gc_partition_state(p);
     }
+
+    vlog(klog.trace, "Recovering groups of {}", p->partition->ntp());
 
     p->loading = true;
     auto timeout


### PR DESCRIPTION
Consumer groups could send `try_abort` request to a wrong tx coordinator.

Fixes https://github.com/redpanda-data/redpanda/issues/10669
Fixes https://github.com/redpanda-data/redpanda-jepsen/issues/26

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none