### PR TITLE
cloud_storage: fix + refactor adjacent segment merging enable/disable

### DIFF
--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -36,8 +36,12 @@ static std::pair<size_t, size_t> get_low_high_segment_size(
 }
 
 adjacent_segment_merger::adjacent_segment_merger(
-  ntp_archiver& parent, retry_chain_logger& ctxlog, bool is_local)
+  ntp_archiver& parent,
+  retry_chain_logger& ctxlog,
+  bool is_local,
+  config::binding<bool> config_enabled)
   : _is_local(is_local)
+  , _config_enabled(std::move(config_enabled))
   , _archiver(parent)
   , _ctxlog(ctxlog)
   , _target_segment_size(
@@ -52,7 +56,9 @@ adjacent_segment_merger::adjacent_segment_merger(
 
 ss::future<> adjacent_segment_merger::stop() { return _gate.close(); }
 
-void adjacent_segment_merger::set_enabled(bool enabled) { _enabled = enabled; }
+void adjacent_segment_merger::set_enabled(bool enabled) {
+    _job_enabled = enabled;
+}
 
 void adjacent_segment_merger::acquire() { _holder = ss::gate::holder(_gate); }
 
@@ -138,13 +144,18 @@ adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
       .consumed = run_quota_t(0),
       .remaining = quota,
     };
+
+    if (!enabled()) {
+        co_return result;
+    }
+
     vlog(
       _ctxlog.debug,
       "Adjacent segment merger run begin, last offset is {}",
       _last);
     for (int i = 0; i < max_reuploads_per_run; i++) {
         if (
-          !_enabled || _as.abort_requested()
+          !enabled() || _as.abort_requested()
           || _archiver.manifest().get_last_offset() == model::offset::max()) {
             // Avoid reuploading anything if last offset is max. This can only
             // happen if the recovery was incomplete and by reuploading any data

--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -149,6 +149,25 @@ adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
         co_return result;
     }
 
+    if (_archiver.ntp_config().is_read_replica_mode_enabled()) {
+        // This should never happen because we should not have been constructed
+        // for a read replica topic: this is a double-check for safety.
+        vlog(
+          _ctxlog.error,
+          "Adjacent segment merging refusing to run on read replica topic");
+        co_return result;
+    }
+
+    if (!_archiver.ntp_config().is_archival_enabled()) {
+        // This should never happen because we should not have been constructed
+        // for a read replica topic: this is a double-check for safety.
+        vlog(
+          _ctxlog.error,
+          "Adjacent segment merging refusing to run on topic with remote.write "
+          "disabled");
+        co_return result;
+    }
+
     vlog(
       _ctxlog.debug,
       "Adjacent segment merger run begin, last offset is {}",

--- a/src/v/archival/adjacent_segment_merger.h
+++ b/src/v/archival/adjacent_segment_merger.h
@@ -25,7 +25,10 @@ namespace archival {
 class adjacent_segment_merger : public housekeeping_job {
 public:
     explicit adjacent_segment_merger(
-      ntp_archiver& parent, retry_chain_logger& ctxlog, bool is_local);
+      ntp_archiver& parent,
+      retry_chain_logger& ctxlog,
+      bool,
+      config::binding<bool>);
 
     ss::future<run_result>
     run(retry_chain_node& rtc, run_quota_t quota) override;
@@ -47,7 +50,17 @@ private:
       const cloud_storage::partition_manifest& manifest);
 
     const bool _is_local;
-    bool _enabled{true};
+
+    bool enabled() { return _config_enabled() && _job_enabled; }
+
+    // Whether segment merging is enabled in the cluster config (i.e. by
+    // the administrator)
+    config::binding<bool> _config_enabled;
+
+    // Whether segment merging is enabled at the housekeeping job level (e.g.
+    // may be disabled when not leader)
+    bool _job_enabled{true};
+
     model::offset _last;
     ntp_archiver& _archiver;
     retry_chain_logger& _ctxlog;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -156,7 +156,9 @@ void ntp_archiver::notify_leadership(std::optional<model::node_id> leader_id) {
         _leader_cond.signal();
     }
     if (_local_segment_merger) {
-        _local_segment_merger->set_enabled(is_leader);
+        _local_segment_merger->set_enabled(
+          is_leader
+          && config::shard_local_cfg().cloud_storage_enable_segment_merging());
     }
 }
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -62,14 +62,21 @@ namespace archival {
 
 static std::unique_ptr<adjacent_segment_merger>
 maybe_make_adjacent_segment_merger(
-  ntp_archiver& self, retry_chain_logger& log, const storage::ntp_config& cfg) {
+  ntp_archiver& self,
+  retry_chain_logger& log,
+  const storage::ntp_config& cfg,
+  bool am_leader) {
     std::unique_ptr<adjacent_segment_merger> result = nullptr;
     if (
       cfg.is_archival_enabled() && !cfg.is_compacted()
       && !cfg.is_read_replica_mode_enabled()) {
-        result = std::make_unique<adjacent_segment_merger>(self, log, true);
-        result->set_enabled(config::shard_local_cfg()
-                              .cloud_storage_enable_segment_merging.value());
+        result = std::make_unique<adjacent_segment_merger>(
+          self,
+          log,
+          true,
+          config::shard_local_cfg()
+            .cloud_storage_enable_segment_merging.bind());
+        result->set_enabled(am_leader);
     }
     return result;
 }
@@ -104,10 +111,8 @@ ntp_archiver::ntp_archiver(
   , _tx_tags(cloud_storage::remote::make_tx_manifest_tags(_ntp, _rev))
   , _segment_index_tags(
       cloud_storage::remote::make_segment_index_tags(_ntp, _rev))
-  , _local_segment_merger(
-      maybe_make_adjacent_segment_merger(*this, _rtclog, parent.log().config()))
-  , _segment_merging_enabled(
-      config::shard_local_cfg().cloud_storage_enable_segment_merging.bind())
+  , _local_segment_merger(maybe_make_adjacent_segment_merger(
+      *this, _rtclog, parent.log().config(), parent.is_leader()))
   , _manifest_upload_interval(
       config::shard_local_cfg()
         .cloud_storage_manifest_max_upload_interval_sec.bind())
@@ -116,12 +121,6 @@ ntp_archiver::ntp_archiver(
     // Override bucket for read-replica
     if (_parent.is_read_replica_mode_enabled()) {
         _bucket_override = _parent.get_read_replica_bucket();
-    } else if (
-      parent.log().config().is_archival_enabled()
-      && !parent.log().config().is_compacted()) {
-        _segment_merging_enabled.watch([this] {
-            _local_segment_merger->set_enabled(_segment_merging_enabled());
-        });
     }
 
     vlog(
@@ -156,9 +155,7 @@ void ntp_archiver::notify_leadership(std::optional<model::node_id> leader_id) {
         _leader_cond.signal();
     }
     if (_local_segment_merger) {
-        _local_segment_merger->set_enabled(
-          is_leader
-          && config::shard_local_cfg().cloud_storage_enable_segment_merging());
+        _local_segment_merger->set_enabled(is_leader);
     }
 }
 

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -555,7 +555,6 @@ private:
 
     // NTP level adjacent segment merging job
     std::unique_ptr<housekeeping_job> _local_segment_merger;
-    config::binding<bool> _segment_merging_enabled;
 
     // The archival metadata stm has its own clean/dirty mechanism, but it
     // is expensive to persistently mark it clean after each segment upload,


### PR DESCRIPTION
While [fixing](https://buildkite.com/redpanda/redpanda/builds/29624#018844e4-4059-4508-827a-9a6e7785a3b1) deletion tests, I noticed that segment merging was happening even when disabled! This was introduced via https://github.com/redpanda-data/redpanda/pull/10538 , and backported to 23.1 in https://github.com/redpanda-data/redpanda/pull/10540

This PR is three commits:
- Fix the logic bug that was enabling it
- Refactor the code so that it's harder to make the same mistake again, by having the merger directly consume a binding to the cluster config, rather than relying on callers to use set_enabled in a config-aware way.
- Additional safety checks against running on read replica/non-remote.write topics, as these currently relied on the caller only constructing the merger when it should run (which works, but is fragile)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
