### PR TITLE
ducktape-deps: bump segment-toy version

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -119,7 +119,7 @@ function install_rust_tools() {
 
   git clone https://github.com/jcsp/segment_toy.git
   pushd segment_toy
-  git reset --hard 0acf2f8f06db94c0c72c13369d9ff1effb799d2d
+  git reset --hard 830a4de9ac5f1c40a52fb4fc68b91996e9e6a86c
   cargo build --release
   cp target/release/rp-storage-tool /usr/local/bin
   popd

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -508,7 +508,7 @@ class BucketView:
     def cloud_log_size_from_ntp_manifest(manifest,
                                          include_below_start_offset=True
                                          ) -> int:
-        if 'segments' not in manifest:
+        if 'segments' not in manifest or len(manifest['segments']) == 0:
             return 0
 
         start_offset = 0


### PR DESCRIPTION
This PR bumps the version of segment-toy used in the ducktape env in order to include a fix for the decoding of partition manifests with replaced segments. A cross-shard iobuf usage in the handling of `unsafe_reset_metadata` is also fixed.

Fixes #10937 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
