### PR TITLE
[v23.1.x] archival: fix segment merging running when disabled

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -142,7 +142,9 @@ void ntp_archiver::notify_leadership(std::optional<model::node_id> leader_id) {
         _leader_cond.signal();
     }
     if (_local_segment_merger) {
-        _local_segment_merger->set_enabled(is_leader);
+        _local_segment_merger->set_enabled(
+          is_leader
+          && config::shard_local_cfg().cloud_storage_enable_segment_merging());
     }
 }
 


### PR DESCRIPTION
On leadership changes, set_enabled was called without any regard for the cluster config that controls
adjacent segment merging.

(cherry picked from commit 623a978162292c868ded01bfbca15bedc58ca837)

Fixes: https://github.com/redpanda-data/redpanda/issues/11002

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
