### PR TITLE
Improve verifiable consumer error

### DIFF
--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -286,6 +286,7 @@ class VerifiableConsumer(BackgroundThreadService):
         # shutdown, when the first consumer is stopped, consumer group is
         # rebalanced and other consumer begin receiving from its partitions
         self.global_state = {}
+        self.interrupted_with_error = None
 
     def _worker(self, idx, node):
         state = VerifiableConsumer.WorkerState(node.account)
@@ -321,32 +322,38 @@ class VerifiableConsumer(BackgroundThreadService):
 
         for line in node.account.ssh_capture(cmd):
             event = self.try_parse_json(node, line.strip())
-            if event is not None:
-                with self.lock:
-                    name = event["name"]
-                    if name == "shutdown_complete":
-                        handler.handle_shutdown_complete()
-                    elif name == "startup_complete":
-                        handler.handle_startup_complete()
-                    elif name == "offsets_committed":
-                        handler.handle_offsets_committed(
-                            event, node, self.logger)
-                        self._update_global_committed(event, state)
-                    elif name == "records_consumed":
-                        handler.handle_records_consumed(event, self.logger)
-                        self._update_global_position(event, state)
-                    elif name == "record_data" and self.on_record_consumed:
-                        self.on_record_consumed(event, node)
-                    elif name == "partitions_revoked":
-                        handler.handle_partitions_revoked(event)
-                    elif name == "partitions_assigned":
-                        handler.handle_partitions_assigned(event)
-                    elif name == "offsets_fetched":
-                        handler.handle_offsets_fetched(event)
-                        self._update_global_committed_fetched(event, state)
-                    else:
-                        self.logger.debug("%s: ignoring unknown event: %s" %
-                                          (str(node.account), event))
+            try:
+                if event is not None:
+                    with self.lock:
+                        name = event["name"]
+                        if name == "shutdown_complete":
+                            handler.handle_shutdown_complete()
+                        elif name == "startup_complete":
+                            handler.handle_startup_complete()
+                        elif name == "offsets_committed":
+                            handler.handle_offsets_committed(
+                                event, node, self.logger)
+                            self._update_global_committed(event, state)
+                        elif name == "records_consumed":
+                            handler.handle_records_consumed(event, self.logger)
+                            self._update_global_position(event, state)
+                        elif name == "record_data" and self.on_record_consumed:
+                            self.on_record_consumed(event, node)
+                        elif name == "partitions_revoked":
+                            handler.handle_partitions_revoked(event)
+                        elif name == "partitions_assigned":
+                            handler.handle_partitions_assigned(event)
+                        elif name == "offsets_fetched":
+                            handler.handle_offsets_fetched(event)
+                            self._update_global_committed_fetched(event, state)
+                        else:
+                            self.logger.debug(
+                                "%s: ignoring unknown event: %s" %
+                                (str(node.account), event))
+            except AssertionError as e:
+                self.logger.warn(f"consumer interrupted with {e}")
+                self.interrupted_with_error = e
+                raise e
 
     def _update_global_position(self, consumed_event, state: WorkerState):
         for consumed_partition in consumed_event["partitions"]:

--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -201,7 +201,7 @@ class VerifiableConsumer(BackgroundThreadService):
                 msg = "%s: Consumed position %d is behind the current "\
                     "committed offset %d for partition %s" % \
                     (self.account_str, min_offset, self.committed[tp], str(tp))
-                if self.verify_offsets:
+                if verify_offsets:
                     raise AssertionError(msg)
                 else:
                     logger.warn(msg)

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -204,6 +204,11 @@ class EndToEndTest(Test):
 
     def await_consumed_offsets(self, last_acked_offsets, timeout_sec):
         def has_finished_consuming():
+            # if consumer was interrupted with error there is no point waiting
+            # for it to finish
+            if self.consumer.interrupted_with_error:
+                raise self.consumer.interrupted_with_error
+
             for partition, offset in last_acked_offsets.items():
                 if partition not in self.last_consumed_offsets:
                     return False


### PR DESCRIPTION
Improved error handling when `VerifiableConsumer` is stopped because of a violation. The change in this PR skips waiting for all the messages to be consumed and exit early if consumer was already stopped. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none