### PR TITLE
Change node_health_report::topics to be ss::chunked_fifo

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -45,6 +45,7 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
+#include <algorithm>
 #include <iterator>
 
 namespace cluster {
@@ -180,14 +181,18 @@ void health_monitor_backend::refresh_nodes_status() {
     }
 }
 
-std::vector<topic_status> filter_topic_status(
-  const std::vector<topic_status>& topics, const partitions_filter& filter) {
+ss::chunked_fifo<topic_status> filter_topic_status(
+  const ss::chunked_fifo<topic_status>& topics,
+  const partitions_filter& filter) {
     // empty filter matches all
     if (filter.namespaces.empty()) {
-        return topics;
+        ss::chunked_fifo<topic_status> copy;
+        copy.reserve(topics.size());
+        std::copy(topics.cbegin(), topics.cend(), std::back_inserter(copy));
+        return copy;
     }
 
-    std::vector<topic_status> filtered;
+    ss::chunked_fifo<topic_status> filtered;
 
     for (auto& tl : topics) {
         topic_status filtered_topic_status{.tp_ns = tl.tp_ns};
@@ -736,7 +741,7 @@ reduce_reports_map(reports_acc_t acc, std::vector<ntp_report> current_reports) {
     return acc;
 }
 } // namespace
-ss::future<std::vector<topic_status>>
+ss::future<ss::chunked_fifo<topic_status>>
 health_monitor_backend::collect_topic_status(partitions_filter filters) {
     auto reports_map = co_await _partition_manager.map_reduce0(
       [&filters](partition_manager& pm) {
@@ -745,7 +750,7 @@ health_monitor_backend::collect_topic_status(partitions_filter filters) {
       reports_acc_t{},
       &reduce_reports_map);
 
-    std::vector<topic_status> topics;
+    ss::chunked_fifo<topic_status> topics;
     topics.reserve(reports_map.size());
     for (auto& [tp_ns, partitions] : reports_map) {
         topics.push_back(

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -19,6 +19,7 @@
 #include "rpc/fwd.h"
 #include "ssx/semaphore.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 
@@ -131,7 +132,7 @@ private:
     std::optional<node_health_report>
     build_node_report(model::node_id, const node_report_filter&);
 
-    ss::future<std::vector<topic_status>>
+    ss::future<ss::chunked_fifo<topic_status>>
       collect_topic_status(partitions_filter);
 
     void refresh_nodes_status();

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -10,6 +10,7 @@
  */
 #include "cluster/health_monitor_types.h"
 
+#include "cluster/drain_manager.h"
 #include "cluster/errc.h"
 #include "cluster/node/types.h"
 #include "features/feature_table.h"
@@ -58,6 +59,45 @@ std::ostream& operator<<(std::ostream& o, const node_state& s) {
     return o;
 }
 
+node_health_report::node_health_report(
+  model::node_id id,
+  node::local_state local_state,
+  ss::chunked_fifo<topic_status> topics,
+  bool include_drain_status,
+  std::optional<drain_manager::drain_status> drain_status)
+  : id(id)
+  , local_state(std::move(local_state))
+  , topics(std::move(topics))
+  , include_drain_status(include_drain_status)
+  , drain_status(drain_status) {}
+
+node_health_report::node_health_report(const node_health_report& other)
+  : id(other.id)
+  , local_state(other.local_state)
+  , topics()
+  , include_drain_status(other.include_drain_status)
+  , drain_status(other.drain_status) {
+    std::copy(
+      other.topics.cbegin(), other.topics.cend(), std::back_inserter(topics));
+}
+
+node_health_report&
+node_health_report::operator=(const node_health_report& other) {
+    if (this == &other) {
+        return *this;
+    }
+    id = other.id;
+    local_state = other.local_state;
+    include_drain_status = other.include_drain_status;
+    drain_status = other.drain_status;
+    ss::chunked_fifo<topic_status> t;
+    t.reserve(other.topics.size());
+    std::copy(
+      other.topics.cbegin(), other.topics.cend(), std::back_inserter(t));
+    topics = std::move(t);
+    return *this;
+}
+
 std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
     fmt::print(
       o,
@@ -73,6 +113,16 @@ std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
       r.local_state.logical_version,
       r.drain_status);
     return o;
+}
+bool operator==(const node_health_report& a, const node_health_report& b) {
+    return a.id == b.id && a.local_state == b.local_state
+           && a.drain_status == b.drain_status
+           && a.topics.size() == b.topics.size()
+           && std::equal(
+             a.topics.cbegin(),
+             a.topics.cend(),
+             b.topics.cbegin(),
+             b.topics.cend());
 }
 
 std::ostream& operator<<(std::ostream& o, const cluster_health_report& r) {

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -119,9 +119,25 @@ struct node_health_report
       serde::compat_version<0>> {
     static constexpr int8_t current_version = 2;
 
+    node_health_report() = default;
+
+    node_health_report(
+      model::node_id,
+      node::local_state,
+      ss::chunked_fifo<topic_status>,
+      bool include_drain_status,
+      std::optional<drain_manager::drain_status>);
+
+    node_health_report(const node_health_report&);
+    node_health_report& operator=(const node_health_report&);
+
+    node_health_report(node_health_report&&) = default;
+    node_health_report& operator=(node_health_report&&) = default;
+    ~node_health_report() = default;
+
     model::node_id id;
     node::local_state local_state;
-    std::vector<topic_status> topics;
+    ss::chunked_fifo<topic_status> topics;
 
     /*
      * nodes running old versions of redpanda will assert that they can decode
@@ -159,13 +175,7 @@ struct node_health_report
     friend std::ostream& operator<<(std::ostream&, const node_health_report&);
 
     friend bool
-    operator==(const node_health_report& a, const node_health_report& b) {
-        // include_drain_status is not serialized and is a signal to adl
-        // encoding. once adl is fully deprecated, the field can be removed and
-        // this changed to defaulted operator==.
-        return a.id == b.id && a.local_state == b.local_state
-               && a.topics == b.topics && a.drain_status == b.drain_status;
-    }
+    operator==(const node_health_report& a, const node_health_report& b);
 };
 
 struct cluster_health_report

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -55,7 +55,11 @@ void check_reports_the_same(
         auto& rr = rhs[i];
         BOOST_TEST_REQUIRE(
           lr.local_state.redpanda_version == rr.local_state.redpanda_version);
-        BOOST_TEST_REQUIRE(lr.topics == rr.topics);
+        BOOST_TEST_REQUIRE(std::equal(
+          lr.topics.cbegin(),
+          lr.topics.cend(),
+          rr.topics.cbegin(),
+          rr.topics.cend()));
         BOOST_TEST_REQUIRE(lr.local_state.disks() == rr.local_state.disks());
         BOOST_TEST_REQUIRE(
           lr.local_state.get_disk_alert() == rr.local_state.get_disk_alert());
@@ -149,7 +153,7 @@ cluster::topic_configuration topic_cfg(
 bool contains_exactly_ntp_leaders(
   ss::logger& logger,
   const std::unordered_set<model::ntp>& expected,
-  const std::vector<cluster::topic_status>& topics) {
+  const ss::chunked_fifo<cluster::topic_status>& topics) {
     auto left = expected;
     for (const auto& t_l : topics) {
         for (const auto& p_l : t_l.partitions) {

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -289,7 +289,7 @@ struct partition_balancer_planner_fixture {
       const std::set<size_t>& nearly_full_nodes = {},
       uint64_t partition_size = default_partition_size) {
         cluster::cluster_health_report health_report;
-        std::vector<cluster::topic_status> topics;
+        ss::chunked_fifo<cluster::topic_status> topics;
         for (const auto& topic : workers.table.local().topics_map()) {
             cluster::topic_status ts;
             ts.tp_ns = topic.second.get_configuration().tp_ns;
@@ -316,7 +316,7 @@ struct partition_balancer_planner_fixture {
             node_report.local_state.set_disk(node_disk);
             health_report.node_reports.push_back(node_report);
         }
-        health_report.node_reports[0].topics = topics;
+        health_report.node_reports[0].topics = std::move(topics);
         return health_report;
     }
 

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -85,11 +85,10 @@ inline node_health_report random_node_health_report() {
     auto random_ds = tests::random_optional(
       [] { return random_drain_status(); });
 
-    return node_health_report{
-      {},
+    return {
       tests::random_named_int<model::node_id>(),
       node::random_local_state(),
-      tests::random_vector(random_topic_status),
+      tests::random_chunked_fifo(random_topic_status),
       random_ds.has_value(),
       random_ds};
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -765,17 +765,16 @@ cluster::cluster_health_report random_cluster_health_report() {
     }
     std::vector<cluster::node_health_report> node_reports;
     for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
-        std::vector<cluster::topic_status> topics;
+        ss::chunked_fifo<cluster::topic_status> topics;
         for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
             topics.push_back(random_topic_status());
         }
-        auto report = cluster::node_health_report{
-          .id = tests::random_named_int<model::node_id>(),
-          .local_state = random_local_state(),
-          .topics = topics,
-          .include_drain_status = true, // so adl considers drain status
-          .drain_status = random_drain_status(),
-        };
+        auto report = cluster::node_health_report(
+          tests::random_named_int<model::node_id>(),
+          random_local_state(),
+          std::move(topics),
+          /*include_drain_status=*/true,
+          random_drain_status());
 
         // Reduce to an ADL-encodable state
         report.local_state.cache_disk = std::nullopt;
@@ -1654,17 +1653,16 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(data);
     }
     {
-        std::vector<cluster::topic_status> topics;
+        ss::chunked_fifo<cluster::topic_status> topics;
         for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
             topics.push_back(random_topic_status());
         }
-        cluster::node_health_report data{
-          .id = tests::random_named_int<model::node_id>(),
-          .local_state = random_local_state(),
-          .topics = topics,
-          .drain_status = random_drain_status(),
-        };
-        data.include_drain_status = true; // so adl considers drain status
+        cluster::node_health_report data(
+          tests::random_named_int<model::node_id>(),
+          random_local_state(),
+          std::move(topics),
+          true,
+          random_drain_status());
 
         // Squash local_state to a form that ADL represents, since we will
         // test ADL roundtrip.
@@ -1673,21 +1671,20 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(data);
     }
     {
-        std::vector<cluster::topic_status> topics;
+        ss::chunked_fifo<cluster::topic_status> topics;
         for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
             topics.push_back(random_topic_status());
         }
-        cluster::node_health_report report{
-          .id = tests::random_named_int<model::node_id>(),
-          .local_state = random_local_state(),
-          .topics = topics,
-          .drain_status = random_drain_status(),
-        };
+        cluster::node_health_report report(
+          tests::random_named_int<model::node_id>(),
+          random_local_state(),
+          std::move(topics),
+          true,
+          random_drain_status());
 
         // Squash to ADL-understood disk state
         report.local_state.cache_disk = report.local_state.data_disk;
 
-        report.include_drain_status = true; // so adl considers drain status
         cluster::get_node_health_reply data{
           .report = report,
         };

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -444,15 +444,19 @@ inline void
 read_value(json::Value const& rd, cluster::node_health_report& obj) {
     model::node_id id;
     cluster::node::local_state local_state;
-    std::vector<cluster::topic_status> topics;
+    ss::chunked_fifo<cluster::topic_status> topics;
     std::optional<cluster::drain_manager::drain_status> drain_status;
 
     read_member(rd, "id", id);
     read_member(rd, "local_state", local_state);
     read_member(rd, "topics", topics);
     read_member(rd, "drain_status", drain_status);
-    obj = cluster::node_health_report{
-      {}, id, local_state, topics, drain_status.has_value(), drain_status};
+    obj = cluster::node_health_report(
+      id,
+      local_state,
+      std::move(topics),
+      drain_status.has_value(),
+      drain_status);
 }
 
 inline void read_value(json::Value const& rd, cluster::node_state& obj) {


### PR DESCRIPTION
Followup from #10810, this also makes node_health_report a `ss::chunked_fifo`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
