### PR TITLE
Avoid nil dereference when inspecting Docker network

### DIFF
--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -134,7 +134,7 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 	if exists && network.IPAMConfig != nil {
 		ipAddress = network.IPAMConfig.IPv4Address
 	} else {
-		return nil, fmt.Errorf("unable to inspect network settings for the container %v", Name(nodeID))
+		return nil, fmt.Errorf("unable to inspect network settings for the container %v, you may have a conflicting 'redpanda' Docker network", Name(nodeID))
 	}
 
 	hostRPCPort, err := getHostPort(

--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -131,8 +131,10 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 	}
 	var ipAddress string
 	network, exists := containerJSON.NetworkSettings.Networks[redpandaNetwork]
-	if exists {
+	if exists && network.IPAMConfig != nil {
 		ipAddress = network.IPAMConfig.IPv4Address
+	} else {
+		return nil, fmt.Errorf("unable to inspect network settings for the container %v", Name(nodeID))
 	}
 
 	hostRPCPort, err := getHostPort(


### PR DESCRIPTION
Fixes #10899. Not familiar with the api here, but at least for now this addresses the segfault and leaves a helpful message about what could be the cause. (A user may need to delete an existing `redpanda` Docker network...that's what fixed it for me.)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
