### PR TITLE
[v22.3.x] cloud_storage: tolerate exceptions in the hydration loop

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -560,8 +560,8 @@ ss::future<> remote_segment::run_hydrate_bg() {
     bool segment_was_cached = false;
     bool txrange_was_cached = false;
 
-    try {
-        while (!_gate.is_closed()) {
+    while (!_gate.is_closed()) {
+        try {
             co_await _bg_cvar.wait(
               [this] { return !_wait_list.empty() || _gate.is_closed(); });
             vlog(
@@ -670,20 +670,23 @@ ss::future<> remote_segment::run_hydrate_bg() {
                 }
                 _wait_list.pop_front();
             }
+        } catch (const ss::broken_condition_variable&) {
+            vlog(_ctxlog.debug, "Hydration loop shut down");
+            set_waiter_errors(std::current_exception());
+            break;
+        } catch (const ss::abort_requested_exception&) {
+            vlog(_ctxlog.debug, "Hydration loop shut down");
+            set_waiter_errors(std::current_exception());
+            break;
+        } catch (const ss::gate_closed_exception&) {
+            vlog(_ctxlog.debug, "Hydration loop shut down");
+            set_waiter_errors(std::current_exception());
+            break;
+        } catch (...) {
+            const auto err = std::current_exception();
+            vlog(_ctxlog.error, "Error in hydration loop: {}", err);
+            set_waiter_errors(err);
         }
-    } catch (const ss::broken_condition_variable&) {
-        vlog(_ctxlog.debug, "Hydration loop shut down");
-        set_waiter_errors(std::current_exception());
-    } catch (const ss::abort_requested_exception&) {
-        vlog(_ctxlog.debug, "Hydration loop shut down");
-        set_waiter_errors(std::current_exception());
-    } catch (const ss::gate_closed_exception&) {
-        vlog(_ctxlog.debug, "Hydration loop shut down");
-        set_waiter_errors(std::current_exception());
-    } catch (...) {
-        const auto err = std::current_exception();
-        vlog(_ctxlog.error, "Error in hydraton loop: {}", err);
-        set_waiter_errors(err);
     }
 
     _hydration_loop_running = false;

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -207,6 +207,7 @@ private:
 
     bool _compacted{false};
     bool _stopped{false};
+    bool _hydration_loop_running{false};
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/utils/tests/input_stream_fanout_test.cc
+++ b/src/v/utils/tests/input_stream_fanout_test.cc
@@ -12,7 +12,6 @@
 #include "bytes/iobuf.h"
 #include "bytes/iostream.h"
 #include "random/generators.h"
-#include "utils/fragmented_vector.h"
 #include "utils/stream_utils.h"
 
 #include <seastar/core/abort_source.hh>
@@ -21,6 +20,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
 
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
@@ -186,6 +186,44 @@ void test_detached_consumer(
         BOOST_REQUIRE(niter >= expected_iters);
     }
     std::apply([](auto&&... s) { (s.close().get(), ...); }, tail);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_mid_read_detach) {
+    // Asserts that if one reader has read some buffers, setting its own bit in
+    // the buffers' masks, and another reader stops which had not read those
+    // buffers, the buffers which got all bits set as a result are cleaned up by
+    // the next reader.
+    iobuf input;
+    for (int i = 0; i < 20; i++) {
+        int sz = random_generators::get_int(100, 32 * 1024);
+        auto b = random_generators::get_bytes(sz);
+        input.append(bytes_to_iobuf(b));
+    }
+    auto is = make_iobuf_input_stream(std::move(input));
+
+    // A read-ahead of 10 will cause several buffers to be pre-loaded
+    auto pair = input_stream_fanout<2>(std::move(is), 10);
+
+    // Wait for produce to fill the buffers
+    {
+        using namespace std::chrono_literals;
+        ss::sleep(10s).get();
+    }
+
+    auto a = std::move(std::get<0>(pair));
+    auto b = std::move(std::get<1>(pair));
+
+    auto deferred = ss::defer([&b] { b.close().get(); });
+
+    // b reads a buffer. It will next read from position 1 in fanout source
+    b.read().get();
+    // a closes and sets all bits to 1 in its mask bit for all buffers in the
+    // source.
+    a.close().get();
+    // when b reads from position 1, it then sets all bits to 1 in that buffer.
+    // before this, the previous buffer should have been removed, preserving the
+    // invariant.
+    BOOST_REQUIRE_NO_THROW(b.read().get());
 }
 
 SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_2) { test_sync_read<2>(4); }


### PR DESCRIPTION
Backport of PR #10828 and #9786.

The fix in #10828 unveiled a deadlock in `input_fanout_stream` which was fixed in #9786.
