### PR TITLE
raft: Use async_adl for serde_async_write

### DIFF
--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -11,12 +11,14 @@
 
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
 #include "raft/group_configuration.h"
 #include "reflection/adl.h"
+#include "reflection/async_adl.h"
 #include "utils/to_string.h"
 #include "vassert.h"
 #include "vlog.h"
@@ -598,7 +600,8 @@ ss::future<> append_entries_request::serde_async_write(iobuf& dst) {
     class streaming_writer {
     public:
         ss::future<ss::stop_iteration> operator()(model::record_batch b) {
-            reflection::serialize(_out, std::move(b));
+            co_await reflection::async_adl<model::record_batch>{}.to(
+              _out, std::move(b));
             ++_count;
             co_return ss::stop_iteration::no;
         }


### PR DESCRIPTION
We are seeing reactor stalls in
`HighThroughputPartitionMovementTest/test_interrupting_partition_movement_under_load` DT test caused by serializing `record_batch`s.

John recently added async adl support in
785201e6e49b7b6bd03f8101232eb645861020f7.

This patch makes use of that so that we can potentially yield in between serializing records in a batch and avoid reactor stalls.

Issue https://github.com/redpanda-data/redpanda/issues/10418

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix 
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport // Possible but would have to backport [5129](https://github.com/redpanda-data/redpanda/pull/5129)
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

