### PR TITLE
Backport-on-merge (continued)

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -189,6 +189,8 @@ jobs:
           ORIG_LABELS: ${{ toJson(github.event.client_payload.github.payload.issue.labels) }}
           ORIG_ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
           CREATE_ISSUE_ON_ERROR: "true"
+          HEAD_BRANCH: ${{ steps.pr_details.outputs.head_branch }}
+          GIT_USER: ${{ steps.user.outputs.username }}
         id: create_issue_on_backport_error
         run: $SCRIPT_DIR/create_issue.sh
         shell: bash

--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -28,14 +28,14 @@ if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
   git cherry-pick -x $BACKPORT_COMMITS
 
   gh pr create
-    --title \"[$BACKPORT_BRANCH] $ORIG_TITLE\"
-    --base \"$BACKPORT_BRANCH\"
-    --label \"kind/backport\"
-    --head \"$GIT_USER:$HEAD_BRANCH\"
-    --draft
-    --repo \"$TARGET_ORG/$TARGET_REPO\"
-    --reviewer \"$ORIG_REVIEWERS\"
-    --milestone \"$TARGET_MILESTONE\"
+    --title \"[$BACKPORT_BRANCH] $ORIG_TITLE\" \\
+    --base \"$BACKPORT_BRANCH\" \\
+    --label \"kind/backport\" \\
+    --head \"$GIT_USER:$HEAD_BRANCH\" \\
+    --draft \\
+    --repo \"$TARGET_ORG/$TARGET_REPO\" \\
+    --reviewer \"$ORIG_REVIEWERS\" \\
+    --milestone \"$TARGET_MILESTONE\" \\
     --body \"Backport of PR $ORIG_ISSUE_URL \""
 
   orig_assignees=$(gh issue view $PR_NUMBER --json author --jq .author.login)

--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -19,6 +19,25 @@ orig_assignees=$ORIG_ASSIGNEES
 
 if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
   additional_body="Note that this issue was created as a placeholder, since the original PR's commit(s) could not be automatically cherry-picked."
+
+  additional_body="$additional_body
+  Here are the commands to execute:
+  \`\`\`
+  git checkout $BACKPORT_BRANCH
+  git checkout -b $GIT_USER/backport-$PR_NUMBER-$BACKPORT_BRANCH-$((RANDOM % 1000))
+  git cherry-pick -x $BACKPORT_COMMITS
+
+  gh pr create
+    --title \"[$BACKPORT_BRANCH] $ORIG_TITLE\"
+    --base \"$BACKPORT_BRANCH\"
+    --label \"kind/backport\"
+    --head \"$GIT_USER:$HEAD_BRANCH\"
+    --draft
+    --repo \"$TARGET_ORG/$TARGET_REPO\"
+    --reviewer \"$ORIG_REVIEWERS\"
+    --milestone \"$TARGET_MILESTONE\"
+    --body \"Backport of PR $ORIG_ISSUE_URL \""
+
   orig_assignees=$(gh issue view $PR_NUMBER --json author --jq .author.login)
 fi
 

--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -20,18 +20,19 @@ orig_assignees=$ORIG_ASSIGNEES
 if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
   additional_body="Note that this issue was created as a placeholder, since the original PR's commit(s) could not be automatically cherry-picked."
 
+  local_user=$(gh api user --jq .login)
   additional_body="$additional_body
   Here are the commands to execute:
   \`\`\`
   git checkout $BACKPORT_BRANCH
-  git checkout -b $GIT_USER/backport-$PR_NUMBER-$BACKPORT_BRANCH-$((RANDOM % 1000))
+  git checkout -b $local_user/backport-$PR_NUMBER-$BACKPORT_BRANCH-$((RANDOM % 1000))
   git cherry-pick -x $BACKPORT_COMMITS
 
   gh pr create
     --title \"[$BACKPORT_BRANCH] $ORIG_TITLE\" \\
     --base \"$BACKPORT_BRANCH\" \\
     --label \"kind/backport\" \\
-    --head \"$GIT_USER:$HEAD_BRANCH\" \\
+    --head \"$local_user:$HEAD_BRANCH\" \\
     --draft \\
     --repo \"$TARGET_ORG/$TARGET_REPO\" \\
     --reviewer \"$ORIG_REVIEWERS\" \\

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -51,8 +51,9 @@ head_branch=$(echo "backport-$backport_issues_numbers$BACKPORT_BRANCH-$suffix" |
 git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
 
 if ! git cherry-pick -x $BACKPORT_COMMITS; then
-  msg="Failed to run cherry-pick command. I executed the below command:\n
+  msg="Failed to run cherry-pick command. I executed the commands below:\n
 \`\`\`\r
+git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
 git cherry-pick -x $BACKPORT_COMMITS
 \`\`\`"
 


### PR DESCRIPTION
Output the full command that can be used to generate the backport. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
