### PR TITLE
config: fix name of cloud_storage_traceful_transfer_timeout_ms

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1403,7 +1403,7 @@ configuration::configuration()
       std::nullopt)
   , cloud_storage_graceful_transfer_timeout_ms(
       *this,
-      "cloud_storage_graceful_transfer_timeout",
+      "cloud_storage_graceful_transfer_timeout_ms",
       "Time limit on waiting for uploads to complete before a leadership "
       "transfer.  If this is null, leadership transfers will proceed without "
       "waiting.",


### PR DESCRIPTION
This is an obscure tunable that was new in 23.1, and I am comfortable betting that nobody was relying on the old name in the wild.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none