### PR TITLE
[v22.3.x] cloud_storage: Handle overlapping segments

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1014,14 +1014,16 @@ remote_segment_batch_reader::read_some(
         if (
           _bytes_consumed != 0 && _bytes_consumed == new_bytes_consumed.value()
           && !_config.over_budget) {
-            throw std::runtime_error(fmt_with_ctx(
+            auto context = fmt_with_ctx(
               fmt::format,
               "segment_reader is stuck, segment ntp: {}, _cur_rp_offset: {}, "
               "_bytes_consumed: "
               "{}",
               _seg->get_ntp(),
               _cur_rp_offset,
-              _bytes_consumed));
+              _bytes_consumed);
+            throw stuck_reader_exception{
+              _cur_rp_offset, _bytes_consumed, context};
         }
         _bytes_consumed = new_bytes_consumed.value();
     }

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -35,6 +35,19 @@
 
 namespace cloud_storage {
 
+class stuck_reader_exception final : public std::runtime_error {
+public:
+    stuck_reader_exception(
+      model::offset cur_rp_offset,
+      size_t cur_bytes_consumed,
+      ss::sstring context)
+      : std::runtime_error{context}
+      , rp_offset(cur_rp_offset)
+      , bytes_consumed(cur_bytes_consumed) {}
+    const model::offset rp_offset;
+    const size_t bytes_consumed;
+};
+
 static constexpr size_t remote_segment_sampling_step_bytes = 64_KiB;
 
 class download_exception : public std::exception {


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/10683, fixes https://github.com/redpanda-data/redpanda/issues/10686

(cherry picked from commit 2712b02dd54aace4e025561deda9a8819970c956)

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x


## Release Notes

* none

### Bug Fixes

* Fixes overlapping segments when consuming in tiered storage read path.
