### PR TITLE
admin: add debug bundle wrapper to the Admin API

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -11,6 +11,9 @@
 
 #include "config/configuration.h"
 
+#include <filesystem>
+#include <unistd.h>
+
 namespace config {
 
 node_config::node_config() noexcept
@@ -169,6 +172,46 @@ node_config::node_config() noexcept
       "injection",
       {.visibility = visibility::tunable},
       std::nullopt)
+  , debug_bundle_write_dir(
+      *this,
+      "debug_bundle_write_dir",
+      "The full path to the directory where debug bundle zip files are stored "
+      "(default: "
+      "/tmp)",
+      {.visibility = visibility::user},
+      "/tmp",
+      [](const std::filesystem::path& write_dir) -> std::optional<ss::sstring> {
+          if (!std::filesystem::exists(write_dir)) {
+              return ss::sstring{"Debug bundle write dir does not exist"};
+          }
+
+          // access is apart of unistd.h
+          if (access(write_dir.c_str(), R_OK | W_OK) != 0) {
+              return ss::sstring{"Debug bundle write dir does not have read "
+                                 "and write permissions"};
+          }
+
+          return std::nullopt;
+      })
+  , rpk_path(
+      *this,
+      "rpk_path",
+      "The path to the RPK binary. Used to create debug bundles (default: "
+      "/usr/bin/rpk)",
+      {.visibility = visibility::user},
+      "/usr/bin/rpk",
+      [](const std::filesystem::path& bin_path) -> std::optional<ss::sstring> {
+          if (!std::filesystem::exists(bin_path)) {
+              return ss::sstring{"RPK path does not exist"};
+          }
+
+          // access is apart of unistd.h
+          if (access(bin_path.c_str(), X_OK) != 0) {
+              return ss::sstring{"RPK path does not have exec permissions"};
+          }
+
+          return std::nullopt;
+      })
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -75,6 +75,9 @@ public:
     property<std::optional<std::filesystem::path>>
       storage_failure_injection_config_path;
 
+    property<std::filesystem::path> debug_bundle_write_dir;
+    property<std::filesystem::path> rpk_path;
+
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {
         return data_directory().path / "pid.lock";

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -395,6 +395,165 @@
               ]
             }
           ]
+        },
+        {
+            "path": "/v1/debug/bundle/actions/create",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Start creating a debug bundle",
+                    "type": "void",
+                    "nickname": "start_debug_bundle",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "logs-since",
+                            "in": "query",
+                            "required": false,
+                            "type": "string"
+                        },
+                        {
+                            "name": "logs-until",
+                            "in": "query",
+                            "required": false,
+                            "type": "string"
+                        },
+                        {
+                            "name": "logs-size-limit",
+                            "in": "query",
+                            "required": false,
+                            "type": "string"
+                        },
+                        {
+                            "name": "metrics-interval",
+                            "in": "query",
+                            "required": false,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "202": {
+                            "description": "Successfully started debug bundle"
+                        },
+                        "429": {
+                            "description": "A bundle is already running"
+                        },
+                        "500": {
+                            "description": "Internal Server error"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "path": "/v1/debug/bundle/files/{filename}",
+            "operations": [
+                {
+                    "method": "HEAD",
+                    "summary": "Returns the status of the debug bundle",
+                    "type": "string",
+                    "nickname": "check_debug_bundle_status",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "filename",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "The debug bundle is completed and ready for download"
+                        },
+                        "404": {
+                            "description": "The debug bundle is running but not yet ready"
+                        },
+                        "410": {
+                            "description": "The debug bundle is not running or it is not on disk"
+                        },
+                        "500": {
+                            "description": "Internal Server error"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "path": "/v1/debug/bundle/files/{filename}",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Fetch the debug bundle archive",
+                    "type": "string",
+                    "nickname": "get_debug_bundle",
+                    "produces": [
+                        "application/zip"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "filename",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successfully fetched the debug bundle"
+                        },
+                        "404": {
+                            "description": "The debug bundle is running but not yet ready"
+                        },
+                        "410": {
+                            "description": "The debug bundle is not running or it is not on disk"
+                        },
+                        "500": {
+                            "description": "Internal Server error"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "path": "/v1/debug/bundle/files/{filename}",
+            "operations": [
+                {
+                    "method": "DELETE",
+                    "summary": "Deletes from disk the zip file containing the bundle",
+                    "type": "string",
+                    "nickname": "delete_debug_bundle",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "filename",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successfully deleted the debug bundle"
+                        },
+                        "404": {
+                            "description": "The debug bundle is running but not yet ready"
+                        },
+                        "410": {
+                            "description": "The debug bundle is not running or it is not on disk"
+                        },
+                        "500": {
+                            "description": "Internal Server error"
+                        }
+                    }
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -45,6 +45,8 @@ enum class service_kind {
     schema_registry,
 };
 
+class debug_bundle;
+
 namespace detail {
 // Helper for static_assert-ing false below.
 template<auto V>
@@ -72,7 +74,8 @@ public:
       pandaproxy::schema_registry::api*,
       ss::sharded<cloud_storage::topic_recovery_service>&,
       ss::sharded<cluster::topic_recovery_status_frontend>&,
-      ss::sharded<cluster::tx_registry_frontend>&);
+      ss::sharded<cluster::tx_registry_frontend>&,
+      ss::sharded<debug_bundle>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -204,7 +207,9 @@ private:
      */
     template<auth_level required_auth, bool peek_auth = false, typename F>
     void register_route_raw_async(
-      ss::httpd::path_description const& path, F handler) {
+      ss::httpd::path_description const& path,
+      F handler,
+      ss::sstring content_type = "json") {
         auto wrapped_handler = [this, handler](
                                  std::unique_ptr<ss::http::request> req,
                                  std::unique_ptr<ss::http::reply> rep)
@@ -237,7 +242,7 @@ private:
         };
 
         auto handler_f = new ss::httpd::function_handler{
-          std::move(wrapped_handler), "json"};
+          std::move(wrapped_handler), content_type};
 
         path.set(_server._routes, handler_f);
     }
@@ -451,6 +456,16 @@ private:
       cloud_storage_usage_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       restart_service_handler(std::unique_ptr<ss::http::request>);
+    ss::future<std::unique_ptr<ss::http::reply>> start_debug_bundle_handler(
+      std::unique_ptr<ss::http::request>,
+      std::unique_ptr<ss::http::reply>,
+      const request_auth_result&);
+    ss::future<ss::json::json_return_type>
+      check_debug_bundle_status_handler(std::unique_ptr<ss::http::request>);
+    ss::future<std::unique_ptr<ss::http::reply>> get_debug_bundle_handler(
+      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
+    ss::future<ss::json::json_return_type>
+      delete_debug_bundle_handler(std::unique_ptr<ss::http::request>);
 
     ss::future<> throw_on_error(
       ss::http::request& req,
@@ -504,4 +519,5 @@ private:
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;
     ss::timer<> _blocked_reactor_notify_reset_timer;
+    ss::sharded<debug_bundle>& _debug_bundle;
 };


### PR DESCRIPTION
Merge https://github.com/redpanda-data/redpanda/pull/10488 first

Recently, a feature was added to RPK that can collect debug information such as logs and metrics details from a Redpanda cluster. This feature is invoked with the command `rpk debug bundle`. There are ways to run this command in cloud environments; however, triggering a debug bundle in on-premise bare-metal solutions is non-trivial.

This PR adds the `debug_bundle` object to the Admin API server and defines new endpoints to:
1. Trigger `rpk debug bundle` from the Admin API
2. Query the debug bundle status from the Admin API
3. Make the debug bundle downloadable from the Admin API
4. Remove the bundle from disk

See https://github.com/redpanda-data/redpanda/issues/10876 for the list of items to do for a feature complete solution.

Fixes #8971

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Adds Admin API endpoints to trigger and manage debug bundles