### PR TITLE
Report minimum storage threshold targets

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -930,6 +930,20 @@ configuration::configuration()
        .example = "3600",
        .visibility = visibility::tunable},
       std::nullopt)
+  , storage_reserve_min_segments(
+      *this,
+      "storage_reserve_min_segments",
+      "The number of segments per partition that the system will attempt to "
+      "reserve disk capcity for. For example, if the maximum segment size is "
+      "configured to be 100 MB, and the value of this option is 2, then in a "
+      "system with 10 partitions Redpanda will attempt to reserve at least 2 "
+      "GB "
+      "of disk space.",
+      {.needs_restart = needs_restart::no,
+       .example = "4",
+       .visibility = visibility::tunable},
+      2,
+      {.min = 1})
   , id_allocator_log_capacity(
       *this,
       "id_allocator_log_capacity",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -193,6 +193,7 @@ struct configuration final : public config_store {
     property<size_t> max_compacted_log_segment_size;
     property<std::optional<std::chrono::seconds>>
       storage_ignore_timestamps_in_future_sec;
+    bounded_property<int16_t> storage_reserve_min_segments;
 
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -804,6 +804,10 @@
                 "target_min_capacity": {
                     "type": "long",
                     "description": "Target minimum capacity"
+                },
+                "target_min_capacity_wanted": {
+                    "type": "long",
+                    "description": "Target minimum capacity wanted"
                 }
             }
         }

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -800,6 +800,10 @@
                 "reclaimable_by_retention": {
                     "type": "long",
                     "description": "Number of bytes currently reclaimable by retention"
+                },
+                "target_min_capacity": {
+                    "type": "long",
+                    "description": "Target minimum capacity"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4177,6 +4177,7 @@ admin_server::get_local_storage_usage_handler(
     ret.index = disk.usage.index;
     ret.compaction = disk.usage.compaction;
     ret.reclaimable_by_retention = disk.reclaim.retention;
+    ret.target_min_capacity = disk.target.min_capacity;
 
     co_return ret;
 }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4178,6 +4178,7 @@ admin_server::get_local_storage_usage_handler(
     ret.compaction = disk.usage.compaction;
     ret.reclaimable_by_retention = disk.reclaim.retention;
     ret.target_min_capacity = disk.target.min_capacity;
+    ret.target_min_capacity_wanted = disk.target.min_capacity_wanted;
 
     co_return ret;
 }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1817,12 +1817,10 @@ log make_disk_backed_log(
 }
 
 /*
- * disk usage and amount reclaimable are best computed together.
- *
  * assumes that the compaction gate is held.
  */
 ss::future<std::pair<usage, reclaim_size_limits>>
-disk_log_impl::disk_usage_and_reclaim(gc_config cfg) {
+disk_log_impl::disk_usage_and_reclaimable_space(gc_config cfg) {
     std::optional<model::offset> max_offset;
     if (config().is_collectable()) {
         cfg = apply_overrides(cfg);
@@ -2113,7 +2111,7 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
      * compute the amount of current disk usage as well as the amount available
      * for being reclaimed.
      */
-    auto [usage, reclaim] = co_await disk_usage_and_reclaim(cfg);
+    auto [usage, reclaim] = co_await disk_usage_and_reclaimable_space(cfg);
 
     /*
      * compute target capacities such as minimum required capacity as well as

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -704,9 +704,12 @@ bool disk_log_impl::is_cloud_retention_active() const {
            && (config().is_archival_enabled());
 }
 
-gc_config disk_log_impl::apply_overrides(gc_config defaults) const {
+/*
+ * applies overrides for non-cloud storage settings
+ */
+gc_config disk_log_impl::apply_base_overrides(gc_config defaults) const {
     if (!config().has_overrides()) {
-        return override_retention_config(defaults);
+        return defaults;
     }
 
     auto ret = defaults;
@@ -734,6 +737,11 @@ gc_config disk_log_impl::apply_overrides(gc_config defaults) const {
           model::timestamp::now().value() - retention_time.value().count());
     }
 
+    return ret;
+}
+
+gc_config disk_log_impl::apply_overrides(gc_config defaults) const {
+    auto ret = apply_base_overrides(defaults);
     return override_retention_config(ret);
 }
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1938,11 +1938,7 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
      */
     auto target = co_await disk_usage_target(cfg);
 
-    co_return usage_report{
-      .usage = usage,
-      .reclaim = reclaim,
-      .target = target,
-    };
+    co_return usage_report(usage, reclaim, target);
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -192,6 +192,8 @@ private:
     ss::future<std::pair<usage, reclaim_size_limits>>
       disk_usage_and_reclaim(gc_config);
     ss::future<usage_target> disk_usage_target(gc_config, usage);
+    ss::future<std::optional<size_t>>
+      disk_usage_target_time_retention(gc_config);
 
 private:
     size_t max_segment_size() const;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -191,7 +191,7 @@ private:
 
     ss::future<std::pair<usage, reclaim_size_limits>>
       disk_usage_and_reclaim(gc_config);
-    ss::future<usage_target> disk_usage_target(gc_config);
+    ss::future<usage_target> disk_usage_target(gc_config, usage);
 
 private:
     size_t max_segment_size() const;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -189,8 +189,13 @@ private:
 
     std::optional<model::offset> retention_offset(gc_config);
 
+    /*
+     * total disk usage and the amount of reclaimable space are most efficiently
+     * computed together given that use cases often use both together.
+     */
     ss::future<std::pair<usage, reclaim_size_limits>>
-      disk_usage_and_reclaim(gc_config);
+      disk_usage_and_reclaimable_space(gc_config);
+
     ss::future<usage_target> disk_usage_target(gc_config, usage);
     ss::future<std::optional<size_t>>
       disk_usage_target_time_retention(gc_config);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -188,6 +188,9 @@ private:
 
     std::optional<model::offset> retention_offset(gc_config);
 
+    ss::future<std::pair<usage, reclaim_size_limits>>
+      disk_usage_and_reclaim(gc_config);
+
 private:
     size_t max_segment_size() const;
     // Computes the segment size based on the latest max_segment_size

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -190,6 +190,7 @@ private:
 
     ss::future<std::pair<usage, reclaim_size_limits>>
       disk_usage_and_reclaim(gc_config);
+    ss::future<usage_target> disk_usage_target(gc_config);
 
 private:
     size_t max_segment_size() const;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -177,6 +177,7 @@ private:
     retention_adjust_timestamps(std::chrono::seconds ignore_in_future);
 
     gc_config apply_overrides(gc_config) const;
+    gc_config apply_base_overrides(gc_config) const;
 
     storage_resources& resources();
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -488,6 +488,10 @@ struct usage {
  *    * size-based retention: the amount of space needed to meet size-based
  *    local retention policy, rounded up to the nearest segment size.
  *
+ *    * time-based retention: attempts to extrapolate the capacity requirements
+ *    by examining recently written data and the apparent rate at which it has
+ *    been written.
+ *
  *    * compaction: compacted topics are kept whole on local storage (ie not
  *    subject to truncation due to local retention policies). for compact,delete
  *    topic the retention policy (not local retention) is used to express how

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -469,18 +469,42 @@ struct usage {
 };
 
 /*
+ * disk usage targets
+ *
+ * min_capacity: minimum amount of storage capacity needed.
+ *
+ * The minimum capacity is intended to capture the minimum amount of disk space
+ * needed for the basic functionality. At a high-level this is expressed as a
+ * minimum number of segments per partition. Formally it is the sum of S *
+ * log.max_segment_size() for each managed log, where S is the value of the
+ * configuration option storage_reserve_min_segments specifying the minimum
+ * number of segments for which space should be reserved.
+ */
+struct usage_target {
+    size_t min_capacity{0};
+
+    friend usage_target operator+(usage_target lhs, const usage_target& rhs) {
+        lhs.min_capacity += rhs.min_capacity;
+        return lhs;
+    }
+};
+
+/*
  * disk usage report
  *
  * usage: disk usage summary for log.
  * reclaim: disk uage reclaim summary for log.
+ * targets: target disk usage statistics.
  */
 struct usage_report {
     usage usage;
     reclaim_size_limits reclaim;
+    usage_target target;
 
     friend usage_report operator+(usage_report lhs, const usage_report& rhs) {
         lhs.usage = lhs.usage + rhs.usage;
         lhs.reclaim = lhs.reclaim + rhs.reclaim;
+        lhs.target = lhs.target + rhs.target;
         return lhs;
     }
 };

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -501,6 +501,14 @@ struct usage_report {
     reclaim_size_limits reclaim;
     usage_target target;
 
+    usage_report() = default;
+
+    usage_report(
+      struct usage usage, reclaim_size_limits reclaim, usage_target target)
+      : usage(usage)
+      , reclaim(reclaim)
+      , target(target) {}
+
     friend usage_report operator+(usage_report lhs, const usage_report& rhs) {
         lhs.usage = lhs.usage + rhs.usage;
         lhs.reclaim = lhs.reclaim + rhs.reclaim;

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -435,7 +435,7 @@ class LocalDiskReportTest(RedpandaTest):
             # 4 partition with default segment size
             # controller partition has default segment size
             # reservation will be for min_segments
-            expected = min_segments * ((1 * 2**30) + \
+            expected = min_segments * ((1 * self.topics[0].segment_bytes) + \
                        (4 * default_segment_size) + \
                        (1 * default_segment_size))
 


### PR DESCRIPTION
Disk space management policy needs to be able to juggle space between the disk cache and log storage. To do this some thresholds will be useful, such as a minimum amount of space that log storage needs for normal functionality, and the minimum amount it needs to meet some basic policies like data retention goals.

This PR adds reporting for
* minimum needed capacity
* minimum capacity needed for `retention.bytes` policies
* minimum capacity needed for `retention.ms` policies

(note that I realize `retention.{bytes,ms}` refers to something different than local retention. in this pr we use the normalized version which for cloud storage will be local retention. i believe i've been using this terminology rather loosely).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
