### PR TITLE
[v23.1.x] rpk disk_irq tuner: warn on msi_irq list empty

### DIFF
--- a/src/go/rpk/pkg/tuners/irq/device_info.go
+++ b/src/go/rpk/pkg/tuners/irq/device_info.go
@@ -38,6 +38,14 @@ type deviceInfo struct {
 	fs       afero.Fs
 }
 
+type EmptyMSIRQError struct {
+	device string
+}
+
+func (e EmptyMSIRQError) Error() string {
+	return fmt.Sprintf("device %q uses MSI IRQs but the list of msi_irqs in sysfs is empty; see https://github.com/redpanda-data/redpanda/issues/10838", e.device)
+}
+
 func (deviceInfo *deviceInfo) GetIRQs(
 	irqConfigDir string, xenDeviceName string,
 ) ([]int, error) {
@@ -53,6 +61,9 @@ func (deviceInfo *deviceInfo) GetIRQs(
 				return nil, err
 			}
 			irqs = append(irqs, irq)
+		}
+		if len(irqs) == 0 {
+			return nil, &EmptyMSIRQError{irqConfigDir}
 		}
 	} else {
 		irqFileName := path.Join(irqConfigDir, "irq")

--- a/src/go/rpk/pkg/tuners/irq/device_info_test.go
+++ b/src/go/rpk/pkg/tuners/irq/device_info_test.go
@@ -38,6 +38,7 @@ func Test_DeviceInfo_GetIRQs(t *testing.T) {
 		irqConfigDir  string
 		xenDeviceName string
 		want          []int
+		wantErr       bool
 	}{
 		{
 			name: "Shall return the IRQs when device is using MSI IRQs",
@@ -49,6 +50,14 @@ func Test_DeviceInfo_GetIRQs(t *testing.T) {
 			},
 			irqConfigDir: "/irq_config/dev1",
 			want:         []int{1, 2, 5, 8},
+		},
+		{
+			name: "Err when is using MSI IRQs but the list is empty",
+			before: func(fs afero.Fs) {
+				_ = afero.WriteFile(fs, "/irq_config/dev1/msi_irqs/", []byte{}, os.ModePerm)
+			},
+			irqConfigDir: "/irq_config/dev1",
+			wantErr:      true,
 		},
 		{
 			name: "Shall return the IRQs when device is using INT#x IRQs",
@@ -112,6 +121,10 @@ func Test_DeviceInfo_GetIRQs(t *testing.T) {
 			tt.before(fs)
 			deviceInfo := NewDeviceInfo(fs, tt.procFile)
 			got, err := deviceInfo.GetIRQs(tt.irqConfigDir, tt.xenDeviceName)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			require.Exactly(t, tt.want, got)
 		})


### PR DESCRIPTION
(manual Cherry pick from commit 88235e5)

Due to a known error introduced in kernel 5.17
some instances that use MSI IRQ can have the list
of IRQs empty in sysfs which makes the tuner fail
and make hwloc seg fault (impossible to tune).

This change only prints a warning instead of an
error and links to the issue where explains
what is the problem and the upstream reports.

Fixes #10886 

## Backports Required
- [ ] none - this is a backport


## Release Notes
### Bug Fixes
* rpk disk_irq tuner now provides a warning for a known issue introduced in kernel 5.17 where instances utilizing MSI IRQ may encounter an empty IRQs list in sysfs that caused hwloc segmentation faults and results in a tuner failure.

