### PR TITLE
Using `chunked_fifo` in `heartbeat_manager`

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -23,6 +23,7 @@
 #include "rpc/types.h"
 #include "vlog.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/timed_out_error.hh>
@@ -74,7 +75,7 @@ static heartbeat_requests requests_for_range(
   const consensus_set& c, clock_type::duration heartbeat_interval) {
     absl::btree_map<
       model::node_id,
-      std::vector<std::pair<
+      ss::chunked_fifo<std::pair<
         heartbeat_metadata,
         heartbeat_manager::follower_request_meta>>>
       pending_beats;

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -23,6 +23,7 @@
 #include <seastar/util/log.hh>
 
 #include <absl/container/btree_map.h>
+#include <absl/container/node_hash_map.h>
 #include <boost/container/flat_set.hpp>
 
 namespace raft::details {
@@ -108,7 +109,7 @@ public:
         node_heartbeat(
           model::node_id t,
           heartbeat_request req,
-          absl::btree_map<raft::group_id, follower_request_meta> seqs)
+          absl::node_hash_map<raft::group_id, follower_request_meta> seqs)
           : target(t)
           , request(std::move(req))
           , meta_map(std::move(seqs)) {}
@@ -117,7 +118,7 @@ public:
         heartbeat_request request;
         // each raft group has its own follower metadata hence we need map to
         // track a sequence per group
-        absl::btree_map<raft::group_id, follower_request_meta> meta_map;
+        absl::node_hash_map<raft::group_id, follower_request_meta> meta_map;
     };
 
     heartbeat_manager(
@@ -155,7 +156,7 @@ private:
     /// \param result if the node return successful heartbeats
     void process_reply(
       model::node_id n,
-      absl::btree_map<raft::group_id, follower_request_meta> groups,
+      const absl::node_hash_map<raft::group_id, follower_request_meta>& groups,
       result<heartbeat_reply> result);
 
     // private members


### PR DESCRIPTION
Using `ss::chunked_fifo` in heartbeats manager when collecting node heartbeat requests. 

Fixes: #10751 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
