### PR TITLE
Address clang16 use after move

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -515,7 +515,10 @@ ss::future<http::client::response_stream_ref> s3_client::do_get_object(
           // here we didn't receive any bytes from the socket and
           // ref->is_header_done() is 'false', we need to prefetch
           // the header first
-          return ref->prefetch_headers().then(
+          // clang-tidy 16.0.4 is reporting an erroneous 'use-after-move' error
+          // when calling `then` after `prefetch_headers`.
+          auto f = ref->prefetch_headers();
+          return f.then(
             [ref = std::move(ref),
              expect_no_such_key,
              is_byte_range_requested]() mutable {

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -851,7 +851,7 @@ ss::future<> members_manager::set_initial_state(
     _id_by_uuid = std::move(id_by_uuid);
 
     co_await _members_table.invoke_on_all(
-      [initial_brokers = std::move(initial_brokers)](members_table& table) {
+      [initial_brokers](members_table& table) {
           table.set_initial_brokers(initial_brokers);
       });
 

--- a/src/v/cluster/node_status_backend.cc
+++ b/src/v/cluster/node_status_backend.cc
@@ -152,13 +152,14 @@ ss::future<result<node_status>> node_status_backend::send_node_status_request(
 
     // auto send_by = rpc::clock_type::now() + _period();
     auto opts = rpc::client_opts(_period());
+    auto timeout = opts.timeout;
     auto reply
       = co_await _node_connection_cache.local()
           .with_node_client<node_status_rpc_client_protocol>(
             _self,
             connection_source_shard,
             target,
-            opts.timeout,
+            timeout,
             [opts = std::move(opts), r = std::move(r)](auto client) mutable {
                 return client.node_status(std::move(r), std::move(opts));
             })

--- a/src/v/cluster/non_replicable_topics_frontend.cc
+++ b/src/v/cluster/non_replicable_topics_frontend.cc
@@ -106,8 +106,11 @@ ss::future<> non_replicable_topics_frontend::create_non_replicable_topics(
         }
     }
     if (!todos.empty()) {
-        auto f = _topics_frontend.local()
-                   .autocreate_non_replicable_topics(todos, timeout)
+        // clang-tidy 16.0.4 is reporting an erroneous 'use-after-move' error
+        // when calling `then` after `autocreate_non_replicable_topics`.
+        auto result = _topics_frontend.local()
+                      .autocreate_non_replicable_topics(todos, timeout);
+        auto f = result
                    .then(
                      [this](const std::vector<cluster::topic_result>& result) {
                          topic_creation_resolved(result);

--- a/src/v/cluster/non_replicable_topics_frontend.cc
+++ b/src/v/cluster/non_replicable_topics_frontend.cc
@@ -108,8 +108,8 @@ ss::future<> non_replicable_topics_frontend::create_non_replicable_topics(
     if (!todos.empty()) {
         // clang-tidy 16.0.4 is reporting an erroneous 'use-after-move' error
         // when calling `then` after `autocreate_non_replicable_topics`.
-        auto result = _topics_frontend.local()
-                      .autocreate_non_replicable_topics(todos, timeout);
+        auto result = _topics_frontend.local().autocreate_non_replicable_topics(
+          todos, timeout);
         auto f = result
                    .then(
                      [this](const std::vector<cluster::topic_result>& result) {

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -200,42 +200,40 @@ ss::future<> partition_balancer_backend::do_tick() {
 
     co_await ss::max_concurrent_for_each(
       plan_data.cancellations, 32, [this, current_term](model::ntp& ntp) {
-          auto f = _topics_frontend
-            .cancel_moving_partition_replicas(
-              ntp,
-              model::timeout_clock::now() + add_move_cmd_timeout,
-              current_term);
+          auto f = _topics_frontend.cancel_moving_partition_replicas(
+            ntp,
+            model::timeout_clock::now() + add_move_cmd_timeout,
+            current_term);
 
           return f.then([ntp = std::move(ntp)](auto errc) {
-                if (errc) {
-                    vlog(
-                      clusterlog.warn,
-                      "submitting {} movement cancellation failed, error: {}",
-                      ntp,
-                      errc.message());
-                }
-            });
+              if (errc) {
+                  vlog(
+                    clusterlog.warn,
+                    "submitting {} movement cancellation failed, error: {}",
+                    ntp,
+                    errc.message());
+              }
+          });
       });
 
     co_await ss::max_concurrent_for_each(
       plan_data.reassignments,
       32,
       [this, current_term](ntp_reassignment& reassignment) {
-          auto f = _topics_frontend
-            .move_partition_replicas(
-              reassignment.ntp,
-              reassignment.allocated.replicas(),
-              model::timeout_clock::now() + add_move_cmd_timeout,
-              current_term);
+          auto f = _topics_frontend.move_partition_replicas(
+            reassignment.ntp,
+            reassignment.allocated.replicas(),
+            model::timeout_clock::now() + add_move_cmd_timeout,
+            current_term);
           return f.then([reassignment = std::move(reassignment)](auto errc) {
-                if (errc) {
-                    vlog(
-                      clusterlog.warn,
-                      "submitting {} reassignment failed, error: {}",
-                      reassignment.ntp,
-                      errc.message());
-                }
-            });
+              if (errc) {
+                  vlog(
+                    clusterlog.warn,
+                    "submitting {} reassignment failed, error: {}",
+                    reassignment.ntp,
+                    errc.message());
+              }
+          });
       });
 }
 

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -163,23 +163,19 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
     auto p_as = _topic_table.local().get_partition_assignment(cmd.key);
     auto ec = co_await dispatch_updates_to_cores(cmd, offset);
     if (!ec) {
-              const auto& ntp = cmd.key;
-              vassert(
-                p_as.has_value(),
-                "Partition {} have to exist before successful "
-                "partition reallocation",
-                ntp);
-              auto to_add = subtract_replica_sets(cmd.value, p_as->replicas);
-              _partition_allocator.local().add_allocations(
-                to_add, get_allocation_domain(ntp));
+        const auto& ntp = cmd.key;
+        vassert(
+          p_as.has_value(),
+          "Partition {} have to exist before successful "
+          "partition reallocation",
+          ntp);
+        auto to_add = subtract_replica_sets(cmd.value, p_as->replicas);
+        _partition_allocator.local().add_allocations(
+          to_add, get_allocation_domain(ntp));
 
-              _partition_balancer_state.local().handle_ntp_update(
-                ntp.ns,
-                ntp.tp.topic,
-                ntp.tp.partition,
-                p_as->replicas,
-                cmd.value);
-          }
+        _partition_balancer_state.local().handle_ntp_update(
+          ntp.ns, ntp.tp.topic, ntp.tp.partition, p_as->replicas, cmd.value);
+    }
     co_return ec;
 }
 ss::future<std::error_code> topic_updates_dispatcher::apply(

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -353,18 +353,18 @@ topics_frontend::dispatch_create_non_replicable_to_leader(
   model::timeout_clock::duration timeout) {
     vlog(clusterlog.trace, "Dispatching create topics to {}", leader);
     auto r = co_await _connections.local()
-                    .with_node_client<cluster::controller_client_protocol>(
-                      _self,
-                      ss::this_shard_id(),
-                      leader,
-                      timeout,
-                      [topics, timeout](controller_client_protocol cp) mutable {
-                          return cp.create_non_replicable_topics(
-                            create_non_replicable_topics_request{
-                              .topics = std::move(topics), .timeout = timeout},
-                            rpc::client_opts(timeout));
-                      })
-                    .then(&rpc::get_ctx_data<create_non_replicable_topics_reply>);
+               .with_node_client<cluster::controller_client_protocol>(
+                 _self,
+                 ss::this_shard_id(),
+                 leader,
+                 timeout,
+                 [topics, timeout](controller_client_protocol cp) mutable {
+                     return cp.create_non_replicable_topics(
+                       create_non_replicable_topics_request{
+                         .topics = std::move(topics), .timeout = timeout},
+                       rpc::client_opts(timeout));
+                 })
+               .then(&rpc::get_ctx_data<create_non_replicable_topics_reply>);
     if (r.has_error()) {
         co_return create_topic_results(topics, map_errc(r.error()));
     }
@@ -779,22 +779,22 @@ topics_frontend::dispatch_create_to_leader(
   model::timeout_clock::duration timeout) {
     vlog(clusterlog.trace, "Dispatching create topics to {}", leader);
     auto r = co_await _connections.local()
-      .with_node_client<cluster::controller_client_protocol>(
-        _self,
-        ss::this_shard_id(),
-        leader,
-        timeout,
-        [topics, timeout](controller_client_protocol cp) mutable {
-            return cp.create_topics(
-              create_topics_request{
-                .topics = std::move(topics), .timeout = timeout},
-              rpc::client_opts(model::timeout_clock::now() + timeout));
-        })
-      .then(&rpc::get_ctx_data<create_topics_reply>);
-            if (r.has_error()) {
-                co_return create_topic_results(topics, map_errc(r.error()));
-            }
-            co_return std::move(r.value().results);
+               .with_node_client<cluster::controller_client_protocol>(
+                 _self,
+                 ss::this_shard_id(),
+                 leader,
+                 timeout,
+                 [topics, timeout](controller_client_protocol cp) mutable {
+                     return cp.create_topics(
+                       create_topics_request{
+                         .topics = std::move(topics), .timeout = timeout},
+                       rpc::client_opts(model::timeout_clock::now() + timeout));
+                 })
+               .then(&rpc::get_ctx_data<create_topics_reply>);
+    if (r.has_error()) {
+        co_return create_topic_results(topics, map_errc(r.error()));
+    }
+    co_return std::move(r.value().results);
 }
 
 ss::future<topic_result> topics_frontend::dispatch_purged_topic_to_leader(
@@ -808,22 +808,22 @@ ss::future<topic_result> topics_frontend::dispatch_purged_topic_to_leader(
       leader);
 
     auto r = co_await _connections.local()
-      .with_node_client<cluster::controller_client_protocol>(
-        _self,
-        ss::this_shard_id(),
-        leader,
-        timeout,
-        [topic, timeout](controller_client_protocol cp) mutable {
-            return cp.purged_topic(
-              purged_topic_request{
-                .topic = std::move(topic), .timeout = timeout},
-              rpc::client_opts(model::timeout_clock::now() + timeout));
-        })
-      .then(&rpc::get_ctx_data<purged_topic_reply>);
-          if (r.has_error()) {
-              co_return topic_result(topic.nt, map_errc(r.error()));
-          }
-          co_return std::move(r.value().result);
+               .with_node_client<cluster::controller_client_protocol>(
+                 _self,
+                 ss::this_shard_id(),
+                 leader,
+                 timeout,
+                 [topic, timeout](controller_client_protocol cp) mutable {
+                     return cp.purged_topic(
+                       purged_topic_request{
+                         .topic = std::move(topic), .timeout = timeout},
+                       rpc::client_opts(model::timeout_clock::now() + timeout));
+                 })
+               .then(&rpc::get_ctx_data<purged_topic_reply>);
+    if (r.has_error()) {
+        co_return topic_result(topic.nt, map_errc(r.error()));
+    }
+    co_return std::move(r.value().result);
 }
 
 bool topics_frontend::validate_topic_name(const model::topic_namespace& topic) {
@@ -1191,8 +1191,8 @@ topics_frontend::do_cancel_moving_partition_replicas(
     co_await ss::max_concurrent_for_each(
       ntps, 32, [this, &results, timeout](model::ntp& ntp) {
           auto f = cancel_moving_partition_replicas(ntp, timeout);
-          return f
-            .then([ntp = std::move(ntp), &results](std::error_code ec) mutable {
+          return f.then(
+            [ntp = std::move(ntp), &results](std::error_code ec) mutable {
                 results.emplace_back(
                   std::move(ntp), map_update_interruption_error_code(ec));
             });

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -442,8 +442,7 @@ client::get_consumer(const group_id& g_id, const member_id& name) {
       consumer_error(g_id, name, error_code::unknown_member_id));
 }
 
-ss::future<>
-client::remove_consumer(group_id g_id, const member_id& name) {
+ss::future<> client::remove_consumer(group_id g_id, const member_id& name) {
     auto c = co_await get_consumer(g_id, name);
     auto& group = _consumers[g_id];
     group.erase(c);

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -132,7 +132,7 @@ public:
     ss::future<shared_consumer_t>
     get_consumer(const group_id& g_id, const member_id& m_id);
 
-    ss::future<> remove_consumer(const group_id& g_id, const member_id& m_id);
+    ss::future<> remove_consumer(group_id g_id, const member_id& m_id);
 
     ss::future<> subscribe_consumer(
       const group_id& group_id,

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -78,8 +78,8 @@ producer::do_send(model::topic_partition tp, model::record_batch batch) {
     auto partition = std::move(topic.partitions[0]);
     if (partition.error_code != error_code::none) {
         throw partition_error(
-            model::topic_partition(topic.name, partition.partition_index),
-            partition.error_code);
+          model::topic_partition(topic.name, partition.partition_index),
+          partition.error_code);
     }
 
     co_return partition;

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -69,26 +69,20 @@ producer::produce(model::topic_partition tp, model::record_batch&& batch) {
 }
 
 ss::future<produce_response::partition>
-producer::do_send(model::topic_partition tp, model::record_batch&& batch) {
-    return _topic_cache.leader(tp)
-      .then([this](model::node_id leader) { return _brokers.find(leader); })
-      .then([tp{std::move(tp)},
-             batch{std::move(batch)}](shared_broker_t broker) mutable {
-          return broker->dispatch(
-            make_produce_request(std::move(tp), std::move(batch)));
-      })
-      .then([](produce_response res) mutable {
-          auto topic = std::move(res.data.responses[0]);
-          auto partition = std::move(topic.partitions[0]);
-          if (partition.error_code != error_code::none) {
-              return ss::make_exception_future<produce_response::partition>(
-                partition_error(
-                  model::topic_partition(topic.name, partition.partition_index),
-                  partition.error_code));
-          }
-          return ss::make_ready_future<produce_response::partition>(
-            std::move(partition));
-      });
+producer::do_send(model::topic_partition tp, model::record_batch batch) {
+    auto leader = co_await _topic_cache.leader(tp);
+    auto broker = co_await _brokers.find(leader);
+    auto res = co_await broker->dispatch(
+      make_produce_request(std::move(tp), std::move(batch)));
+    auto topic = std::move(res.data.responses[0]);
+    auto partition = std::move(topic.partitions[0]);
+    if (partition.error_code != error_code::none) {
+        throw partition_error(
+            model::topic_partition(topic.name, partition.partition_index),
+            partition.error_code);
+    }
+
+    co_return partition;
 }
 
 ss::future<>

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -55,7 +55,7 @@ private:
     ss::future<> send(model::topic_partition tp, model::record_batch&& batch);
 
     ss::future<produce_response::partition>
-    do_send(model::topic_partition tp, model::record_batch&& batch);
+    do_send(model::topic_partition tp, model::record_batch batch);
 
     auto make_consumer(model::topic_partition tp) {
         return [this, tp](model::record_batch&& batch) {

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -322,7 +322,10 @@ connection_context::reserve_request_units(api_key key, size_t size) {
 
 ss::future<>
 connection_context::dispatch_method_once(request_header hdr, size_t size) {
-    return throttle_request(hdr, size)
+    // clang-tidy 16.0.4 is reporting an erroneous 'use-after-move' error when
+    // calling `then` after `throttle_request`.
+    auto sres_in = throttle_request(hdr, size);
+    return sres_in
       .then([this, hdr = std::move(hdr), size](
               session_resources sres_in) mutable {
           if (_server.abort_requested()) {

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1458,8 +1458,10 @@ group::sync_group_stages group::sync_group_completing_rebalance(
     auto assignments = std::move(r).member_assignments();
     add_missing_assignments(assignments);
 
-    auto f = store_group(checkpoint(assignments))
-               .then([this,
+    // clang-tidy 16.0.4 is reporting an erroneous 'use-after-move' error when
+    // calling `then` after `store_group`.
+    auto replicate_result = store_group(checkpoint(assignments));
+    auto f = replicate_result.then([this,
                       response = std::move(response),
                       expected_generation = generation(),
                       assignments = std::move(assignments)](

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -258,8 +258,13 @@ ss::future<response_ptr> create_topics_handler::handle(
     }
 
     // Create the topics with controller on core 0
-    auto c_res = co_await ctx.topics_frontend().create_topics(std::move(to_create), to_timeout(request.data.timeout_ms));
-    co_await wait_for_topics(ctx.metadata_cache(), c_res, ctx.controller_api(), to_timeout(request.data.timeout_ms));
+    auto c_res = co_await ctx.topics_frontend().create_topics(
+      std::move(to_create), to_timeout(request.data.timeout_ms));
+    co_await wait_for_topics(
+      ctx.metadata_cache(),
+      c_res,
+      ctx.controller_api(),
+      to_timeout(request.data.timeout_ms));
     // Append controller results to validation errors
     append_cluster_results(c_res, response.data.topics);
     if (ctx.header().version >= api_version(5)) {

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -269,7 +269,10 @@ create_consumer(server::request_t rq, server::reply_t rp) {
             req_data.auto_offset_reset,
             req_data.auto_commit_enable);
 
-          return client.get_consumer(group_id, req_data.name)
+          // clang-tidy 16.0.4 is reporting an erroneous 'use-after-move' error
+          // when calling `then` after `get_consumer`.
+          auto f = client.get_consumer(group_id, req_data.name);
+          return f
             .then([group_id](const kafka::client::shared_consumer_t&) mutable {
                 auto ec = make_error_condition(
                   reply_error_code::consumer_already_exists);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1734,7 +1734,8 @@ ss::future<vote_reply> consensus::do_vote(vote_request&& r) {
     }
 
     if (_voted_for.id()() < 0) {
-        return write_voted_for({r.node_id, _term})
+        auto node_id = r.node_id;
+        return write_voted_for({node_id, _term})
           .then_wrapped([this, reply = std::move(reply), r = std::move(r)](
                           ss::future<> f) mutable {
               bool granted = false;

--- a/src/v/raft/rpc_client_protocol.cc
+++ b/src/v/raft/rpc_client_protocol.cc
@@ -22,11 +22,12 @@ namespace raft {
 
 ss::future<result<vote_reply>> rpc_client_protocol::vote(
   model::node_id n, vote_request&& r, rpc::client_opts opts) {
+    auto timeout = opts.timeout;
     return _connection_cache.local().with_node_client<raftgen_client_protocol>(
       _self,
       ss::this_shard_id(),
       n,
-      opts.timeout,
+      timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.vote(std::move(r), std::move(opts))
@@ -36,11 +37,12 @@ ss::future<result<vote_reply>> rpc_client_protocol::vote(
 
 ss::future<result<append_entries_reply>> rpc_client_protocol::append_entries(
   model::node_id n, append_entries_request&& r, rpc::client_opts opts) {
+    auto timeout = opts.timeout;
     return _connection_cache.local().with_node_client<raftgen_client_protocol>(
       _self,
       ss::this_shard_id(),
       n,
-      opts.timeout,
+      timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.append_entries(std::move(r), std::move(opts))
@@ -50,11 +52,12 @@ ss::future<result<append_entries_reply>> rpc_client_protocol::append_entries(
 
 ss::future<result<heartbeat_reply>> rpc_client_protocol::heartbeat(
   model::node_id n, heartbeat_request&& r, rpc::client_opts opts) {
+    auto timeout = opts.timeout;
     return _connection_cache.local().with_node_client<raftgen_client_protocol>(
       _self,
       ss::this_shard_id(),
       n,
-      opts.timeout,
+      timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.heartbeat(std::move(r), std::move(opts))
@@ -65,11 +68,12 @@ ss::future<result<heartbeat_reply>> rpc_client_protocol::heartbeat(
 ss::future<result<install_snapshot_reply>>
 rpc_client_protocol::install_snapshot(
   model::node_id n, install_snapshot_request&& r, rpc::client_opts opts) {
+    auto timeout = opts.timeout;
     return _connection_cache.local().with_node_client<raftgen_client_protocol>(
       _self,
       ss::this_shard_id(),
       n,
-      opts.timeout,
+      timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.install_snapshot(std::move(r), std::move(opts))
@@ -79,11 +83,12 @@ rpc_client_protocol::install_snapshot(
 
 ss::future<result<timeout_now_reply>> rpc_client_protocol::timeout_now(
   model::node_id n, timeout_now_request&& r, rpc::client_opts opts) {
+    auto timeout = opts.timeout;
     return _connection_cache.local().with_node_client<raftgen_client_protocol>(
       _self,
       ss::this_shard_id(),
       n,
-      opts.timeout,
+      timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.timeout_now(std::move(r), std::move(opts))
@@ -127,11 +132,12 @@ ss::future<bool> rpc_client_protocol::ensure_disconnect(model::node_id n) {
 ss::future<result<transfer_leadership_reply>>
 rpc_client_protocol::transfer_leadership(
   model::node_id n, transfer_leadership_request&& r, rpc::client_opts opts) {
+    auto timeout = opts.timeout;
     return _connection_cache.local().with_node_client<raftgen_client_protocol>(
       _self,
       ss::this_shard_id(),
       n,
-      opts.timeout,
+      timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.transfer_leadership(std::move(r), std::move(opts))

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -88,7 +88,7 @@ rpc_server::send_reply(ss::lw_shared_ptr<server_context_impl> ctx, netbuf buf) {
     }
     try {
         co_await ctx->conn->write(std::move(view));
-    } catch(...) {
+    } catch (...) {
         auto e = std::current_exception();
         auto disconnect = net::is_disconnect_exception(e);
         if (disconnect) {

--- a/src/v/utils/directory_walker.cc
+++ b/src/v/utils/directory_walker.cc
@@ -23,7 +23,7 @@ directory_walker::walk(std::string_view dirname, walker_type walker_func) {
       [walker_func = std::move(walker_func)](ss::file f) mutable {
           auto s = f.list_directory(std::move(walker_func));
           return s.done().finally([f = std::move(f)]() mutable {
-              return f.close().finally([f = std::move(f)] {});
+              return f.close().finally([f] {});
           });
       });
 }

--- a/src/v/utils/directory_walker.cc
+++ b/src/v/utils/directory_walker.cc
@@ -22,9 +22,8 @@ directory_walker::walk(std::string_view dirname, walker_type walker_func) {
     return ss::open_directory(dirname).then(
       [walker_func = std::move(walker_func)](ss::file f) mutable {
           auto s = f.list_directory(std::move(walker_func));
-          return s.done().finally([f = std::move(f)]() mutable {
-              return f.close().finally([f] {});
-          });
+          return s.done().finally(
+            [f = std::move(f)]() mutable { return f.close().finally([f] {}); });
       });
 }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

`clang-tidy-16` reported a number of false positive 'use-after-move' errors.  This PR addresses those

This appears to be a false-positive, as indicated here: https://github.com/llvm/llvm-project/issues/59612

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
