### PR TITLE
add slash command for triggering release+publish workflow

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -4,6 +4,7 @@ on:
       - ci-repeat-command
       - test-codecov-command
       - cdt-command
+      - test-release-pipeline-command
 
 jobs:
   run-build:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -17,6 +17,7 @@ jobs:
             ci-repeat
             test-codecov
             cdt
+            test-release-pipeline
           static-args: |
             org=redpanda-data
             repo=redpanda


### PR DESCRIPTION
Triggering nightly releases from PRs through slash command.

## Depends on

https://github.com/redpanda-data/vtools/pull/1760

### Ref
redpanda-data/vtools#1753


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
