### PR TITLE
rpk: small fix for utility build script

### DIFF
--- a/src/go/rpk/build.sh
+++ b/src/go/rpk/build.sh
@@ -18,10 +18,9 @@ out_dir="$(go env GOOS)-$(go env GOARCH)"
 
 mkdir -p "${out_dir}"
 
-ver_pkg='github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version'
-cont_pkg='github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/container/common'
-auth0_pkg='github.com/redpanda-data/redpanda/src/go/rpk/pkg/vcloud'
+ver_pkg='github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version'
+cont_pkg='github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common'
 
 go build \
-  -ldflags "-X ${ver_pkg}.version=${version} -X ${ver_pkg}.rev=${rev} -X ${cont_pkg}.tag=${img_tag} -X ${auth0_pkg}.clientId=${clientId}" \
+  -ldflags "-X ${ver_pkg}.version=${version} -X ${ver_pkg}.rev=${rev} -X ${cont_pkg}.tag=${img_tag}" \
   -o "${out_dir}" ./...


### PR DESCRIPTION
2 small fixes

- removed the old auth0 cliend ID ingestion (unused)
- removed the cmd directory which was removed in eaa5530


## Backports Required
- [ ] none - issue does not exist in previous branches

## Release Notes

* none
