### PR TITLE
Handling internal topics in partition balancer planner

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -503,7 +503,10 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
               .partition_autobalancing_concurrent_moves.bind(),
             config::shard_local_cfg()
               .partition_autobalancing_tick_moves_drop_threshold.bind(),
-            config::shard_local_cfg().segment_fallocation_step.bind());
+            config::shard_local_cfg().segment_fallocation_step.bind(),
+            config::shard_local_cfg()
+              .partition_autobalancing_min_size_threshold.bind(),
+            config::shard_local_cfg().raft_learner_recovery_rate.bind());
       })
       .then([this] {
           return _partition_balancer.invoke_on(

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/partition_balancer_types.h"
 #include "cluster/types.h"
+#include "config/property.h"
 #include "model/fundamental.h"
 #include "raft/consensus.h"
 #include "seastarx.h"
@@ -42,7 +43,9 @@ public:
       config::binding<size_t>&& movement_batch_size_bytes,
       config::binding<size_t>&& max_concurrent_actions,
       config::binding<double>&& moves_drop_threshold,
-      config::binding<size_t>&& segment_fallocation_step);
+      config::binding<size_t>&& segment_fallocation_step,
+      config::binding<std::optional<size_t>> min_partition_size_threshold,
+      config::binding<size_t> raft_learner_recovery_rate);
 
     void start();
     ss::future<> stop();
@@ -68,6 +71,7 @@ private:
     void maybe_rearm_timer(bool now = false);
     void on_members_update(model::node_id, model::membership_state);
     void on_topic_table_update();
+    size_t get_min_partition_size_threshold() const;
 
 private:
     using clock_t = ss::lowres_clock;
@@ -88,6 +92,8 @@ private:
     config::binding<size_t> _max_concurrent_actions;
     config::binding<double> _concurrent_moves_drop_threshold;
     config::binding<size_t> _segment_fallocation_step;
+    config::binding<std::optional<size_t>> _min_partition_size_threshold;
+    config::binding<size_t> _raft_learner_recovery_rate;
 
     model::term_id _last_leader_term;
     clock_t::time_point _last_tick_time;

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -929,6 +929,15 @@ void partition_balancer_planner::get_rack_constraint_repair_actions(
     }
 }
 
+/**
+ * This is the place where we decide about the order in which partitions will be
+ * moved in the case when node disk is being full.
+ */
+size_t partition_balancer_planner::calculate_full_disk_partition_move_priority(
+  const reassignable_partition& p) {
+    return p.size_bytes();
+}
+
 /*
  * Function is trying to move ntps out of node that are violating
  * soft_max_disk_usage_ratio. It takes nodes in reverse used space ratio order.
@@ -990,7 +999,8 @@ void partition_balancer_planner::get_full_node_actions(request_context& ctx) {
 
               for (model::node_id node_id : replicas_on_full_nodes) {
                   full_node2priority2ntp[node_id].emplace(
-                    part.size_bytes(), part.ntp());
+                    calculate_full_disk_partition_move_priority(part),
+                    part.ntp());
               }
           },
           [](auto&) {});

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -16,6 +16,7 @@
 #include "cluster/partition_balancer_types.h"
 #include "cluster/scheduling/constraints.h"
 #include "cluster/scheduling/types.h"
+#include "model/namespace.h"
 #include "ssx/sformat.h"
 
 #include <seastar/core/sstring.hh>
@@ -938,17 +939,72 @@ size_t partition_balancer_planner::calculate_full_disk_partition_move_priority(
   model::node_id node_id,
   const reassignable_partition& p,
   const request_context& ctx) {
-    static constexpr size_t min_priority = 0;
-    static constexpr size_t max_priority = 1000000;
+    /**
+     * Definition of priority tiers:
+     *
+     *  - default (not internal one and not the ono that is bellow the size
+     *    threshold) partition
+     *      [max_priority,min_default_priority]
+     *
+     *  - internal partition
+     *      (min_default_priority, min_internal_partition_priority]
+     *
+     *  - small partition (which size is bellow the size threshold)
+     *        (min_internal_partition_priority, min_small_partition_priority]
+     */
+    enum priority_tiers : size_t {
+        max_priority = 1000000,
+        min_default_priority = 500000,
+        min_internal_partition_priority = 300000,
+        min_small_partition_priority = 100000,
+        min_priority = 0
+    };
 
     auto it = ctx.node_disk_reports.find(node_id);
     if (it == ctx.node_disk_reports.end()) {
         return min_priority;
     }
-    // normalize to range between [0,1000000], where max value would represent a
-    // partition that is of the full disk capacity size. We subtract it from the
-    // max priority to prioritize smallest partitions.
-    return max_priority - (max_priority * p.size_bytes()) / it->second.total;
+
+    static constexpr size_t default_range
+      = priority_tiers::max_priority - priority_tiers::min_default_priority;
+
+    // clamp partition size with the total disk space to have well defined
+    // behavior in case the size is incorrectly reported, this is required as we
+    // normalize the size with disk capacity and we do not want the ration of
+    // p_size/disk_capacity to be larger than 1.0.
+    const auto partition_size = std::min(p.size_bytes(), it->second.total);
+
+    if (partition_size < ctx.config().min_partition_size_threshold) {
+        static constexpr size_t range
+          = priority_tiers::min_internal_partition_priority - 1
+            - priority_tiers::min_small_partition_priority;
+
+        // prioritize from largest to smallest one
+        return (range * partition_size)
+                 / ctx.config().min_partition_size_threshold
+               + min_small_partition_priority;
+    }
+    /**
+     * Assign internal partitions to its priority tier, order from smallest to
+     * largest one (the same as all other partitions)
+     */
+    if (
+      p.ntp().ns == model::kafka_internal_namespace
+      || p.ntp().tp.topic == model::kafka_consumer_offsets_topic) {
+        static constexpr size_t range
+          = priority_tiers::min_default_priority - 1
+            - priority_tiers::min_internal_partition_priority;
+
+        return (range - (range * partition_size) / it->second.total)
+               + priority_tiers::min_internal_partition_priority;
+    }
+
+    // normalize and offset to match the default partition priority tier, where
+    // max value would represent a partition that is of the full disk capacity
+    // size. We subtract it from the max priority to prioritize smallest
+    // partitions.
+    return (default_range - (default_range * partition_size) / it->second.total)
+           + priority_tiers::min_default_priority;
 }
 
 /*

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -89,6 +89,8 @@ private:
       std::string_view reason);
     static void get_rack_constraint_repair_actions(request_context&);
     static void get_full_node_actions(request_context&);
+    static size_t
+    calculate_full_disk_partition_move_priority(const reassignable_partition&);
 
     planner_config _config;
     partition_balancer_state& _state;

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -40,6 +40,10 @@ struct planner_config {
     std::chrono::seconds node_availability_timeout_sec;
     // Fallocation step used to calculate upperbound for partition size
     size_t segment_fallocation_step;
+    // Threshold for minimum size of partition that is going to be prioritized
+    // for movement, partitions with size smaller than threshold will have the
+    // lowest priority
+    size_t min_partition_size_threshold;
 };
 
 class partition_balancer_planner {

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -89,8 +89,8 @@ private:
       std::string_view reason);
     static void get_rack_constraint_repair_actions(request_context&);
     static void get_full_node_actions(request_context&);
-    static size_t
-    calculate_full_disk_partition_move_priority(const reassignable_partition&);
+    static size_t calculate_full_disk_partition_move_priority(
+      model::node_id, const reassignable_partition&, const request_context&);
 
     planner_config _config;
     partition_balancer_state& _state;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1751,6 +1751,14 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       0.2,
       &validate_0_to_1_ratio)
+  , partition_autobalancing_min_size_threshold(
+      *this,
+      "partition_autobalancing_min_size_threshold",
+      "Minimum size of partition that is going to be prioritized when "
+      "rebalancing cluster due to disk size threshold being breached. By "
+      "default this value is calculated automaticaly",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
   , enable_leader_balancer(
       *this,
       "enable_leader_balancer",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -347,6 +347,7 @@ struct configuration final : public config_store {
     property<size_t> partition_autobalancing_movement_batch_size_bytes;
     property<size_t> partition_autobalancing_concurrent_moves;
     property<double> partition_autobalancing_tick_moves_drop_threshold;
+    property<std::optional<size_t>> partition_autobalancing_min_size_threshold;
 
     property<bool> enable_leader_balancer;
     enum_property<model::leader_balancer_mode> leader_balancer_mode;


### PR DESCRIPTION
Internal topics should only be moved if there are no other topics to be
moved. Using a minimum priority + 1 for all internal Redpanda topics
makes sure that those topics will be moved as a last one before the one
that falls below the threshold.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none