### PR TITLE
kvstore: Don't pre-reserve negative/huge slots

### DIFF
--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -470,7 +470,7 @@ ss::future<> kvstore::load_snapshot_from_reader(snapshot_reader& reader) {
           batch.header().header_crc));
     }
 
-    _db.reserve(batch.header().last_offset() - batch.header().base_offset);
+    _db.reserve(batch.header().record_count);
     batch.for_each_record([this](model::record r) {
         auto key = iobuf_to_bytes(r.release_key());
         _probe.add_cached_bytes(key.size() + r.value().size_bytes());


### PR DESCRIPTION
In tests we are seeing some cases where `last_offset` ends up being larger than `base_offset`.

This results in trying to reserve a huge number of slots in the hashmap which subsequently leads to crashes (see below).

Fix this by simply looking at the record_count in the header.

`last_offset` being smaller than `base_offset` is a result of `.last_offset_delta` being negative. This looks valid to me as the `record_batch_builder` initiliazes it to:

```
.last_offset_delta = static_cast<int32_t>(_records.size() - 1),
```

so it looks like a valid case for an empty batch. Please correct me if this doesn't sound right.

Internally the absl hash map implementation rounds user given sizes up to power of twos and also merges its control and element array. For values close to `size_t` this doesn't work out anymore because of overflow and then results in allocating a completely different number (very small) compared to what it then tries to memset.

Fixes https://github.com/redpanda-data/redpanda/issues/10788

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none