### PR TITLE
cloud_storage: Handle nested benign exception

### DIFF
--- a/src/v/cloud_storage_clients/tests/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ rp_test(
     backend_detection_test.cc
     s3_client_test.cc
     xml_sax_parser_test.cc
+    exception_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::http v::cloud_storage_clients v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/cloud_storage_clients/tests/exception_test.cc
+++ b/src/v/cloud_storage_clients/tests/exception_test.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/util.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(test_nested_exception) {
+    {
+        auto inner = std::make_exception_ptr(ss::abort_requested_exception{});
+        auto outer = std::make_exception_ptr(ss::gate_closed_exception{});
+        ss::nested_exception ex{inner, outer};
+        BOOST_REQUIRE(
+          cloud_storage_clients::util::has_abort_or_gate_close_exception(ex));
+    }
+
+    {
+        auto inner = std::make_exception_ptr(std::bad_alloc{});
+        auto outer = std::make_exception_ptr(ss::gate_closed_exception{});
+        ss::nested_exception ex{inner, outer};
+        BOOST_REQUIRE(
+          cloud_storage_clients::util::has_abort_or_gate_close_exception(ex));
+    }
+
+    {
+        auto inner = std::make_exception_ptr(std::invalid_argument{""});
+        auto outer = std::make_exception_ptr(
+          ss::no_sharded_instance_exception{});
+        ss::nested_exception ex{inner, outer};
+        BOOST_REQUIRE(
+          !cloud_storage_clients::util::has_abort_or_gate_close_exception(ex));
+    }
+}

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -45,4 +45,6 @@ std::chrono::system_clock::time_point parse_timestamp(std::string_view sv);
 void log_buffer_with_rate_limiting(
   const char* msg, iobuf& buf, ss::logger& logger);
 
+bool has_abort_or_gate_close_exception(const ss::nested_exception& ex);
+
 } // namespace cloud_storage_clients::util


### PR DESCRIPTION
If a nested exception is seen during an HTTP call where either the inner or outer exception is abort or gate closed, then the exception is logged on debug level, to be consistent with how these exception types (abort/gate closed) are handled in isolation.

If both the components of the nested exception are of any other kind, an error is logged.

Fixes https://github.com/redpanda-data/redpanda/issues/10706

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

