### PR TITLE
cloud_storage: enable prefetching chunks

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -495,13 +495,11 @@ ss::future<> remote_segment::do_hydrate_segment() {
       _bucket,
       _path,
       [this, &reservation](uint64_t size_bytes, ss::input_stream<char> s) {
-          if (is_legacy_mode_engaged()) {
-              return put_segment_in_cache_and_create_index(
-                size_bytes, reservation, std::move(s));
-          } else {
-              return put_segment_in_cache(
-                size_bytes, reservation, std::move(s));
-          }
+          // Always create the index because we are in legacy mode if we ended
+          // up hydrating the segment. Legacy mode indicates a missing index, so
+          // we create it here on the fly using the downloaded segment.
+          return put_segment_in_cache_and_create_index(
+            size_bytes, reservation, std::move(s));
       },
       local_rtc);
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -51,6 +51,26 @@
 
 #include <exception>
 
+namespace {
+class bounded_stream final : public ss::data_source_impl {
+public:
+    bounded_stream(ss::input_stream<char>& stream, size_t upto)
+      : _stream{stream}
+      , _upto{upto} {}
+
+    ss::future<ss::temporary_buffer<char>> get() override {
+        auto buf = co_await _stream.read_up_to(_upto);
+        _upto -= buf.size();
+        co_return buf;
+    }
+
+private:
+    ss::input_stream<char>& _stream;
+    size_t _upto;
+};
+
+} // namespace
+
 namespace cloud_storage {
 
 std::filesystem::path

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -131,11 +131,10 @@ public:
     /// implementation, but the index is still required to be present first.
     ss::future<> hydrate();
 
-    /// Hydrate a part of a segment, identified by the given start and end
-    /// offsets. If the end offset is std::nullopt, the last offset in the file
-    /// is used as the end offset.
-    ss::future<> hydrate_chunk(
-      chunk_start_offset_t start, std::optional<chunk_start_offset_t> end);
+    /// Hydrate a part of a segment, identified by the given range. The range
+    /// can contain data for multiple contiguous chunks, in which case multiple
+    /// files are written to cache.
+    ss::future<> hydrate_chunk(segment_chunk_range range);
 
     /// Loads the segment chunk file from cache into an open file handle. If the
     /// file is not present in cache, the returned file handle is unopened.
@@ -303,6 +302,19 @@ private:
 
     std::optional<segment_chunks> _chunks_api;
     std::optional<offset_index::coarse_index_t> _coarse_index;
+
+    class consume_stream {
+    public:
+        consume_stream(
+          remote_segment& remote_segment, segment_chunk_range range);
+
+        ss::future<uint64_t>
+        operator()(uint64_t, ss::input_stream<char> stream);
+
+    private:
+        remote_segment& _segment;
+        segment_chunk_range _range;
+    };
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -213,8 +213,7 @@ private:
 
     /// Stores a segment chunk in cache. The chunk is stored in a path derived
     /// from the segment path: <segment_path>_chunks/chunk_start_file_offset.
-    ss::future<uint64_t> put_chunk_in_cache(
-      uint64_t,
+    ss::future<> put_chunk_in_cache(
       space_reservation_guard&,
       ss::input_stream<char>,
       chunk_start_offset_t chunk_start);
@@ -303,18 +302,7 @@ private:
     std::optional<segment_chunks> _chunks_api;
     std::optional<offset_index::coarse_index_t> _coarse_index;
 
-    class consume_stream {
-    public:
-        consume_stream(
-          remote_segment& remote_segment, segment_chunk_range range);
-
-        ss::future<uint64_t>
-        operator()(uint64_t, ss::input_stream<char> stream);
-
-    private:
-        remote_segment& _segment;
-        segment_chunk_range _range;
-    };
+    friend class split_segment_into_chunk_range_consumer;
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -121,7 +121,10 @@ segment_chunks::do_hydrate_and_materialize(chunk_start_offset_t chunk_start) {
         chunk_end = next->first - 1;
     }
 
-    co_await _segment.hydrate_chunk(chunk_start, chunk_end);
+    co_await _segment.hydrate_chunk(segment_chunk_range{
+      _chunks,
+      config::shard_local_cfg().cloud_storage_chunk_prefetch,
+      chunk_start});
     co_return co_await _segment.materialize_chunk(chunk_start);
 }
 

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -167,4 +167,24 @@ std::unique_ptr<chunk_eviction_strategy> make_eviction_strategy(
   uint64_t max_chunks,
   uint64_t hydrated_chunks);
 
+class segment_chunk_range {
+public:
+    using map_t = absl::
+      btree_map<chunk_start_offset_t, std::optional<chunk_start_offset_t>>;
+
+    segment_chunk_range(
+      const segment_chunks::chunk_map_t& chunks,
+      size_t prefetch,
+      chunk_start_offset_t start);
+
+    std::optional<chunk_start_offset_t> last_offset() const;
+    chunk_start_offset_t first_offset() const;
+
+    map_t::iterator begin();
+    map_t::iterator end();
+
+private:
+    map_t _chunks;
+};
+
 } // namespace cloud_storage

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -45,8 +45,9 @@ public:
     // hydration. The waiters are managed per chunk in `segment_chunk::waiters`.
     // The first reader to request hydration queues the download. The next
     // readers are added to wait list.
-    ss::future<segment_chunk::handle_t>
-    hydrate_chunk(chunk_start_offset_t chunk_start);
+    ss::future<segment_chunk::handle_t> hydrate_chunk(
+      chunk_start_offset_t chunk_start,
+      std::optional<uint16_t> prefetch_override = std::nullopt);
 
     // For all chunks between first and last, increment the
     // required_by_readers_in_future value by one, and increment the
@@ -76,8 +77,9 @@ private:
     // Attempts to download chunk into cache and return the file handle for
     // segment_chunk. Should be retried if there is a failure due to cache
     // eviction between download and opening the file handle.
-    ss::future<ss::file>
-    do_hydrate_and_materialize(chunk_start_offset_t chunk_start);
+    ss::future<ss::file> do_hydrate_and_materialize(
+      chunk_start_offset_t chunk_start,
+      std::optional<uint16_t> prefetch_override = std::nullopt);
 
     // Periodically closes chunk file handles for the space to be reclaimable by
     // cache eviction. The chunks are evicted when they are no longer opened for

--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -27,7 +27,8 @@ public:
       kafka::offset start,
       kafka::offset end,
       int64_t begin_stream_at,
-      ss::file_input_stream_options stream_options);
+      ss::file_input_stream_options stream_options,
+      std::optional<uint16_t> prefetch_override = std::nullopt);
 
     chunk_data_source_impl(const chunk_data_source_impl&) = delete;
     chunk_data_source_impl& operator=(const chunk_data_source_impl&) = delete;
@@ -68,6 +69,7 @@ private:
     ss::abort_source _as;
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
+    std::optional<uint16_t> _prefetch_override;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tests/segment_chunk_test.cc
+++ b/src/v/cloud_storage/tests/segment_chunk_test.cc
@@ -207,3 +207,86 @@ SEASTAR_THREAD_TEST_CASE(test_predictive_chunk_eviction) {
     BOOST_REQUIRE(chunks[2].handle.has_value());
     BOOST_REQUIRE(chunks[2].current_state == chunk_state::hydrated);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_chunk_range_calculations) {
+    segment_chunks::chunk_map_t chunks;
+    auto handle = ss::make_lw_shared(ss::file{});
+    chunks.insert({0, segment_chunk{.handle = handle}});
+    chunks.insert({10, segment_chunk{.handle = handle}});
+    chunks.insert({20, segment_chunk{.handle = handle}});
+    chunks.insert({30, segment_chunk{.handle = handle}});
+    chunks.insert({40, segment_chunk{.handle = handle}});
+    chunks.insert({50, segment_chunk{.handle = handle}});
+    chunks.insert({60, segment_chunk{.handle = handle}});
+    chunks.insert({70, segment_chunk{.handle = handle}});
+    chunks.insert({80, segment_chunk{.handle = handle}});
+    chunks.insert({90, segment_chunk{.handle = handle}});
+
+    {
+        size_t prefetch = 3;
+        chunk_start_offset_t start = 30;
+        segment_chunk_range range{chunks, prefetch, start};
+        BOOST_REQUIRE_EQUAL(range.first_offset(), 30);
+        BOOST_REQUIRE_EQUAL(range.last_offset().value(), 69);
+
+        auto expected_start = 30;
+        auto expected_end = 39;
+
+        for (const auto& [start, end] : range) {
+            BOOST_REQUIRE_EQUAL(expected_start, start);
+            BOOST_REQUIRE_EQUAL(expected_end, end.value());
+            expected_start += 10;
+            expected_end += 10;
+        }
+    }
+
+    {
+        size_t prefetch = 0;
+        chunk_start_offset_t start = 30;
+        segment_chunk_range range{chunks, prefetch, start};
+        BOOST_REQUIRE_EQUAL(range.first_offset(), 30);
+        BOOST_REQUIRE_EQUAL(range.last_offset().value(), 39);
+
+        auto expected_start = 30;
+        auto expected_end = 39;
+
+        for (const auto& [start, end] : range) {
+            BOOST_REQUIRE_EQUAL(expected_start, start);
+            BOOST_REQUIRE_EQUAL(expected_end, end.value());
+            expected_start += 10;
+            expected_end += 10;
+        }
+    }
+
+    {
+        size_t prefetch = 111110;
+        chunk_start_offset_t start = 30;
+        segment_chunk_range range{chunks, prefetch, start};
+        BOOST_REQUIRE_EQUAL(range.first_offset(), 30);
+        BOOST_REQUIRE(!range.last_offset().has_value());
+
+        auto expected_start = 30;
+        auto expected_end = 39;
+
+        for (const auto& [start, end] : range) {
+            BOOST_REQUIRE_EQUAL(expected_start, start);
+            BOOST_REQUIRE_EQUAL(expected_end, end.value_or(99));
+            expected_start += 10;
+            expected_end += 10;
+        }
+    }
+
+    {
+        size_t prefetch = 0;
+        chunk_start_offset_t start = 90;
+        segment_chunk_range range{chunks, prefetch, start};
+        BOOST_REQUIRE_EQUAL(range.first_offset(), 90);
+        BOOST_REQUIRE(!range.last_offset().has_value());
+
+        auto it = range.begin();
+        BOOST_REQUIRE_EQUAL(it->first, 90);
+        BOOST_REQUIRE(!it->second.has_value());
+
+        BOOST_REQUIRE(std::next(it) == range.end());
+    }
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1682,6 +1682,12 @@ configuration::configuration()
       {model::cloud_storage_chunk_eviction_strategy::eager,
        model::cloud_storage_chunk_eviction_strategy::capped,
        model::cloud_storage_chunk_eviction_strategy::predictive})
+  , cloud_storage_chunk_prefetch(
+      *this,
+      "cloud_storage_chunk_prefetch",
+      "Number of chunks to prefetch ahead of every downloaded chunk",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0)
   , superusers(
       *this,
       "superusers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -332,6 +332,7 @@ struct configuration final : public config_store {
     property<bool> cloud_storage_disable_chunk_reads;
     enum_property<model::cloud_storage_chunk_eviction_strategy>
       cloud_storage_chunk_eviction_strategy;
+    property<uint16_t> cloud_storage_chunk_prefetch;
 
     one_or_many_property<ss::sstring> superusers;
 


### PR DESCRIPTION
Chunk prefetching allows fetching more than one segment chunks at once for performance improvement. The http call to fetch data includes a single byte range covering the original chunk plus the prefetch, and the response is written to disk as individual chunk files. 

**Note on potential inefficiency/wasted effort:** With these changes, consider a set of contiguous chunks A,B,C,D,E,F. With a prefetch of 4, when A is downloaded, B,C,D,E are also downloaded. These are not however hydrated or materialized. The chunk files are kept on disk. When/if a request for hydrating B is issued, if it is still on disk, it is directly materialized. If not, it is re-downloaded and then materialized. In the event that B is deleted for some reason (cache eviction) and C,D,E are still on disk, when B is re-hydrated, C,D,E will also be downloaded again, and the chunk files will be overwritten.

With some extra code this could be avoided by only selectively downloading missing chunks from the prefetch list, this implementation takes the simpler approach and just downloads all chunks from B onwards again, assuming that the next few chunks are also absent. 

Fixes https://github.com/redpanda-data/redpanda/issues/11028

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none


Force push:

* [fix bug when calculating number of bytes to read for a given chunk](https://github.com/redpanda-data/redpanda/compare/2b5bafbe1e6eedbecaf8c0a2e07dba8bb43e65a4..a322dc06a4602a2adb2f3ebabcfd42d6480addff) 
