### PR TITLE
cloud_storage: Adjust conditions to reset stuck reader

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -238,23 +238,20 @@ FIXTURE_TEST(test_overlapping_segments, cloud_storage_fixture) {
 
     auto segments = make_segments(batch_types, model::offset(0));
     cloud_storage::partition_manifest manifest(manifest_ntp, manifest_revision);
+
     auto expectations = make_imposter_expectations(
       manifest, segments, false, model::offset_delta(0));
 
-    // Remove one data batch from the first segment, which also removes one
-    // record.
-    auto short_batches = batch_types[0];
-    short_batches.pop_back();
-    const auto short_segment = make_segment(model::offset{0}, short_batches);
+    std::stringstream sstr;
+    manifest.serialize(sstr);
 
-    expectations[0].body = short_segment.bytes;
-
+    auto body = sstr.str();
+    std::string_view to_replace = "\"committed_offset\":5";
+    body.replace(
+      body.find(to_replace), to_replace.size(), "\"committed_offset\":6");
+    expectations.back().body = body;
     set_expectations_and_listen(expectations);
-
-    print_segments(segments);
-
-    // Total offsets scanned are one less than what we initially set up
-    BOOST_REQUIRE(check_scan(*this, kafka::offset(0), 8));
+    BOOST_REQUIRE(check_scan(*this, kafka::offset(0), 9));
 }
 
 FIXTURE_TEST(test_scan_by_kafka_offset_truncated, cloud_storage_fixture) {


### PR DESCRIPTION
When a reader is stuck before reaching EOF and the end offset of the segment overlaps the next segment, we reset the reader. This condition is fixed to include the overlap. The change made recently was not enough to cover overlapping segments correctly.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

### Bug Fixes

* Expands condition for reader reset.

