### PR TITLE
[backport v22.3.x] cloud_storage: Adjust conditions to reset stuck reader

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -344,8 +344,8 @@ public:
                     co_return storage_t{std::move(d)};
                 } catch (const stuck_reader_exception& ex) {
                     vlog(
-                      _ctxlog.error,
-                      "stuck reader: {}, {}",
+                      _ctxlog.warn,
+                      "stuck reader: current rp offset: {}, max rp offset: {}",
                       ex.rp_offset,
                       _reader->max_rp_offset());
 
@@ -361,8 +361,19 @@ public:
                     // reads to proceed.
                     if (
                       model::next_offset(ex.rp_offset)
-                        == _next_segment_base_offset
+                        >= _next_segment_base_offset
                       && !_reader->is_eof()) {
+                        vlog(
+                          _ctxlog.info,
+                          "mismatch between current segment end and manifest "
+                          "data: current rp offset {}, manifest max rp offset "
+                          "{}, next segment base offset {}, reader is EOF: {}. "
+                          "set EOF on reader and try to "
+                          "reset",
+                          ex.rp_offset,
+                          _reader->max_rp_offset(),
+                          _next_segment_base_offset,
+                          _reader->is_eof());
                         _reader->set_eof();
                         continue;
                     }

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -787,23 +787,20 @@ FIXTURE_TEST(test_overlapping_segments, cloud_storage_fixture) {
 
     auto segments = make_segments(batch_types, model::offset(0));
     cloud_storage::partition_manifest manifest(manifest_ntp, manifest_revision);
+
     auto expectations = make_imposter_expectations(
       manifest, segments, false, model::offset_delta(0));
 
-    // Remove one data batch from the first segment, which also removes one
-    // record.
-    auto short_batches = batch_types[0];
-    short_batches.pop_back();
-    const auto short_segment = make_segment(model::offset{0}, short_batches);
+    std::stringstream sstr;
+    manifest.serialize(sstr);
 
-    expectations[0].body = short_segment.bytes;
-
+    auto body = sstr.str();
+    std::string_view to_replace = "\"committed_offset\":5";
+    body.replace(
+      body.find(to_replace), to_replace.size(), "\"committed_offset\":6");
+    expectations.back().body = body;
     set_expectations_and_listen(expectations);
-
-    print_segments(segments);
-
-    // Total offsets scanned are one less than what we initially set up
-    BOOST_REQUIRE(check_scan(*this, kafka::offset(0), 8));
+    BOOST_REQUIRE(check_scan(*this, kafka::offset(0), 9));
 }
 
 FIXTURE_TEST(test_scan_by_kafka_offset_truncated, cloud_storage_fixture) {


### PR DESCRIPTION
manual backport of https://github.com/redpanda-data/redpanda/pull/10709
fixes https://github.com/redpanda-data/redpanda/issues/10713
(cherry picked from commit 600f6ee8def3532aa7d2f99daaf57475a6535451)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
