### PR TITLE
[v22.2.x] cloud_storage: tolerate exceptions in the hydration loop

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -112,6 +112,7 @@ remote_segment::remote_segment(
       meta->delta_offset, model::offset(0), model::offset::max());
 
     // run hydration loop in the background
+    _hydration_loop_running = true;
     ssx::background = run_hydrate_bg();
 }
 
@@ -619,9 +620,22 @@ ss::future<> remote_segment::run_hydrate_bg() {
           "Error in hydraton loop: {}",
           std::current_exception());
     }
+
+    _hydration_loop_running = false;
 }
 
 ss::future<> remote_segment::hydrate() {
+    if (!_hydration_loop_running) {
+        vlog(
+          _ctxlog.error,
+          "Segment {} hydration requested, but the hydration loop is not "
+          "running",
+          _path);
+
+        return ss::make_exception_future<>(std::runtime_error(
+          fmt::format("Hydration loop is not running for segment: {}", _path)));
+    }
+
     return ss::with_gate(_gate, [this] {
         vlog(_ctxlog.debug, "segment {} hydration requested", _path);
         ss::promise<ss::file> p;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -518,8 +518,8 @@ combine_statuses(cache_element_status segment, cache_element_status tx_range) {
 
 ss::future<> remote_segment::run_hydrate_bg() {
     ss::gate::holder guard(_gate);
-    try {
-        while (!_gate.is_closed()) {
+    while (!_gate.is_closed()) {
+        try {
             co_await _bg_cvar.wait(
               [this] { return !_wait_list.empty() || _gate.is_closed(); });
             vlog(
@@ -611,14 +611,15 @@ ss::future<> remote_segment::run_hydrate_bg() {
                 }
                 _wait_list.pop_front();
             }
+        } catch (const ss::broken_condition_variable&) {
+            vlog(_ctxlog.debug, "Hydration loop is stopped");
+            break;
+        } catch (...) {
+            vlog(
+              _ctxlog.error,
+              "Error in hydration loop: {}",
+              std::current_exception());
         }
-    } catch (const ss::broken_condition_variable&) {
-        vlog(_ctxlog.debug, "Hydraton loop is stopped");
-    } catch (...) {
-        vlog(
-          _ctxlog.error,
-          "Error in hydraton loop: {}",
-          std::current_exception());
     }
 
     _hydration_loop_running = false;

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -183,6 +183,8 @@ private:
 
     using tx_range_vec = fragmented_vector<cluster::rm_stm::tx_range>;
     std::optional<tx_range_vec> _tx_range;
+
+    bool _hydration_loop_running{false};
 };
 
 class remote_segment_batch_consumer;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10828 and https://github.com/redpanda-data/redpanda/pull/9786.

The fix in https://github.com/redpanda-data/redpanda/pull/10828 unveiled a deadlock in input_fanout_stream which was fixed in https://github.com/redpanda-data/redpanda/pull/9786.