### PR TITLE
[v22.3.x] rpc: Log broken semaphore errors as timeout

### DIFF
--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -223,6 +223,10 @@ simple_protocol::dispatch_method_once(header h, net::server::resources rs) {
                           "Timing out request on abort_requested_exception "
                           "(shutting down)");
                         reply_buf.set_status(rpc::status::request_timeout);
+                    } catch (const ss::broken_semaphore& e) {
+                        rpclog.debug("Timing out request on broken_semaphore "
+                                     "(shutting down)");
+                        reply_buf.set_status(rpc::status::request_timeout);
                     } catch (...) {
                         rpclog.error(
                           "Service handler threw an exception: {}",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10955
Fixes https://github.com/redpanda-data/redpanda/issues/10965,