### PR TITLE
cloud_storage: fix TieredStorageSinglePartitionTest

### DIFF
--- a/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
@@ -150,7 +150,8 @@ class TieredStorageSinglePartitionTest(RedpandaTest):
         # produced data
         bucket = BucketView(self.redpanda)
         manifest = bucket.manifest_for_ntp(self.topic, 0)
-        uploaded_ts = list(manifest['segments'].values())[-1]['max_timestamp']
+        uploaded_ts = max(s['max_timestamp']
+                          for s in manifest['segments'].values())
         self.logger.info(f"Max uploaded ts = {uploaded_ts}")
 
         lag_seconds = (local_ts - uploaded_ts) / 1000.0


### PR DESCRIPTION
This test was assuming that the last element in the segments map was the most recent, which is not true in general.

Fixes: #10919 

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none