### PR TITLE
archival: leadership based archival metric reporting

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1696,7 +1696,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
       .non_compacted_upload_result = {}, .compacted_upload_result = {}};
 }
 
-uint64_t ntp_archiver::estimate_backlog_size() {
+uint64_t ntp_archiver::estimate_backlog_size() const {
     auto last_offset = manifest().size() ? manifest().get_last_offset()
                                          : model::offset(0);
     auto log_generic = _parent.log();

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1414,11 +1414,6 @@ ntp_archiver::schedule_uploads(std::vector<upload_context> loop_contexts) {
           ctx.upload_kind,
           uploads_remaining);
 
-        // this metric is only relevant for non compacted uploads.
-        if (ctx.upload_kind == segment_upload_kind::non_compacted) {
-            _probe->upload_lag(ctx.last_offset - ctx.start_offset);
-        }
-
         std::exception_ptr ep;
         try {
             while (uploads_remaining > 0 && may_begin_uploads()) {

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -270,6 +270,9 @@ public:
       std::optional<std::reference_wrapper<retry_chain_node>> source_rtc
       = std::nullopt);
 
+    /// Returns the number of Kafka records that are pending upload.
+    int64_t records_pending_upload() const;
+
 private:
     // Labels for contexts in which manifest uploads occur. Used for logging.
     static constexpr const char* housekeeping_ctx_label = "housekeeping";

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -142,7 +142,7 @@ public:
 
     ss::future<cloud_storage::download_result> sync_manifest();
 
-    uint64_t estimate_backlog_size();
+    uint64_t estimate_backlog_size() const;
 
     /// \brief Probe remote storage and truncate the manifest if needed
     ss::future<std::optional<cloud_storage::partition_manifest>>

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -142,7 +142,9 @@ public:
 
     ss::future<cloud_storage::download_result> sync_manifest();
 
-    uint64_t estimate_backlog_size() const;
+    uint64_t estimate_backlog_size();
+    uint64_t last_estimated_backlog_size() const;
+    int64_t last_records_pending_upload() const;
 
     /// \brief Probe remote storage and truncate the manifest if needed
     ss::future<std::optional<cloud_storage::partition_manifest>>
@@ -574,6 +576,9 @@ private:
       _manifest_upload_interval;
 
     ss::sharded<features::feature_table>& _feature_table;
+
+    uint64_t _last_estimated_backlog_size{0};
+    int64_t _last_records_pending_upload{0};
 
     friend class archival_fixture;
 };

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -91,8 +91,8 @@ void ntp_level_probe::setup_dynamic_metrics(const model::ntp& ntp) {
       {
         sm::make_gauge(
           "pending",
-          [this] { return _pending; },
-          sm::description("Pending offsets"),
+          [this] { return _parent.records_pending_upload(); },
+          sm::description("Pending Kafka offsets"),
           labels)
           .aggregate(aggregate_labels),
       });
@@ -166,7 +166,7 @@ void ntp_level_probe::setup_dynamic_public_metrics(const model::ntp& ntp) {
           .aggregate(aggregate_labels),
         sm::make_gauge(
           "records_pending_upload",
-          [this] { return _pending; },
+          [this] { return _parent.records_pending_upload(); },
           sm::description("The number of records in the local log that have "
                           "not yet been uploaded"),
           labels)

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -171,8 +171,13 @@ void ntp_level_probe::setup_dynamic_public_metrics(const model::ntp& ntp) {
                           "not yet been uploaded"),
           labels)
           .aggregate(aggregate_labels),
+        sm::make_gauge(
+          "estimated_backlog_size_bytes",
+          [this] { return _parent.estimate_backlog_size(); },
+          sm::description("Estimated upload backlog size in bytes"),
+          labels)
+          .aggregate(aggregate_labels),
       });
-
 }
 
 upload_housekeeping_probe::upload_housekeeping_probe() {

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -91,7 +91,7 @@ void ntp_level_probe::setup_dynamic_metrics(const model::ntp& ntp) {
       {
         sm::make_gauge(
           "pending",
-          [this] { return _parent.records_pending_upload(); },
+          [this] { return _parent.last_records_pending_upload(); },
           sm::description("Pending Kafka offsets"),
           labels)
           .aggregate(aggregate_labels),
@@ -166,14 +166,14 @@ void ntp_level_probe::setup_dynamic_public_metrics(const model::ntp& ntp) {
           .aggregate(aggregate_labels),
         sm::make_gauge(
           "records_pending_upload",
-          [this] { return _parent.records_pending_upload(); },
+          [this] { return _parent.last_records_pending_upload(); },
           sm::description("The number of records in the local log that have "
                           "not yet been uploaded"),
           labels)
           .aggregate(aggregate_labels),
         sm::make_gauge(
           "estimated_backlog_size_bytes",
-          [this] { return _parent.estimate_backlog_size(); },
+          [this] { return _parent.last_estimated_backlog_size(); },
           sm::description("Estimated upload backlog size in bytes"),
           labels)
           .aggregate(aggregate_labels),

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -45,9 +45,6 @@ public:
     /// Register gap
     void gap_detected(model::offset offset_delta) { _missing += offset_delta; }
 
-    /// Register the offset the ought to be uploaded
-    void upload_lag(model::offset offset_delta) { _pending = offset_delta; }
-
     void segments_deleted(int64_t deleted_count) {
         _segments_deleted += deleted_count;
     };
@@ -72,7 +69,6 @@ public:
     void notify_lost_leadership() {
         _segments_to_delete = 0;
         _segments_in_manifest = 0;
-        _pending = 0;
 
         _dynamic_metrics.reset();
         _dynamic_public_metrics.reset();
@@ -92,8 +88,6 @@ private:
     uint64_t _uploaded_bytes = 0;
     /// Missing offsets due to gaps
     int64_t _missing = 0;
-    /// Width of the offset range yet to be uploaded
-    int64_t _pending = 0;
     /// Number of segments deleted by garbage collection
     int64_t _segments_deleted = 0;
 


### PR DESCRIPTION
This PR reworks the archival probe to differentiate between static and dynamic metrics.
Dynamic metrics are only reported by the leader. This makes the pending offsets metric much more useful. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Improvements
* Added redpanda_cloud_storage_records_pending_upload and redpanda_cloud_storage_estimated_backlog_size metrics. vectorized_ntp_archiver_pending now works in terms of Kafka offsets.
