### PR TITLE
tests: report on high load in debug mode tests

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -78,13 +78,13 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
             try:
                 r = f(self, *args, **kwargs)
             except:
-                log_local_load(self.test_context.test_name,
-                               self.redpanda.logger, t_initial,
-                               disk_stats_initial)
-
                 if not hasattr(self, 'redpanda') or self.redpanda is None:
                     # We failed so early there isn't even a RedpandaService instantiated
                     raise
+
+                log_local_load(self.test_context.test_name,
+                               self.redpanda.logger, t_initial,
+                               disk_stats_initial)
 
                 for redpanda in all_redpandas(self):
                     redpanda.logger.exception(
@@ -101,14 +101,14 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
 
                 raise
             else:
-                log_local_load(self.test_context.test_name,
-                               self.redpanda.logger, t_initial,
-                               disk_stats_initial)
-
                 if not hasattr(self, 'redpanda') or self.redpanda is None:
                     # We passed without instantiating a RedpandaService, for example
                     # in a skipped test
                     return r
+
+                log_local_load(self.test_context.test_name,
+                               self.redpanda.logger, t_initial,
+                               disk_stats_initial)
 
                 # In debug mode, any test writing too much traffic will impose too much
                 # load on the system and destabilize other tests.  Detect this with a

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -120,7 +120,7 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
                         self.redpanda.logger.info(
                             f"Estimated bytes written: {bytes_written}")
                         if bytes_written > debug_mode_data_limit:
-                            raise RuntimeError(
+                            self.redpanda.logger.error(
                                 f"Debug-mode test wrote too much data ({int(bytes_written) // (1024 * 1024)}MiB)"
                             )
 

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0
 
 import functools
+import time
+import psutil
 
 from rptest.services.redpanda import RedpandaService
 from ducktape.mark.resource import ClusterUseMetadata
@@ -36,6 +38,32 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
             if isinstance(svc, RedpandaService) and svc is not test.redpanda:
                 yield svc
 
+    def log_local_load(test_name, logger, t_initial, initial_disk_stats):
+        """
+        Log indicators of system load on the machine running ducktape tests.  When
+        running tests in a single-node docker environment, this is useful to help
+        diagnose whether slow-running/flaky tests are the victim of an overloaded
+        node.
+        """
+        load = psutil.getloadavg()
+        memory = psutil.virtual_memory()
+        swap = psutil.swap_memory()
+        disk_stats = psutil.disk_io_counters()
+        disk_deltas = {}
+        disk_rates = {}
+        runtime = time.time() - t_initial
+        for f in disk_stats._fields:
+            a = getattr(initial_disk_stats, f)
+            b = getattr(disk_stats, f)
+            disk_deltas[f] = b - a
+            disk_rates[f] = (b - a) / runtime
+
+        logger.info(f"Load average after {test_name}: {load}")
+        logger.info(f"Memory after {test_name}: {memory}")
+        logger.info(f"Swap after {test_name}: {swap}")
+        logger.info(f"Disk activity during {test_name}: {disk_deltas}")
+        logger.info(f"Disk rates during {test_name}: {disk_rates}")
+
     def cluster_use_metadata_adder(f):
         Mark.mark(f, ClusterUseMetadata(**kwargs))
 
@@ -45,9 +73,15 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
             # such as RedpandaTest subclasses
             assert hasattr(self, 'redpanda')
 
+            t_initial = time.time()
+            disk_stats_initial = psutil.disk_io_counters()
             try:
                 r = f(self, *args, **kwargs)
             except:
+                log_local_load(self.test_context.test_name,
+                               self.redpanda.logger, t_initial,
+                               disk_stats_initial)
+
                 if not hasattr(self, 'redpanda') or self.redpanda is None:
                     # We failed so early there isn't even a RedpandaService instantiated
                     raise
@@ -67,6 +101,10 @@ def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
 
                 raise
             else:
+                log_local_load(self.test_context.test_name,
+                               self.redpanda.logger, t_initial,
+                               disk_stats_initial)
+
                 if not hasattr(self, 'redpanda') or self.redpanda is None:
                     # We passed without instantiating a RedpandaService, for example
                     # in a skipped test

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3328,6 +3328,15 @@ class RedpandaService(RedpandaServiceBase):
                     f"Oversized controller log detected!  {max_length} records"
                 )
 
+    def estimate_bytes_written(self):
+        samples = self.metrics_sample(
+            "vectorized_io_queue_total_write_bytes_total",
+            nodes=self.started_nodes()).samples
+        if samples:
+            return sum(s.value for s in samples)
+        else:
+            return None
+
 
 def make_redpanda_service(environment):
     """Factory function for instatiating the appropriate RedpandaServiceBase subclass."""

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3331,9 +3331,16 @@ class RedpandaService(RedpandaServiceBase):
                 )
 
     def estimate_bytes_written(self):
-        samples = self.metrics_sample(
-            "vectorized_io_queue_total_write_bytes_total",
-            nodes=self.started_nodes())
+        try:
+            samples = self.metrics_sample(
+                "vectorized_io_queue_total_write_bytes_total",
+                nodes=self.started_nodes())
+        except Exception as e:
+            self.logger.warn(
+                f"Cannot check metrics, did a test finish with all nodes down? ({e})"
+            )
+            return None
+
         if samples is not None and samples.samples:
             return sum(s.value for s in samples.samples)
         else:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2994,7 +2994,9 @@ class RedpandaService(RedpandaServiceBase):
               family = vectorized_cluster_partition_under_replicated_replicas
               sample = vectorized_cluster_partition_under_replicated_replicas
         """
-        nodes = nodes or self.nodes
+        if nodes is None:
+            nodes = self.nodes
+
         sample_values = []
         for node in nodes:
             metrics = self.metrics(node, metrics_endpoint)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3333,9 +3333,9 @@ class RedpandaService(RedpandaServiceBase):
     def estimate_bytes_written(self):
         samples = self.metrics_sample(
             "vectorized_io_queue_total_write_bytes_total",
-            nodes=self.started_nodes()).samples
-        if samples:
-            return sum(s.value for s in samples)
+            nodes=self.started_nodes())
+        if samples is not None and samples.samples:
+            return sum(s.value for s in samples.samples)
         else:
             return None
 


### PR DESCRIPTION
Currently if a test is added that overloads the shared test node, it's hard to notice which one.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none