### PR TITLE
cloud_storage: segment_meta_cstore serde optimizations

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -14,6 +14,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
+#include "serde/serde.h"
 #include "utils/delta_for.h"
 
 #include <bitset>
@@ -733,6 +734,16 @@ public:
           member_fields());
     }
 
+    auto unsafe_alias() const -> column_store {
+        auto tmp = column_store{};
+        details::tuple_map(
+          [](auto& lhs, auto const& rhs) { lhs = rhs.unsafe_alias(); },
+          tmp.columns(),
+          columns());
+        tmp._hints = _hints;
+        return tmp;
+    }
+
 private:
     gauge_col_t _is_compacted{};
     gauge_col_t _size_bytes{};
@@ -959,6 +970,17 @@ public:
         _col = serde::read_nested<column_store>(in, h._bytes_left_limit);
     }
 
+    auto to_iobuf() const {
+        flush_write_buffer();
+        auto tmp = impl{};
+        tmp._col = _col.unsafe_alias();
+        return serde::to_iobuf(std::move(tmp));
+    }
+
+    void from_iobuf(iobuf in) {
+        *this = serde::from_iobuf<impl>(std::move(in));
+    }
+
     void flush_write_buffer() const {
         if (_write_buffer.empty()) {
             return;
@@ -1052,17 +1074,10 @@ void segment_meta_cstore::from_iobuf(iobuf in) {
     // NOTE: this process is not optimal memory-wise, but it's simple and
     // correct. It would require some rewrite on serde to accept a type& out
     // parameter.
-    *_impl = serde::from_iobuf<segment_meta_cstore::impl>(std::move(in));
+    _impl->from_iobuf(std::move(in));
 }
 
-iobuf segment_meta_cstore::to_iobuf() const {
-    impl tmp;
-    for (auto s : *this) {
-        tmp.append(s);
-    }
-
-    return serde::to_iobuf(std::move(tmp));
-}
+iobuf segment_meta_cstore::to_iobuf() const { return _impl->to_iobuf(); }
 
 void segment_meta_cstore::flush_write_buffer() { _impl->flush_write_buffer(); }
 

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -98,8 +98,8 @@ rp_test(
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   add_executable(segment_meta_cstore_fuzz_rpfixture segment_meta_cstore_fuzz.cc)
-  target_compile_options(segment_meta_cstore_fuzz_rpfixture PRIVATE -Og -fsanitize=address,fuzzer)
-  target_link_libraries(segment_meta_cstore_fuzz_rpfixture v::segment_meta_cstore fmt::fmt -fsanitize=address,undefined,fuzzer)
+  target_compile_options(segment_meta_cstore_fuzz_rpfixture PRIVATE -Og -fsanitize=address,undefined,fuzzer -fprofile-instr-generate -fcoverage-mapping)
+  target_link_libraries(segment_meta_cstore_fuzz_rpfixture v::segment_meta_cstore fmt::fmt -fsanitize=address,undefined,fuzzer -fprofile-instr-generate -fcoverage-mapping)
   add_test (
     NAME segment_meta_cstore_fuzz_rpfixture
     COMMAND $<TARGET_FILE:segment_meta_cstore_fuzz_rpfixture> -max_total_time=30 -rss_limit_mb=8192

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -343,6 +343,22 @@ public:
         }
     }
 
+    /// Returns a deltafor_encoder that shares the underlying iobuf
+    /// The method itself is not unsafe, but the returned object can modify the
+    /// original object, so users need to think about the use case
+    auto unsafe_alias() const -> deltafor_encoder {
+        auto tmp = deltafor_encoder{};
+        tmp._initial = _initial;
+        tmp._last = _last;
+        tmp._data = share();
+        tmp._cnt = _cnt;
+
+        if constexpr (!use_nttp_deltastep) {
+            tmp._delta = _delta;
+        }
+        return tmp;
+    }
+
 private:
     template<typename T>
     void _pack_as(const row_t& input) {


### PR DESCRIPTION
previously to_iobuf was achieved by constructing a temporary cstore,
appending all the segments and serializing it. this is done so that
to_iobuf can be const, in turn to be able to use it in
base_manifest::serialize.

To minimize operations and memory, this commits adds the ability to
create a column_store that shares all the iobuf with the *this object,
and then serialize it.

sharing is done by constructing on top of deltafor_encoder::share()
const a series of unsafe_alias() const methods, responsible to construct
the subobjects.

this new schema saves time by not re-encoding the segment_meta, and
saves memory by sharing the underlying iobuf objects, to write them
directly in the final serde iobuf

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none