### PR TITLE
Use `chunked_fifo` to group shard heartbeats

### DIFF
--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -18,6 +18,7 @@
 #include "seastarx.h"
 #include "utils/copy_range.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timed_out_error.hh>
@@ -188,8 +189,10 @@ private:
     using consensus_ptr = seastar::lw_shared_ptr<consensus>;
     using hbeats_t = std::vector<append_entries_request>;
     using hbeats_ptr = ss::foreign_ptr<std::unique_ptr<hbeats_t>>;
+    using groupped_hbeats_ptr = ss::foreign_ptr<
+      std::unique_ptr<ss::chunked_fifo<append_entries_request>>>;
     struct shard_groupped_hbeat_requests {
-        absl::flat_hash_map<ss::shard_id, hbeats_ptr> shard_requests;
+        absl::flat_hash_map<ss::shard_id, groupped_hbeats_ptr> shard_requests;
         std::vector<append_entries_request> group_missing_requests;
     };
 
@@ -253,7 +256,7 @@ private:
     }
 
     ss::future<std::vector<append_entries_reply>>
-    dispatch_hbeats_to_core(ss::shard_id shard, hbeats_ptr requests) {
+    dispatch_hbeats_to_core(ss::shard_id shard, groupped_hbeats_ptr requests) {
         return with_scheduling_group(
           get_scheduling_group(),
           [this, shard, r = std::move(requests)]() mutable {
@@ -267,7 +270,7 @@ private:
     }
 
     ss::future<std::vector<append_entries_reply>>
-    dispatch_hbeats_to_groups(ConsensusManager& m, hbeats_ptr reqs) {
+    dispatch_hbeats_to_groups(ConsensusManager& m, groupped_hbeats_ptr reqs) {
         std::vector<ss::future<append_entries_reply>> futures;
         futures.reserve(reqs->size());
         // dispatch requests in parallel
@@ -306,7 +309,8 @@ private:
                   it,
                   shard,
                   ss::make_foreign(
-                    std::make_unique<std::vector<append_entries_request>>()));
+                    std::make_unique<
+                      ss::chunked_fifo<append_entries_request>>()));
                 it = result;
             }
 


### PR DESCRIPTION
Using `seastar::chunked_fifo` to group shard heartbeats to avoid large memory
allocations.

Fixes: #10747

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none