### PR TITLE
cloud_storage: further cache improvements

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2184,8 +2184,12 @@ ss::future<> ntp_archiver::apply_spillover() {
         }
         auto [str, len] = co_await tail.serialize();
         // Put manifest into cache to avoid roundtrip to the cloud storage
+        auto reservation = co_await _cache.reserve_space(len, 1);
         co_await _cache.put(
-          tail.get_manifest_path()(), str, _conf->upload_io_priority);
+          tail.get_manifest_path()(),
+          str,
+          reservation,
+          _conf->upload_io_priority);
 
         // Spillover manifests were uploaded to S3
         // Replicate metadata

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -1010,9 +1010,11 @@ async_manifest_view::hydrate_manifest(
             co_return error_outcome::manifest_download_error;
         }
         auto [str, len] = co_await manifest.serialize();
+        auto reservation = co_await _cache.local().reserve_space(len, 1);
         co_await _cache.local().put(
           manifest.get_manifest_path()(),
           str,
+          reservation,
           priority_manager::local().shadow_indexing_priority());
         _probe.on_spillover_manifest_hydration();
         vlog(

--- a/src/v/cloud_storage/cache_probe.cc
+++ b/src/v/cloud_storage/cache_probe.cc
@@ -78,6 +78,12 @@ cache_probe::cache_probe() {
                   [this] { return _cur_num_files; },
                   sm::description("Number of objects in cache."))
                   .aggregate(aggregate_labels),
+                sm::make_gauge(
+                  "hwm_files",
+                  [this] { return _hwm_num_files; },
+                  sm::description(
+                    "High watermark of number of objects in cache."))
+                  .aggregate(aggregate_labels),
               });
         }
 

--- a/src/v/cloud_storage/cache_probe.h
+++ b/src/v/cloud_storage/cache_probe.h
@@ -30,7 +30,10 @@ public:
         _cur_size_bytes = size;
         _hwm_size_bytes = std::max(_cur_size_bytes, _hwm_size_bytes);
     }
-    void set_num_files(uint64_t num_files) { _cur_num_files = num_files; }
+    void set_num_files(uint64_t num_files) {
+        _cur_num_files = num_files;
+        _hwm_num_files = std::max(_cur_num_files, _hwm_num_files);
+    }
     void put_started() { ++_cur_in_progress_files; }
     void put_ended() { --_cur_in_progress_files; }
 
@@ -43,6 +46,7 @@ private:
     int64_t _cur_size_bytes = 0;
     int64_t _hwm_size_bytes = 0;
     int64_t _cur_num_files = 0;
+    int64_t _hwm_num_files = 0;
     int64_t _cur_in_progress_files = 0;
 
     ss::metrics::metric_groups _metrics;

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -887,7 +887,7 @@ void cache::do_reserve_space_release(
         // an ERROR log ensures detection if we hit this path in our integration
         // tests.
         vlog(
-          cst_log.warn,
+          cst_log.error,
           "Exceeded cache size limit!  (size={}/{} reserved={}/{} "
           "pending={}/{} max={}/{})",
           _current_cache_size,

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -148,6 +148,10 @@ public:
       uint64_t free_space,
       storage::disk_space_alert alert);
 
+    size_t get_usage_objects() { return _current_cache_objects; }
+
+    uint64_t get_usage_bytes() { return _current_cache_size; }
+
 private:
     /// Load access time tracker from file
     ss::future<> load_access_time_tracker();

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -422,7 +422,7 @@ ss::future<> remote_segment::do_hydrate_segment() {
 
     // RAII reservation object represents the disk space this put will consume
     auto reservation = co_await _cache.reserve_space(
-      _size + storage::segment_index::estimate_size(_size));
+      _size + storage::segment_index::estimate_size(_size), 1);
 
     auto res = co_await _api.download_segment(
       _bucket,
@@ -503,7 +503,7 @@ ss::future<> remote_segment::do_hydrate_txrange() {
         }
 
         auto [stream, size] = co_await manifest.serialize();
-        auto reservation = _cache.reserve_space(size);
+        auto reservation = _cache.reserve_space(size, 1);
         co_await _cache.put(manifest.get_manifest_path(), stream)
           .finally([&s = stream]() mutable { return s.close(); });
     }
@@ -877,7 +877,7 @@ ss::future<> remote_segment::hydrate_chunk(
     }
 
     const auto space_required = end.value_or(_size - 1) - start + 1;
-    const auto reserved = co_await _cache.reserve_space(space_required);
+    const auto reserved = co_await _cache.reserve_space(space_required, 1);
 
     auto res = co_await _api.download_segment(
       _bucket,

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -206,15 +206,19 @@ private:
     ss::future<> do_hydrate_segment();
 
     /// Helper for do_hydrate_segment
-    ss::future<uint64_t>
-      put_segment_in_cache_and_create_index(uint64_t, ss::input_stream<char>);
+    ss::future<uint64_t> put_segment_in_cache_and_create_index(
+      uint64_t, space_reservation_guard&, ss::input_stream<char>);
 
-    ss::future<uint64_t> put_segment_in_cache(uint64_t, ss::input_stream<char>);
+    ss::future<uint64_t> put_segment_in_cache(
+      uint64_t, space_reservation_guard&, ss::input_stream<char>);
 
     /// Stores a segment chunk in cache. The chunk is stored in a path derived
     /// from the segment path: <segment_path>_chunks/chunk_start_file_offset.
     ss::future<uint64_t> put_chunk_in_cache(
-      uint64_t, ss::input_stream<char>, chunk_start_offset_t chunk_start);
+      uint64_t,
+      space_reservation_guard&,
+      ss::input_stream<char>,
+      chunk_start_offset_t chunk_start);
 
     /// Hydrate tx manifest. Method downloads the manifest file to the cache
     /// dir.

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -89,8 +89,10 @@ public:
         auto path = spm.get_manifest_path();
         if (hydrate) {
             auto stream = spm.serialize().get();
+            auto reservation = cache.local().reserve_space(123, 1).get();
             cache.local()
-              .put(path, stream.stream, ss::default_priority_class())
+              .put(
+                path, stream.stream, reservation, ss::default_priority_class())
               .get();
             stream.stream.close().get();
         }

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -53,7 +53,10 @@ public:
       , CACHE_DIR(get_cache_dir(test_dir.get_path())) {
         cache::initialize(CACHE_DIR).get();
         sharded_cache
-          .start(CACHE_DIR, config::mock_binding<uint64_t>(1_MiB + 500_KiB))
+          .start(
+            CACHE_DIR,
+            config::mock_binding<uint64_t>(1_MiB + 500_KiB),
+            config::mock_binding<uint32_t>(100000))
           .get();
         sharded_cache
           .invoke_on_all([](cloud_storage::cache& c) { return c.start(); })

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -61,6 +61,16 @@ public:
         sharded_cache
           .invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
           .get();
+        sharded_cache
+          .invoke_on(
+            ss::shard_id{0},
+            [](cloud_storage::cache& c) {
+                c.notify_disk_status(
+                  100ULL * 1024 * 1024 * 1024,
+                  50ULL * 1024 * 1024 * 1024,
+                  storage::disk_space_alert::ok);
+            })
+          .get();
     }
 
     ~cache_test_fixture() {
@@ -75,12 +85,19 @@ public:
         return data_string;
     }
 
-    void put_into_cache(auto data_string, auto key) {
+    /// @param no_trim: if true, do not reserve space, thereby ensuring that
+    ///                 we will not trim the cache.  This ignores cache size
+    ///                 enforcement.
+    void put_into_cache(auto data_string, auto key, bool no_trim = false) {
         iobuf buf;
         buf.append(data_string.data(), data_string.length());
 
+        auto reservation
+          = no_trim
+              ? space_reservation_guard(sharded_cache.local(), 0, 0)
+              : sharded_cache.local().reserve_space(buf.size_bytes(), 1).get();
         auto input = make_iobuf_input_stream(std::move(buf));
-        sharded_cache.local().put(key, input).get();
+        sharded_cache.local().put(key, input, reservation).get();
     }
 
     ss::future<> clean_up_at_start() {

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -38,7 +38,8 @@ struct cloud_storage_fixture : s3_imposter_fixture {
         cache
           .start(
             tmp_directory.get_path(),
-            config::mock_binding<uint64_t>(1024 * 1024 * 1024))
+            config::mock_binding<uint64_t>(1024 * 1024 * 1024),
+            config::mock_binding<uint32_t>(100000))
           .get();
 
         cache.invoke_on_all([](cloud_storage::cache& c) { return c.start(); })

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1572,6 +1572,16 @@ configuration::configuration()
       "Max size of archival cache",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       20_GiB)
+  , cloud_storage_cache_max_objects(
+      *this,
+      "cloud_storage_cache_max_objects",
+      "Maximum number of objects that may be held in the tiered storage "
+      "cache.  This applies simultaneously with `cloud_storage_cache_size`, "
+      "and which ever limit is hit first will drive trimming of the cache.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      // Enough for a >1TiB cache of 16MiB objects.  Decrease this in case
+      // of issues with trim performance.
+      100000)
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -317,6 +317,7 @@ struct configuration final : public config_store {
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;
+    property<uint32_t> cloud_storage_cache_max_objects;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
     property<std::optional<uint32_t>> cloud_storage_max_readers_per_shard;
     property<std::optional<uint32_t>>

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -912,6 +912,14 @@
                     "type": "long",
                     "description": "Compaction index"
                 },
+                "cloud_storage_cache_bytes": {
+                    "type": "long",
+                    "description": "Bytes in use by tiered storage cache"
+                },
+                "cloud_storage_cache_objects": {
+                    "type": "long",
+                    "description": "Number of objects in tiered storage cache"
+                },
                 "reclaimable_by_retention": {
                     "type": "long",
                     "description": "Number of bytes currently reclaimable by retention"

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cloud_storage/types.h"
 #include "cluster/fwd.h"
 #include "cluster/types.h"
 #include "config/endpoint_tls_config.h"
@@ -77,7 +78,8 @@ public:
       ss::sharded<cluster::topic_recovery_status_frontend>&,
       ss::sharded<cluster::tx_registry_frontend>&,
       ss::sharded<storage::node>&,
-      ss::sharded<memory_sampling>&);
+      ss::sharded<memory_sampling>&,
+      ss::sharded<cloud_storage::cache>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -522,6 +524,7 @@ private:
     ss::sharded<cluster::tx_registry_frontend>& _tx_registry_frontend;
     ss::sharded<storage::node>& _storage_node;
     ss::sharded<memory_sampling>& _memory_sampling_service;
+    ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;
     ss::timer<> _blocked_reactor_notify_reset_timer;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -854,7 +854,8 @@ void application::configure_admin_server() {
       std::ref(topic_recovery_status_frontend),
       std::ref(tx_registry_frontend),
       std::ref(storage_node),
-      std::ref(_memory_sampling))
+      std::ref(_memory_sampling),
+      std::ref(shadow_index_cache))
       .get();
 }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1300,6 +1300,10 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
           config::node().cloud_storage_cache_path(),
           ss::sharded_parameter([] {
               return config::shard_local_cfg().cloud_storage_cache_size.bind();
+          }),
+          ss::sharded_parameter([] {
+              return config::shard_local_cfg()
+                .cloud_storage_cache_max_objects.bind();
           }))
           .get();
 

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -894,7 +894,7 @@ class ManyPartitionsTest(PreallocNodesTest):
     @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_omb(self):
         scale = ScaleParameters(self.redpanda, replication_factor=3)
-        self.redpanda.start(parallel=True)
+        self.redpanda.start()
 
         # We have other OMB benchmark tests, but this one runs at the
         # peak partition count.
@@ -962,7 +962,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             int(scale.expect_bandwidth / len(self.redpanda.nodes) * 3)
         })
 
-        self.redpanda.start(parallel=True)
+        self.redpanda.start()
 
         self.logger.info("Entering topic creation")
         topic_names = [f"scale_{i:06d}" for i in range(0, n_topics)]

--- a/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
@@ -94,9 +94,6 @@ class TieredStorageCacheStressTest(RedpandaTest):
         else:
             raise NotImplementedError(limit_mode)
 
-        assert not self.redpanda.search_log_node(node,
-                                                 "Exceeded cache size limit!")
-
         return any_cache_usage
 
     @cluster(num_nodes=4)

--- a/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
@@ -1,0 +1,271 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
+from rptest.services.redpanda import SISettings, MetricsEndpoint, ResourceSettings
+from rptest.services.admin import Admin
+from rptest.clients.rpk import RpkTool
+from rptest.utils.si_utils import quiesce_uploads
+from typing import Optional
+from ducktape.mark import matrix
+import time
+from enum import Enum
+
+
+class LimitMode(str, Enum):
+    bytes = 'bytes'
+    objects = 'objects'
+    both = 'both'
+
+
+class TieredStorageCacheStressTest(RedpandaTest):
+    segment_upload_interval = 30
+    manifest_upload_interval = 10
+
+    def __init__(self, test_context, *args, **kwargs):
+
+        super().__init__(test_context, *args, **kwargs)
+
+    def setUp(self):
+        # defer redpanda startup to the test
+        pass
+
+    def _validate_node_storage(self, node, limit_mode: LimitMode,
+                               size_limit: Optional[int],
+                               max_objects: Optional[int]):
+        admin = Admin(self.redpanda)
+
+        self.logger.info(
+            f"Validating node {node.name} cache vs limits {size_limit}/{max_objects}"
+        )
+
+        # Read logical space usage according to Redpanda
+        usage = admin.get_local_storage_usage(node)
+        self.logger.info(f"Checking cache usage on {node.name}: {usage}")
+
+        # Read physical space usage according to the operating system
+        node_storage = self.redpanda.node_storage(node)
+        self.logger.info(
+            f"Checked physical cache usage on {node.name}: {node_storage.cache}"
+        )
+
+        # Read HWM stats from Redpanda, in case we transiently violated cache size
+        metrics = self.redpanda.metrics(
+            node, metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        hwm_size = None
+        hwm_objects = None
+        for family in metrics:
+            for sample in family.samples:
+                if sample.name == "redpanda_cloud_storage_cache_space_hwm_size_bytes":
+                    hwm_size = int(sample.value)
+                elif sample.name == "redpanda_cloud_storage_cache_space_hwm_files":
+                    hwm_objects = int(sample.value)
+                #else:
+                #    self.logger.debug(sample.name)
+        assert hwm_size is not None, "Cache HWM metric not found"
+
+        any_cache_usage = (usage['cloud_storage_cache_bytes'] > 0
+                           and usage['cloud_storage_cache_objects'] > 0)
+
+        self.logger.info(
+            f"Admin API cache size[{node.name}]: {usage['cloud_storage_cache_bytes']}/{usage['cloud_storage_cache_objects']}"
+        )
+        self.logger.info(
+            f"Physical cache usage[{node.name}]: {node_storage.cache.bytes}/{node_storage.cache.objects}"
+        )
+        self.logger.info(f"Cache HWM [{node.name}]: {hwm_size}/{hwm_objects}")
+
+        if limit_mode == LimitMode.bytes or limit_mode == LimitMode.both:
+            assert usage['cloud_storage_cache_bytes'] <= size_limit
+            assert node_storage.cache.bytes <= size_limit
+            assert hwm_size <= size_limit
+        elif limit_mode == LimitMode.objects or limit_mode == LimitMode.both:
+            assert usage['cloud_storage_cache_objects'] <= max_objects
+            assert node_storage.cache.objects <= max_objects
+            assert hwm_objects <= max_objects
+        else:
+            raise NotImplementedError(limit_mode)
+
+        assert not self.redpanda.search_log_node(node,
+                                                 "Exceeded cache size limit!")
+
+        return any_cache_usage
+
+    @cluster(num_nodes=4)
+    @matrix(limit_mode=[LimitMode.bytes, LimitMode.objects, LimitMode.both],
+            log_segment_size=[1024 * 1024, 128 * 1024 * 1024])
+    def streaming_cache_test(self, limit_mode, log_segment_size):
+        """
+        Validate that reading data much  larger than the cache proceeds safely
+        and promptly: this exercises the mode where we are reading some data,
+        trimming cache, reading, trimming etc.
+        """
+
+        chunk_size = min(16 * 1024 * 1024, log_segment_size)
+
+        if self.redpanda.dedicated_nodes:
+            partition_count = 128
+
+            # Lowball expectation of bandwidth that should work reliably on
+            # small instance types
+            expect_bandwidth = 100E6
+
+            # Make the cache at least this big (avoid using very small caches when
+            # the segment size is small)
+            at_least_bytes = 20 * 1024 * 1024 * 1024
+        else:
+            # In general, this test should always be run on dedicated nodes: mini-me mode
+            # for developers on fast workstations hacking on the test.
+            partition_count = 16
+            expect_bandwidth = 20E6
+            at_least_bytes = 1 * 1024 * 1024 * 1024
+
+        topic_name = 'streaming-read'
+
+        msg_size = 16384
+
+        # Cache trim interval is 5 seconds.  Cache trim low watermark is 80%.
+        # Effective streaming bandwidth is 20% of cache size every trim period
+        size_limit = max(int((expect_bandwidth * 5) / 0.2),
+                         partition_count * chunk_size)
+        size_limit = max(size_limit, at_least_bytes)
+        # One index per segment, one tx file per segment, one object per chunk bytes
+        max_objects = (size_limit //
+                       log_segment_size) * 2 + size_limit // chunk_size
+
+        if partition_count >= len(self.redpanda.nodes):
+            # If we have multiple partitions then we are spreading load across multiple
+            # nodes, and each node should need a proportionally smaller cache
+            size_limit // len(self.redpanda.nodes)
+
+        # Use interval uploads so that tests can do a "wait til everything uploaded"
+        # check if they want to.
+        extra_rp_conf = {
+            'cloud_storage_segment_max_upload_interval_sec':
+            self.segment_upload_interval,
+            'cloud_storage_manifest_max_upload_interval_sec':
+            self.manifest_upload_interval,
+        }
+
+        si_settings = SISettings(
+            test_context=self.test_context,
+            log_segment_size=log_segment_size,
+        )
+
+        if limit_mode == LimitMode.bytes:
+            si_settings.cloud_storage_cache_size = int(size_limit)
+            si_settings.cloud_storage_cache_max_objects = 2**32 - 1
+        elif limit_mode == LimitMode.objects:
+            si_settings.cloud_storage_cache_size = 2**64 - 1
+            si_settings.cloud_storage_cache_max_objects = int(max_objects)
+        elif limit_mode == LimitMode.both:
+            # This is the normal way of configuring Redpanda, with
+            # safety limits on both data and metadata
+            si_settings.cloud_storage_cache_size = int(size_limit)
+            si_settings.cloud_storage_cache_max_objects = int(max_objects)
+        else:
+            raise NotImplementedError(limit_mode)
+
+        # Write 5x more data than fits in the cache, so that during a consume
+        # cycle we are having to drop+rehydrate it all.
+        data_size = size_limit * 5
+
+        # Write 3x more than one segment size, so that we will be reading from
+        # remote data instead of local data (local retention set to one segment)
+        data_size = max(data_size, log_segment_size * 3 * partition_count)
+
+        msg_count = data_size // msg_size
+
+        # We will run with artificially constrained memory, to minimize use of
+        # the batch cache and ensure that tiered storage reads are not using
+        # egregious amounts of memory.  The memory is within the official system
+        # requirements (2GB per core).  Use a small core count so that if we're
+        # running on a system with plenty of cores, we don't spread out the
+        # partitions such that each core has lots of slack memory.
+        self.redpanda.set_resource_settings(
+            ResourceSettings(memory_mb=4096, num_cpus=2))
+
+        self.redpanda.set_extra_rp_conf(extra_rp_conf)
+        self.redpanda.set_si_settings(si_settings)
+        self.redpanda.start()
+
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(
+            topic_name,
+            partitions=partition_count,
+            replicas=3,
+            config={
+                # Minimal local retention, to send traffic to remote
+                # storage.
+                'retention.local.target.bytes': log_segment_size,
+            })
+
+        self.logger.info(
+            f"Writing {data_size} bytes, will be read using {size_limit}/{max_objects} cache"
+        )
+
+        # Sanity check test parameters against the nodes we are running on
+        disk_space_required = size_limit + data_size
+        assert self.redpanda.get_node_disk_free(
+        ) >= disk_space_required, f"Need at least {disk_space_required} bytes space"
+
+        # Write out the data.  We will write + read in separate phases in order
+        # that this test cleanly exercises the read path.
+        t1 = time.time()
+        KgoVerifierProducer.oneshot(
+            self.test_context,
+            self.redpanda,
+            topic_name,
+            msg_size=msg_size,
+            msg_count=data_size // msg_size,
+            batch_max_bytes=msg_size * 8,
+            timeout_sec=(data_size / expect_bandwidth) * 2)
+        produce_duration = time.time() - t1
+        self.logger.info(
+            f"Produced {data_size} bytes in {produce_duration} seconds, {(data_size/produce_duration)/1000000.0:.2f}MB/s"
+        )
+
+        # Wait for uploads to complete
+        quiesce_uploads(self.redpanda, [topic_name], 30)
+
+        # Read all the data, validate that we read complete and achieve
+        # the streaming bandwidth that we expect
+        t1 = time.time()
+        expect_duration = data_size // expect_bandwidth
+        self.logger.info(
+            f"Consuming, expected duration {expect_duration:.2f}s")
+        consumer = KgoVerifierSeqConsumer.oneshot(self.test_context,
+                                                  self.redpanda,
+                                                  topic_name,
+                                                  loop=False,
+                                                  timeout_sec=expect_duration *
+                                                  2)
+        assert consumer.consumer_status.validator.valid_reads == msg_count
+        assert consumer.consumer_status.validator.invalid_reads == 0
+        assert consumer.consumer_status.validator.out_of_scope_invalid_reads == 0
+        consume_duration = time.time() - t1
+        consume_rate = data_size / consume_duration
+        self.logger.info(
+            f"Consumed {data_size} bytes in {consume_duration} seconds, {consume_rate/1000000.0:.2f}MB/s"
+        )
+
+        # If we are not keeping up, it indicates an issue with trimming logic, such as
+        # backing off too much or not trimming enough each time: there is a generous
+        # 2x margin to make the test robust: if this _still_ fails, something is up.
+        assert consume_rate > expect_bandwidth / 2
+
+        # Validate that the cache end state is within configured limit
+        nodes_cache_used = self.redpanda.for_nodes(
+            self.redpanda.nodes, lambda n: self._validate_node_storage(
+                n, limit_mode, size_limit, max_objects))
+
+        # At least one node should have _something_ in its cache, or something is wrong with our test
+        assert any(nodes_cache_used) is True

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -64,6 +64,29 @@ class KgoVerifierService(Service):
     def __del__(self):
         self._release_port()
 
+    @classmethod
+    def oneshot(cls, *args, **kwargs):
+        """
+        Convenience method for constructing, running and releasing node.
+
+        Invoke with the same arguments as constructor, and optionally also
+        `timeout_sec` if you would like to configure the wait timeout.
+
+        Returns the finished instance, so that one can read its status methods
+        to verify message counts etc
+        """
+
+        if 'timeout_sec' in kwargs:
+            timeout_kwargs = {'timeout_sec': kwargs.pop('timeout_sec')}
+        else:
+            timeout_kwargs = {}
+
+        inst = cls(*args, **kwargs)
+        inst.start()
+        inst.wait(**timeout_kwargs)
+        inst.free()
+        return inst
+
     def _release_port(self):
         for node in self.nodes:
             port_map = getattr(node, "kgo_verifier_ports", dict())
@@ -432,17 +455,18 @@ class ConsumerStatus:
 
 
 class KgoVerifierSeqConsumer(KgoVerifierService):
-    def __init__(self,
-                 context,
-                 redpanda,
-                 topic,
-                 msg_size,
-                 max_msgs=None,
-                 max_throughput_mb=None,
-                 nodes=None,
-                 debug_logs=False,
-                 trace_logs=False,
-                 loop=True):
+    def __init__(
+            self,
+            context,
+            redpanda,
+            topic,
+            msg_size=None,  # TODO: redundant, remove
+            max_msgs=None,
+            max_throughput_mb=None,
+            nodes=None,
+            debug_logs=False,
+            trace_logs=False,
+            loop=True):
         super(KgoVerifierSeqConsumer,
               self).__init__(context, redpanda, topic, msg_size, nodes,
                              debug_logs, trace_logs)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2556,11 +2556,12 @@ class RedpandaService(RedpandaServiceBase):
         nodes = [(n, None) for n in self.nodes]
         for _ in range(3):
             retries = []
-            for node, _ in nodes:
-                pct_diff, reclaimable_diff, *deets = inspect_node(node)
+            results = self.for_nodes(nodes, lambda n: (n, inspect_node(n)))
+            for (node, (pct_diff, reclaimable_diff, *deets)) in results:
                 if pct_diff > 0.05 + reclaimable_diff:
                     retries.append(
                         (node, (pct_diff, reclaimable_diff, *deets)))
+
             if not retries:
                 # all good
                 return

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -358,6 +358,7 @@ class SISettings:
                  cloud_storage_api_endpoint: str = 'minio-s3',
                  cloud_storage_api_endpoint_port: int = 9000,
                  cloud_storage_cache_size: int = 160 * 1000000,
+                 cloud_storage_cache_max_objects: Optional[int] = None,
                  cloud_storage_enable_remote_read: bool = True,
                  cloud_storage_enable_remote_write: bool = True,
                  cloud_storage_max_connections: Optional[int] = None,
@@ -407,6 +408,7 @@ class SISettings:
 
         self.log_segment_size = log_segment_size
         self.cloud_storage_cache_size = cloud_storage_cache_size
+        self.cloud_storage_cache_max_objects = cloud_storage_cache_max_objects
         self.cloud_storage_enable_remote_read = cloud_storage_enable_remote_read
         self.cloud_storage_enable_remote_write = cloud_storage_enable_remote_write
         self.cloud_storage_max_connections = cloud_storage_max_connections
@@ -511,6 +513,10 @@ class SISettings:
         conf["log_segment_size"] = self.log_segment_size
         conf["cloud_storage_enabled"] = True
         conf["cloud_storage_cache_size"] = self.cloud_storage_cache_size
+        if self.cloud_storage_cache_max_objects is not None:
+            conf[
+                "cloud_storage_cache_max_objects"] = self.cloud_storage_cache_max_objects
+
         conf[
             'cloud_storage_enable_remote_read'] = self.cloud_storage_enable_remote_read
         conf[

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -11,6 +11,7 @@ import os
 import re
 import itertools
 from typing import Optional
+from dataclasses import dataclass
 
 
 class Segment:
@@ -154,11 +155,26 @@ class PartitionNotFoundError(Exception):
     pass
 
 
+@dataclass
+class NodeCacheStorage:
+    # Total size of the directory according to `du`
+    bytes: int
+
+    # Total number of non-directory files in the cache dir.  This count
+    # overlaps with subsequent type-specific object counts
+    objects: int
+
+    # Number of .index files
+    indices: int
+
+
 class NodeStorage:
-    def __init__(self, name, data_dir):
+    def __init__(self, name: str, data_dir: str, cache_dir: str):
         self.data_dir = data_dir
+        self.cache_dir = cache_dir
         self.ns = dict()
         self.name = name
+        self.cache = None
 
     def add_namespace(self, ns, path):
         n = Namespace(ns, path)
@@ -182,6 +198,9 @@ class NodeStorage:
             )
 
         return partitions[partition_idx].segments.values()
+
+    def set_cache_stats(self, stats: NodeCacheStorage):
+        self.cache = stats
 
 
 class ClusterStorage:

--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -201,7 +201,7 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
         self._assert_files_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$')
         self._assert_files_in_cache(f'.*kafka/{self.topic}/.*index$')
 
-    @cluster(num_nodes=4)
+    @cluster(num_nodes=4, log_allow_list=["Exceeded cache size limit"])
     def test_read_when_cache_smaller_than_segment_size(self):
         self.si_settings.cloud_storage_cache_size = 1048576 * 4
         self.redpanda.set_si_settings(self.si_settings)

--- a/tests/rptest/tests/node_id_assignment_test.py
+++ b/tests/rptest/tests/node_id_assignment_test.py
@@ -160,8 +160,7 @@ class NodeIdAssignmentParallel(RedpandaTest):
     def test_assign_multiple_nodes(self):
         self.redpanda.start(self.redpanda.nodes[1:],
                             auto_assign_node_id=True,
-                            omit_seeds_on_idx_one=False,
-                            parallel=True)
+                            omit_seeds_on_idx_one=False)
 
         def check_num_nodes():
             brokers = self.redpanda._admin.get_brokers()

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -94,9 +94,7 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # Seed nodes need to be started in parallel because they need to be
         # able to form a quorum before they become ready.
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_with_rpk,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_with_rpk)
         for node in self.redpanda.nodes:
             node_ids.add(self.redpanda.node_id(node))
         assert len(node_ids) == 3, f"Node IDs: {node_ids}"
@@ -125,16 +123,13 @@ class RpkRedpandaStartTest(RedpandaTest):
                     f"{rpk} redpanda config set redpanda.rpc_server " \
                     f"'{{\"address\":\"{node.account.hostname}\",\"port\":33145}}'")
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 config_bootstrap_with_rpk,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, config_bootstrap_with_rpk)
 
         # Run a start with no arguments, as is done when Redpanda is run by a
         # systemd service.
-        self.redpanda._for_nodes(
+        self.redpanda.for_nodes(
             self.redpanda.nodes,
-            lambda n: self.redpanda.start_node_with_rpk(n, clean_node=False),
-            parallel=True)
+            lambda n: self.redpanda.start_node_with_rpk(n, clean_node=False))
         node_ids = set()
         for node in self.redpanda.nodes:
             node_ids.add(self.redpanda.node_id(node))
@@ -265,9 +260,7 @@ class RpkRedpandaStartTest(RedpandaTest):
             # the limits when TLS is enabled.
             node.account.ssh("sysctl fs.inotify.max_user_instances=512")
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 setup_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, setup_cluster)
 
         seeds_str = ",".join(
             [f"{n.account.hostname}" for n in self.redpanda.nodes])
@@ -285,9 +278,7 @@ class RpkRedpandaStartTest(RedpandaTest):
             assert self.redpanda.search_log_node(
                 node, "redpanda.rpc_server_tls:{ enabled: 1")
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_cluster)
 
         # To validate that everything works fine we check that
         # formed a cluster and we can produce and consume from it
@@ -306,9 +297,7 @@ class RpkRedpandaStartTest(RedpandaTest):
             pass
 
         self.redpanda.stop()
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_cluster)
         try:
             for i in range(50, 100):
                 self.rpk.produce(topic, f"k-{i}", f"v-test-{i}", timeout=5)
@@ -337,9 +326,7 @@ class RpkRedpandaStartTest(RedpandaTest):
 
             self.redpanda.start_node_with_rpk(node, clean_node=False)
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 setup_and_start,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, setup_and_start)
 
         # Check that we don't enable rpc and print a warning
         assert self.redpanda.search_log_all(
@@ -368,9 +355,7 @@ class RpkRedpandaStartTest(RedpandaTest):
                            f"[{self.rpc_server_tls()}]")
             node.account.ssh("sysctl fs.inotify.max_user_instances=512")
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 setup_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, setup_cluster)
 
         seeds_str = ",".join(
             [f"{n.account.hostname}" for n in self.redpanda.nodes])
@@ -385,9 +370,7 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # On first start we validate that TLS is disabled and produce
         # to a topic.
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_cluster)
         assert self.redpanda.search_log_all(
             "redpanda.rpc_server_tls:{ enabled: 0", self.redpanda.nodes)
 
@@ -414,9 +397,7 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # Restart and validate rpc_server_tls is enabled.
         self.redpanda.stop()
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_cluster)
         assert self.redpanda.search_log_all(
             "redpanda.rpc_server_tls:{ enabled: 1", self.redpanda.nodes)
 

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -194,10 +194,9 @@ class BucketScrubSelfTest(RedpandaTest):
         # Initially a bucket scrub should pass
         self.logger.info(f"Running baseline scrub")
         self.redpanda.stop_and_scrub_object_storage()
-        self.redpanda._for_nodes(
+        self.redpanda.for_nodes(
             self.redpanda.nodes,
-            lambda n: self.redpanda.start_node(n, first_start=False),
-            parallel=True)
+            lambda n: self.redpanda.start_node(n, first_start=False))
 
         # Go delete a segment: pick one arbitrarily, but it must be one
         # that is linked into a manifest to constitute a corruption.
@@ -230,10 +229,9 @@ class BucketScrubSelfTest(RedpandaTest):
             segment_key,
             validate=True)
 
-        self.redpanda._for_nodes(
+        self.redpanda.for_nodes(
             self.redpanda.nodes,
-            lambda n: self.redpanda.start_node(n, first_start=False),
-            parallel=True)
+            lambda n: self.redpanda.start_node(n, first_start=False))
 
 
 class SimpleSelfTest(Test):


### PR DESCRIPTION
- Cache size is now limited by object count, as well as byte count, to avoid issues where many small objects stress the metadata/trimming code
- A new test validates that a read workload reading data much beyond the cache size proceeds with good performance as long as the cache is large enough that trimming 20% every 5 seconds enables the reader to proceed.  This will cache any "stutters" in the cache management, or issues with prompt trimming.
- ENOSPC errors in cache ::put are handled explicitly by blocking writes and immediately trimming.
- The reservation mechanism is revised to require all put() calls to provide a reservation, and to release reserved capacity atomically at the same time as the actual used capacity is updated at the end of a put.
- When a cache trim has failed to free enough space to allow a reservation to succeed, a new `_last_trim_failed` flag is used to permit subsequent reservations to proceed without each one having to wait for the cache trim interval.
- Various test improvements: update tiered_storage_single_partition_test to do a consume, add a `oneshot` helper to kgo-verifier services, 

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
