### PR TITLE
cloud_storage: apply fetch request timeouts to hydration

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -271,6 +271,11 @@ public:
                     co_await set_end_of_stream();
                     co_return storage_t{};
                 }
+
+                if (model::timeout_clock::now() > deadline) {
+                    throw ss::timed_out_error();
+                }
+
                 auto reader_delta = _reader->current_delta();
                 if (
                   !_ot_state->empty()

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -121,14 +121,15 @@ public:
       kafka::offset start,
       kafka::offset end,
       std::optional<model::timestamp>,
-      ss::io_priority_class);
+      ss::io_priority_class,
+      model::timeout_clock::time_point);
 
     /// Hydrate the segment for segment meta version v2 or lower. For v3 or
     /// higher, only hydrate the index. If the index hydration fails, fall back
     /// to old mode where the full segment is hydrated. For v3 or higher
     /// versions, the actual segment data is hydrated by the data source
     /// implementation, but the index is still required to be present first.
-    ss::future<> hydrate();
+    ss::future<> hydrate(std::optional<model::timeout_clock::time_point> deadline);
 
     /// Hydrate a part of a segment, identified by the given start and end
     /// offsets. If the end offset is std::nullopt, the last offset in the file
@@ -376,7 +377,8 @@ public:
 
 private:
     friend class single_record_consumer;
-    ss::future<std::unique_ptr<storage::continuous_batch_parser>> init_parser();
+    ss::future<std::unique_ptr<storage::continuous_batch_parser>>
+      init_parser(model::timeout_clock::time_point);
 
     size_t produce(model::record_batch batch);
 


### PR DESCRIPTION
Followup to https://github.com/redpanda-data/redpanda/pull/10839 -- that one is for backport, this one is not.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none