### PR TITLE
tests: extend log allow list for CloudStorageTimingStressTest

### DIFF
--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -439,7 +439,16 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
 
             self.logger.info(f"All checks completed successfuly")
 
-    @cluster(num_nodes=5)
+    @cluster(
+        num_nodes=5,
+        log_allow_list=[
+            # Reader might hit the tail of the log that is being reaped
+            # https://github.com/redpanda-data/redpanda/issues/10851
+            r"Error in hydraton loop: .*Connection reset by peer",
+            r"failed to hydrate chunk.*Connection reset by peer",
+            r"failed to hydrate chunk.*NotFound",
+            r"failed to hydrate chunk.*abort_requested"
+        ])
     @skip_debug_mode
     def test_cloud_storage(self):
         """
@@ -454,12 +463,15 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
 
         self.epilogue()
 
-    @cluster(num_nodes=5,
-             log_allow_list=[
-                 r"Error in hydraton loop: .*Connection reset by peer",
-                 r"failed to hydrate chunk.*Connection reset by peer",
-                 r"failed to hydrate chunk.*NotFound"
-             ])
+    @cluster(
+        num_nodes=5,
+        log_allow_list=[
+            # https://github.com/redpanda-data/redpanda/issues/10851
+            r"Error in hydraton loop: .*Connection reset by peer",
+            r"failed to hydrate chunk.*Connection reset by peer",
+            r"failed to hydrate chunk.*NotFound",
+            r"failed to hydrate chunk.*abort_requested"
+        ])
     @skip_debug_mode
     def test_cloud_storage_with_partition_moves(self):
         """


### PR DESCRIPTION
Chunk-wise hydration is chattier with errors than legacy segment-wise hydration.

We should remove these allow lists once the read path is smart enough to distinguish expected from unexpected 404s by checking the manifest after a 404.

Related: https://github.com/redpanda-data/redpanda/issues/10851

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none