### PR TITLE
rpk: add FileHeader to files in debug bundle zip

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -211,7 +211,11 @@ func writeFileToZip(ps *stepParams, filename string, contents []byte) error {
 	ps.m.Lock()
 	defer ps.m.Unlock()
 
-	wr, err := ps.w.Create(filename)
+	wr, err := ps.w.CreateHeader(&zip.FileHeader{
+		Name:     filename,
+		Method:   zip.Deflate,
+		Modified: time.Now(),
+	})
 	if err != nil {
 		return err
 	}
@@ -267,7 +271,11 @@ func writeCommandOutputToZipLimit(
 	// Strip any non-default library path
 	cmd.Env = osutil.SystemLdPathEnv()
 
-	wr, err := ps.w.Create(filename)
+	wr, err := ps.w.CreateHeader(&zip.FileHeader{
+		Name:     filename,
+		Method:   zip.Deflate,
+		Modified: time.Now(),
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Small fix: add FileHeader to files in debug bundle zip to save the correct modified time.

Fixes #10676 
## Backports Required
- [ ] none - papercut/not impactful enough to backport

## Release Notes
### Bug Fixes

* bugfix: add correct file metadata to files in the debug bundle generated by `rpk debug bundle` 
