### PR TITLE
[v22.2.x] raft: reject linearizable_barrier if not is_leader()

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -560,6 +560,14 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
         co_return make_error_code(errc::shutting_down);
     }
 
+    if (!is_leader()) {
+        // Callers may expect that our offsets (including commit offset) are
+        // all correct after their barrier completes, so do not allow them
+        // to barrier if we are in the state where we are elected but have
+        // not yet finished replicating the first batch of the new term.
+        co_return raft::errc::not_leader;
+    }
+
     if (_vstate != vote_state::leader) {
         co_return result<model::offset>(make_error_code(errc::not_leader));
     }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/10921
Fixes https://github.com/redpanda-data/redpanda/issues/10993,