### PR TITLE
cloud_storage: Handle overlapping segments

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -318,25 +318,56 @@ public:
                   "Invoking 'read_some' on current log reader with config: "
                   "{}",
                   _reader->config());
-                auto result = co_await _reader->read_some(deadline, *_ot_state);
-                if (!result) {
+
+                try {
+                    auto result = co_await _reader->read_some(
+                      deadline, *_ot_state);
+                    if (!result) {
+                        vlog(
+                          _ctxlog.debug,
+                          "Error while reading from stream '{}'",
+                          result.error());
+                        co_await set_end_of_stream();
+                        throw std::system_error(result.error());
+                    }
+                    data_t d = std::move(result.value());
+                    for (const auto& batch : d) {
+                        _partition->_probe.add_bytes_read(
+                          batch.header().size_bytes);
+                        _partition->_probe.add_records_read(
+                          batch.record_count());
+                    }
+                    if (
+                      _first_produced_offset == model::offset{} && !d.empty()) {
+                        _first_produced_offset = d.front().base_offset();
+                    }
+                    co_return storage_t{std::move(d)};
+                } catch (const stuck_reader_exception& ex) {
                     vlog(
-                      _ctxlog.debug,
-                      "Error while reading from stream '{}'",
-                      result.error());
-                    co_await set_end_of_stream();
-                    throw std::system_error(result.error());
+                      _ctxlog.error,
+                      "stuck reader: {}, {}",
+                      ex.rp_offset,
+                      _reader->max_rp_offset());
+
+                    // If the reader is stuck because of a mismatch between
+                    // segment data and manifest entry, set reader to EOF and
+                    // try to reset reader on the next loop iteration. We only
+                    // do this when the reader has not reached eof. For example,
+                    // the segment ends at offset 10 but the manifest has max
+                    // offset at 11 for the segment, with offset 11 actually
+                    // present in the next segment. When the reader is stuck,
+                    // the current offset will be 10 which we will not be able
+                    // to read from. Switching to the next segment should enable
+                    // reads to proceed.
+                    if (
+                      model::next_offset(ex.rp_offset)
+                        == _next_segment_base_offset
+                      && !_reader->is_eof()) {
+                        _reader->set_eof();
+                        continue;
+                    }
+                    throw;
                 }
-                data_t d = std::move(result.value());
-                for (const auto& batch : d) {
-                    _partition->_probe.add_bytes_read(
-                      batch.header().size_bytes);
-                    _partition->_probe.add_records_read(batch.record_count());
-                }
-                if (_first_produced_offset == model::offset{} && !d.empty()) {
-                    _first_produced_offset = d.front().base_offset();
-                }
-                co_return storage_t{std::move(d)};
             }
         } catch (const ss::gate_closed_exception&) {
             vlog(
@@ -454,6 +485,11 @@ private:
           "{}",
           _reader->config().start_offset,
           _reader->max_rp_offset());
+
+        // The next offset should be below the next segment base offset if the
+        // reader has not finished. If the next offset to be read from has
+        // reached the next segment but the reader is not finished, then the
+        // state is inconsistent.
         if (_reader->is_eof()) {
             auto prev_max_offset = _reader->max_rp_offset();
             auto config = _reader->config();

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1014,14 +1014,16 @@ remote_segment_batch_reader::read_some(
         if (
           _bytes_consumed != 0 && _bytes_consumed == new_bytes_consumed.value()
           && !_config.over_budget) {
-            throw std::runtime_error(fmt_with_ctx(
+            auto context = fmt_with_ctx(
               fmt::format,
               "segment_reader is stuck, segment ntp: {}, _cur_rp_offset: {}, "
               "_bytes_consumed: "
               "{}",
               _seg->get_ntp(),
               _cur_rp_offset,
-              _bytes_consumed));
+              _bytes_consumed);
+            throw stuck_reader_exception{
+              _cur_rp_offset, _bytes_consumed, context};
         }
         _bytes_consumed = new_bytes_consumed.value();
     }

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -35,6 +35,25 @@
 
 namespace cloud_storage {
 
+<<<<<<< HEAD
+=======
+class stuck_reader_exception final : public std::runtime_error {
+public:
+    stuck_reader_exception(
+      model::offset cur_rp_offset,
+      size_t cur_bytes_consumed,
+      ss::sstring context)
+      : std::runtime_error{context}
+      , rp_offset(cur_rp_offset)
+      , bytes_consumed(cur_bytes_consumed) {}
+    const model::offset rp_offset;
+    const size_t bytes_consumed;
+};
+
+std::filesystem::path
+generate_remote_index_path(const cloud_storage::remote_segment_path& p);
+
+>>>>>>> 2712b02dd (cloud_storage: Handle overlapping segments)
 static constexpr size_t remote_segment_sampling_step_bytes = 64_KiB;
 
 class download_exception : public std::exception {

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -774,6 +774,38 @@ FIXTURE_TEST(test_scan_by_kafka_offset, cloud_storage_fixture) {
     BOOST_REQUIRE(check_fetch(*this, kafka::offset(10), false));
 }
 
+FIXTURE_TEST(test_overlapping_segments, cloud_storage_fixture) {
+    batch_t data = {
+      .num_records = 1, .type = model::record_batch_type::raft_data};
+    batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, conf, conf, data, data, data},
+      {conf, conf, conf, data, data, data},
+      {conf, conf, conf, data, data, data},
+    };
+
+    auto segments = make_segments(batch_types, model::offset(0));
+    cloud_storage::partition_manifest manifest(manifest_ntp, manifest_revision);
+    auto expectations = make_imposter_expectations(
+      manifest, segments, false, model::offset_delta(0));
+
+    // Remove one data batch from the first segment, which also removes one
+    // record.
+    auto short_batches = batch_types[0];
+    short_batches.pop_back();
+    const auto short_segment = make_segment(model::offset{0}, short_batches);
+
+    expectations[0].body = short_segment.bytes;
+
+    set_expectations_and_listen(expectations);
+
+    print_segments(segments);
+
+    // Total offsets scanned are one less than what we initially set up
+    BOOST_REQUIRE(check_scan(*this, kafka::offset(0), 8));
+}
+
 FIXTURE_TEST(test_scan_by_kafka_offset_truncated, cloud_storage_fixture) {
     // mo: 6    11 12   17
     //     [b    ] [c    ] end


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/10683, fixes https://github.com/redpanda-data/redpanda/issues/10686

(cherry picked from commit 2712b02dd54aace4e025561deda9a8819970c956)

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x


## Release Notes

* none

### Bug Fixes

* Fixes overlapping segments when consuming in tiered storage read path.
