### PR TITLE
Integrate a CPU profiler into RP

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 6e869a2068ab27ca84ffbe0fe7f7f172fdcde01c
+  GIT_TAG 6f442562679c4a9307c3f4c7daf0a3ab976e0eaf
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   LIST_SEPARATOR |

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2191,7 +2191,20 @@ configuration::configuration()
       "per shard, larger sizes prevent running out of memory because of too "
       "many concurrent fetch requests.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      1_MiB) {}
+      1_MiB)
+  , cpu_profiler_enabled(
+      *this,
+      "cpu_profiler_enabled",
+      "Enables cpu profiling for Redpanda",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
+  , cpu_profiler_sample_period_ms(
+      *this,
+      "cpu_profiler_sample_period_ms",
+      "The sample period for the CPU profiler",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      100ms,
+      {.min = 1ms}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -440,6 +440,9 @@ struct configuration final : public config_store {
 
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
     property<size_t> kafka_memory_batch_size_estimate_for_fetch;
+    // debug controls
+    property<bool> cpu_profiler_enabled;
+    bounded_property<std::chrono::milliseconds> cpu_profiler_sample_period_ms;
 
     configuration();
 

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -472,9 +472,69 @@
               ]
             }
           ]
+        },
+        {
+            "path": "/v1/debug/cpu_profile",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Gets the samples from the CPU profiler",
+                    "nickname": "cpu_profile",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "type": "array",
+                    "items": {
+                        "type": "cpu_profile_shard_samples"
+                    },
+                    "parameters": [
+                        {
+                            "name": "shard",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
+        "cpu_profile_shard_samples": {
+            "id": "cpu_profile_sample",
+            "description": "cpu profile sample",
+            "properties": {
+                "shard_id": {
+                    "type": "long",
+                    "description": "the shard the sample originated from"
+                },
+                "dropped_samples": {
+                    "type": "long",
+                    "description": "number of samples that had to be dropped due to space limitations"
+                },
+                "samples": {
+                    "type": "array",
+                    "items": {
+                        "type": "cpu_profile_sample"
+                    }
+                }
+            }
+        },
+        "cpu_profile_sample": {
+            "id": "cpu_profile_sample",
+            "description": "cpu profile sample",
+            "properties": {
+                "user_backtrace": {
+                    "type": "string",
+                    "description": "user backtrace"
+                },
+                "occurrences": {
+                    "type": "long",
+                    "description": "number of times this backtrace has occurred"
+                }
+            }
+        },
         "leader_info": {
             "id": "leader_info",
             "description": "Leader info",

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -19,6 +19,7 @@
 #include "model/metadata.h"
 #include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/fwd.h"
+#include "resource_mgmt/cpu_profiler.h"
 #include "resource_mgmt/memory_sampling.h"
 #include "rpc/connection_cache.h"
 #include "seastarx.h"
@@ -79,7 +80,8 @@ public:
       ss::sharded<cluster::tx_registry_frontend>&,
       ss::sharded<storage::node>&,
       ss::sharded<memory_sampling>&,
-      ss::sharded<cloud_storage::cache>&);
+      ss::sharded<cloud_storage::cache>&,
+      ss::sharded<resources::cpu_profiler>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -468,6 +470,8 @@ private:
 
     // Debug routes
     ss::future<ss::json::json_return_type>
+      cpu_profile_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
       cloud_storage_usage_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       restart_service_handler(std::unique_ptr<ss::http::request>);
@@ -525,6 +529,8 @@ private:
     ss::sharded<storage::node>& _storage_node;
     ss::sharded<memory_sampling>& _memory_sampling_service;
     ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
+    ss::sharded<resources::cpu_profiler>& _cpu_profiler;
+
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;
     ss::timer<> _blocked_reactor_notify_reset_timer;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -865,7 +865,8 @@ void application::configure_admin_server() {
       std::ref(tx_registry_frontend),
       std::ref(storage_node),
       std::ref(_memory_sampling),
-      std::ref(shadow_index_cache))
+      std::ref(shadow_index_cache),
+      std::ref(_cpu_profiler))
       .get();
 }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -424,6 +424,16 @@ void application::initialize(
 
     _abort_on_oom->watch(oom_config_watch);
 
+    construct_service(
+      _cpu_profiler,
+      ss::sharded_parameter(
+        [] { return config::shard_local_cfg().cpu_profiler_enabled.bind(); }),
+      ss::sharded_parameter([] {
+          return config::shard_local_cfg().cpu_profiler_sample_period_ms.bind();
+      }))
+      .get();
+    _cpu_profiler.invoke_on_all(&resources::cpu_profiler::start).get();
+
     /*
      * allocate per-core zstd decompression workspace and per-core
      * async_stream_zstd workspaces. it can be several megabytes in size, so do

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -38,6 +38,7 @@
 #include "raft/fwd.h"
 #include "redpanda/admin_server.h"
 #include "redpanda/monitor_unsafe_log_flag.h"
+#include "resource_mgmt/cpu_profiler.h"
 #include "resource_mgmt/cpu_scheduling.h"
 #include "resource_mgmt/memory_groups.h"
 #include "resource_mgmt/memory_sampling.h"
@@ -268,6 +269,8 @@ private:
     ss::metrics::metric_groups _metrics;
     ss::sharded<ssx::metrics::public_metrics_group> _public_metrics;
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
+
+    ss::sharded<resources::cpu_profiler> _cpu_profiler;
 
     std::unique_ptr<cluster::node_isolation_watcher> _node_isolation_watcher;
 

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -11,6 +11,7 @@ v_cc_library(
   NAME storage_resource_mgmt
   SRCS
     storage.cc
+    logger.cc
   DEPS
     Seastar::seastar
     v::cloud_storage

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -3,6 +3,8 @@ v_cc_library(
   SRCS
     available_memory.cc
     memory_sampling.cc
+    cpu_profiler.cc
+    logger.cc
   DEPS
     Seastar::seastar
   )
@@ -11,7 +13,6 @@ v_cc_library(
   NAME storage_resource_mgmt
   SRCS
     storage.cc
-    logger.cc
   DEPS
     Seastar::seastar
     v::cloud_storage

--- a/src/v/resource_mgmt/cpu_profiler.cc
+++ b/src/v/resource_mgmt/cpu_profiler.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "resource_mgmt/cpu_profiler.h"
+
+#include "random/generators.h"
+#include "resource_mgmt/logger.h"
+#include "ssx/future-util.h"
+#include "ssx/sformat.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/internal/cpu_profiler.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/util/later.hh>
+
+#include <iterator>
+
+namespace resources {
+
+cpu_profiler::cpu_profiler(
+  config::binding<bool>&& enabled,
+  config::binding<std::chrono::milliseconds>&& sample_period)
+  : _query_timer([this] { poll_samples(); })
+  , _enabled(std::move(enabled))
+  , _sample_period(std::move(sample_period)) {
+    _enabled.watch([this] { on_enabled_change(); });
+    _sample_period.watch([this] { on_sample_period_change(); });
+}
+
+ss::future<> cpu_profiler::start() {
+    seastar::engine().set_cpu_profiler_period(_sample_period());
+    seastar::engine().set_cpu_profiler_enabled(_enabled());
+
+    if (_enabled()) {
+        // Arm the timer to fire whenever the profiler collects
+        // the maximum number of traces it can retain.
+        _query_timer.arm_periodic(ss::max_number_of_traces * _sample_period());
+    }
+
+    return ss::now();
+}
+
+ss::future<> cpu_profiler::stop() {
+    _query_timer.cancel();
+    co_await _gate.close();
+}
+
+ss::future<std::vector<cpu_profiler::shard_samples>>
+cpu_profiler::results(std::optional<ss::shard_id> shard_id) {
+    if (_gate.is_closed()) {
+        co_return std::vector<shard_samples>{};
+    }
+    auto holder = _gate.hold();
+
+    std::vector<shard_samples> results{};
+
+    if (shard_id) {
+        auto shard_result = co_await container().invoke_on(
+          shard_id.value(), [](auto& s) { return s.shard_results(); });
+
+        results.emplace_back(
+          shard_result.shard,
+          shard_result.dropped_samples,
+          std::move(shard_result.samples));
+    } else {
+        results = co_await container().map_reduce0(
+          [](auto& s) { return s.shard_results(); },
+          std::vector<shard_samples>{},
+          [](std::vector<shard_samples> results, shard_samples shard_result) {
+              results.emplace_back(
+                shard_result.shard,
+                shard_result.dropped_samples,
+                std::move(shard_result.samples));
+              return results;
+          });
+    }
+
+    co_return results;
+}
+
+cpu_profiler::shard_samples cpu_profiler::shard_results() const {
+    size_t dropped_samples = 0;
+    absl::node_hash_map<ss::simple_backtrace, size_t> backtraces;
+    for (auto& results_buffer : _results_buffers) {
+        dropped_samples += results_buffer.dropped_samples;
+        for (auto& result : results_buffer.samples) {
+            backtraces[result.user_backtrace]++;
+        }
+    }
+
+    std::vector<sample> results{};
+    results.reserve(backtraces.size());
+
+    for (auto& backtrace : backtraces) {
+        results.emplace_back(
+          ssx::sformat("{}", backtrace.first), backtrace.second);
+    }
+
+    return {ss::this_shard_id(), dropped_samples, results};
+}
+
+void cpu_profiler::poll_samples() {
+    std::vector<ss::cpu_profiler_trace> results_buffer;
+    if (_results_buffers.size() < number_of_results_buffers) {
+        results_buffer = std::vector<ss::cpu_profiler_trace>{
+          ss::max_number_of_traces};
+    } else {
+        results_buffer = std::move(_results_buffers.back().samples);
+        _results_buffers.pop_back();
+    }
+
+    auto dropped_samples = ss::engine().profiler_results(results_buffer);
+
+    resourceslog.trace(
+      "Polled {} samples from the CPU profiler", results_buffer.size());
+
+    _results_buffers.emplace_front(dropped_samples, std::move(results_buffer));
+}
+
+void cpu_profiler::on_enabled_change() {
+    if (_gate.is_closed()) {
+        return;
+    }
+
+    ss::engine().set_cpu_profiler_enabled(_enabled());
+    _query_timer.cancel();
+
+    if (_enabled()) {
+        _query_timer.arm_periodic(ss::max_number_of_traces * _sample_period());
+    }
+}
+
+void cpu_profiler::on_sample_period_change() {
+    if (_gate.is_closed()) {
+        return;
+    }
+
+    ss::engine().set_cpu_profiler_period(_sample_period());
+}
+
+} // namespace resources

--- a/src/v/resource_mgmt/cpu_profiler.h
+++ b/src/v/resource_mgmt/cpu_profiler.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/property.h"
+#include "seastarx.h"
+
+#include <seastar/core/internal/cpu_profiler.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/timer.hh>
+#include <seastar/util/backtrace.hh>
+
+#include <absl/container/node_hash_map.h>
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+
+namespace resources {
+
+/**
+ * The `cpu_profiler` service polls traces from seastar at fixed intervals.
+ * It then aggregates the traces and provides methods for other services
+ * to view them.
+ */
+class cpu_profiler : public ss::peering_sharded_service<cpu_profiler> {
+    // The number of results buffers to retain. Each of these buffers
+    // are `ss::max_number_of_traces` * 1568bytes in size (196KiB).
+    // Each buffer has samples from a window of
+    // `_sample_rate` * `ss::max_number_of_traces` milliseconds.
+    //
+    // At 10 results buffers with a 100ms sample rate this service
+    // retains samples representative of the last 2 minutes of CPU
+    // activity.
+    static constexpr size_t number_of_results_buffers{10};
+
+public:
+    struct sample {
+        ss::sstring user_backtrace;
+        size_t occurrences;
+
+        sample(ss::sstring ub, size_t o)
+          : user_backtrace(std::move(ub))
+          , occurrences(o) {}
+    };
+
+    struct shard_samples {
+        ss::shard_id shard;
+        size_t dropped_samples;
+        std::vector<sample> samples;
+    };
+
+    cpu_profiler(
+      config::binding<bool>&&, config::binding<std::chrono::milliseconds>&&);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    // Collects `shard_results()` for each shard in a node and returns
+    // them as a vector.
+    ss::future<std::vector<shard_samples>>
+    results(std::optional<ss::shard_id> shard_id);
+
+    // Returns the samples and dropped samples from the shard this function
+    // is called on.
+    shard_samples shard_results() const;
+
+private:
+    // Used to poll seastar at set intervals to capture all samples
+    ss::timer<ss::lowres_clock> _query_timer;
+    ss::gate _gate;
+
+    // Configuration for seastar's cpu profiler
+    config::binding<bool> _enabled;
+    config::binding<std::chrono::milliseconds> _sample_period;
+
+    struct profiler_result {
+        size_t dropped_samples;
+        std::vector<seastar::cpu_profiler_trace> samples;
+    };
+
+    // Buffers to copy sampled traces from seastar into so
+    // we're not reallocating every call.
+    // The oldest results buffer is overwritten when polling
+    // for new samples from seastar.
+    std::deque<profiler_result> _results_buffers;
+
+    void poll_samples();
+
+    void on_enabled_change();
+    void on_sample_period_change();
+};
+
+} // namespace resources

--- a/src/v/resource_mgmt/logger.cc
+++ b/src/v/resource_mgmt/logger.cc
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "resource_mgmt/logger.h"
+
+namespace resources {
+ss::logger resourceslog{"resources"};
+} // namespace resources

--- a/src/v/resource_mgmt/logger.h
+++ b/src/v/resource_mgmt/logger.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace resources {
+extern ss::logger resourceslog;
+} // namespace resources

--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ rp_test(
   UNIT_TEST
   BINARY_NAME resource_mgmt
   SOURCES
+    cpu_profiler_test.cc
     available_memory_test.cc
   LIBRARIES v::seastar_testing_main v::resource_mgmt v::config
   LABELS resource_mgmt

--- a/src/v/resource_mgmt/tests/cpu_profiler_test.cc
+++ b/src/v/resource_mgmt/tests/cpu_profiler_test.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "config/configuration.h"
+#include "config/property.h"
+#include "resource_mgmt/cpu_profiler.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <exception>
+
+SEASTAR_THREAD_TEST_CASE(test_cpu_profiler) {
+    using namespace std::literals;
+
+    resources::cpu_profiler cp(
+      config::mock_binding(true), config::mock_binding(2ms));
+    cp.start().get();
+
+    // The profiler service will request samples from seastar every
+    // 256ms since the sample rate is 2ms. So we need to be running
+    // for at least that long to ensure the service pulls in samples.
+    auto end_time = ss::lowres_clock::now() + 256ms + 10ms;
+    while (ss::lowres_clock::now() < end_time) {
+        // yield to allow timer to trigger and lowres_clock to update
+        ss::thread::maybe_yield();
+    }
+
+    auto results = cp.shard_results();
+    BOOST_TEST(results.samples.size() >= 1);
+}

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1007,3 +1007,9 @@ class Admin:
                              "debug/sampled_memory_profile",
                              node=node,
                              **kwargs).json()
+
+    def get_cpu_profile(self, node=None):
+        """
+        Get the CPU profile of a node.
+        """
+        return self._request("get", "debug/cpu_profile", node=node).json()

--- a/tests/rptest/tests/cpu_profiler_admin_api_test.py
+++ b/tests/rptest/tests/cpu_profiler_admin_api_test.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+from rptest.services.redpanda import LoggingConfig
+from rptest.clients.types import TopicSpec
+from rptest.services.kgo_repeater_service import repeater_traffic
+
+
+class CPUProfilerAdminAPITest(RedpandaTest):
+    topics = (TopicSpec(partition_count=30, replication_factor=3), )
+
+    def __init__(self, test_context):
+        super(CPUProfilerAdminAPITest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            log_config=LoggingConfig('info',
+                                     logger_levels={'resources': 'trace'}),
+            extra_rp_conf={
+                "cpu_profiler_enabled": True,
+                "cpu_profiler_sample_period_ms": 50,
+            })
+
+        self.admin = Admin(self.redpanda)
+
+    @cluster(num_nodes=4)
+    def test_get_cpu_profile(self):
+        # Provide traffic so there is something to sample.
+        with repeater_traffic(context=self.test_context,
+                              redpanda=self.redpanda,
+                              topic=self.topic,
+                              msg_size=4096,
+                              workers=1) as repeater:
+            repeater.await_group_ready()
+            repeater.await_progress(1024, timeout_sec=75)
+
+            profile = self.admin.get_cpu_profile()
+
+            assert len(profile) > 0, "At least one shard should exist"
+            assert len(
+                profile[0]["samples"]
+            ) > 0, "At least one cpu profile should've been collected."


### PR DESCRIPTION
An integration of the seastar CPU profiler PR [here](https://github.com/redpanda-data/seastar/pull/48) into Redpanda. This PR provides a service that controls and polls samples from the seastar CPU profilers. It also provides an admin api endpoint the returns samples in the following json format;

```json
[
    {
        "shard_id": 0, 
        "user_backtrace": "0x687335a 0x65d4cf5 /lib64/libc.so.6+0x3cb1f /home/brandonallard/data/projects/redpanda-3/vbuild/release/clang/rp_deps_install/lib/libc++.so.1+0x51764 0  x65f9da0 0x65f6d49 0x6507d61 0x6505e7f 0x2099d2e 0x6929979 /lib64/libc.so.6+0x2750f /lib64/libc.so.6+0x275c8 0x2094124",
        "occurrences": 1
    },
   ...
]                                                 

```

The build will fail until the seastar PR is merged and vtools is updated.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features

* Adds a built-in CPU profiler configured with the `cpu_profiler_enabled` and `cpu_profiler_sample_rate_ms` cluster properties