### PR TITLE
Add initial version of the tx registry service (dynamic txn partitioning)

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -83,6 +83,7 @@ v_cc_library(
     id_allocator.cc
     id_allocator_frontend.cc
     rm_partition_frontend.cc
+    tx_registry_frontend.cc
     tx_gateway_frontend.cc
     tx_gateway.cc
     service.cc

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -19,6 +19,8 @@ class controller_stm;
 class controller_stm_shard;
 class id_allocator_frontend;
 class rm_partition_frontend;
+class tx_registry_frontend;
+class tx_coordinator_mapper;
 class tm_stm_cache;
 class tm_stm_cache_manager;
 class tx_gateway_frontend;

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -172,6 +172,10 @@ ss::future<> health_manager::do_tick() {
         }
 
         if (ok) {
+            ok = co_await ensure_topic_replication(model::tx_registry_nt);
+        }
+
+        if (ok) {
             const model::topic_namespace schema_registry_nt{
               model::kafka_namespace, model::schema_registry_internal_tp.topic};
             ok = co_await ensure_topic_replication(schema_registry_nt);

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -107,4 +107,10 @@ ss::future<abort_group_tx_reply> tx_gateway::abort_group_tx(
     return _rm_group_proxy->abort_group_tx_locally(std::move(request));
 }
 
+ss::future<find_coordinator_reply> tx_gateway::find_coordinator(
+  find_coordinator_request&&, rpc::streaming_context&) {
+    co_return find_coordinator_reply(
+      std::nullopt, tx_errc::unknown_server_error);
+}
+
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -12,6 +12,7 @@
 #include "cluster/logger.h"
 #include "cluster/rm_partition_frontend.h"
 #include "cluster/tx_gateway_frontend.h"
+#include "cluster/tx_registry_frontend.h"
 #include "cluster/types.h"
 #include "model/namespace.h"
 #include "model/record.h"
@@ -27,11 +28,13 @@ tx_gateway::tx_gateway(
   ss::smp_service_group ssg,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
   rm_group_proxy* group_proxy,
-  ss::sharded<cluster::rm_partition_frontend>& rm_partition_frontend)
+  ss::sharded<cluster::rm_partition_frontend>& rm_partition_frontend,
+  ss::sharded<cluster::tx_registry_frontend>& tx_registry_frontend)
   : tx_gateway_service(sg, ssg)
   , _tx_gateway_frontend(tx_gateway_frontend)
   , _rm_group_proxy(group_proxy)
-  , _rm_partition_frontend(rm_partition_frontend) {}
+  , _rm_partition_frontend(rm_partition_frontend)
+  , _tx_registry_frontend(tx_registry_frontend) {}
 
 ss::future<fetch_tx_reply>
 tx_gateway::fetch_tx(fetch_tx_request&& request, rpc::streaming_context&) {
@@ -108,9 +111,8 @@ ss::future<abort_group_tx_reply> tx_gateway::abort_group_tx(
 }
 
 ss::future<find_coordinator_reply> tx_gateway::find_coordinator(
-  find_coordinator_request&&, rpc::streaming_context&) {
-    co_return find_coordinator_reply(
-      std::nullopt, tx_errc::unknown_server_error);
+  find_coordinator_request&& r, rpc::streaming_context&) {
+    return _tx_registry_frontend.local().find_coordinator_locally(r.tid);
 }
 
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.h
+++ b/src/v/cluster/tx_gateway.h
@@ -34,7 +34,8 @@ public:
       ss::smp_service_group,
       ss::sharded<cluster::tx_gateway_frontend>&,
       rm_group_proxy*,
-      ss::sharded<cluster::rm_partition_frontend>&);
+      ss::sharded<cluster::rm_partition_frontend>&,
+      ss::sharded<cluster::tx_registry_frontend>&);
 
     ss::future<init_tm_tx_reply>
     init_tm_tx(init_tm_tx_request&&, rpc::streaming_context&) override;
@@ -76,5 +77,6 @@ private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     rm_group_proxy* _rm_group_proxy;
     ss::sharded<cluster::rm_partition_frontend>& _rm_partition_frontend;
+    ss::sharded<cluster::tx_registry_frontend>& _tx_registry_frontend;
 };
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.h
+++ b/src/v/cluster/tx_gateway.h
@@ -69,6 +69,9 @@ public:
     ss::future<abort_group_tx_reply>
     abort_group_tx(abort_group_tx_request&&, rpc::streaming_context&) override;
 
+    ss::future<find_coordinator_reply> find_coordinator(
+      find_coordinator_request&&, rpc::streaming_context&) override;
+
 private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     rm_group_proxy* _rm_group_proxy;

--- a/src/v/cluster/tx_gateway.json
+++ b/src/v/cluster/tx_gateway.json
@@ -59,6 +59,11 @@
             "name": "fetch_tx",
             "input_type": "fetch_tx_request",
             "output_type": "fetch_tx_reply"
+        },
+        {
+            "name": "find_coordinator",
+            "input_type": "find_coordinator_request",
+            "output_type": "find_coordinator_reply"
         }
     ]
 }

--- a/src/v/cluster/tx_registry_frontend.cc
+++ b/src/v/cluster/tx_registry_frontend.cc
@@ -1,0 +1,284 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/tx_registry_frontend.h"
+
+#include "cluster/controller.h"
+#include "cluster/logger.h"
+#include "cluster/members_table.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
+#include "cluster/topics_frontend.h"
+#include "cluster/tx_coordinator_mapper.h"
+#include "cluster/tx_gateway_service.h"
+#include "cluster/tx_helpers.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "model/namespace.h"
+#include "model/record_batch_reader.h"
+#include "rpc/connection_cache.h"
+#include "vformat.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/do_with.hh>
+#include <seastar/core/sharded.hh>
+
+namespace cluster {
+using namespace std::chrono_literals;
+
+cluster::errc map_errc_fixme(std::error_code ec);
+
+tx_registry_frontend::tx_registry_frontend(
+  ss::smp_service_group ssg,
+  ss::sharded<cluster::partition_manager>& partition_manager,
+  ss::sharded<cluster::shard_table>& shard_table,
+  ss::sharded<cluster::metadata_cache>& metadata_cache,
+  ss::sharded<rpc::connection_cache>& connection_cache,
+  ss::sharded<partition_leaders_table>& leaders,
+  std::unique_ptr<cluster::controller>& controller,
+  ss::sharded<cluster::tx_coordinator_mapper>& tx_coordinator_ntp_mapper,
+  ss::sharded<features::feature_table>& feature_table)
+  : _ssg(ssg)
+  , _partition_manager(partition_manager)
+  , _shard_table(shard_table)
+  , _metadata_cache(metadata_cache)
+  , _connection_cache(connection_cache)
+  , _leaders(leaders)
+  , _controller(controller)
+  , _tx_coordinator_ntp_mapper(tx_coordinator_ntp_mapper)
+  , _feature_table(feature_table)
+  , _metadata_dissemination_retries(
+      config::shard_local_cfg().metadata_dissemination_retries.value())
+  , _metadata_dissemination_retry_delay_ms(
+      config::shard_local_cfg().metadata_dissemination_retry_delay_ms.value()) {
+}
+
+ss::future<find_coordinator_reply> tx_registry_frontend::find_coordinator(
+  kafka::transactional_id tid, model::timeout_clock::duration timeout) {
+    if (!_feature_table.local().is_active(
+          features::feature::transaction_partitioning)) {
+        co_return co_await find_coordinator_statically(tid);
+    }
+
+    auto has_topic = true;
+
+    if (!_metadata_cache.local().contains(
+          model::tx_registry_nt, model::partition_id(0))) {
+        has_topic = co_await try_create_tx_registry_topic();
+    }
+
+    if (!has_topic) {
+        vlog(
+          clusterlog.warn,
+          "can't find {} in the metadata cache",
+          model::tx_registry_nt);
+        co_return find_coordinator_reply(
+          std::nullopt, std::nullopt, errc::topic_not_exists);
+    }
+
+    auto _self = _controller->self();
+
+    auto r = find_coordinator_reply(
+      std::nullopt, std::nullopt, errc::not_leader);
+
+    auto retries = _metadata_dissemination_retries;
+    auto delay_ms = _metadata_dissemination_retry_delay_ms;
+    std::optional<std::string> error;
+    while (!_as.abort_requested() && 0 < retries--) {
+        auto leader_opt = _leaders.local().get_leader(model::tx_registry_ntp);
+        if (unlikely(!leader_opt)) {
+            error = vformat(
+              fmt::runtime("can't find {} in the leaders cache"),
+              model::tx_registry_ntp);
+            vlog(
+              clusterlog.trace,
+              "waiting for {} to fill leaders cache, retries left: {}",
+              model::tx_registry_ntp,
+              retries);
+            co_await sleep_abortable(delay_ms, _as);
+            continue;
+        }
+        auto leader = leader_opt.value();
+
+        if (leader == _self) {
+            r = co_await find_coordinator_locally(tid);
+        } else {
+            vlog(
+              clusterlog.trace,
+              "dispatching find_coordinator({}) from {} to {} ",
+              tid,
+              _self,
+              leader);
+            r = co_await dispatch_find_coordinator(leader, tid, timeout);
+        }
+
+        if (likely(r.ec == errc::success)) {
+            error = std::nullopt;
+            break;
+        }
+
+        if (likely(r.ec != errc::replication_error)) {
+            error = vformat(
+              fmt::runtime("find_coordinator({}) failed with {}"), tid, r.ec);
+            break;
+        }
+
+        error = vformat(
+          fmt::runtime("find_coordinator({}) failed with {}"), tid, r.ec);
+        vlog(
+          clusterlog.trace,
+          "find_coordinator({}) failed, retries left: {}",
+          tid,
+          retries);
+        co_await sleep_abortable(delay_ms, _as);
+    }
+
+    if (error) {
+        vlog(clusterlog.warn, "{}", error.value());
+    }
+
+    co_return r;
+}
+
+ss::future<find_coordinator_reply>
+tx_registry_frontend::dispatch_find_coordinator(
+  model::node_id leader,
+  kafka::transactional_id tid,
+  model::timeout_clock::duration timeout) {
+    return _connection_cache.local()
+      .with_node_client<cluster::tx_gateway_client_protocol>(
+        _controller->self(),
+        ss::this_shard_id(),
+        leader,
+        timeout,
+        [timeout, tid](tx_gateway_client_protocol cp) {
+            return cp.find_coordinator(
+              find_coordinator_request(tid),
+              rpc::client_opts(model::timeout_clock::now() + timeout));
+        })
+      .then(&rpc::get_ctx_data<find_coordinator_reply>)
+      .then([](result<find_coordinator_reply> r) {
+          if (r.has_error()) {
+              vlog(
+                clusterlog.warn,
+                "got error {} on remote find_coordinator",
+                r.error().message());
+
+              return find_coordinator_reply(
+                std::nullopt, std::nullopt, errc::timeout);
+          }
+          return r.value();
+      });
+}
+
+ss::future<find_coordinator_reply>
+tx_registry_frontend::find_coordinator_locally(kafka::transactional_id tid) {
+    auto shard = _shard_table.local().shard_for(model::tx_registry_ntp);
+
+    if (unlikely(!shard)) {
+        auto retries = _metadata_dissemination_retries;
+        auto delay_ms = _metadata_dissemination_retry_delay_ms;
+        auto aborted = false;
+        while (!aborted && !shard && 0 < retries--) {
+            aborted = !co_await sleep_abortable(delay_ms, _as);
+            shard = _shard_table.local().shard_for(model::tx_registry_ntp);
+        }
+
+        if (!shard) {
+            vlog(
+              clusterlog.warn,
+              "can't find {} in the shard table",
+              model::tx_registry_ntp);
+            co_return find_coordinator_reply(
+              std::nullopt, std::nullopt, errc::not_leader);
+        }
+    }
+
+    co_return co_await _partition_manager.invoke_on(
+      *shard, _ssg, [this, tid](cluster::partition_manager& mgr) mutable {
+          auto partition = mgr.get(model::tx_registry_ntp);
+          if (!partition) {
+              vlog(
+                clusterlog.warn,
+                "can't get partition by {} ntp",
+                model::tx_registry_ntp);
+              return ss::make_ready_future<find_coordinator_reply>(
+                find_coordinator_reply(
+                  std::nullopt, std::nullopt, errc::topic_not_exists));
+          }
+          return do_find_coordinator_locally(tid);
+      });
+}
+
+ss::future<find_coordinator_reply>
+tx_registry_frontend::do_find_coordinator_locally(kafka::transactional_id tid) {
+    return find_coordinator_statically(tid);
+}
+
+ss::future<find_coordinator_reply>
+tx_registry_frontend::find_coordinator_statically(kafka::transactional_id tid) {
+    std::optional<model::node_id> leader = std::nullopt;
+
+    auto ntp = co_await _tx_coordinator_ntp_mapper.local().ntp_for(tid);
+    if (ntp) {
+        leader = _metadata_cache.local().get_leader_id(ntp.value());
+    } else {
+        vlog(
+          txlog.warn,
+          "Topic {} doesn't exist in metadata cache",
+          model::tx_manager_nt);
+    }
+
+    co_return find_coordinator_reply(leader, ntp, errc::success);
+}
+
+ss::future<bool> tx_registry_frontend::try_create_tx_registry_topic() {
+    cluster::topic_configuration topic{
+      model::kafka_internal_namespace,
+      model::tx_registry_topic,
+      1,
+      _controller->internal_topic_replication()};
+
+    topic.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::none;
+
+    return _controller->get_topics_frontend()
+      .local()
+      .autocreate_topics(
+        {std::move(topic)}, config::shard_local_cfg().create_topic_timeout_ms())
+      .then([](std::vector<cluster::topic_result> res) {
+          vassert(res.size() == 1, "expected exactly one result");
+          if (res[0].ec == cluster::errc::topic_already_exists) {
+              return true;
+          }
+          if (res[0].ec != cluster::errc::success) {
+              vlog(
+                clusterlog.warn,
+                "can not create {}/{} topic - error: {}",
+                model::kafka_internal_namespace,
+                model::tx_registry_topic,
+                cluster::make_error_code(res[0].ec).message());
+              return false;
+          }
+          return true;
+      })
+      .handle_exception([](std::exception_ptr e) {
+          vlog(
+            clusterlog.warn,
+            "can not create {}/{} topic - error: {}",
+            model::kafka_internal_namespace,
+            model::tx_registry_topic,
+            e);
+          return false;
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -70,5 +70,6 @@ private:
       find_coordinator_statically(kafka::transactional_id);
 
     ss::future<bool> try_create_tx_registry_topic();
+    ss::future<bool> try_create_tx_topic();
 };
 } // namespace cluster

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/fwd.h"
+#include "cluster/types.h"
+#include "features/feature_table.h"
+#include "rpc/fwd.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/sharded.hh>
+
+#include <vector>
+
+namespace cluster {
+
+class tx_registry_frontend {
+public:
+    tx_registry_frontend(
+      ss::smp_service_group,
+      ss::sharded<cluster::partition_manager>&,
+      ss::sharded<cluster::shard_table>&,
+      ss::sharded<cluster::metadata_cache>&,
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<partition_leaders_table>&,
+      std::unique_ptr<cluster::controller>&,
+      ss::sharded<cluster::tx_coordinator_mapper>&,
+      ss::sharded<features::feature_table>&);
+
+    ss::future<find_coordinator_reply>
+      find_coordinator(kafka::transactional_id, model::timeout_clock::duration);
+
+    ss::future<find_coordinator_reply>
+      find_coordinator_locally(kafka::transactional_id);
+
+    ss::future<> stop() {
+        _as.request_abort();
+        return ss::make_ready_future<>();
+    }
+
+private:
+    ss::abort_source _as;
+    ss::smp_service_group _ssg;
+    ss::sharded<cluster::partition_manager>& _partition_manager;
+    ss::sharded<cluster::shard_table>& _shard_table;
+    ss::sharded<cluster::metadata_cache>& _metadata_cache;
+    ss::sharded<rpc::connection_cache>& _connection_cache;
+    ss::sharded<partition_leaders_table>& _leaders;
+    std::unique_ptr<cluster::controller>& _controller;
+    ss::sharded<cluster::tx_coordinator_mapper>& _tx_coordinator_ntp_mapper;
+    ss::sharded<features::feature_table>& _feature_table;
+    int16_t _metadata_dissemination_retries{1};
+    std::chrono::milliseconds _metadata_dissemination_retry_delay_ms;
+
+    ss::future<find_coordinator_reply> dispatch_find_coordinator(
+      model::node_id, kafka::transactional_id, model::timeout_clock::duration);
+
+    ss::future<find_coordinator_reply>
+      do_find_coordinator_locally(kafka::transactional_id);
+
+    ss::future<find_coordinator_reply>
+      find_coordinator_statically(kafka::transactional_id);
+
+    ss::future<bool> try_create_tx_registry_topic();
+};
+} // namespace cluster

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -972,6 +972,17 @@ std::ostream& operator<<(std::ostream& o, const abort_group_tx_reply& r) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const find_coordinator_request& r) {
+    fmt::print(o, "{{tid {}}}", r.tid);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const find_coordinator_reply& r) {
+    fmt::print(
+      o, "{{coordinator {} ntp {} ec {}}}", r.coordinator, r.ntp, r.ec);
+    return o;
+}
+
 std::ostream&
 operator<<(std::ostream& o, const configuration_update_request& cr) {
     fmt::print(o, "{{broker: {} target_node: {}}}", cr.node, cr.target_node);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -992,6 +992,8 @@ struct find_coordinator_request
       find_coordinator_request,
       serde::version<0>,
       serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
     kafka::transactional_id tid;
 
     find_coordinator_request() noexcept = default;
@@ -1014,6 +1016,8 @@ struct find_coordinator_reply
       find_coordinator_reply,
       serde::version<0>,
       serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
     std::optional<model::node_id> coordinator{std::nullopt};
     std::optional<model::ntp> ntp{std::nullopt};
     errc ec{errc::generic_tx_error};

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -987,6 +987,57 @@ struct abort_group_tx_reply
     auto serde_fields() { return std::tie(ec); }
 };
 
+struct find_coordinator_request
+  : serde::envelope<
+      find_coordinator_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    kafka::transactional_id tid;
+
+    find_coordinator_request() noexcept = default;
+
+    find_coordinator_request(kafka::transactional_id tid)
+      : tid(std::move(tid)) {}
+
+    friend bool
+    operator==(const find_coordinator_request&, const find_coordinator_request&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const find_coordinator_request& r);
+
+    auto serde_fields() { return std::tie(tid); }
+};
+
+struct find_coordinator_reply
+  : serde::envelope<
+      find_coordinator_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    std::optional<model::node_id> coordinator{std::nullopt};
+    std::optional<model::ntp> ntp{std::nullopt};
+    errc ec{errc::generic_tx_error};
+
+    find_coordinator_reply() noexcept = default;
+
+    find_coordinator_reply(
+      std::optional<model::node_id> coordinator,
+      std::optional<model::ntp> ntp,
+      errc ec)
+      : coordinator(coordinator)
+      , ntp(ntp)
+      , ec(ec) {}
+
+    friend bool
+    operator==(const find_coordinator_reply&, const find_coordinator_reply&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const find_coordinator_reply& r);
+
+    auto serde_fields() { return std::tie(coordinator, ntp, ec); }
+};
+
 /// Old-style request sent by node to join raft-0
 /// - Does not specify logical version
 /// - Always specifies node_id

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -626,7 +626,7 @@ configuration::configuration()
       "transaction_coordinator_partitions",
       "Amount of partitions for transactions coordinator",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      16)
+      50)
   , transaction_coordinator_cleanup_policy(
       *this,
       "transaction_coordinator_cleanup_policy",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -453,6 +453,12 @@ configuration::configuration()
       "Time to wait state catch up before rejecting a request",
       {.visibility = visibility::user},
       10s)
+  , find_coordinator_timeout_ms(
+      *this,
+      "find_coordinator_timeout_ms",
+      "Time to wait for a response from tx_registry",
+      {.visibility = visibility::user},
+      2000ms)
   , seq_table_min_size(
       *this,
       "seq_table_min_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -112,6 +112,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> tm_sync_timeout_ms;
     deprecated_property tm_violation_recovery_policy;
     property<std::chrono::milliseconds> rm_sync_timeout_ms;
+    property<std::chrono::milliseconds> find_coordinator_timeout_ms;
     property<uint32_t> seq_table_min_size;
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
     deprecated_property rm_violation_recovery_policy;

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/topics_frontend.h"
 #include "cluster/tx_gateway_frontend.h"
+#include "cluster/tx_registry_frontend.h"
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
@@ -92,10 +93,13 @@ ss::future<response_ptr> find_coordinator_handler::handle(
           std::move(ctx),
           [request = std::move(request),
            tx_id = std::move(tx_id)](request_context& ctx) mutable {
-              return ctx.tx_gateway_frontend().find_coordinator(tx_id).then(
-                [&ctx](std::optional<model::node_id> leader) {
-                    if (leader) {
-                        return handle_leader(ctx, *leader);
+              return ctx.tx_registry_frontend()
+                .find_coordinator(
+                  tx_id,
+                  config::shard_local_cfg().find_coordinator_timeout_ms())
+                .then([&ctx](cluster::find_coordinator_reply r) {
+                    if (r.coordinator) {
+                        return handle_leader(ctx, *r.coordinator);
                     }
                     return ctx.respond(find_coordinator_response(
                       error_code::coordinator_not_available));

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -208,6 +208,10 @@ public:
         return _conn->server().coordinator_mapper();
     }
 
+    cluster::tx_registry_frontend& tx_registry_frontend() {
+        return _conn->server().tx_registry_frontend();
+    }
+
     const ss::sstring& listener() const { return _conn->listener(); }
     std::optional<security::sasl_server>& sasl() { return _conn->sasl(); }
     security::credential_store& credentials() {

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -98,6 +98,7 @@ server::server(
   ss::sharded<cluster::security_frontend>& sec_fe,
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
+  ss::sharded<cluster::tx_registry_frontend>& tx_registry_frontend,
   std::optional<qdc_monitor::config> qdc_config,
   ssx::thread_worker& tw) noexcept
   : net::server(cfg, klog)
@@ -125,6 +126,7 @@ server::server(
   , _security_frontend(sec_fe)
   , _controller_api(controller_api)
   , _tx_gateway_frontend(tx_gateway_frontend)
+  , _tx_registry_frontend(tx_registry_frontend)
   , _mtls_principal_mapper(
       config::shard_local_cfg().kafka_mtls_principal_mapping_rules.bind())
   , _gssapi_principal_mapper(

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -57,6 +57,7 @@ public:
       ss::sharded<cluster::security_frontend>&,
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
+      ss::sharded<cluster::tx_registry_frontend>&,
       std::optional<qdc_monitor::config>,
       ssx::thread_worker&) noexcept;
 
@@ -99,6 +100,9 @@ public:
     }
     cluster::tx_gateway_frontend& tx_gateway_frontend() {
         return _tx_gateway_frontend.local();
+    }
+    cluster::tx_registry_frontend& tx_registry_frontend() {
+        return _tx_registry_frontend.local();
     }
     kafka::group_router& group_router() { return _group_router.local(); }
     cluster::shard_table& shard_table() { return _shard_table.local(); }
@@ -191,6 +195,7 @@ private:
     ss::sharded<cluster::security_frontend>& _security_frontend;
     ss::sharded<cluster::controller_api>& _controller_api;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
+    ss::sharded<cluster::tx_registry_frontend>& _tx_registry_frontend;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;
     security::tls::principal_mapper _mtls_principal_mapper;

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -65,6 +65,14 @@ inline const model::ntp id_allocator_ntp(
   model::id_allocator_topic,
   model::partition_id(0));
 
+inline const model::topic tx_registry_topic("tx_registry");
+inline const model::topic_namespace
+  tx_registry_nt(model::kafka_internal_namespace, tx_registry_topic);
+inline const model::ntp tx_registry_ntp(
+  model::kafka_internal_namespace,
+  model::tx_registry_topic,
+  model::partition_id(0));
+
 inline const model::topic_partition schema_registry_internal_tp{
   model::topic{"_schemas"}, model::partition_id{0}};
 

--- a/src/v/redpanda/admin/api-doc/transaction.json
+++ b/src/v/redpanda/admin/api-doc/transaction.json
@@ -26,6 +26,28 @@
             ]
         },
         {
+            "path": "/v1/transaction/{transactional_id}/find_coordinator",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get tx coordinator by tx.id",
+                    "type": "find_coordinator_reply",
+                    "nickname": "find_coordinator",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "transactional_id",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "/v1/transaction/{transactional_id}/delete_partition",
             "operations": [
                 {
@@ -73,6 +95,42 @@
         }
     ],
     "models": {
+        "ntp": {
+            "id": "ntp",
+            "description": "NTP",
+            "properties": {
+                "ns": {
+                    "type": "string",
+                    "description": "Namespace"
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "Topic"
+                },
+                "partition": {
+                    "type": "long",
+                    "description": "Partition id"
+                }
+            }
+        },
+        "find_coordinator_reply": {
+            "id": "find_coordinator_reply",
+            "description": "find_coordinator_reply",
+            "properties": {
+                "coordinator": {
+                    "type": "long",
+                    "description": "node id"
+                },
+                "ntp": {
+                    "type": "ntp",
+                    "description": "NTP"
+                },
+                "ec": {
+                    "type": "long",
+                    "description": "errc"
+                }
+            }
+        },
         "producer_identity": {
             "id": "producer_identity",
             "description": "Producer identity",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -41,6 +41,7 @@
 #include "cluster/topic_recovery_status_rpc_handler.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/tx_gateway_frontend.h"
+#include "cluster/tx_registry_frontend.h"
 #include "cluster/types.h"
 #include "cluster_config_schema_util.h"
 #include "config/configuration.h"
@@ -201,7 +202,8 @@ admin_server::admin_server(
   pandaproxy::schema_registry::api* schema_registry,
   ss::sharded<cloud_storage::topic_recovery_service>& topic_recovery_svc,
   ss::sharded<cluster::topic_recovery_status_frontend>&
-    topic_recovery_status_frontend)
+    topic_recovery_status_frontend,
+  ss::sharded<cluster::tx_registry_frontend>& tx_registry_frontend)
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
@@ -222,6 +224,7 @@ admin_server::admin_server(
   , _schema_registry(schema_registry)
   , _topic_recovery_service(topic_recovery_svc)
   , _topic_recovery_status_frontend(topic_recovery_status_frontend)
+  , _tx_registry_frontend(tx_registry_frontend)
   , _default_blocked_reactor_notify(
       ss::engine().get_blocked_reactor_notify_ms()) {}
 
@@ -3458,15 +3461,17 @@ admin_server::delete_partition_handler(std::unique_ptr<ss::http::request> req) {
     }
     auto transaction_id = req->param["transactional_id"];
     kafka::transactional_id tid(transaction_id);
-    auto tx_ntp = co_await tx_frontend.local().get_static_ntp(tid);
-    if (!tx_ntp) {
+
+    auto r = co_await _tx_registry_frontend.local().find_coordinator(
+      tid, config::shard_local_cfg().find_coordinator_timeout_ms());
+    if (!r.ntp) {
         throw ss::httpd::bad_request_exception("Coordinator not available");
     }
-    if (need_redirect_to_leader(*tx_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, *tx_ntp);
+    if (need_redirect_to_leader(*r.ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, *r.ntp);
     }
 
-    tx_ntp = co_await tx_frontend.local().get_ntp(tid);
+    auto tx_ntp = co_await tx_frontend.local().get_ntp(tid);
     if (!tx_ntp) {
         throw ss::httpd::bad_request_exception("Coordinator not available");
     }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3454,6 +3454,30 @@ admin_server::get_all_transactions_handler(
 }
 
 ss::future<ss::json::json_return_type>
+admin_server::find_tx_coordinator_handler(
+  std::unique_ptr<ss::http::request> req) {
+    auto transaction_id = req->param["transactional_id"];
+    kafka::transactional_id tid(transaction_id);
+    auto r = co_await _tx_registry_frontend.local().find_coordinator(
+      tid, config::shard_local_cfg().find_coordinator_timeout_ms());
+
+    ss::httpd::transaction_json::find_coordinator_reply reply;
+    if (r.coordinator) {
+        reply.coordinator = r.coordinator.value()();
+    }
+    if (r.ntp) {
+        ss::httpd::transaction_json::ntp ntp;
+        ntp.ns = r.ntp->ns();
+        ntp.topic = r.ntp->tp.topic();
+        ntp.partition = r.ntp->tp.partition();
+        reply.ntp = ntp;
+    }
+    reply.ec = static_cast<int>(r.ec);
+
+    co_return ss::json::json_return_type(std::move(reply));
+}
+
+ss::future<ss::json::json_return_type>
 admin_server::delete_partition_handler(std::unique_ptr<ss::http::request> req) {
     auto& tx_frontend = _partition_manager.local().get_tx_frontend();
     if (!tx_frontend.local_is_initialized()) {
@@ -3518,6 +3542,12 @@ void admin_server::register_transaction_routes() {
       ss::httpd::transaction_json::delete_partition,
       [this](std::unique_ptr<ss::http::request> req) {
           return delete_partition_handler(std::move(req));
+      });
+
+    register_route<user>(
+      ss::httpd::transaction_json::find_coordinator,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return find_tx_coordinator_handler(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -71,7 +71,8 @@ public:
       pandaproxy::rest::api*,
       pandaproxy::schema_registry::api*,
       ss::sharded<cloud_storage::topic_recovery_service>&,
-      ss::sharded<cluster::topic_recovery_status_frontend>&);
+      ss::sharded<cluster::topic_recovery_status_frontend>&,
+      ss::sharded<cluster::tx_registry_frontend>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -495,6 +496,7 @@ private:
     ss::sharded<cloud_storage::topic_recovery_service>& _topic_recovery_service;
     ss::sharded<cluster::topic_recovery_status_frontend>&
       _topic_recovery_status_frontend;
+    ss::sharded<cluster::tx_registry_frontend>& _tx_registry_frontend;
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;
     ss::timer<> _blocked_reactor_notify_reset_timer;

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -407,6 +407,8 @@ private:
       get_all_transactions_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       delete_partition_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      find_tx_coordinator_handler(std::unique_ptr<ss::http::request>);
 
     /// Cluster routes
     ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -849,7 +849,8 @@ void application::configure_admin_server() {
       _proxy.get(),
       _schema_registry.get(),
       std::ref(topic_recovery_service),
-      std::ref(topic_recovery_status_frontend))
+      std::ref(topic_recovery_status_frontend),
+      std::ref(tx_registry_frontend))
       .get();
 }
 
@@ -1477,8 +1478,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       _rm_group_proxy.get(),
       std::ref(rm_partition_frontend),
       std::ref(feature_table),
-      std::ref(tm_stm_cache_manager),
-      std::ref(tx_coordinator_ntp_mapper))
+      std::ref(tm_stm_cache_manager))
       .get();
     _kafka_conn_quotas
       .start([]() {
@@ -1618,6 +1618,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         std::ref(controller->get_security_frontend()),
         std::ref(controller->get_api()),
         std::ref(tx_gateway_frontend),
+        std::ref(tx_registry_frontend),
         qdc_config,
         std::ref(*thread_worker))
       .get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -49,6 +49,7 @@
 #include "cluster/topics_frontend.h"
 #include "cluster/tx_gateway.h"
 #include "cluster/tx_gateway_frontend.h"
+#include "cluster/tx_registry_frontend.h"
 #include "cluster/types.h"
 #include "compression/async_stream_zstd.h"
 #include "compression/stream_zstd.h"
@@ -1391,6 +1392,11 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         coprocessing->start().get();
     }
 
+    syschecks::systemd_message("Creating tx coordinator mapper").get();
+    construct_service(
+      tx_coordinator_ntp_mapper, std::ref(metadata_cache), model::tx_manager_nt)
+      .get();
+
     syschecks::systemd_message("Creating id allocator frontend").get();
     construct_service(
       id_allocator_frontend,
@@ -1401,6 +1407,20 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(_connection_cache),
       std::ref(controller->get_partition_leaders()),
       std::ref(controller))
+      .get();
+
+    syschecks::systemd_message("Creating tx registry frontend").get();
+    construct_service(
+      tx_registry_frontend,
+      smp_service_groups.raft_smp_sg(),
+      std::ref(partition_manager),
+      std::ref(shard_table),
+      std::ref(metadata_cache),
+      std::ref(_connection_cache),
+      std::ref(controller->get_partition_leaders()),
+      std::ref(controller),
+      std::ref(tx_coordinator_ntp_mapper),
+      std::ref(feature_table))
       .get();
 
     syschecks::systemd_message("Creating group resource manager frontend")
@@ -1435,11 +1455,6 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       usage_manager,
       std::ref(controller->get_health_monitor()),
       std::ref(storage))
-      .get();
-
-    syschecks::systemd_message("Creating tx coordinator mapper").get();
-    construct_service(
-      tx_coordinator_ntp_mapper, std::ref(metadata_cache), model::tx_manager_nt)
       .get();
 
     syschecks::systemd_message("Creating tx coordinator frontend").get();
@@ -2050,7 +2065,8 @@ void application::start_runtime_services(
             smp_service_groups.raft_smp_sg(),
             std::ref(tx_gateway_frontend),
             _rm_group_proxy.get(),
-            std::ref(rm_partition_frontend)));
+            std::ref(rm_partition_frontend),
+            std::ref(tx_registry_frontend)));
 
           if (!start_raft_rpc_early) {
               runtime_services.push_back(std::make_unique<raft::service<

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -105,7 +105,9 @@ public:
       topic_recovery_status_frontend;
     ss::sharded<cloud_storage::topic_recovery_service> topic_recovery_service;
 
+    ss::sharded<cluster::tx_coordinator_mapper> tx_coordinator_ntp_mapper;
     ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
+    ss::sharded<cluster::tx_registry_frontend> tx_registry_frontend;
     ss::sharded<cluster::metadata_cache> metadata_cache;
     ss::sharded<cluster::metadata_dissemination_service>
       md_dissemination_service;
@@ -116,7 +118,6 @@ public:
     ss::sharded<cluster::self_test_backend> self_test_backend;
     ss::sharded<cluster::self_test_frontend> self_test_frontend;
     ss::sharded<cluster::shard_table> shard_table;
-    ss::sharded<cluster::tx_coordinator_mapper> tx_coordinator_ntp_mapper;
     ss::sharded<cluster::tm_stm_cache_manager> tm_stm_cache_manager;
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -138,6 +138,7 @@ public:
           app.controller->get_security_frontend(),
           app.controller->get_api(),
           app.tx_gateway_frontend,
+          app.tx_registry_frontend,
           std::nullopt,
           *app.thread_worker);
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -632,6 +632,13 @@ class Admin:
         path = f"transaction/{tid}/delete_partition/?{params}"
         return self._request('post', path, node=node)
 
+    def find_tx_coordinator(self, tid, node=None):
+        """
+        Find tx coordinator by tx.id
+        """
+        path = f"transaction/{tid}/find_coordinator"
+        return self._request('get', path, node=node)
+
     def set_partition_replicas(self,
                                topic,
                                partition,

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -1011,7 +1011,8 @@ class UpgradeTransactionManagerMultiPartition(RedpandaTest):
             "Incompatible downgrade detected", "unknown fence record version",
             "unsupported tx_snapshot_header version",
             "unsupported seq_snapshot_header version",
-            "assert - Backtrace below:"
+            "assert - Backtrace below:",
+            "Version 5 is not supported. We only support versions up to 4"
         ])
     def fail_to_downgrade_full_cluster_test(self):
         unique_versions = wait_for_num_versions(self.redpanda, 1)


### PR DESCRIPTION
This PR introduces tx registry service which will be responsible for managing the mapping between the tx.id space and tx coordinator's partitions and for moving tx.id and ranges of tx.id between partitions

So far the service supports only find_coordinator rpc which is backed by static partitioning.

Fixes #9886

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none