### PR TITLE
rpc: Log broken semaphore errors as timeout

### DIFF
--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -233,6 +233,10 @@ ss::future<> rpc_server::dispatch_method_once(
                           "Timing out request on abort_requested_exception "
                           "(shutting down)");
                         reply_buf.set_status(rpc::status::request_timeout);
+                    } catch (const ss::broken_semaphore& e) {
+                        rpclog.debug("Timing out request on broken_semaphore "
+                                     "(shutting down)");
+                        reply_buf.set_status(rpc::status::request_timeout);
                     } catch (...) {
                         rpclog.error(
                           "Service handler threw an exception: {}",


### PR DESCRIPTION
When a broken semaphore error is encountered during dispatching a method, it should be treated as a timeout instead of a service error.

Fixes https://github.com/redpanda-data/redpanda/issues/10906

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none
