### PR TITLE
[v23.1.x] config: fix name of cloud_storage_traceful_transfer_timeout_ms

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1382,7 +1382,7 @@ configuration::configuration()
       std::nullopt)
   , cloud_storage_graceful_transfer_timeout_ms(
       *this,
-      "cloud_storage_graceful_transfer_timeout",
+      "cloud_storage_graceful_transfer_timeout_ms",
       "Time limit on waiting for uploads to complete before a leadership "
       "transfer.  If this is null, leadership transfers will proceed without "
       "waiting.",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10947
