### PR TITLE
schema_registry/avro: Canonicalize AVRO schema

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -142,6 +142,37 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
     return writer.resolve(reader) != avro::RESOLVE_NO_MATCH;
 }
 
+enum class object_type { complex, field };
+
+template<object_type type>
+struct member_sorter {
+    bool operator()(
+      json::Document::Member const& lhs, json::Document::Member const& rhs) {
+        constexpr auto order = [](std::string_view name) {
+            auto val = string_switch<char>(name)
+                         .match("type", type == object_type::complex ? 0 : 1)
+                         .match("name", type == object_type::complex ? 1 : 0)
+                         .match("namespace", 2)
+                         .match("doc", 3)
+                         .match("fields", 4)
+                         .match("order", 5)
+                         .match("symbols", 6)
+                         .match("items", 7)
+                         .match("values", 8)
+                         .match("default", 9)
+                         .match("size", 10)
+                         .match("aliases", 11)
+                         .default_match(std::numeric_limits<char>::max());
+            return val;
+        };
+        constexpr auto as_string_view = [](json::Value const& v) {
+            return std::string_view{v.GetString(), v.GetStringLength()};
+        };
+        return order(as_string_view(lhs.name))
+               < order(as_string_view(rhs.name));
+    }
+};
+
 result<void> sanitize(json::Value& v, json::MemoryPoolAllocator& alloc);
 result<void> sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc);
 result<void> sanitize(json::Value::Array& a, json::MemoryPoolAllocator& alloc);
@@ -187,14 +218,27 @@ result<void> sanitize_avro_type(
   json::MemoryPoolAllocator& alloc) {
     auto type = string_switch<std::optional<avro::Type>>(type_sv)
                   .match("record", avro::Type::AVRO_RECORD)
+                  .match("array", avro::Type::AVRO_ARRAY)
+                  .match("enum", avro::Type::AVRO_ENUM)
+                  .match("map", avro::Type::AVRO_MAP)
+                  .match("fixed", avro::Type::AVRO_FIXED)
                   .default_match(std::nullopt);
     if (!type.has_value()) {
+        std::sort(o.begin(), o.end(), member_sorter<object_type::field>{});
         return outcome::success();
     }
 
     switch (type.value()) {
+    case avro::AVRO_ARRAY:
+    case avro::AVRO_ENUM:
+    case avro::AVRO_FIXED:
+    case avro::AVRO_MAP:
+        std::sort(o.begin(), o.end(), member_sorter<object_type::complex>{});
+        break;
     case avro::AVRO_RECORD: {
-        return sanitize_record(o, alloc);
+        auto res = sanitize_record(o, alloc);
+        std::sort(o.begin(), o.end(), member_sorter<object_type::complex>{});
+        return res;
     }
     default:
         break;
@@ -280,17 +324,14 @@ sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
         auto res = sanitize(t_it->value, alloc);
         if (res.has_error()) {
             return res.assume_error();
-        }
-
-        if (t_it->value.GetType() == json::Type::kStringType) {
+        } else if (t_it->value.GetType() == json::Type::kStringType) {
             std::string_view type_sv = {
               t_it->value.GetString(), t_it->value.GetStringLength()};
             auto res = sanitize_avro_type(o, type_sv, alloc);
             if (res.has_error()) {
                 return res.assume_error();
             }
-        }
-        if (t_it->value.GetType() == json::Type::kArrayType) {
+        } else if (t_it->value.GetType() == json::Type::kArrayType) {
             auto a = t_it->value.GetArray();
             for (auto& m : a) {
                 if (m.IsString()) {
@@ -299,6 +340,15 @@ sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
                         return res.assume_error();
                     }
                 }
+            }
+            auto res = sanitize_avro_type(o, "field", alloc);
+            if (res.has_error()) {
+                return res.assume_error();
+            }
+        } else if (t_it->value.GetType() == json::Type::kObjectType) {
+            auto res = sanitize_avro_type(o, "field", alloc);
+            if (res.has_error()) {
+                return res.assume_error();
             }
         }
     }

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -200,6 +200,16 @@ sharded_store::project_ids(subject_schema schema) {
 
 ss::future<bool> sharded_store::upsert(
   seq_marker marker,
+  unparsed_schema schema,
+  schema_id id,
+  schema_version version,
+  is_deleted deleted) {
+    auto canonical = co_await make_canonical_schema(schema);
+    co_return co_await upsert(marker, canonical, id, version, deleted);
+}
+
+ss::future<bool> sharded_store::upsert(
+  seq_marker marker,
   canonical_schema schema,
   schema_id id,
   schema_version version,

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -50,6 +50,13 @@ public:
       schema_version version,
       is_deleted deleted);
 
+    ss::future<bool> upsert(
+      seq_marker marker,
+      unparsed_schema schema,
+      schema_id id,
+      schema_version version,
+      is_deleted deleted);
+
     ss::future<bool> has_schema(schema_id id);
     ss::future<subject_schema> has_schema(canonical_schema schema);
 

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -318,6 +318,7 @@ struct schema_value {
     }
 };
 
+using unparsed_schema_value = schema_value<unparsed_schema_defnition_tag>;
 using canonical_schema_value = schema_value<canonical_schema_definition_tag>;
 
 template<typename Tag>
@@ -604,6 +605,9 @@ public:
     }
 };
 
+template<typename Encoding = ::json::UTF8<>>
+using unparsed_schema_value_handler
+  = schema_value_handler<unparsed_schema_defnition_tag, Encoding>;
 template<typename Encoding = ::json::UTF8<>>
 using canonical_schema_value_handler
   = schema_value_handler<canonical_schema_definition_tag, Encoding>;
@@ -1147,9 +1151,9 @@ struct consume_to_store {
         case topic_key_type::noop:
             break;
         case topic_key_type::schema: {
-            std::optional<canonical_schema_value> val;
+            std::optional<unparsed_schema_value> val;
             if (!record.value().empty()) {
-                val.emplace(from_json_iobuf<canonical_schema_value_handler<>>(
+                val.emplace(from_json_iobuf<unparsed_schema_value_handler<>>(
                   record.release_value()));
             }
             co_await apply(

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -25,6 +25,7 @@
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/seq_writer.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/store.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "raft/types.h"
 #include "storage/record_batch_builder.h"
@@ -296,8 +297,9 @@ public:
     }
 };
 
+template<typename Tag>
 struct schema_value {
-    canonical_schema schema;
+    typed_schema<Tag> schema;
     schema_version version;
     schema_id id;
     is_deleted deleted{false};
@@ -316,9 +318,11 @@ struct schema_value {
     }
 };
 
+using canonical_schema_value = schema_value<canonical_schema_definition_tag>;
+
+template<typename Tag>
 inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::schema_value& val) {
+  ::json::Writer<::json::StringBuffer>& w, const schema_value<Tag>& val) {
     w.StartObject();
     w.Key("subject");
     ::json::rjson_serialize(w, val.schema.sub());
@@ -353,7 +357,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Encoding = ::json::UTF8<>>
+template<typename Tag, typename Encoding = ::json::UTF8<>>
 class schema_value_handler final : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,
@@ -374,15 +378,15 @@ class schema_value_handler final : public json::base_handler<Encoding> {
 
     struct mutable_schema {
         subject sub{invalid_subject};
-        canonical_schema_definition::raw_string def;
+        typename typed_schema_definition<Tag>::raw_string def;
         schema_type type{schema_type::avro};
-        canonical_schema::references refs;
+        typename typed_schema<Tag>::references refs;
     };
     mutable_schema _schema;
 
 public:
     using Ch = typename json::base_handler<Encoding>::Ch;
-    using rjson_parse_result = schema_value;
+    using rjson_parse_result = schema_value<Tag>;
     rjson_parse_result result;
 
     schema_value_handler()
@@ -498,7 +502,7 @@ public:
             return true;
         }
         case state::definition: {
-            _schema.def = canonical_schema_definition::raw_string{
+            _schema.def = typename typed_schema_definition<Tag>::raw_string{
               ss::sstring{sv}};
             _state = state::object;
             return true;
@@ -599,6 +603,10 @@ public:
         return std::exchange(_state, state::object) == state::references;
     }
 };
+
+template<typename Encoding = ::json::UTF8<>>
+using canonical_schema_value_handler
+  = schema_value_handler<canonical_schema_definition_tag, Encoding>;
 
 struct config_key {
     static constexpr topic_key_type keytype{topic_key_type::config};
@@ -1139,9 +1147,9 @@ struct consume_to_store {
         case topic_key_type::noop:
             break;
         case topic_key_type::schema: {
-            std::optional<schema_value> val;
+            std::optional<canonical_schema_value> val;
             if (!record.value().empty()) {
-                val.emplace(from_json_iobuf<schema_value_handler<>>(
+                val.emplace(from_json_iobuf<canonical_schema_value_handler<>>(
                   record.release_value()));
             }
             co_await apply(
@@ -1180,8 +1188,11 @@ struct consume_to_store {
         co_await _sequencer.advance_offset(offset);
     }
 
+    template<typename Tag>
     ss::future<> apply(
-      model::offset offset, schema_key key, std::optional<schema_value> val) {
+      model::offset offset,
+      schema_key key,
+      std::optional<schema_value<Tag>> val) {
         if (key.magic != 0 && key.magic != 1) {
             throw exception(
               error_code::topic_parse_error,

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -111,7 +111,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
 
     auto good_schema_1 = pps::as_record_batch(
       pps::schema_key{sequence, node_id, subject0, version0, magic1},
-      pps::schema_value{{subject0, string_def0}, version0, id0});
+      pps::canonical_schema_value{{subject0, string_def0}, version0, id0});
     BOOST_REQUIRE_NO_THROW(c(good_schema_1.copy()).get());
 
     auto s_res = s.get_subject_schema(
@@ -123,7 +123,8 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
       {.name{"ref"}, .sub{subject0}, .version{version0}}};
     auto good_schema_ref_1 = pps::as_record_batch(
       pps::schema_key{sequence, node_id, subject0, version1, magic1},
-      pps::schema_value{{subject0, string_def0, refs}, version1, id1});
+      pps::canonical_schema_value{
+        {subject0, string_def0, refs}, version1, id1});
     BOOST_REQUIRE_NO_THROW(c(good_schema_ref_1.copy()).get());
 
     auto s_ref_res = s.get_subject_schema(
@@ -140,7 +141,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
 
     auto bad_schema_magic = pps::as_record_batch(
       pps::schema_key{sequence, node_id, subject0, version0, magic2},
-      pps::schema_value{{subject0, string_def0}, version0, id0});
+      pps::canonical_schema_value{{subject0, string_def0}, version0, id0});
     BOOST_REQUIRE_THROW(c(bad_schema_magic.copy()).get(), pps::exception);
 
     BOOST_REQUIRE(

--- a/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
@@ -25,7 +25,7 @@ pps::unparsed_schema_definition not_minimal{
   pps::schema_type::avro};
 
 pps::canonical_schema_definition not_minimal_sanitized{
-  R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]})",
+  R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]})",
   pps::schema_type::avro};
 
 pps::unparsed_schema_definition leading_dot{
@@ -33,7 +33,7 @@ pps::unparsed_schema_definition leading_dot{
   pps::schema_type::avro};
 
 pps::canonical_schema_definition leading_dot_sanitized{
-  R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":"r1","type":"record"}]},{"name":"two","type":["null","r1"]}]})",
+  R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"type":"record","name":"r1","fields":[{"name":"f1","type":["null","string"]}]}]},{"name":"two","type":["null","r1"]}]})",
   pps::schema_type::avro};
 
 pps::unparsed_schema_definition leading_dot_ns{
@@ -41,7 +41,53 @@ pps::unparsed_schema_definition leading_dot_ns{
   pps::schema_type::avro};
 
 pps::canonical_schema_definition leading_dot_ns_sanitized{
-  R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":"r1","type":"record","namespace":".ns"}]},{"name":"two","type":["null",".ns.r1"]}]})",
+  R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"type":"record","name":"r1","namespace":".ns","fields":[{"name":"f1","type":["null","string"]}]}]},{"name":"two","type":["null",".ns.r1"]}]})",
+  pps::schema_type::avro};
+
+pps::unparsed_schema_definition record_not_sorted{
+  R"({"name":"sort_record","type":"record","aliases":["alias"],"fields":[{"type":"string","name":"one"}],"namespace":"ns","doc":"doc"})",
+  pps::schema_type::avro};
+
+pps::canonical_schema_definition record_sorted_sanitized{
+  R"({"type":"record","name":"sort_record","namespace":"ns","doc":"doc","fields":[{"name":"one","type":"string"}],"aliases":["alias"]})",
+  pps::schema_type::avro};
+
+pps::unparsed_schema_definition enum_not_sorted{
+  R"({"name":"ns.sort_enum","type":"enum","aliases":["alias"],"symbols":["one", "two", "three"],"default":"two","doc":"doc"})",
+  pps::schema_type::avro};
+
+pps::canonical_schema_definition enum_sorted_sanitized{
+  R"({"type":"enum","name":"sort_enum","namespace":"ns","doc":"doc","symbols":["one","two","three"],"default":"two","aliases":["alias"]})",
+  pps::schema_type::avro};
+
+pps::unparsed_schema_definition array_not_sorted{
+  R"({"type": "array", "default": [], "items" : "string"})",
+  pps::schema_type::avro};
+
+pps::canonical_schema_definition array_sorted_sanitized{
+  R"({"type":"array","items":"string","default":[]})", pps::schema_type::avro};
+
+pps::unparsed_schema_definition map_not_sorted{
+  R"({"type": "map", "default": {}, "values" : "string"})",
+  pps::schema_type::avro};
+
+pps::canonical_schema_definition map_sorted_sanitized{
+  R"({"type":"map","values":"string","default":{}})", pps::schema_type::avro};
+
+pps::unparsed_schema_definition fixed_not_sorted{
+  R"({"size":16, "type": "fixed", "aliases":["fixed"], "name":"ns.sorted_fixed"})",
+  pps::schema_type::avro};
+
+pps::canonical_schema_definition fixed_sorted_sanitized{
+  R"({"type":"fixed","name":"sorted_fixed","namespace":"ns","size":16,"aliases":["fixed"]})",
+  pps::schema_type::avro};
+
+pps::unparsed_schema_definition record_of_obj_unsanitized{
+  R"({"name":"sort_record_of_obj","type":"record","fields":[{"type":{"type":"string","connect.parameters":{"tidb_type":"TEXT"}},"default":"","name":"field"}]})",
+  pps::schema_type::avro};
+
+pps::canonical_schema_definition record_of_obj_sanitized{
+  R"({"type":"record","name":"sort_record_of_obj","fields":[{"name":"field","type":{"type":"string","connect.parameters":{"tidb_type":"TEXT"}},"default":""}]})",
   pps::schema_type::avro};
 
 BOOST_AUTO_TEST_CASE(test_sanitize_avro_minify) {
@@ -60,6 +106,42 @@ BOOST_AUTO_TEST_CASE(test_sanitize_avro_name_ns) {
     BOOST_REQUIRE_EQUAL(
       pps::sanitize_avro_schema_definition(leading_dot_ns).value(),
       leading_dot_ns_sanitized);
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_record_sorting) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(record_not_sorted).value(),
+      record_sorted_sanitized);
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_enum_sorting) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(enum_not_sorted).value(),
+      enum_sorted_sanitized);
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_array_sorting) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(array_not_sorted).value(),
+      array_sorted_sanitized);
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_map_sorting) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(map_not_sorted).value(),
+      map_sorted_sanitized);
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_fixed_sorting) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(fixed_not_sorted).value(),
+      fixed_sorted_sanitized);
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_record_of_obj_sorting) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(record_of_obj_unsanitized).value(),
+      record_of_obj_sanitized);
 }
 
 pps::canonical_schema_definition debezium_schema{

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -49,7 +49,7 @@ constexpr std::string_view avro_schema_value_sv{
   "schema": "{\"type\":\"string\"}",
   "deleted": true
 })"};
-const pps::schema_value avro_schema_value{
+const pps::canonical_schema_value avro_schema_value{
   .schema{
     pps::subject{"my-kafka-value"},
     pps::canonical_schema_definition{
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
 
     {
         auto val = ppj::rjson_parse(
-          avro_schema_value_sv.data(), pps::schema_value_handler<>{});
+          avro_schema_value_sv.data(), pps::canonical_schema_value_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_value, val);
 
         auto str = ppj::rjson_serialize(avro_schema_value);

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -105,7 +105,7 @@ using unparsed_schema_definition
 ///
 /// This form is stored on the topic and returned to the user.
 using canonical_schema_definition
-  = typed_schema_definition<struct canonical_schema_defnition_tag>;
+  = typed_schema_definition<struct canonical_schema_definition_tag>;
 
 static const unparsed_schema_definition invalid_schema_definition{
   "", schema_type::avro};

--- a/tests/rptest/remote_scripts/schema_registry_test_helper.py
+++ b/tests/rptest/remote_scripts/schema_registry_test_helper.py
@@ -22,7 +22,7 @@ HTTP_POST_HEADERS = {
     "Content-Type": "application/vnd.schemaregistry.v1+json"
 }
 
-schema_template = '{"type":"record","name":"record_%s","fields":[{"type":"string","name":"f1"}]}'
+schema_template = '{"type":"record","name":"record_%s","fields":[{"name":"f1","type":"string"}]}'
 
 
 class WriteWorker(threading.Thread):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -46,10 +46,10 @@ HTTP_POST_HEADERS = {
     "Content-Type": "application/vnd.schemaregistry.v1+json"
 }
 
-schema1_def = '{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]}'
-schema2_def = '{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2","default":"foo"}]}'
-schema3_def = '{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2"}]}'
-invalid_avro = '{"type":"notatype","name":"myrecord","fields":[{"type":"string","name":"f1"}]}'
+schema1_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
+schema2_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"string","default":"foo"}]}'
+schema3_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"string"}]}'
+invalid_avro = '{"type":"notatype","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 
 simple_proto_def = """
 syntax = "proto3";


### PR DESCRIPTION
Additional sanitization:
* Sort members of all complex types
* Sort members of record fields

Fix #7609

NOTE: This is not [Parsing Canonical Form](https://avro.apache.org/docs/1.11.1/specification/#parsing-canonical-form-for-schemas), but it is equivalent.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Schema Registry: Canonicalize AVRO schema so that syntactic differences don't fail lookups by schema contents.