### PR TITLE
cloud_storage: write remote lifecycle markers after purge

### DIFF
--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -10,6 +10,7 @@
 
 #include "archival/types.h"
 #include "cloud_storage/fwd.h"
+#include "cloud_storage/lifecycle_marker.h"
 #include "cluster/fwd.h"
 #include "cluster/types.h"
 
@@ -73,6 +74,12 @@ private:
         uint32_t self;
         uint32_t total;
     };
+
+    ss::future<cloud_storage::upload_result> write_remote_lifecycle_marker(
+      const cluster::nt_revision&,
+      cloud_storage_clients::bucket_name& bucket,
+      cloud_storage::lifecycle_status status,
+      retry_chain_node& parent_rtc);
 
     /// Find our index out of all shards in the cluster
     global_position get_global_position();

--- a/src/v/cloud_storage/lifecycle_marker.h
+++ b/src/v/cloud_storage/lifecycle_marker.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage_clients/types.h"
+#include "cluster/types.h"
+#include "hashing/xx.h"
+
+namespace cloud_storage {
+
+// Lifecycle states of a tiered storage topic:
+//
+//                |--- Topic deletion with remote.delete=false
+//                v
+// ┌──────────┬──────►┌───────────┐
+// │   Live   │       │ Offloaded │
+// └────┬─────┘◄──────┴───────────┘
+//      │         ^
+//      │         |--- Topic recovery (by user)
+//      │
+//      │
+//      │ Topic deletion with remote.delete=true
+//      ▼
+// ┌──────────┐
+// │  Purging │
+// └────┬─────┘
+//      │
+//      │
+//      │ Topic purge complete (by scrubber)
+//      ▼
+// ┌──────────┐
+// │  Purged  │
+// └──────────┘
+enum class lifecycle_status : uint8_t {
+    // exists in a live redpanda cluster.
+    live = 1,
+
+    // still exists in a cluster's controller, but is in the process
+    // of being cleaned up.
+    purging = 2,
+
+    // cluster has finished cleaning up, and dropped the topic from
+    // its controller state.  Possible that there could be stray orphan
+    // objects still to clean up.
+    purged = 3,
+
+    // Cluster has dropped local state for the topic, but not deleted
+    // any data: this topic is elegible for being revive on the same or
+    // another cluster.
+    offloaded = 4,
+};
+
+/**
+ * The remote lifecycle marker is the object storage equivalent of the
+ * controllers nt_lifecycle_marker.  It is left behind after topic deletion
+ * as a tombstone that enables
+ *  - readers to unambiguously understand that the
+ *    topic is deleted and not just missing
+ *  - scrubbers to know that it is safe to erase stray objects within the
+ *    NT that the lifecycle describes.
+ *
+ * For normal not-deleted topics, this marker doesn't tell you anything more
+ * than the topic manifest.  The main difference between this and the topic
+ * manifest is:
+ * - This structure knows how to represent post-deletion states, such as
+ *   a topic that has been deleted with remote.delete=false
+ * - This structure is unique to the namespace-topic-revision, whereas the
+ *   topic manifest omits revision in its key, so if a topic is deleted and
+ *   another topic is created with the same name, the topic manifests would
+ *   collide, but the lifecycle markers may coexist.
+ */
+struct remote_nt_lifecycle_marker
+  : serde::envelope<
+      remote_nt_lifecycle_marker,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    /// ID of the cluster that wrote this marker, in case multiple clusters
+    /// are addressing the same bucket
+    ss::sstring cluster_id;
+
+    /// The unique identify of the topic-revision.  This will also be present
+    /// in the object key, but including it in the body is convenient for
+    /// readers.
+    cluster::nt_revision topic;
+
+    lifecycle_status status;
+
+    cloud_storage_clients::object_key get_key() {
+        return generate_key(
+          topic.nt.ns, topic.nt.tp, topic.initial_revision_id);
+    }
+
+    static cloud_storage_clients::object_key generate_key(
+      const model::ns& ns,
+      const model::topic& tp,
+      model::initial_revision_id rev) {
+        constexpr uint32_t bitmask = 0xF0000000;
+        auto path = fmt::format("{}/{}", ns(), tp());
+        uint32_t hash = bitmask & xxhash_32(path.data(), path.size());
+        return cloud_storage_clients::object_key(
+          fmt::format("{:08x}/meta/{}/{}_lifecycle.bin", hash, path, rev()));
+    }
+};
+
+} // namespace cloud_storage
+
+template<>
+struct fmt::formatter<cloud_storage::lifecycle_status> final
+  : fmt::formatter<std::string_view> {
+    template<typename FormatContext>
+    auto
+    format(const cloud_storage::lifecycle_status& s, FormatContext& ctx) const {
+        using status = cloud_storage::lifecycle_status;
+        const char* str = "unknown";
+        if (s == status::live) {
+            str = "live";
+        } else if (s == status::purging) {
+            str = "purging";
+        } else if (s == status::purged) {
+            str = "purged";
+        } else if (s == status::offloaded) {
+            str = "offloaded";
+        }
+
+        return formatter<string_view>::format(str, ctx);
+    }
+};

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -1358,6 +1358,17 @@ cloud_storage_clients::object_tag_formatter remote::make_segment_index_tags(
     return tags;
 }
 
+cloud_storage_clients::object_tag_formatter remote::make_lifecycle_marker_tags(
+  const model::ns& ns,
+  const model::topic& topic,
+  const model::initial_revision_id rev) {
+    auto tags = default_lifecycle_marker_tags;
+    tags.add("rp-ns", ns());
+    tags.add("rp-topic", topic());
+    tags.add("rp-rev", rev());
+    return tags;
+}
+
 cloud_storage_clients::object_tag_formatter remote::make_tx_manifest_tags(
   const model::ntp& ntp, model::initial_revision_id rev) {
     // Note: tx-manifest is related to segment (contains data which are used
@@ -1376,6 +1387,9 @@ const cloud_storage_clients::object_tag_formatter
   = {{"rp-type", "partition-manifest"}};
 const cloud_storage_clients::object_tag_formatter remote::default_index_tags = {
   {"rp-type", "segment-index"}};
+const cloud_storage_clients::object_tag_formatter
+  remote::default_lifecycle_marker_tags
+  = {{"rp-type", "lifecycle-marker"}};
 
 ss::future<api_activity_notification>
 remote::subscribe(remote::event_filter& filter) {

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -124,6 +124,8 @@ public:
     static const cloud_storage_clients::object_tag_formatter
       default_topic_manifest_tags;
     static const cloud_storage_clients::object_tag_formatter default_index_tags;
+    static const cloud_storage_clients::object_tag_formatter
+      default_lifecycle_marker_tags;
 
     /// Functor that returns fresh input_stream object that can be used
     /// to re-upload and will return all data that needs to be uploaded
@@ -447,6 +449,11 @@ public:
 
     static cloud_storage_clients::object_tag_formatter make_segment_index_tags(
       const model::ntp& ntp, model::initial_revision_id rev);
+    static cloud_storage_clients::object_tag_formatter
+    make_lifecycle_marker_tags(
+      const model::ns& ns,
+      const model::topic& topic,
+      const model::initial_revision_id rev);
 
 private:
     ss::future<upload_result> delete_objects_sequentially(

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -117,6 +117,53 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/v1/cloud_storage/lifecycle",
+      "operations": [
+        {
+          "method": "GET",
+          "summary": "Get lifecycle markers for topics pending deletion",
+          "operationId": "get_cloud_storage_lifecycle",
+          "nickname": "get_cloud_storage_lifecycle",
+          "type": "get_lifecycle_response",
+          "parameters": [],
+          "produces": [
+            "application/json"
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "message": "Success"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/v1/cloud_storage/lifecycle/{topic}/{revision}",
+      "operations": [
+        {
+          "method": "DELETE",
+          "summary": "Forcibly drop a lifecycle marker for a topic, this may leave data behind in the tiered storage bucket",
+          "operationId": "delete_cloud_storage_lifecycle",
+          "nickname": "delete_cloud_storage_lifecycle",
+          "parameters": [
+            {
+              "name": "topic",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "revision",
+              "in": "path",
+              "required": true,
+              "type": "integer"
+            }
+          ]
+        }
+      ]
     }
   ],
   "models": {
@@ -244,6 +291,34 @@
             "type": "long",
             "nullable": true,
             "description": "The last Kafka offset accessible locally (inclusive)"
+        }
+      }
+    },
+    "lifecycle_marker": {
+      "id": "lifecycle_marker",
+      "description": "Lifecycle status of a topic (e.g. during deletion)",
+      "properties": {
+        "ns": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        },
+        "revision_id": {
+          "type": "long"
+        },
+        "status": {
+          "type": "string"
+        }
+      }
+    },
+    "get_lifecycle_response": {
+      "id": "get_lifecycle_response",
+      "description": "Response body of GET to the cloud_storage/lifecycle endpoint",
+      "properties": {
+        "markers": {
+          "type": "array",
+          "items": {"type":  "lifecycle_marker"}
         }
       }
     }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -429,6 +429,10 @@ private:
     query_automated_recovery(std::unique_ptr<ss::http::request> req);
     ss::future<ss::json::json_return_type>
     get_partition_cloud_storage_status(std::unique_ptr<ss::http::request> req);
+    ss::future<ss::json::json_return_type>
+    get_cloud_storage_lifecycle(std::unique_ptr<ss::http::request> req);
+    ss::future<ss::json::json_return_type>
+    delete_cloud_storage_lifecycle(std::unique_ptr<ss::http::request> req);
     ss::future<std::unique_ptr<ss::http::reply>> get_manifest(
       std::unique_ptr<ss::http::request> req,
       std::unique_ptr<ss::http::reply> rep);

--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -15,7 +15,7 @@ rm -rf client-swarm
 
 git clone https://github.com/jcsp/segment_toy.git
 pushd segment_toy
-git reset --hard 830a4de9ac5f1c40a52fb4fc68b91996e9e6a86c
+git reset --hard b101a31927d48e513bec21ad500c048c91e7c192
 cargo build --release
 cp target/release/rp-storage-tool /usr/local/bin
 popd

--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -155,10 +155,11 @@ class ABSClient:
 
     def list_objects(self,
                      bucket: str,
-                     topic: Optional[str] = None) -> Iterator[ObjectMetadata]:
+                     topic: Optional[str] = None,
+                     prefix: Optional[str] = None) -> Iterator[ObjectMetadata]:
         container_client = ContainerClient.from_connection_string(
             self.conn_str, container_name=bucket)
-        for blob_props in container_client.list_blobs():
+        for blob_props in container_client.list_blobs(name_starts_with=prefix):
             if topic is not None and key_to_topic(blob_props.name) != topic:
                 self.logger.debug(f"Skip {blob_props.name} for {topic}")
                 continue

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -417,6 +417,18 @@ class Admin:
     def get_features(self, node=None):
         return self._request("GET", "features", node=node).json()
 
+    def get_cloud_storage_lifecycle_markers(self, node=None):
+        return self._request("GET", "cloud_storage/lifecycle",
+                             node=node).json()
+
+    def delete_cloud_storage_lifecycle_marker(self,
+                                              topic,
+                                              revision,
+                                              node=None):
+        return self._request("DELETE",
+                             f"cloud_storage/lifecycle/{topic}/{revision}",
+                             node=node)
+
     def supports_feature(self, feature_name: str, nodes=None):
         """
         Returns true whether all nodes in 'nodes' support the given feature. If

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3585,7 +3585,7 @@ class RedpandaService(RedpandaServiceBase):
         bucket = self.si_settings.cloud_storage_bucket
         environment = ' '.join(f'{k}=\"{v}\"' for k, v in vars.items())
         output = node.account.ssh_output(
-            f"{environment} rp-storage-tool --backend {backend} scan --source {bucket}",
+            f"{environment} rp-storage-tool --backend {backend} scan-metadata --source {bucket}",
             combine_stderr=False,
             allow_fail=True,
             timeout_sec=30)
@@ -3595,6 +3595,8 @@ class RedpandaService(RedpandaServiceBase):
         except:
             self.logger.error(f"Error running bucket scrub: {output}")
             raise
+        else:
+            self.logger.info(json.dumps(report, indent=2))
 
         # Example of a report:
         # {"malformed_manifests":[],
@@ -3617,10 +3619,10 @@ class RedpandaService(RedpandaServiceBase):
         permitted_anomalies = {"segments_outside_manifest"}
 
         # Whether any anomalies were found
-        any_anomalies = any(len(v) for v in report.values())
+        any_anomalies = any(len(v) for v in report['anomalies'].values())
 
         # List of fatal anomalies found
-        fatal_anomalies = set(k for k, v in report.items()
+        fatal_anomalies = set(k for k, v in report['anomalies'].items()
                               if len(v) and k not in permitted_anomalies)
 
         if not any_anomalies:


### PR DESCRIPTION
This is worth landing in 23.2 ahead of more general scrubbing functionality, because it disambiguates situations where we see partial content for a topic, and can't tell if the system is damaged, or if it just did an incomplete deletion.

- [X] Extend Bucketview to understand the markers
- [X] Extend deletion tests to assert that the markers are present

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none