### PR TITLE
tests: bump segment toy version

### DIFF
--- a/tests/docker/ducktape-deps.sh
+++ b/tests/docker/ducktape-deps.sh
@@ -119,7 +119,7 @@ function install_rust_tools() {
 
   git clone https://github.com/jcsp/segment_toy.git
   pushd segment_toy
-  git reset --hard 830a4de9ac5f1c40a52fb4fc68b91996e9e6a86c
+  git reset --hard a81eac69a92eba73895e9a455ede27c981f701d5
   cargo build --release
   cp target/release/rp-storage-tool /usr/local/bin
   popd


### PR DESCRIPTION
A new field was added to the partition manifest: archive_size_bytes.
Update `segment_toy` to a version that can decode the new field.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
