### PR TITLE
Log broken out sizes for partition stm snapshots

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -712,6 +712,15 @@ uint64_t partition::non_log_disk_size_bytes() const {
         idalloc_size = _id_allocator_stm->get_snapshot_size();
     }
 
+    vlog(
+      clusterlog.trace,
+      "non-log disk size: raft {} rm {} tm {} archival {} idalloc {}",
+      raft_size,
+      rm_size,
+      tm_size,
+      archival_size,
+      idalloc_size);
+
     return raft_size + rm_size.value_or(0) + tm_size.value_or(0)
            + archival_size.value_or(0) + idalloc_size.value_or(0);
 }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -3001,6 +3001,10 @@ uint64_t rm_stm::get_snapshot_size() const {
     for (const auto& snapshot_size : _abort_snapshot_sizes) {
         abort_snapshots_size += snapshot_size.second;
     }
+    vlog(
+      clusterlog.trace,
+      "rm_stm: aborted snapshots size {}",
+      abort_snapshots_size);
     return persisted_stm::get_snapshot_size() + abort_snapshots_size;
 }
 


### PR DESCRIPTION
Log some additional size information to help debug storage disk usage inconsistencies.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
