### PR TITLE
operator: close kadm connections created by console controller

### DIFF
--- a/src/go/k8s/pkg/console/admin.go
+++ b/src/go/k8s/pkg/console/admin.go
@@ -86,7 +86,12 @@ func NewKafkaAdmin(
 	if err != nil {
 		return nil, fmt.Errorf("creating kafka client: %w", err)
 	}
-	return kadm.NewClient(kclient), nil
+	admClient := kadm.NewClient(kclient)
+	go func() {
+		<-ctx.Done()
+		admClient.Close()
+	}()
+	return admClient, nil
 }
 
 func getSASLOpt(


### PR DESCRIPTION
The console controller leaks kadm connections when ensuring it has its own user. This change will close the connection when the context is done. This is done by controller-runtime when the Reconcile has finished. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* close Redpanda admin connection after reconciling the Console user and ACL.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
