### PR TITLE
Fix aborted txs being visible

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1941,8 +1941,8 @@ model::offset rm_stm::last_stable_offset() {
         // transactions.
         return std::min(first_tx_start, next_to_apply);
     }
-    // no inflight transactions.
-    return model::next_offset(last_visible_index);
+    // no inflight transactions until last_applied (incl.)
+    return next_to_apply;
 }
 
 static void filter_intersecting(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -696,12 +696,18 @@ ss::future<tx_errc> rm_stm::do_prepare_tx(
           "Error \"{}\" on replicating pid:{} prepare batch",
           r.error(),
           pid);
+        if (_c->is_leader() && _c->term() == synced_term) {
+            co_await _c->step_down("prepare_tx replication error");
+        }
         co_return tx_errc::unknown_server_error;
     }
 
     if (!co_await wait_no_throw(
           model::offset(r.value().last_offset()),
           model::timeout_clock::now() + timeout)) {
+        if (_c->is_leader() && _c->term() == synced_term) {
+            co_await _c->step_down("prepare_tx apply error");
+        }
         co_return tx_errc::unknown_server_error;
     }
 
@@ -2233,8 +2239,13 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                       cr.error(),
                       pid,
                       tx_seq);
+                    if (_c->is_leader() && _c->term() == synced_term) {
+                        co_await _c->step_down(
+                          "try_abort(commit) replication error");
+                    }
                     co_return tx_errc::unknown_server_error;
                 }
+
                 if (_mem_state.last_end_tx < cr.value().last_offset) {
                     _mem_state.last_end_tx = cr.value().last_offset;
                 }
@@ -2247,6 +2258,9 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                       "applied pid:{} tx_seq:{}",
                       pid,
                       tx_seq);
+                    if (_c->is_leader() && _c->term() == synced_term) {
+                        co_await _c->step_down("try_abort(commit) apply error");
+                    }
                     co_return tx_errc::timeout;
                 }
                 co_return tx_errc::none;
@@ -2270,8 +2284,13 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                       cr.error(),
                       pid,
                       tx_seq);
+                    if (_c->is_leader() && _c->term() == synced_term) {
+                        co_await _c->step_down(
+                          "try_abort(abort) replication error");
+                    }
                     co_return tx_errc::unknown_server_error;
                 }
+
                 if (_mem_state.last_end_tx < cr.value().last_offset) {
                     _mem_state.last_end_tx = cr.value().last_offset;
                 }
@@ -2284,6 +2303,9 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
                       "pid:{} tx_seq:{}",
                       pid,
                       tx_seq);
+                    if (_c->is_leader() && _c->term() == synced_term) {
+                        co_await _c->step_down("try_abort(abort) apply error");
+                    }
                     co_return tx_errc::timeout;
                 }
                 co_return tx_errc::none;
@@ -2303,19 +2325,25 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
         vlog(_ctx_log.trace, "expiring pid:{}", pid);
         auto batch = make_tx_control_batch(
           pid, model::control_record_type::tx_abort);
+
         auto reader = model::make_memory_record_batch_reader(std::move(batch));
         auto cr = co_await _c->replicate(
           _insync_term,
           std::move(reader),
           raft::replicate_options(raft::consistency_level::quorum_ack));
+
         if (!cr) {
             vlog(
               _ctx_log.warn,
               "Error \"{}\" on replicating pid:{} autoabort/abort batch",
               cr.error(),
               pid);
+            if (_c->is_leader() && _c->term() == synced_term) {
+                co_await _c->step_down("try_abort(abort) replication error");
+            }
             co_return tx_errc::unknown_server_error;
         }
+
         if (_mem_state.last_end_tx < cr.value().last_offset) {
             _mem_state.last_end_tx = cr.value().last_offset;
         }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1939,16 +1939,28 @@ model::offset rm_stm::last_stable_offset() {
         }
     }
 
+    auto synced_leader = _c->is_leader() && _c->term() == _insync_term
+                         && _mem_state.term == _insync_term;
+
+    model::offset lso{-1};
     auto last_visible_index = _c->last_visible_index();
     auto next_to_apply = model::next_offset(last_applied);
     if (first_tx_start <= last_visible_index) {
         // There are in flight transactions < high water mark that may
         // not be applied yet. We still need to consider only applied
         // transactions.
-        return std::min(first_tx_start, next_to_apply);
+        lso = std::min(first_tx_start, next_to_apply);
+    } else if (synced_leader) {
+        // no inflight transactions in (last_applied, last_visible_index]
+        lso = model::next_offset(last_visible_index);
+    } else {
+        // a follower or hasn't synced yet leader doesn't know about the
+        // txes in the (last_applied, last_visible_index] range so we
+        // should not advance lso beyond last_applied
+        lso = next_to_apply;
     }
-    // no inflight transactions until last_applied (incl.)
-    return next_to_apply;
+    _mem_state.last_lso = std::max(_mem_state.last_lso, lso);
+    return _mem_state.last_lso;
 }
 
 static void filter_intersecting(

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -752,6 +752,12 @@ private:
           estimated;
         model::offset last_end_tx{-1};
 
+        // depending on the inflight state we may use last_applied or
+        // committed_index as LSO; the alternation between them may
+        // violate LSO monotonicity so we need to explicitly maintain
+        // it with last_lso
+        model::offset last_lso{-1};
+
         // FIELDS TO GO AFTER GA
         // a map from producer_identity (a session) to the first offset of
         // the current transaction in this session


### PR DESCRIPTION
When we treat last_visible_index as LSO there is a chance of it being ahead of last applied offset so we can't conclude that the stm doesn't have ongoing txs

fixes https://github.com/redpanda-data/redpanda/issues/10097

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none