### PR TITLE
config: add configs for debug bundle on Admin API

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -11,6 +11,9 @@
 
 #include "config/configuration.h"
 
+#include <filesystem>
+#include <unistd.h>
+
 namespace config {
 
 node_config::node_config() noexcept
@@ -169,6 +172,46 @@ node_config::node_config() noexcept
       "injection",
       {.visibility = visibility::tunable},
       std::nullopt)
+  , debug_bundle_write_dir(
+      *this,
+      "debug_bundle_write_dir",
+      "The full path to the directory where debug bundle zip files are stored "
+      "(default: "
+      "/tmp)",
+      {.visibility = visibility::user},
+      "/tmp",
+      [](const std::filesystem::path& write_dir) -> std::optional<ss::sstring> {
+          if (!std::filesystem::exists(write_dir)) {
+              return ss::sstring{"Debug bundle write dir does not exist"};
+          }
+
+          // access is apart of unistd.h
+          if (access(write_dir.c_str(), R_OK | W_OK) != 0) {
+              return ss::sstring{"Debug bundle write dir does not have read "
+                                 "and write permissions"};
+          }
+
+          return std::nullopt;
+      })
+  , rpk_path(
+      *this,
+      "rpk_path",
+      "The path to the RPK binary. Used to create debug bundles (default: "
+      "/usr/bin/rpk)",
+      {.visibility = visibility::user},
+      "/usr/bin/rpk",
+      [](const std::filesystem::path& bin_path) -> std::optional<ss::sstring> {
+          if (!std::filesystem::exists(bin_path)) {
+              return ss::sstring{"RPK path does not exist"};
+          }
+
+          // access is apart of unistd.h
+          if (access(bin_path.c_str(), X_OK) != 0) {
+              return ss::sstring{"RPK path does not have exec permissions"};
+          }
+
+          return std::nullopt;
+      })
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -75,6 +75,9 @@ public:
     property<std::optional<std::filesystem::path>>
       storage_failure_injection_config_path;
 
+    property<std::filesystem::path> debug_bundle_write_dir;
+    property<std::filesystem::path> rpk_path;
+
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {
         return data_directory().path / "pid.lock";


### PR DESCRIPTION
Merge this PR before https://github.com/redpanda-data/redpanda/pull/10488

Recently, a feature was added to RPK that can collect debug information such as logs and metrics details from a Redpanda cluster. This feature is invoked with the command `rpk debug bundle`. There are ways to run this command in cloud environments; however, triggering a debug bundle in on-premise bare-metal solutions is non-trivial.

This PR adds config options to support running `rpk debug bundle` on the Admin API server.

See https://github.com/redpanda-data/redpanda/issues/10876 for the list of items to do for a feature complete solution.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none