### PR TITLE
[v22.2.x] cloud_storage_clients/s3: fix shutdown error handling

### DIFF
--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -605,7 +605,9 @@ ss::future<> client::put_object(
                 });
             })
             .handle_exception_type(
-              [](const ss::abort_requested_exception&) { return ss::now(); })
+              [](const ss::abort_requested_exception& err) {
+                  return ss::make_exception_future<>(err);
+              })
             .handle_exception_type([this](const rest_error_response& err) {
                 _probe->register_failure(err.code());
                 return ss::make_exception_future<>(err);


### PR DESCRIPTION
Backport of PR #10107 

We were returning ss::now(), indicating success, when the underlying http client threw an abort_requested exception during a PUT.

If we very unlucky, then:
- A PUT is ongoing during shutdown
- We do early shutdown of cloud_storage_clients in application::shutdown
- The PUT has not yet been acked by the server.
- The PUT appears to succeed to ntp_archiver, and it proceeds to compose an archival_metadata_stm batch and issue a write.
- application::shutdown hasn't yet got far enough to shut down raft, so the stm write is accepted.
- The end state is that archival_metadata_stm thinks a segment has been uploaded, but the segment is not present in the object store.

(cherry picked from commit 12a09cc184e24109d2cf824abb117c07abee151a)

Fixes https://github.com/redpanda-data/redpanda/issues/10730

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none