### PR TITLE
tests: bump upload timeouts in cloud_retention_test

### DIFF
--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -158,7 +158,7 @@ class CloudRetentionTest(PreallocNodesTest):
                 return True
 
         # Wait for the last data to be uploaded
-        wait_until(all_data_uploaded, timeout_sec=60, backoff_sec=10)
+        wait_until(all_data_uploaded, timeout_sec=300, backoff_sec=10)
 
         def check_total_size(include_below_start_offset):
             try:
@@ -250,7 +250,7 @@ class CloudRetentionTest(PreallocNodesTest):
             return True
 
         wait_until(uploaded_all_partitions,
-                   timeout_sec=60,
+                   timeout_sec=300,
                    backoff_sec=5,
                    err_msg="Waiting for all parents to upload cloud data")
 


### PR DESCRIPTION
These were occasionally being just missed when running in docker.  There was no particular reason to expect 1GB of uploads to complete in 60 seconds, and the purpose of the tests is not to measure the speed of uploads, so bump these to a generous five minutes.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
