### PR TITLE
tests: bump upload timeouts in cloud_retention_test

### DIFF
--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -146,7 +146,7 @@ class CloudRetentionTest(PreallocNodesTest):
                 self.logger.warn(f"error getting bucket size: {e}")
                 return False
 
-        wait_until(check_bucket_size, timeout_sec=60, backoff_sec=5)
+        wait_until(check_bucket_size, timeout_sec=300, backoff_sec=5)
 
         consumer.wait()
         self.logger.info("finished consuming")
@@ -214,7 +214,7 @@ class CloudRetentionTest(PreallocNodesTest):
             return True
 
         wait_until(uploaded_all_partitions,
-                   timeout_sec=60,
+                   timeout_sec=300,
                    backoff_sec=5,
                    err_msg="Waiting for all parents to upload cloud data")
 


### PR DESCRIPTION
These were occasionally being just missed when running in docker.  There was no particular reason to expect 1GB of uploads to complete in 60 seconds, and the purpose of the tests is not to measure the speed of uploads, so bump these to a generous five minutes.

(cherry picked from commit 979cec18011df430818b210760562dd7e26de074)

Fixes https://github.com/redpanda-data/redpanda/issues/10803


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
