### PR TITLE
cloud_storage: improved debug on partition manifest parse error

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1375,7 +1375,15 @@ ss::future<> partition_manifest::update(iobuf buf) {
     } else {
         rapidjson::ParseErrorCode e = reader.GetParseErrorCode();
         size_t o = reader.GetErrorOffset();
-        vlog(cst_log.debug, "Failed to parse manifest: {}", buf.hexdump(2048));
+
+        // Hexdump 1kb region around the bad manifest
+        buf.trim_front(o - std::min(size_t{512}, o));
+        vlog(
+          cst_log.warn,
+          "Failed to parse manifest at 0x{:08x}: {}",
+          o,
+          buf.hexdump(1024));
+
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "Failed to parse partition manifest {}: {} at offset {}",


### PR DESCRIPTION
- Log at WARN, so that we actually get the message on prod systems
- hexdump the region around the parse error, rather than the first bytes in the manifest.

This is more important than it used to be, now that we have admin API for loading in arbitrary manifests, which can fail.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none