### PR TITLE
[v23.1.x] cloud_storage: improved debug on partition manifest parse error

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1144,8 +1144,15 @@ ss::future<> partition_manifest::update(ss::input_stream<char> is) {
     } else {
         rapidjson::ParseErrorCode e = reader.GetParseErrorCode();
         size_t o = reader.GetErrorOffset();
+
+        // Hexdump 1kb region around the bad manifest
+        result.trim_front(o - std::min(size_t{512}, o));
         vlog(
-          cst_log.debug, "Failed to parse manifest: {}", result.hexdump(2048));
+          cst_log.warn,
+          "Failed to parse manifest at 0x{:08x}: {}",
+          o,
+          result.hexdump(1024));
+
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "Failed to parse partition manifest {}: {} at offset {}",


### PR DESCRIPTION
- Log at WARN, so that we actually get the message on prod systems
- hexdump the region around the parse error, rather than the first bytes in the manifest.

This is more important than it used to be, now that we have admin API for loading in arbitrary manifests, which can fail.

(cherry picked from commit abbd6eadb8f1abbfe61ea75a66da745197e27a36)

Fixes https://github.com/redpanda-data/redpanda/issues/10862

## Backports Required


- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

