### PR TITLE
tests: use timeouts on http requests to avoid potential runner hangs

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -278,7 +278,8 @@ class StatusThread(threading.Thread):
 
     def is_ready(self):
         try:
-            r = requests.get(self._parent._remote_url(self._node, "status"))
+            r = requests.get(self._parent._remote_url(self._node, "status"),
+                             timeout=10)
         except Exception as e:
             # Broad exception handling for any lower level connection errors etc
             # that might not be properly classed as `requests` exception.

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -865,7 +865,7 @@ class RedpandaServiceBase(Service):
         metrics_endpoint = ("/metrics" if metrics_endpoint
                             == MetricsEndpoint.METRICS else "/public_metrics")
         url = f"http://{node.account.hostname}:9644{metrics_endpoint}"
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=10)
         assert resp.status_code == 200
         return text_string_to_metric_families(resp.text)
 


### PR DESCRIPTION
This was inspired by this timed out job: https://buildkite.com/redpanda/redpanda/builds/29147#01881ed9-e56b-4632-baa6-73e6ad49e3e1

`requests` unfortunately doesn't have any timeout by default.  That means that any place we use it from the ducktape runner node risks hanging the whole job if the http request hangs.

It's not 100% that this is exactly what was happening, but it makes sense to rule this out as a possible source of mystery hangs.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
