### PR TITLE
tests: skip test_basic_compaction in debug mode

### DIFF
--- a/tests/rptest/tests/compaction_e2e_test.py
+++ b/tests/rptest/tests/compaction_e2e_test.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import sys
 from ducktape.mark import matrix, ok_to_fail
 from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool
@@ -16,6 +15,7 @@ from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.default import DefaultClient
 from rptest.services.cluster import cluster
+from rptest.utils.mode_checks import skip_debug_mode
 
 from rptest.services.compacted_verifier import CompactedVerifier, Workload
 
@@ -24,7 +24,7 @@ class CompactionE2EIdempotencyTest(RedpandaTest):
     def __init__(self, test_context):
         extra_rp_conf = {}
 
-        self.segment_size = 5 * 1024 * 1024 if not self.debug_mode else 1024 * 1024
+        self.segment_size = 5 * 1024 * 1024
         self.partition_count = 3
 
         super(CompactionE2EIdempotencyTest,
@@ -39,6 +39,7 @@ class CompactionE2EIdempotencyTest(RedpandaTest):
             partitions.append([len(p.segments) for p in topic_partitions])
         return partitions
 
+    @skip_debug_mode
     @cluster(num_nodes=4)
     @matrix(
         initial_cleanup_policy=[


### PR DESCRIPTION
Even the modest expectation of writing 15MB of data in 300s is violated sometimes when running
on docker.

Fixes https://github.com/redpanda-data/redpanda/issues/10500

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
