### PR TITLE
Log chunk hydration failures caused by partition shutdown as debug

### DIFF
--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -47,6 +47,8 @@ private:
     // offset.
     ss::future<> load_stream_for_chunk(chunk_start_offset_t chunk_start);
 
+    ss::future<> maybe_close_stream();
+
     segment_chunks& _chunks;
     remote_segment& _segment;
 

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -452,7 +452,6 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             r"Error in hydraton loop: .*Connection reset by peer",
             r"failed to hydrate chunk.*Connection reset by peer",
             r"failed to hydrate chunk.*NotFound",
-            r"failed to hydrate chunk.*abort_requested"
         ])
     @parametrize(cleanup_policy="delete")
     @parametrize(cleanup_policy="compact,delete")
@@ -477,7 +476,6 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             r"Error in hydraton loop: .*Connection reset by peer",
             r"failed to hydrate chunk.*Connection reset by peer",
             r"failed to hydrate chunk.*NotFound",
-            r"failed to hydrate chunk.*abort_requested"
         ])
     @parametrize(cleanup_policy="delete")
     @parametrize(cleanup_policy="compact,delete")

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -712,7 +712,11 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
         # Topic creation happens here
         super().setUp()
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=8,
+             log_allow_list=[
+                 r"failed to hydrate chunk.*Connection reset by peer",
+                 r"failed to hydrate chunk.*NotFound"
+             ])
     @matrix(short_retention=[False, True],
             cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode


### PR DESCRIPTION
* When a remote partition is shutting down, log chunk hydration failures due to this as debug. 
* Change ducktape tests where the log allow list was set to ignore these errors.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
