### PR TITLE
archival: handle deletion of topics with spilled over manifests

### DIFF
--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -64,6 +64,10 @@ void adjacent_segment_merger::acquire() { _holder = ss::gate::holder(_gate); }
 
 void adjacent_segment_merger::release() { _holder.release(); }
 
+ss::sstring adjacent_segment_merger::name() const {
+    return ssx::sformat("adjacent_segment_merger:{}", _archiver.get_ntp());
+}
+
 std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
   model::offset local_start_offset,
   const cloud_storage::partition_manifest& manifest) {

--- a/src/v/archival/adjacent_segment_merger.h
+++ b/src/v/archival/adjacent_segment_merger.h
@@ -44,6 +44,8 @@ public:
     void acquire() override;
     void release() override;
 
+    ss::sstring name() const override;
+
 private:
     std::optional<adjacent_segment_run> scan_manifest(
       model::offset local_start_offset,

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -529,7 +529,7 @@ scrubber::write_remote_lifecycle_marker(
     cloud_storage::remote_nt_lifecycle_marker remote_marker{
       .cluster_id = config::shard_local_cfg().cluster_id().value_or(""),
       .topic = nt_revision,
-      .status = cloud_storage::lifecycle_status::purged,
+      .status = status,
     };
     auto marker_key = remote_marker.get_key();
 

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -561,6 +561,8 @@ void scrubber::acquire() { _holder = ss::gate::holder(_gate); }
 
 void scrubber::release() { _holder.release(); }
 
+ss::sstring scrubber::name() const { return "scrubber"; }
+
 bool scrubber::collected_manifests::empty() const {
     return !current_serde.has_value() && !current_json.has_value()
            && spillover.empty();

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -281,7 +281,7 @@ ss::future<scrubber::purge_result> scrubber::purge_manifest(
     // one during housekeeping we should drop out.  Maybe retry_chain_node
     // could have a "drop out on slowdown" flag?
     const auto erase_result = co_await cloud_storage::remote_partition::erase(
-      _api, bucket, std::move(manifest), manifest_key, _as);
+      _api, bucket, std::move(manifest), manifest_key, manifest_purge_rtc);
 
     result.ops += estimate_delete_ops;
 

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -89,10 +89,7 @@ ss::future<scrubber::purge_result> scrubber::purge_partition(
         co_return purge_result{
           .status = purge_status::retryable_failure, .ops = 0};
     } else if (collected->empty()) {
-        vlog(
-          ctxlog.info,
-          "Inline deletion already cleaned-up everything. Nothing to purge",
-          ntp);
+        vlog(ctxlog.debug, "Nothing to purge for {}", ntp);
         co_return purge_result{.status = purge_status::success, .ops = 0};
     }
 

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -9,6 +9,7 @@
  */
 
 #include "archival/types.h"
+#include "cloud_storage/base_manifest.h"
 #include "cloud_storage/fwd.h"
 #include "cloud_storage/lifecycle_marker.h"
 #include "cluster/fwd.h"
@@ -69,6 +70,32 @@ private:
       model::ntp,
       model::initial_revision_id,
       retry_chain_node& rtc);
+
+    struct collected_manifests {
+        using flat_t
+          = std::pair<std::vector<ss::sstring>, std::optional<ss::sstring>>;
+
+        std::optional<ss::sstring> current_serde;
+        std::optional<ss::sstring> current_json;
+        std::vector<ss::sstring> spillover;
+
+        bool empty() const;
+        [[nodiscard]] flat_t flatten();
+    };
+
+    ss::future<std::optional<collected_manifests>> collect_manifest_paths(
+      const cloud_storage_clients::bucket_name&,
+      model::ntp,
+      model::initial_revision_id,
+      retry_chain_node&);
+
+    ss::future<purge_result> purge_manifest(
+      const cloud_storage_clients::bucket_name&,
+      model::ntp,
+      model::initial_revision_id,
+      remote_manifest_path,
+      cloud_storage::manifest_format,
+      retry_chain_node&);
 
     struct global_position {
         uint32_t self;

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -46,6 +46,8 @@ public:
     void acquire() override;
     void release() override;
 
+    ss::sstring name() const override;
+
 private:
     enum class purge_status : uint8_t {
         success,

--- a/src/v/archival/tests/upload_housekeeping_service_test.cc
+++ b/src/v/archival/tests/upload_housekeeping_service_test.cc
@@ -78,6 +78,8 @@ public:
 
     void release() override { _holder.release(); }
 
+    ss::sstring name() const override { return "mock_job"; }
+
     size_t executed{0};
     size_t interrupt_cnt{0};
 

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -160,6 +160,8 @@ public:
     virtual ss::future<run_result>
     run(retry_chain_node& rtc, run_quota_t quota) = 0;
 
+    virtual ss::sstring name() const = 0;
+
 private:
     friend class housekeeping_workflow;
     intrusive_list_hook _hook{};

--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -145,7 +145,9 @@ void upload_housekeeping_service::rearm_idle_timer() {
 
 void upload_housekeeping_service::idle_timer_callback() {
     vlog(_ctxlog.debug, "Cloud storage is idle");
-    if (_workflow.state() == housekeeping_state::idle) {
+    if (
+      _workflow.state() == housekeeping_state::idle
+      || _workflow.state() == housekeeping_state::pause) {
         vlog(_ctxlog.debug, "Activating upload housekeeping");
         _workflow.resume(false);
     }

--- a/src/v/archival/upload_housekeeping_service.h
+++ b/src/v/archival/upload_housekeeping_service.h
@@ -229,12 +229,12 @@ private:
     /// Idle timeout, the service is activated when remote
     /// api is idle for longer than '_idle_timeout'
     config::binding<std::chrono::milliseconds> _idle_timeout;
+    /// Idle timeout with jitter
+    simple_time_jitter<ss::lowres_clock> _idle_jittery_timeout;
     /// Timeout that defines the duration of epoch
     config::binding<std::chrono::milliseconds> _epoch_duration;
     /// Idle threshold
     config::binding<double> _api_idle_threshold;
-    /// Jitter for timers
-    simple_time_jitter<ss::lowres_clock> _time_jitter;
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
     cloud_storage::remote::event_filter _filter;

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1108,6 +1108,7 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
   cloud_storage::remote& api,
   cloud_storage_clients::bucket_name bucket,
   partition_manifest manifest,
+  remote_manifest_path manifest_path,
   ss::abort_source& as) {
     // This function is called after ::stop, so we may not use our
     // main retry_chain_node which is bound to our abort source,
@@ -1183,7 +1184,6 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
 
     // If we got this far, we succeeded deleting all objects referenced by
     // the manifest, so many delete the manifest itself.
-    auto manifest_path = manifest.get_manifest_path();
     vlog(
       cst_log.debug,
       "[{}] Erasing partition manifest {}",
@@ -1245,7 +1245,9 @@ ss::future<> remote_partition::try_erase(ss::abort_source& as) {
         co_return;
     }
 
-    co_await erase(_api, _bucket, std::move(manifest), as);
+    auto path = manifest.get_manifest_path(
+      cloud_storage::manifest_format::serde);
+    co_await erase(_api, _bucket, std::move(manifest), std::move(path), as);
 }
 
 void remote_partition::offload_segment(model::offset o) {

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1164,7 +1164,10 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
           *(batch_keys.begin()),
           *(--batch_keys.end()));
 
-        for (const auto& object_set : {batch_keys, tx_batch_keys, index_keys}) {
+        for (auto& object_set : std::vector{
+               std::move(batch_keys),
+               std::move(tx_batch_keys),
+               std::move(index_keys)}) {
             if (
               co_await api.delete_objects(
                 bucket, std::move(object_set), local_rtc)

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1022,17 +1022,16 @@ bool remote_partition::bounds_timestamp(model::timestamp t) const {
     }
 }
 
-static constexpr ss::lowres_clock::duration erase_timeout = 60s;
-static constexpr ss::lowres_clock::duration erase_backoff = 1s;
+static constexpr ss::lowres_clock::duration finalize_timeout = 20s;
+static constexpr ss::lowres_clock::duration finalize_backoff = 1s;
 
-ss::future<remote_partition::finalize_result>
-remote_partition::finalize(ss::abort_source& as) {
+ss::future<> remote_partition::finalize(ss::abort_source& as) {
     vlog(_ctxlog.info, "Finalizing remote storage state...");
 
     // This function is called after ::stop, so we may not use our
     // main retry_chain_node which is bound to our abort source,
     // and construct a special one.
-    retry_chain_node local_rtc(as, erase_timeout, erase_backoff);
+    retry_chain_node local_rtc(as, finalize_timeout, finalize_backoff);
     const auto& stm_manifest = _manifest_view->stm_manifest();
 
     partition_manifest remote_manifest(
@@ -1044,11 +1043,10 @@ remote_partition::finalize(ss::abort_source& as) {
 
     if (manifest_get_result != download_result::success) {
         vlog(
-          _ctxlog.debug,
-          "Failed to fetch manifest during finalize(), maybe another node "
-          "already completed deletion. Error: {}",
+          _ctxlog.error,
+          "Failed to fetch manifest during finalize(). Error: {}",
           manifest_get_result);
-        co_return finalize_result{.get_status = manifest_get_result};
+        co_return;
     }
 
     if (
@@ -1061,16 +1059,11 @@ remote_partition::finalize(ss::abort_source& as) {
           "for deletion during finalize",
           remote_manifest.get_insync_offset(),
           stm_manifest.get_insync_offset());
-        co_return finalize_result{
-          .manifest = std::move(remote_manifest),
-          .get_status = manifest_get_result};
     } else if (
       remote_manifest.get_insync_offset() < stm_manifest.get_insync_offset()) {
-        // TODO: should this be behind a feature table check?
-
         // The remote manifest is out of date, upload a fresh one
         vlog(
-          _ctxlog.debug,
+          _ctxlog.info,
           "Remote manifest has older state than local ({} < {}), attempting to "
           "upload latest manifest",
           remote_manifest.get_insync_offset(),
@@ -1089,9 +1082,6 @@ remote_partition::finalize(ss::abort_source& as) {
               "be left in incomplete state after topic deletion. Error: {}",
               manifest_put_result);
         }
-
-        co_return finalize_result{
-          .manifest = std::nullopt, .get_status = manifest_get_result};
     } else {
         // Remote and local state is in sync, no action required.
         vlog(
@@ -1099,11 +1089,21 @@ remote_partition::finalize(ss::abort_source& as) {
           "Remote manifest is in sync with local state during finalize "
           "(insync_offset={})",
           stm_manifest.get_insync_offset());
-        co_return finalize_result{
-          .manifest = std::nullopt, .get_status = manifest_get_result};
     }
 }
 
+/**
+ * The caller is responsible for determining whether it is appropriate
+ * to delete data in S3, for example it is not appropriate if this is
+ * a read replica topic.
+ *
+ * Q: Why is erase() part of remote_partition, when in general writes
+ *    flow through the archiver and remote_partition is mainly for
+ *    reads?
+ * A: Because the erase operation works in terms of what it reads from
+ *    S3, not the state of the archival metadata stm (which can be out
+ *    of date if e.g. we were not the leader)
+ */
 ss::future<remote_partition::erase_result> remote_partition::erase(
   cloud_storage::remote& api,
   cloud_storage_clients::bucket_name bucket,
@@ -1111,6 +1111,7 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
   remote_manifest_path manifest_path,
   retry_chain_node& parent_rtc) {
     retry_chain_node local_rtc(&parent_rtc);
+    retry_chain_logger ctxlog(cst_log, local_rtc);
 
     auto replaced_segments = manifest.replaced_segments();
 
@@ -1156,7 +1157,7 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
         }
 
         vlog(
-          cst_log.info,
+          ctxlog.info,
           "[{}] Erasing segments {}-{}",
           manifest.get_ntp(),
           *(batch_keys.begin()),
@@ -1171,7 +1172,7 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
                 bucket, std::move(object_set), local_rtc)
               != upload_result::success) {
                 vlog(
-                  cst_log.info,
+                  ctxlog.info,
                   "[{}] Failed to erase some segments, deferring deletion",
                   manifest.get_ntp());
                 co_return erase_result::failed;
@@ -1182,7 +1183,7 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
     // If we got this far, we succeeded deleting all objects referenced by
     // the manifest, so many delete the manifest itself.
     vlog(
-      cst_log.debug,
+      ctxlog.debug,
       "[{}] Erasing partition manifest {}",
       manifest.get_ntp(),
       manifest_path);
@@ -1191,7 +1192,7 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
         bucket, cloud_storage_clients::object_key(manifest_path), local_rtc)
       != upload_result::success) {
         vlog(
-          cst_log.info,
+          ctxlog.info,
           "[{}] Failed to erase {}, deferring deletion",
           manifest.get_ntp(),
           manifest_path);
@@ -1199,53 +1200,6 @@ ss::future<remote_partition::erase_result> remote_partition::erase(
     };
 
     co_return erase_result::erased;
-}
-
-/**
- * The caller is responsible for determining whether it is appropriate
- * to delete data in S3, for example it is not appropriate if this is
- * a read replica topic.
- *
- * Q: Why is try_erase() part of remote_partition, when in general writes
- *    flow through the archiver and remote_partition is mainly for
- *    reads?
- * A: Because the erase operation works in terms of what it reads from
- *    S3, not the state of the archival metadata stm (which can be out
- *    of date if e.g. we were not the leader)
- */
-ss::future<> remote_partition::try_erase(ss::abort_source& as) {
-    const auto& stm_manifest = _manifest_view->stm_manifest();
-    vlog(
-      _ctxlog.info,
-      "Attempting to erase remote storage content for {}",
-      stm_manifest.get_ntp());
-
-    // This function is called after ::stop, so we may not use our
-    // main retry_chain_node which is bound to our abort source,
-    // and construct a special one.
-    retry_chain_node erase_rtc(as, erase_timeout, erase_backoff);
-
-    // Download manifest because we may not be running on the most up to
-    // date node, but hopefully the latest leader will have uploaded
-    // manifest in finalize().
-    partition_manifest manifest(
-      stm_manifest.get_ntp(), stm_manifest.get_revision_id());
-    auto [manifest_get_result, result_fmt]
-      = co_await _api.try_download_partition_manifest(
-        _bucket, manifest, erase_rtc, true);
-
-    if (manifest_get_result != download_result::success) {
-        vlog(
-          _ctxlog.info,
-          "Failed to fetch manifest {}, deferring cleanup on topic erase",
-          manifest.get_manifest_path(result_fmt));
-        co_return;
-    }
-
-    auto path = manifest.get_manifest_path(
-      cloud_storage::manifest_format::serde);
-    co_await erase(
-      _api, _bucket, std::move(manifest), std::move(path), erase_rtc);
 }
 
 void remote_partition::offload_segment(model::offset o) {

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -153,6 +153,7 @@ public:
       cloud_storage::remote&,
       cloud_storage_clients::bucket_name,
       partition_manifest,
+      remote_manifest_path,
       ss::abort_source&);
 
     /// Hook for materialized_segment to notify us when a segment is evicted

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -131,21 +131,8 @@ public:
     ss::future<std::vector<model::tx_range>>
     aborted_transactions(offset_range offsets);
 
-    struct finalize_result {
-        // If this is set, use this manifest for deletion instead of the usual
-        // local state (the remote content was newer than our local content)
-        std::optional<partition_manifest> manifest;
-        download_result get_status{download_result::failed};
-    };
-
-    /// Flush metadata to object storage, prior to a topic deletion with
-    /// remote deletion disabled.
-    ss::future<finalize_result> finalize(ss::abort_source&);
-
-    /// Remove objects from S3, on a best effort basis that may drop out
-    /// on failures.  Robust deletion is delegated to the scrubber if this
-    /// doesn't get it all done.
-    ss::future<> try_erase(ss::abort_source&);
+    /// Flush metadata to object storage, prior to a topic deletion
+    ss::future<> finalize(ss::abort_source&);
 
     enum class erase_result { erased, failed };
 

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -154,7 +154,7 @@ public:
       cloud_storage_clients::bucket_name,
       partition_manifest,
       remote_manifest_path,
-      ss::abort_source&);
+      retry_chain_node&);
 
     /// Hook for materialized_segment to notify us when a segment is evicted
     void offload_segment(model::offset);

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -293,7 +293,7 @@ public:
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
     ss::future<> remove_persistent_state();
-    ss::future<> remove_remote_persistent_state(ss::abort_source& as);
+    ss::future<> finalize_remote_partition(ss::abort_source& as);
 
     std::optional<model::offset> get_term_last_offset(model::term_id) const;
 

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -339,7 +339,7 @@ partition_manager::remove(const model::ntp& ntp, partition_removal_mode mode) {
       .then([this, ntp] { return _storage.log_mgr().remove(ntp); })
       .then([this, partition, mode] {
           if (mode == partition_removal_mode::global) {
-              return partition->remove_remote_persistent_state(_as);
+              return partition->finalize_remote_partition(_as);
           } else {
               return ss::now();
           }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -155,7 +155,8 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
         auto tombstone = nt_lifecycle_marker{
           .config = tp->second.get_configuration(),
           .initial_revision_id = tp->second.get_remote_revision().value_or(
-            model::initial_revision_id(tp->second.get_revision()))};
+            model::initial_revision_id(tp->second.get_revision())),
+          .timestamp = ss::lowres_system_clock::now()};
 
         _lifecycle_markers.emplace(soft_del.topic, tombstone);
         vlog(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1077,7 +1077,7 @@ std::ostream& operator<<(std::ostream& o, const cloud_storage_mode& mode) {
 std::ostream& operator<<(std::ostream& o, const nt_revision& ntr) {
     fmt::print(
       o,
-      "{{ns: {{{}}}, topic: {{}}, revision: {{{}}}}}",
+      "{{ns: {}, topic: {}, revision: {}}}",
       ntr.nt.ns,
       ntr.nt.tp,
       ntr.initial_revision_id);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1964,6 +1964,9 @@ struct nt_lifecycle_marker
 
     model::initial_revision_id initial_revision_id;
 
+    std::optional<ss::lowres_system_clock::time_point> timestamp;
+
+    // Note that the serialisation of `timestamp` is explicitly avoided.
     auto serde_fields() { return std::tie(config, initial_revision_id); }
 };
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1489,6 +1489,12 @@ configuration::configuration()
       "contention.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
+  , cloud_storage_topic_purge_grace_period_ms(
+      *this,
+      "cloud_storage_topic_purge_grace_period_ms",
+      "Grace period during which the scrubber will refuse to purge the topic.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      30s)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -294,6 +294,8 @@ struct configuration final : public config_store {
       cloud_storage_spillover_manifest_max_segments;
     bounded_property<size_t> cloud_storage_manifest_cache_size;
     property<std::chrono::milliseconds> cloud_storage_manifest_cache_ttl_ms;
+    property<std::chrono::milliseconds>
+      cloud_storage_topic_purge_grace_period_ms;
 
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;

--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -55,12 +55,31 @@ retry_chain_node::retry_chain_node(
 
 retry_chain_node::retry_chain_node(
   ss::abort_source& as,
+  ss::lowres_clock::time_point deadline,
+  ss::lowres_clock::duration backoff,
+  retry_strategy retry_strategy)
+  : retry_chain_node(as, deadline, backoff) {
+    _retry_strategy = retry_strategy;
+}
+
+retry_chain_node::retry_chain_node(
+  ss::abort_source& as,
   ss::lowres_clock::duration timeout,
   ss::lowres_clock::duration backoff)
   : retry_chain_node(as, ss::lowres_clock::now() + timeout, backoff) {}
 
+retry_chain_node::retry_chain_node(
+  ss::abort_source& as,
+  ss::lowres_clock::duration timeout,
+  ss::lowres_clock::duration backoff,
+  retry_strategy retry_strategy)
+  : retry_chain_node(as, timeout, backoff) {
+    _retry_strategy = retry_strategy;
+}
+
 retry_chain_node::retry_chain_node(retry_chain_node* parent)
-  : _id(parent->add_child())
+  : _retry_strategy{parent->_retry_strategy}
+  , _id(parent->add_child())
   , _backoff{parent->_backoff}
   , _deadline{parent->_deadline}
   , _parent{parent} {
@@ -70,8 +89,15 @@ retry_chain_node::retry_chain_node(retry_chain_node* parent)
 }
 
 retry_chain_node::retry_chain_node(
+  retry_strategy retry_strategy, retry_chain_node* parent)
+  : retry_chain_node(parent) {
+    _retry_strategy = retry_strategy;
+}
+
+retry_chain_node::retry_chain_node(
   ss::lowres_clock::duration backoff, retry_chain_node* parent)
-  : _id(parent->add_child())
+  : _retry_strategy{parent->_retry_strategy}
+  , _id(parent->add_child())
   , _backoff{std::chrono::duration_cast<std::chrono::milliseconds>(backoff)}
   , _deadline{parent->_deadline}
   , _parent{parent} {
@@ -85,10 +111,19 @@ retry_chain_node::retry_chain_node(
 }
 
 retry_chain_node::retry_chain_node(
+  ss::lowres_clock::duration backoff,
+  retry_strategy retry_strategy,
+  retry_chain_node* parent)
+  : retry_chain_node(backoff, parent) {
+    _retry_strategy = retry_strategy;
+}
+
+retry_chain_node::retry_chain_node(
   ss::lowres_clock::time_point deadline,
   ss::lowres_clock::duration backoff,
   retry_chain_node* parent)
-  : _id(parent->add_child())
+  : _retry_strategy{parent->_retry_strategy}
+  , _id(parent->add_child())
   , _backoff{std::chrono::duration_cast<std::chrono::milliseconds>(backoff)}
   , _deadline{deadline}
   , _parent{parent} {
@@ -106,11 +141,30 @@ retry_chain_node::retry_chain_node(
     vassert(
       len < max_retry_chain_depth, "Retry chain is too deep, {} >= 8", len);
 }
+
+retry_chain_node::retry_chain_node(
+  ss::lowres_clock::time_point deadline,
+  ss::lowres_clock::duration backoff,
+  retry_strategy retry_strategy,
+  retry_chain_node* parent)
+  : retry_chain_node(deadline, backoff, parent) {
+    _retry_strategy = retry_strategy;
+}
+
 retry_chain_node::retry_chain_node(
   ss::lowres_clock::duration timeout,
   ss::lowres_clock::duration backoff,
   retry_chain_node* parent)
   : retry_chain_node(ss::lowres_clock::now() + timeout, backoff, parent) {}
+
+retry_chain_node::retry_chain_node(
+  ss::lowres_clock::duration timeout,
+  ss::lowres_clock::duration backoff,
+  retry_strategy retry_strategy,
+  retry_chain_node* parent)
+  : retry_chain_node(timeout, backoff, parent) {
+    _retry_strategy = retry_strategy;
+}
 
 retry_chain_node* retry_chain_node::get_parent() {
     if (std::holds_alternative<retry_chain_node*>(_parent)) {
@@ -173,7 +227,7 @@ bool retry_chain_node::same_root(const retry_chain_node& other) const {
     return get_root() == other.get_root();
 }
 
-retry_permit retry_chain_node::retry(retry_strategy st) {
+retry_permit retry_chain_node::retry() {
     auto& as = root_abort_source();
     as.check();
 
@@ -186,12 +240,12 @@ retry_permit retry_chain_node::retry(retry_strategy st) {
         return {.is_allowed = false, .abort_source = &as, .delay = 0ms};
     }
 
-    if (st == retry_strategy::disallow && _retry != 0) {
+    if (_retry_strategy == retry_strategy::disallow && _retry != 0) {
         return {.is_allowed = false, .abort_source = &as, .delay = 0ms};
     }
 
-    auto required_delay = [this, &st]() -> ss::lowres_clock::duration {
-        switch (st) {
+    auto required_delay = [this]() -> ss::lowres_clock::duration {
+        switch (_retry_strategy) {
         case retry_strategy::backoff:
             return get_backoff();
         case retry_strategy::polling:

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -155,6 +155,8 @@ enum class retry_strategy {
     polling,
     /// Exponential backoff
     backoff,
+    /// No retries
+    disallow
 };
 
 /// Retry permit

--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -67,6 +67,12 @@ class ABSClient:
         blob_service = BlobServiceClient.from_connection_string(self.conn_str)
         blob_service.create_container(name)
 
+    def empty_and_delete_bucket(self, name: str, parallel=False):
+        """
+        Simply proxy into `delete_bucket` as that deletes the blobs too
+        """
+        self.delete_bucket(name)
+
     def delete_bucket(self, name: str):
         blob_service = BlobServiceClient.from_connection_string(self.conn_str)
         blob_service.delete_container(name)

--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -121,6 +121,13 @@ class S3Client:
             err_msg=
             f"Bucket {name} didn't become visible to ListObjectsvv2 requests")
 
+    def empty_and_delete_bucket(self, name, parallel=False):
+        failed_deletions = self.cloud_storage_client.empty_bucket(
+            self._si_settings.cloud_storage_bucket, parallel=parallel)
+
+        assert len(failed_deletions) == 0
+        self.delete_bucket(name)
+
     def delete_bucket(self, name):
         self.logger.info(f"Deleting bucket {name}...")
         try:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2266,15 +2266,11 @@ class RedpandaService(RedpandaServiceBase):
         self.logger.debug(
             f"Deleting bucket/container: {self._si_settings.cloud_storage_bucket}"
         )
-        assert self.cloud_storage_client is not None
 
-        failed_deletions = self.cloud_storage_client.empty_bucket(
+        assert self.cloud_storage_client is not None
+        self.cloud_storage_client.empty_and_delete_bucket(
             self._si_settings.cloud_storage_bucket,
-            # If on dedicate nodes, assume tests may be high scale and do parallel deletion
             parallel=self.dedicated_nodes)
-        assert len(failed_deletions) == 0
-        self.cloud_storage_client.delete_bucket(
-            self._si_settings.cloud_storage_bucket)
 
     def get_objects_from_si(self):
         assert self.cloud_storage_client is not None


### PR DESCRIPTION
This PR updates the topic deletion logic to make it aware of spillover manifests.
Deletion of spillover manifests and their segments is done as part of the scrub,
which means it can be retried as many times as required.

The general approach is to:
1. Issue ListObjects request to find all manifests
2. Starting with the current manifests, iterate over all manifests found
   in the bucket and delete all their associated segments and, finally,
   the manifest itself.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

