### PR TITLE
rptest: tighten cloud deleted segments check

### DIFF
--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -389,13 +389,11 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
         assert self.redpanda.metric_sum(
             "vectorized_cloud_storage_successful_downloads_total") > 0
 
-        assert self.redpanda.metric_sum(
-            "redpanda_cloud_storage_deleted_segments_total",
-            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS) > 0
+        bucket_view = BucketView(self.redpanda)
+        bucket_view.assert_segments_deleted(self.topic, partition=0)
 
         if "compact" in cleanup_policy:
             # Assert that compacted segment re-upload operated during the test
-            bucket_view = BucketView(self.redpanda)
             bucket_view.assert_at_least_n_uploaded_segments_compacted(
                 self.topic, partition=0, revision=self._initial_revision, n=1)
         else:

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -856,3 +856,11 @@ class BucketView:
         assert len(manifest_data.get(
             'replaced',
             [])) > 0, f"No replaced segments after compacted segments uploaded"
+
+    def assert_segments_deleted(self, topic: str, partition: int):
+        manifest = self.manifest_for_ntp(topic, partition)
+        assert manifest.get('start_offset', 0) > 0
+
+        first_segment = min(manifest['segments'].values(),
+                            key=lambda seg: seg['base_offset'])
+        assert first_segment['base_offset'] > 0


### PR DESCRIPTION
This test transfers leadership around, which can result in the partition getting removed from a specific shard. This also includes removal of the archiver and its probes. The assertion for the number of deleted segments will fail if:
* partition move changes replica set completely
* no further deletions happen after the move

The issue is fixed in this commit by checking inferring deletion from the manifest instead of the metric.

Fixes #10978

## Backports Required
- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
