### PR TITLE
Schedule decom-related partition movements in partition balancer

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -497,6 +497,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
               .partition_autobalancing_tick_interval_ms.bind(),
             config::shard_local_cfg()
               .partition_autobalancing_movement_batch_size_bytes.bind(),
+            config::shard_local_cfg()
+              .partition_autobalancing_concurrent_moves.bind(),
             config::shard_local_cfg().segment_fallocation_step.bind());
       })
       .then([this] {

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -145,7 +145,6 @@ private:
     void reallocations_for_even_partition_count(
       update_meta&, partition_allocation_domain);
 
-    ss::future<> calculate_reallocations_after_decommissioned(update_meta&);
     ss::future<> calculate_reallocations_after_recommissioned(update_meta&);
     std::vector<model::ntp> ntps_moving_from_node_older_than(
       model::node_id, model::revision_id) const;

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -281,10 +281,10 @@ members_manager::apply_update(model::record_batch b) {
       [this, update_offset](decommission_node_cmd cmd) mutable {
           auto id = cmd.key;
           vlog(
-            clusterlog.trace,
+            clusterlog.info,
             "applying decommission_node_cmd, offset: {}, node id: {}",
-            id,
-            update_offset);
+            update_offset,
+            id);
 
           return dispatch_updates_to_cores(update_offset, cmd)
             .then([this, id, update_offset](std::error_code error) {
@@ -305,10 +305,10 @@ members_manager::apply_update(model::record_batch b) {
       [this, update_offset](recommission_node_cmd cmd) mutable {
           auto id = cmd.key;
           vlog(
-            clusterlog.trace,
+            clusterlog.info,
             "applying recommission_node_cmd, offset: {}, node id: {}",
-            id,
-            update_offset);
+            update_offset,
+            id);
 
           // TODO: remove this part after we introduce simplified raft
           // configuration handling as this will be commands driven
@@ -364,10 +364,10 @@ members_manager::apply_update(model::record_batch b) {
 
           model::node_id id = cmd.key;
           vlog(
-            clusterlog.trace,
+            clusterlog.info,
             "applying finish_reallocations_cmd, offset: {}, node id: {}",
-            id,
-            update_offset);
+            update_offset,
+            id);
 
           if (auto it = _in_progress_updates.find(id);
               it != _in_progress_updates.end()) {
@@ -395,11 +395,11 @@ members_manager::apply_update(model::record_batch b) {
       },
       [this, update_offset](maintenance_mode_cmd cmd) {
           vlog(
-            clusterlog.trace,
+            clusterlog.info,
             "applying maintenance_mode_cmd, offset: {}, node id: {}, enabled: "
             "{}",
-            cmd.key,
             update_offset,
+            cmd.key,
             cmd.value);
 
           return dispatch_updates_to_cores(update_offset, cmd)

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -44,6 +44,7 @@ partition_balancer_backend::partition_balancer_backend(
   config::binding<unsigned>&& storage_space_alert_free_threshold_percent,
   config::binding<std::chrono::milliseconds>&& tick_interval,
   config::binding<size_t>&& movement_batch_size_bytes,
+  config::binding<size_t>&& max_concurrent_actions,
   config::binding<size_t>&& segment_fallocation_step)
   : _raft0(std::move(raft0))
   , _controller_stm(controller_stm.local())
@@ -58,6 +59,7 @@ partition_balancer_backend::partition_balancer_backend(
       std::move(storage_space_alert_free_threshold_percent))
   , _tick_interval(std::move(tick_interval))
   , _movement_batch_size_bytes(std::move(movement_batch_size_bytes))
+  , _max_concurrent_actions(std::move(max_concurrent_actions))
   , _segment_fallocation_step(std::move(segment_fallocation_step))
   , _timer([this] { tick(); }) {}
 
@@ -140,6 +142,7 @@ ss::future<> partition_balancer_backend::do_tick() {
             .soft_max_disk_usage_ratio = soft_max_disk_usage_ratio,
             .hard_max_disk_usage_ratio = hard_max_disk_usage_ratio,
             .movement_disk_size_batch = _movement_batch_size_bytes(),
+            .max_concurrent_actions = _max_concurrent_actions(),
             .node_availability_timeout_sec = _availability_timeout(),
             .segment_fallocation_step = _segment_fallocation_step()},
           _state,

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -44,10 +44,6 @@ public:
     void start();
     ss::future<> stop();
 
-    bool is_enabled() const {
-        return _mode() == model::partition_autobalancing_mode::continuous;
-    }
-
     bool is_leader() const { return _raft0->is_leader(); }
 
     std::optional<model::node_id> leader_id() const {
@@ -63,8 +59,6 @@ public:
 private:
     void tick();
     ss::future<> do_tick();
-
-    void on_mode_changed();
 
 private:
     consensus_ptr _raft0;

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -39,6 +39,7 @@ public:
       config::binding<unsigned>&& storage_space_alert_free_threshold_percent,
       config::binding<std::chrono::milliseconds>&& tick_interval,
       config::binding<size_t>&& movement_batch_size_bytes,
+      config::binding<size_t>&& max_concurrent_actions,
       config::binding<size_t>&& segment_fallocation_step);
 
     void start();
@@ -75,6 +76,7 @@ private:
     config::binding<unsigned> _storage_space_alert_free_threshold_percent;
     config::binding<std::chrono::milliseconds> _tick_interval;
     config::binding<size_t> _movement_batch_size_bytes;
+    config::binding<size_t> _max_concurrent_actions;
     config::binding<size_t> _segment_fallocation_step;
 
     model::term_id _last_leader_term;

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -86,8 +86,10 @@ public:
     const planner_config& config() const { return _parent._config; }
 
     bool is_batch_full() const {
-        return _planned_moves_size_bytes
-               >= _parent._config.movement_disk_size_batch;
+        return _planned_moves_size_bytes >= config().movement_disk_size_batch
+               || (state().topics().updates_in_progress().size()
+                   + _reassignments.size() + _cancellations.size())
+                    >= config().max_concurrent_actions;
     }
 
 private:

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -81,7 +81,10 @@ private:
     void init_ntp_sizes_from_health_report(
       const cluster_health_report& health_report, request_context&);
 
-    static void get_unavailable_nodes_actions(request_context&);
+    static void get_node_drain_actions(
+      request_context&,
+      const absl::flat_hash_set<model::node_id>&,
+      std::string_view reason);
     static void get_rack_constraint_repair_actions(request_context&);
     static void get_full_node_actions(request_context&);
 

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -14,6 +14,7 @@
 #include "cluster/partition_balancer_types.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/topic_table.h"
+#include "model/metadata.h"
 
 #include <absl/container/flat_hash_map.h>
 
@@ -25,6 +26,7 @@ struct ntp_reassignment {
 };
 
 struct planner_config {
+    model::partition_autobalancing_mode mode;
     // If node disk usage goes over this ratio planner will actively move
     // partitions away from the node.
     double soft_max_disk_usage_ratio;

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -35,6 +35,8 @@ struct planner_config {
     double hard_max_disk_usage_ratio;
     // Size of partitions that can be planned to move in one request
     size_t movement_disk_size_batch;
+    // Max number of actions that can be scheduled in one planning iteration
+    size_t max_concurrent_actions;
     std::chrono::seconds node_availability_timeout_sec;
     // Fallocation step used to calculate upperbound for partition size
     size_t segment_fallocation_step;

--- a/src/v/cluster/tests/partition_balancer_bench.cc
+++ b/src/v/cluster/tests/partition_balancer_bench.cc
@@ -34,6 +34,8 @@ PERF_TEST_C(partition_balancer_planner_fixture, unavailable_nodes) {
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
+
     perf_tests::start_measuring_time();
     auto plan_data = planner.plan_actions(hr, fm);
     perf_tests::stop_measuring_time();

--- a/src/v/cluster/tests/partition_balancer_bench.cc
+++ b/src/v/cluster/tests/partition_balancer_bench.cc
@@ -17,7 +17,7 @@ PERF_TEST_C(partition_balancer_planner_fixture, unavailable_nodes) {
         ss::thread_attributes thread_attr;
         co_await ss::async(thread_attr, [this] {
             allocator_register_nodes(3);
-            create_topic("topic-1", 2000, 3);
+            create_topic("topic-1", 20000, 3);
             allocator_register_nodes(2);
         });
 
@@ -25,10 +25,6 @@ PERF_TEST_C(partition_balancer_planner_fixture, unavailable_nodes) {
     }
 
     uint64_t local_partition_size = 10_KiB;
-    uint64_t movement_batch_partitions_amount = (reallocation_batch_size
-                                                 + local_partition_size - 1)
-                                                / local_partition_size;
-
     auto hr = create_health_report({}, {}, local_partition_size);
 
     std::set<size_t> unavailable_nodes = {0};
@@ -41,5 +37,8 @@ PERF_TEST_C(partition_balancer_planner_fixture, unavailable_nodes) {
     perf_tests::stop_measuring_time();
 
     const auto& reassignments = plan_data.reassignments;
-    BOOST_REQUIRE_EQUAL(reassignments.size(), movement_batch_partitions_amount);
+    vassert(
+      reassignments.size() == max_concurrent_actions,
+      "unexpected reassignments size: {}",
+      reassignments.size());
 }

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -85,16 +85,20 @@ public:
 };
 
 struct partition_balancer_planner_fixture {
-    partition_balancer_planner_fixture()
-      : planner(
-        cluster::planner_config{
-          .soft_max_disk_usage_ratio = 0.8,
-          .hard_max_disk_usage_ratio = 0.95,
-          .movement_disk_size_batch = reallocation_batch_size,
-          .node_availability_timeout_sec = std::chrono::minutes(1),
-          .segment_fallocation_step = 16},
-        workers.state.local(),
-        workers.allocator.local()) {}
+    cluster::partition_balancer_planner make_planner(
+      model::partition_autobalancing_mode mode
+      = model::partition_autobalancing_mode::continuous) {
+        return cluster::partition_balancer_planner(
+          cluster::planner_config{
+            .mode = mode,
+            .soft_max_disk_usage_ratio = 0.8,
+            .hard_max_disk_usage_ratio = 0.95,
+            .movement_disk_size_batch = reallocation_batch_size,
+            .node_availability_timeout_sec = std::chrono::minutes(1),
+            .segment_fallocation_step = 16},
+          workers.state.local(),
+          workers.allocator.local());
+    }
 
     cluster::topic_configuration_assignment make_tp_configuration(
       const ss::sstring& topic, int partitions, int16_t replication_factor) {
@@ -341,6 +345,5 @@ struct partition_balancer_planner_fixture {
     }
 
     controller_workers workers;
-    cluster::partition_balancer_planner planner;
     int last_node_idx{};
 };

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -34,6 +34,7 @@ constexpr uint64_t nearly_full_node_free_size = 41_MiB;
 constexpr uint64_t default_partition_size = 10_MiB;
 constexpr uint64_t not_full_node_free_size = 150_MiB;
 constexpr uint64_t reallocation_batch_size = default_partition_size * 2 - 1_MiB;
+constexpr uint64_t max_concurrent_actions = 50;
 constexpr std::chrono::seconds node_unavailable_timeout = std::chrono::minutes(
   5);
 
@@ -94,6 +95,7 @@ struct partition_balancer_planner_fixture {
             .soft_max_disk_usage_ratio = 0.8,
             .hard_max_disk_usage_ratio = 0.95,
             .movement_disk_size_batch = reallocation_batch_size,
+            .max_concurrent_actions = max_concurrent_actions,
             .node_availability_timeout_sec = std::chrono::minutes(1),
             .segment_fallocation_step = 16},
           workers.state.local(),

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -71,6 +71,7 @@ FIXTURE_TEST(test_stable, partition_balancer_planner_fixture) {
     auto hr = create_health_report();
     auto fm = create_follower_metrics();
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
     check_violations(plan_data, {}, {});
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
@@ -100,6 +101,7 @@ FIXTURE_TEST(test_node_down, partition_balancer_planner_fixture) {
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, {});
@@ -137,6 +139,7 @@ FIXTURE_TEST(test_no_quorum_for_partition, partition_balancer_planner_fixture) {
     std::set<size_t> unavailable_nodes = {0, 1};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
 }
@@ -170,6 +173,7 @@ FIXTURE_TEST(
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, {});
@@ -208,6 +212,7 @@ FIXTURE_TEST(
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, {});
@@ -246,6 +251,7 @@ FIXTURE_TEST(
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, full_nodes);
@@ -277,6 +283,7 @@ FIXTURE_TEST(test_move_from_full_node, partition_balancer_planner_fixture) {
 
     auto fm = create_follower_metrics();
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, {}, full_nodes);
@@ -317,6 +324,7 @@ FIXTURE_TEST(
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, {});
@@ -364,6 +372,7 @@ FIXTURE_TEST(
     auto hr = create_health_report(full_nodes);
     auto fm = create_follower_metrics();
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
     check_violations(plan_data, {}, full_nodes);
 
@@ -410,6 +419,7 @@ FIXTURE_TEST(
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
     check_violations(plan_data, unavailable_nodes, full_nodes);
 
@@ -460,6 +470,7 @@ FIXTURE_TEST(test_move_part_of_replicas, partition_balancer_planner_fixture) {
     hr.node_reports[1].local_state.data_disk.free -= 1_MiB;
     hr.node_reports[2].local_state.data_disk.free -= 2_MiB;
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, {}, full_nodes);
@@ -517,6 +528,7 @@ FIXTURE_TEST(
         }
     }
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, {}, full_nodes);
@@ -570,6 +582,7 @@ FIXTURE_TEST(test_lot_of_partitions, partition_balancer_planner_fixture) {
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
     check_violations(plan_data, unavailable_nodes, {});
 
@@ -628,6 +641,7 @@ FIXTURE_TEST(test_node_cancelation, partition_balancer_planner_fixture) {
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto planner_result = planner.plan_actions(hr, fm);
 
     BOOST_REQUIRE_EQUAL(planner_result.reassignments.size(), 1);
@@ -688,6 +702,7 @@ FIXTURE_TEST(test_rack_awareness, partition_balancer_planner_fixture) {
     std::set<size_t> unavailable_nodes = {0};
     auto fm = create_follower_metrics(unavailable_nodes);
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, {});
@@ -722,6 +737,7 @@ FIXTURE_TEST(
 
     set_maintenance_mode(model::node_id{3});
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, {});
@@ -751,6 +767,7 @@ FIXTURE_TEST(
     auto fm = create_follower_metrics(unavailable_nodes);
     set_decommissioning(model::node_id{3});
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, {});
@@ -786,6 +803,7 @@ FIXTURE_TEST(
         model::broker_shard{model::node_id{3}, 0},
       });
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, unavailable_nodes, {});
@@ -851,6 +869,7 @@ FIXTURE_TEST(test_rack_awareness_repair, partition_balancer_planner_fixture) {
     auto hr = create_health_report();
     auto fm = create_follower_metrics({});
 
+    auto planner = make_planner();
     auto plan_data = planner.plan_actions(hr, fm);
 
     check_violations(plan_data, {}, {});
@@ -866,6 +885,26 @@ FIXTURE_TEST(test_rack_awareness_repair, partition_balancer_planner_fixture) {
         }
         BOOST_REQUIRE_EQUAL(racks.size(), 3);
     }
+    BOOST_REQUIRE_EQUAL(plan_data.cancellations.size(), 0);
+    BOOST_REQUIRE_EQUAL(plan_data.failed_actions_count, 0);
+}
+
+FIXTURE_TEST(balancing_modes, partition_balancer_planner_fixture) {
+    allocator_register_nodes(3, {"rack_A", "rack_B", "rack_B"});
+    create_topic("topic-1", 2, 3);
+    allocator_register_nodes(1, {"rack_C"});
+
+    std::set<size_t> full_nodes = {2};
+    auto hr = create_health_report(full_nodes);
+
+    std::set<size_t> unavailable_nodes = {1};
+    auto fm = create_follower_metrics(unavailable_nodes);
+
+    auto planner = make_planner(model::partition_autobalancing_mode::node_add);
+    auto plan_data = planner.plan_actions(hr, fm);
+
+    check_violations(plan_data, {}, {});
+    BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
     BOOST_REQUIRE_EQUAL(plan_data.cancellations.size(), 0);
     BOOST_REQUIRE_EQUAL(plan_data.failed_actions_count, 0);
 }

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -734,6 +734,11 @@ class RedpandaServiceBase(Service):
         'kafka_connections_max': 2048,
         'kafka_connections_max_per_ip': 1024,
         'kafka_connections_max_overrides': ["1.2.3.4:5"],
+
+        # TODO: we need this to not wait too long before moves are scheduled
+        # after decommission. Get rid of this after event-driven balancer execution
+        # is implemented.
+        "partition_autobalancing_tick_interval_ms": 5000,
     }
 
     logs = {
@@ -2628,6 +2633,10 @@ class RedpandaService(RedpandaServiceBase):
             # this configuration property was introduced in 22.2.1, ensure
             # it doesn't appear in older configurations
             conf.pop('cloud_storage_credentials_source', None)
+        if cur_ver != RedpandaInstaller.HEAD and cur_ver < (22, 2, 1):
+            # this configuration property was introduced in 22.2.1, ensure
+            # it doesn't appear in older configurations
+            conf.pop('partition_autobalancing_tick_interval_ms', None)
 
         if self._security.enable_sasl:
             self.logger.debug("Enabling SASL in cluster configuration")


### PR DESCRIPTION
Schedule decommission-related partition movements in partition balancer. `members_backend` now simply checks that no partitions are left on the decommed node to finish decommissioning.

Also, now that the partition balancer can operate with moving partitions, make it respect the `partition_autobalancing_concurrent_moves` config property. Generally this will result in smaller movement batches, which is a good thing if we can run the balancer more often.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Improvements
* Partition movements related to node decommission now take free disk space and health of target nodes into account.
* Partition balancer now takes `partition_autobalancing_concurrent_moves` configuration property into account.