### PR TITLE
[v23.1.x] cloud_storage: escape hatch to reset metadata partition manifest

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -463,6 +463,10 @@ bool partition_manifest::contains(const segment_name& name) const {
 
 void partition_manifest::delete_replaced_segments() { _replaced.clear(); }
 
+void partition_manifest::unsafe_reset() {
+    *this = partition_manifest{_ntp, _rev};
+}
+
 bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
     if (new_start_offset > _start_offset && !_segments.empty()) {
         auto it = _segments.upper_bound(new_start_offset);

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -259,8 +259,11 @@ public:
     /// Find element of the manifest by offset
     const_iterator find(model::offset o) const;
 
-    /// Get insert iterator for segments set
+    /// Get inesrt iterator for segments set
     std::insert_iterator<segment_map> get_insert_iterator();
+
+    /// Update manifest file from iobuf
+    ss::future<> update(iobuf buf);
 
     /// Update manifest file from input_stream (remote set)
     ss::future<> update(ss::input_stream<char> is) override;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -253,6 +253,17 @@ public:
     /// \returns true if start offset was moved
     bool advance_start_offset(model::offset start_offset);
 
+    /// \brief Resets the state of the manifest to the default constructed
+    /// state.
+    ///
+    /// Should only be used as a part of an escape hatch, not during the
+    /// regular operation of a partition.
+    ///
+    /// There may not be anything necessarily unsafe about this, but marking
+    /// "unsafe" to deter further authors from using with giving this a lot of
+    /// thought.
+    void unsafe_reset();
+
     /// Get segment if available or nullopt
     const segment_meta* get(const key& key) const;
     const segment_meta* get(const segment_name& name) const;

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -1778,6 +1778,20 @@ SEASTAR_THREAD_TEST_CASE(test_timequery_out_of_order) {
       == std::nullopt);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_reset_manifest) {
+    partition_manifest m;
+    m.update(make_manifest_stream(complete_manifest_json)).get();
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(
+      path, "60000000/meta/test-ns/test-topic/42_1/manifest.json");
+    BOOST_REQUIRE_EQUAL(m.size(), 4);
+
+    partition_manifest expected{m.get_ntp(), m.get_revision_id()};
+
+    m.unsafe_reset();
+    BOOST_REQUIRE(m == expected);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_generate_segment_name_format) {
     static constexpr std::string_view raw = R"json({
         "version": 1,

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -50,6 +50,8 @@ public:
     command_batch_builder& operator=(const command_batch_builder&) = delete;
     command_batch_builder& operator=(command_batch_builder&&) = default;
     ~command_batch_builder() = default;
+    /// Reset the manifest.
+    command_batch_builder& reset_metadata();
     /// Add segments to the batch
     command_batch_builder&
       add_segments(std::vector<cloud_storage::segment_meta>);
@@ -192,6 +194,7 @@ private:
     struct truncate_cmd;
     struct update_start_offset_cmd;
     struct cleanup_metadata_cmd;
+    struct reset_metadata_cmd;
     struct snapshot;
 
     friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
@@ -206,6 +209,7 @@ private:
     void apply_truncate(const start_offset& so);
     void apply_cleanup_metadata();
     void apply_update_start_offset(const start_offset& so);
+    void apply_reset_metadata();
 
 private:
     prefix_logger _logger;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -814,6 +814,103 @@ partition::transfer_leadership(transfer_leadership_request req) {
     co_return co_await _raft->do_transfer_leadership(req);
 }
 
+ss::future<> partition::unsafe_reset_remote_partition_manifest(iobuf buf) {
+    vlog(clusterlog.info, "[{}] Unsafe manifest reset requested", ntp());
+
+    if (!(config::shard_local_cfg().cloud_storage_enabled()
+          && _archival_meta_stm)) {
+        vlog(
+          clusterlog.warn,
+          "[{}] Archival STM not present. Skipping unsafe reset ...",
+          ntp());
+        throw std::runtime_error("Archival STM not present");
+    }
+
+    if (_archiver != nullptr) {
+        vlog(
+          clusterlog.warn,
+          "[{}] Remote write path in use. Skipping unsafe reset ...",
+          ntp());
+        throw std::runtime_error("Remote write path in use");
+    }
+
+    // Deserialise provided manifest
+    cloud_storage::partition_manifest req_m{
+      _raft->ntp(), _raft->log_config().get_initial_revision()};
+    co_await req_m.update(std::move(buf));
+
+    // A generous timeout of 60 seconds is used as it applies
+    // for the replication multiple batches.
+    auto deadline = ss::lowres_clock::now() + 60s;
+    std::vector<cluster::command_batch_builder> builders;
+
+    auto reset_builder = _archival_meta_stm->batch_start(deadline, _as);
+
+    // Add command to drop manifest. When applied, the current manifest
+    // will be replaced with a default constructed one.
+    reset_builder.reset_metadata();
+    builders.push_back(std::move(reset_builder));
+
+    // Add segments. Note that we only add, and omit the replaced segments.
+    // This should only be done in the context of a last-ditch effort to
+    // restore functionality to a partition. Replaced segments are likely
+    // unimportant.
+    constexpr size_t segments_per_batch = 256;
+    std::vector<cloud_storage::segment_meta> segments;
+    segments.reserve(segments_per_batch);
+
+    for (const auto& [_, s] : req_m) {
+        segments.emplace_back(s);
+        if (segments.size() == segments_per_batch) {
+            auto segments_builder = _archival_meta_stm->batch_start(
+              deadline, _as);
+            segments_builder.add_segments(std::move(segments));
+            builders.push_back(std::move(segments_builder));
+
+            segments.clear();
+        }
+    }
+
+    if (segments.size() > 0) {
+        auto segments_builder = _archival_meta_stm->batch_start(deadline, _as);
+        segments_builder.add_segments(std::move(segments));
+        builders.push_back(std::move(segments_builder));
+    }
+
+    size_t idx = 0;
+    for (auto& builder : builders) {
+        vlog(
+          clusterlog.info,
+          "Unsafe reset replicating batch {}/{}",
+          idx + 1,
+          builders.size());
+
+        auto errc = co_await builder.replicate();
+        if (errc) {
+            if (errc == raft::errc::shutting_down) {
+                // During shutdown, act like we hit an abort source rather
+                // than trying to log+handle this like a write error.
+                throw ss::abort_requested_exception();
+            }
+
+            vlog(
+              clusterlog.warn,
+              "[{}] Unsafe reset failed to update archival STM: {}",
+              ntp(),
+              errc.message());
+            throw std::runtime_error(
+              fmt::format("Failed to update archival STM: {}", errc.message()));
+        }
+
+        ++idx;
+    }
+
+    vlog(
+      clusterlog.info,
+      "[{}] Unsafe reset replicated STM commands successfully",
+      ntp());
+}
+
 std::ostream& operator<<(std::ostream& o, const partition& x) {
     return o << x._raft;
 }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -311,6 +311,8 @@ public:
         }
     }
 
+    ss::future<> unsafe_reset_remote_partition_manifest(iobuf buf);
+
 private:
     ss::future<std::optional<storage::timequery_result>>
       cloud_storage_timequery(storage::timequery_config);

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -245,6 +245,42 @@
                     ]
                 }
             ]
+        },
+        {
+          "path": "/v1/debug/unsafe_reset_metadata/{topic}/{partition}",
+          "operations": [
+            {
+              "method": "POST",
+              "summary": "Resets the manifest, updating all replicas with the given manifest. This is very unsafe, so be sure the provided manifest actually has valid contents. Formatting aside, very little validation will be done on the requested manifest.",
+              "operationId": "unsafe_reset_metadata",
+              "nickname": "unsafe_reset_metadata",
+              "parameters": [
+                {
+                  "name": "topic",
+                  "in": "path",
+                  "required": true,
+                  "type": "string"
+                },
+                {
+                  "name": "partition",
+                  "in": "path",
+                  "required": true,
+                  "type": "integer"
+                },
+                {
+                  "name": "body",
+                  "required": true,
+                  "paramType": "body"
+                }
+              ],
+              "responseMessages": [
+                {
+                  "code": 200,
+                  "message": "Partition metadata is reset"
+                }
+              ]
+            }
+          ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3867,6 +3867,15 @@ void admin_server::register_debug_routes() {
         -> ss::future<ss::json::json_return_type> {
           return get_partition_state_handler(std::move(req));
       });
+
+    request_handler_fn unsafe_reset_metadata_handler = [this](
+                                                         auto req, auto reply) {
+        return unsafe_reset_metadata(std::move(req), std::move(reply));
+    };
+
+    register_route<superuser>(
+      ss::httpd::debug_json::unsafe_reset_metadata,
+      std::move(unsafe_reset_metadata_handler));
 }
 
 ss::future<ss::json::json_return_type>
@@ -4097,6 +4106,56 @@ ss::future<ss::json::json_return_type> admin_server::sync_local_state_handler(
         }
     }
     co_return ss::json::json_return_type(ss::json::json_void());
+}
+
+ss::future<std::unique_ptr<ss::reply>> admin_server::unsafe_reset_metadata(
+  std::unique_ptr<ss::request> request, std::unique_ptr<ss::reply> reply) {
+    reply->set_content_type("json");
+
+    auto ntp = parse_ntp_from_request(request->param, model::kafka_namespace);
+    if (need_redirect_to_leader(ntp, _metadata_cache)) {
+        vlog(logger.info, "Need to redirect unsafe reset metadata request");
+        throw co_await redirect_to_leader(*request, ntp);
+    }
+    if (request->content_length <= 0) {
+        throw ss::httpd::bad_request_exception("Empty request content");
+    }
+
+    ss::sstring content = request->content;
+
+    iobuf buf;
+    buf.append(request->content.data(), request->content.size());
+
+    content = {};
+
+    const auto shard = _shard_table.local().shard_for(ntp);
+    if (!shard) {
+        throw ss::httpd::not_found_exception(fmt::format(
+          "{} could not be found on the node. Perhaps it has been moved "
+          "during the redirect.",
+          ntp));
+    }
+
+    try {
+        co_await _partition_manager.invoke_on(
+          *shard,
+          [ntp = std::move(ntp), buf = std::move(buf), shard](
+            auto& pm) mutable {
+              auto partition = pm.get(ntp);
+              if (!partition) {
+                  throw ss::httpd::not_found_exception(
+                    fmt::format("Could not find {} on shard {}", ntp, *shard));
+              }
+
+              return partition->unsafe_reset_remote_partition_manifest(
+                std::move(buf));
+          });
+    } catch (const std::runtime_error& err) {
+        throw ss::httpd::server_error_exception(err.what());
+    }
+
+    reply->set_status(ss::httpd::reply::status_type::ok);
+    co_return reply;
 }
 
 ss::future<std::unique_ptr<ss::reply>>

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2441,8 +2441,8 @@ void admin_server::register_broker_routes() {
 
 // Helpers for partition routes
 namespace {
-model::ntp parse_ntp_from_request(ss::httpd::parameters& param) {
-    auto ns = model::ns(param["namespace"]);
+
+model::ntp parse_ntp_from_request(ss::httpd::parameters& param, model::ns ns) {
     auto topic = model::topic(param["topic"]);
 
     model::partition_id partition;
@@ -2458,7 +2458,11 @@ model::ntp parse_ntp_from_request(ss::httpd::parameters& param) {
           fmt::format("Invalid partition id {}", partition));
     }
 
-    return model::ntp(std::move(ns), std::move(topic), partition);
+    return {std::move(ns), std::move(topic), partition};
+}
+
+model::ntp parse_ntp_from_request(ss::httpd::parameters& param) {
+    return parse_ntp_from_request(param, model::ns(param["namespace"]));
 }
 
 } // namespace

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4121,12 +4121,7 @@ ss::future<std::unique_ptr<ss::reply>> admin_server::unsafe_reset_metadata(
         throw ss::httpd::bad_request_exception("Empty request content");
     }
 
-    ss::sstring content = request->content;
-
-    iobuf buf;
-    buf.append(request->content.data(), request->content.size());
-
-    content = {};
+    ss::sstring content = std::move(request->content);
 
     const auto shard = _shard_table.local().shard_for(ntp);
     if (!shard) {
@@ -4139,13 +4134,17 @@ ss::future<std::unique_ptr<ss::reply>> admin_server::unsafe_reset_metadata(
     try {
         co_await _partition_manager.invoke_on(
           *shard,
-          [ntp = std::move(ntp), buf = std::move(buf), shard](
+          [ntp = std::move(ntp), content = std::move(content), shard](
             auto& pm) mutable {
               auto partition = pm.get(ntp);
               if (!partition) {
                   throw ss::httpd::not_found_exception(
                     fmt::format("Could not find {} on shard {}", ntp, *shard));
               }
+
+              iobuf buf;
+              buf.append(content.data(), content.size());
+              content = {};
 
               return partition->unsafe_reset_remote_partition_manifest(
                 std::move(buf));

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -374,6 +374,8 @@ private:
       sync_local_state_handler(std::unique_ptr<ss::httpd::request>);
     ss::future<std::unique_ptr<ss::reply>> initiate_topic_scan_and_recovery(
       std::unique_ptr<ss::request>, std::unique_ptr<ss::reply>);
+    ss::future<std::unique_ptr<ss::reply>> unsafe_reset_metadata(
+      std::unique_ptr<ss::request>, std::unique_ptr<ss::reply>);
     ss::future<ss::json::json_return_type>
     query_automated_recovery(std::unique_ptr<ss::httpd::request> req);
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -442,6 +442,12 @@ class Admin:
                 return False
         return True
 
+    def unsafe_reset_cloud_metadata(self, topic, partition, manifest):
+        return self._request(
+            'POST',
+            f"debug/unsafe_reset_metadata/{topic}/{partition}",
+            json=manifest)
+
     def put_feature(self, feature_name, body):
         return self._request("PUT", f"features/{feature_name}", json=body)
 


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/10806
Also brings in [3d08cc3](https://github.com/redpanda-data/redpanda/commit/3d08cc3544d03ee224528cce9840762b0e6e1173)

Fixes https://github.com/redpanda-data/redpanda/issues/10813

Conflicts:
* Pulled in a partial backport of a commit for utility methods
* Upload policy seems like it's different in this version than dev, so updated the test to sleep instead of wait for uploads to complete

Based on https://github.com/redpanda-data/redpanda/pull/10787

The goal of this PR is to add an escape hatch that can reset the in-memory contents of the archival manifest across all replicas, given an input JSON. When manifests are incorrect (e.g. from older buggy versions), we need a way to reset in-memory state without bringing down all replicas.

This is implemented as an archival metadata stm batch type that resets the manifest to the default-constructed manifest. This is used with batched add_segment commands to reset to include all segments included in an input JSON.

There's a few important caveats, which make this tool an absolute last resort to be used with guidance from the
storage team:
1. Remote write needs to be disabled on the topic; the request will be refused otherwise
2. This request should only be used Redpanda <= v23.1 as it does not set some fields in the manifest

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none