### PR TITLE
cloud storage make partition_manifest::update_with_json sync

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1392,7 +1392,7 @@ struct partition_manifest_handler
     }
 };
 
-ss::future<> partition_manifest::update_with_json(iobuf buf) {
+void partition_manifest::update_with_json(iobuf buf) {
     iobuf_istreambuf ibuf(buf);
     std::istream stream(&ibuf);
     json::IStreamWrapper wrapper(stream);
@@ -1412,8 +1412,6 @@ ss::future<> partition_manifest::update_with_json(iobuf buf) {
           rapidjson::GetParseError_En(e),
           o));
     }
-
-    co_return;
 }
 
 ss::future<> partition_manifest::update(
@@ -1424,7 +1422,7 @@ ss::future<> partition_manifest::update(
 
     switch (serialization_format) {
     case manifest_format::json:
-        co_await update_with_json(std::move(result));
+        update_with_json(std::move(result));
         break;
     case manifest_format::serde:
         from_iobuf(std::move(result));

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -322,7 +322,7 @@ public:
     const_iterator find(model::offset o) const;
 
     /// Update manifest file from iobuf
-    ss::future<> update_with_json(iobuf buf);
+    void update_with_json(iobuf buf);
 
     /// Update manifest file from input_stream (remote set)
     ss::future<> update(

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -1993,7 +1993,7 @@ SEASTAR_THREAD_TEST_CASE(test_partition_manifest_v2_json) {
     partition_manifest m;
     auto buf = iobuf{};
     buf.append(v2_json.data(), v2_json.size());
-    m.update_with_json(std::move(buf)).get();
+    m.update_with_json(std::move(buf));
     BOOST_CHECK_EQUAL(m.size(), 0);
     BOOST_CHECK_EQUAL(m.replaced_segments_count(), 0);
 }

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1036,7 +1036,7 @@ ss::future<> partition::unsafe_reset_remote_partition_manifest(iobuf buf) {
     // Deserialise provided manifest
     cloud_storage::partition_manifest req_m{
       _raft->ntp(), _raft->log_config().get_initial_revision()};
-    co_await req_m.update_with_json(std::move(buf));
+    req_m.update_with_json(std::move(buf));
 
     // A generous timeout of 60 seconds is used as it applies
     // for the replication multiple batches.


### PR DESCRIPTION
this pr makes partition_manifest::update_with_json sync, the async aspect wasn't really used

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none