### PR TITLE
[v22.3.x] cloud_storage: escape hatch to reset metadata partition manifest

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -442,6 +442,10 @@ bool partition_manifest::contains(const segment_name& name) const {
 
 void partition_manifest::delete_replaced_segments() { _replaced.clear(); }
 
+void partition_manifest::unsafe_reset() {
+    *this = partition_manifest{_ntp, _rev};
+}
+
 bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
     if (new_start_offset > _start_offset && !_segments.empty()) {
         auto it = _segments.upper_bound(new_start_offset);

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -239,6 +239,17 @@ public:
     /// \returns true if start offset was moved
     bool advance_start_offset(model::offset start_offset);
 
+    /// \brief Resets the state of the manifest to the default constructed
+    /// state.
+    ///
+    /// Should only be used as a part of an escape hatch, not during the
+    /// regular operation of a partition.
+    ///
+    /// There may not be anything necessarily unsafe about this, but marking
+    /// "unsafe" to deter further authors from using with giving this a lot of
+    /// thought.
+    void unsafe_reset();
+
     /// Get segment if available or nullopt
     const segment_meta* get(const key& key) const;
     const segment_meta* get(const segment_name& name) const;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -245,8 +245,11 @@ public:
     /// Find element of the manifest by offset
     const_iterator find(model::offset o) const;
 
-    /// Get insert iterator for segments set
+    /// Get inesrt iterator for segments set
     std::insert_iterator<segment_map> get_insert_iterator();
+
+    /// Update manifest file from iobuf
+    ss::future<> update(iobuf buf);
 
     /// Update manifest file from input_stream (remote set)
     ss::future<> update(ss::input_stream<char> is) override;

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -1700,6 +1700,20 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_out_of_order) {
       == std::nullopt);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_reset_manifest) {
+    partition_manifest m;
+    m.update(make_manifest_stream(complete_manifest_json)).get();
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(
+      path, "60000000/meta/test-ns/test-topic/42_1/manifest.json");
+    BOOST_REQUIRE_EQUAL(m.size(), 4);
+
+    partition_manifest expected{m.get_ntp(), m.get_revision_id()};
+
+    m.unsafe_reset();
+    BOOST_REQUIRE(m == expected);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
     static constexpr std::string_view raw = R"json({
         "version": 1,

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -83,6 +83,13 @@ struct archival_metadata_stm::cleanup_metadata_cmd {
     static constexpr cmd_key key{3};
 };
 
+struct archival_metadata_stm::reset_metadata_cmd {
+    static constexpr cmd_key key{8};
+
+    // Unused, left available in case it's useful to pass in further arguments.
+    using value = iobuf;
+};
+
 struct archival_metadata_stm::snapshot
   : public serde::
       envelope<snapshot, serde::version<1>, serde::compat_version<0>> {
@@ -123,6 +130,14 @@ command_batch_builder::command_batch_builder(
   , _deadline(deadline)
   , _as(as)
   , _holder(stm._gate) {}
+
+command_batch_builder& command_batch_builder::reset_metadata() {
+    iobuf key_buf = serde::to_iobuf(
+      archival_metadata_stm::reset_metadata_cmd::key);
+    iobuf empty_buf;
+    _builder.add_raw_kv(std::move(key_buf), std::move(empty_buf));
+    return *this;
+}
 
 command_batch_builder& command_batch_builder::add_segments(
   std::vector<cloud_storage::segment_meta> add_segments) {
@@ -531,6 +546,9 @@ ss::future<> archival_metadata_stm::apply(model::record_batch b) {
         case cleanup_metadata_cmd::key:
             apply_cleanup_metadata();
             break;
+        case reset_metadata_cmd::key:
+            apply_reset_metadata();
+            break;
         };
     });
 
@@ -754,6 +772,11 @@ void archival_metadata_stm::apply_update_start_offset(const start_offset& so) {
     } else {
         vlog(_logger.debug, "Start offset updated to {}", get_start_offset());
     }
+}
+
+void archival_metadata_stm::apply_reset_metadata() {
+    vlog(_logger.info, "Resetting manifest");
+    _manifest->unsafe_reset();
 }
 
 std::vector<cloud_storage::partition_manifest::lw_segment_meta>

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -49,6 +49,8 @@ public:
     command_batch_builder& operator=(const command_batch_builder&) = delete;
     command_batch_builder& operator=(command_batch_builder&&) = default;
     ~command_batch_builder() = default;
+    /// Reset the manifest.
+    command_batch_builder& reset_metadata();
     /// Add segments to the batch
     command_batch_builder&
       add_segments(std::vector<cloud_storage::segment_meta>);
@@ -171,6 +173,7 @@ private:
     struct truncate_cmd;
     struct update_start_offset_cmd;
     struct cleanup_metadata_cmd;
+    struct reset_metadata_cmd;
     struct snapshot;
 
     friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
@@ -185,6 +188,7 @@ private:
     void apply_truncate(const start_offset& so);
     void apply_cleanup_metadata();
     void apply_update_start_offset(const start_offset& so);
+    void apply_reset_metadata();
 
 private:
     prefix_logger _logger;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -584,6 +584,95 @@ ss::future<> partition::remove_remote_persistent_state(ss::abort_source& as) {
     }
 }
 
+ss::future<> partition::unsafe_reset_remote_partition_manifest(iobuf buf) {
+    vlog(clusterlog.info, "[{}] Unsafe manifest reset requested", ntp());
+
+    if (!(config::shard_local_cfg().cloud_storage_enabled()
+          && _archival_meta_stm)) {
+        vlog(
+          clusterlog.warn,
+          "[{}] Archival STM not present. Skipping unsafe reset ...",
+          ntp());
+        throw std::runtime_error("Archival STM not present");
+    }
+
+    // Deserialise provided manifest
+    cloud_storage::partition_manifest req_m{
+      _raft->ntp(), _raft->log_config().get_initial_revision()};
+    co_await req_m.update(std::move(buf));
+
+    // A generous timeout of 60 seconds is used as it applies
+    // for the replication multiple batches.
+    auto deadline = ss::lowres_clock::now() + 60s;
+    std::vector<cluster::command_batch_builder> builders;
+
+    auto reset_builder = _archival_meta_stm->batch_start(deadline, _as);
+
+    // Add command to drop manifest. When applied, the current manifest
+    // will be replaced with a default constructed one.
+    reset_builder.reset_metadata();
+    builders.push_back(std::move(reset_builder));
+
+    // Add segments. Note that we only add, and omit the replaced segments.
+    // This should only be done in the context of a last-ditch effort to
+    // restore functionality to a partition. Replaced segments are likely
+    // unimportant.
+    constexpr size_t segments_per_batch = 256;
+    std::vector<cloud_storage::segment_meta> segments;
+    segments.reserve(segments_per_batch);
+
+    for (const auto& [_, s] : req_m) {
+        segments.emplace_back(s);
+        if (segments.size() == segments_per_batch) {
+            auto segments_builder = _archival_meta_stm->batch_start(
+              deadline, _as);
+            segments_builder.add_segments(std::move(segments));
+            builders.push_back(std::move(segments_builder));
+
+            segments.clear();
+        }
+    }
+
+    if (segments.size() > 0) {
+        auto segments_builder = _archival_meta_stm->batch_start(deadline, _as);
+        segments_builder.add_segments(std::move(segments));
+        builders.push_back(std::move(segments_builder));
+    }
+
+    size_t idx = 0;
+    for (auto& builder : builders) {
+        vlog(
+          clusterlog.info,
+          "Unsafe reset replicating batch {}/{}",
+          idx + 1,
+          builders.size());
+
+        auto errc = co_await builder.replicate();
+        if (errc) {
+            if (errc == raft::errc::shutting_down) {
+                // During shutdown, act like we hit an abort source rather
+                // than trying to log+handle this like a write error.
+                throw ss::abort_requested_exception();
+            }
+
+            vlog(
+              clusterlog.warn,
+              "[{}] Unsafe reset failed to update archival STM: {}",
+              ntp(),
+              errc.message());
+            throw std::runtime_error(
+              fmt::format("Failed to update archival STM: {}", errc.message()));
+        }
+
+        ++idx;
+    }
+
+    vlog(
+      clusterlog.info,
+      "[{}] Unsafe reset replicated STM commands successfully",
+      ntp());
+}
+
 std::ostream& operator<<(std::ostream& o, const partition& x) {
     return o << x._raft;
 }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -274,6 +274,8 @@ public:
 
     consensus_ptr raft() const { return _raft; }
 
+    ss::future<> unsafe_reset_remote_partition_manifest(iobuf buf);
+
 private:
     ss::future<std::optional<storage::timequery_result>>
       cloud_storage_timequery(storage::timequery_config);

--- a/src/v/cluster/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/tests/archival_metadata_stm_test.cc
@@ -36,6 +36,8 @@
 
 using namespace std::chrono_literals;
 
+static ss::abort_source never_abort;
+
 struct archival_metadata_stm_base_fixture
   : mux_state_machine_fixture
   , http_imposter_fixture {
@@ -486,6 +488,45 @@ FIXTURE_TEST(test_archival_stm_batching, archival_metadata_stm_fixture) {
     batcher.replicate().get();
     BOOST_REQUIRE(archival_stm->manifest().size() == 2);
     BOOST_REQUIRE(archival_stm->get_start_offset() == model::offset(0));
+    BOOST_REQUIRE(archival_stm->manifest().replaced_segments().size() == 0);
+    BOOST_REQUIRE(
+      archival_stm->manifest().begin()->second.archiver_term
+      == model::term_id(2));
+}
+
+FIXTURE_TEST(test_reset_metadata, archival_metadata_stm_fixture) {
+    wait_for_confirmed_leader();
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(segment_meta{
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(99),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+    m.push_back(segment_meta{
+      .base_offset = model::offset(100),
+      .committed_offset = model::offset(199),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+
+    // Replicate add_segment_cmd command that adds segment with offset 0
+    archival_stm->add_segments(m, ss::lowres_clock::now() + 10s, never_abort)
+      .get();
+    BOOST_REQUIRE(archival_stm->manifest().size() == 2);
+
+    // Reset the manifest and update the start offset, term id, etc.
+    auto batcher = archival_stm->batch_start(
+      ss::lowres_clock::now() + 10s, never_abort);
+    m.clear();
+    m.push_back(segment_meta{
+      .base_offset = model::offset(100),
+      .committed_offset = model::offset(199),
+      .archiver_term = model::term_id(2),
+      .segment_term = model::term_id(2)});
+    batcher.reset_metadata();
+    batcher.add_segments(std::move(m));
+    batcher.replicate().get();
+    BOOST_REQUIRE(archival_stm->manifest().size() == 1);
+    BOOST_REQUIRE(archival_stm->get_start_offset() == model::offset(100));
     BOOST_REQUIRE(archival_stm->manifest().replaced_segments().size() == 0);
     BOOST_REQUIRE(
       archival_stm->manifest().begin()->second.archiver_term

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -61,6 +61,42 @@
                     ]
                 }
             ]
+        },
+        {
+          "path": "/v1/debug/unsafe_reset_metadata/{topic}/{partition}",
+          "operations": [
+            {
+              "method": "POST",
+              "summary": "Resets the manifest, updating all replicas with the given manifest. This is very unsafe, so be sure the provided manifest actually has valid contents. Formatting aside, very little validation will be done on the requested manifest.",
+              "operationId": "unsafe_reset_metadata",
+              "nickname": "unsafe_reset_metadata",
+              "parameters": [
+                {
+                  "name": "topic",
+                  "in": "path",
+                  "required": true,
+                  "type": "string"
+                },
+                {
+                  "name": "partition",
+                  "in": "path",
+                  "required": true,
+                  "type": "integer"
+                },
+                {
+                  "name": "body",
+                  "required": true,
+                  "paramType": "body"
+                }
+              ],
+              "responseMessages": [
+                {
+                  "code": 200,
+                  "message": "Partition metadata is reset"
+                }
+              ]
+            }
+          ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3212,6 +3212,15 @@ void admin_server::register_debug_routes() {
 
           return ss::make_ready_future<ss::json::json_return_type>(ret);
       });
+
+    request_handler_fn unsafe_reset_metadata_handler = [this](
+                                                         auto req, auto reply) {
+        return unsafe_reset_metadata(std::move(req), std::move(reply));
+    };
+
+    register_route<superuser>(
+      ss::httpd::debug_json::unsafe_reset_metadata,
+      std::move(unsafe_reset_metadata_handler));
 }
 ss::future<ss::json::json_return_type>
 admin_server::get_partition_balancer_status_handler(
@@ -3422,6 +3431,58 @@ ss::future<ss::json::json_return_type> admin_server::sync_local_state_handler(
         }
     }
     co_return ss::json::json_return_type(ss::json::json_void());
+}
+
+ss::future<std::unique_ptr<ss::http::reply>>
+admin_server::unsafe_reset_metadata(
+  std::unique_ptr<ss::http::request> request,
+  std::unique_ptr<ss::http::reply> reply) {
+    reply->set_content_type("json");
+
+    auto ntp = parse_ntp_from_request(request->param, model::kafka_namespace);
+    if (need_redirect_to_leader(ntp, _metadata_cache)) {
+        vlog(logger.info, "Need to redirect unsafe reset metadata request");
+        throw co_await redirect_to_leader(*request, ntp);
+    }
+    if (request->content_length <= 0) {
+        throw ss::httpd::bad_request_exception("Empty request content");
+    }
+
+    ss::sstring content = request->content;
+
+    iobuf buf;
+    buf.append(request->content.data(), request->content.size());
+
+    content = {};
+
+    const auto shard = _shard_table.local().shard_for(ntp);
+    if (!shard) {
+        throw ss::httpd::not_found_exception(fmt::format(
+          "{} could not be found on the node. Perhaps it has been moved "
+          "during the redirect.",
+          ntp));
+    }
+
+    try {
+        co_await _partition_manager.invoke_on(
+          *shard,
+          [ntp = std::move(ntp), buf = std::move(buf), shard](
+            auto& pm) mutable {
+              auto partition = pm.get(ntp);
+              if (!partition) {
+                  throw ss::httpd::not_found_exception(
+                    fmt::format("Could not find {} on shard {}", ntp, *shard));
+              }
+
+              return partition->unsafe_reset_remote_partition_manifest(
+                std::move(buf));
+          });
+    } catch (const std::runtime_error& err) {
+        throw ss::httpd::server_error_exception(err.what());
+    }
+
+    reply->set_status(ss::http::reply::status_type::ok);
+    co_return reply;
 }
 
 void admin_server::register_shadow_indexing_routes() {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2332,8 +2332,8 @@ void admin_server::register_broker_routes() {
 
 // Helpers for partition routes
 namespace {
-model::ntp parse_ntp_from_request(ss::httpd::parameters& param) {
-    auto ns = model::ns(param["namespace"]);
+
+model::ntp parse_ntp_from_request(ss::httpd::parameters& param, model::ns ns) {
     auto topic = model::topic(param["topic"]);
 
     model::partition_id partition;
@@ -2349,7 +2349,11 @@ model::ntp parse_ntp_from_request(ss::httpd::parameters& param) {
           fmt::format("Invalid partition id {}", partition));
     }
 
-    return model::ntp(std::move(ns), std::move(topic), partition);
+    return {std::move(ns), std::move(topic), partition};
+}
+
+model::ntp parse_ntp_from_request(ss::httpd::parameters& param) {
+    return parse_ntp_from_request(param, model::ns(param["namespace"]));
 }
 
 } // namespace

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3437,10 +3437,10 @@ ss::future<ss::json::json_return_type> admin_server::sync_local_state_handler(
     co_return ss::json::json_return_type(ss::json::json_void());
 }
 
-ss::future<std::unique_ptr<ss::http::reply>>
+ss::future<std::unique_ptr<ss::httpd::reply>>
 admin_server::unsafe_reset_metadata(
-  std::unique_ptr<ss::http::request> request,
-  std::unique_ptr<ss::http::reply> reply) {
+  std::unique_ptr<ss::httpd::request> request,
+  std::unique_ptr<ss::httpd::reply> reply) {
     reply->set_content_type("json");
 
     auto ntp = parse_ntp_from_request(request->param, model::kafka_namespace);
@@ -3485,7 +3485,7 @@ admin_server::unsafe_reset_metadata(
         throw ss::httpd::server_error_exception(err.what());
     }
 
-    reply->set_status(ss::http::reply::status_type::ok);
+    reply->set_status(ss::httpd::reply::status_type::ok);
     co_return reply;
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -216,6 +216,49 @@ private:
         path.set(_server._routes, handler_f);
     }
 
+    using request_handler_fn
+      = ss::noncopyable_function<ss::future<std::unique_ptr<ss::reply>>(
+        std::unique_ptr<ss::request>, std::unique_ptr<ss::reply>)>;
+
+    /**
+     * Handler implementation to allow control over the reply. Accepts a handler
+     * function which takes as parameters both the http request and the reply.
+     * The supplied function can set the reply status code and content.
+     */
+    template<auth_level required_auth>
+    struct handler_impl final : public ss::httpd::handler_base {
+        handler_impl(admin_server& server, request_handler_fn handler)
+          : _server{server}
+          , _handler{std::move(handler)} {}
+
+        ss::future<std::unique_ptr<ss::httpd::reply>> handle(
+          [[maybe_unused]] const ss::sstring& path,
+          std::unique_ptr<ss::request> request,
+          std::unique_ptr<ss::reply> reply) override {
+            auto auth_state = _server.apply_auth<required_auth>(*request);
+            _server.log_request(*request, auth_state);
+
+            const auto url = request->get_url();
+            return ss::futurize_invoke(
+                     _handler, std::move(request), std::move(reply))
+              .handle_exception(
+                _server.exception_intercepter<
+                  decltype(_handler(std::move(request), std::move(reply))
+                             .get0())>(url, auth_state));
+        }
+
+        admin_server& _server;
+        request_handler_fn _handler;
+    };
+
+    template<auth_level required_auth>
+    void register_route(
+      ss::httpd::path_description const& path, request_handler_fn handler) {
+        path.set(
+          _server._routes,
+          new handler_impl<required_auth>{*this, std::move(handler)});
+    }
+
     void log_request(
       const ss::httpd::request& req,
       const request_auth_result& auth_state) const;

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -315,6 +315,8 @@ private:
     /// Shadow indexing routes
     ss::future<ss::json::json_return_type>
       sync_local_state_handler(std::unique_ptr<ss::httpd::request>);
+    ss::future<std::unique_ptr<ss::httpd::reply>> unsafe_reset_metadata(
+      std::unique_ptr<ss::httpd::request>, std::unique_ptr<ss::httpd::reply>);
 
     ss::future<ss::json::json_return_type>
       redpanda_services_restart_handler(std::unique_ptr<ss::httpd::request>);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -415,6 +415,12 @@ class Admin:
                 return False
         return True
 
+    def unsafe_reset_cloud_metadata(self, topic, partition, manifest):
+        return self._request(
+            'POST',
+            f"debug/unsafe_reset_metadata/{topic}/{partition}",
+            json=manifest)
+
     def put_feature(self, feature_name, body):
         return self._request("PUT", f"features/{feature_name}", json=body)
 

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -6,6 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import json
 import random
 import time
 
@@ -24,9 +25,10 @@ from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
 from rptest.services.redpanda import SISettings
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.prealloc_nodes import PreallocNodesTest
-from rptest.util import Scale, wait_until_segments
+from rptest.util import Scale, wait_until_segments, wait_for_local_storage_truncate
 from rptest.util import (
     produce_until_segments,
+    wait_until_result,
     wait_for_removal_of_n_segments,
 )
 from rptest.utils.si_utils import nodes_report_cloud_segments, S3Snapshot
@@ -67,6 +69,7 @@ class EndToEndShadowIndexingBase(EndToEndTest):
                                         extra_rp_conf=extra_rp_conf,
                                         environment=environment)
         self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
 
     def setUp(self):
         assert self.redpanda
@@ -80,6 +83,129 @@ class EndToEndShadowIndexingBase(EndToEndTest):
 
 
 class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
+    def _all_uploads_done(self):
+        topic_description = self.rpk.describe_topic(self.topic)
+        partition = next(topic_description)
+
+        hwm = partition.high_watermark
+
+        manifest = None
+        try:
+            s3_snapshot = S3Snapshot(self.topics, self.redpanda.s3_client,
+                                     self.si_settings.cloud_storage_bucket,
+                                     self.logger)
+            manifest = s3_snapshot.manifest_for_ntp(self.topic, 0)
+        except Exception as e:
+            self.logger.info(
+                f"Exception thrown while retrieving the manifest: {e}")
+            return False
+
+        top_segment = max(manifest['segments'].values(),
+                          key=lambda seg: seg['base_offset'])
+        uploaded_raft_offset = top_segment['committed_offset']
+        uploaded_kafka_offset = uploaded_raft_offset - top_segment[
+            'delta_offset_end']
+        self.logger.info(
+            f"Remote HWM {uploaded_kafka_offset} (raft {uploaded_raft_offset}), local hwm {hwm}"
+        )
+
+        # -1 because uploaded offset is inclusive, hwm is exclusive
+        if uploaded_kafka_offset < (hwm - 1):
+            return False
+
+        return True
+
+    @cluster(num_nodes=4)
+    def test_reset(self):
+        brokers = self.redpanda.started_nodes()
+
+        msg_count_before_reset = 50 * (self.segment_size // 2056)
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=2056,
+                                       msg_count=msg_count_before_reset,
+                                       debug_logs=True,
+                                       trace_logs=True)
+
+        producer.start()
+        producer.wait(timeout_sec=60)
+        producer.free()
+
+        time.sleep(30)
+        # wait_until(lambda: self._all_uploads_done() == True,
+        #            timeout_sec=60,
+        #            backoff_sec=5)
+
+        s3_snapshot = S3Snapshot(self.topics, self.redpanda.s3_client,
+                                 self.si_settings.cloud_storage_bucket,
+                                 self.logger)
+        manifest = s3_snapshot.manifest_for_ntp(self.topic, 0)
+
+        self.rpk.alter_topic_config(self.topic, 'redpanda.remote.write',
+                                    'false')
+        time.sleep(1)
+
+        # Tweak the manifest as follows: remove the last 6 segments and update
+        # the last offset accordingly.
+        sorted_segments = sorted(manifest['segments'].items(),
+                                 key=lambda entry: entry[1]['base_offset'])
+
+        for name, meta in sorted_segments[-6:]:
+            manifest['segments'].pop(name)
+
+        manifest['last_offset'] = sorted_segments[-7][1]['committed_offset']
+
+        json_man = json.dumps(manifest)
+        self.logger.info(f"Re-setting manifest to:{json_man}")
+
+        self.redpanda._admin.unsafe_reset_cloud_metadata(
+            self.topic, 0, manifest)
+
+        self.rpk.alter_topic_config(self.topic, 'redpanda.remote.write',
+                                    'true')
+
+        msg_count_after_reset = 10 * (self.segment_size // 2056)
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=2056,
+                                       msg_count=msg_count_after_reset,
+                                       debug_logs=True,
+                                       trace_logs=True)
+
+        producer.start()
+        producer.wait(timeout_sec=30)
+        producer.free()
+
+        time.sleep(30)
+        # wait_until(lambda: self._all_uploads_done() == True,
+        #            timeout_sec=60,
+        #            backoff_sec=5)
+
+        # Enable aggresive local retention to test the cloud storage read path.
+        self.rpk.alter_topic_config(self.topic, 'retention.local.target.bytes',
+                                    self.segment_size * 5)
+
+        wait_for_local_storage_truncate(self.redpanda,
+                                        self.topic,
+                                        target_bytes=6 * self.segment_size,
+                                        partition_idx=0,
+                                        timeout_sec=30)
+
+        consumer = KgoVerifierSeqConsumer(self.test_context,
+                                          self.redpanda,
+                                          self.topic,
+                                          msg_size=2056,
+                                          debug_logs=True,
+                                          trace_logs=True)
+
+        consumer.start()
+        consumer.wait(timeout_sec=60)
+
+        assert consumer.consumer_status.validator.invalid_reads == 0
+        assert consumer.consumer_status.validator.valid_reads >= msg_count_before_reset + msg_count_after_reset
+
     @cluster(num_nodes=5)
     def test_write(self):
         """Write at least 10 segments, set retention policy to leave only 5


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/10806

Conflicts:
* It's trickier to check from within the partition whether remote write is enabled since archiver lifecycle is no longer tied to the partition. I've removed the guardrail that previously bailed out if the archiver was enabled.
* Pulled in a couple partial backports of commits for utility methods
* Replaced ducktape test waits that don't quiesce in 22.3 with sleeps.

Based on https://github.com/redpanda-data/redpanda/pull/10787

The goal of this PR is to add an escape hatch that can reset the in-memory contents of the archival manifest across all replicas, given an input JSON. When manifests are incorrect (e.g. from older buggy versions), we need a way to reset in-memory state without bringing down all replicas.

This is implemented as an archival metadata stm batch type that resets the manifest to the default-constructed manifest. This is used with batched add_segment commands to reset to include all segments included in an input JSON.

There's a few important caveats, which make this tool an absolute last resort to be used with guidance from the
storage team:
1. Remote write needs to be disabled on the topic; the request will be refused otherwise
2. This request should only be used Redpanda <= v23.1 as it does not set some fields in the manifest

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none