### PR TITLE
tests: fix timeout in test_cloud_size_based_retention

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -400,9 +400,12 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             self.logger.debug(f"Current cloud log size is: {cloud_log_size}")
             return cloud_log_size
 
-        # Wait for everything to be uploaded to the cloud.
+        # Wait for everything to be uploaded to the cloud.  This should take at most
+        # the bandwidth time for the amount of data we produced, plus the segment
+        # upload interval (set to 10s via fast_uploads), plus the manifest upload
+        # interval (set to 1s via fast_uploads).
         wait_until(lambda: cloud_log_size() >= total_bytes,
-                   timeout_sec=10,
+                   timeout_sec=30,
                    backoff_sec=2,
                    err_msg=f"Segments not uploaded")
 


### PR DESCRIPTION
This was previously racing a 10s timeout against a 10s upload interval for the last segment.  It probably usually worked because segment boundaries happened to fall in a place where enough bytes got uploaded anyway, but fails if the segment boundaries mean we really need the last segment to get uploaded.

Fixes https://github.com/redpanda-data/redpanda/issues/9791

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none