### PR TITLE
topic_recovery: more straightforward prefix generation

### DIFF
--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -97,16 +97,11 @@ const s3_imposter_fixture::expectation recovery_state{
 std::vector<s3_imposter_fixture::expectation>
 generate_no_manifests_expectations(
   std::vector<s3_imposter_fixture::expectation> additional_expectations) {
-    std::vector<uint64_t> prefixes;
-    prefixes.reserve(16);
-    for (uint64_t i = 0x00000000; i <= 0xF0000000; i += 0x10000000) {
-        prefixes.emplace_back(i);
-    }
+    const char hex_chars[] = "0123456789abcdef";
     std::vector<s3_imposter_fixture::expectation> expectations;
-    expectations.reserve(prefixes.size());
-    for (const auto& prefix_bitmask : prefixes) {
+    for (int i = 0; i < 16; ++i) {
         expectations.emplace_back(s3_imposter_fixture::expectation{
-          .url = fmt::format("/?list-type=2&prefix={:08x}/", prefix_bitmask),
+          .url = fmt::format("/?list-type=2&prefix={}0000000/", hex_chars[i]),
           .body = no_manifests,
         });
     }

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -229,13 +229,10 @@ collect_manifest_paths(
     auto rtc = make_rtc(as, cfg);
 
     // Look under each manifest prefix for topic manifests.
-    std::array<uint64_t, 16> prefixes;
-    for (int i = 0; i < 16; ++i) {
-        prefixes.at(i) = 0x10000000 * static_cast<uint64_t>(i);
-    }
+    const char hex_chars[] = "0123456789abcdef";
     std::vector<remote_segment_path> paths;
-    for (const auto& prefix_bitmask : prefixes) {
-        const auto prefix = fmt::format("{:08x}/", prefix_bitmask);
+    for (int i = 0; i < 16; ++i) {
+        const auto prefix = fmt::format("{}0000000/", hex_chars[i]);
         auto rtc = make_rtc(as, cfg);
 
         // This request is restricted to prefix, it should only return the


### PR DESCRIPTION
In some ARM builds (and maybe more?) we'd see requests like list&prefix=e0000013d900/ instead of the expected 00000000, 10000000, etc.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
