### PR TITLE
features: feature flag enhancements for 23.2

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -122,14 +122,6 @@ ss::future<> config_manager::wait_for_bootstrap() {
         if (leader == _self) {
             // We are the leader.  Proceed to bootstrap cluster
             // configuration from our local configuration.
-            if (!_feature_table.local().is_active(
-                  features::feature::central_config)) {
-                vlog(
-                  clusterlog.trace,
-                  "Central config feature not active, waiting");
-                co_await _feature_table.local().await_feature(
-                  features::feature::central_config, _as.local());
-            }
             co_await do_bootstrap();
             vlog(clusterlog.info, "Completed bootstrap as leader");
         } else {

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -139,6 +139,11 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
                 update_node_version(
                   *config::node().node_id(),
                   features::feature_table::get_latest_logical_version());
+            } else if (_am_controller_leader) {
+                // In any case, kick the background update loop when
+                // we gain leadership, in case there is work to do like
+                // auto-activating some features.
+                _update_wait.signal();
             }
         });
 
@@ -244,13 +249,44 @@ ss::future<> feature_manager::maybe_update_active_version() {
         failed = true;
     }
 
+    // Even if we didn't advance our logical version, we might have some
+    // features to activate due to policy changes across different redpanda
+    // binaries with the same logical version
+    auto activate_features = auto_activate_features(
+      _feature_table.local().get_active_version());
+    if (!activate_features.empty() && _am_controller_leader) {
+        vlog(clusterlog.info, "Activating features after upgrade...");
+
+        auto data = feature_update_cmd_data{
+          .logical_version = _feature_table.local().get_active_version()};
+        for (const auto spec : activate_features) {
+            vlog(
+              clusterlog.info,
+              "Activating feature {} (logical version {})",
+              spec.get().name,
+              _feature_table.local().get_active_version());
+            data.actions.push_back(cluster::feature_update_action{
+              .feature_name = ss::sstring(spec.get().name),
+              .action = feature_update_action::action_t::activate});
+        }
+
+        co_await replicate_feature_update_cmd(std::move(data));
+    }
+
     try {
         if (failed) {
             // Sleep for a while before next iteration of our outer do_until
             co_await ss::sleep_abortable(status_retry, _as.local());
         } else {
-            // Sleep until we have some updates to process
-            co_await _update_wait.wait([this]() { return !_updates.empty(); });
+            // Sleep until we have some node version updates to process, or
+            // some feature activations to do.
+            co_await _update_wait.wait([this]() {
+                return (!_updates.empty()
+                        || !auto_activate_features(
+                              _feature_table.local().get_active_version())
+                              .empty())
+                       && _am_controller_leader;
+            });
         }
     } catch (ss::condition_variable_timed_out&) {
         // Wait complete - proceed around next loop of do_until
@@ -258,6 +294,55 @@ ss::future<> feature_manager::maybe_update_active_version() {
         // Shutting down - nextiteration will drop out
     } catch (ss::sleep_aborted&) {
         // Shutting down - next iteration will drop out
+    }
+}
+
+std::vector<std::reference_wrapper<const features::feature_spec>>
+feature_manager::auto_activate_features(cluster_version effective_version) {
+    std::vector<std::reference_wrapper<const features::feature_spec>> result;
+
+    if (config::shard_local_cfg().features_auto_enable()) {
+        /*
+         * We auto-enable features if:
+         * - They are not disabled
+         * - Their required version is satisfied
+         * - Their policy is not explicit_only
+         * - The global features_auto_enable setting is true.
+         */
+        for (const auto& fs : _feature_table.local().get_feature_state()) {
+            if (
+              (fs.get_state() == features::feature_state::state::unavailable
+               || fs.get_state() == features::feature_state::state::available)
+              && fs.spec.available_rule
+                   == features::feature_spec::available_policy::always
+              && effective_version >= fs.spec.require_version) {
+                result.push_back(fs.spec);
+            }
+        }
+    }
+
+    return result;
+}
+
+ss::future<>
+feature_manager::replicate_feature_update_cmd(feature_update_cmd_data data) {
+    auto new_version = data.logical_version;
+    auto cmd = feature_update_cmd(
+      std::move(data),
+      0 // unused
+    );
+
+    auto timeout = model::timeout_clock::now() + status_retry;
+    auto err = co_await replicate_and_wait(
+      _stm, _feature_table, _as, std::move(cmd), timeout);
+    if (err == errc::not_leader) {
+        // Harmless, we lost leadership so the new controller
+        // leader is responsible for picking up where we left off.
+        co_return;
+    } else if (err) {
+        // Raise exception to trigger backoff+retry
+        throw std::runtime_error(fmt::format(
+          "Error storing cluster version {}: {}", new_version, err));
     }
 }
 
@@ -393,49 +478,18 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     auto data = feature_update_cmd_data{.logical_version = max_version};
 
     // Identify any features which should auto-activate in this version
-    if (config::shard_local_cfg().features_auto_enable()) {
-        /*
-         * We auto-enable features if:
-         * - They are not disabled
-         * - Their required version is satisfied
-         * - Their policy is not explicit_only
-         * - The global features_auto_enable setting is true.
-         */
-        for (const auto& fs : _feature_table.local().get_feature_state()) {
-            if (
-              fs.get_state() == features::feature_state::state::unavailable
-              && fs.spec.available_rule
-                   == features::feature_spec::available_policy::always
-              && max_version >= fs.spec.require_version) {
-                vlog(
-                  clusterlog.info,
-                  "Auto-activating feature {} (logical version {})",
-                  fs.spec.name,
-                  max_version);
-                data.actions.push_back(cluster::feature_update_action{
-                  .feature_name = ss::sstring(fs.spec.name),
-                  .action = feature_update_action::action_t::activate});
-            }
-        }
+    for (const auto spec : auto_activate_features(max_version)) {
+        vlog(
+          clusterlog.info,
+          "Auto-activating feature {} (logical version {})",
+          spec.get().name,
+          max_version);
+        data.actions.push_back(cluster::feature_update_action{
+          .feature_name = ss::sstring(spec.get().name),
+          .action = feature_update_action::action_t::activate});
     }
 
-    auto cmd = feature_update_cmd(
-      std::move(data),
-      0 // unused
-    );
-
-    auto timeout = model::timeout_clock::now() + status_retry;
-    auto err = co_await replicate_and_wait(
-      _stm, _feature_table, _as, std::move(cmd), timeout);
-    if (err == errc::not_leader) {
-        // Harmless, we lost leadership so the new controller
-        // leader is responsible for picking up where we left off.
-        co_return;
-    } else if (err) {
-        // Raise exception to trigger backoff+retry
-        throw std::runtime_error(fmt::format(
-          "Error storing cluster version {}: {}", max_version, err));
-    }
+    co_await replicate_feature_update_cmd(std::move(data));
 
     vlog(clusterlog.info, "Updated cluster (logical version {})", max_version);
 }

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -122,6 +122,7 @@ private:
     bool updates_pending() {
         return (!_updates.empty()
                 || !auto_activate_features(
+                      _feature_table.local().get_original_version(),
                       _feature_table.local().get_active_version())
                       .empty())
                && _am_controller_leader;
@@ -138,7 +139,7 @@ private:
     // upgraded Redpanda to a binary in the same logical version with a
     // different activation policy for the feature.
     std::vector<std::reference_wrapper<const features::feature_spec>>
-      auto_activate_features(cluster_version);
+      auto_activate_features(cluster_version, cluster_version);
 
     ss::sharded<controller_stm>& _stm;
     ss::sharded<ss::abort_source>& _as;

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -112,6 +112,17 @@ private:
 
     ss::future<> maybe_log_license_check_info();
 
+    // Compose a command struct, replicate it via raft and wait for apply.
+    // Silently swallow not_leader errors, raise on other errors;
+    ss::future<> replicate_feature_update_cmd(feature_update_cmd_data data);
+
+    // Discover features that may now be auto-activated: usually this happens
+    // when we activate a new logical version, but it may also happen if we
+    // upgraded Redpanda to a binary in the same logical version with a
+    // different activation policy for the feature.
+    std::vector<std::reference_wrapper<const features::feature_spec>>
+      auto_activate_features(cluster_version);
+
     ss::sharded<controller_stm>& _stm;
     ss::sharded<ss::abort_source>& _as;
     ss::gate _gate;

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -107,8 +107,25 @@ private:
      */
     void set_node_to_latest_version(model::node_id);
 
+    /// Background loop body: calls the functions that may update the
+    /// active version and/or activate features.
+    ss::future<> maybe_update_feature_table();
+
+    /// Consume _updates and evaluate whether the cluster version may advance
     ss::future<> do_maybe_update_active_version();
-    ss::future<> maybe_update_active_version();
+
+    /// Check _feature_table for any features that are elegible to auto
+    /// activate but not yet active.
+    ss::future<> do_maybe_activate_features();
+
+    /// Whether there is work to do in maybe_update_feature_table
+    bool updates_pending() {
+        return (!_updates.empty()
+                || !auto_activate_features(
+                      _feature_table.local().get_active_version())
+                      .empty())
+               && _am_controller_leader;
+    }
 
     ss::future<> maybe_log_license_check_info();
 

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -229,8 +229,7 @@ std::optional<node_health_report> health_monitor_backend::build_node_report(
     }
 
     report.drain_status = it->second.drain_status;
-    report.include_drain_status = _feature_table.local().is_active(
-      features::feature::maintenance_mode);
+    report.include_drain_status = true;
 
     return report;
 }
@@ -651,8 +650,7 @@ health_monitor_backend::collect_current_node_health(node_report_filter filter) {
       = features::feature_table::get_latest_logical_version();
 
     ret.drain_status = co_await _drain_manager.local().status();
-    ret.include_drain_status = _feature_table.local().is_active(
-      features::feature::maintenance_mode);
+    ret.include_drain_status = true;
 
     if (filter.include_partitions) {
         ret.topics = co_await collect_topic_status(

--- a/src/v/cluster/members_frontend.cc
+++ b/src/v/cluster/members_frontend.cc
@@ -135,14 +135,6 @@ members_frontend::recommission_node(model::node_id id) {
 
 ss::future<std::error_code>
 members_frontend::set_maintenance_mode(model::node_id id, bool enabled) {
-    if (!_feature_table.local().is_active(
-          features::feature::maintenance_mode)) {
-        vlog(
-          clusterlog.info,
-          "Maintenance mode feature is not active (upgrade in progress?)");
-        co_return errc::invalid_node_operation;
-    }
-
     auto leader = _leaders.local().get_leader(model::controller_ntp);
     if (!leader) {
         co_return errc::no_leader_controller;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2774,11 +2774,7 @@ uint8_t rm_stm::active_snapshot_version() {
         return tx_snapshot_v3::version;
     }
 
-    if (_feature_table.local().is_active(
-          features::feature::rm_stm_kafka_cache)) {
-        return tx_snapshot_v2::version;
-    }
-    return tx_snapshot_v1::version;
+    return tx_snapshot_v2::version;
 }
 
 template<class T>

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -25,16 +25,6 @@ namespace features {
 
 std::string_view to_string_view(feature f) {
     switch (f) {
-    case feature::central_config:
-        return "central_config";
-    case feature::consumer_offsets:
-        return "consumer_offsets";
-    case feature::maintenance_mode:
-        return "maintenance_mode";
-    case feature::mtls_authentication:
-        return "mtls_authentication";
-    case feature::rm_stm_kafka_cache:
-        return "rm_stm_kafka_cache";
     case feature::serde_raft_0:
         return "serde_raft_0";
     case feature::license:

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -340,7 +340,11 @@ void feature_table::on_update() {
 void feature_table::apply_action(const feature_update_action& fua) {
     auto feature_id_opt = resolve_name(fua.feature_name);
     if (!feature_id_opt.has_value()) {
-        vlog(featureslog.warn, "Ignoring action {}, unknown feature", fua);
+        if (features::retired_features.contains(fua.feature_name)) {
+            vlog(featureslog.debug, "Ignoring action {}, retired feature", fua);
+        } else {
+            vlog(featureslog.warn, "Ignoring action {}, unknown feature", fua);
+        }
         return;
     } else {
         if (ss::this_shard_id() == 0) {

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -60,8 +60,9 @@ enum class feature : std::uint64_t {
     force_partition_reconfiguration = 1ULL << 26U,
 
     // Dummy features for testing only
-    test_alpha = 1ULL << 62U,
-    test_bravo = 1ULL << 63U,
+    test_alpha = 1ULL << 61U,
+    test_bravo = 1ULL << 62U,
+    test_charlie = 1ULL << 63U,
 };
 
 // Eventually, once a feature has been in use for a while, it is no longer
@@ -261,22 +262,6 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{10},
     "force_partition_reconfiguration",
     feature::force_partition_reconfiguration,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
-
-  // For testing, a feature that does not auto-activate
-  feature_spec{
-    cluster::cluster_version{2001},
-    "__test_alpha",
-    feature::test_alpha,
-    feature_spec::available_policy::explicit_only,
-    feature_spec::prepare_policy::always},
-
-  // For testing, a feature that auto-activates
-  feature_spec{
-    cluster::cluster_version{2001},
-    "__test_bravo",
-    feature::test_bravo,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -243,7 +243,7 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{10},
     "controller_snapshots",
     feature::controller_snapshots,
-    feature_spec::available_policy::explicit_only,
+    feature_spec::available_policy::new_clusters_only,
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{10},

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -65,6 +65,14 @@ enum class feature : std::uint64_t {
     test_bravo = 1ULL << 63U,
 };
 
+
+// Eventually, once a feature has been in use for a while, it is no longer
+// behind a feature flag, and the flag itself is retired.  We remember a list
+// of all retired features, because this enables us to distinguish between
+// controller messages for unknown features (unexpected), and controller messages
+// that refer to features that have been retired.
+inline const std::set<std::string_view> retired_features;
+
 /**
  * The definition of a feature specifies rules for when it should
  * be activated,

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -78,6 +78,10 @@ struct feature_spec {
         // The feature only becomes available once all cluster nodes
         // are recent enough *and* an administrator explicitly enables it.
         explicit_only,
+
+        // The feature proceeds to activate only if the cluster's original
+        // version is >= the feature's require_version
+        new_clusters_only,
     };
 
     // Policy defining whether the feature passes through 'preparing'

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -31,12 +31,11 @@ namespace features {
 
 struct feature_table_snapshot;
 
+/// The integers in this enum must be unique wrt each other, but _not_ over
+/// all time.  We always serialize features to string names, the integer is
+/// only used at runtime.  Therefore it is safe to re-use an integer that
+/// has been made available by another feature being retired.
 enum class feature : std::uint64_t {
-    central_config = 1ULL,
-    consumer_offsets = 1ULL << 1U,
-    maintenance_mode = 1ULL << 2U,
-    mtls_authentication = 1ULL << 3U,
-    rm_stm_kafka_cache = 1ULL << 4U,
     serde_raft_0 = 1ULL << 5U,
     license = 1ULL << 6U,
     raft_improved_configuration = 1ULL << 7U,
@@ -65,13 +64,21 @@ enum class feature : std::uint64_t {
     test_bravo = 1ULL << 63U,
 };
 
-
 // Eventually, once a feature has been in use for a while, it is no longer
 // behind a feature flag, and the flag itself is retired.  We remember a list
 // of all retired features, because this enables us to distinguish between
-// controller messages for unknown features (unexpected), and controller messages
-// that refer to features that have been retired.
-inline const std::set<std::string_view> retired_features;
+// controller messages for unknown features (unexpected), and controller
+// messages that refer to features that have been retired.
+//
+// retired does *not* mean the functionality is gone: it just means it
+// is no longer guarded by a feature flag.
+inline const std::set<std::string_view> retired_features = {
+  "central_config",
+  "consumer_offsets",
+  "maintenance_mode",
+  "mtls_authentication",
+  "rm_stm_kafka_cache",
+};
 
 /**
  * The definition of a feature specifies rules for when it should
@@ -124,36 +131,6 @@ struct feature_spec {
 };
 
 constexpr static std::array feature_schema{
-  feature_spec{
-    cluster::cluster_version{1},
-    "central_config",
-    feature::central_config,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
-  feature_spec{
-    cluster::cluster_version{2},
-    "consumer_offsets",
-    feature::consumer_offsets,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
-  feature_spec{
-    cluster::cluster_version{3},
-    "maintenance_mode",
-    feature::maintenance_mode,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
-  feature_spec{
-    cluster::cluster_version{3},
-    "mtls_authentication",
-    feature::mtls_authentication,
-    feature_spec::available_policy::explicit_only,
-    feature_spec::prepare_policy::always},
-  feature_spec{
-    cluster::cluster_version{4},
-    "rm_stm_kafka_cache",
-    feature::rm_stm_kafka_cache,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{5},
     "serde_raft_0",

--- a/src/v/features/feature_table_snapshot.cc
+++ b/src/v/features/feature_table_snapshot.cc
@@ -43,6 +43,7 @@ void feature_table_snapshot::apply(feature_table& ft) const {
 
     ft.set_active_version(version);
     ft._license = license;
+
     for (auto& cur_state : ft._feature_state) {
         const auto& spec = cur_state.spec;
         auto snap_state_iter = std::find_if(

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -79,11 +79,10 @@ SEASTAR_THREAD_TEST_CASE(feature_table_test_hook_off) {
 SEASTAR_THREAD_TEST_CASE(feature_table_strings) {
     BOOST_REQUIRE_EQUAL(to_string_view(feature::test_alpha), mock_feature);
     BOOST_REQUIRE_EQUAL(
-      to_string_view(feature::consumer_offsets), "consumer_offsets");
+      to_string_view(feature::rpc_v2_by_default), "rpc_v2_by_default");
+    BOOST_REQUIRE_EQUAL(to_string_view(feature::kafka_gssapi), "kafka_gssapi");
     BOOST_REQUIRE_EQUAL(
-      to_string_view(feature::central_config), "central_config");
-    BOOST_REQUIRE_EQUAL(
-      to_string_view(feature::maintenance_mode), "maintenance_mode");
+      to_string_view(feature::node_isolation), "node_isolation");
 }
 
 /**
@@ -314,11 +313,11 @@ FIXTURE_TEST(feature_table_old_snapshot, feature_table_fixture) {
     snapshot.version = features::feature_table::get_earliest_logical_version();
     snapshot.states = {
       features::feature_state_snapshot{
-        .name = "central_config",
+        .name = "serde_raft_0",
         .state = feature_state::state::available,
       },
       features::feature_state_snapshot{
-        .name = "mtls_authentication",
+        .name = "__test_alpha",
         .state = feature_state::state::active,
       },
     };
@@ -327,11 +326,11 @@ FIXTURE_TEST(feature_table_old_snapshot, feature_table_fixture) {
 
     // Fast-forwarded feature should still be active.
     BOOST_CHECK(
-      ft.get_state(feature::central_config).get_state()
+      ft.get_state(feature::serde_raft_0).get_state()
       == feature_state::state::active);
     // A feature with explicit available_policy should be activated by the
     // snapshot.
     BOOST_CHECK(
-      ft.get_state(feature::mtls_authentication).get_state()
+      ft.get_state(feature::test_alpha).get_state()
       == feature_state::state::active);
 }

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -297,19 +297,6 @@ static ss::future<std::vector<resp_resource_t>> alter_broker_configuartion(
   request_context& ctx, std::vector<req_resource_t> resources) {
     std::vector<resp_resource_t> responses;
     responses.reserve(resources.size());
-
-    // If central config is disabled, we cannot set broker properties
-    if (!ctx.feature_table().local().is_active(
-          features::feature::central_config)) {
-        co_return co_await unsupported_broker_configuration<
-          req_resource_t,
-          resp_resource_t>(
-          std::move(resources),
-          "changing broker properties via this API is not enabled");
-
-        co_return responses;
-    }
-
     for (const auto& resource : resources) {
         cluster::config_update_request req;
 

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -47,13 +47,6 @@ join_group_request make_join_group_request(
 struct consumer_offsets_fixture : public redpanda_thread_fixture {
     void
     wait_for_consumer_offsets_topic(const kafka::group_instance_id& group) {
-        app.controller->get_feature_table()
-          .local()
-          .await_feature(
-            features::feature::consumer_offsets,
-            app.controller->get_abort_source().local())
-          .get();
-
         auto client = make_kafka_client().get0();
 
         client.connect().get();

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2152,6 +2152,21 @@ void admin_server::register_features_routes() {
               res.features.push(item);
           }
 
+          // Report all retired features as active (the code they previously
+          // guarded is now on by default).  This enables external programs
+          // to check the state of a particular feature flag in perpetuity
+          // without having to deal with the ambiguous case of the feature
+          // being missing (i.e. unsure if redpanda is too old to have
+          // the feature flag, or too new to have it).
+          for (const auto& retired_name : features::retired_features) {
+              ss::httpd::features_json::feature_state item;
+              item.name = ss::sstring(retired_name);
+              item.state = ss::httpd::features_json::feature_state::
+                feature_state_state::active;
+              item.was_active = true;
+              res.features.push(item);
+          }
+
           return ss::make_ready_future<ss::json::json_return_type>(
             std::move(res));
       });

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1998,6 +1998,39 @@ static json::validator make_feature_put_validator() {
     return json::validator(schema);
 }
 
+/// Features are state machines, with multiple 'disabled' states.  Simplify
+/// this into the higher level states the the admin API reports to users.
+/// (see state machine diagram in feature_state.h)
+ss::httpd::features_json::feature_state::feature_state_state
+feature_state_to_high_level(features::feature_state::state state) {
+    switch (state) {
+    case features::feature_state::state::active:
+        return ss::httpd::features_json::feature_state::feature_state_state::
+          active;
+        break;
+    case features::feature_state::state::unavailable:
+        return ss::httpd::features_json::feature_state::feature_state_state::
+          unavailable;
+        break;
+    case features::feature_state::state::available:
+        return ss::httpd::features_json::feature_state::feature_state_state::
+          available;
+        break;
+    case features::feature_state::state::preparing:
+        return ss::httpd::features_json::feature_state::feature_state_state::
+          preparing;
+        break;
+    case features::feature_state::state::disabled_clean:
+    case features::feature_state::state::disabled_active:
+    case features::feature_state::state::disabled_preparing:
+        return ss::httpd::features_json::feature_state::feature_state_state::
+          disabled;
+        break;
+
+        // Exhaustive match
+    }
+}
+
 ss::future<ss::json::json_return_type>
 admin_server::put_feature_handler(std::unique_ptr<ss::http::request> req) {
     static thread_local auto feature_put_validator(
@@ -2008,18 +2041,42 @@ admin_server::put_feature_handler(std::unique_ptr<ss::http::request> req) {
 
     auto feature_name = req->param["feature_name"];
 
-    if (!_controller->get_feature_table()
-           .local()
-           .resolve_name(feature_name)
-           .has_value()) {
+    auto feature_id = _controller->get_feature_table().local().resolve_name(
+      feature_name);
+    if (!feature_id.has_value()) {
         throw ss::httpd::bad_request_exception("Unknown feature name");
     }
+
+    // Retrieve the current state and map to high level disabled/enabled value
+    auto& feature_state = _controller->get_feature_table().local().get_state(
+      feature_id.value());
+    auto current_state = feature_state_to_high_level(feature_state.get_state());
 
     cluster::feature_update_action action{.feature_name = feature_name};
     auto& new_state_str = doc["state"];
     if (new_state_str == "active") {
+        if (
+          current_state
+          == ss::httpd::features_json::feature_state::feature_state_state::
+            active) {
+            vlog(
+              logger.info,
+              "Ignoring request to activate feature '{}', already active",
+              feature_name);
+            co_return ss::json::json_void();
+        }
         action.action = cluster::feature_update_action::action_t::activate;
     } else if (new_state_str == "disabled") {
+        if (
+          current_state
+          == ss::httpd::features_json::feature_state::feature_state_state::
+            disabled) {
+            vlog(
+              logger.info,
+              "Ignoring request to disable feature '{}', already disabled",
+              feature_name);
+            co_return ss::json::json_void();
+        }
         action.action = cluster::feature_update_action::action_t::deactivate;
     } else {
         throw ss::httpd::bad_request_exception("Invalid state");
@@ -2112,31 +2169,7 @@ void admin_server::register_features_routes() {
                 fs.spec.name,
                 fs.get_state());
               item.name = ss::sstring(fs.spec.name);
-
-              switch (fs.get_state()) {
-              case features::feature_state::state::active:
-                  item.state = ss::httpd::features_json::feature_state::
-                    feature_state_state::active;
-                  break;
-              case features::feature_state::state::unavailable:
-                  item.state = ss::httpd::features_json::feature_state::
-                    feature_state_state::unavailable;
-                  break;
-              case features::feature_state::state::available:
-                  item.state = ss::httpd::features_json::feature_state::
-                    feature_state_state::available;
-                  break;
-              case features::feature_state::state::preparing:
-                  item.state = ss::httpd::features_json::feature_state::
-                    feature_state_state::preparing;
-                  break;
-              case features::feature_state::state::disabled_clean:
-              case features::feature_state::state::disabled_active:
-              case features::feature_state::state::disabled_preparing:
-                  item.state = ss::httpd::features_json::feature_state::
-                    feature_state_state::disabled;
-                  break;
-              }
+              item.state = feature_state_to_high_level(fs.get_state());
 
               switch (fs.get_state()) {
               case features::feature_state::state::active:

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1399,13 +1399,6 @@ admin_server::patch_cluster_config_handler(
   request_auth_result const& auth_state) {
     static thread_local auto cluster_config_validator(
       make_cluster_config_validator());
-
-    if (!_controller->get_feature_table().local().is_active(
-          features::feature::central_config)) {
-        throw ss::httpd::bad_request_exception(
-          "Central config feature not active (upgrade in progress?)");
-    }
-
     auto doc = parse_json_body(*req);
     apply_validator(cluster_config_validator, doc);
 
@@ -2332,13 +2325,6 @@ ss::future<ss::json::json_return_type> admin_server::recomission_broker_handler(
 ss::future<ss::json::json_return_type>
 admin_server::start_broker_maintenance_handler(
   std::unique_ptr<ss::http::request> req) {
-    if (!_controller->get_feature_table().local().is_active(
-          features::feature::maintenance_mode)) {
-        throw ss::httpd::bad_request_exception(
-          "Maintenance mode feature not active (upgrade in "
-          "progress?)");
-    }
-
     if (_controller->get_members_table().local().node_count() < 2) {
         throw ss::httpd::bad_request_exception(
           "Maintenance mode may not be used on a single node "
@@ -2356,12 +2342,6 @@ admin_server::start_broker_maintenance_handler(
 ss::future<ss::json::json_return_type>
 admin_server::stop_broker_maintenance_handler(
   std::unique_ptr<ss::http::request> req) {
-    if (!_controller->get_feature_table().local().is_active(
-          features::feature::maintenance_mode)) {
-        throw ss::httpd::bad_request_exception(
-          "Maintenance mode feature not active (upgrade in "
-          "progress?)");
-    }
     model::node_id id = parse_broker_id(*req);
     auto ec = co_await _controller->get_members_frontend()
                 .local()

--- a/tests/rptest/scale_tests/large_controller_snapshot_test.py
+++ b/tests/rptest/scale_tests/large_controller_snapshot_test.py
@@ -66,8 +66,6 @@ class LargeControllerSnapshotTest(RedpandaTest):
         admin = Admin(self.redpanda, default_node=seed_nodes[0])
         rpk = RpkTool(self.redpanda)
 
-        admin.put_feature("controller_snapshots", {"state": "active"})
-
         if self.redpanda.dedicated_nodes:
             # approx. 5k partition replicas per shard
             n_topics = 50

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1220,6 +1220,13 @@ class RedpandaService(RedpandaServiceBase):
     def set_environment(self, environment: dict[str, str]):
         self._environment.update(environment)
 
+    def unset_environment(self, keys: list):
+        for k in keys:
+            try:
+                del self._environment[k]
+            except KeyError:
+                pass
+
     def set_extra_node_conf(self, node, conf):
         assert node in self.nodes, f"where node is {node.name}"
         self._extra_node_conf[node] = conf

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -79,7 +79,7 @@ class FeaturesTestBase(RedpandaTest):
             f"Version mismatch: {initial_version} vs {self.head_latest_logical_version}"
 
         assert self._get_features_map(
-            features_response)['central_config']['state'] == 'active'
+            features_response)['license']['state'] == 'active'
 
         return features_response
 

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -20,7 +20,13 @@ from rptest.util import expect_exception
 
 from ducktape.errors import TimeoutError as DucktapeTimeoutError
 from ducktape.utils.util import wait_until
+from ducktape.mark import parametrize
 from rptest.util import wait_until_result
+
+FEATURE_ALPHA_NAME = "__test_alpha"
+FEATURE_BRAVO_NAME = "__test_bravo"
+FEATURE_CHARLIE_NAME = "__test_charlie"
+TEST_FEATURES_VERSION = 2001
 
 
 class FeaturesTestBase(RedpandaTest):
@@ -101,18 +107,6 @@ class FeaturesTestBase(RedpandaTest):
         # it relies on periodic health messages
         wait_until(check, timeout_sec=20, backoff_sec=1)
 
-
-class FeaturesMultiNodeTest(FeaturesTestBase):
-    """
-    Multi-node variant of tests is the 'normal' execution path for feature manager.
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, num_brokers=3, **kwargs)
-
-    @cluster(num_nodes=3)
-    def test_get_features(self):
-        self._assert_default_features()
-
     def _wait_for_feature_everywhere(self, fn):
         """
         Apply a GET check to all nodes, for writes that are expected to
@@ -130,6 +124,18 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         # a particularly long timeout: it's here for when tests run very slow.
         wait_until(check, timeout_sec=10, backoff_sec=0.5)
 
+
+class FeaturesMultiNodeTest(FeaturesTestBase):
+    """
+    Multi-node variant of tests is the 'normal' execution path for feature manager.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=3, **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_get_features(self):
+        self._assert_default_features()
+
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_explicit_activation(self):
         """
@@ -138,18 +144,17 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
 
         # Parameters of the compiled-in test feature
         feature_alpha_version = 2001
-        feature_alpha_name = "__test_alpha"
 
         initial_version = self.admin.get_features()['cluster_version']
         assert (initial_version < feature_alpha_version)
         # Initially, before setting the magic environment variable, dummy test features
         # should be hidden
-        assert feature_alpha_name not in self._get_features_map().keys()
+        assert FEATURE_ALPHA_NAME not in self._get_features_map().keys()
 
         self.redpanda.set_environment({'__REDPANDA_TEST_FEATURES': "ON"})
         self.redpanda.restart_nodes(self.redpanda.nodes)
         assert self._get_features_map(
-        )[feature_alpha_name]['state'] == 'unavailable'
+        )[FEATURE_ALPHA_NAME]['state'] == 'unavailable'
 
         # Version is too low, feature should be unavailable
         assert initial_version == self.admin.get_features()['cluster_version']
@@ -172,30 +177,30 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         # Feature should become available now that version increased.  It should NOT
         # become active, because it has an explicit_only policy for activation.
         self._wait_for_feature_everywhere(
-            lambda fm: fm[feature_alpha_name]['state'] == 'available')
+            lambda fm: fm[FEATURE_ALPHA_NAME]['state'] == 'available')
 
         # Disable the feature, see that it enters the expected state
-        self.admin.put_feature(feature_alpha_name, {"state": "disabled"})
+        self.admin.put_feature(FEATURE_ALPHA_NAME, {"state": "disabled"})
         self._wait_for_feature_everywhere(
-            lambda fm: fm[feature_alpha_name]['state'] == 'disabled')
+            lambda fm: fm[FEATURE_ALPHA_NAME]['state'] == 'disabled')
 
-        state = self._get_features_map()[feature_alpha_name]
+        state = self._get_features_map()[FEATURE_ALPHA_NAME]
         assert state['state'] == 'disabled'
         assert state['was_active'] == False
 
         # Write to admin API to enable the feature
-        self.admin.put_feature(feature_alpha_name, {"state": "active"})
+        self.admin.put_feature(FEATURE_ALPHA_NAME, {"state": "active"})
 
         # This is an async check because propagation of feature_table is async
         self._wait_for_feature_everywhere(
-            lambda fm: fm[feature_alpha_name]['state'] == 'active')
+            lambda fm: fm[FEATURE_ALPHA_NAME]['state'] == 'active')
 
         # Disable the feature, see that it enters the expected state
-        self.admin.put_feature(feature_alpha_name, {"state": "disabled"})
+        self.admin.put_feature(FEATURE_ALPHA_NAME, {"state": "disabled"})
         self._wait_for_feature_everywhere(
-            lambda fm: fm[feature_alpha_name]['state'] == 'disabled')
+            lambda fm: fm[FEATURE_ALPHA_NAME]['state'] == 'disabled')
 
-        state = self._get_features_map()[feature_alpha_name]
+        state = self._get_features_map()[FEATURE_ALPHA_NAME]
         assert state['state'] == 'disabled'
         assert state['was_active'] == True
 
@@ -534,3 +539,123 @@ class FeaturesUpgradeAssertionTest(FeaturesTestBase):
         self.redpanda.start_node(
             upgrade_node,
             override_cfg_params={'upgrade_override_checks': True})
+
+
+class FeaturesUpgradeActivationTest(FeaturesTestBase):
+    def setUp(self):
+        pass
+
+    @cluster(num_nodes=1)
+    @parametrize(upgrade=False)
+    @parametrize(upgrade=True)
+    def test_new_cluster_only_activation(self, upgrade: bool):
+        if upgrade:
+            self.redpanda.set_environment({
+                '__REDPANDA_TEST_FEATURES':
+                "ON",
+                "__REDPANDA_LATEST_LOGICAL_VERSION":
+                TEST_FEATURES_VERSION - 1
+            })
+        else:
+            self.redpanda.set_environment({
+                '__REDPANDA_TEST_FEATURES':
+                "ON",
+                "__REDPANDA_LATEST_LOGICAL_VERSION":
+                TEST_FEATURES_VERSION,
+            })
+
+        self.redpanda.start()
+
+        if upgrade:
+            for f in [
+                    FEATURE_ALPHA_NAME, FEATURE_CHARLIE_NAME,
+                    FEATURE_CHARLIE_NAME
+            ]:
+                # Pre-upgrade, none of the features should be available
+                assert self._get_features_map()[f]['state'] == 'unavailable'
+
+            self.redpanda.set_environment({
+                '__REDPANDA_TEST_FEATURES':
+                "ON",
+                "__REDPANDA_LATEST_LOGICAL_VERSION":
+                TEST_FEATURES_VERSION,
+            })
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+            self.redpanda.wait_until(lambda: self._get_features_map()[
+                FEATURE_ALPHA_NAME]['state'] == 'available',
+                                     timeout_sec=30,
+                                     backoff_sec=1)
+        else:
+            # No upgrade: feature should be available from time zero.
+            assert self._get_features_map(
+            )[FEATURE_ALPHA_NAME]['state'] == 'available'
+
+        # Once we are on the test feature version, auto-active features should be on
+        assert self._get_features_map(
+        )[FEATURE_BRAVO_NAME]['state'] == 'active'
+
+        # Once we are on the test feature version, new_clusters_only features' state
+        # should depend on whether we upgraded or we were always at this version.
+        assert self._get_features_map()[FEATURE_CHARLIE_NAME][
+            'state'] == 'available' if upgrade else 'active'
+
+    @cluster(num_nodes=1)
+    @parametrize(disable=False)
+    @parametrize(disable=True)
+    def test_policy_change_in_minor_release(self, disable: bool):
+        self.redpanda.set_environment({
+            '__REDPANDA_TEST_FEATURES':
+            "ON",
+            "__REDPANDA_LATEST_LOGICAL_VERSION":
+            TEST_FEATURES_VERSION,
+            "__REDPANDA_TEST_FEATURE_NO_AUTO_ACTIVATE_BRAVO":
+            'true',
+        })
+        self.logger.info(f"test: env={self.redpanda._environment}")
+        self.redpanda.start()
+
+        # The feature's policy is explicit_only, it should only go to available, not active
+        assert self._get_features_map(
+        )[FEATURE_BRAVO_NAME]['state'] == 'available'
+
+        # Ensure that the config manager background loop isn't activating wrongly
+        time.sleep(10)
+        assert self._get_features_map(
+        )[FEATURE_BRAVO_NAME]['state'] == 'available'
+
+        # Ensure that restarts don't activate the feature
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        time.sleep(10)
+        assert self._get_features_map(
+        )[FEATURE_BRAVO_NAME]['state'] == 'available'
+
+        if disable:
+            # Explicitly disable the feature: this should prevent it auto activating
+            # after the simulated upgrade
+            self.admin.put_feature(FEATURE_BRAVO_NAME, {"state": "disabled"})
+            self._wait_for_feature_everywhere(
+                lambda fm: fm[FEATURE_BRAVO_NAME]['state'] == 'disabled')
+
+        # Simulate upgrading to a .z release that changes the feature's policy to ::always
+        self.redpanda.unset_environment(
+            ["__REDPANDA_TEST_FEATURE_NO_AUTO_ACTIVATE_BRAVO"])
+        self.redpanda.set_environment({
+            '__REDPANDA_TEST_FEATURES':
+            "ON",
+            "__REDPANDA_LATEST_LOGICAL_VERSION":
+            TEST_FEATURES_VERSION
+        })
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        if disable:
+            # Because feature was explicitly disabled, it should not auto-activate
+            assert self._get_features_map(
+            )[FEATURE_BRAVO_NAME]['state'] == 'disabled'
+            time.sleep(10)
+            # ...even after time for some background ticks
+            assert self._get_features_map(
+            )[FEATURE_BRAVO_NAME]['state'] == 'disabled'
+        else:
+            # Now that the feature's policy is to auto-activate, it should activate
+            self._wait_for_feature_everywhere(
+                lambda fm: fm[FEATURE_BRAVO_NAME]['state'] == 'active')

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -100,8 +100,9 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
         if controller_snapshots:
             self.redpanda.set_cluster_config(
                 {"controller_snapshot_max_age_sec": 1})
+        else:
             self.redpanda._admin.put_feature("controller_snapshots",
-                                             {"state": "active"})
+                                             {"state": "disabled"})
 
         # Kill a majority of nodes
         (killed, alive) = self._stop_majority_nodes()
@@ -147,8 +148,9 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
         if controller_snapshots:
             self.redpanda.set_cluster_config(
                 {"controller_snapshot_max_age_sec": 1})
+        else:
             self.redpanda._admin.put_feature("controller_snapshots",
-                                             {"state": "active"})
+                                             {"state": "disabled"})
 
         self.topic = "topic"
         self.client().create_topic(

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -168,12 +168,11 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
             return
 
         if enable_controller_snapshots:
-            if recovery == RESTART_RECOVERY:
-                Admin(self.redpanda).put_feature("controller_snapshots",
-                                                 {"state": "active"})
-            else:
+            if recovery != RESTART_RECOVERY:
                 # doesn't make sense to test controller snapshots if nodes don't get
                 # restarted
+                Admin(self.redpanda).put_feature("controller_snapshots",
+                                                 {"state": "disabled"})
                 cleanup_on_early_exit(self)
                 return
 

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -776,7 +776,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         if enable_controller_snapshots:
             self.redpanda.set_cluster_config(
                 {"controller_snapshot_max_age_sec": 1})
-            admin.put_feature("controller_snapshots", {"state": "active"})
+        else:
+            admin.put_feature("controller_snapshots", {"state": "disabled"})
 
         spec = TopicSpec(partition_count=partition_count, replication_factor=3)
         self.client().create_topic(spec)

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -246,13 +246,12 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         # start redpanda process
         self._start_redpanda(num_to_upgrade, enable_controller_snapshots)
 
+        admin = Admin(self.redpanda)
         if enable_controller_snapshots:
-            admin = Admin(self.redpanda)
-            admin.put_feature("controller_snapshots", {"state": "active"})
-            self.redpanda.await_feature_active("controller_snapshots",
-                                               timeout_sec=30)
             self.redpanda.set_cluster_config(
                 {"controller_snapshot_max_age_sec": 1})
+        else:
+            admin.put_feature("controller_snapshots", {"state": "disabled"})
 
         # create some initial topics
         self._create_topics(10)

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -551,7 +551,9 @@ class CreateTopicUpgradeTest(RedpandaTest):
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         # Wait for properties migration to run
-        self.redpanda.await_feature_active("cloud_retention", timeout_sec=30)
+        self.redpanda.await_feature("cloud_retention",
+                                    active=True,
+                                    timeout_sec=30)
 
         self.logger.info(
             f"Config status after upgrade: {self.redpanda._admin.get_cluster_config_status()}"
@@ -644,7 +646,9 @@ class CreateTopicUpgradeTest(RedpandaTest):
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         # Wait for any migration steps to complete
-        self.redpanda.await_feature_active('cloud_retention', timeout_sec=30)
+        self.redpanda.await_feature("cloud_retention",
+                                    active=True,
+                                    timeout_sec=30)
 
         non_si_configs = self.rpk.describe_topic_configs(
             "test-topic-with-retention")
@@ -800,7 +804,9 @@ class CreateTopicUpgradeTest(RedpandaTest):
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         # Wait for any migration steps to complete
-        self.redpanda.await_feature_active('cloud_retention', timeout_sec=30)
+        self.redpanda.await_feature('cloud_retention',
+                                    active=True,
+                                    timeout_sec=30)
 
         # Because legacy Redpanda treated cloud_storage_enable_remote_write as
         # an override to the topic property (even if the topic remote.write was explicitly


### PR DESCRIPTION
- Add a new `new_clusters_only` activation policy for features we would like to activate by default on new systems, without the risk of switching them on during upgrades to existing clusters.
- Add logic for handling changes to activation policy between Redpanda minor versions.  So if in a later 23.2.z we choose to make a feature always on by default, we can make that change (although this is generally not going to be a great practice, as minor releases should be bug fixes).
- Add a list of 'retired features' and move features from Redpanda <22.2 here: these refer to functionality which is now always-on and doesn't need to be behind a feature flag.
- Make controller snapshots use the `new_clusters_only` mode.
- Add a defensive measure in admin API to ignore no-op PUTs to feature API, as we may be seeing more use of this API by external clients that might do an imperfect job of reconciling things.

~TODO~to-done:
- [x] Amend controller snapshot tests that switch it on/off while assuming it's off by default
- [x] Add tests for new feature manager behaviors

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none