### PR TITLE
cluster: include ntp in timequery logs

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -601,9 +601,9 @@ partition::local_timequery(storage::timequery_config cfg) {
             // Query raced with prefix truncation
             vlog(
               clusterlog.debug,
-              "timequery (raft) ts={} raced with truncation (start_timestamp "
-              "{}, "
-              "result {})",
+              "timequery (raft) {} ts={} raced with truncation "
+              "(start_timestamp {}, result {})",
+              _raft->ntp(),
               cfg.time,
               _raft->log().start_timestamp(),
               result->time);
@@ -622,8 +622,9 @@ partition::local_timequery(storage::timequery_config cfg) {
             // Ref https://github.com/redpanda-data/redpanda/issues/9669
             vlog(
               clusterlog.debug,
-              "Timequery (raft) ts={} miss on local log (start_timestamp {}, "
-              "result {})",
+              "Timequery (raft) {} ts={} miss on local log (start_timestamp "
+              "{}, result {})",
+              _raft->ntp(),
               cfg.time,
               _raft->log().start_timestamp(),
               result->time);
@@ -636,8 +637,9 @@ partition::local_timequery(storage::timequery_config cfg) {
             // have the same timestamp and are present in cloud storage.
             vlog(
               clusterlog.debug,
-              "Timequery (raft) ts={} hit start_offset in local log "
+              "Timequery (raft) {} ts={} hit start_offset in local log "
               "(start_offset {} start_timestamp {}, result {})",
+              _raft->ntp(),
               _raft->log().offsets().start_offset,
               cfg.time,
               _raft->log().start_timestamp(),


### PR DESCRIPTION
These were hard to make sense of on real systems
where many ntps would be timequery'd around
the same moment.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none