### PR TITLE
rptest: harden final storage consistency check

### DIFF
--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -726,6 +726,10 @@
                 "compaction": {
                     "type": "long",
                     "description": "Compaction index"
+                },
+                "reclaimable_by_retention": {
+                    "type": "long",
+                    "description": "Number of bytes currently reclaimable by retention"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4042,6 +4042,7 @@ admin_server::get_local_storage_usage_handler(
     ret.data = disk.usage.data + other;
     ret.index = disk.usage.index;
     ret.compaction = disk.usage.compaction;
+    ret.reclaimable_by_retention = disk.reclaim.retention;
 
     co_return ret;
 }

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2134,11 +2134,13 @@ class RedpandaService(RedpandaServiceBase):
             observed disk usage.
             """
             try:
+                observed = list(self.data_stat(node))
                 reported = self._admin.get_local_storage_usage(node)
+
+                observed_total = sum(s for _, s in filter(tracked, observed))
                 reported_total = reported["data"] + reported[
                     "index"] + reported["compaction"]
-                observed = list(self.data_stat(node))
-                observed_total = sum(s for _, s in filter(tracked, observed))
+
                 diff = observed_total - reported_total
                 return abs(
                     diff / reported_total


### PR DESCRIPTION
This set of patches is meant to harden the storage consistency check that runs
at the end ducktape tests. For each node, it queries the `local_storage_usage` endpoint
and compares the reported size with the size of the data directory.

To make this check more robust a couple of things are done:
1. Perform the local check first. This should reduce the time delta between the two checks
and make it less likely for Redpanda's retention application to race with the check.
2. Add the percentage of data reclaimable by retention in the max allowed diff (previously `5%`).

Fixes #10582


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
