### PR TITLE
[v23.1.x] Backport of bd73f10597aacf6b237834b5bfabd248e6b78864

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -365,7 +365,7 @@ ss::future<error_code> replicated_partition::validate_fetch_offset(
           _partition->high_watermark());
     }
 
-    co_return fetch_offset >= start_offset() && fetch_offset <= high_watermark()
+    co_return fetch_offset >= start_offset() && fetch_offset <= log_end_offset()
       ? error_code::none
       : error_code::offset_out_of_range;
 }


### PR DESCRIPTION
An upstream Kafka validates if fetch offset is between start offset and log end offset. Fixed validation in Redpanda as we were validating the end of range with high watermark.

Signed-off-by: Michal Maslanka <michal@redpanda.com>
(cherry picked from commit bd73f10597aacf6b237834b5bfabd248e6b78864)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none