### PR TITLE
Use opaque records in Raft append entries message

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1175,6 +1175,10 @@ public:
         // redpanda offset.
         batch.header().base_offset = kafka::offset_cast(
           rp_to_kafka(batch.base_offset()));
+        // since base offset isn't accounted into Kafka crc we need to only
+        // update header_crc
+        batch.header().header_crc = model::internal_header_only_crc(
+          batch.header());
 
         size_t sz = _parent.produce(std::move(batch));
 

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -2046,8 +2046,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
             tests::random_named_int<model::revision_id>()},
           pmd,
           model::make_memory_record_batch_reader(std::move(batches_in)),
-          raft::append_entries_request::flush_after_append(
-            tests::random_bool()),
+          raft::flush_after_append(tests::random_bool()),
         };
 
         // append_entries_request -> iobuf

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -2051,10 +2051,10 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
         // append_entries_request -> iobuf
         iobuf serde_out;
-        const auto node_id = data.node_id;
-        const auto target_node_id = data.target_node_id;
-        const auto meta = data.meta;
-        const auto flush = data.flush;
+        const auto node_id = data.source_node();
+        const auto target_node_id = data.target_node();
+        const auto meta = data.metadata();
+        const auto flush = data.is_flush_required();
         serde::write_async(serde_out, std::move(data)).get();
 
         // iobuf -> append_entries_request
@@ -2062,13 +2062,13 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         auto from_serde
           = serde::read_async<raft::append_entries_request>(serde_in).get0();
 
-        BOOST_REQUIRE(from_serde.node_id == node_id);
-        BOOST_REQUIRE(from_serde.target_node_id == target_node_id);
-        BOOST_REQUIRE(from_serde.meta == meta);
-        BOOST_REQUIRE(from_serde.flush == flush);
+        BOOST_REQUIRE(from_serde.source_node() == node_id);
+        BOOST_REQUIRE(from_serde.target_node() == target_node_id);
+        BOOST_REQUIRE(from_serde.metadata() == meta);
+        BOOST_REQUIRE(from_serde.is_flush_required() == flush);
 
         auto batches_from_serde = model::consume_reader_to_memory(
-                                    std::move(from_serde.batches()),
+                                    std::move(from_serde).release_batches(),
                                     model::no_timeout)
                                     .get0();
         BOOST_REQUIRE(gold.size() > 0);

--- a/src/v/compat/model_compat.h
+++ b/src/v/compat/model_compat.h
@@ -10,10 +10,12 @@
  */
 #pragma once
 
+#include "bytes/iobuf.h"
 #include "compat/check.h"
 #include "compat/json.h"
 #include "compat/model_generator.h"
 #include "model/metadata.h"
+#include "model/record.h"
 
 namespace compat {
 
@@ -40,5 +42,70 @@ GEN_COMPAT_CHECK(
       json_read(tp_ns);
       json_read(partitions);
   });
+
+GEN_COMPAT_CHECK(
+  model::record_batch_header,
+  {
+      json_write(header_crc);
+      json_write(size_bytes);
+      json_write(type);
+      json_write(base_offset);
+      json_write(crc);
+      json_write(attrs);
+      json_write(last_offset_delta);
+      json_write(first_timestamp);
+      json_write(max_timestamp);
+      json_write(producer_id);
+      json_write(producer_epoch);
+      json_write(base_sequence);
+      json_write(record_count);
+  },
+  {
+      json_read(header_crc);
+      json_read(size_bytes);
+      json_read(type);
+      json_read(base_offset);
+      json_read(crc);
+      json_read(attrs);
+      json_read(last_offset_delta);
+      json_read(first_timestamp);
+      json_read(max_timestamp);
+      json_read(producer_id);
+      json_read(producer_epoch);
+      json_read(base_sequence);
+      json_read(record_count);
+  });
+
+template<>
+struct compat_check<model::record_batch> {
+    static constexpr std::string_view name = "model::record_batch";
+
+    static std::vector<model::record_batch> create_test_cases() {
+        return generate_instances<model::record_batch>();
+    }
+
+    static void
+    to_json(model::record_batch b, json::Writer<json::StringBuffer>& wr) {
+        json::write_member(wr, "header", b.header());
+        json::write_member(wr, "data", b.data().copy());
+    }
+
+    static model::record_batch from_json(json::Value& v) {
+        model::record_batch_header header;
+        iobuf data;
+        json::read_member(v, "header", header);
+        json::read_member(v, "data", data);
+
+        return {header, std::move(data)};
+    }
+
+    static std::vector<compat_binary> to_binary(model::record_batch obj) {
+        return {compat_binary::serde(obj.copy())};
+    }
+
+    static void check(model::record_batch obj, compat_binary test) {
+        verify_serde_only(obj.copy(), std::move(test));
+    }
+};
 
 } // namespace compat

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -563,7 +563,7 @@ struct compat_check<raft::append_entries_request> {
         raft::vnode node;
         raft::vnode target;
         raft::protocol_metadata meta;
-        raft::append_entries_request::flush_after_append flush;
+        raft::flush_after_append flush;
         model::record_batch_reader::data_t batches;
 
         json::read_member(rd, "node_id", node);

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -510,8 +510,13 @@ struct compat_check<raft::heartbeat_reply> {
 template<>
 inline std::pair<raft::append_entries_request, raft::append_entries_request>
 compat_copy(raft::append_entries_request r) {
+    auto metadata = r.metadata();
+    auto target_node = r.target_node();
+    auto source_node = r.source_node();
+    auto flush = r.is_flush_required();
+
     auto a_batches = model::consume_reader_to_memory(
-                       std::move(r.batches()), model::no_timeout)
+                       std::move(r).release_batches(), model::no_timeout)
                        .get0();
 
     ss::circular_buffer<model::record_batch> b_batches;
@@ -520,18 +525,18 @@ compat_copy(raft::append_entries_request r) {
     }
 
     raft::append_entries_request a(
-      r.node_id,
-      r.target_node_id,
-      r.meta,
+      source_node,
+      target_node,
+      metadata,
       model::make_memory_record_batch_reader(std::move(a_batches)),
-      r.flush);
+      flush);
 
     raft::append_entries_request b(
-      r.node_id,
-      r.target_node_id,
-      r.meta,
+      source_node,
+      target_node,
+      metadata,
       model::make_memory_record_batch_reader(std::move(b_batches)),
-      r.flush);
+      flush);
 
     return {std::move(a), std::move(b)};
 }
@@ -549,12 +554,12 @@ struct compat_check<raft::append_entries_request> {
 
     static void to_json(
       raft::append_entries_request obj, json::Writer<json::StringBuffer>& wr) {
-        json_write(node_id);
-        json_write(target_node_id);
-        json_write(meta);
-        json_write(flush);
+        json::write_member(wr, "node_id", obj.source_node());
+        json::write_member(wr, "target_node_id", obj.target_node());
+        json::write_member(wr, "meta", obj.metadata());
+        json::write_member(wr, "flush", obj.is_flush_required());
         auto batches = model::consume_reader_to_memory(
-                         std::move(obj.batches()), model::no_timeout)
+                         std::move(obj).release_batches(), model::no_timeout)
                          .get0();
         json::write_member(wr, "batches", batches);
     }
@@ -590,35 +595,41 @@ struct compat_check<raft::append_entries_request> {
         auto decoded = decode_serde_only<raft::append_entries_request>(
           std::move(test));
 
-        if (decoded.node_id != expected.node_id) {
+        if (decoded.source_node() != expected.source_node()) {
             throw compat_error(fmt::format(
-              "Expected node_id {} got {}", expected.node_id, decoded.node_id));
+              "Expected node_id {} got {}",
+              expected.source_node(),
+              decoded.source_node()));
         }
 
-        if (decoded.target_node_id != expected.target_node_id) {
+        if (decoded.target_node() != expected.target_node()) {
             throw compat_error(fmt::format(
               "Expected target_node_id {} got {}",
-              expected.target_node_id,
-              decoded.target_node_id));
+              expected.target_node(),
+              decoded.target_node()));
         }
 
-        if (decoded.meta != expected.meta) {
+        if (decoded.metadata() != expected.metadata()) {
             throw compat_error(fmt::format(
-              "Expected meta {} got {}", expected.meta, decoded.meta));
+              "Expected meta {} got {}",
+              expected.metadata(),
+              decoded.metadata()));
         }
 
-        if (decoded.flush != expected.flush) {
+        if (decoded.is_flush_required() != expected.is_flush_required()) {
             throw compat_error(fmt::format(
-              "Expected flush {} got {}", expected.flush, decoded.flush));
+              "Expected flush {} got {}",
+              expected.is_flush_required(),
+              decoded.is_flush_required()));
         }
 
         auto decoded_batches = model::consume_reader_to_memory(
-                                 std::move(decoded.batches()),
+                                 std::move(decoded).release_batches(),
                                  model::no_timeout)
                                  .get0();
 
         auto expected_batches = model::consume_reader_to_memory(
-                                  std::move(expected.batches()),
+                                  std::move(expected).release_batches(),
                                   model::no_timeout)
                                   .get0();
 

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -317,8 +317,7 @@ struct instance_generator<raft::append_entries_request> {
           instance_generator<raft::protocol_metadata>::random(),
           model::make_memory_record_batch_reader(
             model::test::make_random_batches(model::offset(0), 3, false)),
-          raft::append_entries_request::flush_after_append(
-            tests::random_bool()),
+          raft::flush_after_append(tests::random_bool()),
         };
     }
 

--- a/src/v/compat/raft_json.h
+++ b/src/v/compat/raft_json.h
@@ -155,13 +155,18 @@ inline void read_value(json::Value const& rd, model::record_attributes& out) {
 inline void rjson_serialize(
   json::Writer<json::StringBuffer>& wr, const model::record_batch_header& obj) {
     wr.StartObject();
+    json_write(header_crc);
     json_write(size_bytes);
     json_write(base_offset);
+    json_write(type);
     json_write(crc);
     json_write(attrs);
     json_write(last_offset_delta);
     json_write(first_timestamp);
     json_write(max_timestamp);
+    json_write(producer_id);
+    json_write(producer_epoch);
+    json_write(base_sequence);
     json_write(record_count);
     wr.EndObject();
 }
@@ -203,13 +208,18 @@ inline void rjson_serialize(
 
 inline void read_value(json::Value const& rd, model::record_batch_header& out) {
     model::record_batch_header obj;
+    json_read(header_crc);
     json_read(size_bytes);
     json_read(base_offset);
+    json_read(type);
     json_read(crc);
     json_read(attrs);
     json_read(last_offset_delta);
     json_read(first_timestamp);
     json_read(max_timestamp);
+    json_read(producer_id);
+    json_read(producer_epoch);
+    json_read(base_sequence);
     json_read(record_count);
     out = obj;
 }

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -36,6 +36,7 @@
 #include "json/document.h"
 #include "json/prettywriter.h"
 #include "json/writer.h"
+#include "model/record.h"
 #include "seastarx.h"
 #include "utils/base64.h"
 #include "utils/file_io.h"
@@ -143,7 +144,9 @@ using compat_checks = type_list<
   cluster::incremental_topic_updates,
   cluster::topic_properties_update,
   cluster::update_topic_properties_request,
-  cluster::update_topic_properties_reply>;
+  cluster::update_topic_properties_reply,
+  model::record_batch_header,
+  model::record_batch>;
 
 template<typename T>
 struct corpus_helper {

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -71,6 +71,8 @@ std::string_view to_string_view(feature f) {
         return "force_partition_reconfiguration";
     case feature::schema_id_validation:
         return "schema_id_validation";
+    case feature::raft_append_entries_serde:
+        return "raft_append_entries_serde";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -59,6 +59,7 @@ enum class feature : std::uint64_t {
     transaction_partitioning = 1ULL << 25U,
     force_partition_reconfiguration = 1ULL << 26U,
     schema_id_validation = 1ULL << 27U,
+    raft_append_entries_serde = 1ULL << 28U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -269,6 +270,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{10},
     "schema_id_validation",
     feature::schema_id_validation,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{10},
+    "raft_append_entries_serde",
+    feature::raft_append_entries_serde,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -423,7 +423,7 @@ struct record_batch_header {
         return h;
     }
     bool operator==(const record_batch_header& other) const {
-        return size_bytes == other.size_bytes
+        return header_crc == other.header_crc && size_bytes == other.size_bytes
                && base_offset == other.base_offset && crc == other.crc
                && attrs == other.attrs
                && last_offset_delta == other.last_offset_delta

--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -97,7 +97,7 @@ ss::future<> append_entries_buffer::do_flush(
         ssx::semaphore_units op_lock_units = std::move(u);
         replies.reserve(requests.size());
         for (auto& req : requests) {
-            if (req.flush) {
+            if (req.is_flush_required()) {
                 needs_flush = true;
             }
             try {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -626,7 +626,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
           meta(),
           model::make_memory_record_batch_reader(
             ss::circular_buffer<model::record_batch>{}),
-          append_entries_request::flush_after_append::no);
+          flush_after_append::no);
         auto seq = next_follower_sequence(target);
         sequences.emplace(target, seq);
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -637,7 +637,8 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
                    .append_entries(
                      target.id(),
                      std::move(req),
-                     rpc::client_opts(_replicate_append_timeout))
+                     rpc::client_opts(_replicate_append_timeout),
+                     use_all_serde_append_entries())
                    .then([this, id = target.id(), seq, dirty_offset](
                            result<append_entries_reply> reply) {
                        process_append_entries_reply(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1961,12 +1961,10 @@ consensus::do_append_entries(append_entries_request&& r) {
               }
               return do_append_entries(std::move(r));
           })
-          .handle_exception([this, reply = std::move(reply)](
-                              const std::exception_ptr& e) mutable {
+          .handle_exception([this, reply](const std::exception_ptr& e) mutable {
               vlog(_ctxlog.warn, "Error occurred while truncating log - {}", e);
               reply.result = append_entries_reply::status::failure;
-              return ss::make_ready_future<append_entries_reply>(
-                std::move(reply));
+              return ss::make_ready_future<append_entries_reply>(reply);
           });
     }
 
@@ -1986,12 +1984,11 @@ consensus::do_append_entries(append_entries_request&& r) {
                 return make_append_entries_reply(target, ofs);
             });
       })
-      .handle_exception([this, reply = std::move(reply)](
-                          const std::exception_ptr& e) mutable {
+      .handle_exception([this, reply](const std::exception_ptr& e) mutable {
           vlog(
             _ctxlog.warn, "Error occurred while appending log entries - {}", e);
           reply.result = append_entries_reply::status::failure;
-          return ss::make_ready_future<append_entries_reply>(std::move(reply));
+          return ss::make_ready_future<append_entries_reply>(reply);
       })
       .finally([this] {
           // we do not want to include our disk flush latency into

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -673,6 +673,12 @@ private:
     void maybe_upgrade_configuration_to_v4(group_configuration&);
 
     void update_confirmed_term();
+
+    bool use_all_serde_append_entries() const {
+        return _features.is_active(
+          features::feature::raft_append_entries_serde);
+    }
+
     // args
     vnode _self;
     raft::group_id _group;

--- a/src/v/raft/consensus_client_protocol.h
+++ b/src/v/raft/consensus_client_protocol.h
@@ -31,7 +31,10 @@ public:
         vote(model::node_id, vote_request&&, rpc::client_opts) = 0;
 
         virtual ss::future<result<append_entries_reply>> append_entries(
-          model::node_id, append_entries_request&&, rpc::client_opts)
+          model::node_id,
+          append_entries_request&&,
+          rpc::client_opts,
+          bool use_all_serde_encoding)
           = 0;
 
         virtual ss::future<result<heartbeat_reply>>
@@ -68,9 +71,10 @@ public:
     ss::future<result<append_entries_reply>> append_entries(
       model::node_id target_node,
       append_entries_request&& r,
-      rpc::client_opts opts) {
+      rpc::client_opts opts,
+      bool use_all_serde_encoding) {
         return _impl->append_entries(
-          target_node, std::move(r), std::move(opts));
+          target_node, std::move(r), std::move(opts), use_all_serde_encoding);
     }
 
     ss::future<result<heartbeat_reply>> heartbeat(

--- a/src/v/raft/raftgen.json
+++ b/src/v/raft/raftgen.json
@@ -34,6 +34,11 @@
             "name": "transfer_leadership",
             "input_type": "transfer_leadership_request",
             "output_type": "transfer_leadership_reply"
+        },
+        {
+            "name": "append_entries_full_serde",
+            "input_type": "append_entries_request_serde_wrapper",
+            "output_type": "append_entries_reply"
         }
     ]
 }

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -150,7 +150,7 @@ ss::future<> recovery_stm::do_recover(ss::io_priority_class iopc) {
     }
 
     auto flush = should_flush(follower_committed_match_index);
-    if (flush == append_entries_request::flush_after_append::yes) {
+    if (flush == flush_after_append::yes) {
         _recovered_bytes_since_flush = 0;
     }
 
@@ -169,7 +169,7 @@ bool recovery_stm::state_changed() {
            || meta.value()->last_sent_offset == lstats.dirty_offset;
 }
 
-append_entries_request::flush_after_append
+flush_after_append
 recovery_stm::should_flush(model::offset follower_committed_match_index) const {
     constexpr size_t checkpoint_flush_size = 1_MiB;
 
@@ -203,8 +203,7 @@ recovery_stm::should_flush(model::offset follower_committed_match_index) const {
     const bool should_checkpoint_flush = _recovered_bytes_since_flush
                                          >= checkpoint_flush_size;
 
-    return append_entries_request::flush_after_append(
-      is_last || should_checkpoint_flush);
+    return flush_after_append(is_last || should_checkpoint_flush);
 }
 
 ss::future<std::optional<model::record_batch_reader>>
@@ -398,7 +397,7 @@ ss::future<> recovery_stm::install_snapshot() {
 
 ss::future<> recovery_stm::replicate(
   model::record_batch_reader&& reader,
-  append_entries_request::flush_after_append flush,
+  flush_after_append flush,
   ssx::semaphore_units mem_units) {
     // collect metadata for append entries request
     // last persisted offset is last_offset of batch before the first one in the

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -513,7 +513,11 @@ ss::future<result<append_entries_reply>> recovery_stm::dispatch_append_entries(
       ss::make_lw_shared<std::vector<ssx::semaphore_units>>(std::move(units)));
 
     return _ptr->_client_protocol
-      .append_entries(_node_id.id(), std::move(r), std::move(opts))
+      .append_entries(
+        _node_id.id(),
+        std::move(r),
+        std::move(opts),
+        _ptr->use_all_serde_append_entries())
       .then([this](result<append_entries_reply> reply) {
           return _ptr->validate_reply_target_node(
             "append_entries_recovery", reply, _node_id.id());

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -34,9 +34,7 @@ private:
     read_range_for_recovery(model::offset, ss::io_priority_class, bool, size_t);
 
     ss::future<> replicate(
-      model::record_batch_reader&&,
-      append_entries_request::flush_after_append,
-      ssx::semaphore_units);
+      model::record_batch_reader&&, flush_after_append, ssx::semaphore_units);
     ss::future<result<append_entries_reply>> dispatch_append_entries(
       append_entries_request&&, std::vector<ssx::semaphore_units>);
     std::optional<follower_index_metadata*> get_follower_meta();
@@ -49,8 +47,7 @@ private:
     ss::future<> close_snapshot_reader();
     bool state_changed();
     bool is_recovery_finished();
-    append_entries_request::flush_after_append
-      should_flush(model::offset) const;
+    flush_after_append should_flush(model::offset) const;
     consensus* _ptr;
     vnode _node_id;
     model::offset _base_batch_offset;

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -228,7 +228,7 @@ ss::future<> replicate_batcher::flush(
         ss::circular_buffer<model::record_batch> data;
         std::vector<item_ptr> notifications;
         ssx::semaphore_units item_memory_units(_max_batch_size_sem, 0);
-        auto needs_flush = append_entries_request::flush_after_append::no;
+        auto needs_flush = flush_after_append::no;
 
         for (auto& n : item_cache) {
             if (
@@ -238,8 +238,7 @@ ss::future<> replicate_batcher::flush(
                 item_memory_units.adopt(std::move(units));
                 if (
                   n->get_consistency_level() == consistency_level::quorum_ack) {
-                    needs_flush
-                      = append_entries_request::flush_after_append::yes;
+                    needs_flush = flush_after_append::yes;
                 }
                 for (auto& b : batches) {
                     b.set_term(term);

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -317,7 +317,7 @@ ss::future<> replicate_batcher::do_flush(
   append_entries_request req,
   std::vector<ssx::semaphore_units> u,
   absl::flat_hash_map<vnode, follower_req_seq> seqs) {
-    auto needs_flush = req.flush;
+    auto needs_flush = req.is_flush_required();
     _ptr->_probe.replicate_batch_flushed();
     auto stm = ss::make_lw_shared<replicate_entries_stm>(
       _ptr, std::move(req), std::move(seqs));

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -9,9 +9,13 @@
 
 #include "raft/replicate_entries_stm.h"
 
+#include "features/feature_table.h"
 #include "likely.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "outcome.h"
 #include "outcome_future_utils.h"
 #include "raft/consensus.h"
 #include "raft/consensus_utils.h"
@@ -23,34 +27,33 @@
 #include "rpc/types.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/util/defer.hh>
 
 #include <chrono>
+#include <memory>
 
 namespace raft {
 using namespace std::chrono_literals;
 
-ss::future<append_entries_request> replicate_entries_stm::share_request() {
+ss::future<model::record_batch_reader> replicate_entries_stm::share_batches() {
     // one extra copy is needed for retries
-    return with_semaphore(_share_sem, 1, [this] {
-        return details::foreign_share_n(std::move(_req->batches()), 2)
-          .then([this](std::vector<model::record_batch_reader> readers) {
-              // keep a copy around until the end
-              _req->batches() = std::move(readers.back());
-              readers.pop_back();
-              return append_entries_request(
-                _req->node_id,
-                _req->meta,
-                std::move(readers.back()),
-                _req->flush);
-          });
-    });
+    auto u = co_await _share_mutex.get_units();
+
+    auto readers = co_await details::foreign_share_n(
+      std::move(_batches.value()), 2);
+
+    // keep a copy around until the end
+    _batches = std::move(readers.back());
+    readers.pop_back();
+
+    co_return std::move(readers.back());
 }
 
 ss::future<result<append_entries_reply>> replicate_entries_stm::flush_log() {
     using ret_t = result<append_entries_reply>;
     auto flush_f = ss::now();
-    if (_req->flush) {
+    if (_is_flush_required) {
         flush_f = _ptr->flush_log();
     }
 
@@ -91,17 +94,16 @@ clock_type::time_point replicate_entries_stm::append_entries_timeout() {
 
 ss::future<result<append_entries_reply>>
 replicate_entries_stm::send_append_entries_request(
-  vnode n, append_entries_request req) {
+  vnode n, model::record_batch_reader batches) {
     _ptr->update_node_append_timestamp(n);
-    vlog(_ctxlog.trace, "Sending append entries request {} to {}", req.meta, n);
 
-    req.target_node_id = n;
+    vlog(_ctxlog.trace, "Sending append entries request {} to {}", _meta, n);
 
     auto opts = rpc::client_opts(append_entries_timeout());
     opts.resource_units = ss::make_foreign<ss::lw_shared_ptr<units_t>>(_units);
 
     auto f = _ptr->_fstats.get_append_entries_unit(n).then_wrapped(
-      [this, req = std::move(req), opts = std::move(opts), n](
+      [this, batches = std::move(batches), opts = std::move(opts), n](
         ss::future<ssx::semaphore_units> f) mutable {
           // we want to signal dispatch semaphore after calling append entries.
           // When dispatch semaphore is released the append_entries_stm releases
@@ -117,7 +119,11 @@ replicate_entries_stm::send_append_entries_request(
           auto u = f.get();
 
           return _ptr->_client_protocol
-            .append_entries(n.id(), std::move(req), std::move(opts))
+            .append_entries(
+              n.id(),
+              append_entries_request(
+                _ptr->self(), n, _meta, std::move(batches), _is_flush_required),
+              std::move(opts))
             .then([this, target_node_id = n.id()](
                     result<append_entries_reply> reply) {
                 return _ptr->validate_reply_target_node(
@@ -172,26 +178,26 @@ ss::future<result<append_entries_reply>>
 replicate_entries_stm::dispatch_single_retry(vnode id) {
     if (id == _ptr->_self) {
         return flush_log();
-    } else {
-        return share_request().then(
-          [this, id](append_entries_request r) mutable {
-              return send_append_entries_request(id, std::move(r));
-          });
     }
+    return share_batches().then(
+      [this, id](model::record_batch_reader batches) mutable {
+          return send_append_entries_request(id, std::move(batches));
+      });
 }
 
 ss::future<result<storage::append_result>>
 replicate_entries_stm::append_to_self() {
-    return share_request()
-      .then([this](append_entries_request req) mutable {
-          vlog(_ctxlog.trace, "Self append entries - {}", req.meta);
+    return share_batches()
+      .then([this](model::record_batch_reader batches) mutable {
+          vlog(_ctxlog.trace, "Self append entries - {}", _meta);
+
           _ptr->_last_write_consistency_level
-            = _req->flush ? consistency_level::quorum_ack
-                          : consistency_level::leader_ack;
+            = _is_flush_required ? consistency_level::quorum_ack
+                                 : consistency_level::leader_ack;
           return _ptr->disk_append(
-            std::move(req.batches()),
-            _req->flush ? consensus::update_last_quorum_index::yes
-                        : consensus::update_last_quorum_index::no);
+            std::move(batches),
+            _is_flush_required ? consensus::update_last_quorum_index::yes
+                               : consensus::update_last_quorum_index::no);
       })
       .then([this](storage::append_result res) {
           vlog(_ctxlog.trace, "Leader append result: {}", res);
@@ -239,14 +245,14 @@ inline bool replicate_entries_stm::should_skip_follower_request(vnode id) {
               id);
             return true;
         }
-        if (it->second.last_sent_offset != _req->meta.prev_log_index) {
+        if (it->second.last_sent_offset != _meta.prev_log_index) {
             vlog(
               _ctxlog.trace,
               "Skipping sending append request to {} - last sent offset: {}, "
               "expected follower last offset: {}",
               id,
               it->second.last_sent_offset,
-              _req->meta.prev_log_index);
+              _meta.prev_log_index);
             return true;
         }
         return false;
@@ -299,7 +305,7 @@ ss::future<result<replicate_result>> replicate_entries_stm::apply(units_t u) {
         // Wait until all RPCs will be dispatched
         return _dispatch_sem.wait(_requests_count).then([this] {
             // release memory reservations, and destroy data
-            _req.reset();
+            _batches.reset();
             _units.release();
         });
     });
@@ -418,9 +424,10 @@ replicate_entries_stm::replicate_entries_stm(
   append_entries_request r,
   absl::flat_hash_map<vnode, follower_req_seq> seqs)
   : _ptr(p)
-  , _req(std::make_unique<append_entries_request>(std::move(r)))
+  , _meta(r.metadata())
+  , _is_flush_required(r.is_flush_required())
+  , _batches(std::move(r).release_batches())
   , _followers_seq(std::move(seqs))
-  , _share_sem(1, "raft/repl-entries")
   , _ctxlog(_ptr->_ctxlog) {}
 
 replicate_entries_stm::~replicate_entries_stm() {

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -123,7 +123,8 @@ replicate_entries_stm::send_append_entries_request(
               n.id(),
               append_entries_request(
                 _ptr->self(), n, _meta, std::move(batches), _is_flush_required),
-              std::move(opts))
+              std::move(opts),
+              _ptr->use_all_serde_append_entries())
             .then([this, target_node_id = n.id()](
                     result<append_entries_reply> reply) {
                 return _ptr->validate_reply_target_node(

--- a/src/v/raft/rpc_client_protocol.h
+++ b/src/v/raft/rpc_client_protocol.h
@@ -35,7 +35,10 @@ public:
     vote(model::node_id, vote_request&&, rpc::client_opts) final;
 
     ss::future<result<append_entries_reply>> append_entries(
-      model::node_id, append_entries_request&&, rpc::client_opts) final;
+      model::node_id,
+      append_entries_request&&,
+      rpc::client_opts,
+      bool use_all_serde_encoding) final;
 
     ss::future<result<heartbeat_reply>>
     heartbeat(model::node_id, heartbeat_request&&, rpc::client_opts) final;

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -79,7 +79,7 @@ public:
               m.meta,
               model::make_memory_record_batch_reader(
                 ss::circular_buffer<model::record_batch>{}),
-              append_entries_request::flush_after_append::no);
+              flush_after_append::no);
             reqs.push_back(std::move(append_req));
         };
 

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -535,3 +535,64 @@ SEASTAR_THREAD_TEST_CASE(snapshot_metadata_backward_compatibility) {
     BOOST_REQUIRE_EQUAL(
       metadata.log_start_delta, raft::offset_translator_delta{});
 }
+
+SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
+    auto batches = model::test::make_random_batches(model::offset(1), 3, false);
+
+    for (auto& b : batches) {
+        b.set_term(model::term_id(123));
+    }
+
+    auto rdr = model::make_memory_record_batch_reader(std::move(batches));
+    // share readers to have a copy of data to compare
+    auto readers = raft::details::share_n(std::move(rdr), 2).get0();
+
+    auto meta = raft::protocol_metadata{
+      .group = raft::group_id(1),
+      .commit_index = model::offset(100),
+      .term = model::term_id(10),
+      .prev_log_index = model::offset(99),
+      .prev_log_term = model::term_id(-1),
+      .last_visible_index = model::offset(200),
+    };
+    raft::append_entries_request req(
+      raft::vnode(model::node_id(1), model::revision_id(10)),
+      raft::vnode(model::node_id(10), model::revision_id(101)),
+      meta,
+      std::move(readers.back()));
+
+    readers.pop_back();
+
+    const auto src_node = req.source_node();
+    const auto target_node = req.target_node();
+
+    raft::append_entries_request_serde_wrapper wrapper(std::move(req));
+
+    iobuf buf;
+    serde::write_async(buf, std::move(wrapper)).get();
+    iobuf_parser parser(std::move(buf));
+    auto decoded_wrapper
+      = serde::read_async<raft::append_entries_request_serde_wrapper>(parser)
+          .get();
+    auto decoded_req = std::move(decoded_wrapper).release();
+
+    BOOST_REQUIRE_EQUAL(decoded_req.source_node(), src_node);
+    BOOST_REQUIRE_EQUAL(decoded_req.target_node(), target_node);
+    BOOST_REQUIRE_EQUAL(decoded_req.metadata().group, meta.group);
+    BOOST_REQUIRE_EQUAL(decoded_req.metadata().commit_index, meta.commit_index);
+    BOOST_REQUIRE_EQUAL(decoded_req.metadata().term, meta.term);
+    BOOST_REQUIRE_EQUAL(
+      decoded_req.metadata().prev_log_index, meta.prev_log_index);
+    BOOST_REQUIRE_EQUAL(
+      decoded_req.metadata().prev_log_term, meta.prev_log_term);
+    BOOST_REQUIRE_EQUAL(
+      decoded_req.metadata().last_visible_index, meta.last_visible_index);
+
+    auto batches_result = model::consume_reader_to_memory(
+                            std::move(readers.back()), model::no_timeout)
+                            .get0();
+    std::move(decoded_req)
+      .release_batches()
+      .consume(checking_consumer(std::move(batches_result)), model::no_timeout)
+      .get0();
+}

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -19,6 +19,7 @@
 #include "raft/group_configuration.h"
 #include "reflection/adl.h"
 #include "reflection/async_adl.h"
+#include "serde/serde.h"
 #include "utils/to_string.h"
 #include "vassert.h"
 #include "vlog.h"
@@ -617,36 +618,72 @@ ss::future<> append_entries_request::serde_async_write(iobuf& dst) {
         iobuf _out;
     };
 
-    iobuf out = co_await batches().consume(
+    iobuf out = co_await _batches.consume(
       streaming_writer{}, model::no_timeout);
 
-    write(out, node_id);
-    write(out, target_node_id);
-    write(out, meta);
-    write(out, flush);
+    write(out, _source_node);
+    write(out, _target_node_id);
+    write(out, _meta);
+    write(out, _flush);
 
     write(dst, std::move(out));
 }
 
-ss::future<> append_entries_request::serde_async_read(
-  iobuf_parser& src, const serde::header hdr) {
+ss::future<append_entries_request>
+append_entries_request::serde_async_direct_read(
+  iobuf_parser& src, size_t bytes_left_limit) {
+    using serde::read_async_nested;
     using serde::read_nested;
-    auto tmp = read_nested<iobuf>(src, hdr._bytes_left_limit);
+
+    auto tmp = co_await read_async_nested<iobuf>(src, bytes_left_limit);
     iobuf_parser in(std::move(tmp));
 
     auto batch_count = read_nested<uint32_t>(in, 0U);
-    auto batches = fragmented_vector<model::record_batch>{};
+    // use chunked fifo as usually batches size is small
+    fragmented_vector<model::record_batch> batches{};
+
     for (uint32_t i = 0; i < batch_count; ++i) {
-        batches.push_back(reflection::adl<model::record_batch>{}.from(in));
+        auto b = co_await reflection::async_adl<model::record_batch>{}.from(in);
+        batches.push_back(std::move(b));
         co_await ss::coroutine::maybe_yield();
     }
 
-    _batches = model::make_foreign_fragmented_memory_record_batch_reader(
-      std::move(batches));
-    node_id = read_nested<raft::vnode>(in, 0U);
-    target_node_id = read_nested<raft::vnode>(in, 0U);
-    meta = read_nested<raft::protocol_metadata>(in, 0U);
-    flush = read_nested<raft::flush_after_append>(in, 0U);
+    auto node_id = read_nested<raft::vnode>(in, 0U);
+    auto target_node_id = read_nested<raft::vnode>(in, 0U);
+    auto meta = read_nested<raft::protocol_metadata>(in, 0U);
+    auto flush = read_nested<raft::flush_after_append>(in, 0U);
+
+    co_return append_entries_request(
+      node_id,
+      target_node_id,
+      meta,
+      model::make_foreign_fragmented_memory_record_batch_reader(
+        std::move(batches)),
+      flush);
+}
+
+append_entries_request
+append_entries_request::make_foreign(append_entries_request&& req) {
+    auto src_node = req._source_node;
+    auto target_node = req._target_node_id;
+    auto metadata = req._meta;
+    auto flush = req._flush;
+    return {
+      src_node,
+      target_node,
+      metadata,
+      model::make_foreign_record_batch_reader(std::move(req).release_batches()),
+      flush};
+}
+std::ostream& operator<<(std::ostream& o, const append_entries_request& r) {
+    fmt::print(
+      o,
+      "node_id {} target_node_id {} meta {} batches {}",
+      r._node_id,
+      r._target_node_id,
+      r._meta,
+      r._batches);
+    return o;
 }
 
 } // namespace raft

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -646,8 +646,7 @@ ss::future<> append_entries_request::serde_async_read(
     node_id = read_nested<raft::vnode>(in, 0U);
     target_node_id = read_nested<raft::vnode>(in, 0U);
     meta = read_nested<raft::protocol_metadata>(in, 0U);
-    flush = read_nested<raft::append_entries_request::flush_after_append>(
-      in, 0U);
+    flush = read_nested<raft::flush_after_append>(in, 0U);
 }
 
 } // namespace raft

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -194,6 +194,7 @@ struct follower_metrics {
     bool is_live;
     bool under_replicated;
 };
+using flush_after_append = ss::bool_class<struct flush_after_append_tag>;
 
 struct append_entries_request
   : serde::envelope<
@@ -201,7 +202,6 @@ struct append_entries_request
       serde::version<0>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
-    using flush_after_append = ss::bool_class<struct flush_after_append_tag>;
 
     /*
      * default initialize with no record batch reader. default construction

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -243,6 +243,33 @@ inline security::acl_operation random_acl_operation() {
        security::acl_operation::describe});
 }
 
+inline model::record_batch_type random_batch_type() {
+    return random_generators::random_choice(
+      std::vector<model::record_batch_type>{
+        model::record_batch_type::raft_data,
+        model::record_batch_type::raft_configuration,
+        model::record_batch_type::controller,
+        model::record_batch_type::kvstore,
+        model::record_batch_type::checkpoint,
+        model::record_batch_type::topic_management_cmd,
+        model::record_batch_type::ghost_batch,
+        model::record_batch_type::id_allocator,
+        model::record_batch_type::tx_prepare,
+        model::record_batch_type::tx_fence,
+        model::record_batch_type::tm_update,
+        model::record_batch_type::user_management_cmd,
+        model::record_batch_type::acl_management_cmd,
+        model::record_batch_type::group_prepare_tx,
+        model::record_batch_type::group_commit_tx,
+        model::record_batch_type::group_abort_tx,
+        model::record_batch_type::node_management_cmd,
+        model::record_batch_type::data_policy_management_cmd,
+        model::record_batch_type::archival_metadata,
+        model::record_batch_type::cluster_config_cmd,
+        model::record_batch_type::feature_update,
+      });
+}
+
 inline security::acl_permission random_acl_permission() {
     return random_generators::random_choice<security::acl_permission>(
       {security::acl_permission::allow, security::acl_permission::deny});


### PR DESCRIPTION
Introduced new append entries request type and endpoint. The new type
leverages `serde` based serialization of `model::record_batch` in
request `record_batch_reader`. The new serialization does not
materialize batch records but uses an opaque `iobuf` to serialize batch
payload.

Fixes: #10743

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
-  fixed large allocations when replicating batches with large number of records