### PR TITLE
Create issue on error (gh action) improvement

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -189,6 +189,9 @@ jobs:
           ORIG_LABELS: ${{ toJson(github.event.client_payload.github.payload.issue.labels) }}
           ORIG_ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
           CREATE_ISSUE_ON_ERROR: "true"
+          ORIG_REVIEWERS: ${{ steps.reviewers.outputs.reviewers }}
+          HEAD_BRANCH: ${{ steps.pr_details.outputs.head_branch }}
+          GIT_USER: ${{ steps.user.outputs.username }}
         id: create_issue_on_backport_error
         run: $SCRIPT_DIR/create_issue.sh
         shell: bash

--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -19,6 +19,20 @@ orig_assignees=$ORIG_ASSIGNEES
 
 if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
   additional_body="Note that this issue was created as a placeholder, since the original PR's commit(s) could not be automatically cherry-picked."
+
+  additional_body="$additional_body
+  Command I attempted to execute:
+  gh pr create
+    --title \"[$BACKPORT_BRANCH] $ORIG_TITLE\"
+    --base \"$BACKPORT_BRANCH\"
+    --label \"kind/backport\"
+    --head \"$GIT_USER:$HEAD_BRANCH\"
+    --draft
+    --repo \"$TARGET_ORG/$TARGET_REPO\"
+    --reviewer \"$ORIG_REVIEWERS\"
+    --milestone \"$TARGET_MILESTONE\"
+    --body \"Backport of PR $ORIG_ISSUE_URL $backport_issue_urls\""
+
   orig_assignees=$(gh issue view $PR_NUMBER --json author --jq .author.login)
 fi
 


### PR DESCRIPTION
Added the gh pr create command attempted to the body of a tracking issue if backportbot fails to create a PR right away.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
