### PR TITLE
rpk container: add admin API addresses to help text

### DIFF
--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -416,29 +416,38 @@ func renderClusterInfo(c common.Client) ([]*common.NodeState, error) {
 }
 
 func renderClusterInteract(nodes []*common.NodeState) {
-	var brokers []string
+	var (
+		brokers    []string
+		adminAddrs []string
+	)
 	for _, node := range nodes {
 		if node.Running {
 			brokers = append(brokers, nodeAddr(node.HostKafkaPort))
+			adminAddrs = append(adminAddrs, nodeAddr(node.HostAdminPort))
 		}
 	}
-	if len(brokers) == 0 {
+	if len(brokers) == 0 || len(adminAddrs) == 0 {
 		return
 	}
 
 	m := `
 You can use rpk to interact with this cluster. E.g:
 
-	rpk cluster info --brokers %s
+    rpk cluster info --brokers %s
+    rpk cluster health --api-urls %s
 
 You may also set an environment variable with the comma-separated list of
-broker addresses:
+broker and admin API addresses:
 
-	export REDPANDA_BROKERS="%s"
-	rpk cluster info
+    export REDPANDA_BROKERS="%s"
+    export REDPANDA_API_ADMIN_ADDRS="%s"
+    rpk cluster info
+    rpk cluster health
+
 `
 	b := strings.Join(brokers, ",")
-	fmt.Printf(m, b, b)
+	a := strings.Join(adminAddrs, ",")
+	fmt.Printf(m, b, a, b, a)
 }
 
 func nodeAddr(port uint) string {


### PR DESCRIPTION
A QOL improvement while we get a way to select the ports on start, now rpk prints the admin API addresses ready to c&p to the terminal.

Related to https://github.com/redpanda-data/redpanda/issues/7937


Example:

**On start:**
```
rpk container start -n 3
Checking for a local image...
Creating network redpanda
Starting cluster...
Waiting for the cluster to be ready...

Cluster started!
NODE-ID  STATUS   KAFKA-ADDRESS    ADMIN-ADDRESS    PROXY-ADDRESS
0        running  127.0.0.1:37229  127.0.0.1:32801  127.0.0.1:41981
1        running  127.0.0.1:37027  127.0.0.1:34167  127.0.0.1:45041
2        running  127.0.0.1:43015  127.0.0.1:45907  127.0.0.1:40815

You can use rpk to interact with this cluster. E.g:

    rpk cluster info --brokers 127.0.0.1:37229,127.0.0.1:37027,127.0.0.1:43015
    rpk cluster health --api-urls 127.0.0.1:32801,127.0.0.1:34167,127.0.0.1:45907

You may also set an environment variable with the comma-separated list of
broker and admin API addresses:

    export REDPANDA_BROKERS="127.0.0.1:37229,127.0.0.1:37027,127.0.0.1:43015"
    export REDPANDA_API_ADMIN_ADDRS="127.0.0.1:32801,127.0.0.1:34167,127.0.0.1:45907"
    rpk cluster info
    rpk cluster health
```

**Status:**

```
rpk container status
NODE-ID  STATUS   KAFKA-ADDRESS    ADMIN-ADDRESS    PROXY-ADDRESS
0        running  127.0.0.1:37229  127.0.0.1:32801  127.0.0.1:41981
1        running  127.0.0.1:37027  127.0.0.1:34167  127.0.0.1:45041
2        running  127.0.0.1:43015  127.0.0.1:45907  127.0.0.1:40815

You can use rpk to interact with this cluster. E.g:

    rpk cluster info --brokers 127.0.0.1:37229,127.0.0.1:37027,127.0.0.1:43015
    rpk cluster health --api-urls 127.0.0.1:32801,127.0.0.1:34167,127.0.0.1:45907

You may also set an environment variable with the comma-separated list of
broker and admin API addresses:

    export REDPANDA_BROKERS="127.0.0.1:37229,127.0.0.1:37027,127.0.0.1:43015"
    export REDPANDA_API_ADMIN_ADDRS="127.0.0.1:32801,127.0.0.1:34167,127.0.0.1:45907"
    rpk cluster info
    rpk cluster health
```
## Backports Required
- [ ] v23.1.x


## Release Notes
### Improvements

* rpk now prints the admin API addresses and the respective environment variable when creating a container cluster or querying the status of one: `rpk container start` and `rpk container status`
