### PR TITLE
kafka: revert #10371

### DIFF
--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -12,8 +12,6 @@
 #include "config/base_property.h"
 #include "config/property.h"
 
-#include <optional>
-
 namespace config {
 
 /**
@@ -26,21 +24,10 @@ namespace detail {
  * Traits required for a type to be usable with `numeric_bounds`
  */
 template<typename T>
-concept numeric = requires(const T& x, const T& y) {
-    x - y;
-    x + y;
-    x / 2;
-    { x < y } -> std::same_as<bool>;
-    { x > y } -> std::same_as<bool>;
-};
-
-/**
- * Traits required for a type to be usable with `numeric_integral_bounds`
- */
-template<typename T>
-concept numeric_integral = requires(const T& x, const T& y) {
-    requires numeric<T>;
-    x % y;
+concept numeric = requires(const T& x) {
+    {x % x};
+    { x < x } -> std::same_as<bool>;
+    { x > x } -> std::same_as<bool>;
 };
 
 /**
@@ -71,36 +58,20 @@ struct inner_type<T> {
     using inner = typename T::value_type;
 };
 
-/**
- * Traits for the bounds types
- */
-template<typename T>
-concept bounds = requires(T bounds, const typename T::underlying_t& value) {
-    {
-        bounds.min
-        } -> std::convertible_to<std::optional<typename T::underlying_t>>;
-    {
-        bounds.max
-        } -> std::convertible_to<std::optional<typename T::underlying_t>>;
-    { bounds.validate(value) } -> std::same_as<std::optional<ss::sstring>>;
-    { bounds.clamp(value) } -> std::same_as<typename T::underlying_t>;
-};
-
 } // namespace detail
 
 /**
- * Define valid bounds for an integral numeric configuration property.
+ * Define valid bounds for a numeric configuration property.
  */
 template<typename T>
-requires detail::numeric_integral<T>
-struct numeric_integral_bounds {
-    using underlying_t = T;
+requires detail::numeric<T>
+struct numeric_bounds {
     std::optional<T> min = std::nullopt;
     std::optional<T> max = std::nullopt;
     std::optional<T> align = std::nullopt;
     std::optional<odd_even_constraint> oddeven = std::nullopt;
 
-    T clamp(const T& original) const {
+    T clamp(T& original) {
         T result = original;
 
         if (align.has_value()) {
@@ -119,7 +90,7 @@ struct numeric_integral_bounds {
         return result;
     }
 
-    std::optional<ss::sstring> validate(const T& value) const {
+    std::optional<ss::sstring> validate(T& value) {
         if (min.has_value() && value < min.value()) {
             return fmt::format("too small, must be at least {}", min.value());
         } else if (max.has_value() && value > max.value()) {
@@ -140,48 +111,7 @@ struct numeric_integral_bounds {
     }
 };
 
-/**
- * Define valid bounds for any numeric configuration property.
- */
-template<detail::numeric T>
-struct numeric_bounds {
-    using underlying_t = T;
-    std::optional<T> min = std::nullopt;
-    std::optional<T> max = std::nullopt;
-
-    T clamp(T value) const {
-        if (min.has_value()) {
-            value = std::max(min.value(), value);
-        }
-        if (max.has_value()) {
-            value = std::min(max.value(), value);
-        }
-        return value;
-    }
-
-    std::optional<ss::sstring> validate(const T& value) const {
-        if (min.has_value() && value < min.value()) {
-            return fmt::format("too small, must be at least {}", min.value());
-        } else if (max.has_value() && value > max.value()) {
-            return fmt::format("too large, must be at most {}", max.value());
-        }
-        return std::nullopt;
-    }
-};
-
-/**
- * A property that validates its value against the constraints defined by \p B
- *
- * \tparam T Underlying property value type
- * \tparam B Bounds class, like \ref numeric_integral_bounds or
- *      \ref numeric_bounds, or user defined that satisfies \ref detail::bounds
- * \tparam I Always default
- */
-template<
-  typename T,
-  template<typename> typename B = numeric_integral_bounds,
-  typename I = typename detail::inner_type<T>::inner>
-requires detail::bounds<B<I>>
+template<typename T, typename I = typename detail::inner_type<T>::inner>
 class bounded_property : public property<T> {
 public:
     bounded_property(
@@ -190,7 +120,7 @@ public:
       std::string_view desc,
       base_property::metadata meta,
       T def,
-      B<I> bounds,
+      numeric_bounds<I> bounds,
       std::optional<legacy_default<T>> legacy = std::nullopt)
       : property<T>(
         conf,
@@ -265,9 +195,11 @@ private:
 
         if (_bounds.min.has_value() && _bounds.max.has_value()) {
             // Take midpoint of min/max and align it.
-            guess = _bounds.clamp(
-              _bounds.min.value()
-              + (_bounds.max.value() - _bounds.min.value()) / 2);
+            guess = _bounds.min.value()
+                    + (_bounds.max.value() - _bounds.min.value()) / 2;
+            if (_bounds.align.has_value()) {
+                guess -= guess % _bounds.align.value();
+            }
         } else {
             if constexpr (reflection::is_std_optional<T>) {
                 if (property<T>::_default.has_value()) {
@@ -284,7 +216,7 @@ private:
         return fmt::format("{}", guess);
     }
 
-    B<I> _bounds;
+    numeric_bounds<I> _bounds;
 
     // The example value is stored rather than generated on the fly, to
     // satisfy the example() interface that wants a string_view: it

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1968,15 +1968,7 @@ configuration::configuration()
       "Interval, in seconds, of how often a message informing the operator "
       "that unsafe strings are permitted",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      300s)
-  , kafka_memory_share_for_fetch(
-      *this,
-      "kafka_memory_share_for_fetch",
-      "The share of kafka subsystem memory that can be used for fetch read "
-      "buffers, as a fraction of kafka subsystem memory amount",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      0.3,
-      {.min = 0.0, .max = 1.0}) {}
+      300s) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1975,17 +1975,8 @@ configuration::configuration()
       "The share of kafka subsystem memory that can be used for fetch read "
       "buffers, as a fraction of kafka subsystem memory amount",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      0.5,
-      {.min = 0.0, .max = 1.0})
-  , kafka_memory_batch_size_estimate_for_fetch(
-      *this,
-      "kafka_memory_batch_size_estimate_for_fetch",
-      "The size of the batch used to estimate memory consumption for Fetch "
-      "requests, in bytes. Smaller sizes allow more concurrent fetch requests "
-      "per shard, larger sizes prevent running out of memory because of too "
-      "many concurrent fetch requests.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      1_MiB) {}
+      0.3,
+      {.min = 0.0, .max = 1.0}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -405,7 +405,6 @@ struct configuration final : public config_store {
     property<std::chrono::seconds> legacy_unsafe_log_warning_interval_sec;
 
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
-    property<size_t> kafka_memory_batch_size_estimate_for_fetch;
 
     configuration();
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -404,8 +404,6 @@ struct configuration final : public config_store {
     property<bool> legacy_permit_unsafe_log_operation;
     property<std::chrono::seconds> legacy_unsafe_log_warning_interval_sec;
 
-    bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
-
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/config/tests/bounded_property_test.cc
+++ b/src/v/config/tests/bounded_property_test.cc
@@ -12,20 +12,12 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
-#include <optional>
-
-static_assert(config::detail::bounds<config::numeric_integral_bounds<int>>);
-static_assert(config::detail::bounds<config::numeric_bounds<double>>);
-
 namespace {
 
 struct test_config : public config::config_store {
     config::bounded_property<int32_t> bounded_int;
     config::bounded_property<std::optional<int32_t>> bounded_int_opt;
     config::bounded_property<int16_t> odd_constraint;
-    config::bounded_property<double, config::numeric_bounds> bounded_double;
-    config::bounded_property<std::optional<double>, config::numeric_bounds>
-      bounded_double_opt;
 
     test_config()
       : bounded_int(
@@ -48,24 +40,10 @@ struct test_config : public config::config_store {
           "Property value has to be odd",
           {},
           1,
-          {.oddeven = config::odd_even_constraint::odd})
-      , bounded_double(
-          *this,
-          "bounded_double",
-          "A float with some bounds set",
-          {},
-          1.618033988749,
-          {.min = -1, .max = 2.236067977})
-      , bounded_double_opt(
-          *this,
-          "bounded_double_opt",
-          "An options float with some bounds set",
-          {},
-          std::nullopt,
-          {.min = -1, .max = 2.236067977}) {}
+          {.oddeven = config::odd_even_constraint::odd}) {}
 };
 
-SEASTAR_THREAD_TEST_CASE(numeric_integral_bounds) {
+SEASTAR_THREAD_TEST_CASE(numeric_bounds) {
     auto cfg = test_config();
 
     // We are checking numeric bounds, not YAML syntax/type validation.  The
@@ -121,48 +99,6 @@ SEASTAR_THREAD_TEST_CASE(numeric_integral_bounds) {
     // Misaligned: clamp to next lowest alignment
     cfg.bounded_int.set_value(YAML::Load("8197"));
     BOOST_CHECK(cfg.bounded_int() == 8192);
-}
-
-SEASTAR_THREAD_TEST_CASE(numeric_fp_bounds) {
-    auto cfg = test_config();
-
-    // We are checking numeric bounds, not YAML syntax/type validation.  The
-    // latter shows up as exceptions from validate/set_value, rather than
-    // as structured errors, and is not covered by this test.
-    auto valid_values = {"-1", "-0.1", "1.618033988749", "2", "2.236067977"};
-    auto invalid_values = {
-      "-1000.9", "-1.0001", "3", "4095", "4097", "32769", "2000000000"};
-
-    std::optional<config::validation_error> verr;
-
-    for (const auto& v : valid_values) {
-        verr = cfg.bounded_double.validate(YAML::Load(v));
-        BOOST_TEST(!verr.has_value());
-
-        verr = cfg.bounded_double_opt.validate(YAML::Load(v));
-        BOOST_TEST(!verr.has_value());
-    }
-
-    for (const auto& v : invalid_values) {
-        verr = cfg.bounded_double.validate(YAML::Load(v));
-        BOOST_TEST(verr.has_value());
-
-        verr = cfg.bounded_double_opt.validate(YAML::Load(v));
-        BOOST_TEST(verr.has_value());
-    }
-
-    // Optional variant should also always consider nullopt to be valid.
-    verr = cfg.bounded_double_opt.validate(std::nullopt);
-    BOOST_TEST(!verr.has_value());
-
-    // # Invalid values should be clamped by set_value
-    // Too low: clamp to minimum
-    cfg.bounded_double.set_value(YAML::Load("-2"));
-    BOOST_TEST(cfg.bounded_double() == -1);
-
-    // Too high: clamp to maximum
-    cfg.bounded_double.set_value(YAML::Load("1000000"));
-    BOOST_TEST(cfg.bounded_double() == 2.236067977);
 }
 
 } // namespace

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -49,7 +49,6 @@
 
 namespace kafka {
 static constexpr std::chrono::milliseconds default_fetch_timeout = 5s;
-
 /**
  * Make a partition response error.
  */
@@ -919,14 +918,4 @@ std::ostream& operator<<(std::ostream& o, const consumer_info& ci) {
     fmt::print(o, "rack_id: {}, fetch_offset: {}", ci);
     return o;
 }
-
-size_t fetch_memory_estimator(
-  const size_t request_size, connection_context& /*conn_ctx*/) {
-    return request_size
-             * 3 // appx memory for fetch plans, fetch configs, read results
-           + config::shard_local_cfg()
-               .kafka_memory_batch_size_estimate_for_fetch();
-    // at least one batch of the data will be read
-}
-
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -355,10 +355,8 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
         total_max_bytes += c.cfg.max_bytes;
     }
 
-    // bytes_left comes from the fetch plan and also accounts for the max_bytes
-    // field in the fetch request
-    const size_t max_bytes_per_fetch = std::min<size_t>(
-      config::shard_local_cfg().kafka_max_bytes_per_fetch(), octx.bytes_left);
+    auto max_bytes_per_fetch
+      = config::shard_local_cfg().kafka_max_bytes_per_fetch();
     if (total_max_bytes > max_bytes_per_fetch) {
         auto per_partition = max_bytes_per_fetch / ntp_fetch_configs.size();
         vlog(
@@ -429,7 +427,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
         return ss::now();
     }
 
-    const bool foreign_read = shard != ss::this_shard_id();
+    bool foreign_read = shard != ss::this_shard_id();
 
     // dispatch to remote core
     return octx.rctx.partition_manager()

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -147,9 +147,10 @@ static ss::future<read_result> read_from_partition(
  */
 static ss::future<read_result> do_read_from_ntp(
   cluster::partition_manager& cluster_pm,
-  op_context& octx,
+  const replica_selector& replica_selector,
   ntp_fetch_config ntp_config,
-  bool foreign_read) {
+  bool foreign_read,
+  std::optional<model::timeout_clock::time_point> deadline) {
     /*
      * lookup the ntp's partition
      */
@@ -215,7 +216,7 @@ static ss::future<read_result> do_read_from_ntp(
         if (unlikely(!lso)) {
             co_return read_result(lso.error());
         }
-        auto preferred_replica = octx.rctx.replica_selector().select_replica(
+        auto preferred_replica = replica_selector.select_replica(
           consumer_info{
             .fetch_offset = ntp_config.cfg.start_offset,
             .rack_id = ntp_config.cfg.consumer_rack_id},
@@ -234,7 +235,7 @@ static ss::future<read_result> do_read_from_ntp(
         }
     }
     co_return co_await read_from_partition(
-      std::move(*kafka_partition), ntp_config.cfg, foreign_read, octx.deadline);
+      std::move(*kafka_partition), ntp_config.cfg, foreign_read, deadline);
 }
 
 static ntp_fetch_config
@@ -244,12 +245,17 @@ make_ntp_fetch_config(const model::ntp& ntp, const fetch_config& fetch_cfg) {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager& cluster_pm,
-  op_context& octx,
+  const replica_selector& replica_selector,
   const model::ntp& ntp,
   fetch_config config,
-  bool foreign_read) {
+  bool foreign_read,
+  std::optional<model::timeout_clock::time_point> deadline) {
     return do_read_from_ntp(
-      cluster_pm, octx, make_ntp_fetch_config(ntp, config), foreign_read);
+      cluster_pm,
+      replica_selector,
+      make_ntp_fetch_config(ntp, config),
+      foreign_read,
+      deadline);
 }
 
 static void fill_fetch_responses(
@@ -375,7 +381,12 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
       std::move(ntp_fetch_configs),
       [&cluster_pm, &octx, foreign_read](const ntp_fetch_config& ntp_cfg) {
           auto p_id = ntp_cfg.ntp().tp.partition;
-          return do_read_from_ntp(cluster_pm, octx, ntp_cfg, foreign_read)
+          return do_read_from_ntp(
+                   cluster_pm,
+                   octx.rctx.replica_selector(),
+                   ntp_cfg,
+                   foreign_read,
+                   octx.deadline)
             .then([p_id](read_result res) {
                 res.partition = p_id;
                 return res;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -30,7 +30,6 @@
 #include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "resource_mgmt/io_priority.h"
-#include "ssx/semaphore.h"
 #include "storage/parser_utils.h"
 #include "utils/to_string.h"
 
@@ -144,113 +143,6 @@ static ss::future<read_result> read_from_partition(
 }
 
 /**
- * Consume proper amounts of units from memory semaphores and return them as
- * semaphore_units. Fetch semaphore units returned are the indication of
- * available resources: if none, there is no memory for the operation;
- * if less than \p max_bytes, the fetch should be capped to that size.
- *
- * \param max_bytes The limit of how much data is going to be fetched
- * \param obligatory_batch_read Set to true for the first ntp in the fetch
- *   fetch request, at least one batch must be fetched for that ntp. Also it
- *   is assumed that a batch size has already been consumed from kafka
- *   memory semaphore for it.
- */
-read_result::memory_units_t reserve_memory_units(
-  const request_context& rctx,
-  const size_t max_bytes,
-  const bool obligatory_batch_read) {
-    read_result::memory_units_t memory_units;
-    const size_t memory_kafka_now = rctx.memory_sem().current();
-    const size_t memory_fetch = rctx.memory_fetch_sem().current();
-    const size_t batch_size_estimate
-      = config::shard_local_cfg().kafka_memory_batch_size_estimate_for_fetch();
-
-    if (obligatory_batch_read) {
-        // `batch_size_estimate` units has already been consumed from
-        // memory_sem in the very beginning of request handling
-        // (see \ref fetch_memory_estimator,
-        // \ref connection_context::reserve_request_units). Since
-        // `obligatory_batch_read` only appear once per \ref
-        // fetch_ntps_in_parallel call, it is used to avoid taking that
-        // amount from memory_sem twice.
-        // Note on changing `kafka_memory_batch_size_estimate_for_fetch`
-        // property at runtime: it is possible that when the property is
-        // changed, the value for `batch_size_estimate` will be different in
-        // `fetch_memory_estimator()` and here, and the `memory_kafka_before`
-        // value will be off. However this will be a one time event that should
-        // not cause dramatic consequences. An alternative would be to store a
-        // copy of the value in each request context which will not be necessary
-        // at least 99.99% of times.
-        const size_t memory_kafka_before = memory_kafka_now
-                                           + batch_size_estimate;
-        // don't reserve more than available, unless it's less than a batch
-        const size_t fetch_size = std::max(
-          batch_size_estimate,
-          std::min({max_bytes, memory_kafka_before, memory_fetch}));
-        memory_units.fetch = ss::consume_units(
-          rctx.memory_fetch_sem(), fetch_size);
-        // remember: a batch has been reserved upfront
-        memory_units.kafka = ss::consume_units(
-          rctx.memory_sem(), fetch_size - batch_size_estimate);
-    } else {
-        // don't try to reserve less than a batch
-        const size_t requested_fetch_size = std::max(
-          max_bytes, batch_size_estimate);
-        // but don't reserve more than available
-        const size_t fetch_size = std::min(
-          {requested_fetch_size, memory_kafka_now, memory_fetch});
-        // if not enough memory is available, nothing is reserved
-        if (fetch_size >= batch_size_estimate) {
-            memory_units.fetch = ss::consume_units(
-              rctx.memory_fetch_sem(), fetch_size);
-            memory_units.kafka = ss::consume_units(
-              rctx.memory_sem(), fetch_size);
-        }
-    }
-
-    return memory_units;
-}
-
-/**
- * Make the \p units hold exactly \p target_bytes, by consuming more units
- * from \p sem or by returning extra units back.
- */
-static void adjust_semaphore_units(
-  ssx::semaphore& sem, ssx::semaphore_units& units, const size_t target_bytes) {
-    if (target_bytes < units.count()) {
-        units.return_units(units.count() - target_bytes);
-    }
-    if (target_bytes > units.count()) {
-        units.adopt(ss::consume_units(sem, target_bytes - units.count()));
-    }
-}
-
-/**
- * Memory units have been reserved before the read op based on an estimation.
- * Now when we know how much data has actually been read, return any extra
- * amount.
- */
-static void adjust_memory_units(
-  const request_context& rctx,
-  read_result::memory_units_t& memory_units,
-  const size_t read_bytes,
-  const bool obligatory_read) {
-    const size_t batch_size_estimate
-      = config::shard_local_cfg().kafka_memory_batch_size_estimate_for_fetch();
-    // for kafka memsemaphore, account for the pre-allocated amount that is not
-    // in the units counter
-    const size_t read_after_obligatory = obligatory_read
-                                           ? std::max(
-                                               read_bytes, batch_size_estimate)
-                                               - batch_size_estimate
-                                           : read_bytes;
-    adjust_semaphore_units(
-      rctx.memory_fetch_sem(), memory_units.fetch, read_bytes);
-    adjust_semaphore_units(
-      rctx.memory_sem(), memory_units.kafka, read_after_obligatory);
-}
-
-/**
  * Entry point for reading from an ntp. This is executed on NTP home core and
  * build error responses if anything goes wrong.
  */
@@ -258,20 +150,7 @@ static ss::future<read_result> do_read_from_ntp(
   cluster::partition_manager& cluster_pm,
   op_context& octx,
   ntp_fetch_config ntp_config,
-  bool foreign_read,
-  const bool obligatory_batch_read) {
-    // control available memory
-    read_result::memory_units_t memory_units;
-    if (!ntp_config.cfg.skip_read) {
-        memory_units = reserve_memory_units(
-          octx.rctx, ntp_config.cfg.max_bytes, obligatory_batch_read);
-        if (!memory_units.fetch) {
-            ntp_config.cfg.skip_read = true;
-        } else if (ntp_config.cfg.max_bytes > memory_units.fetch.count()) {
-            ntp_config.cfg.max_bytes = memory_units.fetch.count();
-        }
-    }
-
+  bool foreign_read) {
     /*
      * lookup the ntp's partition
      */
@@ -355,13 +234,8 @@ static ss::future<read_result> do_read_from_ntp(
               preferred_replica);
         }
     }
-    read_result result = co_await read_from_partition(
+    co_return co_await read_from_partition(
       std::move(*kafka_partition), ntp_config.cfg, foreign_read, octx.deadline);
-
-    adjust_memory_units(
-      octx.rctx, memory_units, result.data_size_bytes(), obligatory_batch_read);
-    result.memory_units = std::move(memory_units);
-    co_return result;
 }
 
 static ntp_fetch_config
@@ -374,14 +248,9 @@ ss::future<read_result> read_from_ntp(
   op_context& octx,
   const model::ntp& ntp,
   fetch_config config,
-  bool foreign_read,
-  const bool obligatory_batch_read) {
+  bool foreign_read) {
     return do_read_from_ntp(
-      cluster_pm,
-      octx,
-      make_ntp_fetch_config(ntp, config),
-      foreign_read,
-      obligatory_batch_read);
+      cluster_pm, octx, make_ntp_fetch_config(ntp, config), foreign_read);
 }
 
 static void fill_fetch_responses(
@@ -505,14 +374,11 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
         }
     }
 
-    const auto first_p_id = ntp_fetch_configs.front().ntp().tp.partition;
     auto results = co_await ssx::parallel_transform(
       std::move(ntp_fetch_configs),
-      [&cluster_pm, &octx, foreign_read, first_p_id](
-        const ntp_fetch_config& ntp_cfg) {
-          const auto p_id = ntp_cfg.ntp().tp.partition;
-          return do_read_from_ntp(
-                   cluster_pm, octx, ntp_cfg, foreign_read, first_p_id == p_id)
+      [&cluster_pm, &octx, foreign_read](const ntp_fetch_config& ntp_cfg) {
+          auto p_id = ntp_cfg.ntp().tp.partition;
+          return do_read_from_ntp(cluster_pm, octx, ntp_cfg, foreign_read)
             .then([p_id](read_result res) {
                 res.partition = p_id;
                 return res;

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -229,11 +229,6 @@ struct read_result {
     using foreign_data_t = ss::foreign_ptr<std::unique_ptr<iobuf>>;
     using data_t = std::unique_ptr<iobuf>;
     using variant_t = std::variant<data_t, foreign_data_t>;
-    struct memory_units_t {
-        ssx::semaphore_units kafka;
-        ssx::semaphore_units fetch;
-    };
-
     explicit read_result(error_code e)
       : error(e) {}
 
@@ -311,7 +306,6 @@ struct read_result {
     error_code error;
     model::partition_id partition;
     std::vector<cluster::rm_stm::tx_range> aborted_transactions;
-    memory_units_t memory_units;
 };
 // struct aggregating fetch requests and corresponding response iterators for
 // the same shard
@@ -368,7 +362,6 @@ ss::future<read_result> read_from_ntp(
   op_context&,
   const model::ntp&,
   fetch_config,
-  bool,
-  bool obligatory_batch_read);
+  bool);
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -347,9 +347,10 @@ struct fetch_plan {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
-  op_context&,
+  const replica_selector&,
   const model::ntp&,
   fetch_config,
-  bool);
+  bool,
+  std::optional<model::timeout_clock::time_point>);
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -19,19 +19,7 @@
 
 namespace kafka {
 
-/**
- * Estimate the minimum size of memory required for a fetch request.
- *
- * Fetch request processing is adaptive to the amount of memory available,
- * controlled by kafka::server::memory_fetch_sem(). It can decide to read
- * from less partitions than requested. However it is required to read from
- * at least a single partition, and the amount of memory required for that
- * is accounted for upfront by this estimator.
- */
-memory_estimate_fn fetch_memory_estimator;
-
-using fetch_handler
-  = single_stage_handler<fetch_api, 4, 11, fetch_memory_estimator>;
+using fetch_handler = single_stage_handler<fetch_api, 4, 11>;
 
 /*
  * Fetch operation context

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -363,10 +363,6 @@ struct fetch_plan {
     }
 };
 
-/*
- * Unit Tests Exposure
- */
-
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
   op_context&,
@@ -374,8 +370,5 @@ ss::future<read_result> read_from_ntp(
   fetch_config,
   bool,
   bool obligatory_batch_read);
-
-read_result::memory_units_t reserve_memory_units(
-  const request_context& rctx, size_t max_bytes, bool obligatory_batch_read);
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -236,14 +236,6 @@ public:
         return _conn->server().get_replica_selector();
     }
 
-    ssx::semaphore& memory_sem() const noexcept {
-        return _conn->server().memory();
-    }
-
-    ssx::semaphore& memory_fetch_sem() const noexcept {
-        return _conn->server().memory_fetch_sem();
-    }
-
 private:
     template<typename ResponseType>
     void update_usage_stats(const ResponseType& r, size_t response_size) {

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -130,41 +130,14 @@ server::server(
   , _gssapi_principal_mapper(
       config::shard_local_cfg().sasl_kerberos_principal_mapping.bind())
   , _krb_configurator(config::shard_local_cfg().sasl_kerberos_config.bind())
-  , _memory_fetch_sem(
-      static_cast<size_t>(
-        cfg->local().max_service_memory_per_core
-        * config::shard_local_cfg().kafka_memory_share_for_fetch()),
-      "kafka/server-mem-fetch")
   , _thread_worker(tw)
   , _replica_selector(
       std::make_unique<rack_aware_replica_selector>(_metadata_cache.local())) {
-    vlog(
-      klog.debug,
-      "Starting kafka server with {} byte limit on fetch requests",
-      _memory_fetch_sem.available_units());
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);
     }
-    setup_metrics();
     _probe.setup_metrics();
     _probe.setup_public_metrics();
-}
-
-void server::setup_metrics() {
-    namespace sm = ss::metrics;
-    if (config::shard_local_cfg().disable_metrics()) {
-        return;
-    }
-
-    _metrics.add_group(
-      prometheus_sanitize::metrics_name(cfg.name),
-      {
-        sm::make_total_bytes(
-          "fetch_avail_mem_bytes",
-          [this] { return _memory_fetch_sem.current(); },
-          sm::description(ssx::sformat(
-            "{}: Memory available for fetch request processing", cfg.name))),
-      });
 }
 
 ss::scheduling_group server::fetch_scheduling_group() const {

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -165,11 +165,7 @@ public:
         return *_replica_selector;
     }
 
-    ssx::semaphore& memory_fetch_sem() noexcept { return _memory_fetch_sem; }
-
 private:
-    void setup_metrics();
-
     ss::smp_service_group _smp_group;
     ss::scheduling_group _fetch_scheduling_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
@@ -196,10 +192,7 @@ private:
     security::tls::principal_mapper _mtls_principal_mapper;
     security::gssapi_principal_mapper _gssapi_principal_mapper;
     security::krb5::configurator _krb_configurator;
-    ssx::semaphore _memory_fetch_sem;
-
     class latency_probe _probe;
-    ss::metrics::metric_groups _metrics;
     ssx::thread_worker& _thread_worker;
     std::unique_ptr<replica_selector> _replica_selector;
 };

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -170,17 +170,13 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
           std::move(rctx), ss::default_smp_service_group());
         octx.deadline = model::no_timeout;
         auto shard = octx.rctx.shards().shard_for(ntp).value();
-        kafka::read_result res = octx.rctx.partition_manager()
-                                   .invoke_on(
-                                     shard,
-                                     [&octx, ntp, config](
-                                       cluster::partition_manager& pm) {
-                                         return kafka::read_from_ntp(
-                                           pm, octx, ntp, config, true, false);
-                                     })
-                                   .get0();
-        BOOST_TEST_REQUIRE(res.has_data());
-        return res;
+        return octx.rctx.partition_manager()
+          .invoke_on(
+            shard,
+            [&octx, ntp, config](cluster::partition_manager& pm) {
+                return kafka::read_from_ntp(pm, octx, ntp, config, true, false);
+            })
+          .get0();
     };
     wait_for_controller_leadership().get0();
     auto ntp = make_data(get_next_partition_revision_id().get());

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -174,7 +174,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
           .invoke_on(
             shard,
             [&octx, ntp, config](cluster::partition_manager& pm) {
-                return kafka::read_from_ntp(pm, octx, ntp, config, true, false);
+                return kafka::read_from_ntp(pm, octx, ntp, config, true);
             })
           .get0();
     };

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -73,7 +73,7 @@ struct config_connection_rate_bindings {
 
 struct server_configuration {
     std::vector<server_endpoint> addrs;
-    int64_t max_service_memory_per_core = 0;
+    int64_t max_service_memory_per_core;
     std::optional<int> listen_backlog;
     std::optional<int> tcp_recv_buf;
     std::optional<int> tcp_send_buf;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -114,8 +114,6 @@ public:
         app.wire_up_and_start(*app_signal, true);
 
         configs.start(ss::sstring("fixture_config")).get();
-        configs.local().max_service_memory_per_core
-          = memory_groups::rpc_total_memory();
 
         // used by request context builder
         proto = std::make_unique<kafka::server>(

--- a/tests/rptest/tests/memory_stress_test.py
+++ b/tests/rptest/tests/memory_stress_test.py
@@ -9,7 +9,7 @@
 
 from enum import Enum
 
-from ducktape.mark import ok_to_fail, parametrize
+from ducktape.mark import ok_to_fail
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.kaf_consumer import KafConsumer
@@ -36,12 +36,10 @@ class MemoryStressTest(RedpandaTest):
         # enabling each test case to customize its ResourceSettings
         pass
 
+    @ok_to_fail  # until the fix is delivered
     @cluster(num_nodes=5)
     @skip_debug_mode
-    @parametrize(memory_share_for_fetch=0.05)
-    @parametrize(memory_share_for_fetch=0.5)
-    @parametrize(memory_share_for_fetch=0.8)
-    def test_fetch_with_many_partitions(self, memory_share_for_fetch: float):
+    def test_fetch_with_many_partitions(self):
         """
         Exhaust memory by consuming from too many partitions in a single Fetch
         API request.
@@ -49,15 +47,11 @@ class MemoryStressTest(RedpandaTest):
         # memory_mb does not work with debug redpanda build, therefore the test
         # only makes sense with release redpanda, hence @skip_debug_mode
         self.redpanda.set_resource_settings(
-            ResourceSettings(memory_mb=512, num_cpus=1))
+            ResourceSettings(memory_mb=256, num_cpus=1))
         self.redpanda.set_seed_servers(self.redpanda.nodes)
-        self.redpanda.add_extra_rp_conf({
-            "kafka_batch_max_bytes":
-            10 * 1024 * 1024,
-            "kafka_memory_share_for_fetch":
-            memory_share_for_fetch
-        })
         self.redpanda.start(omit_seeds_on_idx_one=False)
+        self.redpanda.set_cluster_config(
+            {"kafka_batch_max_bytes": 10 * 1024 * 1024})
 
         # the maximum message size that does not make redpanda OOM with all
         # the other params as they are is 64 MiB
@@ -74,9 +68,8 @@ class MemoryStressTest(RedpandaTest):
             150 * 500_000)
         produce_timeout = msg_count * msg_size // 2184533
         self.logger.info(
-            f"Starting producer. msg_size={msg_size}, msg_count={msg_count}, "
-            f"partiton_count={partition_count}, rpk_response_timeout={rpk_response_timeout}, "
-            f"produce_timeout={produce_timeout}")
+            f"Starting producer. msg_size={msg_size}, msg_count={msg_count}, partiton_count={partition_count}, rpk_response_timeout={rpk_response_timeout}, produce_timeout={produce_timeout}"
+        )
 
         producer = RpkProducer(self.test_context,
                                self.redpanda,


### PR DESCRIPTION

#10371 is suspected of causing:
- https://github.com/redpanda-data/redpanda/issues/10664
- Numerous "failed to consume up to offsets" failures

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none