### PR TITLE
redpanda: add debug bundle class

### DIFF
--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -44,6 +44,7 @@ v_cc_library(
     cli_parser.cc
     application.cc
     monitor_unsafe_log_flag.cc
+    debug_bundle.cc
   DEPS
     Seastar::seastar
     v::cluster

--- a/src/v/redpanda/debug_bundle.cc
+++ b/src/v/redpanda/debug_bundle.cc
@@ -1,0 +1,499 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "redpanda/debug_bundle.h"
+
+#include "ssx/future-util.h"
+#include "vlog.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/log.hh>
+#include <seastar/util/process.hh>
+
+#include <fmt/format.h>
+
+#include <filesystem>
+#include <optional>
+#include <stdexcept>
+#include <system_error>
+
+using namespace std::chrono_literals;
+
+static ss::logger bundle_log{"debug_bundle"};
+
+static constexpr auto rpk_abort_sleep_ms = 10ms;
+
+namespace debug_bundle {
+
+ss::sstring make_bundle_filename(
+  const std::filesystem::path write_dir, const ss::sstring filename) {
+    auto bundle_name = write_dir / std::string{filename};
+    return bundle_name.string();
+}
+
+errc make_rpk_err_value(std::error_code err) { return errc(err.value()); }
+
+ss::sstring to_journalctl_fmt(std::chrono::year_month_day ymd) {
+    return fmt::format(
+      "{}-{}-{}",
+      static_cast<int>(ymd.year()),
+      static_cast<unsigned>(ymd.month()),
+      static_cast<unsigned>(ymd.day()));
+}
+
+ss::sstring to_time_fmt(metric_interval_t metric) {
+    if (metric.units == "ns") {
+        return fmt::format(
+          "{}ns", std::chrono::nanoseconds{metric.interval_ms}.count());
+    } else if (metric.units == "us") {
+        return fmt::format(
+          "{}us", std::chrono::microseconds{metric.interval_ms}.count());
+    } else if (metric.units == "ms") {
+        return fmt::format("{}ms", metric.interval_ms.count());
+    } else if (metric.units == "s") {
+        return fmt::format(
+          "{}s",
+          std::chrono::duration_cast<std::chrono::seconds>(metric.interval_ms)
+            .count());
+    } else if (metric.units == "m") {
+        return fmt::format(
+          "{}m",
+          std::chrono::duration_cast<std::chrono::minutes>(metric.interval_ms)
+            .count());
+    } else if (metric.units == "h") {
+        return fmt::format(
+          "{}h",
+          std::chrono::duration_cast<std::chrono::hours>(metric.interval_ms)
+            .count());
+    } else if (metric.units == "d") {
+        return fmt::format(
+          "{}d",
+          std::chrono::duration_cast<std::chrono::days>(metric.interval_ms)
+            .count());
+    } else if (metric.units == "w") {
+        return fmt::format(
+          "{}w",
+          std::chrono::duration_cast<std::chrono::weeks>(metric.interval_ms)
+            .count());
+    } else if (metric.units == "y") {
+        return fmt::format(
+          "{}y",
+          std::chrono::duration_cast<std::chrono::years>(metric.interval_ms)
+            .count());
+    } else {
+        vlog(
+          bundle_log.warn,
+          "Unknown units {} for metrics-interval, defaulting to ms");
+        return fmt::format("{}ms", metric.interval_ms.count());
+    }
+}
+
+rpk_debug_bundle::rpk_debug_bundle()
+  : process{nullptr}
+  , control{ss::make_ready_future<>()}
+  , creds{std::nullopt} {}
+
+rpk_debug_bundle::rpk_debug_bundle(
+  ss::sstring host_path,
+  ss::sstring host_home,
+  const std::filesystem::path write_dir,
+  const std::filesystem::path rpk_path,
+  const debug_bundle_params params,
+  std::optional<debug_bundle_credentials> creds)
+  : process{nullptr}
+  , control{ss::make_ready_future<>()}
+  , host_path{host_path}
+  , host_home{host_home}
+  , write_dir{write_dir}
+  , rpk_path{rpk_path}
+  , params{std::move(params)}
+  , creds{std::move(creds)} {}
+
+std::vector<ss::sstring> rpk_debug_bundle::make_rpk_args() {
+    auto bundle_name = make_bundle_filename(
+      write_dir, ss::sstring{default_bundle_name});
+    std::vector<ss::sstring> rpk_argv{
+      rpk_path.string(), "debug", "bundle", "--output", bundle_name};
+
+    if (creds.has_value()) {
+        rpk_argv.push_back("--user");
+        rpk_argv.push_back(creds->username);
+        rpk_argv.push_back("--password");
+        rpk_argv.push_back(creds->password);
+        rpk_argv.push_back("--sasl-mechanism");
+        rpk_argv.push_back(creds->mechanism);
+    }
+
+    if (params.logs_since.has_value()) {
+        rpk_argv.push_back("--logs-since");
+        rpk_argv.push_back(to_journalctl_fmt(params.logs_since.value()));
+    }
+
+    if (params.logs_until.has_value()) {
+        rpk_argv.push_back("--logs-until");
+        rpk_argv.push_back(to_journalctl_fmt(params.logs_until.value()));
+    }
+
+    if (params.logs_size_limit.has_value()) {
+        rpk_argv.push_back("--logs-size-limit");
+        rpk_argv.push_back(params.logs_size_limit.value());
+    }
+
+    if (params.metrics_interval.has_value()) {
+        rpk_argv.push_back("--metrics-interval");
+        rpk_argv.push_back(to_time_fmt(params.metrics_interval.value()));
+    }
+
+    return rpk_argv;
+}
+
+template<class>
+inline constexpr bool always_false_v = false;
+
+errc rpk_debug_bundle::handle_wait_status(
+  ss::experimental::process::wait_status wstatus) {
+    return ss::visit(
+      wstatus,
+      [](ss::experimental::process::wait_exited exit_status) {
+          if (exit_status.exit_code != 0) {
+              vlog(
+                bundle_log.error,
+                "Bundle creation exited with code {}",
+                exit_status.exit_code);
+              return errc::process_fail;
+          } else {
+              vlog(
+                bundle_log.debug,
+                "Bundle creation successful, debug bundle {}",
+                default_bundle_name);
+              return errc::success;
+          }
+      },
+      [](ss::experimental::process::wait_signaled exit_signal) {
+          vlog(
+            bundle_log.error,
+            "Bundle creation terminated with signal {}",
+            exit_signal.terminating_signal);
+          return errc::process_fail;
+      });
+}
+
+ss::future<>
+consume_input_stream(ss::input_stream<char> stream, bool is_stdout) {
+    ss::sstring stream_name{is_stdout ? "stdout" : "stderr"};
+
+    while (!stream.eof()) {
+        auto buf = co_await stream.read();
+        if (buf.empty()) {
+            continue;
+        }
+
+        std::string str_buf{buf.begin(), buf.end()}, line;
+        std::stringstream ss(str_buf);
+        while (!ss.eof()) {
+            std::getline(ss, line);
+            vlog(bundle_log.trace, "{} line {}", stream_name, line);
+        }
+    }
+}
+
+ss::future<> rpk_debug_bundle::handle_process() {
+    if (process == nullptr) {
+        vlog(
+          bundle_log.error,
+          "Failed to run rpk debug bunde: process is undefined");
+        co_return;
+    }
+
+    co_await consume_input_stream(process->stdout(), true);
+    auto wstatus = co_await process->wait();
+    auto err = handle_wait_status(wstatus);
+    if (err != errc::success) {
+        co_await consume_input_stream(process->stderr(), false);
+    }
+    // A null process indicates that the fork is not running
+    process = nullptr;
+}
+
+ss::future<> rpk_debug_bundle::start_process() {
+    auto units = co_await process_mu.get_units();
+    auto rpk_argv = make_rpk_args();
+    try {
+        auto p = co_await ss::experimental::spawn_process(
+          rpk_path, {.argv = rpk_argv, .env = {host_path, host_home}});
+        process = std::make_unique<ss::experimental::process>(std::move(p));
+    } catch (const std::system_error& ec) {
+        vlog(
+          bundle_log.error,
+          "Process spawn failed: {} - {}",
+          ec.code(),
+          ec.what());
+        co_return;
+    }
+
+    control = handle_process();
+}
+
+ss::future<std::error_code> rpk_debug_bundle::do_remove(ss::sstring filename) {
+    auto units = co_await process_mu.get_units();
+    co_await ss::remove_file(make_bundle_filename(write_dir, filename));
+    co_await ss::sync_directory(write_dir.c_str());
+    co_return errc::success;
+}
+
+errc rpk_debug_bundle::do_abort(bool use_sigkill) {
+    try {
+        if (use_sigkill) {
+            process->kill();
+        } else {
+            process->terminate();
+        }
+    } catch (const std::system_error& ec) {
+        // A system error is thrown when SIGTERM/SIGKILL are called on an
+        // already dead process, handle that case here.
+        vlog(
+          bundle_log.trace,
+          "{} failed, process already dead: ec {}",
+          use_sigkill ? "SIGKILL" : "SIGTERM",
+          ec);
+        return errc::nothing_running;
+    }
+    return errc::success;
+}
+
+debug_bundle::debug_bundle(
+  const std::filesystem::path write_dir, const std::filesystem::path rpk_path)
+  : _write_dir{write_dir}
+  , _rpk_cmd{rpk_path}
+  , _rpk{nullptr} {}
+
+ss::sstring debug_bundle::get_host_path_env() {
+    auto host_env = std::getenv("PATH");
+    if (!host_env) {
+        vlog(
+          bundle_log.warn,
+          "Failed to get 'PATH' environmental variable, the debug bundle may "
+          "be incomplete due to missing dependencies");
+        return "PATH=/usr/bin:/usr/local/bin";
+    } else {
+        return fmt::format("PATH={}", host_env);
+    }
+}
+
+ss::sstring debug_bundle::get_home_dir_env() {
+    auto home_dir = std::getenv("HOME");
+    if (!home_dir) {
+        vlog(
+          bundle_log.warn,
+          "Failed to get 'HOME' environmental variable, the debug bundle may "
+          "fail to run");
+        return "";
+    } else {
+        return fmt::format("HOME={}", home_dir);
+    }
+}
+
+ss::future<> debug_bundle::start() {
+    vlog(bundle_log.info, "Starting debug bundle ...");
+    _host_path = get_host_path_env();
+    _host_home = get_home_dir_env();
+    co_return;
+}
+
+ss::future<> debug_bundle::stop() {
+    vlog(bundle_log.info, "Stopping debug bundle ...");
+    auto core0_running = co_await is_core0_running();
+    if (core0_running) {
+        co_await container().invoke_on(
+          debug_bundle_shard_id,
+          [](debug_bundle& b) { return b.do_abort(true); });
+    }
+
+    co_await _rpk_gate.close();
+}
+
+ss::future<bool> debug_bundle::is_rpk_running() {
+    co_return (_rpk != nullptr && _rpk->process != nullptr);
+}
+
+ss::future<bool> debug_bundle::is_core0_running() {
+    co_return co_await container().invoke_on(
+      debug_bundle_shard_id,
+      [](debug_bundle& b) { return b.is_rpk_running(); });
+}
+
+ss::future<std::error_code> debug_bundle::start_creating_bundle(
+  const debug_bundle_params params,
+  std::optional<debug_bundle_credentials> creds) {
+    gate_guard guard{_rpk_gate};
+    auto units = co_await _rpk_mu.get_units();
+
+    auto core0_running = co_await is_core0_running();
+    if (core0_running) {
+        co_return errc::already_running;
+    }
+
+    co_await container().invoke_on(
+      debug_bundle_shard_id,
+      [this, params{std::move(params)}, creds{std::move(creds)}](
+        debug_bundle& b) mutable {
+          _rpk.reset(new rpk_debug_bundle{
+            b._host_path,
+            b._host_home,
+            b.get_write_dir(),
+            b._rpk_cmd,
+            std::move(params),
+            std::move(creds)});
+          ssx::spawn_with_gate(
+            _rpk_gate, [this] { return _rpk->start_process(); });
+      });
+
+    co_return errc::success;
+}
+
+ss::future<std::error_code> debug_bundle::is_ready(ss::sstring filename) {
+    // First check if the requested filename is actually a bundle
+    // TODO(@NyaliaLui): In the future when we support more than 1 bundle on
+    // disk, this condition will evolve to check if the filename follows our
+    // naming scheme.
+    if (filename != default_bundle_name) {
+        co_return errc::invalid_filename;
+    }
+
+    // Then check if the requested filename is on disk
+    auto exists = co_await ss::file_exists(
+      make_bundle_filename(get_write_dir(), filename));
+    auto core0_running = co_await is_core0_running();
+    if (!exists) {
+        if (core0_running) {
+            co_return errc::bundle_not_ready;
+        } else {
+            co_return errc::bundle_not_on_disk;
+        }
+    } else {
+        // It is possible for the status check to occur in a small window where
+        // the spawned process is still running but RPK has written to disk
+        // already.
+        if (core0_running) {
+            co_return errc::bundle_not_ready;
+        }
+    }
+
+    co_return errc::success;
+}
+
+ss::future<std::error_code> debug_bundle::remove_bundle(ss::sstring filename) {
+    gate_guard guard{_rpk_gate};
+    auto units = co_await _rpk_mu.get_units();
+
+    auto err = co_await is_ready(filename);
+    if (make_rpk_err_value(err) != errc::success) {
+        co_return err;
+    }
+
+    co_return co_await container().invoke_on(
+      debug_bundle_shard_id, [&filename](debug_bundle& b) {
+          // rpk.do_remove will acquire the mutex that protects spawned
+          // processes. This is to protect against situations where a new
+          // process is spawned before remove is called.
+          return b._rpk->do_remove(filename);
+      });
+}
+
+ss::future<std::error_code> debug_bundle::do_abort(bool use_sigkill) {
+    if (_rpk == nullptr || _rpk->process == nullptr) {
+        co_return errc::nothing_running;
+    }
+
+    co_return _rpk->do_abort(use_sigkill);
+}
+
+ss::future<std::error_code> force_stop(debug_bundle& b) {
+    // If process is running
+    // do SIGTERM
+    // WAIT
+    // If process is still running (process is stopped at the end of
+    // rpk_debug_bundle::handle_process()) otherwise, do SIGKILL
+
+    auto rpk_running = co_await b.is_rpk_running();
+    if (!rpk_running) {
+        // First check returns nothing_running because the abort is unecessary
+        co_return errc::nothing_running;
+    }
+
+    co_await b.do_abort(false);
+
+    co_await ss::sleep(rpk_abort_sleep_ms);
+
+    rpk_running = co_await b.is_rpk_running();
+    if (!rpk_running) {
+        // Second check returns success because the abort worked
+        co_return errc::success;
+    }
+
+    co_await b.do_abort(true);
+
+    // Do not reset _rpk here, only debug_bundle::start_creating_bundle() can do
+    // that
+    // TODO(@NyaliaLui): make a Singleton class for _rpk with
+    // start_creating_bundle() as the only friend
+    co_return errc::success;
+}
+
+ss::future<std::error_code> maybe_remove_aborted_bundle(debug_bundle& b) {
+    auto units = co_await b._rpk_mu.get_units();
+
+    auto rpk_running = co_await b.is_rpk_running();
+    if (rpk_running) {
+        co_return errc::nothing_running;
+    }
+
+    auto bundle_name = make_bundle_filename(
+      b.get_write_dir(), ss::sstring{default_bundle_name});
+    bool exists = co_await ss::file_exists(bundle_name);
+
+    if (exists) {
+        vlog(
+          bundle_log.debug, "Removing aborted bundle {}", default_bundle_name);
+        // rpk_debug_bundle::do_remove() will acquire the mutex that protects
+        // spawned processes.
+        co_return co_await b._rpk->do_remove(bundle_name);
+    }
+
+    co_return errc::success;
+}
+
+ss::future<std::error_code> debug_bundle::abort_bundle() {
+    gate_guard guard{_rpk_gate};
+
+    auto core0_running = co_await is_core0_running();
+    if (!core0_running) {
+        co_return errc::nothing_running;
+    }
+
+    auto err = co_await container().invoke_on(
+      debug_bundle_shard_id, [](debug_bundle& b) { return force_stop(b); });
+
+    if (make_rpk_err_value(err) != errc::success) {
+        co_return err;
+    }
+
+    // Remove the bundle after abort is successful.
+    co_return co_await container().invoke_on(
+      debug_bundle_shard_id, [](debug_bundle& b) {
+          // maybe_remove_aborted_bundle will acquire the rpk mutex
+          return maybe_remove_aborted_bundle(b);
+      });
+}
+
+} // namespace debug_bundle

--- a/src/v/redpanda/debug_bundle.h
+++ b/src/v/redpanda/debug_bundle.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "utils/gate_guard.h"
+#include "utils/mutex.h"
+#include "utils/request_auth.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/process.hh>
+
+#include <chrono>
+#include <concepts>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <vector>
+
+namespace debug_bundle {
+
+enum class errc : int16_t {
+    success = 0, // must be 0
+    already_running,
+    nothing_running,
+    bundle_not_ready,
+    bundle_not_on_disk,
+    invalid_filename,
+    process_fail,
+};
+
+struct errc_category final : public std::error_category {
+    const char* name() const noexcept final { return "debug_bundle::errc"; }
+
+    std::string message(int c) const final {
+        switch (static_cast<errc>(c)) {
+        case errc::success:
+            return "Success";
+        case errc::already_running:
+            return "Bundle creation is already running";
+        case errc::nothing_running:
+            return "Bundle creation is not running";
+        case errc::bundle_not_ready:
+            return "Bundle creation is running but the file is not yet ready";
+        case errc::bundle_not_on_disk:
+            return "Bundle creation is not running or the file is not on disk";
+        case errc::invalid_filename:
+            return "Filename does not refer to a debug bundle";
+        case errc::process_fail:
+            return "Spawned process failed to run";
+        }
+        return "debug_bundle::errc::unknown";
+    }
+};
+inline const std::error_category& error_category() noexcept {
+    static errc_category e;
+    return e;
+}
+inline std::error_code make_error_code(errc e) noexcept {
+    return std::error_code(static_cast<int>(e), error_category());
+}
+
+static constexpr ss::shard_id debug_bundle_shard_id = 0;
+
+// metric_t represents the type for metrics_interval flag to rpk. That flag
+// could have any time units such as ms or h. Therefore, this struct is meant to
+// capture and represent any time unit.
+struct metric_interval_t {
+    std::chrono::milliseconds interval_ms;
+    ss::sstring units;
+
+    metric_interval_t(std::chrono::milliseconds interval, ss::sstring u)
+      : interval_ms{interval}
+      , units{u} {}
+};
+
+ss::sstring to_journalctl_fmt(std::chrono::year_month_day ymd);
+ss::sstring to_time_fmt(metric_interval_t metric);
+
+struct debug_bundle_params {
+    std::optional<std::chrono::year_month_day> logs_since;
+    std::optional<std::chrono::year_month_day> logs_until;
+    std::optional<ss::sstring> logs_size_limit;
+    std::optional<metric_interval_t> metrics_interval;
+
+    debug_bundle_params()
+      : logs_since{std::nullopt}
+      , logs_until{std::nullopt}
+      , logs_size_limit{std::nullopt}
+      , metrics_interval{std::nullopt} {}
+};
+
+struct debug_bundle_credentials {
+    ss::sstring username;
+    ss::sstring password;
+    ss::sstring mechanism;
+};
+
+struct rpk_debug_bundle {
+    std::unique_ptr<ss::experimental::process> process;
+    mutex process_mu;
+    ss::future<> control;
+    ss::sstring host_path;
+    ss::sstring host_home;
+    const std::filesystem::path write_dir;
+    const std::filesystem::path rpk_path;
+    const debug_bundle_params params;
+    std::optional<debug_bundle_credentials> creds;
+
+    rpk_debug_bundle();
+    rpk_debug_bundle(
+      ss::sstring host_path,
+      ss::sstring host_home,
+      const std::filesystem::path write_dir,
+      const std::filesystem::path rpk_path,
+      const debug_bundle_params params,
+      std::optional<debug_bundle_credentials> creds);
+
+    ss::future<> start_process();
+    ss::future<> handle_process();
+
+    std::vector<ss::sstring> make_rpk_args();
+    errc handle_wait_status(ss::experimental::process::wait_status wstatus);
+    ss::future<std::error_code> do_remove(ss::sstring filename);
+    errc do_abort(bool use_sigkill);
+};
+
+ss::sstring make_bundle_filename(
+  const std::filesystem::path write_dir, const ss::sstring filename);
+
+errc make_rpk_err_value(std::error_code err);
+
+constexpr std::string_view default_bundle_name = "debug-bundle.zip";
+
+class debug_bundle : public ss::peering_sharded_service<debug_bundle> {
+public:
+    debug_bundle(
+      const std::filesystem::path write_dir,
+      const std::filesystem::path rpk_path);
+
+    ss::future<> start();
+    ss::future<std::error_code> start_creating_bundle(
+      const debug_bundle_params params,
+      std::optional<debug_bundle_credentials> creds);
+    ss::future<> stop();
+    ss::future<std::error_code> remove_bundle(ss::sstring filename);
+    ss::future<std::error_code> abort_bundle();
+
+    const std::filesystem::path& get_write_dir() const { return _write_dir; }
+    ss::future<std::error_code> is_ready(ss::sstring filename);
+
+    template<
+      std::invocable<> Func,
+      typename Futurator = ss::futurize<std::invoke_result_t<Func>>>
+    typename Futurator::type with_lock(Func&& func) {
+        gate_guard guard{_rpk_gate};
+        auto units = co_await _rpk_mu.get_units();
+        co_return co_await Futurator::invoke(std::forward<Func>(func));
+    }
+
+private:
+    friend ss::future<std::error_code> force_stop(debug_bundle& b);
+    friend ss::future<std::error_code>
+    maybe_remove_aborted_bundle(debug_bundle& b);
+
+    const std::filesystem::path _write_dir;
+    ss::sstring _host_path;
+    ss::sstring _host_home;
+    const std::filesystem::path _rpk_cmd;
+    ss::gate _rpk_gate;
+    mutex _rpk_mu;
+    std::unique_ptr<rpk_debug_bundle> _rpk;
+
+    ss::sstring get_host_path_env();
+    ss::sstring get_home_dir_env();
+    ss::future<bool> is_rpk_running();
+    ss::future<bool> is_core0_running();
+
+    // do_nonblocking_abort will throw, from seastar level, if there is no
+    // process running
+    ss::future<std::error_code> do_abort(bool use_sigkill);
+};
+
+} // namespace debug_bundle
+
+namespace std {
+template<>
+struct is_error_code_enum<debug_bundle::errc> : true_type {};
+} // namespace std

--- a/src/v/redpanda/tests/CMakeLists.txt
+++ b/src/v/redpanda/tests/CMakeLists.txt
@@ -6,3 +6,12 @@ rp_test(
         LIBRARIES Boost::unit_test_framework v::application
         LABELS cli_parse
 )
+
+rp_test(
+        UNIT_TEST
+        BINARY_NAME debug_bundle
+        SOURCES debug_bundle_tests.cc
+        DEFINITIONS BOOST_TEST_DYN_LINK
+        LIBRARIES v::seastar_testing_main v::application
+        LABELS debug_bundle
+)

--- a/src/v/redpanda/tests/debug_bundle_tests.cc
+++ b/src/v/redpanda/tests/debug_bundle_tests.cc
@@ -1,0 +1,285 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/node_config.h"
+#include "redpanda/debug_bundle.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+
+inline ss::logger test_log("test");
+
+using namespace std::chrono_literals;
+
+struct bundle_fixture : public redpanda_thread_fixture {
+    bundle_fixture()
+      : redpanda_thread_fixture(
+        model::node_id(1),
+        9092,
+        33145,
+        8082,
+        8081,
+        43189,
+        {},
+        ssx::sformat("test.dir_{}", time(0)),
+        std::nullopt,
+        true,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        configure_node_id::yes,
+        empty_seed_starts_cluster::yes,
+        std::nullopt,
+        true) {}
+};
+
+FIXTURE_TEST(check_environment, bundle_fixture) {
+    wait_for_controller_leadership().get();
+
+    // Check making rpk error value
+    {
+        auto err = make_error_code(debug_bundle::errc::success);
+        BOOST_CHECK_EQUAL(
+          debug_bundle::make_rpk_err_value(err), debug_bundle::errc::success);
+    }
+
+    auto write_dir_conf = config::node().debug_bundle_write_dir.value();
+    auto rpk_path = config::node().rpk_path.value();
+    // The checks in this test do not use futures, therefore a sharded bundle is
+    // not needed.
+    debug_bundle::debug_bundle bundle{write_dir_conf, rpk_path};
+
+    // Check creating full bundle filename
+    {
+        BOOST_CHECK_EQUAL(bundle.get_write_dir(), write_dir_conf);
+        auto write_dir_size = bundle.get_write_dir().string().size();
+        auto full_file_path = debug_bundle::make_bundle_filename(
+          bundle.get_write_dir(),
+          ss::sstring{debug_bundle::default_bundle_name});
+        BOOST_CHECK_EQUAL(
+          full_file_path.substr(0, write_dir_size),
+          bundle.get_write_dir().string());
+        // Ignore the slash in the file path
+        BOOST_CHECK_EQUAL(
+          full_file_path.substr(write_dir_size + 1),
+          debug_bundle::default_bundle_name);
+    }
+
+    // Check debug bundle params default constructor
+    {
+        debug_bundle::debug_bundle_params params;
+        BOOST_CHECK(params.logs_since == std::nullopt);
+        BOOST_CHECK(params.logs_until == std::nullopt);
+        BOOST_CHECK(params.logs_size_limit == std::nullopt);
+        BOOST_CHECK(params.metrics_interval == std::nullopt);
+    }
+
+    // Check rpk args with bundle params and credentials
+    {
+        std::chrono::year_month_day logs_since_ymd{
+          std::chrono::year{2023}, std::chrono::month{5}, std::chrono::day{31}};
+        std::chrono::year_month_day logs_until_ymd{
+          std::chrono::year{2023}, std::chrono::month{6}, std::chrono::day{11}};
+        debug_bundle::debug_bundle_params params;
+        params.logs_since = std::make_optional(logs_since_ymd);
+        params.logs_until = std::make_optional(logs_until_ymd);
+        params.logs_size_limit = std::make_optional<ss::sstring>("100MiB");
+        debug_bundle::metric_interval_t metric{10s, "ms"};
+        params.metrics_interval = std::make_optional(metric);
+
+        debug_bundle::debug_bundle_credentials creds{
+          .username = security::credential_user{"admin"},
+          .password = security::credential_password{"admin"},
+          .mechanism = ss::sstring{"SCRAM-SHA-256"}};
+
+        auto full_file_path = debug_bundle::make_bundle_filename(
+          bundle.get_write_dir(),
+          ss::sstring{debug_bundle::default_bundle_name});
+        auto is_cred_flag = [&creds](const ss::sstring& flag) {
+            return flag == "--user" || flag == "--password"
+                   || flag == "--sasl-mechanism" || flag == creds.username
+                   || flag == creds.password || flag == creds.mechanism;
+        };
+        auto is_params_flag = [&params](const ss::sstring& flag) {
+            return flag == "--logs-since" || flag == "--logs-until"
+                   || flag == "--logs-size-limit"
+                   || flag == "--metrics-interval"
+                   || flag
+                        == debug_bundle::to_journalctl_fmt(
+                          params.logs_since.value())
+                   || flag
+                        == debug_bundle::to_journalctl_fmt(
+                          params.logs_until.value())
+                   || flag == params.logs_size_limit.value()
+                   || flag
+                        == debug_bundle::to_time_fmt(
+                          params.metrics_interval.value());
+        };
+        auto is_flag_ok = [&is_cred_flag,
+                           &is_params_flag,
+                           &rpk_path,
+                           &full_file_path](const ss::sstring& flag) {
+            if (flag == rpk_path.string()) {
+                vlog(test_log.info, "Found rpk path {}", flag);
+                return true;
+            }
+
+            // These flags are hardcoded within "make_rpk_args"
+            if (flag == "debug" || flag == "bundle" || flag == "--output") {
+                return true;
+            }
+
+            if (flag == full_file_path) {
+                vlog(test_log.info, "Found file path {}", flag);
+                return true;
+            }
+
+            if (is_params_flag(flag)) {
+                vlog(test_log.info, "Found param {}", flag);
+                return true;
+            }
+
+            if (is_cred_flag(flag)) {
+                vlog(test_log.info, "Found cred {}", flag);
+                return true;
+            }
+
+            return false;
+        };
+
+        std::optional<debug_bundle::debug_bundle_credentials> creds_opt
+          = std::make_optional(creds);
+        debug_bundle::rpk_debug_bundle rpk{
+          ss::sstring{""},
+          ss::sstring{""},
+          write_dir_conf,
+          rpk_path,
+          params,
+          creds_opt};
+        auto rpk_argv = rpk.make_rpk_args();
+        for (const auto& flag : rpk_argv) {
+            BOOST_CHECK(is_flag_ok(flag));
+        }
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(check_wait_status_handler) {
+    // const std::filesystem::path true_cmd{"/bin/true"},
+    // false_cmd{"/bin/false"}, sleep_cmd{"/bin/sleep"};
+
+    debug_bundle::rpk_debug_bundle rpk;
+
+    auto make_exit_code = [](int code) {
+        return ss::experimental::process::wait_exited{code};
+    };
+
+    auto make_exit_signal = [](int signal) {
+        return ss::experimental::process::wait_signaled{signal};
+    };
+
+    // Check failed cmd
+    {
+        // Expect to see an error log with exit status 1
+        auto err = rpk.handle_wait_status(make_exit_code(1));
+        BOOST_CHECK_EQUAL(err, debug_bundle::errc::process_fail);
+    }
+
+    // Check sucessful cmd
+    {
+        auto err = rpk.handle_wait_status(make_exit_code(0));
+        BOOST_CHECK_EQUAL(err, debug_bundle::errc::success);
+    }
+
+    // std::vector<ss::sstring> sleep_argv{sleep_cmd.string(), "30"};
+
+    // Check SIGTERM'd cmd
+    {
+        // Expect to see an error log with signal 15
+        auto err = rpk.handle_wait_status(make_exit_signal(15));
+        BOOST_CHECK_EQUAL(err, debug_bundle::errc::process_fail);
+    }
+
+    // Check SIGKILL'd cmd
+    {
+        // Expect to see an error log with signal 9
+        auto err = rpk.handle_wait_status(make_exit_signal(9));
+        BOOST_CHECK_EQUAL(err, debug_bundle::errc::process_fail);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(ready_debug_bundle) {
+    ss::sstring invalid_file{"xxx.zip"};
+    ss::sharded<debug_bundle::debug_bundle> bundle;
+    bundle
+      .start(
+        config::node().debug_bundle_write_dir.value(),
+        config::node().rpk_path.value())
+      .get();
+    auto action = ss::defer([&bundle] { bundle.stop().get(); });
+
+    // Check for invalid file name
+    {
+        auto err = bundle.local().is_ready(invalid_file).get();
+        BOOST_CHECK_EQUAL(
+          debug_bundle::make_rpk_err_value(err),
+          debug_bundle::errc::invalid_filename);
+
+        err = bundle.local().remove_bundle(invalid_file).get();
+        BOOST_CHECK_EQUAL(
+          debug_bundle::make_rpk_err_value(err),
+          debug_bundle::errc::invalid_filename);
+    }
+
+    // Check that the bundle is not on disk
+    {
+        auto in_progress_file = ss::sstring{debug_bundle::default_bundle_name};
+        auto err = bundle.local().is_ready(in_progress_file).get();
+        BOOST_CHECK_EQUAL(
+          debug_bundle::make_rpk_err_value(err),
+          debug_bundle::errc::bundle_not_on_disk);
+
+        err = bundle.local().remove_bundle(in_progress_file).get();
+        BOOST_CHECK_EQUAL(
+          debug_bundle::make_rpk_err_value(err),
+          debug_bundle::errc::bundle_not_on_disk);
+    }
+
+    // Put zip archive on disk
+    auto zip_filename = debug_bundle::make_bundle_filename(
+      bundle.local().get_write_dir(),
+      ss::sstring{debug_bundle::default_bundle_name});
+    auto zip_file
+      = ss::open_file_dma(zip_filename, ss::open_flags::create).get0();
+    auto exists = ss::file_exists(zip_filename).get();
+    BOOST_CHECK(exists);
+
+    // Check that the bundle is "ready" since it is on disk, then remove it
+    {
+        auto in_progress_file = ss::sstring{debug_bundle::default_bundle_name};
+        auto err = bundle.local().is_ready(in_progress_file).get();
+        BOOST_CHECK_EQUAL(
+          debug_bundle::make_rpk_err_value(err), debug_bundle::errc::success);
+
+        err = bundle.local().remove_bundle(in_progress_file).get();
+        BOOST_CHECK_EQUAL(
+          debug_bundle::make_rpk_err_value(err), debug_bundle::errc::success);
+
+        exists = ss::file_exists(zip_filename).get();
+        BOOST_CHECK(!exists);
+    }
+
+    zip_file.close().get();
+}

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -94,7 +94,8 @@ public:
       configure_node_id use_node_id = configure_node_id::yes,
       const empty_seed_starts_cluster empty_seed_starts_cluster_val
       = empty_seed_starts_cluster::yes,
-      std::optional<uint32_t> kafka_admin_topic_api_rate = std::nullopt)
+      std::optional<uint32_t> kafka_admin_topic_api_rate = std::nullopt,
+      bool enable_sasl = false)
       : app(ssx::sformat("redpanda-{}", node_id()))
       , proxy_port(proxy_port)
       , schema_reg_port(schema_reg_port)
@@ -112,7 +113,8 @@ public:
           std::move(cloud_cfg),
           use_node_id,
           empty_seed_starts_cluster_val,
-          kafka_admin_topic_api_rate);
+          kafka_admin_topic_api_rate,
+          enable_sasl);
         app.initialize(
           proxy_config(proxy_port),
           proxy_client_config(kafka_port),
@@ -288,7 +290,8 @@ public:
       configure_node_id use_node_id = configure_node_id::yes,
       const empty_seed_starts_cluster empty_seed_starts_cluster_val
       = empty_seed_starts_cluster::yes,
-      std::optional<uint32_t> kafka_admin_topic_api_rate = std::nullopt) {
+      std::optional<uint32_t> kafka_admin_topic_api_rate = std::nullopt,
+      bool enable_sasl = false) {
         auto base_path = std::filesystem::path(data_dir);
         ss::smp::invoke_on_all([node_id,
                                 kafka_port,
@@ -301,7 +304,8 @@ public:
                                 cloud_cfg,
                                 use_node_id,
                                 empty_seed_starts_cluster_val,
-                                kafka_admin_topic_api_rate]() mutable {
+                                kafka_admin_topic_api_rate,
+                                enable_sasl]() mutable {
             auto& config = config::shard_local_cfg();
 
             config.get("enable_pid_file").set_value(false);
@@ -376,6 +380,10 @@ public:
             if (kafka_admin_topic_api_rate) {
                 config.get("kafka_admin_topic_api_rate")
                   .set_value(kafka_admin_topic_api_rate);
+            }
+
+            if (enable_sasl) {
+                config.get("enable_sasl").set_value(enable_sasl);
             }
         }).get0();
     }


### PR DESCRIPTION
Moved #10488 to here because it had too many comments.

Merge this PR before https://github.com/redpanda-data/redpanda/pull/10889

Recently, a feature was added to RPK that can collect debug information such as logs and metrics details from a Redpanda cluster. This feature is invoked with the command `rpk debug bundle`. There are ways to run this command in cloud environments; however, triggering a debug bundle in on-premise bare-metal solutions is non-trivial.

This PR adds a class that uses Seastar's experimental features [Process](https://docs.seastar.io/master/classseastar_1_1experimental_1_1process.html#a4695d3bec052594c4e04c1e021e4851f) and [Spawn Process](https://docs.seastar.io/master/group__interprocess-module.html#ga843e8b5c2a5508fd840e25f405e05521) to trigger RPK in a process fork and manage that fork.

See https://github.com/redpanda-data/redpanda/issues/10876 for the list of items to do for a feature complete solution.

Changes from force-push `8dfb233` and `cfbfe2b`:
- Protect changes to `process` and `status` with a lock and gate
- Removed http bits
- Style edits
- Added unit tests
- Use `std::error_code` instead of throwing errors
- Created `rpk::debug_bundle_error` category for `std::error_code`
- Added factory methods for the default bundle name and undefined PATH
- Added wrapper methods for handling the wait_status from `process.wait()`

Changes from force-puse `75721d2`:
- Improve logging
- Removed the consumer in favor of `process.stdou().read()`
- Return lower-level `errc` type from `handle_wait_status`
- No longer tracking a `status` variable or a status enum, instead rely on the presence of the spawned process to indicate that rpk is running
- Remove excess calls to `process.wait()`
- Refactor abort to wait a few milliseconds before checking and sending SIGKILL signal
- Fix gate_guard locations
- Create a wrapper for the spawned process, named `rpk_debug_bundle`
- Improve `handle_wait_status` unit test
- Rename `debug_bundle_error` to `errc` to better match the pattern used in the rest of the tree
- Move `rpk_err.h` into `debug_bundle.h`
- Fix includes
- Use `std::string_view` for `constexpr` types instead of a factory method
- Improve namespacing
- make `get_write_dir` const qualified
- Accept cross-core args by value to avoid lifetime issues
- Use non-string based types for `debug_bundle_params`. I didn't get to `logs-size-limit` yet though, that needs to follow the validation of the go code found at https://github.com/docker/go-units/blob/master/size.go#L91
- Use valid `$PATH` and `$HOME` paths as the defaults
- Use `ssx::spawn_with_gate` instead of `ssx::background`
- Use the correct `rpk_mu` on each core
- Use `std::visit` to determine which `std::variant` is used with type-checking
- Use `ss::file_exists` to avoid a reactor stall
- Use `mutable` lambdas where there are capture-by-move to avoid copy-constructor calls

Changes from force-push `540303e`:
- Replace `std::visit` with `ss::visit`

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none