### PR TITLE
rptest: cloud timing test epilogue tweaks

### DIFF
--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -63,7 +63,7 @@ upload_housekeeping_service::upload_housekeeping_service(
   , _rtc(_as)
   , _ctxlog(archival_log, _rtc)
   , _filter(_rtc)
-  , _workflow(_rtc, sg)
+  , _workflow(_rtc, sg, _probe)
   , _api_utilization(
       std::make_unique<sliding_window_t>(0.0, _idle_timeout(), ma_resolution)) {
     _idle_timer.set_callback([this] { return idle_timer_callback(); });


### PR DESCRIPTION
This commit fixes the metric queries at the end of the cloud storage
timing tests and asserts on them. A new variant of the test was
introduced in order to stress the local segment merging code.
Previously, the segment merger was idling as the topic always had
compaction enabled.

Fixes #10727

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none