### PR TITLE
Hide rpk wasm commands

### DIFF
--- a/src/go/rpk/pkg/cli/wasm/wasm.go
+++ b/src/go/rpk/pkg/cli/wasm/wasm.go
@@ -17,8 +17,9 @@ import (
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "wasm",
-		Short: "Deploy and remove inline WASM engine scripts",
+		Use:    "wasm",
+		Short:  "Deploy and remove inline WASM engine scripts",
+		Hidden: true,
 	}
 	p.InstallKafkaFlags(cmd)
 	cmd.AddCommand(


### PR DESCRIPTION
We've removed the js wasm API from the tree, as well as the sidecar in
the local container, so in the current (and upcoming) release the
existing wasm functionality doesn't work.

Hopefully this will only be hidden for a short time as we revampt this
feature.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
