### PR TITLE
archival: default min size for merge to chunk size

### DIFF
--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -21,11 +21,12 @@
 namespace archival {
 
 static std::pair<size_t, size_t> get_low_high_segment_size(
+  size_t chunk_size,
   size_t segment_size,
   config::binding<std::optional<size_t>>& low_wm,
   config::binding<std::optional<size_t>>& high_wm) {
     auto high_watermark = high_wm().value_or(segment_size);
-    auto low_watermark = low_wm().value_or(high_watermark / 2);
+    auto low_watermark = low_wm().value_or(chunk_size);
     if (low_watermark >= high_watermark) {
         // Low watermark can't be equal to high watermark
         // otherwise the merger want be able to find upload
@@ -62,6 +63,7 @@ std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
   model::offset local_start_offset,
   const cloud_storage::partition_manifest& manifest) {
     auto [min_segment_size, max_segment_size] = get_low_high_segment_size(
+      config::shard_local_cfg().cloud_storage_cache_chunk_size(),
       _archiver.get_local_segment_size(),
       _min_segment_size,
       _target_segment_size);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1398,7 +1398,7 @@ configuration::configuration()
       *this,
       "cloud_storage_segment_size_min",
       "Smallest acceptable segment size in the cloud storage. Default: "
-      "cloud_storage_segment_size_target/2",
+      "cloud_storage_cache_chunk_size",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
   , cloud_storage_graceful_transfer_timeout_ms(


### PR DESCRIPTION
This commit changes the default for the segment merger configuration in order to make it less aggressive (i.e. don't make the re-uploaded segments larger than they need to be). Since the read path now supports chunked reads and the memory overhead of a segment has been greatly reduced, there's limited benefits from having very large segments in the cloud.

More explicitly, `cloud_storage_segment_size_min` (the smallest preferred segment size in the cloud) now defaults to the chunk size used by the read path.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
