### PR TITLE
Fixed Raft voter priority override with single replica topics

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -883,10 +883,10 @@ void consensus::dispatch_vote(bool leadership_transfer) {
     // lower our required priority for next time.
     _target_priority = next_target_priority();
 
+    const auto& latest_config = _configuration_manager.get_latest();
     // skip sending vote request if current node is not a voter in current
     // configuration
-    if (!_configuration_manager.get_latest().is_allowed_to_request_votes(
-          _self)) {
+    if (!latest_config.is_allowed_to_request_votes(_self)) {
         arm_vote_timeout();
         return;
     }
@@ -894,14 +894,24 @@ void consensus::dispatch_vote(bool leadership_transfer) {
     // if priority is to low, skip dispatching votes, do not take priority into
     // account when we transfer leadership
     if (current_priority_to_low && !leadership_transfer) {
+        const bool is_only_voter = latest_config.unique_voter_count() == 1
+                                   && latest_config.is_voter(_self);
+        if (!is_only_voter) {
+            vlog(
+              _ctxlog.trace,
+              "current node priority {} is lower than target {} (next vote {})",
+              self_priority,
+              cur_target_priority,
+              _target_priority);
+            arm_vote_timeout();
+            return;
+        }
         vlog(
-          _ctxlog.trace,
-          "current node priority {} is lower than target {} (next vote {})",
+          _ctxlog.info,
+          "current node priority {} is lower than target {}, however the node "
+          "is the only voter, continue with dispatching vote",
           self_priority,
-          cur_target_priority,
-          _target_priority);
-        arm_vote_timeout();
-        return;
+          cur_target_priority);
     }
     // background, acquire lock, transition state
     ssx::background

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -183,7 +183,11 @@ ss::future<bool> prevote_stm::do_prevote() {
 
     // process results
     return process_replies().then([this]() {
-        if (_success && _ptr->_node_priority_override == zero_voter_priority) {
+        const auto only_voter = _config->unique_voter_count() == 1
+                                && _config->is_voter(_ptr->self());
+        if (
+          _success && !only_voter
+          && _ptr->_node_priority_override == zero_voter_priority) {
             vlog(
               _ctxlog.debug,
               "Ignoring successful pre-vote. Node priority too low: {}",

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -235,8 +235,9 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
         _ptr->_vstate = consensus::vote_state::follower;
         co_return;
     }
-
-    if (_ptr->_node_priority_override == zero_voter_priority) {
+    const auto only_voter = _config->unique_voter_count() == 1
+                            && _config->is_voter(_ptr->self());
+    if (!only_voter && _ptr->_node_priority_override == zero_voter_priority) {
         vlog(
           _ctxlog.debug,
           "Ignoring successful vote. Node priority too low: {}",

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -367,7 +367,7 @@ class FeaturesSingleNodeUpgradeTest(FeaturesTestBase):
         self.redpanda.restart_nodes([self.redpanda.nodes[0]])
         wait_until(lambda: self.head_latest_logical_version == self.admin.
                    get_features()['cluster_version'],
-                   timeout_sec=5,
+                   timeout_sec=10,
                    backoff_sec=1)
 
 


### PR DESCRIPTION
Redpanda Raft implementation exposes an API allowing to override a voter
priority. This is used by the drain manager when a node is in
maintenance mode. In current implementation when the only voter is in
maintenance mode the Raft group is not able to elect a leader as the
reported priority it to low (the priority override in maintenance is set to 0).

Fixed Raft implementation to make sure that it prioritize an
availability over the user priority preference. If a node is the only
voter the priority override is ignored.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fixed not being able to elect a leader in situation when only voter is in maintenance mode