### PR TITLE
rpk: keep consistent order for outputs

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -19,6 +19,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/twmb/types"
 )
 
 func newHealthOverviewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -67,6 +68,7 @@ following conditions are met:
 }
 
 func printHealthOverview(hov *admin.ClusterHealthOverview) {
+	types.Sort(hov)
 	out.Section("CLUSTER HEALTH OVERVIEW")
 	overviewFormat := `Healthy:               %v
 Controller ID:               %v


### PR DESCRIPTION
Fixes #9661

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* rpk now displays a sorted node list in `rpk cluster health`.