### PR TITLE
Node-wide throughput exemptions for clients

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -1242,8 +1242,7 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
                       return cloud_roles::aws_region_name{};
                   } else {
                       static_assert(
-                        cloud_storage_clients::always_false_v<cfg_type>,
-                        "Unknown client type");
+                        always_false_v<cfg_type>, "Unknown client type");
                       return cloud_roles::aws_region_name{};
                   }
               },
@@ -1293,9 +1292,7 @@ cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
               return cloud_roles::abs_credentials{
                 cfg.storage_account_name, cfg.shared_key.value()};
           } else {
-              static_assert(
-                cloud_storage_clients::always_false_v<cfg_type>,
-                "Unknown client type");
+              static_assert(always_false_v<cfg_type>, "Unknown client type");
               return cloud_roles::aws_credentials{};
           }
       },

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -97,9 +97,6 @@ using client_configuration_variant = std::variant<Ts...>;
 using client_configuration
   = client_configuration_variant<abs_configuration, s3_configuration>;
 
-template<typename>
-inline constexpr bool always_false_v = false;
-
 model::cloud_storage_backend infer_backend_from_configuration(
   const client_configuration& client_config,
   model::cloud_credentials_source cloud_storage_credentials_source);

--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     base_property.cc
     rjson_serialization.cc
     validators.cc
+    throughput_control_group.cc
   DEPS
     v::json
     v::model

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2038,9 +2038,27 @@ configuration::configuration()
       *this,
       "kafka_throughput_controlled_api_keys",
       "List of Kafka API keys that are subject to cluster-wide "
-      "and node-wide thoughput limit control",
+      "and node-wide throughput limit control",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {"produce", "fetch"})
+  , kafka_throughput_control(
+      *this,
+      "kafka_throughput_control",
+      "List of throughput control groups that define exclusions from node-wide "
+      "throughput limits. Each group consists of: (\"name\" (optional) - any "
+      "unique group name, \"client_id\" - regex to match client_id). "
+      "A connection is assigned the first matching group, then the connection "
+      "is excluded from throughput control.",
+      {
+        .needs_restart = needs_restart::no,
+        .example
+        = R"([{'name': 'first_group','client_id': 'client1'}, {'client_id': 'consumer-\d+'}, {'name': 'catch all'}])",
+        .visibility = visibility::user,
+      },
+      {},
+      [](auto& v) {
+          return validate_throughput_control_groups(v.cbegin(), v.cend());
+      })
   , node_isolation_heartbeat_timeout(
       *this,
       "node_isolation_heartbeat_timeout",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -18,6 +18,7 @@
 #include "config/data_directory_path.h"
 #include "config/endpoint_tls_config.h"
 #include "config/property.h"
+#include "config/throughput_control_group.h"
 #include "config/tls_config.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
@@ -409,6 +410,7 @@ struct configuration final : public config_store {
     property<double> kafka_quota_balancer_min_shard_throughput_ratio;
     bounded_property<int64_t> kafka_quota_balancer_min_shard_throughput_bps;
     property<std::vector<ss::sstring>> kafka_throughput_controlled_api_keys;
+    property<std::vector<throughput_control_group>> kafka_throughput_control;
 
     bounded_property<int64_t> node_isolation_heartbeat_timeout;
 

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -8,7 +8,8 @@ set(srcs
     advertised_kafka_api_test.cc
     seed_server_property_test.cc
     cloud_credentials_source_test.cc
-    validator_tests.cc)
+    validator_tests.cc
+    throughput_control_group_test.cc)
 
 rp_test(
   UNIT_TEST

--- a/src/v/config/tests/throughput_control_group_test.cc
+++ b/src/v/config/tests/throughput_control_group_test.cc
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "config/config_store.h"
+#include "config/property.h"
+#include "config/throughput_control_group.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/interface.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <yaml-cpp/emitterstyle.h>
+#include <yaml-cpp/exceptions.h>
+
+#include <algorithm>
+#include <exception>
+#include <locale>
+#include <vector>
+
+using namespace std::string_literals;
+
+SEASTAR_THREAD_TEST_CASE(throughput_control_group_test) {
+    std::vector<config::throughput_control_group> tcgv;
+    tcgv.emplace_back();
+
+    struct test_config : public config::config_store {
+        config::property<std::vector<config::throughput_control_group>> cgroups;
+        test_config()
+          : cgroups(*this, "cgroups", "") {}
+    };
+
+    auto cfg_node = YAML::Load(R"(
+cgroups:
+    - name: ""
+      client_id: client_id-1
+    - client_id: cli.+_id-\d+
+    - client_id: another unnamed group indended to verify this passes validation
+    - name: match-nothing-group
+      client_id: ""
+    - name: cgroup-catchall because no clientid group given
+)");
+    cfg_node.SetStyle(YAML::EmitterStyle::Flow);
+
+    test_config cfg;
+    BOOST_TEST(cfg.read_yaml(cfg_node).empty());
+    BOOST_TEST(
+      YAML::Dump(config::to_yaml(cfg, config::redact_secrets{false}))
+      == YAML::Dump(cfg_node));
+    BOOST_TEST(cfg.cgroups().size() == 5);
+    for (auto& cg : cfg.cgroups()) {
+        BOOST_TEST(!cg.throughput_limit_node_in_bps);
+        BOOST_TEST(!cg.throughput_limit_node_out_bps);
+        BOOST_TEST(cg.validate().empty());
+    }
+    BOOST_TEST(cfg.cgroups()[0].name == "");
+    BOOST_TEST(!cfg.cgroups()[0].is_noname());
+    BOOST_TEST(cfg.cgroups()[1].name != "");
+    BOOST_TEST(cfg.cgroups()[1].is_noname());
+    BOOST_TEST(cfg.cgroups()[3].name == "match-nothing-group");
+    BOOST_TEST(
+      (config::find_throughput_control_group(
+         cfg.cgroups().cbegin(), cfg.cgroups().cend(), "client_id-1")
+       == cfg.cgroups().cbegin()));
+    BOOST_TEST(
+      (config::find_throughput_control_group(
+         cfg.cgroups().cbegin(), cfg.cgroups().cend(), "clinet_id-2")
+       == cfg.cgroups().cbegin() + 1));
+    BOOST_TEST(
+      (config::find_throughput_control_group(
+         cfg.cgroups().cbegin(), cfg.cgroups().cend(), "nonclient_id")
+       == cfg.cgroups().cbegin() + 4));
+    BOOST_TEST(!validate_throughput_control_groups(
+      cfg.cgroups().cbegin(), cfg.cgroups().cend()));
+
+    // Failure cases
+
+    // Control characters in names. In YAML, control characters [are not
+    // allowed](https://yaml.org/spec/1.2.2/#51-character-set) in the stream and
+    // should be [escaped](https://yaml.org/spec/1.2.2/#57-escaped-characters).
+    // Yaml-cpp does not recognize escape sequences. It fails with
+    // YAML::ParseException on some control characters (like \0), but lets
+    // others through (like \b). throughput_control_group parser should not
+    // let any through though.
+    BOOST_CHECK_THROW(
+      cfg.read_yaml(YAML::Load("cgroups: [{name: n\0, client_id: c1}]"s)),
+      YAML::Exception);
+    BOOST_TEST(
+      !cfg.read_yaml(YAML::Load("cgroups: [{name: n1, client_id: c-1-\b-2}]"s))
+         .empty());
+
+    // Invalid regex syntax
+    BOOST_TEST(
+      !cfg.read_yaml(YAML::Load(R"(cgroups: [{name: n, client_id: "[A-Z}"}])"s))
+         .empty());
+    BOOST_TEST(
+      !cfg.read_yaml(YAML::Load(R"(cgroups: [{name: n, client_id: "*"}])"s))
+         .empty());
+
+    // Specify any throupghput limit
+    BOOST_TEST(
+      !cfg
+         .read_yaml(YAML::Load(
+           R"(cgroups: [{name: n, client_id: c, throughput_limit_node_in_bps: 0}])"s))
+         .empty());
+    BOOST_TEST(
+      !cfg
+         .read_yaml(YAML::Load(
+           R"(cgroups: [{name: n, client_id: c, throughput_limit_node_out_bps: 100}])"s))
+         .empty());
+
+    // Duplicate group names other than unnamed
+    BOOST_TEST(cfg
+                 .read_yaml(YAML::Load(
+                   R"(cgroups: [{name: developers}, {name: developers}])"s))
+                 .empty());
+    BOOST_TEST(
+      validate_throughput_control_groups(
+        cfg.cgroups().cbegin(), cfg.cgroups().cend())
+        .value_or("")
+        .find("uplicate")
+      != ss::sstring::npos);
+}

--- a/src/v/config/throughput_control_group.cc
+++ b/src/v/config/throughput_control_group.cc
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "throughput_control_group.h"
+
+#include "config/convert.h"
+#include "ssx/sformat.h"
+#include "utils/to_string.h"
+#include "utils/utf8.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <fmt/core.h>
+#include <re2/re2.h>
+#include <re2/stringpiece.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <string>
+
+using namespace std::string_literals;
+
+namespace {
+
+template<typename T>
+requires std::same_as<T, ss::sstring> || std::same_as<T, std::string>
+bool contains_control_characters(const T& s) {
+    const auto& ctype = std::use_facet<std::ctype<char>>(
+      std::locale::classic());
+    const char* const end = s.c_str() + s.length();
+    return ctype.scan_is(std::ctype_base::cntrl, s.c_str(), end) != end;
+}
+
+} // namespace
+
+namespace config {
+
+namespace ids {
+constexpr const char* name = "name";
+constexpr const char* client_id = "client_id";
+constexpr const char* tp_limit_node_in = "throughput_limit_node_in_bps";
+constexpr const char* tp_limit_node_out = "throughput_limit_node_out_bps";
+} // namespace ids
+
+static const ss::sstring noname(1, '\0');
+
+throughput_control_group::throughput_control_group() = default;
+throughput_control_group::throughput_control_group(
+  throughput_control_group&&) noexcept
+  = default;
+throughput_control_group&
+throughput_control_group::operator=(throughput_control_group&&) noexcept
+  = default;
+throughput_control_group::~throughput_control_group() noexcept = default;
+
+throughput_control_group::throughput_control_group(
+  const throughput_control_group& other)
+  : name(other.name)
+  , client_id_re(
+      other.client_id_re
+        ? std::make_unique<re2::RE2>(other.client_id_re->pattern())
+        : std::unique_ptr<re2::RE2>{})
+  , throughput_limit_node_in_bps(other.throughput_limit_node_in_bps)
+  , throughput_limit_node_out_bps(other.throughput_limit_node_out_bps) {}
+
+throughput_control_group&
+throughput_control_group::operator=(const throughput_control_group& other) {
+    return *this = throughput_control_group(other);
+}
+
+std::ostream&
+operator<<(std::ostream& os, const throughput_control_group& tcg) {
+    fmt::print(
+      os,
+      "{{group_name: {}, client_id: {}, throughput_limit_node_in_bps: {}, "
+      "throughput_limit_node_out_bps: {}}}",
+      tcg.name,
+      tcg.client_id_re ? tcg.client_id_re->pattern() : ""s,
+      tcg.throughput_limit_node_in_bps,
+      tcg.throughput_limit_node_out_bps);
+    return os;
+}
+
+bool throughput_control_group::match_client_id(
+  const ss::sstring& client_id) const {
+    if (!client_id_re) {
+        // omitted match criterion means "always match"
+        return true;
+    }
+    return re2::RE2::FullMatch(
+      re2::StringPiece(client_id.c_str(), client_id.length()), *client_id_re);
+}
+
+bool throughput_control_group::is_noname() const noexcept {
+    return name == noname;
+}
+
+ss::sstring throughput_control_group::validate() const {
+    if (unlikely(name != noname && contains_control_character(name))) {
+        return "Group name contains invalid character";
+    }
+    if (unlikely(client_id_re && !client_id_re->ok())) {
+        return ss::format("Invalid client_id regex. {}", client_id_re->error());
+    }
+    return {};
+}
+
+} // namespace config
+
+namespace YAML {
+
+Node convert<config::throughput_control_group>::encode(const type& tcg) {
+    Node node;
+    if (tcg.name != config::noname) {
+        node[config::ids::name] = tcg.name;
+    }
+    if (tcg.client_id_re) {
+        node[config::ids::client_id] = tcg.client_id_re->pattern();
+    }
+    return node;
+}
+
+bool convert<config::throughput_control_group>::decode(
+  const Node& node, type& tcg) {
+    config::throughput_control_group res;
+    if (const auto& n = node[config::ids::name]; n) {
+        res.name = n.as<ss::sstring>();
+        if (contains_control_characters(res.name)) {
+            return false;
+        }
+    } else {
+        res.name = config::noname;
+    }
+    if (const auto& n = node[config::ids::client_id]; n) {
+        const auto s = n.as<std::string>();
+        if (contains_control_characters(s)) {
+            return false;
+        }
+        res.client_id_re = std::make_unique<re2::RE2>(s);
+        if (!res.client_id_re->ok()) {
+            return false;
+        }
+    } else {
+        res.client_id_re.reset();
+    }
+    if (const auto& n = node[config::ids::tp_limit_node_in]; n) {
+        // only the no-limit option is supported yet
+        return false;
+    } else {
+        res.throughput_limit_node_in_bps = std::nullopt;
+    }
+    if (const auto& n = node[config::ids::tp_limit_node_out]; n) {
+        // only the no-limit option is supported yet
+        return false;
+    } else {
+        res.throughput_limit_node_out_bps = std::nullopt;
+    }
+
+    tcg = std::move(res);
+    return true;
+}
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const config::throughput_control_group& tcg) {
+    w.StartObject();
+    if (tcg.name != config::noname) {
+        w.Key(config::ids::name);
+        w.String(tcg.name);
+    }
+    if (tcg.client_id_re) {
+        w.Key(config::ids::client_id);
+        w.String(tcg.client_id_re->pattern());
+    }
+    w.EndObject();
+}
+
+} // namespace json

--- a/src/v/config/throughput_control_group.cc
+++ b/src/v/config/throughput_control_group.cc
@@ -13,6 +13,7 @@
 
 #include "config/convert.h"
 #include "ssx/sformat.h"
+#include "utils/functional.h"
 #include "utils/to_string.h"
 #include "utils/utf8.h"
 
@@ -21,11 +22,14 @@
 #include <fmt/core.h>
 #include <re2/re2.h>
 #include <re2/stringpiece.h>
+#include <yaml-cpp/node/node.h>
 
 #include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>
+#include <type_traits>
+#include <variant>
 
 using namespace std::string_literals;
 
@@ -51,7 +55,41 @@ constexpr const char* tp_limit_node_in = "throughput_limit_node_in_bps";
 constexpr const char* tp_limit_node_out = "throughput_limit_node_out_bps";
 } // namespace ids
 
+constexpr char selector_prefix = '+';
+constexpr std::string_view selector_empty = "empty";
+
 static const ss::sstring noname(1, '\0');
+
+struct copyable_RE2 : re2::RE2 {
+    copyable_RE2(const copyable_RE2& other)
+      : RE2(other.pattern()) {}
+    copyable_RE2& operator=(const copyable_RE2&) = delete;
+    copyable_RE2(copyable_RE2&&) noexcept = delete;
+    copyable_RE2& operator=(copyable_RE2&&) noexcept = delete;
+    explicit copyable_RE2(const std::string& s)
+      : RE2(s) {}
+    friend std::ostream& operator<<(std::ostream& os, const copyable_RE2& re) {
+        fmt::print(os, "{}", re.pattern());
+        return os;
+    }
+};
+
+struct client_id_matcher_type {
+    // nullopt stands for the empty client_id value
+    std::optional<copyable_RE2> v;
+    client_id_matcher_type() = default;
+    explicit client_id_matcher_type(const copyable_RE2& d)
+      : v(d) {}
+    friend std::ostream& operator<<(
+      std::ostream& os, const std::unique_ptr<client_id_matcher_type>& mt) {
+        if (mt) {
+            fmt::print(os, "{{v: {}}}", mt->v);
+        } else {
+            fmt::print(os, "null");
+        }
+        return os;
+    }
+};
 
 throughput_control_group::throughput_control_group() = default;
 throughput_control_group::throughput_control_group(
@@ -65,10 +103,10 @@ throughput_control_group::~throughput_control_group() noexcept = default;
 throughput_control_group::throughput_control_group(
   const throughput_control_group& other)
   : name(other.name)
-  , client_id_re(
-      other.client_id_re
-        ? std::make_unique<re2::RE2>(other.client_id_re->pattern())
-        : std::unique_ptr<re2::RE2>{})
+  , client_id_matcher(
+      other.client_id_matcher
+        ? std::make_unique<client_id_matcher_type>(*other.client_id_matcher)
+        : std::unique_ptr<client_id_matcher_type>{})
   , throughput_limit_node_in_bps(other.throughput_limit_node_in_bps)
   , throughput_limit_node_out_bps(other.throughput_limit_node_out_bps) {}
 
@@ -84,20 +122,28 @@ operator<<(std::ostream& os, const throughput_control_group& tcg) {
       "{{group_name: {}, client_id: {}, throughput_limit_node_in_bps: {}, "
       "throughput_limit_node_out_bps: {}}}",
       tcg.name,
-      tcg.client_id_re ? tcg.client_id_re->pattern() : ""s,
+      tcg.client_id_matcher,
       tcg.throughput_limit_node_in_bps,
       tcg.throughput_limit_node_out_bps);
     return os;
 }
 
 bool throughput_control_group::match_client_id(
-  const ss::sstring& client_id) const {
-    if (!client_id_re) {
+  const std::optional<std::string_view> client_id) const {
+    if (!client_id_matcher) {
         // omitted match criterion means "always match"
         return true;
     }
-    return re2::RE2::FullMatch(
-      re2::StringPiece(client_id.c_str(), client_id.length()), *client_id_re);
+    if (!client_id_matcher->v) {
+        // empty client_id match
+        // only missing client_id matches the empty
+        return !client_id;
+    }
+    // regex match
+    // missing client_id never matches a re
+    return client_id
+           && re2::RE2::FullMatch(
+             re2::StringPiece(*client_id), *client_id_matcher->v);
 }
 
 bool throughput_control_group::is_noname() const noexcept {
@@ -108,10 +154,21 @@ ss::sstring throughput_control_group::validate() const {
     if (unlikely(name != noname && contains_control_character(name))) {
         return "Group name contains invalid character";
     }
-    if (unlikely(client_id_re && !client_id_re->ok())) {
-        return ss::format("Invalid client_id regex. {}", client_id_re->error());
+    if (!client_id_matcher) {
+        // omitted value always ok
+        return {};
     }
-    return {};
+    if (!client_id_matcher->v) {
+        // empty match always ok
+        return {};
+    }
+    // regex match: check if the regex is valid
+    if (likely(client_id_matcher->v->ok())) {
+        return {};
+    } else {
+        return ss::format(
+          "Invalid client_id regex. {}", client_id_matcher->v->error());
+    }
 }
 
 } // namespace config
@@ -119,46 +176,79 @@ ss::sstring throughput_control_group::validate() const {
 namespace YAML {
 
 Node convert<config::throughput_control_group>::encode(const type& tcg) {
+    using namespace config;
     Node node;
-    if (tcg.name != config::noname) {
-        node[config::ids::name] = tcg.name;
+
+    if (tcg.name != noname) {
+        node[ids::name] = tcg.name;
     }
-    if (tcg.client_id_re) {
-        node[config::ids::client_id] = tcg.client_id_re->pattern();
+
+    if (tcg.client_id_matcher) {
+        YAML::Node client_id_node = node[ids::client_id];
+        if (!tcg.client_id_matcher->v) {
+            // the empty match
+            client_id_node = fmt::format(
+              "{}{}", selector_prefix, selector_empty);
+        } else {
+            // regex
+            client_id_node = tcg.client_id_matcher->v->pattern();
+        }
     }
+
     return node;
 }
 
 bool convert<config::throughput_control_group>::decode(
   const Node& node, type& tcg) {
-    config::throughput_control_group res;
-    if (const auto& n = node[config::ids::name]; n) {
+    using namespace config;
+    throughput_control_group res;
+
+    if (const auto& n = node[ids::name]; n) {
         res.name = n.as<ss::sstring>();
         if (contains_control_characters(res.name)) {
             return false;
         }
     } else {
-        res.name = config::noname;
+        res.name = noname;
     }
-    if (const auto& n = node[config::ids::client_id]; n) {
+
+    if (const auto& n = node[ids::client_id]; n) {
         const auto s = n.as<std::string>();
         if (contains_control_characters(s)) {
             return false;
         }
-        res.client_id_re = std::make_unique<re2::RE2>(s);
-        if (!res.client_id_re->ok()) {
-            return false;
+        if (!s.empty() && s[0] == selector_prefix) {
+            // an explicit selector
+            const std::string_view selector_name(
+              std::next(s.cbegin()), s.cend());
+            if (selector_name == selector_empty) {
+                res.client_id_matcher
+                  = std::make_unique<client_id_matcher_type>();
+            } else {
+                return false;
+            }
+        } else {
+            // a regex
+            const copyable_RE2 re{s};
+            if (!re.ok()) {
+                return false;
+            }
+            res.client_id_matcher = std::make_unique<client_id_matcher_type>(
+              re);
         }
     } else {
-        res.client_id_re.reset();
+        // nothing
+        res.client_id_matcher.reset();
     }
-    if (const auto& n = node[config::ids::tp_limit_node_in]; n) {
+
+    if (const auto& n = node[ids::tp_limit_node_in]; n) {
         // only the no-limit option is supported yet
         return false;
     } else {
         res.throughput_limit_node_in_bps = std::nullopt;
     }
-    if (const auto& n = node[config::ids::tp_limit_node_out]; n) {
+
+    if (const auto& n = node[ids::tp_limit_node_out]; n) {
         // only the no-limit option is supported yet
         return false;
     } else {
@@ -176,15 +266,25 @@ namespace json {
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const config::throughput_control_group& tcg) {
+    using namespace config;
     w.StartObject();
-    if (tcg.name != config::noname) {
-        w.Key(config::ids::name);
+
+    if (tcg.name != noname) {
+        w.Key(ids::name);
         w.String(tcg.name);
     }
-    if (tcg.client_id_re) {
-        w.Key(config::ids::client_id);
-        w.String(tcg.client_id_re->pattern());
+
+    if (tcg.client_id_matcher) {
+        w.Key(ids::client_id);
+        if (!tcg.client_id_matcher->v) {
+            // empty match
+            w.String(fmt::format("{}{}", selector_prefix, selector_empty));
+        } else {
+            // regex match
+            w.String(tcg.client_id_matcher->v->pattern());
+        }
     }
+
     w.EndObject();
 }
 

--- a/src/v/config/throughput_control_group.h
+++ b/src/v/config/throughput_control_group.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <string_view>
 
 namespace re2 {
 class RE2;
@@ -47,12 +48,12 @@ struct throughput_control_group {
     friend std::ostream&
     operator<<(std::ostream& os, const throughput_control_group& tcg);
 
-    bool match_client_id(const ss::sstring& client_id) const;
+    bool match_client_id(std::optional<std::string_view> client_id) const;
     bool is_noname() const noexcept;
     ss::sstring validate() const;
 
     ss::sstring name;
-    std::unique_ptr<re2::RE2> client_id_re;
+    std::unique_ptr<struct client_id_matcher_type> client_id_matcher;
     // nuillopt means unlimited:
     std::optional<int64_t> throughput_limit_node_in_bps;
     std::optional<int64_t> throughput_limit_node_out_bps;
@@ -66,7 +67,9 @@ detail::property_type_name<throughput_control_group>() {
 
 template<class InputIt>
 InputIt find_throughput_control_group(
-  const InputIt first, const InputIt last, const ss::sstring& client_id) {
+  const InputIt first,
+  const InputIt last,
+  const std::optional<std::string_view> client_id) {
     return std::find_if(
       first, last, [&client_id](const config::throughput_control_group& cg) {
           return cg.match_client_id(client_id);

--- a/src/v/config/throughput_control_group.h
+++ b/src/v/config/throughput_control_group.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/property.h"
+#include "json/_include_first.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
+#include "seastarx.h"
+
+#include <seastar/core/print.hh>
+#include <seastar/core/sstring.hh>
+
+#include <yaml-cpp/node/node.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+
+namespace re2 {
+class RE2;
+}
+
+namespace config {
+
+struct throughput_control_group {
+    throughput_control_group();
+    throughput_control_group(const throughput_control_group&);
+    throughput_control_group& operator=(const throughput_control_group&);
+    throughput_control_group(throughput_control_group&&) noexcept;
+    throughput_control_group& operator=(throughput_control_group&&) noexcept;
+    ~throughput_control_group() noexcept;
+
+    friend bool
+    operator==(const throughput_control_group&, const throughput_control_group&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const throughput_control_group& tcg);
+
+    bool match_client_id(const ss::sstring& client_id) const;
+    bool is_noname() const noexcept;
+    ss::sstring validate() const;
+
+    ss::sstring name;
+    std::unique_ptr<re2::RE2> client_id_re;
+    // nuillopt means unlimited:
+    std::optional<int64_t> throughput_limit_node_in_bps;
+    std::optional<int64_t> throughput_limit_node_out_bps;
+};
+
+template<>
+consteval std::string_view
+detail::property_type_name<throughput_control_group>() {
+    return "config::throughput_control_group";
+}
+
+template<class InputIt>
+InputIt find_throughput_control_group(
+  const InputIt first, const InputIt last, const ss::sstring& client_id) {
+    return std::find_if(
+      first, last, [&client_id](const config::throughput_control_group& cg) {
+          return cg.match_client_id(client_id);
+      });
+}
+
+template<class InputIt>
+std::optional<ss::sstring>
+validate_throughput_control_groups(const InputIt first, const InputIt last) {
+    // verify that group names are unique where set
+    // o(n^2/2) algo because we don't expect many items
+    for (auto i = first; i != last; ++i) {
+        if (const auto verr = i->validate(); unlikely(!verr.empty())) {
+            return ss::format(
+              "Validation failed for throughput control group #{}: {}. cgroup: "
+              "{{{}}}",
+              std::distance(first, i),
+              verr,
+              *i);
+        }
+        if (i->is_noname()) {
+            continue;
+        }
+        if (unlikely(
+              std::any_of(first, i, [i](const throughput_control_group& cg) {
+                  return cg.name == i->name;
+              }))) {
+            return ss::format(
+              "Duplicate throughput control group name: {}", i->name);
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace config
+
+namespace YAML {
+template<>
+struct convert<config::throughput_control_group> {
+    using type = config::throughput_control_group;
+    static Node encode(const type& rhs);
+    static bool decode(const Node& node, type& rhs);
+};
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const config::throughput_control_group& ep);
+
+} // namespace json

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -24,6 +24,7 @@
 #include "kafka/server/response.h"
 #include "kafka/server/server.h"
 #include "kafka/server/snc_quota_manager.h"
+#include "likely.h"
 #include "net/exceptions.h"
 #include "security/exceptions.h"
 #include "units.h"
@@ -42,6 +43,29 @@
 using namespace std::chrono_literals;
 
 namespace kafka {
+
+connection_context::connection_context(
+  class server& s,
+  ss::lw_shared_ptr<net::connection> conn,
+  std::optional<security::sasl_server> sasl,
+  bool enable_authorizer,
+  std::optional<security::tls::mtls_state> mtls_state,
+  config::binding<uint32_t> max_request_size,
+  config::conversion_binding<std::vector<bool>, std::vector<ss::sstring>>
+    kafka_throughput_controlled_api_keys) noexcept
+  : _server(s)
+  , conn(conn)
+  , _sasl(std::move(sasl))
+  // tests may build a context without a live connection
+  , _client_addr(conn ? conn->addr.addr() : ss::net::inet_address{})
+  , _enable_authorizer(enable_authorizer)
+  , _authlog(_client_addr, client_port())
+  , _mtls_state(std::move(mtls_state))
+  , _max_request_size(std::move(max_request_size))
+  , _kafka_throughput_controlled_api_keys(
+      std::move(kafka_throughput_controlled_api_keys)) {}
+
+connection_context::~connection_context() noexcept = default;
 
 ss::future<> connection_context::process() {
     while (true) {
@@ -215,9 +239,12 @@ connection_context::record_tp_and_calculate_throttle(
     // Throttle on shard wide quotas
     snc_quota_manager::delays_t shard_delays;
     if (_kafka_throughput_controlled_api_keys().at(hdr.key)) {
-        _server.snc_quota_mgr().record_request_receive(request_size, now);
+        _server.snc_quota_mgr().get_or_create_quota_context(
+          _snc_quota_context, hdr.client_id);
+        _server.snc_quota_mgr().record_request_receive(
+          *_snc_quota_context, request_size, now);
         shard_delays = _server.snc_quota_mgr().get_shard_delays(
-          _throttled_until, now);
+          *_snc_quota_context, now);
     }
 
     // Sum up
@@ -335,7 +362,18 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
               return ss::make_ready_future<>();
           }
           if (_kafka_throughput_controlled_api_keys().at(hdr.key)) {
-              _server.snc_quota_mgr().record_request_intake(size);
+              // Normally we can only get here after a prior call to
+              // snc_quota_mgr().get_or_create_quota_context() in
+              // record_tp_and_calculate_throttle(), but there is possibility
+              // that the changing configuration could still take us into this
+              // branch with unmatching (and even null) _snc_quota_context.
+              // Simply an unmatching _snc_quota_context is no big deal because
+              // it is a one off event, but we need protection from it being
+              // nullptr
+              if (likely(_snc_quota_context)) {
+                  _server.snc_quota_mgr().record_request_intake(
+                    *_snc_quota_context, size);
+              }
           }
 
           auto sres = ss::make_lw_shared(std::move(sres_in));
@@ -526,7 +564,11 @@ ss::future<> connection_context::maybe_process_responses() {
         auto response_size = msg.size();
         auto request_key = resp_and_res.resources->request_data.request_key;
         if (_kafka_throughput_controlled_api_keys().at(request_key)) {
-            _server.snc_quota_mgr().record_response(response_size);
+            // see the comment in dispatch_method_once()
+            if (likely(_snc_quota_context)) {
+                _server.snc_quota_mgr().record_response(
+                  *_snc_quota_context, response_size);
+            }
         }
         _server.handler_probe(request_key).add_bytes_sent(response_size);
         try {

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -334,7 +334,9 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
               // protect against shutdown behavior
               return ss::make_ready_future<>();
           }
-          _server.snc_quota_mgr().record_request_intake(size);
+          if (_kafka_throughput_controlled_api_keys().at(hdr.key)) {
+              _server.snc_quota_mgr().record_request_intake(size);
+          }
 
           auto sres = ss::make_lw_shared(std::move(sres_in));
 

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -117,20 +117,9 @@ public:
       std::optional<security::tls::mtls_state> mtls_state,
       config::binding<uint32_t> max_request_size,
       config::conversion_binding<std::vector<bool>, std::vector<ss::sstring>>
-        kafka_throughput_controlled_api_keys) noexcept
-      : _server(s)
-      , conn(conn)
-      , _sasl(std::move(sasl))
-      // tests may build a context without a live connection
-      , _client_addr(conn ? conn->addr.addr() : ss::net::inet_address{})
-      , _enable_authorizer(enable_authorizer)
-      , _authlog(_client_addr, client_port())
-      , _mtls_state(std::move(mtls_state))
-      , _max_request_size(std::move(max_request_size))
-      , _kafka_throughput_controlled_api_keys(
-          std::move(kafka_throughput_controlled_api_keys)) {}
+        kafka_throughput_controlled_api_keys) noexcept;
+    ~connection_context() noexcept;
 
-    ~connection_context() noexcept = default;
     connection_context(const connection_context&) = delete;
     connection_context(connection_context&&) = delete;
     connection_context& operator=(const connection_context&) = delete;
@@ -352,9 +341,9 @@ private:
     ctx_log _authlog;
     std::optional<security::tls::mtls_state> _mtls_state;
     config::binding<uint32_t> _max_request_size;
-    ss::lowres_clock::time_point _throttled_until;
     config::conversion_binding<std::vector<bool>, std::vector<ss::sstring>>
       _kafka_throughput_controlled_api_keys;
+    std::unique_ptr<snc_quota_context> _snc_quota_context;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -25,5 +25,6 @@ class request_context;
 class rm_group_frontend;
 class rm_group_proxy_impl;
 class usage_manager;
+class snc_quota_context;
 
 } // namespace kafka

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -19,6 +19,8 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
+#include <iterator>
+#include <memory>
 #include <numeric>
 
 using namespace std::chrono_literals;
@@ -248,14 +250,61 @@ snc_quota_manager::calc_node_quota_default() const {
     return default_quota;
 }
 
+void snc_quota_manager::get_or_create_quota_context(
+  std::unique_ptr<snc_quota_context>& ctx,
+  std::optional<std::string_view> client_id) {
+    if (likely(ctx)) {
+        // NB: comparing string_view to sstring might be suboptimal
+        if (likely(ctx->_client_id == client_id)) {
+            // the context is the right one
+            return;
+        }
+
+        // either of the context indexing propeties have changed on the client
+        // within the same connection. This is an unexpected path, quotas may
+        // misbehave if we ever get here. The design is based on assumption that
+        // this should not happen. If it does happen with a supported client, we
+        // probably should start supporting multiple quota contexts per
+        // connection
+        vlog(
+          klog.warn,
+          "qm - client_id has changed on the connection. Quotas are reset now. "
+          "Old client_id: {}, new client_id: {}",
+          ctx->_client_id,
+          client_id);
+    }
+
+    ctx = std::make_unique<snc_quota_context>(client_id);
+    const auto tcgroup_it = config::find_throughput_control_group(
+      _kafka_throughput_control().cbegin(),
+      _kafka_throughput_control().cend(),
+      client_id);
+    if (tcgroup_it == _kafka_throughput_control().cend()) {
+        ctx->_exempt = false;
+        vlog(klog.debug, "qm - No throughput control group assigned");
+    } else {
+        ctx->_exempt = true;
+        if (tcgroup_it->is_noname()) {
+            vlog(
+              klog.debug,
+              "qm - Assigned throughput control group #{}",
+              std::distance(_kafka_throughput_control().cbegin(), tcgroup_it));
+        } else {
+            vlog(
+              klog.debug,
+              "qm - Assigned throughput control group: {}",
+              tcgroup_it->name);
+        }
+    }
+}
+
 snc_quota_manager::delays_t snc_quota_manager::get_shard_delays(
-  clock::time_point& connection_throttle_until,
-  const clock::time_point now) const {
+  snc_quota_context& ctx, const clock::time_point now) const {
     delays_t res;
 
     // force throttle whatever the client did not do on its side
-    if (now < connection_throttle_until) {
-        res.enforce = connection_throttle_until - now;
+    if (now < ctx._throttled_until) {
+        res.enforce = ctx._throttled_until - now;
     }
 
     // throttling delay the connection should be requested to throttle
@@ -263,23 +312,36 @@ snc_quota_manager::delays_t snc_quota_manager::get_shard_delays(
     res.request = std::min(
       _max_kafka_throttle_delay(),
       std::max(eval_delay(_shard_quota.in), eval_delay(_shard_quota.eg)));
-    connection_throttle_until = now + res.request;
+    ctx._throttled_until = now + res.request;
 
     return res;
 }
 
 void snc_quota_manager::record_request_receive(
-  const size_t request_size, const clock::time_point now) noexcept {
+  snc_quota_context& ctx,
+  const size_t request_size,
+  const clock::time_point now) noexcept {
+    if (ctx._exempt) {
+        return;
+    }
     _shard_quota.in.use(request_size, now);
 }
 
 void snc_quota_manager::record_request_intake(
-  const size_t request_size) noexcept {
+  snc_quota_context& ctx, const size_t request_size) noexcept {
+    if (ctx._exempt) {
+        return;
+    }
     _probe.rec_traffic_in(request_size);
 }
 
 void snc_quota_manager::record_response(
-  const size_t request_size, const clock::time_point now) noexcept {
+  snc_quota_context& ctx,
+  const size_t request_size,
+  const clock::time_point now) noexcept {
+    if (ctx._exempt) {
+        return;
+    }
     _shard_quota.eg.use(request_size, now);
 }
 

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -148,6 +148,7 @@ snc_quota_manager::snc_quota_manager()
   , _kafka_quota_balancer_min_shard_throughput_bps(
       config::shard_local_cfg()
         .kafka_quota_balancer_min_shard_throughput_bps.bind())
+  , _kafka_throughput_control(config::shard_local_cfg().kafka_throughput_control.bind())
   , _node_quota_default{calc_node_quota_default()}
   , _shard_quota{
       .in {node_to_shard_quota(_node_quota_default.in),

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "config/property.h"
+#include "config/throughput_control_group.h"
 #include "seastarx.h"
 #include "utils/bottomless_token_bucket.h"
 #include "utils/mutex.h"
@@ -171,6 +172,8 @@ private:
       _kafka_quota_balancer_node_period;
     config::binding<double> _kafka_quota_balancer_min_shard_throughput_ratio;
     config::binding<quota_t> _kafka_quota_balancer_min_shard_throughput_bps;
+    config::binding<std::vector<config::throughput_control_group>>
+      _kafka_throughput_control;
 
     // operational, only used in the balancer shard
     ss::timer<ss::lowres_clock> _balancer_timer;

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -19,10 +19,12 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/sstring.hh>
 #include <seastar/core/timer.hh>
 
 #include <chrono>
 #include <optional>
+#include <string_view>
 
 namespace kafka {
 
@@ -58,6 +60,29 @@ private:
     size_t _traffic_in = 0;
 };
 
+class snc_quota_context {
+public:
+    explicit snc_quota_context(std::optional<std::string_view> client_id)
+      : _client_id(client_id) {}
+
+private:
+    friend class snc_quota_manager;
+
+    // Indexing
+    std::optional<ss::sstring> _client_id;
+
+    // Configuration
+
+    /// Whether the connection belongs to an exempt tput control group
+    bool _exempt{false};
+
+    // Operating
+
+    /// What time the client on this conection should throttle (be throttled)
+    /// until
+    ss::lowres_clock::time_point _throttled_until;
+};
+
 /// Isolates \ref quota_manager functionality related to
 /// shard/node/cluster (SNC) wide quotas and limits
 class snc_quota_manager
@@ -83,28 +108,38 @@ public:
         clock::duration request{0};
     };
 
+    /// Depending on the other arguments, create or actualize or keep the
+    /// existing \p ctx. The context object is supposed to be stored
+    /// in the connection context, and created only once per connection
+    /// lifetime. However since the kafka API allows changing client_id of a
+    /// connection on the fly, we may need to replace the existing context with
+    /// a new one if that happens (actualize).
+    /// \post (bool)ctx == true
+    void get_or_create_quota_context(
+      std::unique_ptr<snc_quota_context>& ctx,
+      std::optional<std::string_view> client_id);
+
     /// Determine throttling required by shard level TP quotas.
-    /// @param connection_throttle_until (in,out) until what time the client
-    /// on this conection should throttle until. If it does not, this throttling
-    /// will be enforced on the next call. In: value from the last call, out:
-    /// value saved until the next call.
-    delays_t get_shard_delays(
-      clock::time_point& connection_throttle_until,
-      clock::time_point now) const;
+    delays_t get_shard_delays(snc_quota_context&, clock::time_point now) const;
 
     /// Record the request size when it has arrived from the transport.
     /// This should be done before calling \ref get_shard_delays because the
     /// recorded request size is used to calculate throttling parameters.
     void record_request_receive(
-      size_t request_size, clock::time_point now = clock::now()) noexcept;
+      snc_quota_context&,
+      size_t request_size,
+      clock::time_point now = clock::now()) noexcept;
 
     /// Record the request size when the request data is about to be consumed.
     /// This data is used to represent throttled throughput.
-    void record_request_intake(size_t request_size) noexcept;
+    void
+    record_request_intake(snc_quota_context&, size_t request_size) noexcept;
 
     /// Record the response size for all purposes
     void record_response(
-      size_t request_size, clock::time_point now = clock::now()) noexcept;
+      snc_quota_context&,
+      size_t request_size,
+      clock::time_point now = clock::now()) noexcept;
 
     /// Metrics probe object
     const snc_quotas_probe& get_snc_quotas_probe() const noexcept {

--- a/src/v/utils/functional.h
+++ b/src/v/utils/functional.h
@@ -14,6 +14,9 @@
 #include <functional>
 #include <optional>
 
+template<typename>
+inline constexpr bool always_false_v = false;
+
 template<typename T, typename U = typename T::value_type>
 concept SupportsPushBack = requires(T a, U b) {
     { a.push_back(b) } -> std::same_as<void>;

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -589,7 +589,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             elif p['type'] == "array" and p['items']['type'] == 'string':
                 valid_value = ["custard", "cream"]
             else:
-                raise NotImplementedError(p['type'])
+                raise NotImplementedError(f"{p['type']} in {name}")
 
             if name == 'sasl_mechanisms':
                 # The default value is ['SCRAM'], but the array cannot contain


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR introduces a feature to make client_ids specified by a value, regex, or by a special selector for missing client_ids exempt from throughput control. Connections presenting a matching client_id value will not have the size of their requests accounted for throughput control, not they will be throttled.

The new configuration is forward looking to support the fully functional throughput control groups, this is why it may look too bulky for this specific PR.

Fixes #10575

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features

* A client_id, or a group of client_ids specified with a regex, can now be excluded from node wide throughput control. The new cluster property `kafka_throughput_control` can be used to define throughput control groups for which Kafka traffic will not be limited by the values specified by `kafka_throughput_limit_node_*_bps`.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->