### PR TITLE
Limit memory used while fetching many partitions

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2082,7 +2082,16 @@ configuration::configuration()
       "buffers, as a fraction of kafka subsystem memory amount",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       0.5,
-      {.min = 0.0, .max = 1.0}) {}
+      {.min = 0.0, .max = 1.0})
+  , kafka_memory_batch_size_estimate_for_fetch(
+      *this,
+      "kafka_memory_batch_size_estimate_for_fetch",
+      "The size of the batch used to estimate memory consumption for Fetch "
+      "requests, in bytes. Smaller sizes allow more concurrent fetch requests "
+      "per shard, larger sizes prevent running out of memory because of too "
+      "many concurrent fetch requests.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      1_MiB) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2074,7 +2074,15 @@ configuration::configuration()
       "kafka_schema_id_validation_cache_capacity",
       "Per-shard capacity of the cache for validating schema IDs.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      128) {}
+      128)
+  , kafka_memory_share_for_fetch(
+      *this,
+      "kafka_memory_share_for_fetch",
+      "The share of kafka subsystem memory that can be used for fetch read "
+      "buffers, as a fraction of kafka subsystem memory amount",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      0.5,
+      {.min = 0.0, .max = 1.0}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -420,6 +420,8 @@ struct configuration final : public config_store {
     // schema id validation
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
+    bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -421,6 +421,7 @@ struct configuration final : public config_store {
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
+    property<size_t> kafka_memory_batch_size_estimate_for_fetch;
 
     configuration();
 

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -136,6 +136,7 @@ public:
     connection_context& operator=(const connection_context&) = delete;
     connection_context& operator=(connection_context&&) = delete;
 
+    /// The instance of \ref kafka::server on the shard serving the connection
     server& server() { return _server; }
     const ss::sstring& listener() const { return conn->name(); }
     std::optional<security::sasl_server>& sasl() { return _sasl; }

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -31,6 +31,7 @@
 #include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "resource_mgmt/io_priority.h"
+#include "ssx/semaphore.h"
 #include "storage/parser_utils.h"
 #include "utils/to_string.h"
 
@@ -142,6 +143,100 @@ static ss::future<read_result> read_from_partition(
       std::move(aborted_transactions));
 }
 
+read_result::memory_units_t::~memory_units_t() noexcept {
+    if (shard == ss::this_shard_id()) {
+        return;
+    }
+    auto f = ss::smp::submit_to(
+      shard, [uk = std::move(kafka), uf = std::move(fetch)]() mutable noexcept {
+          uk.return_all();
+          uf.return_all();
+      });
+    if (!f.available()) {
+        ss::engine().run_in_background(std::move(f));
+    }
+}
+
+/**
+ * Consume proper amounts of units from memory semaphores and return them as
+ * semaphore_units. Fetch semaphore units returned are the indication of
+ * available resources: if none, there is no memory for the operation;
+ * if less than \p max_bytes, the fetch should be capped to that size.
+ *
+ * \param max_bytes The limit of how much data is going to be fetched
+ * \param obligatory_batch_read Set to true for the first ntp in the fetch
+ *   fetch request, at least one batch must be fetched for that ntp. Also it
+ *   is assumed that a batch size has already been consumed from kafka
+ *   memory semaphore for it.
+ */
+read_result::memory_units_t reserve_memory_units(
+  ssx::semaphore& memory_sem,
+  ssx::semaphore& memory_fetch_sem,
+  const size_t max_bytes,
+  const bool obligatory_batch_read) {
+    read_result::memory_units_t memory_units;
+    const size_t memory_kafka_now = memory_sem.current();
+    const size_t memory_fetch = memory_fetch_sem.current();
+    const size_t batch_size_estimate
+      = config::shard_local_cfg().kafka_memory_batch_size_estimate_for_fetch();
+
+    if (obligatory_batch_read) {
+        // cap what we want at what we have, but no further down than a single
+        // batch size - with \ref obligatory_batch_read, it must be fetched
+        // regardless
+        const size_t fetch_size = std::max(
+          batch_size_estimate,
+          std::min({max_bytes, memory_kafka_now, memory_fetch}));
+        memory_units.fetch = ss::consume_units(memory_fetch_sem, fetch_size);
+        memory_units.kafka = ss::consume_units(memory_sem, fetch_size);
+    } else {
+        // max_bytes is how much we prepare to read from this ntp, but no less
+        // than one full batch
+        const size_t requested_fetch_size = std::max(
+          max_bytes, batch_size_estimate);
+        // cap what we want at what we have
+        const size_t fetch_size = std::min(
+          {requested_fetch_size, memory_kafka_now, memory_fetch});
+        // only reserve memory if we have space for at least one batch,
+        // otherwise this ntp will be skipped
+        if (fetch_size >= batch_size_estimate) {
+            memory_units.fetch = ss::consume_units(
+              memory_fetch_sem, fetch_size);
+            memory_units.kafka = ss::consume_units(memory_sem, fetch_size);
+        }
+    }
+
+    return memory_units;
+}
+
+/**
+ * Make the \p units hold exactly \p target_bytes, by consuming more units
+ * from \p sem or by returning extra units back.
+ */
+static void adjust_semaphore_units(
+  ssx::semaphore& sem, ssx::semaphore_units& units, const size_t target_bytes) {
+    if (target_bytes < units.count()) {
+        units.return_units(units.count() - target_bytes);
+    }
+    if (target_bytes > units.count()) {
+        units.adopt(ss::consume_units(sem, target_bytes - units.count()));
+    }
+}
+
+/**
+ * Memory units have been reserved before the read op based on an estimation.
+ * Now when we know how much data has actually been read, return any extra
+ * amount.
+ */
+static void adjust_memory_units(
+  ssx::semaphore& memory_sem,
+  ssx::semaphore& memory_fetch_sem,
+  read_result::memory_units_t& memory_units,
+  const size_t read_bytes) {
+    adjust_semaphore_units(memory_sem, memory_units.kafka, read_bytes);
+    adjust_semaphore_units(memory_fetch_sem, memory_units.fetch, read_bytes);
+}
+
 /**
  * Entry point for reading from an ntp. This is executed on NTP home core and
  * build error responses if anything goes wrong.
@@ -151,7 +246,25 @@ static ss::future<read_result> do_read_from_ntp(
   const replica_selector& replica_selector,
   ntp_fetch_config ntp_config,
   bool foreign_read,
-  std::optional<model::timeout_clock::time_point> deadline) {
+  std::optional<model::timeout_clock::time_point> deadline,
+  const bool obligatory_batch_read,
+  ssx::semaphore& memory_sem,
+  ssx::semaphore& memory_fetch_sem) {
+    // control available memory
+    read_result::memory_units_t memory_units;
+    if (!ntp_config.cfg.skip_read) {
+        memory_units = reserve_memory_units(
+          memory_sem,
+          memory_fetch_sem,
+          ntp_config.cfg.max_bytes,
+          obligatory_batch_read);
+        if (!memory_units.fetch) {
+            ntp_config.cfg.skip_read = true;
+        } else if (ntp_config.cfg.max_bytes > memory_units.fetch.count()) {
+            ntp_config.cfg.max_bytes = memory_units.fetch.count();
+        }
+    }
+
     /*
      * lookup the ntp's partition
      */
@@ -235,8 +348,13 @@ static ss::future<read_result> do_read_from_ntp(
               preferred_replica);
         }
     }
-    co_return co_await read_from_partition(
+    read_result result = co_await read_from_partition(
       std::move(*kafka_partition), ntp_config.cfg, foreign_read, deadline);
+
+    adjust_memory_units(
+      memory_sem, memory_fetch_sem, memory_units, result.data_size_bytes());
+    result.memory_units = std::move(memory_units);
+    co_return result;
 }
 
 ss::future<read_result> read_from_ntp(
@@ -245,13 +363,19 @@ ss::future<read_result> read_from_ntp(
   const model::ktp& ktp,
   fetch_config config,
   bool foreign_read,
-  std::optional<model::timeout_clock::time_point> deadline) {
+  std::optional<model::timeout_clock::time_point> deadline,
+  const bool obligatory_batch_read,
+  ssx::semaphore& memory_sem,
+  ssx::semaphore& memory_fetch_sem) {
     return do_read_from_ntp(
       cluster_pm,
       replica_selector,
       {ktp, std::move(config)},
       foreign_read,
-      deadline);
+      deadline,
+      obligatory_batch_read,
+      memory_sem,
+      memory_fetch_sem);
 }
 
 static void fill_fetch_responses(
@@ -349,7 +473,9 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
   std::vector<ntp_fetch_config> ntp_fetch_configs,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline,
-  const size_t bytes_left) {
+  const size_t bytes_left,
+  ssx::semaphore& memory_sem,
+  ssx::semaphore& memory_fetch_sem) {
     size_t total_max_bytes = 0;
     for (const auto& c : ntp_fetch_configs) {
         total_max_bytes += c.cfg.max_bytes;
@@ -373,17 +499,26 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
         }
     }
 
+    const auto first_p_id = ntp_fetch_configs.front().ktp().get_partition();
     auto results = co_await ssx::parallel_transform(
       std::move(ntp_fetch_configs),
-      [&cluster_pm, &replica_selector, deadline, foreign_read](
-        const ntp_fetch_config& ntp_cfg) {
+      [&cluster_pm,
+       &replica_selector,
+       deadline,
+       foreign_read,
+       first_p_id,
+       &memory_sem,
+       &memory_fetch_sem](const ntp_fetch_config& ntp_cfg) {
           auto p_id = ntp_cfg.ktp().get_partition();
           return do_read_from_ntp(
                    cluster_pm,
                    replica_selector,
                    ntp_cfg,
                    foreign_read,
-                   deadline)
+                   deadline,
+                   first_p_id == p_id,
+                   memory_sem,
+                   memory_fetch_sem)
             .then([p_id](read_result res) {
                 res.partition = p_id;
                 return res;
@@ -439,10 +574,8 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
       .invoke_on(
         shard,
         octx.ssg,
-        [foreign_read,
-         deadline = octx.deadline,
-         configs = std::move(fetch.requests),
-         &octx](cluster::partition_manager& mgr) mutable {
+        [foreign_read, configs = std::move(fetch.requests), &octx](
+          cluster::partition_manager& mgr) mutable {
             // &octx is captured only to immediately use its accessors here so
             // that there is a list of all objects accessed next to `invoke_on`.
             // This is meant to help avoiding unintended cross shard access
@@ -451,8 +584,10 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
               octx.rctx.server().local().get_replica_selector(),
               std::move(configs),
               foreign_read,
-              deadline,
-              octx.bytes_left);
+              octx.deadline,
+              octx.bytes_left,
+              octx.rctx.server().local().memory(),
+              octx.rctx.server().local().memory_fetch_sem());
         })
       .then([responses = std::move(fetch.responses),
              start_time = fetch.start_time,

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -169,7 +169,7 @@ read_result::memory_units_t::~memory_units_t() noexcept {
  *   is assumed that a batch size has already been consumed from kafka
  *   memory semaphore for it.
  */
-read_result::memory_units_t reserve_memory_units(
+static read_result::memory_units_t reserve_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
   const size_t max_bytes,
@@ -357,6 +357,8 @@ static ss::future<read_result> do_read_from_ntp(
     co_return result;
 }
 
+namespace testing {
+
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager& cluster_pm,
   const replica_selector& replica_selector,
@@ -377,6 +379,17 @@ ss::future<read_result> read_from_ntp(
       memory_sem,
       memory_fetch_sem);
 }
+
+read_result::memory_units_t reserve_memory_units(
+  ssx::semaphore& memory_sem,
+  ssx::semaphore& memory_fetch_sem,
+  const size_t max_bytes,
+  const bool obligatory_batch_read) {
+    return kafka::reserve_memory_units(
+      memory_sem, memory_fetch_sem, max_bytes, obligatory_batch_read);
+}
+
+} // namespace testing
 
 static void fill_fetch_responses(
   op_context& octx,

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -448,7 +448,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
             // This is meant to help avoiding unintended cross shard access
             return fetch_ntps_in_parallel(
               mgr,
-              octx.rctx.replica_selector(),
+              octx.rctx.server().local().get_replica_selector(),
               std::move(configs),
               foreign_read,
               deadline,

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -367,6 +367,11 @@ struct fetch_plan {
     }
 };
 
+/*
+ * Unit Tests Exposure
+ */
+namespace testing {
+
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
   const replica_selector&,
@@ -378,13 +383,18 @@ ss::future<read_result> read_from_ntp(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem);
 
-namespace testing {
 /**
  * Create a fetch plan with the simple fetch planner.
  *
  * Exposed for testing/benchmarking only.
  */
 kafka::fetch_plan make_simple_fetch_plan(op_context& octx);
-} // namespace testing
 
+read_result::memory_units_t reserve_memory_units(
+  ssx::semaphore& memory_sem,
+  ssx::semaphore& memory_fetch_sem,
+  const size_t max_bytes,
+  const bool obligatory_batch_read);
+
+} // namespace testing
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -246,6 +246,8 @@ public:
         return _conn->server().get_replica_selector();
     }
 
+    ss::sharded<server>& server() { return _conn->server().container(); }
+
 private:
     template<typename ResponseType>
     void update_usage_stats(const ResponseType& r, size_t response_size) {

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -242,10 +242,6 @@ public:
         return _conn->server().controller_api();
     }
 
-    const replica_selector& replica_selector() const {
-        return _conn->server().get_replica_selector();
-    }
-
     ss::sharded<server>& server() { return _conn->server().container(); }
 
 private:

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -133,15 +133,42 @@ server::server(
   , _gssapi_principal_mapper(
       config::shard_local_cfg().sasl_kerberos_principal_mapping.bind())
   , _krb_configurator(config::shard_local_cfg().sasl_kerberos_config.bind())
+  , _memory_fetch_sem(
+      static_cast<size_t>(
+        cfg->local().max_service_memory_per_core
+        * config::shard_local_cfg().kafka_memory_share_for_fetch()),
+      "kafka/server-mem-fetch")
   , _thread_worker(tw)
   , _replica_selector(
       std::make_unique<rack_aware_replica_selector>(_metadata_cache.local()))
   , _schema_registry(sr) {
+    vlog(
+      klog.debug,
+      "Starting kafka server with {} byte limit on fetch requests",
+      _memory_fetch_sem.available_units());
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);
     }
+    setup_metrics();
     _probe.setup_metrics();
     _probe.setup_public_metrics();
+}
+
+void server::setup_metrics() {
+    namespace sm = ss::metrics;
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name(cfg.name),
+      {
+        sm::make_total_bytes(
+          "fetch_avail_mem_bytes",
+          [this] { return _memory_fetch_sem.current(); },
+          sm::description(ssx::sformat(
+            "{}: Memory available for fetch request processing", cfg.name))),
+      });
 }
 
 ss::scheduling_group server::fetch_scheduling_group() const {

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -183,7 +183,11 @@ public:
         return _handler_probes.get_probe(key);
     }
 
+    ssx::semaphore& memory_fetch_sem() noexcept { return _memory_fetch_sem; }
+
 private:
+    void setup_metrics();
+
     ss::smp_service_group _smp_group;
     ss::scheduling_group _fetch_scheduling_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
@@ -211,10 +215,11 @@ private:
     security::tls::principal_mapper _mtls_principal_mapper;
     security::gssapi_principal_mapper _gssapi_principal_mapper;
     security::krb5::configurator _krb_configurator;
+    ssx::semaphore _memory_fetch_sem;
 
     handler_probe_manager _handler_probes;
-
     class latency_probe _probe;
+    ss::metrics::metric_groups _metrics;
     ssx::thread_worker& _thread_worker;
     std::unique_ptr<replica_selector> _replica_selector;
     const std::unique_ptr<pandaproxy::schema_registry::api>& _schema_registry;

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -38,7 +38,9 @@
 
 namespace kafka {
 
-class server final : public net::server {
+class server final
+  : public net::server
+  , public ss::peering_sharded_service<server> {
 public:
     server(
       ss::sharded<net::server_configuration>*,

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ rp_test(
     handler_interface_test.cc
     quota_managers_test.cc
     validator_tests.cc
+    fetch_unit_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka v::coproc
   LABELS kafka

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -168,19 +168,25 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
         auto octx = kafka::op_context(
           std::move(rctx), ss::default_smp_service_group());
         auto shard = octx.rctx.shards().shard_for(ktp).value();
-        return octx.rctx.partition_manager()
-          .invoke_on(
-            shard,
-            [ktp, config, &octx](cluster::partition_manager& pm) {
-                return kafka::read_from_ntp(
-                  pm,
-                  octx.rctx.server().local().get_replica_selector(),
-                  ktp,
-                  config,
-                  true,
-                  model::no_timeout);
-            })
-          .get0();
+        kafka::read_result res
+          = octx.rctx.partition_manager()
+              .invoke_on(
+                shard,
+                [&octx, ktp, config](cluster::partition_manager& pm) {
+                    return kafka::read_from_ntp(
+                      pm,
+                      octx.rctx.server().local().get_replica_selector(),
+                      ktp,
+                      config,
+                      true,
+                      model::no_timeout,
+                      false,
+                      octx.rctx.server().local().memory(),
+                      octx.rctx.server().local().memory_fetch_sem());
+                })
+              .get0();
+        BOOST_TEST_REQUIRE(res.has_data());
+        return res;
     };
     wait_for_controller_leadership().get0();
     auto ntp = make_data(get_next_partition_revision_id().get());

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -174,7 +174,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
             [ktp, config, &octx](cluster::partition_manager& pm) {
                 return kafka::read_from_ntp(
                   pm,
-                  octx.rctx.replica_selector(),
+                  octx.rctx.server().local().get_replica_selector(),
                   ktp,
                   config,
                   true,

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -173,7 +173,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
               .invoke_on(
                 shard,
                 [&octx, ktp, config](cluster::partition_manager& pm) {
-                    return kafka::read_from_ntp(
+                    return kafka::testing::read_from_ntp(
                       pm,
                       octx.rctx.server().local().get_replica_selector(),
                       ktp,

--- a/src/v/kafka/server/tests/fetch_unit_test.cc
+++ b/src/v/kafka/server/tests/fetch_unit_test.cc
@@ -1,0 +1,147 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/handlers/fetch.h"
+#include "seastarx.h"
+#include "ssx/semaphore.h"
+
+#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+struct reserve_mem_units_test_result {
+    size_t kafka, fetch;
+    explicit reserve_mem_units_test_result(size_t size)
+      : kafka(size)
+      , fetch(size) {}
+    reserve_mem_units_test_result(size_t kafka_, size_t fetch_)
+      : kafka(kafka_)
+      , fetch(fetch_) {}
+    friend bool operator==(
+      const reserve_mem_units_test_result&,
+      const reserve_mem_units_test_result&)
+      = default;
+    friend std::ostream&
+    operator<<(std::ostream& s, const reserve_mem_units_test_result& v) {
+        return s << "{kafka: " << v.kafka << ", fetch: " << v.fetch << "}";
+    }
+};
+
+BOOST_AUTO_TEST_CASE(reserve_memory_units_test) {
+    using namespace kafka;
+    using namespace std::chrono_literals;
+    using r = reserve_mem_units_test_result;
+
+    // reserve memory units, return how many memory units have been reserved
+    // from each memory semaphore
+    ssx::semaphore memory_sem{100_MiB, "test_memory_sem"};
+    ssx::semaphore memory_fetch_sem{50_MiB, "test_memory_fetch_sem"};
+    const auto test_case =
+      [&memory_sem, &memory_fetch_sem](
+        size_t max_bytes,
+        bool obligatory_batch_read) -> reserve_mem_units_test_result {
+        auto mu = kafka::testing::reserve_memory_units(
+          memory_sem, memory_fetch_sem, max_bytes, obligatory_batch_read);
+        return {mu.kafka.count(), mu.fetch.count()};
+    };
+
+    static constexpr size_t batch_size = 1_MiB;
+
+    // below are test prerequisites, tests are done based on these assumptions
+    // if these are not valid, the test needs a change
+    size_t kafka_mem = memory_sem.available_units();
+    size_t fetch_mem = memory_fetch_sem.available_units();
+    BOOST_TEST(fetch_mem > batch_size * 3);
+    BOOST_TEST_REQUIRE(kafka_mem > fetch_mem);
+    BOOST_TEST_REQUIRE(batch_size > 100);
+
+    // *** plenty of memory cases
+    // kafka_mem > fetch_mem > batch_size
+    // Reserved memory is limited by the fetch memory semaphore
+    BOOST_TEST(test_case(batch_size / 100, false) == r(batch_size));
+    BOOST_TEST(test_case(batch_size / 100, true) == r(batch_size));
+    BOOST_TEST(test_case(batch_size, false) == r(batch_size));
+    BOOST_TEST(test_case(batch_size, true) == r(batch_size));
+    BOOST_TEST(test_case(batch_size * 3, false) == r(batch_size * 3));
+    BOOST_TEST(test_case(batch_size * 3, true) == r(batch_size * 3));
+    BOOST_TEST(test_case(fetch_mem, false) == r(fetch_mem));
+    BOOST_TEST(test_case(fetch_mem, true) == r(fetch_mem));
+    BOOST_TEST(test_case(fetch_mem + 1, false) == r(fetch_mem));
+    BOOST_TEST(test_case(fetch_mem + 1, true) == r(fetch_mem));
+    BOOST_TEST(test_case(kafka_mem, false) == r(fetch_mem));
+    BOOST_TEST(test_case(kafka_mem, true) == r(fetch_mem));
+
+    // *** still a lot of mem but kafka mem somewhat used:
+    // fetch_mem > kafka_mem > batch_size (fetch_mem - kafka_mem < batch_size)
+    // Obligatory reads to not come into play yet because we still have more
+    // memory than a single batch, but the amount of memory reserved is limited
+    // by the smaller semaphore, which is kafka_mem in this case
+    auto memsemunits = ss::consume_units(
+      memory_sem, kafka_mem - fetch_mem + 1000);
+    kafka_mem = memory_sem.available_units();
+    BOOST_TEST_REQUIRE(kafka_mem < fetch_mem);
+    BOOST_TEST_REQUIRE(kafka_mem > batch_size + 1000);
+
+    BOOST_TEST(test_case(batch_size, false) == r(batch_size));
+    BOOST_TEST(test_case(batch_size, true) == r(batch_size));
+    BOOST_TEST(test_case(kafka_mem - 100, false) == r(kafka_mem - 100));
+    BOOST_TEST(test_case(kafka_mem - 100, true) == r(kafka_mem - 100));
+    BOOST_TEST(test_case(kafka_mem + 100, false) == r(kafka_mem));
+    BOOST_TEST(test_case(kafka_mem + 100, true) == r(kafka_mem));
+    BOOST_TEST(test_case(fetch_mem + 100, false) == r(kafka_mem));
+    BOOST_TEST(test_case(fetch_mem + 100, true) == r(kafka_mem));
+
+    memsemunits.return_all();
+    kafka_mem = memory_sem.available_units();
+
+    // *** low on fetch memory tests
+    // kafka_mem > batch_size > fetch_mem
+    // Under this condition, unless obligatory_batch_read, we cannot reserve
+    // memory as it's not enough for at least a single batch.
+    // If obligatory_batch_read, the reserved amount will always be a single
+    // batch.
+    memsemunits = ss::consume_units(
+      memory_fetch_sem, fetch_mem - batch_size + 1000);
+    fetch_mem = memory_fetch_sem.available_units();
+    BOOST_TEST_REQUIRE(kafka_mem > batch_size);
+    BOOST_TEST_REQUIRE(fetch_mem < batch_size);
+
+    BOOST_TEST(test_case(fetch_mem - 100, false) == r(0));
+    BOOST_TEST(test_case(fetch_mem - 100, true) == r(batch_size));
+    BOOST_TEST(test_case(batch_size - 100, false) == r(0));
+    BOOST_TEST(test_case(batch_size - 100, true) == r(batch_size));
+    BOOST_TEST(test_case(kafka_mem - 100, false) == r(0));
+    BOOST_TEST(test_case(kafka_mem - 100, true) == r(batch_size));
+    BOOST_TEST(test_case(kafka_mem + 100, false) == r(0));
+    BOOST_TEST(test_case(kafka_mem + 100, true) == r(batch_size));
+
+    memsemunits.return_all();
+    fetch_mem = memory_fetch_sem.available_units();
+
+    // *** low on kafka memory tests
+    // fetch_mem > batch_size > kafka_mem
+    // Essentially the same behaviour as in low fetch memory cases
+    memsemunits = ss::consume_units(memory_sem, kafka_mem - batch_size + 1000);
+    kafka_mem = memory_sem.available_units();
+    BOOST_TEST_REQUIRE(kafka_mem < batch_size);
+    BOOST_TEST_REQUIRE(fetch_mem > batch_size);
+
+    BOOST_TEST(test_case(kafka_mem - 100, false) == r(0));
+    BOOST_TEST(test_case(kafka_mem - 100, true) == r(batch_size));
+    BOOST_TEST(test_case(batch_size - 100, false) == r(0));
+    BOOST_TEST(test_case(batch_size - 100, true) == r(batch_size));
+    BOOST_TEST(test_case(batch_size + 100, false) == r(0));
+    BOOST_TEST(test_case(batch_size + 100, true) == r(batch_size));
+    BOOST_TEST(test_case(fetch_mem - 100, false) == r(0));
+    BOOST_TEST(test_case(fetch_mem - 100, true) == r(batch_size));
+    BOOST_TEST(test_case(fetch_mem + 100, false) == r(0));
+    BOOST_TEST(test_case(fetch_mem + 100, true) == r(batch_size));
+
+    memsemunits.return_all();
+    kafka_mem = memory_sem.available_units();
+}

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -73,7 +73,7 @@ struct config_connection_rate_bindings {
 
 struct server_configuration {
     std::vector<server_endpoint> addrs;
-    int64_t max_service_memory_per_core;
+    int64_t max_service_memory_per_core = 0;
     std::optional<int> listen_backlog;
     std::optional<int> tcp_recv_buf;
     std::optional<int> tcp_send_buf;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -123,7 +123,11 @@ public:
         app.check_environment();
         app.wire_up_and_start(*app_signal, true);
 
-        configs.start(ss::sstring("fixture_config")).get();
+        net::server_configuration scfg("fixture_config");
+        scfg.max_service_memory_per_core = memory_groups::rpc_total_memory();
+        scfg.disable_metrics = net::metrics_disabled::yes;
+        scfg.disable_public_metrics = net::public_metrics_disabled::yes;
+        configs.start(scfg).get();
 
         // used by request context builder
         proto

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -45,6 +45,7 @@
 #include "pandaproxy/schema_registry/configuration.h"
 #include "redpanda/application.h"
 #include "resource_mgmt/cpu_scheduling.h"
+#include "ssx/thread_worker.h"
 #include "storage/directories.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/async.h"
@@ -125,30 +126,32 @@ public:
         configs.start(ss::sstring("fixture_config")).get();
 
         // used by request context builder
-        proto = std::make_unique<kafka::server>(
-          &configs,
-          app.smp_service_groups.kafka_smp_sg(),
-          app.sched_groups.fetch_sg(),
-          app.metadata_cache,
-          app.controller->get_topics_frontend(),
-          app.controller->get_config_frontend(),
-          app.controller->get_feature_table(),
-          app.quota_mgr,
-          app.snc_quota_mgr,
-          app.group_router,
-          app.usage_manager,
-          app.shard_table,
-          app.partition_manager,
-          app.id_allocator_frontend,
-          app.controller->get_credential_store(),
-          app.controller->get_authorizer(),
-          app.controller->get_security_frontend(),
-          app.controller->get_api(),
-          app.tx_gateway_frontend,
-          app.tx_registry_frontend,
-          std::nullopt,
-          *app.thread_worker,
-          app.schema_registry());
+        proto
+          .start(
+            &configs,
+            app.smp_service_groups.kafka_smp_sg(),
+            app.sched_groups.fetch_sg(),
+            std::ref(app.metadata_cache),
+            std::ref(app.controller->get_topics_frontend()),
+            std::ref(app.controller->get_config_frontend()),
+            std::ref(app.controller->get_feature_table()),
+            std::ref(app.quota_mgr),
+            std::ref(app.snc_quota_mgr),
+            std::ref(app.group_router),
+            std::ref(app.usage_manager),
+            std::ref(app.shard_table),
+            std::ref(app.partition_manager),
+            std::ref(app.id_allocator_frontend),
+            std::ref(app.controller->get_credential_store()),
+            std::ref(app.controller->get_authorizer()),
+            std::ref(app.controller->get_security_frontend()),
+            std::ref(app.controller->get_api()),
+            std::ref(app.tx_gateway_frontend),
+            std::ref(app.tx_registry_frontend),
+            std::nullopt,
+            std::ref(*app.thread_worker),
+            std::ref(app.schema_registry()))
+          .get();
 
         configs.stop().get();
     }
@@ -226,6 +229,7 @@ public:
 
     ~redpanda_thread_fixture() {
         shutdown();
+        proto.stop().get();
         if (remove_on_shutdown) {
             std::filesystem::remove_all(data_dir);
         }
@@ -645,7 +649,7 @@ public:
     conn_ptr make_connection_context() {
         security::sasl_server sasl(security::sasl_server::sasl_state::complete);
         return ss::make_lw_shared<kafka::connection_context>(
-          *proto,
+          proto.local(),
           nullptr,
           std::move(sasl),
           false,
@@ -689,7 +693,7 @@ public:
     uint16_t schema_reg_port;
     std::filesystem::path data_dir;
     ss::sharded<net::server_configuration> configs;
-    std::unique_ptr<kafka::server> proto;
+    ss::sharded<kafka::server> proto;
     bool remove_on_shutdown;
     std::unique_ptr<::stop_signal> app_signal;
 };


### PR DESCRIPTION
A semaphore is added to `kafka::server` to control the memory used for the buffers in the fetch path. The semaphore is set to a configurable fraction of kafka shard memory (default 0.5). As the fetch work is delegated to different shards, the first partition requested from a shard is always served, other partitions may be skipped if the memory semaphore on the shard does not have enough units available. Memory reservation is done based on the estimation of 1 MiB per batch (default, configurable), which is adjusted as soon as the real used size is known. The semaphore is local to the partition home shard.

The overall kafka server memory semaphore is also used the same way, so sizes of fetch responses are also limited from the overall kafka server perspective as well. It is also the partition home shard's semaphore, not the one associated with the connection that has received the fetch request. This is done because the memory for the buffers is acquired on the partition home shard.

Fetch request memory estimator is not changed, because it only works with the memory semaphore associated with the connection shard, and at the time of the estimation we don't even know what shards will be affected.

Neither of the semaphores is waited upon, the amounts only get consumed from there. Both semaphores can go negative as the result. So, when overused:
* fetch memory semaphore does not delay anything, but `read_from_ntp`s will only perform the minimal read then (one batch per shard's part of the plan)
* kafka server memory semaphore will do the same, and additionally it will delay incoming requests served by the shard.

Actually, fetch memory semaphore is never waited upon and could have been an integer instead. The only reason it is a semaphore is a convenience of `semaphore_units`.

As a side effect, this PR adds support for floating point bounded properties.

The differences from the reverted #10371 are:
* In 10371, both semaphores decremented before reading from partition were the ones associated with the connection shard; now they both are the ones associated with the partition home shard. Besides the fact that was a logic error, in 10371 that also caused the kafka server memory semaphore to be used in both connection shard (for request memory estimation), and in other (partition) shards. Allegedly due to promises in the semaphore waitlist created and signalled in different shard, there was memory corruption that was manifested in an unrelated location.
* In 10371 there was an attempt made to estimate request memory with a custom `fetch_memory_estimator`, not done in this PR because memory estimator only affects connection shard memory semaphore, while the idea of the PR is to account memory against the memory semaphores of the shards where the memory is getting allocated.

Fixes #3409.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Memory control is improved in Fetch request handler, covering the cases when a client tries to fetch too many partitions lead by the same shard. Some of the request partitions will not be fetched if the broker does not have enough memory for that, or if that would violate constraints set by `kafka_max_bytes_per_fetch` and `fetch_max_bytes`.

* If `kafka_max_bytes_per_fetch` is not configured properly, redpanda is now more robust against huge Fetch requests by controlling memory consumption dynamically.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
