### PR TITLE
Soft assert on different sizes of `shard_fetch` collections

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -390,6 +390,21 @@ static void fill_fetch_responses(
   std::vector<op_context::response_placeholder_ptr> responses,
   std::vector<std::unique_ptr<hdr_hist::measurement>> metrics) {
     auto range = boost::irange<size_t>(0, results.size());
+    if (unlikely(
+          results.size() != responses.size()
+          || results.size() != metrics.size())) {
+        // soft assert & recovery attempt
+        vlog(
+          klog.error,
+          "Results, responses, and metrics counts must be the same. "
+          "results: {}, responses: {}, metrics: {}. "
+          "Only the common subset will be processed",
+          results.size(),
+          responses.size(),
+          metrics.size());
+        range = boost::irange<size_t>(
+          0, std::min({results.size(), responses.size(), metrics.size()}));
+    }
     for (auto idx : range) {
         auto& res = results[idx];
         auto& resp_it = responses[idx];

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -531,6 +531,21 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
     co_return results;
 }
 
+bool shard_fetch::empty() const {
+    if (unlikely(
+          requests.size() != responses.size()
+          || responses.size() != metrics.size())) {
+        vlog(
+          klog.error,
+          "there have to be equal number of fetch requests, responses, and "
+          "metrics for single shard. requests: {}, responses: {}, metrics: {}",
+          requests.size(),
+          responses.size(),
+          metrics.size());
+    }
+    return requests.empty();
+}
+
 /**
  * Top-level handler for fetching from single shard. The result is
  * unwrapped and any errors from the storage sub-system are translated
@@ -545,7 +560,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
         return ss::now();
     }
     // no requests for this shard, do nothing
-    if (fetch.requests.empty()) {
+    if (fetch.empty()) {
         return ss::now();
     }
 

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -324,17 +324,8 @@ struct shard_fetch {
         responses.push_back(r_ph);
         metrics.push_back(std::move(m));
     }
+    bool empty() const;
 
-    bool empty() const {
-        vassert(
-          requests.size() == responses.size(),
-          "there have to be equal number of fetch requests and responsens for "
-          "single shard. requests count: {}, response count {}",
-          requests.size(),
-          responses.size());
-
-        return requests.empty();
-    }
     ss::shard_id shard;
     std::vector<ntp_fetch_config> requests;
     std::vector<op_context::response_placeholder_ptr> responses;


### PR DESCRIPTION
Soft assert that `shard_fetch` collections (requests/results, responses, and metrics) have  the same size. That's an invariant, and there is a chance that #10664 is caused by breaking it. This change will let us better diagnose the issue next time it happens.

Re #10664

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
