### PR TITLE
k8s: fix formatting in shell script

### DIFF
--- a/src/go/k8s/hack/get-redpanda-info.sh
+++ b/src/go/k8s/hack/get-redpanda-info.sh
@@ -18,12 +18,12 @@ for cl in $(kubectl -n $script_namespace get cluster --output=jsonpath='{.items.
 
   tls_enabled=$(kubectl -n $script_namespace get cluster $cl --output=jsonpath='{.spec.configuration.adminApi[0].tls.enabled}')
   curl_arguments="-s http"
-  if [[ $tls_enabled = "true" ]]; then
+  if [[ $tls_enabled == "true" ]]; then
     curl_arguments="-sk https"
   fi
 
   mtls_enabled=$(kubectl -n $script_namespace get cluster $cl --output=jsonpath='{.spec.configuration.adminApi[0].tls.requireClientAuth}')
-  if [[ $mtls_enabled = "true" ]]; then
+  if [[ $mtls_enabled == "true" ]]; then
     curl_arguments="-sk --cert /etc/tls/certs/admin/tls.crt --key /etc/tls/certs/admin/tls.key https"
   fi
 


### PR DESCRIPTION
This trips the shell formatting check on redpanda PRs.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none