### PR TITLE
Removed lock contention when writing Raft snapshots

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1317,7 +1317,10 @@ ss::future<> consensus::do_start() {
                 return _offset_translator.start(
                   must_reset, std::move(bootstrap));
             })
-            .then([this] { return hydrate_snapshot(); })
+            .then([this] {
+                return _snapshot_lock.with(
+                  [this] { return hydrate_snapshot(); });
+            })
             .then([this] {
                 vlog(
                   _ctxlog.debug,
@@ -1988,7 +1991,9 @@ consensus::install_snapshot(install_snapshot_request&& r) {
     return with_gate(_bg, [this, r = std::move(r)]() mutable {
         return _op_lock
           .with([this, r = std::move(r)]() mutable {
-              return do_install_snapshot(std::move(r));
+              return _snapshot_lock.with([this, r = std::move(r)]() mutable {
+                  return do_install_snapshot(std::move(r));
+              });
           })
           .handle_exception_type([this](const ss::broken_semaphore&) {
               return install_snapshot_reply{.term = _term, .success = false};
@@ -2214,7 +2219,7 @@ ss::future<install_snapshot_reply> consensus::finish_snapshot(
 
 ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
     model::offset last_included_index = cfg.last_included_index;
-    bool updated = co_await _op_lock
+    bool updated = co_await _snapshot_lock
                      .with([this, cfg = std::move(cfg)]() mutable {
                          // do nothing, we already have snapshot for this offset
                          // MUST be checked under the _op_lock

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2258,16 +2258,18 @@ ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
     co_await _log.truncate_prefix(storage::truncate_prefix_config(
       model::next_offset(last_included_index), _scheduling.default_iopc));
 
-    co_await _op_lock.with([this, last_included_index] {
-        return _configuration_manager.prefix_truncate(last_included_index)
-          .then([this, last_included_index] {
-              return _offset_translator.prefix_truncate(last_included_index);
-          })
-          .then([this, last_included_index] {
-              // when log was prefix truncate flushed offset should be
-              // equal to at least last snapshot index
-              _flushed_offset = std::max(last_included_index, _flushed_offset);
-          });
+    /*
+     * We do not need to keep an oplock when updating the flushed offset here as
+     * it is only moved forward so there is no risk of moving the flushed offset
+     * back, also there is no risk incorrectly marking dirty batches flushed as
+     * the offset will be at most equal to log start offset
+     */
+    _flushed_offset = std::max(last_included_index, _flushed_offset);
+
+    co_await _snapshot_lock.with([this, last_included_index]() mutable {
+        return ss::when_all_succeed(
+          _configuration_manager.prefix_truncate(last_included_index),
+          _offset_translator.prefix_truncate(last_included_index));
     });
 }
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -728,6 +728,12 @@ private:
     /// all raft operations must happen exclusively since the common case
     /// is for the operation to touch the disk
     mutex _op_lock;
+    /// since snapshot state is orthogonal to raft state when writing snapshot
+    /// it is enough to grab the snapshot mutex, there is no need to keep
+    /// oplock, if the two locks are expected to be acquired at the same time
+    /// the snapshot lock should always be an internal (taken after the
+    /// _op_lock)
+    mutex _snapshot_lock;
     /// used for notifying when commits happened to log
     event_manager _event_manager;
     probe _probe;


### PR DESCRIPTION
### Separate snapshot protecting mutex

When writing a snapshot Raft uses the state that is a part of already
committed log, offset translator and configuration manager. The snapshot
does not relay on the protocol state that mutates. This observation
allows to write snapshot outside of Raft operation mutex as that
operation is not changing any of the current state and does not relay on
the current state. Using separate mutex to protect the snapshot reduces
contention and does not influence the write path latency.

### Do not hold `_op_lock` when truncating config manager and offset translator

When prefix truncating configuration manager and offset translator the
main raft operation mutex doesn't have to be held. Prefix truncation
only mutates the state that is no longer changed by any other operation
than persisting a snapshot. It is enough to make the operation mutually
exclusive with other snapshot related operations.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Fixed increased produce latency related with deleting segments