### PR TITLE
cloud_storage: escape hatch to reset metadata partition manifest 

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -792,3 +792,43 @@ FIXTURE_TEST(
       archival_stm->get_start_kafka_offset(), kafka::offset(200));
     BOOST_REQUIRE_EQUAL(archival_stm->get_start_offset(), model::offset(1000));
 }
+
+FIXTURE_TEST(test_reset_metadata, archival_metadata_stm_fixture) {
+    wait_for_confirmed_leader();
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(segment_meta{
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(99),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+    m.push_back(segment_meta{
+      .base_offset = model::offset(100),
+      .committed_offset = model::offset(199),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+
+    // Replicate add_segment_cmd command that adds segment with offset 0
+    archival_stm
+      ->add_segments(
+        m, std::nullopt, ss::lowres_clock::now() + 10s, never_abort)
+      .get();
+    BOOST_REQUIRE(archival_stm->manifest().size() == 2);
+
+    // Reset the manifest and update the start offset, term id, etc.
+    auto batcher = archival_stm->batch_start(
+      ss::lowres_clock::now() + 10s, never_abort);
+    m.clear();
+    m.push_back(segment_meta{
+      .base_offset = model::offset(100),
+      .committed_offset = model::offset(199),
+      .archiver_term = model::term_id(2),
+      .segment_term = model::term_id(2)});
+    batcher.reset_metadata();
+    batcher.add_segments(std::move(m));
+    batcher.replicate().get();
+    BOOST_REQUIRE(archival_stm->manifest().size() == 1);
+    BOOST_REQUIRE(archival_stm->get_start_offset() == model::offset(100));
+    BOOST_REQUIRE(archival_stm->manifest().replaced_segments().size() == 0);
+    BOOST_REQUIRE(
+      archival_stm->manifest().begin()->archiver_term == model::term_id(2));
+}

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1359,11 +1359,8 @@ struct partition_manifest_handler
     }
 };
 
-ss::future<> partition_manifest::update(ss::input_stream<char> is) {
-    iobuf result;
-    auto os = make_iobuf_ref_output_stream(result);
-    co_await ss::copy(is, os);
-    iobuf_istreambuf ibuf(result);
+ss::future<> partition_manifest::update(iobuf buf) {
+    iobuf_istreambuf ibuf(buf);
     std::istream stream(&ibuf);
     json::IStreamWrapper wrapper(stream);
     rapidjson::Reader reader;
@@ -1374,8 +1371,7 @@ ss::future<> partition_manifest::update(ss::input_stream<char> is) {
     } else {
         rapidjson::ParseErrorCode e = reader.GetParseErrorCode();
         size_t o = reader.GetErrorOffset();
-        vlog(
-          cst_log.debug, "Failed to parse manifest: {}", result.hexdump(2048));
+        vlog(cst_log.debug, "Failed to parse manifest: {}", buf.hexdump(2048));
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "Failed to parse partition manifest {}: {} at offset {}",
@@ -1384,6 +1380,13 @@ ss::future<> partition_manifest::update(ss::input_stream<char> is) {
           o));
     }
     co_return;
+}
+
+ss::future<> partition_manifest::update(ss::input_stream<char> is) {
+    iobuf result;
+    auto os = make_iobuf_ref_output_stream(result);
+    co_await ss::copy(is, os);
+    co_return co_await update(std::move(result));
 }
 
 void partition_manifest::update(partition_manifest_handler&& handler) {

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -627,6 +627,10 @@ bool partition_manifest::advance_start_kafka_offset(
     return true;
 }
 
+void partition_manifest::unsafe_reset() {
+    *this = partition_manifest{_ntp, _rev, _mem_tracker};
+}
+
 bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
     const auto previous_start_offset = _start_offset;
 

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -286,6 +286,9 @@ public:
     /// Find element of the manifest by offset
     const_iterator find(model::offset o) const;
 
+    /// Update manifest file from iobuf
+    ss::future<> update(iobuf buf);
+
     /// Update manifest file from input_stream (remote set)
     ss::future<> update(ss::input_stream<char> is) override;
 

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -279,6 +279,17 @@ public:
     /// \returns true if start_offset was moved
     bool advance_start_kafka_offset(kafka::offset start_offset);
 
+    /// \brief Resets the state of the manifest to the default constructed
+    /// state.
+    ///
+    /// Should only be used as a part of an escape hatch, not during the
+    /// regular operation of a partition.
+    ///
+    /// There may not be anything necessarily unsafe about this, but marking
+    /// "unsafe" to deter further authors from using with giving this a lot of
+    /// thought.
+    void unsafe_reset();
+
     /// Get segment if available or nullopt
     std::optional<segment_meta> get(const key& key) const;
     std::optional<segment_meta> get(const segment_name& name) const;

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -1890,6 +1890,21 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_out_of_order) {
       == std::nullopt);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_reset_manifest) {
+    partition_manifest m;
+    m.update(make_manifest_stream(complete_manifest_json)).get();
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(
+      path, "60000000/meta/test-ns/test-topic/42_1/manifest.json");
+    BOOST_REQUIRE_EQUAL(m.size(), 5);
+
+    partition_manifest expected{
+      m.get_ntp(), m.get_revision_id(), m.mem_tracker()};
+
+    m.unsafe_reset();
+    BOOST_REQUIRE(m == expected);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
     static constexpr std::string_view raw = R"json({
         "version": 1,

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -51,6 +51,8 @@ public:
     command_batch_builder& operator=(const command_batch_builder&) = delete;
     // command_batch_builder& operator=(command_batch_builder&&) = default;
     ~command_batch_builder() = default;
+    /// Reset the manifest.
+    command_batch_builder& reset_metadata();
     /// Add segments to the batch
     command_batch_builder&
       add_segments(std::vector<cloud_storage::segment_meta>);
@@ -246,6 +248,7 @@ private:
     struct mark_clean_cmd;
     struct truncate_archive_init_cmd;
     struct truncate_archive_commit_cmd;
+    struct reset_metadata_cmd;
     struct snapshot;
 
     friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
@@ -264,6 +267,7 @@ private:
     void apply_truncate_archive_init(const start_offset_with_delta& so);
     void apply_truncate_archive_commit(const start_offset& so);
     void apply_update_start_kafka_offset(kafka::offset so);
+    void apply_reset_metadata();
 
 private:
     prefix_logger _logger;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -362,6 +362,8 @@ public:
 
     result<std::vector<raft::follower_metrics>> get_follower_metrics() const;
 
+    ss::future<> unsafe_reset_remote_partition_manifest(iobuf buf);
+
 private:
     ss::future<std::optional<storage::timequery_result>>
       cloud_storage_timequery(storage::timequery_config);

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -359,6 +359,42 @@
                     ]
                 }
             ]
+        },
+        {
+          "path": "/v1/debug/unsafe_reset_metadata/{topic}/{partition}",
+          "operations": [
+            {
+              "method": "POST",
+              "summary": "Resets the manifest, updating all replicas with the given manifest. This is very unsafe, so be sure the provided manifest actually has valid contents. Formatting aside, very little validation will be done on the requested manifest.",
+              "operationId": "unsafe_reset_metadata",
+              "nickname": "unsafe_reset_metadata",
+              "parameters": [
+                {
+                  "name": "topic",
+                  "in": "path",
+                  "required": true,
+                  "type": "string"
+                },
+                {
+                  "name": "partition",
+                  "in": "path",
+                  "required": true,
+                  "type": "integer"
+                },
+                {
+                  "name": "body",
+                  "required": true,
+                  "paramType": "body"
+                }
+              ],
+              "responseMessages": [
+                {
+                  "code": 200,
+                  "message": "Partition metadata is reset"
+                }
+              ]
+            }
+          ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4103,6 +4103,15 @@ void admin_server::register_debug_routes() {
         -> ss::future<ss::json::json_return_type> {
           return get_local_storage_usage_handler(std::move(req));
       });
+
+    request_handler_fn unsafe_reset_metadata_handler = [this](
+                                                         auto req, auto reply) {
+        return unsafe_reset_metadata(std::move(req), std::move(reply));
+    };
+
+    register_route<superuser>(
+      ss::httpd::debug_json::unsafe_reset_metadata,
+      std::move(unsafe_reset_metadata_handler));
 }
 
 ss::future<ss::json::json_return_type>
@@ -4361,6 +4370,58 @@ ss::future<ss::json::json_return_type> admin_server::sync_local_state_handler(
         }
     }
     co_return ss::json::json_return_type(ss::json::json_void());
+}
+
+ss::future<std::unique_ptr<ss::http::reply>>
+admin_server::unsafe_reset_metadata(
+  std::unique_ptr<ss::http::request> request,
+  std::unique_ptr<ss::http::reply> reply) {
+    reply->set_content_type("json");
+
+    auto ntp = parse_ntp_from_request(request->param, model::kafka_namespace);
+    if (need_redirect_to_leader(ntp, _metadata_cache)) {
+        vlog(logger.info, "Need to redirect unsafe reset metadata request");
+        throw co_await redirect_to_leader(*request, ntp);
+    }
+    if (request->content_length <= 0) {
+        throw ss::httpd::bad_request_exception("Empty request content");
+    }
+
+    ss::sstring content = request->content;
+
+    iobuf buf;
+    buf.append(request->content.data(), request->content.size());
+
+    content = {};
+
+    const auto shard = _shard_table.local().shard_for(ntp);
+    if (!shard) {
+        throw ss::httpd::not_found_exception(fmt::format(
+          "{} could not be found on the node. Perhaps it has been moved "
+          "during the redirect.",
+          ntp));
+    }
+
+    try {
+        co_await _partition_manager.invoke_on(
+          *shard,
+          [ntp = std::move(ntp), buf = std::move(buf), shard](
+            auto& pm) mutable {
+              auto partition = pm.get(ntp);
+              if (!partition) {
+                  throw ss::httpd::not_found_exception(
+                    fmt::format("Could not find {} on shard {}", ntp, *shard));
+              }
+
+              return partition->unsafe_reset_remote_partition_manifest(
+                std::move(buf));
+          });
+    } catch (const std::runtime_error& err) {
+        throw ss::httpd::server_error_exception(err.what());
+    }
+
+    reply->set_status(ss::http::reply::status_type::ok);
+    co_return reply;
 }
 
 ss::future<std::unique_ptr<ss::http::reply>>

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -417,6 +417,8 @@ private:
     /// Shadow indexing routes
     ss::future<ss::json::json_return_type>
       sync_local_state_handler(std::unique_ptr<ss::http::request>);
+    ss::future<std::unique_ptr<ss::http::reply>> unsafe_reset_metadata(
+      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
     ss::future<std::unique_ptr<ss::http::reply>>
       initiate_topic_scan_and_recovery(
         std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -442,6 +442,12 @@ class Admin:
                 return False
         return True
 
+    def unsafe_reset_cloud_metadata(self, topic, partition, manifest):
+        return self._request(
+            'POST',
+            f"debug/unsafe_reset_metadata/{topic}/{partition}",
+            json=manifest)
+
     def put_feature(self, feature_name, body):
         return self._request("PUT", f"features/{feature_name}", json=body)
 

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -6,6 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import json
 import random
 import re
 import time
@@ -30,6 +31,7 @@ from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import Scale, wait_until_segments
 from rptest.util import (
     produce_until_segments,
+    wait_until_result,
     wait_for_removal_of_n_segments,
     wait_for_local_storage_truncate,
 )
@@ -75,6 +77,7 @@ class EndToEndShadowIndexingBase(EndToEndTest):
                                         extra_rp_conf=extra_rp_conf,
                                         environment=environment)
         self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
 
     def setUp(self):
         assert self.redpanda
@@ -88,6 +91,124 @@ class EndToEndShadowIndexingBase(EndToEndTest):
 
 
 class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
+    def _all_uploads_done(self):
+        topic_description = self.rpk.describe_topic(self.topic)
+        partition = next(topic_description)
+
+        hwm = partition.high_watermark
+
+        manifest = None
+        try:
+            bucket = BucketView(self.redpanda)
+            manifest = bucket.manifest_for_ntp(self.topic, partition.id)
+        except Exception as e:
+            self.logger.info(
+                f"Exception thrown while retrieving the manifest: {e}")
+            return False
+
+        top_segment = max(manifest['segments'].values(),
+                          key=lambda seg: seg['base_offset'])
+        uploaded_raft_offset = top_segment['committed_offset']
+        uploaded_kafka_offset = uploaded_raft_offset - top_segment[
+            'delta_offset_end']
+        self.logger.info(
+            f"Remote HWM {uploaded_kafka_offset} (raft {uploaded_raft_offset}), local hwm {hwm}"
+        )
+
+        # -1 because uploaded offset is inclusive, hwm is exclusive
+        if uploaded_kafka_offset < (hwm - 1):
+            return False
+
+        return True
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_reset(self, cloud_storage_type):
+        brokers = self.redpanda.started_nodes()
+
+        msg_count_before_reset = 50 * (self.segment_size // 2056)
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=2056,
+                                       msg_count=msg_count_before_reset,
+                                       debug_logs=True,
+                                       trace_logs=True)
+
+        producer.start()
+        producer.wait(timeout_sec=60)
+        producer.free()
+
+        wait_until(lambda: self._all_uploads_done() == True,
+                   timeout_sec=60,
+                   backoff_sec=5)
+
+        s3_snapshot = BucketView(self.redpanda, topics=self.topics)
+        manifest = s3_snapshot.manifest_for_ntp(self.topic, 0)
+
+        self.rpk.alter_topic_config(self.topic, 'redpanda.remote.write',
+                                    'false')
+        time.sleep(1)
+
+        # Tweak the manifest as follows: remove the last 6 segments and update
+        # the last offset accordingly.
+        sorted_segments = sorted(manifest['segments'].items(),
+                                 key=lambda entry: entry[1]['base_offset'])
+
+        for name, meta in sorted_segments[-6:]:
+            manifest['segments'].pop(name)
+
+        manifest['last_offset'] = sorted_segments[-7][1]['committed_offset']
+
+        json_man = json.dumps(manifest)
+        self.logger.info(f"Re-setting manifest to:{json_man}")
+
+        self.redpanda._admin.unsafe_reset_cloud_metadata(
+            self.topic, 0, manifest)
+
+        self.rpk.alter_topic_config(self.topic, 'redpanda.remote.write',
+                                    'true')
+
+        msg_count_after_reset = 10 * (self.segment_size // 2056)
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=2056,
+                                       msg_count=msg_count_after_reset,
+                                       debug_logs=True,
+                                       trace_logs=True)
+
+        producer.start()
+        producer.wait(timeout_sec=30)
+        producer.free()
+
+        wait_until(lambda: self._all_uploads_done() == True,
+                   timeout_sec=60,
+                   backoff_sec=5)
+
+        # Enable aggresive local retention to test the cloud storage read path.
+        self.rpk.alter_topic_config(self.topic, 'retention.local.target.bytes',
+                                    self.segment_size * 5)
+
+        wait_for_local_storage_truncate(self.redpanda,
+                                        self.topic,
+                                        target_bytes=6 * self.segment_size,
+                                        partition_idx=0,
+                                        timeout_sec=30)
+
+        consumer = KgoVerifierSeqConsumer(self.test_context,
+                                          self.redpanda,
+                                          self.topic,
+                                          msg_size=2056,
+                                          debug_logs=True,
+                                          trace_logs=True)
+
+        consumer.start()
+        consumer.wait(timeout_sec=60)
+
+        assert consumer.consumer_status.validator.invalid_reads == 0
+        assert consumer.consumer_status.validator.valid_reads >= msg_count_before_reset + msg_count_after_reset
+
     @cluster(num_nodes=5)
     @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_write(self, cloud_storage_type):


### PR DESCRIPTION
Based on https://github.com/redpanda-data/redpanda/pull/10787

The goal of this PR is to add an escape hatch that can reset the in-memory contents of the archival manifest across all replicas, given an input JSON. When manifests are incorrect (e.g. from older buggy versions), we need a way to reset in-memory state without bringing down all replicas.

This is implemented as an archival metadata stm batch type that resets the manifest to the default-constructed manifest. This is used with batched add_segment commands to reset to include all segments included in an input JSON.

There's a few important caveats, which make this tool an absolute last resort to be used with guidance from the
storage team:
1. Remote write needs to be disabled on the topic; the request will be refused otherwise
2. This request should only be used Redpanda <= v23.1 as it does not set some fields in the manifest

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [X] v22.3.x
- [ ] v22.2.x

## Release Notes
* none