### PR TITLE
add missing includes

### DIFF
--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -18,6 +18,7 @@
 #include <seastar/core/smp.hh>
 
 #include <absl/container/btree_map.h>
+#include <absl/container/btree_set.h>
 
 #include <exception>
 #include <variant>

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -46,6 +46,7 @@
 #include <charconv>
 #include <iterator>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <stdexcept>
 #include <tuple>

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -18,6 +18,7 @@
 #include "segment_meta_cstore.h"
 #include "serde/envelope.h"
 #include "serde/serde.h"
+#include "utils/fragmented_vector.h"
 #include "utils/tracking_allocator.h"
 
 #include <seastar/core/iostream.hh>

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -20,6 +20,8 @@
 
 #include <seastar/util/log.hh>
 
+#include <absl/container/btree_map.h>
+
 #include <variant>
 
 namespace cloud_storage {

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -20,6 +20,8 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/http/httpd.hh>
 
+#include <absl/container/flat_hash_set.h>
+
 #include <chrono>
 #include <exception>
 #include <map>

--- a/src/v/cloud_storage/tx_range_manifest.h
+++ b/src/v/cloud_storage/tx_range_manifest.h
@@ -15,6 +15,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
+#include "utils/fragmented_vector.h"
 
 #include <rapidjson/document.h>
 

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -17,6 +17,8 @@
 
 #include <seastar/core/future.hh>
 
+#include <absl/container/flat_hash_map.h>
+
 #include <optional>
 #include <vector>
 

--- a/src/v/cluster/partition_balancer_state.h
+++ b/src/v/cluster/partition_balancer_state.h
@@ -16,6 +16,8 @@
 
 #include <seastar/core/sharded.hh>
 
+#include <absl/container/btree_set.h>
+
 namespace cluster {
 
 /// Class that stores state that is needed for functioning of the partition

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -36,6 +36,7 @@
 #include <absl/container/btree_map.h>
 #include <absl/container/btree_set.h>
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 #include <system_error>
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -36,6 +36,8 @@
 #include <seastar/core/sstring.hh>
 
 #include <absl/container/btree_set.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 #include <absl/hash/hash.h>
 #include <fmt/format.h>
 

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -16,6 +16,7 @@
 #include "json/writer.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
+#include "utils/fragmented_vector.h"
 #include "utils/named_type.h"
 
 #include <seastar/net/inet_address.hh>

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -19,6 +19,8 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
+#include <numeric>
+
 using namespace std::chrono_literals;
 
 namespace kafka {

--- a/src/v/model/ktp.h
+++ b/src/v/model/ktp.h
@@ -18,6 +18,9 @@
 
 #include <seastar/core/sstring.hh>
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
+
 #include <concepts>
 #include <functional>
 #include <string_view>

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -19,6 +19,7 @@
 #include "seastarx.h"
 #include "ssx/semaphore.h"
 #include "utils/hdr_hist.h"
+#include "vassert.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -23,6 +23,10 @@
 #include <seastar/net/inet_address.hh>
 #include <seastar/testing/thread_test_case.hh>
 
+#include <absl/container/btree_set.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
 #include <boost/functional/hash.hpp>
 #include <boost/test/unit_test.hpp>
 

--- a/src/v/storage/file_sanitizer_types.h
+++ b/src/v/storage/file_sanitizer_types.h
@@ -15,6 +15,8 @@
 #include "model/fundamental.h"
 #include "model/record_batch_types.h"
 
+#include <absl/container/flat_hash_map.h>
+
 #include <optional>
 #include <string_view>
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -20,6 +20,7 @@
 #include "storage/file_sanitizer_types.h"
 #include "storage/fwd.h"
 #include "tristate.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/file.hh> //io_priority

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -22,6 +22,7 @@
 #include <seastar/net/ip.hh>
 
 #include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
 #include <bits/stdint-uintn.h>
 
 #include <iterator>

--- a/src/v/utils/tests/uuid_test.cc
+++ b/src/v/utils/tests/uuid_test.cc
@@ -13,6 +13,7 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
+#include <absl/container/flat_hash_map.h>
 #include <boost/test/unit_test.hpp>
 
 using test_uuid = named_type<uuid_t, struct test_uuid_tag>;


### PR DESCRIPTION
Serde update to `tag_invoke` #9132 lead to several missing includes because `serde.h` does not include data structures. Serde not including all concrete data structures (such as `absl::*`) is desired but reveals missing includes in the codebase. This PR adds those missing includes.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none