### PR TITLE
[v22.3.x] admin: map replicated_entry_truncated error to 503 http error code

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -798,6 +798,7 @@ ss::future<> admin_server::throw_on_error(
         case raft::errc::configuration_change_in_progress:
         case raft::errc::leadership_transfer_in_progress:
         case raft::errc::shutting_down:
+        case raft::errc::replicated_entry_truncated:
             throw ss::httpd::base_exception(
               fmt::format("Not ready: {}", ec.message()),
               ss::httpd::reply::status_type::service_unavailable);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/8494
Fixes https://github.com/redpanda-data/redpanda/issues/10694,