### PR TITLE
operator: make controller logs traceable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Run gofumpt
       run: |
-        find src/go -type f -name '*.go' | xargs -n1 gofumpt -w -lang=1.20
+        find src/go -type f -not -name 'zz*' -name '*.go' | xargs -n1 "$HOME/.local/bin/gofumpt" -w -lang=1.20
         git diff --exit-code
 
   py:

--- a/src/go/k8s/apis/redpanda/v1alpha1/zz_generated.deepcopy.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/zz_generated.deepcopy.go
@@ -16,9 +16,8 @@ package v1alpha1
 
 import (
 	"encoding/json"
-
 	metav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/src/go/k8s/config/samples/one_node_cluster.yaml
+++ b/src/go/k8s/config/samples/one_node_cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: one-node-cluster
 spec:
-  image: "vectorized/redpanda"
+  image: "redpandadata/redpanda"
   version: "latest"
   replicas: 1
   resources:

--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_drift.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,8 +35,6 @@ import (
 
 const (
 	defaultDriftCheckPeriod = 1 * time.Minute
-
-	debugLogLevel = 4
 )
 
 // ClusterConfigurationDriftReconciler detects drifts in the cluster configuration and triggers a reconciliation.
@@ -55,10 +54,10 @@ type ClusterConfigurationDriftReconciler struct {
 func (r *ClusterConfigurationDriftReconciler) Reconcile(
 	ctx context.Context, req ctrl.Request,
 ) (ctrl.Result, error) {
-	log := r.Log.WithValues("redpandacluster", req.NamespacedName)
+	log := ctrl.LoggerFrom(ctx).WithName("ClusterConfigurationDriftReconciler.Reconcile")
 
-	log.V(debugLogLevel).Info(fmt.Sprintf("Starting configuration drift reconcile loop for %v", req.NamespacedName))
-	defer log.V(debugLogLevel).Info(fmt.Sprintf("Finished configuration drift reconcile loop for %v", req.NamespacedName))
+	log.V(logger.DebugLevel).Info("Starting configuration drift reconcile loop")
+	defer log.V(logger.DebugLevel).Info("Finished configuration drift reconcile loop")
 
 	var redpandaCluster redpandav1alpha1.Cluster
 	if err := r.Get(ctx, req.NamespacedName, &redpandaCluster); err != nil {

--- a/src/go/k8s/pkg/console/console.go
+++ b/src/go/k8s/pkg/console/console.go
@@ -19,10 +19,6 @@ import (
 	redpandav1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 )
 
-const (
-	debugLogLevel = 4
-)
-
 // ConsoleConfig is the config passed to the Redpanda Console app
 type ConsoleConfig struct {
 	// Grabbed from https://github.com/redpanda-data/console/

--- a/src/go/k8s/pkg/console/sasl.go
+++ b/src/go/k8s/pkg/console/sasl.go
@@ -138,15 +138,16 @@ func (k *KafkaSA) Key() (nsn types.NamespacedName) {
 
 // Cleanup implements ManagedResource interface
 func (k *KafkaSA) Cleanup(ctx context.Context) error {
+	log := k.log.WithName("KafkaSACleanup")
 	if !controllerutil.ContainsFinalizer(k.consoleobj, ConsoleSAFinalizer) {
 		return nil
 	}
 
 	if exp, err := redpandav1alpha1.FinalizersExpired(k.consoleobj); err != nil {
-		k.log.Error(err, "invalid configuration for finalizers timeout")
+		log.Error(err, "invalid configuration for finalizers timeout")
 	} else if exp {
 		// Just delete the finalizers and forget
-		k.log.Info("finalizers timed out for console: removing SA finalizer")
+		log.Info("finalizers timed out for console: removing SA finalizer")
 		controllerutil.RemoveFinalizer(k.consoleobj, ConsoleSAFinalizer)
 		return k.Update(ctx, k.consoleobj)
 	}
@@ -238,15 +239,16 @@ func (k *KafkaACL) Key() (nsn types.NamespacedName) {
 
 // Cleanup implements ManagedResource interface
 func (k *KafkaACL) Cleanup(ctx context.Context) error {
+	log := k.log.WithName("KafkaACL.Cleanup")
 	if !controllerutil.ContainsFinalizer(k.consoleobj, ConsoleACLFinalizer) {
 		return nil
 	}
 
 	if exp, err := redpandav1alpha1.FinalizersExpired(k.consoleobj); err != nil {
-		k.log.Error(err, "invalid configuration for finalizers timeout")
+		log.Error(err, "invalid configuration for finalizers timeout")
 	} else if exp {
 		// Just delete the finalizers and forget
-		k.log.Info("finalizers timed out for console: removing ACL finalizer")
+		log.Info("finalizers timed out for console: removing ACL finalizer")
 		controllerutil.RemoveFinalizer(k.consoleobj, ConsoleACLFinalizer)
 		return k.Update(ctx, k.consoleobj)
 	}

--- a/src/go/k8s/pkg/resources/configuration/patch.go
+++ b/src/go/k8s/pkg/resources/configuration/patch.go
@@ -142,8 +142,9 @@ func convertStringToStringArray(value string) ([]string, error) {
 //
 //nolint:gocritic // code more readable
 func PropertiesEqual(
-	log logr.Logger, v1, v2 interface{}, metadata admin.ConfigPropertyMetadata,
+	l logr.Logger, v1, v2 interface{}, metadata admin.ConfigPropertyMetadata,
 ) bool {
+	log := l.WithName("PropertiesEqual")
 	switch metadata.Type {
 	case "number":
 		if f1, f2, ok := bothFloat64(v1, v2); ok {

--- a/src/go/k8s/pkg/resources/ingress.go
+++ b/src/go/k8s/pkg/resources/ingress.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/go-logr/logr"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,8 +31,6 @@ const (
 
 	// SSLPassthroughAnnotation is the annotation for ingress nginx SSL passthrough
 	SSLPassthroughAnnotation = "nginx.ingress.kubernetes.io/ssl-passthrough" //nolint:gosec // This value does not contain credentials.
-
-	debugLogLevel = 4
 
 	// LEClusterIssuer is the LetsEncrypt issuer
 	LEClusterIssuer = "letsencrypt-dns-prod"
@@ -63,7 +62,7 @@ func NewIngress(
 	subdomain string,
 	svcName string,
 	svcPortName string,
-	logger logr.Logger,
+	l logr.Logger,
 ) *IngressResource {
 	return &IngressResource{
 		client,
@@ -76,7 +75,7 @@ func NewIngress(
 		nil,
 		nil,
 		"",
-		logger.WithValues(
+		l.WithValues(
 			"Kind", ingressKind(),
 		),
 	}
@@ -166,7 +165,7 @@ func (r *IngressResource) Ensure(ctx context.Context) error {
 	ingressDisabled := r.userConfig != nil && r.userConfig.Enabled != nil && !*r.userConfig.Enabled
 	emptyHost := r.host() == ""
 	if ingressDisabled || emptyHost {
-		r.logger.V(debugLogLevel).Info("ingress will not be created", "disabled", ingressDisabled, "empty_host", emptyHost)
+		r.logger.V(logger.DebugLevel).Info("ingress will not be created", "disabled", ingressDisabled, "empty_host", emptyHost)
 		key := r.Key()
 		ingress := netv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cisco-open/k8s-objectmatcher/patch"
+	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/prometheus/common/expfmt"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -107,7 +108,7 @@ func (r *StatefulSetResource) runUpdate(
 
 func (r *StatefulSetResource) isClusterHealthy(ctx context.Context) error {
 	if !featuregates.ClusterHealth(r.pandaCluster.Status.Version) {
-		r.logger.V(debugLogLevel).Info("Cluster health endpoint is not available", "version", r.pandaCluster.Spec.Version)
+		r.logger.V(logger.DebugLevel).Info("Cluster health endpoint is not available", "version", r.pandaCluster.Spec.Version)
 		return nil
 	}
 

--- a/src/go/k8s/pkg/resources/superusers.go
+++ b/src/go/k8s/pkg/resources/superusers.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,7 +68,7 @@ func NewSuperUsers(
 	scheme *runtime.Scheme,
 	username string,
 	suffix string,
-	logger logr.Logger,
+	l logr.Logger,
 ) *SuperUsersResource {
 	prefixedUsername := redpandav1alpha1.SuperUsersPrefix + username
 	return &SuperUsersResource{
@@ -76,7 +77,7 @@ func NewSuperUsers(
 		object,
 		prefixedUsername,
 		suffix,
-		logger.WithValues(
+		l.WithValues(
 			"Kind", ingressKind(),
 		),
 	}
@@ -94,7 +95,7 @@ func (r *SuperUsersResource) Ensure(ctx context.Context) error {
 	}
 	created, err := CreateIfNotExists(ctx, r, obj, r.logger)
 	if !created && redpandav1alpha1.SuperUsersPrefix != "" {
-		r.logger.V(debugLogLevel).Info(
+		r.logger.V(logger.DebugLevel).Info(
 			"Ignoring --superusers-prefix because SuperUser Secret is already created",
 			"prefix", redpandav1alpha1.SuperUsersPrefix,
 			"superUserSecret", r.Key(),


### PR DESCRIPTION
Make each reconciler use a unique name, and each reconcile loop use a unique id. This will allow easy tracing of specific controller loops to see which actions were associated with that loop.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix

## Release Notes



* none

