### PR TITLE
Push the locally-created branch only when necessary.

### DIFF
--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -28,9 +28,9 @@ if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
   \`\`\`
   git checkout $BACKPORT_BRANCH
   git checkout -b $local_branch
-  git push origin $local_branch
   git cherry-pick -x $BACKPORT_COMMITS
 
+  git push origin $local_branch
   gh pr create \\
     --title \"[$BACKPORT_BRANCH] $ORIG_TITLE\" \\
     --base \"$BACKPORT_BRANCH\" \\


### PR DESCRIPTION


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none
