### PR TITLE
rpk disk_irq tuner: warn on msi_irq list empty

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/tune/tune.go
+++ b/src/go/rpk/pkg/cli/redpanda/tune/tune.go
@@ -25,6 +25,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/factory"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/hwloc"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/irq"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -166,6 +167,14 @@ func tune(
 		if res.IsFailed() {
 			errMsg = res.Error().Error()
 			exit1 = true
+			// A warning is given (instead of error) when the list of MSI IRQs
+			// in sysfs is empty due to a known upstream problem introduced in
+			// kernel 5.17.
+			// See: https://github.com/redpanda-data/redpanda/issues/10838
+			if ee := (*irq.EmptyMSIRQError)(nil); errors.As(res.Error(), &ee) {
+				exit1 = false
+				supported = false
+			}
 		}
 		results = append(results, result{tunerName, !res.IsFailed(), enabled, supported, errMsg})
 	}

--- a/src/go/rpk/pkg/tuners/irq/device_info.go
+++ b/src/go/rpk/pkg/tuners/irq/device_info.go
@@ -38,6 +38,14 @@ type deviceInfo struct {
 	fs       afero.Fs
 }
 
+type EmptyMSIRQError struct {
+	device string
+}
+
+func (e EmptyMSIRQError) Error() string {
+	return fmt.Sprintf("device %q uses MSI IRQs but the list of msi_irqs in sysfs is empty; see https://github.com/redpanda-data/redpanda/issues/10838", e.device)
+}
+
 func (deviceInfo *deviceInfo) GetIRQs(
 	irqConfigDir string, xenDeviceName string,
 ) ([]int, error) {
@@ -53,6 +61,9 @@ func (deviceInfo *deviceInfo) GetIRQs(
 				return nil, err
 			}
 			irqs = append(irqs, irq)
+		}
+		if len(irqs) == 0 {
+			return nil, &EmptyMSIRQError{irqConfigDir}
 		}
 	} else {
 		irqFileName := path.Join(irqConfigDir, "irq")

--- a/src/go/rpk/pkg/tuners/irq/device_info_test.go
+++ b/src/go/rpk/pkg/tuners/irq/device_info_test.go
@@ -38,6 +38,7 @@ func Test_DeviceInfo_GetIRQs(t *testing.T) {
 		irqConfigDir  string
 		xenDeviceName string
 		want          []int
+		wantErr       bool
 	}{
 		{
 			name: "Shall return the IRQs when device is using MSI IRQs",
@@ -49,6 +50,14 @@ func Test_DeviceInfo_GetIRQs(t *testing.T) {
 			},
 			irqConfigDir: "/irq_config/dev1",
 			want:         []int{1, 2, 5, 8},
+		},
+		{
+			name: "Err when is using MSI IRQs but the list is empty",
+			before: func(fs afero.Fs) {
+				_ = afero.WriteFile(fs, "/irq_config/dev1/msi_irqs/", []byte{}, os.ModePerm)
+			},
+			irqConfigDir: "/irq_config/dev1",
+			wantErr:      true,
 		},
 		{
 			name: "Shall return the IRQs when device is using INT#x IRQs",
@@ -112,6 +121,10 @@ func Test_DeviceInfo_GetIRQs(t *testing.T) {
 			tt.before(fs)
 			deviceInfo := NewDeviceInfo(fs, tt.procFile)
 			got, err := deviceInfo.GetIRQs(tt.irqConfigDir, tt.xenDeviceName)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			require.Exactly(t, tt.want, got)
 		})


### PR DESCRIPTION
Due to a known error introduced in kernel 5.17
some instances that use MSI IRQ can have the list
of IRQs empty in sysfs which makes the tuner fail
and make hwloc seg fault (impossible to tune).

This change only prints a warning instead of an
error and links to the issue where explains
what is the problem and the upstream reports.

Fixes #10838

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes
* rpk disk_irq tuner now provides a warning for a known issue introduced in kernel 5.17 where instances utilizing MSI IRQ may encounter an empty IRQs list in sysfs that caused hwloc segmentation faults and results in a tuner failure. 
