### PR TITLE
[v22.3.x] Cache observability improvements

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -108,6 +108,7 @@ uint64_t cache::get_total_cleaned() { return _total_cleaned; }
 ss::future<> cache::consume_cache_space(size_t sz) {
     vassert(ss::this_shard_id() == 0, "This method can only run on shard 0");
     _current_cache_size += sz;
+    probe.set_size(_current_cache_size);
     if (_current_cache_size > _max_cache_size) {
         if (ss::lowres_clock::now() - _last_clean_up > min_clean_up_interval) {
             auto units = ss::try_get_units(_cleanup_sm, 1);
@@ -178,11 +179,14 @@ ss::future<> cache::clean_up_at_start() {
 ss::future<> cache::clean_up_cache() {
     vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
     gate_guard guard{_gate};
+
+    vlog(cst_log.info, "Scanning cache prior to trim...");
     auto [current_cache_size, candidates_for_deletion, _]
       = co_await _walker.walk(_cache_dir.native(), _access_time_tracker);
     _current_cache_size = current_cache_size;
     probe.set_size(_current_cache_size);
-    probe.set_num_files(candidates_for_deletion.size());
+    auto initial_object_count = candidates_for_deletion.size();
+    probe.set_num_files(initial_object_count);
 
     // Updating the access time tracker in case if some files were removed
     // from cache directory by the user manually.
@@ -195,6 +199,12 @@ ss::future<> cache::clean_up_cache() {
 
     uint64_t deleted_size = 0;
     if (_current_cache_size >= _max_cache_size) {
+        vlog(
+          cst_log.info,
+          "Trimming cache ({} >= {})",
+          _current_cache_size,
+          _max_cache_size);
+
         auto size_to_delete
           = _current_cache_size
             - (_max_cache_size * (long double)_cache_size_low_watermark);
@@ -270,9 +280,11 @@ ss::future<> cache::clean_up_cache() {
         }
         _total_cleaned += deleted_size;
         _current_cache_size -= deleted_size;
+        probe.set_size(_current_cache_size);
+        probe.set_num_files(initial_object_count - i_to_delete);
         vlog(
-          cst_log.debug,
-          "Cache eviction deleted {} files of total size {}.",
+          cst_log.info,
+          "Trimmed cache: deleted {} files of total size {}.",
           i_to_delete,
           deleted_size);
     }


### PR DESCRIPTION
Much has changed on `dev` -- this is a small improvement to the observability on stable branches.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none