### PR TITLE
tests: add timeouts to various SSH calls

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -101,7 +101,7 @@ class KgoVerifierService(Service):
         trace = '--trace' if self._trace_logs else ''
         wrapped_cmd = f"nohup {cmd} --remote --remote-port {self._remote_port} {debug} {trace}> {self.log_path} 2>&1 & echo $!"
         self.logger.debug(f"spawn {self.who_am_i()}: {wrapped_cmd}")
-        pid_str = node.account.ssh_output(wrapped_cmd)
+        pid_str = node.account.ssh_output(wrapped_cmd, timeout_sec=10)
         self.logger.debug(
             f"spawned {self.who_am_i()} node={node.name} pid={pid_str} port={self._remote_port}"
         )


### PR DESCRIPTION
I saw a stuck test hit the global ducktape timeout and print a backtrace in the rp-storage-tool call during test shutdown.

Paramiko has an unfortunate timeout-less default: so we must invent some timeouts for places we call into SSH, otherwise anything that hangs on the other end of the connection can hang our tests.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
