### PR TITLE
Assert CPU <50% at the end of ducktape tests

### DIFF
--- a/tests/rptest/k8s_tests/simple_k8s_test.py
+++ b/tests/rptest/k8s_tests/simple_k8s_test.py
@@ -6,6 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import os
 
 from ducktape.tests.test import Test
 from rptest.services.cluster import cluster
@@ -19,6 +20,15 @@ class SimpleK8sTest(Test):
         """
         super(SimpleK8sTest, self).__init__(test_context)
         self.redpanda = RedpandaServiceK8s(test_context, 1)
+
+    @property
+    def debug_mode(self):
+        """
+        Useful for tests that want to change behaviour when running on
+        the much slower debug builds of redpanda, which generally cannot
+        keep up with significant quantities of data or partition counts.
+        """
+        return os.environ.get('BUILD_TYPE', None) == 'debug'
 
     @cluster(num_nodes=1, check_allowed_error_logs=False)
     def test_k8s(self):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -65,6 +65,8 @@ Partition = collections.namedtuple('Partition',
 MetricSample = collections.namedtuple(
     'MetricSample', ['family', 'sample', 'node', 'value', 'labels'])
 
+CpuMetric = collections.namedtuple('CpuMetric', ['shard_samples', 'timestamp'])
+
 SaslCredentials = collections.namedtuple("SaslCredentials",
                                          ["username", "password", "algorithm"])
 # Map of path -> (checksum, size)
@@ -876,7 +878,7 @@ class RedpandaServiceBase(Service):
                             == MetricsEndpoint.METRICS else "/public_metrics")
         url = f"http://{node.account.hostname}:9644{metrics_endpoint}"
         resp = requests.get(url, timeout=10)
-        assert resp.status_code == 200
+        assert resp.status_code == 200, f"Expected successful HTTP response: {resp.status_code}"
         return text_string_to_metric_families(resp.text)
 
     def metric_sum(self,
@@ -983,8 +985,6 @@ class RedpandaServiceBase(Service):
     def _for_nodes(self, nodes, cb: callable, *, parallel: bool) -> list:
         if not parallel:
             # Trivial case: just loop and call
-            for n in nodes:
-                cb(n)
             return list(map(cb, nodes))
 
         n_workers = len(nodes)
@@ -1950,21 +1950,24 @@ class RedpandaService(RedpandaServiceBase):
 
         node.account.ssh(cmd)
 
+    def _check_node(self, node):
+        pid = self.redpanda_pid(node)
+        if not pid:
+            self.logger.warn(f"No redpanda PIDs found on {node.name}")
+            return False
+
+        if not node.account.exists(f"/proc/{pid}"):
+            self.logger.warn(f"PID {pid} (node {node.name}) dead")
+            return False
+
+        # fall through
+        return True
+
     def all_up(self):
-        def check_node(node):
-            pid = self.redpanda_pid(node)
-            if not pid:
-                self.logger.warn(f"No redpanda PIDs found on {node.name}")
-                return False
-
-            if not node.account.exists(f"/proc/{pid}"):
-                self.logger.warn(f"PID {pid} (node {node.name}) dead")
-                return False
-
-            # fall through
-            return True
-
-        return all(self._for_nodes(self._started, check_node, parallel=True))
+        return all(
+            self._for_nodes(self._started,
+                            lambda n: self._check_node(n),
+                            parallel=True))
 
     def wait_until(self, fn, timeout_sec, backoff_sec, err_msg=None):
         """
@@ -3712,6 +3715,70 @@ class RedpandaService(RedpandaServiceBase):
             return sum(s.value for s in samples.samples)
         else:
             return None
+
+    def assert_cpu_not_busy(self):
+        try:
+            self._assert_cluster_cpu_utilization_over_period(
+                period_seconds=1, max_utilization=0.50)
+        except AssertionError as e:
+            # Fallback to a larger window if something like compaction was running.
+            self.logger.warn(
+                f">50% CPU utilization over 1 second window, falling back to a 5 second sample: {e}"
+            )
+            self._assert_cluster_cpu_utilization_over_period(
+                period_seconds=5, max_utilization=0.50)
+
+    def _assert_cluster_cpu_utilization_over_period(self, period_seconds: int,
+                                                    max_utilization: float):
+        # Ignore any nodes that were killed during a test run
+        nodes = [n for n in self.started_nodes() if self._check_node(n)]
+        initial_node_samples = self._for_nodes(
+            nodes, lambda n: self._cpu_busy_seconds_sample(n), parallel=True)
+        time.sleep(period_seconds)
+        node_samples = self._for_nodes(
+            nodes, lambda n: self._cpu_busy_seconds_sample(n), parallel=True)
+        for (start, end, node) in zip(initial_node_samples,
+                                      node_samples,
+                                      nodes,
+                                      strict=True):
+            for (start_sample, end_sample) in zip(start.shard_samples,
+                                                  end.shard_samples,
+                                                  strict=True):
+                self._assert_cpu_utilization(node,
+                                             start_sample,
+                                             start.timestamp.value,
+                                             end_sample,
+                                             end.timestamp.value,
+                                             max_utilization=max_utilization)
+
+    def _assert_cpu_utilization(self, node, start_sample, start_time,
+                                end_sample, end_time, max_utilization: float):
+        actual_period = end_time - start_time
+        actual_utilization = (end_sample.value -
+                              start_sample.value) / actual_period
+        shard_id = start_sample.labels["shard"]
+        assert actual_utilization < max_utilization, f"Node: {node.name} shard: {shard_id} cpu utilization too high, actual: {actual_utilization}, expected: {max_utilization}"
+
+    def _cpu_busy_seconds_sample(self, n) -> CpuMetric:
+        """
+        Extract all the cpu utilization for a node, sorted by shard.
+
+        Also includes a timestamp of the process' uptime as a way to 
+        accurately diff two samples.
+        """
+        all_metrics = self.metrics(
+            n, metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        cpu_busy_seconds_metrics = []
+        process_uptime = None
+        for metric in all_metrics:
+            if metric.name == "redpanda_cpu_busy_seconds_total":
+                cpu_busy_seconds_metrics = sorted(
+                    metric.samples, key=lambda s: s.labels["shard"])
+            elif metric.name == "redpanda_application_uptime_seconds_total":
+                process_uptime = metric
+
+        assert cpu_busy_seconds_metrics and process_uptime, "Unable to find metric 'redpanda_cpu_busy_seconds_total' and 'redpanda_application_uptime_seconds_total'"
+        return CpuMetric(cpu_busy_seconds_metrics, process_uptime.samples[0])
 
 
 def make_redpanda_service(context, num_brokers, **kwargs):

--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -33,7 +33,10 @@ class AvailabilityTests(EndToEndFinjectorTest):
                             producer_timeout_sec=producer_timeout_sec,
                             consumer_timeout_sec=consumer_timeout_sec)
 
-    @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    # Don't check CPU metrics if a node is down
+    @cluster(num_nodes=5,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     def test_availability_when_one_node_failed(self):
         self.redpanda = make_redpanda_service(
             self.test_context,
@@ -63,7 +66,9 @@ class AvailabilityTests(EndToEndFinjectorTest):
 
         self.validate_records()
 
-    @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=5,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     def test_recovery_after_catastrophic_failure(self):
 
         self.redpanda = make_redpanda_service(

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -528,7 +528,8 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # Should not succeed!
                 assert False
 
-    @cluster(num_nodes=3)
+    # Disable cpu check because this test disables metrics, which that check needs
+    @cluster(num_nodes=3, check_cpu_idle=False)
     def test_valid_settings(self):
         """
         Bulk exercise of all config settings & the schema endpoint:

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -225,7 +225,7 @@ class ClusterMetricsTest(RedpandaTest):
              lambda a, b: a == b == 0)
         ])
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, check_cpu_idle=False)
     def cluster_metrics_disabled_by_config_test(self):
         """
         Test that the cluster level metrics have the expected values

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -351,7 +351,9 @@ class PartitionBalancerTest(PartitionBalancerService):
                             consumer_timeout_sec=CONSUMER_TIMEOUT)
 
     @skip_debug_mode
-    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=7,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     def test_unavailable_nodes(self):
         self.start_redpanda(num_nodes=5)
 
@@ -402,7 +404,9 @@ class PartitionBalancerTest(PartitionBalancerService):
         wait_for_recovery_throttle_rate(self.redpanda, new_value)
 
     @skip_debug_mode
-    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=6,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     def test_movement_cancellations(self):
         self.start_redpanda(num_nodes=4)
 
@@ -458,7 +462,9 @@ class PartitionBalancerTest(PartitionBalancerService):
             ), f"bad rack placement {racks} for partition id: {p.id} (replicas: {p.replicas})"
 
     @skip_debug_mode
-    @cluster(num_nodes=8, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=8,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     def test_rack_awareness(self):
         extra_rp_conf = self._extra_rp_conf | {"enable_rack_awareness": True}
         self.redpanda = make_redpanda_service(self.test_context,
@@ -565,7 +571,8 @@ class PartitionBalancerTest(PartitionBalancerService):
     @skip_debug_mode
     @cluster(num_nodes=7,
              log_allow_list=CHAOS_LOG_ALLOW_LIST +
-             RACE_BETWEEN_DELETION_AND_ADDING_PARTITION)
+             RACE_BETWEEN_DELETION_AND_ADDING_PARTITION,
+             check_cpu_idle=False)
     def test_fuzz_admin_ops(self):
         self.start_redpanda(num_nodes=5)
 
@@ -740,7 +747,9 @@ class PartitionBalancerTest(PartitionBalancerService):
             assert used_ratio < 0.81
 
     @skip_debug_mode
-    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=7,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     @matrix(kill_same_node=[True, False])
     def test_maintenance_mode(self, kill_same_node):
         """
@@ -821,7 +830,8 @@ class PartitionBalancerTest(PartitionBalancerService):
 
     @skip_debug_mode
     @cluster(num_nodes=7,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST + STARTUP_SEQUENCE_ABORTED)
+             log_allow_list=CHAOS_LOG_ALLOW_LIST + STARTUP_SEQUENCE_ABORTED,
+             check_cpu_idle=False)
     @matrix(kill_same_node=[True, False], decommission_first=[True, False])
     def test_decommission(self, kill_same_node, decommission_first):
         """
@@ -938,7 +948,9 @@ class PartitionBalancerTest(PartitionBalancerService):
                             consumer_timeout_sec=CONSUMER_TIMEOUT)
 
     @skip_debug_mode
-    @cluster(num_nodes=4, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=4,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     def test_transfer_controller_leadership(self):
         """
         Test that unavailability timeout is correctly restarted after controller

--- a/tests/rptest/tests/redpanda_binary_test.py
+++ b/tests/rptest/tests/redpanda_binary_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import re
+import os
 
 from ducktape.tests.test import Test
 from rptest.services.cluster import cluster
@@ -23,7 +24,16 @@ class RedpandaBinaryTest(Test):
         super(RedpandaBinaryTest, self).__init__(test_context=test_context)
         self.redpanda = make_redpanda_service(self.test_context, 1)
 
-    @cluster(num_nodes=1, check_allowed_error_logs=False)
+    @property
+    def debug_mode(self):
+        """
+        Useful for tests that want to change behaviour when running on
+        the much slower debug builds of redpanda, which generally cannot
+        keep up with significant quantities of data or partition counts.
+        """
+        return os.environ.get('BUILD_TYPE', None) == 'debug'
+
+    @cluster(num_nodes=1, check_allowed_error_logs=False, check_cpu_idle=False)
     def test_version(self):
         version_cmd = f"{self.redpanda.find_binary('redpanda')} --version"
         version_lines = [

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -72,6 +72,15 @@ class RedpandaKerberosTestBase(Test):
 
         self.client = KrbClient(test_context, self.kdc, self.redpanda)
 
+    @property
+    def debug_mode(self):
+        """
+        Useful for tests that want to change behaviour when running on
+        the much slower debug builds of redpanda, which generally cannot
+        keep up with significant quantities of data or partition counts.
+        """
+        return os.environ.get('BUILD_TYPE', None) == 'debug'
+
     def setUp(self):
         self.redpanda.logger.info("Starting KDC")
         self.kdc.start()

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -6,6 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import os
 
 from ducktape.mark import matrix
 from ducktape.tests.test import Test
@@ -245,6 +246,15 @@ class SimpleSelfTest(Test):
     def __init__(self, test_context):
         super(SimpleSelfTest, self).__init__(test_context)
         self.redpanda = make_redpanda_service(test_context, 3)
+
+    @property
+    def debug_mode(self):
+        """
+        Useful for tests that want to change behaviour when running on
+        the much slower debug builds of redpanda, which generally cannot
+        keep up with significant quantities of data or partition counts.
+        """
+        return os.environ.get('BUILD_TYPE', None) == 'debug'
 
     def setUp(self):
         self.redpanda.start()

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -885,7 +885,10 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
 
         self.check_consume(2)
 
-    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    # Don't check CPU idle as that uses public metrics that aren't available on v22
+    @cluster(num_nodes=3,
+             log_allow_list=RESTART_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     def upgrade_coordinator_test(self):
         def get_tx_coordinator():
             admin = Admin(self.redpanda)
@@ -896,7 +899,10 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
 
         self.do_upgrade_with_tx(get_tx_coordinator)
 
-    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    # Don't check CPU idle as that uses public metrics that aren't available on v22
+    @cluster(num_nodes=3,
+             log_allow_list=RESTART_LOG_ALLOW_LIST,
+             check_cpu_idle=False)
     def upgrade_topic_test(self):
         topic_name = self.topics[0].name
 


### PR DESCRIPTION
Assert that nodes have <50% CPU usage before teardown

In ducktape during test teardown, poll metrics to assert that we don't have a bunch of work that isn't being cleaned up properly.

We poll over a 1 second interval, then fallback to a 5 second interval in the case of compaction happening in the background.

These checks are disabled for now on a few tests that do not shutdown cleanly nodes, as the metrics requests fail. There should be followup work to enable the checks on those tests.

Fixes: #10837

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
