### PR TITLE
Require conn_quota::units stay on a single shard

### DIFF
--- a/src/v/bytes/oncore.cc
+++ b/src/v/bytes/oncore.cc
@@ -20,12 +20,11 @@ static_assert(std::is_same_v<oncore::shard_id_type, ss::shard_id>);
 oncore::oncore()
   : _owner_shard(ss::this_shard_id()) {}
 
-void oncore::verify_shard_source_location(const char* file, int linenum) const {
+void oncore::assert_shard_source_location(const vlog::file_line fl) const {
     vassert(
       _owner_shard == ss::this_shard_id(),
-      "{}:{} - Shard missmatch -  Operation on shard: {}. Owner shard:{}",
-      file,
-      linenum,
+      "{} - Shard missmatch -  Operation on shard: {}. Owner shard:{}",
+      fl,
       ss::this_shard_id(),
       _owner_shard);
 }

--- a/src/v/bytes/oncore.h
+++ b/src/v/bytes/oncore.h
@@ -26,16 +26,16 @@ public:
     // owner shard set on construction
     oncore();
 
-    void verify_shard_source_location(const char* file, int linenum) const;
+    void assert_shard_source_location(
+      const vlog::file_line = vlog::file_line::current()) const;
 
 private:
     shard_id_type _owner_shard;
 };
 
-// Next function should be replace with source_location in c++20 very soon
+// Debug builds assert, no checks in release builds
 // NOLINTNEXTLINE
 #define oncore_debug_verify(member)                                            \
     do {                                                                       \
-        expression_in_debug_mode((member).verify_shard_source_location(        \
-          get_file_basename(), __LINE__));                                     \
+        expression_in_debug_mode((member).assert_shard_source_location());     \
     } while (0)

--- a/src/v/net/conn_quota.cc
+++ b/src/v/net/conn_quota.cc
@@ -20,6 +20,7 @@
 namespace net {
 
 conn_quota::units::~units() noexcept {
+    _verify_shard.assert_shard_source_location();
     if (_quotas) {
         (*_quotas).get().put(_addr);
     }

--- a/src/v/net/conn_quota.cc
+++ b/src/v/net/conn_quota.cc
@@ -450,8 +450,11 @@ void conn_quota::do_put(ss::net::inet_address addr) {
 
     auto home_shard = addr_to_shard(addr);
     if (home_shard == ss::this_shard_id()) {
-        vlog(rpc::rpclog.trace, "do_put: release directly to home");
         auto allowance = get_home_allowance(addr);
+        vlog(
+          rpc::rpclog.trace,
+          "do_put: release directly to home allowance={}",
+          allowance);
         allowance->put();
         if (should_leave_reclaim(*allowance)) {
             cancel_reclaim_to(addr, allowance);

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "bytes/oncore.h"
 #include "config/property.h"
 #include "seastar/core/gate.hh"
 #include "seastar/core/sharded.hh"
@@ -61,12 +62,14 @@ public:
         units(units const&) = delete;
         units& operator=(units const&) = delete;
         units(units&& rhs) noexcept
-          : _addr(rhs._addr) {
+          : _addr(rhs._addr)
+          , _verify_shard(rhs._verify_shard) {
             _quotas = std::exchange(rhs._quotas, std::nullopt);
         }
         units& operator=(units&& rhs) noexcept {
             _quotas = std::exchange(rhs._quotas, std::nullopt);
             _addr = rhs._addr;
+            _verify_shard = rhs._verify_shard;
             return *this;
         }
 
@@ -83,6 +86,7 @@ public:
     private:
         std::optional<std::reference_wrapper<conn_quota>> _quotas;
         ss::net::inet_address _addr;
+        oncore _verify_shard;
     };
 
     using config_fn = std::function<conn_quota_config()>;

--- a/src/v/vlog.h
+++ b/src/v/vlog.h
@@ -13,25 +13,14 @@
 
 // NOLINTNEXTLINE
 #define fmt_with_ctx(method, fmt, args...)                                     \
-    method(                                                                    \
-      "{}:{} - " fmt,                                                          \
-      (const char*)&__FILE__[vlog_internal::log_basename_start<                \
-        vlog_internal::basename_index(__FILE__)>::value],                      \
-      __LINE__,                                                                \
-      ##args)
+    method("{} - " fmt, vlog::file_line::current(), ##args)
 
 // NOLINTNEXTLINE
 #define vlog(method, fmt, args...) fmt_with_ctx(method, fmt, ##args)
 
 // NOLINTNEXTLINE
 #define fmt_with_ctx_level(logger, level, fmt, args...)                        \
-    logger.log(                                                                \
-      level,                                                                   \
-      "{}:{} - " fmt,                                                          \
-      (const char*)&__FILE__[vlog_internal::log_basename_start<                \
-        vlog_internal::basename_index(__FILE__)>::value],                      \
-      __LINE__,                                                                \
-      ##args)
+    logger.log(level, "{} - " fmt, vlog::file_line::current(), ##args)
 
 // NOLINTNEXTLINE
 #define vlogl(logger, level, fmt, args...)                                     \


### PR DESCRIPTION
This makes the API contract more explicit since we now require the
connection quota units doesn't change shards.

Related: #10544

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
