### PR TITLE
Dynamic tx coordinator partitioning: add tx_registry_stm

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -106,6 +106,7 @@ v_cc_library(
     controller.cc
     partition.cc
     partition_probe.cc
+    tx_registry_stm.cc
     id_allocator_stm.cc
     persisted_stm.cc
     tm_stm_cache.cc

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -21,6 +21,7 @@ class id_allocator_frontend;
 class rm_partition_frontend;
 class log_eviction_stm;
 class tx_registry_frontend;
+class tx_registry_stm;
 class tx_coordinator_mapper;
 class tm_stm_cache;
 class tm_stm_cache_manager;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -19,6 +19,7 @@
 #include "cluster/partition_probe.h"
 #include "cluster/rm_stm.h"
 #include "cluster/tm_stm.h"
+#include "cluster/tx_registry_stm.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/property.h"
@@ -262,6 +263,10 @@ public:
         return _raft->get_latest_configuration_offset();
     }
 
+    ss::shared_ptr<cluster::tx_registry_stm> tx_registry_stm() {
+        return _tx_registry_stm;
+    }
+
     ss::shared_ptr<cluster::id_allocator_stm> id_allocator_stm() {
         return _id_allocator_stm;
     }
@@ -448,6 +453,7 @@ private:
     consensus_ptr _raft;
     ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
+    ss::shared_ptr<cluster::tx_registry_stm> _tx_registry_stm;
     ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<cluster::tm_stm> _tm_stm;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1955,8 +1955,10 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
         if (tx_data != _log_state.current_txes.end()) {
             tm_partition = tx_data->second.tm_partition;
         }
-        auto r = co_await _tx_gateway_frontend.local().try_abort(
-          tm_partition, pid, *tx_seq, _sync_timeout);
+
+        auto r = co_await _tx_gateway_frontend.local().route_globally(
+          cluster::try_abort_request(
+            tm_partition, pid, tx_seq.value(), _sync_timeout));
         if (r.ec == tx_errc::none) {
             if (r.commited) {
                 vlog(

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ set(srcs
     feature_barrier_test.cc
     tm_stm_tests.cc
     tm_coordinator_mapper_tests.cc
-    tm_tx_hash_ranges_tests.cc
+    tx_hash_ranges_tests.cc
     rm_stm_tests.cc
     rm_stm_compatibility_test.cc
     id_allocator_stm_test.cc

--- a/src/v/cluster/tests/tm_coordinator_mapper_tests.cc
+++ b/src/v/cluster/tests/tm_coordinator_mapper_tests.cc
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0
 
 #include "cluster/tm_stm.h"
-#include "cluster/tm_tx_hash_ranges.h"
 #include "cluster/tx_coordinator_mapper.h"
+#include "cluster/tx_hash_ranges.h"
 
 #include <seastar/testing/thread_test_case.hh>
 

--- a/src/v/cluster/tests/tm_coordinator_mapper_tests.cc
+++ b/src/v/cluster/tests/tm_coordinator_mapper_tests.cc
@@ -16,9 +16,9 @@
 #include <cstdint>
 
 void check_hash_range_distribuiton(int32_t partitions_amount) {
-    cluster::tm_hash_ranges_set hash_ranges{};
+    cluster::tx_hash_ranges_set hash_ranges{};
     for (int i = 0; i < partitions_amount; ++i) {
-        hash_ranges.ranges.push_back(cluster::default_tm_hash_range(
+        hash_ranges.ranges.push_back(cluster::default_hash_range(
           model::partition_id(i), partitions_amount));
     }
     BOOST_REQUIRE_EQUAL(hash_ranges.ranges[0].first, 0);
@@ -65,9 +65,9 @@ void check_get_partition_from_default_distribution(int32_t partitions_amount) {
         cluster::tx_tm_hash_max, partitions_amount),
       model::partition_id(partitions_amount - 1));
 
-    cluster::tm_hash_ranges_set hash_ranges{};
+    cluster::tx_hash_ranges_set hash_ranges{};
     for (int i = 0; i < partitions_amount; ++i) {
-        hash_ranges.ranges.push_back(cluster::default_tm_hash_range(
+        hash_ranges.ranges.push_back(cluster::default_hash_range(
           model::partition_id(i), partitions_amount));
     }
 
@@ -84,7 +84,7 @@ void check_get_partition_from_default_distribution(int32_t partitions_amount) {
 
         BOOST_REQUIRE_EQUAL(
           cluster::get_partition_from_default_distribution(
-            cluster::tm_tx_hash_type(
+            cluster::tx_hash_type(
               (uint64_t(hash_ranges.ranges[i].first)
                + uint64_t(hash_ranges.ranges[i].last))
               / 2),

--- a/src/v/cluster/tests/tm_tx_hash_ranges_tests.cc
+++ b/src/v/cluster/tests/tm_tx_hash_ranges_tests.cc
@@ -16,19 +16,19 @@
 #include <cstdint>
 
 SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
-    cluster::tm_hash_range range_start(0, 100);
-    cluster::tm_hash_range range_middle(101, cluster::tx_tm_hash_max - 100);
-    cluster::tm_hash_range range_end(
+    cluster::tx_hash_range range_start(0, 100);
+    cluster::tx_hash_range range_middle(101, cluster::tx_tm_hash_max - 100);
+    cluster::tx_hash_range range_end(
       cluster::tx_tm_hash_max - 99, cluster::tx_tm_hash_max);
-    cluster::tm_tx_hash_ranges_errc add_res;
+    cluster::tx_hash_ranges_errc add_res;
 
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
     add_res = hosted_transactions_1.add_range(range_start);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_1.add_range(range_middle);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_1.add_range(range_end);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.hash_ranges.ranges[0].first, 0);
     BOOST_REQUIRE_EQUAL(
@@ -37,11 +37,11 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
     add_res = hosted_transactions_2.add_range(range_start);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_2.add_range(range_end);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_2.add_range(range_middle);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.hash_ranges.ranges[0].first, 0);
     BOOST_REQUIRE_EQUAL(
@@ -50,11 +50,11 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
 
     cluster::tm_tx_hosted_transactions hosted_transactions_3{};
     add_res = hosted_transactions_3.add_range(range_end);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_3.add_range(range_middle);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_3.add_range(range_start);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_3.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_3.hash_ranges.ranges[0].first, 0);
     BOOST_REQUIRE_EQUAL(
@@ -63,63 +63,63 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
-    cluster::tm_tx_hash_ranges_errc add_res;
-    cluster::tm_hash_range range_100_200(100, 200);
-    cluster::tm_hash_range range_100_150(100, 150);
-    cluster::tm_hash_range range_150_170(150, 170);
-    cluster::tm_hash_range range_170_200(170, 200);
+    cluster::tx_hash_ranges_errc add_res;
+    cluster::tx_hash_range range_100_200(100, 200);
+    cluster::tx_hash_range range_100_150(100, 150);
+    cluster::tx_hash_range range_150_170(150, 170);
+    cluster::tx_hash_range range_170_200(170, 200);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
     add_res = hosted_transactions_1.add_range(range_100_200);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_1.add_range(range_100_150);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_1.add_range(range_150_170);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_1.add_range(range_170_200);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
     add_res = hosted_transactions_2.add_range(range_100_150);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_2.add_range(range_150_170);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_2.add_range(range_170_200);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_3{};
     add_res = hosted_transactions_3.add_range(range_150_170);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_3.add_range(range_100_150);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_3.add_range(range_170_200);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 }
 
 SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
-    cluster::tm_tx_hash_ranges_errc add_res;
+    cluster::tx_hash_ranges_errc add_res;
 
     kafka::transactional_id tx_id("tx_1");
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
     add_res = hosted_transactions_1.add_range({0, cluster::tx_tm_hash_max});
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_1.include_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_1.exclude_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE(!hosted_transactions_1.contains(tx_id));
     add_res = hosted_transactions_1.include_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE(hosted_transactions_1.contains(tx_id));
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.included_transactions.size(), 0);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
     add_res = hosted_transactions_2.exclude_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::not_hosted);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::not_hosted);
     add_res = hosted_transactions_2.include_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE(hosted_transactions_2.contains(tx_id));
     add_res = hosted_transactions_2.exclude_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.excluded_transactions.size(), 0);
 }

--- a/src/v/cluster/tests/tm_tx_hash_ranges_tests.cc
+++ b/src/v/cluster/tests/tm_tx_hash_ranges_tests.cc
@@ -23,11 +23,14 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
     cluster::tx_hash_ranges_errc add_res;
 
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
-    add_res = hosted_transactions_1.add_range(range_start);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_1.add_range(range_middle);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_middle);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_1.add_range(range_end);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.hash_ranges.ranges[0].first, 0);
@@ -36,11 +39,14 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       cluster::tx_tm_hash_max);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
-    add_res = hosted_transactions_2.add_range(range_start);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_2.add_range(range_end);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_2.add_range(range_middle);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_middle);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.hash_ranges.ranges[0].first, 0);
@@ -49,11 +55,14 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       cluster::tx_tm_hash_max);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_3{};
-    add_res = hosted_transactions_3.add_range(range_end);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_3.add_range(range_middle);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_middle);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_3.add_range(range_start);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_3.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_3.hash_ranges.ranges[0].first, 0);
@@ -70,29 +79,39 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
     cluster::tx_hash_range range_170_200(170, 200);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
-    add_res = hosted_transactions_1.add_range(range_100_200);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_100_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_1.add_range(range_100_150);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_1.add_range(range_150_170);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_1.add_range(range_170_200);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
-    add_res = hosted_transactions_2.add_range(range_100_150);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_2.add_range(range_150_170);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_2.add_range(range_170_200);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_3{};
-    add_res = hosted_transactions_3.add_range(range_150_170);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_3.add_range(range_100_150);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_3.add_range(range_170_200);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 }
 
@@ -101,25 +120,35 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
 
     kafka::transactional_id tx_id("tx_1");
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
-    add_res = hosted_transactions_1.add_range({0, cluster::tx_tm_hash_max});
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, {0, cluster::tx_tm_hash_max});
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_1.include_transaction(tx_id);
+    add_res = cluster::hosted_transactions::include_transaction(
+      hosted_transactions_1, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_1.exclude_transaction(tx_id);
+    add_res = cluster::hosted_transactions::exclude_transaction(
+      hosted_transactions_1, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    BOOST_REQUIRE(!hosted_transactions_1.contains(tx_id));
-    add_res = hosted_transactions_1.include_transaction(tx_id);
+    BOOST_REQUIRE(
+      !cluster::hosted_transactions::contains(hosted_transactions_1, tx_id));
+    add_res = cluster::hosted_transactions::include_transaction(
+      hosted_transactions_1, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    BOOST_REQUIRE(hosted_transactions_1.contains(tx_id));
+    BOOST_REQUIRE(
+      cluster::hosted_transactions::contains(hosted_transactions_1, tx_id));
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.included_transactions.size(), 0);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
-    add_res = hosted_transactions_2.exclude_transaction(tx_id);
+    add_res = cluster::hosted_transactions::exclude_transaction(
+      hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::not_hosted);
-    add_res = hosted_transactions_2.include_transaction(tx_id);
+    add_res = cluster::hosted_transactions::include_transaction(
+      hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    BOOST_REQUIRE(hosted_transactions_2.contains(tx_id));
-    add_res = hosted_transactions_2.exclude_transaction(tx_id);
+    BOOST_REQUIRE(
+      cluster::hosted_transactions::contains(hosted_transactions_2, tx_id));
+    add_res = cluster::hosted_transactions::exclude_transaction(
+      hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.excluded_transactions.size(), 0);
 }

--- a/src/v/cluster/tests/tx_hash_ranges_tests.cc
+++ b/src/v/cluster/tests/tx_hash_ranges_tests.cc
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "cluster/tm_tx_hash_ranges.h"
+#include "cluster/tm_stm.h"
+#include "cluster/tx_hash_ranges.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
@@ -22,7 +23,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       cluster::tx_tm_hash_max - 99, cluster::tx_tm_hash_max);
     cluster::tx_hash_ranges_errc add_res;
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_1{};
+    cluster::tm_stm::hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -38,7 +39,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       hosted_transactions_1.hash_ranges.ranges[0].last,
       cluster::tx_tm_hash_max);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_2{};
+    cluster::tm_stm::hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_2, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -54,7 +55,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       hosted_transactions_2.hash_ranges.ranges[0].last,
       cluster::tx_tm_hash_max);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_3{};
+    cluster::tm_stm::hosted_txs hosted_transactions_3{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_3, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -78,7 +79,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
     cluster::tx_hash_range range_150_170(150, 170);
     cluster::tx_hash_range range_170_200(170, 200);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_1{};
+    cluster::tm_stm::hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, range_100_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -92,7 +93,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
       hosted_transactions_1, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_2{};
+    cluster::tm_stm::hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_2, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -103,7 +104,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
       hosted_transactions_2, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_3{};
+    cluster::tm_stm::hosted_txs hosted_transactions_3{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_3, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -119,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
     cluster::tx_hash_ranges_errc add_res;
 
     kafka::transactional_id tx_id("tx_1");
-    cluster::tm_tx_hosted_transactions hosted_transactions_1{};
+    cluster::tm_stm::hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, {0, cluster::tx_tm_hash_max});
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -138,7 +139,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
       cluster::hosted_transactions::contains(hosted_transactions_1, tx_id));
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.included_transactions.size(), 0);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_2{};
+    cluster::tm_stm::hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::exclude_transaction(
       hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::not_hosted);

--- a/src/v/cluster/tests/tx_hash_ranges_tests.cc
+++ b/src/v/cluster/tests/tx_hash_ranges_tests.cc
@@ -23,7 +23,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       cluster::tx_tm_hash_max - 99, cluster::tx_tm_hash_max);
     cluster::tx_hash_ranges_errc add_res;
 
-    cluster::tm_stm::hosted_txs hosted_transactions_1{};
+    cluster::tm_stm::locally_hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -39,7 +39,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       hosted_transactions_1.hash_ranges.ranges[0].last,
       cluster::tx_tm_hash_max);
 
-    cluster::tm_stm::hosted_txs hosted_transactions_2{};
+    cluster::tm_stm::locally_hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_2, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -55,7 +55,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       hosted_transactions_2.hash_ranges.ranges[0].last,
       cluster::tx_tm_hash_max);
 
-    cluster::tm_stm::hosted_txs hosted_transactions_3{};
+    cluster::tm_stm::locally_hosted_txs hosted_transactions_3{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_3, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -79,7 +79,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
     cluster::tx_hash_range range_150_170(150, 170);
     cluster::tx_hash_range range_170_200(170, 200);
 
-    cluster::tm_stm::hosted_txs hosted_transactions_1{};
+    cluster::tm_stm::locally_hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, range_100_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -93,7 +93,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
       hosted_transactions_1, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 
-    cluster::tm_stm::hosted_txs hosted_transactions_2{};
+    cluster::tm_stm::locally_hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_2, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -104,7 +104,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
       hosted_transactions_2, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
 
-    cluster::tm_stm::hosted_txs hosted_transactions_3{};
+    cluster::tm_stm::locally_hosted_txs hosted_transactions_3{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_3, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -120,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
     cluster::tx_hash_ranges_errc add_res;
 
     kafka::transactional_id tx_id("tx_1");
-    cluster::tm_stm::hosted_txs hosted_transactions_1{};
+    cluster::tm_stm::locally_hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, {0, cluster::tx_tm_hash_max});
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -139,7 +139,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
       cluster::hosted_transactions::contains(hosted_transactions_1, tx_id));
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.included_transactions.size(), 0);
 
-    cluster::tm_stm::hosted_txs hosted_transactions_2{};
+    cluster::tm_stm::locally_hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::exclude_transaction(
       hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::not_hosted);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -140,11 +140,11 @@ ss::future<tm_stm::op_status> tm_stm::try_init_hosted_transactions(
     }
 
     model::partition_id partition = get_partition();
-    auto initial_hash_range = default_tm_hash_range(
+    auto initial_hash_range = default_hash_range(
       partition, tx_coordinator_partition_amount);
     tm_tx_hosted_transactions initial_hosted_transactions{};
     auto res = initial_hosted_transactions.add_range(initial_hash_range);
-    if (res == tm_tx_hash_ranges_errc::success) {
+    if (res == tx_hash_ranges_errc::success) {
         initial_hosted_transactions.inited = true;
         co_return co_await update_hosted_transactions(
           term, std::move(initial_hosted_transactions));
@@ -160,7 +160,7 @@ ss::future<tm_stm::op_status> tm_stm::include_hosted_transaction(
     }
     auto new_hosted_tx = _hosted_txes;
     auto res = new_hosted_tx.include_transaction(tx_id);
-    if (res == tm_tx_hash_ranges_errc::success) {
+    if (res == tx_hash_ranges_errc::success) {
         co_return co_await update_hosted_transactions(
           term, std::move(new_hosted_tx));
     } else {
@@ -175,7 +175,7 @@ ss::future<tm_stm::op_status> tm_stm::exclude_hosted_transaction(
     }
     auto new_hosted_tx = _hosted_txes;
     auto res = new_hosted_tx.exclude_transaction(tx_id);
-    if (res == tm_tx_hash_ranges_errc::success) {
+    if (res == tx_hash_ranges_errc::success) {
         co_return co_await update_hosted_transactions(
           term, std::move(new_hosted_tx));
     } else {

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -143,7 +143,8 @@ ss::future<tm_stm::op_status> tm_stm::try_init_hosted_transactions(
     auto initial_hash_range = default_hash_range(
       partition, tx_coordinator_partition_amount);
     tm_tx_hosted_transactions initial_hosted_transactions{};
-    auto res = initial_hosted_transactions.add_range(initial_hash_range);
+    auto res = hosted_transactions::add_range(
+      initial_hosted_transactions, initial_hash_range);
     if (res == tx_hash_ranges_errc::success) {
         initial_hosted_transactions.inited = true;
         co_return co_await update_hosted_transactions(
@@ -159,7 +160,7 @@ ss::future<tm_stm::op_status> tm_stm::include_hosted_transaction(
         co_return op_status::unknown;
     }
     auto new_hosted_tx = _hosted_txes;
-    auto res = new_hosted_tx.include_transaction(tx_id);
+    auto res = hosted_transactions::include_transaction(new_hosted_tx, tx_id);
     if (res == tx_hash_ranges_errc::success) {
         co_return co_await update_hosted_transactions(
           term, std::move(new_hosted_tx));
@@ -174,7 +175,7 @@ ss::future<tm_stm::op_status> tm_stm::exclude_hosted_transaction(
         co_return op_status::unknown;
     }
     auto new_hosted_tx = _hosted_txes;
-    auto res = new_hosted_tx.exclude_transaction(tx_id);
+    auto res = hosted_transactions::exclude_transaction(new_hosted_tx, tx_id);
     if (res == tx_hash_ranges_errc::success) {
         co_return co_await update_hosted_transactions(
           term, std::move(new_hosted_tx));
@@ -821,7 +822,7 @@ bool tm_stm::hosts(const kafka::transactional_id& tx_id) {
           features::feature::transaction_partitioning)) {
         return true;
     }
-    return _hosted_txes.contains(tx_id);
+    return hosted_transactions::contains(_hosted_txes, tx_id);
 }
 
 ss::future<>

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -135,6 +135,9 @@ ss::future<tm_stm::op_status> tm_stm::try_init_hosted_transactions(
     }
 
     auto units = co_await _cache->write_lock();
+    if (_hosted_txes.inited) {
+        co_return op_status::success;
+    }
 
     model::partition_id partition = get_partition();
     auto initial_hash_range = default_tm_hash_range(

--- a/src/v/cluster/tm_tx_hash_ranges.h
+++ b/src/v/cluster/tm_tx_hash_ranges.h
@@ -172,6 +172,83 @@ struct draining_txs
     auto serde_fields() { return std::tie(id, ranges, transactions); }
 };
 
+namespace hosted_transactions {
+template<class T>
+tx_hash_ranges_errc
+exclude_transaction(T& self, const kafka::transactional_id& tx_id) {
+    if (self.excluded_transactions.contains(tx_id)) {
+        return tx_hash_ranges_errc::success;
+    }
+    if (self.included_transactions.contains(tx_id)) {
+        self.included_transactions.erase(tx_id);
+        vassert(
+          !self.hash_ranges.contains(get_tx_id_hash(tx_id)),
+          "hash_ranges must not contain included txes");
+        return tx_hash_ranges_errc::success;
+    }
+    tx_hash_type hash = get_tx_id_hash(tx_id);
+    if (!self.hash_ranges.contains(hash)) {
+        return tx_hash_ranges_errc::not_hosted;
+    }
+    self.excluded_transactions.insert(tx_id);
+    return tx_hash_ranges_errc::success;
+}
+
+template<class T>
+tx_hash_ranges_errc
+include_transaction(T& self, const kafka::transactional_id& tx_id) {
+    if (self.included_transactions.contains(tx_id)) {
+        return tx_hash_ranges_errc::success;
+    }
+    if (self.excluded_transactions.contains(tx_id)) {
+        self.excluded_transactions.erase(tx_id);
+        vassert(
+          self.hash_ranges.contains(get_tx_id_hash(tx_id)),
+          "hash_ranges must contain excluded txes");
+        return tx_hash_ranges_errc::success;
+    }
+    tx_hash_type hash = get_tx_id_hash(tx_id);
+    if (self.hash_ranges.contains(hash)) {
+        return tx_hash_ranges_errc::intersection;
+    }
+    self.included_transactions.insert(tx_id);
+    return tx_hash_ranges_errc::success;
+}
+
+template<class T>
+tx_hash_ranges_errc add_range(T& self, const tx_hash_range& range) {
+    if (self.hash_ranges.intersects(range)) {
+        return tx_hash_ranges_errc::intersection;
+    }
+    for (const auto& tx_id : self.excluded_transactions) {
+        tx_hash_type hash = get_tx_id_hash(tx_id);
+        if (range.contains(hash)) {
+            self.excluded_transactions.erase(tx_id);
+        }
+    }
+    for (const auto& tx_id : self.included_transactions) {
+        tx_hash_type hash = get_tx_id_hash(tx_id);
+        if (range.contains(hash)) {
+            self.included_transactions.erase(tx_id);
+        }
+    }
+    self.hash_ranges.add_range(range);
+    return tx_hash_ranges_errc::success;
+}
+
+template<class T>
+bool contains(T& self, const kafka::transactional_id& tx_id) {
+    if (self.excluded_transactions.contains(tx_id)) {
+        return false;
+    }
+    if (self.included_transactions.contains(tx_id)) {
+        return true;
+    }
+    auto tx_id_hash = get_tx_id_hash(tx_id);
+    return self.hash_ranges.contains(tx_id_hash);
+}
+} // namespace hosted_transactions
+
 struct tm_tx_hosted_transactions
   : serde::envelope<
       tm_tx_hosted_transactions,
@@ -204,77 +281,6 @@ struct tm_tx_hosted_transactions
           excluded_transactions,
           included_transactions,
           draining);
-    }
-
-    tx_hash_ranges_errc
-    exclude_transaction(const kafka::transactional_id& tx_id) {
-        if (excluded_transactions.contains(tx_id)) {
-            return tx_hash_ranges_errc::success;
-        }
-        if (included_transactions.contains(tx_id)) {
-            included_transactions.erase(tx_id);
-            vassert(
-              !hash_ranges.contains(get_tx_id_hash(tx_id)),
-              "hash_ranges must not contain included txes");
-            return tx_hash_ranges_errc::success;
-        }
-        tx_hash_type hash = get_tx_id_hash(tx_id);
-        if (!hash_ranges.contains(hash)) {
-            return tx_hash_ranges_errc::not_hosted;
-        }
-        excluded_transactions.insert(tx_id);
-        return tx_hash_ranges_errc::success;
-    }
-
-    tx_hash_ranges_errc
-    include_transaction(const kafka::transactional_id& tx_id) {
-        if (included_transactions.contains(tx_id)) {
-            return tx_hash_ranges_errc::success;
-        }
-        if (excluded_transactions.contains(tx_id)) {
-            excluded_transactions.erase(tx_id);
-            vassert(
-              hash_ranges.contains(get_tx_id_hash(tx_id)),
-              "hash_ranges must not contain excluded txes");
-            return tx_hash_ranges_errc::success;
-        }
-        tx_hash_type hash = get_tx_id_hash(tx_id);
-        if (hash_ranges.contains(hash)) {
-            return tx_hash_ranges_errc::intersection;
-        }
-        included_transactions.insert(tx_id);
-        return tx_hash_ranges_errc::success;
-    }
-
-    tx_hash_ranges_errc add_range(tx_hash_range range) {
-        if (hash_ranges.intersects(range)) {
-            return tx_hash_ranges_errc::intersection;
-        }
-        for (const auto& tx_id : excluded_transactions) {
-            tx_hash_type hash = get_tx_id_hash(tx_id);
-            if (range.contains(hash)) {
-                excluded_transactions.erase(tx_id);
-            }
-        }
-        for (const auto& tx_id : included_transactions) {
-            tx_hash_type hash = get_tx_id_hash(tx_id);
-            if (range.contains(hash)) {
-                included_transactions.erase(tx_id);
-            }
-        }
-        hash_ranges.add_range(range);
-        return tx_hash_ranges_errc::success;
-    }
-
-    bool contains(const kafka::transactional_id& tx_id) {
-        if (excluded_transactions.contains(tx_id)) {
-            return false;
-        }
-        if (included_transactions.contains(tx_id)) {
-            return true;
-        }
-        auto tx_id_hash = get_tx_id_hash(tx_id);
-        return hash_ranges.contains(tx_id_hash);
     }
 };
 

--- a/src/v/cluster/tx_coordinator_mapper.h
+++ b/src/v/cluster/tx_coordinator_mapper.h
@@ -12,7 +12,7 @@
 #pragma once
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_manager.h"
-#include "cluster/tm_tx_hash_ranges.h"
+#include "cluster/tx_hash_ranges.h"
 #include "hashing/murmur.h"
 #include "kafka/protocol/types.h"
 #include "kafka/types.h"

--- a/src/v/cluster/tx_coordinator_mapper.h
+++ b/src/v/cluster/tx_coordinator_mapper.h
@@ -26,8 +26,8 @@
 namespace cluster {
 
 inline model::partition_id get_partition_from_default_distribution(
-  tm_tx_hash_type tx_id_hash, int32_t partitions_amount) {
-    tm_tx_hash_type default_partition_range_size = get_default_range_size(
+  tx_hash_type tx_id_hash, int32_t partitions_amount) {
+    tx_hash_type default_partition_range_size = get_default_range_size(
       partitions_amount);
     int32_t partition = int32_t(tx_id_hash / default_partition_range_size);
 
@@ -74,7 +74,7 @@ public:
         }
         int32_t partitions_amount = cfg->partition_count;
 
-        tm_tx_hash_type tx_id_hash = get_tx_id_hash(tx_id);
+        tx_hash_type tx_id_hash = get_tx_id_hash(tx_id);
         auto partition = get_partition_from_default_distribution(
           tx_id_hash, partitions_amount);
         co_return model::ntp(_tp_ns.ns, _tp_ns.tp, partition);

--- a/src/v/cluster/tx_coordinator_mapper.h
+++ b/src/v/cluster/tx_coordinator_mapper.h
@@ -57,15 +57,12 @@ inline model::partition_id get_partition_from_default_distribution(
 
 class tx_coordinator_mapper {
 public:
-    explicit tx_coordinator_mapper(
-      ss::sharded<cluster::metadata_cache>& md,
-      model::topic_namespace tx_coordinator_topic)
-      : _md(md)
-      , _tp_ns(std::move(tx_coordinator_topic)) {}
+    explicit tx_coordinator_mapper(ss::sharded<cluster::metadata_cache>& md)
+      : _md(md) {}
 
     ss::future<std::optional<model::ntp>>
     ntp_for(kafka::transactional_id tx_id) const {
-        auto cfg = _md.local().get_topic_cfg(_tp_ns);
+        auto cfg = _md.local().get_topic_cfg(model::tx_manager_nt);
         if (!cfg) {
             // Transaction coordinator topic not exist in cache
             // should be catched by caller (find_coordinator)
@@ -77,15 +74,15 @@ public:
         tx_hash_type tx_id_hash = get_tx_id_hash(tx_id);
         auto partition = get_partition_from_default_distribution(
           tx_id_hash, partitions_amount);
-        co_return model::ntp(_tp_ns.ns, _tp_ns.tp, partition);
+        co_return model::ntp(
+          model::tx_manager_nt.ns, model::tx_manager_nt.tp, partition);
     }
 
-    const model::ns& ns() const { return _tp_ns.ns; }
-    const model::topic& topic() const { return _tp_ns.tp; }
+    const model::ns& ns() const { return model::tx_manager_nt.ns; }
+    const model::topic& topic() const { return model::tx_manager_nt.tp; }
 
 private:
     ss::sharded<cluster::metadata_cache>& _md;
-    model::topic_namespace _tp_ns;
 };
 
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -119,7 +119,7 @@ ss::future<abort_group_tx_reply> tx_gateway::abort_group_tx(
 
 ss::future<find_coordinator_reply> tx_gateway::find_coordinator(
   find_coordinator_request&& r, rpc::streaming_context&) {
-    return _tx_registry_frontend.local().find_coordinator_locally(r.tid);
+    return _tx_registry_frontend.local().route_locally(std::move(r));
 }
 
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -44,8 +44,7 @@ tx_gateway::fetch_tx(fetch_tx_request&& request, rpc::streaming_context&) {
 
 ss::future<try_abort_reply>
 tx_gateway::try_abort(try_abort_request&& request, rpc::streaming_context&) {
-    return _tx_gateway_frontend.local().try_abort_locally(
-      request.tm, request.pid, request.tx_seq, request.timeout);
+    return _tx_gateway_frontend.local().route_locally(std::move(request));
 }
 
 ss::future<init_tm_tx_reply>

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -986,37 +986,16 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
     auto leader = leader_opt.value();
     auto _self = _controller->self();
 
-    if (leader == _self) {
-        co_return co_await init_tm_tx_locally(
-          tx_id,
-          transaction_timeout_ms,
-          timeout,
-          expected_pid,
-          tx_ntp.tp.partition);
+    if (leader != _self) {
+        co_return cluster::init_tm_tx_reply{tx_errc::not_coordinator};
     }
 
-    // Kafka does not dispatch this request. So we should delete this logic in
-    // future TODO: https://github.com/redpanda-data/redpanda/issues/6418
-    co_return cluster::init_tm_tx_reply{tx_errc::not_coordinator};
-
-    vlog(
-      txlog.trace,
-      "dispatching name:init_tm_tx, tx_id:{}, from:{}, to:{}",
+    co_return co_await init_tm_tx_locally(
       tx_id,
-      _self,
-      leader);
-
-    auto reply = co_await dispatch_init_tm_tx(
-      leader, tx_id, transaction_timeout_ms, timeout);
-
-    vlog(
-      txlog.trace,
-      "received name:init_tm_tx, tx_id:{}, pid:{}, ec: {}",
-      tx_id,
-      reply.pid,
-      reply.ec);
-
-    co_return reply;
+      transaction_timeout_ms,
+      timeout,
+      expected_pid,
+      tx_ntp.tp.partition);
 }
 
 ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx_locally(
@@ -1098,34 +1077,6 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx_locally(
       reply.ec);
 
     co_return reply;
-}
-
-ss::future<init_tm_tx_reply> tx_gateway_frontend::dispatch_init_tm_tx(
-  model::node_id leader,
-  kafka::transactional_id tx_id,
-  std::chrono::milliseconds transaction_timeout_ms,
-  model::timeout_clock::duration timeout) {
-    return _connection_cache.local()
-      .with_node_client<cluster::tx_gateway_client_protocol>(
-        _controller->self(),
-        ss::this_shard_id(),
-        leader,
-        timeout,
-        [tx_id, transaction_timeout_ms, timeout](
-          tx_gateway_client_protocol cp) {
-            return cp.init_tm_tx(
-              init_tm_tx_request{tx_id, transaction_timeout_ms, timeout},
-              rpc::client_opts(model::timeout_clock::now() + timeout));
-        })
-      .then(&rpc::get_ctx_data<init_tm_tx_reply>)
-      .then([](result<init_tm_tx_reply> r) {
-          if (r.has_error()) {
-              vlog(txlog.warn, "got error {} on remote init tm tx", r.error());
-              return init_tm_tx_reply{tx_errc::invalid_txn_state};
-          }
-
-          return r.value();
-      });
 }
 
 namespace {

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -47,16 +47,6 @@ public:
     ss::future<bool> hosts(model::partition_id, kafka::transactional_id);
     ss::future<fetch_tx_reply> fetch_tx_locally(
       kafka::transactional_id, model::term_id, model::partition_id);
-    ss::future<try_abort_reply> try_abort(
-      model::partition_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration);
-    ss::future<try_abort_reply> try_abort_locally(
-      model::partition_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration);
     ss::future<init_tm_tx_reply> init_tm_tx(
       kafka::transactional_id,
       std::chrono::milliseconds transaction_timeout_ms,
@@ -76,6 +66,9 @@ public:
     ss::future<return_all_txs_res> get_all_transactions();
     ss::future<result<tm_transaction, tx_errc>>
       describe_tx(kafka::transactional_id);
+
+    ss::future<try_abort_reply> route_globally(try_abort_request&&);
+    ss::future<try_abort_reply> route_locally(try_abort_request&&);
 
     ss::future<tx_errc> delete_partition_from_tx(
       kafka::transactional_id, tm_transaction::tx_partition);
@@ -173,17 +166,6 @@ private:
       model::partition_id,
       model::timeout_clock::duration,
       ss::lw_shared_ptr<available_promise<checked<tm_transaction, tx_errc>>>);
-    ss::future<try_abort_reply> dispatch_try_abort(
-      model::node_id,
-      model::partition_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration);
-    ss::future<try_abort_reply> do_try_abort(
-      ss::shared_ptr<tm_stm>,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration);
     ss::future<try_abort_reply> do_try_abort(
       model::term_id,
       ss::shared_ptr<tm_stm>,
@@ -277,6 +259,9 @@ private:
 
     ss::future<result<tm_transaction, tx_errc>>
       describe_tx(ss::shared_ptr<tm_stm>, kafka::transactional_id);
+
+    ss::future<try_abort_reply>
+    process_locally(ss::shared_ptr<tm_stm>, try_abort_request&&);
 
     void expire_old_txs();
     ss::future<> expire_old_txs(model::ntp);

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -195,11 +195,6 @@ private:
     ss::future<tx_errc>
       do_init_hosted_transactions(ss::shared_ptr<cluster::tm_stm>);
 
-    ss::future<cluster::init_tm_tx_reply> dispatch_init_tm_tx(
-      model::node_id,
-      kafka::transactional_id,
-      std::chrono::milliseconds,
-      model::timeout_clock::duration);
     ss::future<cluster::init_tm_tx_reply> init_tm_tx_locally(
       kafka::transactional_id,
       std::chrono::milliseconds,

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -249,6 +249,15 @@ private:
     template<typename Func>
     auto with_stm(model::partition_id tm, Func&& func);
 
+    template<typename T>
+    ss::future<typename T::reply> do_dispatch(model::node_id, T&&);
+
+    template<typename T>
+    ss::future<typename T::reply> do_route_globally(model::ntp, T&&);
+
+    template<typename T>
+    ss::future<typename T::reply> do_route_locally(model::ntp, T&&);
+
     ss::future<add_paritions_tx_reply> do_add_partition_to_tx(
       ss::shared_ptr<tm_stm>,
       add_paritions_tx_request,

--- a/src/v/cluster/tx_registry_frontend.cc
+++ b/src/v/cluster/tx_registry_frontend.cc
@@ -25,6 +25,7 @@
 #include "model/namespace.h"
 #include "model/record_batch_reader.h"
 #include "rpc/connection_cache.h"
+#include "utils/gate_guard.h"
 #include "vformat.h"
 
 #include <seastar/core/coroutine.hh>
@@ -267,6 +268,8 @@ tx_registry_frontend::find_coordinator_locally(kafka::transactional_id tid) {
         co_return find_coordinator_reply(
           std::nullopt, std::nullopt, errc::not_leader);
     }
+
+    gate_guard guard{_gate};
 
     co_return co_await container().invoke_on(
       *shard, _ssg, [tid](tx_registry_frontend& self) mutable {

--- a/src/v/cluster/tx_registry_frontend.cc
+++ b/src/v/cluster/tx_registry_frontend.cc
@@ -1,4 +1,4 @@
-// Copyright 2020 Redpanda Data, Inc.
+// Copyright 2023 Redpanda Data, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md

--- a/src/v/cluster/tx_registry_frontend.cc
+++ b/src/v/cluster/tx_registry_frontend.cc
@@ -282,19 +282,60 @@ tx_registry_frontend::find_coordinator_locally(kafka::transactional_id tid) {
                             errc::generic_tx_error));
                     }
                     auto stm = r.value();
-                    return stm->read_lock().then(
-                      [&self, tid](ss::basic_rwlock<>::holder unit) mutable {
-                          return self.do_find_coordinator_locally(tid).finally(
-                            [u = std::move(unit)] {});
-                      });
+                    return self.do_find_coordinator_locally(stm, tid);
                 });
           });
       });
 }
 
 ss::future<find_coordinator_reply>
-tx_registry_frontend::do_find_coordinator_locally(kafka::transactional_id tid) {
-    return find_coordinator_statically(tid);
+tx_registry_frontend::do_find_coordinator_locally(
+  ss::shared_ptr<cluster::tx_registry_stm> stm, kafka::transactional_id tid) {
+    auto term_opt = co_await stm->sync();
+    if (!term_opt.has_value()) {
+        vlog(clusterlog.info, "can't sync tx registry");
+        co_return find_coordinator_reply(
+          std::nullopt, std::nullopt, errc::not_leader);
+    }
+    auto term = term_opt.value();
+
+    if (stm->seen_unknown_batch_subtype()) {
+        // it may happen only if there was a downgrade from a a patch release
+        // we assume that before it happen a user restore default static
+        // partitioning so it's safe to fall back to it
+        co_return co_await find_coordinator_statically(tid);
+    }
+
+    auto cfg = _metadata_cache.local().get_topic_cfg(model::tx_manager_nt);
+    if (!cfg) {
+        vlog(
+          clusterlog.warn,
+          "can't find {} in the metadata cache",
+          model::tx_manager_nt);
+        co_return find_coordinator_reply(
+          std::nullopt, std::nullopt, errc::topic_not_exists);
+    }
+
+    auto wunits = co_await stm->write_lock();
+    auto inited = co_await stm->try_init_mapping(term, cfg->partition_count);
+    if (!inited) {
+        co_return find_coordinator_reply(
+          std::nullopt, std::nullopt, errc::not_leader);
+    }
+    wunits.return_all();
+
+    auto runits = co_await stm->read_lock();
+
+    auto partition = stm->find_hosting_partition(tid);
+    if (!partition) {
+        co_return find_coordinator_reply(
+          std::nullopt, std::nullopt, errc::generic_tx_error);
+    }
+
+    auto ntp = model::ntp(
+      model::tx_manager_nt.ns, model::tx_manager_nt.tp, partition.value());
+    auto leader = _metadata_cache.local().get_leader_id(ntp);
+    co_return find_coordinator_reply(leader, ntp, errc::success);
 }
 
 ss::future<find_coordinator_reply>

--- a/src/v/cluster/tx_registry_frontend.cc
+++ b/src/v/cluster/tx_registry_frontend.cc
@@ -492,7 +492,6 @@ tx_registry_frontend::do_route_locally(T&& request) {
                             vlog(txlog.trace, "sending name:{} {}", T::name, r);
                             return r;
                         });
-                      ;
                   });
             });
       });

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -42,7 +42,7 @@ public:
       find_coordinator(kafka::transactional_id, model::timeout_clock::duration);
 
     ss::future<find_coordinator_reply>
-      find_coordinator_locally(kafka::transactional_id);
+    route_locally(find_coordinator_request&&);
 
     ss::future<> stop() {
         _as.request_abort();
@@ -73,8 +73,8 @@ private:
     ss::future<find_coordinator_reply> dispatch_find_coordinator(
       model::node_id, kafka::transactional_id, model::timeout_clock::duration);
 
-    ss::future<find_coordinator_reply> do_find_coordinator_locally(
-      ss::shared_ptr<cluster::tx_registry_stm>, kafka::transactional_id);
+    ss::future<find_coordinator_reply> process_locally(
+      ss::shared_ptr<cluster::tx_registry_stm>, find_coordinator_request&&);
 
     ss::future<find_coordinator_reply>
       find_coordinator_statically(kafka::transactional_id);

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -22,7 +22,8 @@
 
 namespace cluster {
 
-class tx_registry_frontend {
+class tx_registry_frontend final
+  : public ss::peering_sharded_service<tx_registry_frontend> {
 public:
     tx_registry_frontend(
       ss::smp_service_group,
@@ -50,6 +51,7 @@ public:
 
 private:
     ss::abort_source _as;
+    ss::gate _gate;
     ss::smp_service_group _ssg;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::shard_table>& _shard_table;
@@ -61,6 +63,9 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     int16_t _metadata_dissemination_retries{1};
     std::chrono::milliseconds _metadata_dissemination_retry_delay_ms;
+
+    template<typename Func>
+    auto with_stm(Func&& func);
 
     ss::future<find_coordinator_reply> dispatch_find_coordinator(
       model::node_id, kafka::transactional_id, model::timeout_clock::duration);

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -11,6 +11,8 @@
 
 #pragma once
 #include "cluster/fwd.h"
+#include "cluster/tx_gateway_frontend.h"
+#include "cluster/tx_registry_stm.h"
 #include "cluster/types.h"
 #include "features/feature_table.h"
 #include "rpc/fwd.h"
@@ -37,6 +39,9 @@ public:
       ss::sharded<features::feature_table>&);
 
     ss::future<bool> ensure_tx_topic_exists();
+
+    ss::future<describe_tx_registry_reply>
+    route_locally(describe_tx_registry_request&&);
 
     ss::future<find_coordinator_reply>
       find_coordinator(kafka::transactional_id, model::timeout_clock::duration);
@@ -75,6 +80,9 @@ private:
 
     ss::future<find_coordinator_reply> process_locally(
       ss::shared_ptr<cluster::tx_registry_stm>, find_coordinator_request&&);
+
+    ss::future<describe_tx_registry_reply> process_locally(
+      ss::shared_ptr<cluster::tx_registry_stm>, describe_tx_registry_request&&);
 
     ss::future<find_coordinator_reply>
       find_coordinator_statically(kafka::transactional_id);

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -64,6 +64,9 @@ private:
     int16_t _metadata_dissemination_retries{1};
     std::chrono::milliseconds _metadata_dissemination_retry_delay_ms;
 
+    template<typename T>
+    ss::future<typename T::reply> do_route_locally(T&&);
+
     template<typename Func>
     auto with_stm(Func&& func);
 

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -70,8 +70,8 @@ private:
     ss::future<find_coordinator_reply> dispatch_find_coordinator(
       model::node_id, kafka::transactional_id, model::timeout_clock::duration);
 
-    ss::future<find_coordinator_reply>
-      do_find_coordinator_locally(kafka::transactional_id);
+    ss::future<find_coordinator_reply> do_find_coordinator_locally(
+      ss::shared_ptr<cluster::tx_registry_stm>, kafka::transactional_id);
 
     ss::future<find_coordinator_reply>
       find_coordinator_statically(kafka::transactional_id);

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Redpanda Data, Inc.
+ * Copyright 2023 Redpanda Data, Inc.
  *
  * Use of this software is governed by the Business Source License
  * included in the file licenses/BSL.md

--- a/src/v/cluster/tx_registry_stm.cc
+++ b/src/v/cluster/tx_registry_stm.cc
@@ -1,0 +1,97 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/tx_registry_stm.h"
+
+#include "cluster/logger.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "raft/consensus.h"
+#include "raft/errc.h"
+#include "raft/types.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+namespace cluster {
+
+tx_registry_stm::tx_registry_stm(ss::logger& logger, raft::consensus* c)
+  : tx_registry_stm(logger, c, config::shard_local_cfg()) {}
+
+tx_registry_stm::tx_registry_stm(
+  ss::logger& logger, raft::consensus* c, config::configuration& cfg)
+  : persisted_stm(tx_registry_snapshot, logger, c)
+  , _sync_timeout(cfg.tx_registry_sync_timeout_ms.bind())
+  , _log_capacity(cfg.tx_registry_log_capacity.bind()) {}
+
+ss::future<checked<model::term_id, errc>> tx_registry_stm::sync() {
+    return ss::with_gate(_gate, [this] { return do_sync(_sync_timeout()); });
+}
+
+ss::future<checked<model::term_id, errc>>
+tx_registry_stm::do_sync(model::timeout_clock::duration timeout) {
+    if (!_raft->is_leader()) {
+        co_return errc::not_leader;
+    }
+
+    auto ready = co_await persisted_stm::sync(timeout);
+    if (!ready) {
+        co_return errc::generic_tx_error;
+    }
+    co_return _insync_term;
+}
+
+ss::future<> tx_registry_stm::apply(const model::record_batch& b) {
+    _processed++;
+    if (_processed > _log_capacity()) {
+        ssx::spawn_with_gate(_gate, [this] { return truncate_log_prefix(); });
+    }
+
+    return ss::now();
+}
+
+ss::future<> tx_registry_stm::truncate_log_prefix() {
+    if (_is_truncating) {
+        return ss::now();
+    }
+    if (_processed <= _log_capacity()) {
+        return ss::now();
+    }
+    _is_truncating = true;
+    return _raft
+      ->write_snapshot(raft::write_snapshot_cfg(_next_snapshot, iobuf()))
+      .then([this] {
+          _next_snapshot = last_applied_offset();
+          _processed = 0;
+      })
+      .finally([this] { _is_truncating = false; });
+}
+
+ss::future<>
+tx_registry_stm::apply_local_snapshot(stm_snapshot_header, iobuf&&) {
+    return ss::make_exception_future<>(
+      std::logic_error("tx_registry_stm doesn't support snapshots"));
+}
+
+ss::future<stm_snapshot> tx_registry_stm::take_local_snapshot() {
+    return ss::make_exception_future<stm_snapshot>(
+      std::logic_error("tx_registry_stm doesn't support snapshots"));
+}
+
+ss::future<> tx_registry_stm::apply_raft_snapshot(const iobuf&) {
+    return write_lock().then(
+      [this]([[maybe_unused]] ss::basic_rwlock<>::holder unit) {
+          _next_snapshot = _raft->start_offset();
+          _processed = 0;
+          return ss::now();
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/tx_registry_stm.h
+++ b/src/v/cluster/tx_registry_stm.h
@@ -13,8 +13,10 @@
 
 #include "cluster/fwd.h"
 #include "cluster/persisted_stm.h"
+#include "cluster/tx_hash_ranges.h"
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "raft/consensus.h"
 #include "raft/errc.h"
 #include "raft/logger.h"
 #include "raft/state_machine.h"
@@ -22,6 +24,7 @@
 #include "utils/mutex.h"
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_set.h>
 
 namespace config {
 struct configuration;
@@ -31,6 +34,27 @@ namespace cluster {
 
 class tx_registry_stm final : public persisted_stm<> {
 public:
+    enum class batch_subtype : int32_t { tx_mapping = 1 };
+
+    struct tx_mapping
+      : serde::
+          envelope<tx_mapping, serde::version<0>, serde::compat_version<0>> {
+        repartitioning_id id;
+        absl::flat_hash_map<model::partition_id, hosted_txs> mapping;
+
+        tx_mapping() = default;
+
+        tx_mapping(
+          repartitioning_id id,
+          absl::flat_hash_map<model::partition_id, hosted_txs> mapping)
+          : id(id)
+          , mapping(std::move(mapping)) {}
+
+        friend bool operator==(const tx_mapping&, const tx_mapping&) = default;
+
+        auto serde_fields() { return std::tie(id, mapping); }
+    };
+
     explicit tx_registry_stm(ss::logger&, raft::consensus*);
 
     explicit tx_registry_stm(
@@ -48,14 +72,35 @@ public:
 
     ss::future<checked<model::term_id, errc>> sync();
 
+    ss::future<bool>
+    try_init_mapping(model::term_id term, int32_t partitions_count);
+
+    bool seen_unknown_batch_subtype() const {
+        return _seen_unknown_batch_subtype;
+    }
+
+    bool is_initialized() const { return _initialized; }
+
+    const tx_mapping& get_mapping() const { return _mapping; }
+
     std::string_view get_name() const final { return "tx_registry_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 private:
+    ss::future<bool> do_write_mapping(model::term_id, tx_mapping);
+
     ss::future<checked<model::term_id, errc>>
       do_sync(model::timeout_clock::duration);
 
-    ss::future<> apply(const model::record_batch&) final;
+    ss::future<result<raft::replicate_result>>
+    replicate_quorum_ack(model::term_id term, model::record_batch&& batch) {
+        return _raft->replicate(
+          term,
+          model::make_memory_record_batch_reader(std::move(batch)),
+          raft::replicate_options{raft::consistency_level::quorum_ack});
+    }
+
+    ss::future<> apply(const model::record_batch&) override;
 
     ss::future<> truncate_log_prefix();
     ss::future<> apply_local_snapshot(stm_snapshot_header, iobuf&&) override;
@@ -72,6 +117,9 @@ private:
     int64_t _processed{0};
     config::binding<int16_t> _log_capacity;
     model::offset _next_snapshot{-1};
+    bool _initialized{false};
+    bool _seen_unknown_batch_subtype{false};
+    tx_mapping _mapping;
 
     bool _is_truncating{false};
 };

--- a/src/v/cluster/tx_registry_stm.h
+++ b/src/v/cluster/tx_registry_stm.h
@@ -75,6 +75,9 @@ public:
     ss::future<bool>
     try_init_mapping(model::term_id term, int32_t partitions_count);
 
+    std::optional<model::partition_id>
+      find_hosting_partition(kafka::transactional_id);
+
     bool seen_unknown_batch_subtype() const {
         return _seen_unknown_batch_subtype;
     }

--- a/src/v/cluster/tx_registry_stm.h
+++ b/src/v/cluster/tx_registry_stm.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "cluster/persisted_stm.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "raft/errc.h"
+#include "raft/logger.h"
+#include "raft/state_machine.h"
+#include "utils/expiring_promise.h"
+#include "utils/mutex.h"
+
+#include <absl/container/flat_hash_map.h>
+
+namespace config {
+struct configuration;
+}
+
+namespace cluster {
+
+class tx_registry_stm final : public persisted_stm<> {
+public:
+    explicit tx_registry_stm(ss::logger&, raft::consensus*);
+
+    explicit tx_registry_stm(
+      ss::logger&, raft::consensus*, config::configuration&);
+
+    ss::gate& gate() { return _gate; }
+
+    ss::future<ss::basic_rwlock<>::holder> read_lock() {
+        return _lock.hold_read_lock();
+    }
+
+    ss::future<ss::basic_rwlock<>::holder> write_lock() {
+        return _lock.hold_write_lock();
+    }
+
+    ss::future<checked<model::term_id, errc>> sync();
+
+    std::string_view get_name() const final { return "tx_registry_stm"; }
+    ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
+
+private:
+    ss::future<checked<model::term_id, errc>>
+      do_sync(model::timeout_clock::duration);
+
+    ss::future<> apply(const model::record_batch&) final;
+
+    ss::future<> truncate_log_prefix();
+    ss::future<> apply_local_snapshot(stm_snapshot_header, iobuf&&) override;
+    ss::future<stm_snapshot> take_local_snapshot() override;
+    ss::future<> apply_raft_snapshot(const iobuf&) final;
+
+    config::binding<std::chrono::milliseconds> _sync_timeout;
+    ss::basic_rwlock<> _lock;
+
+    // Unlike the data partitions tx_registry_stm doesn't rely on the eviction
+    // stm and manages log truncations on its own. STM counts the number of
+    // applied commands and when it (`_processed`) surpasses
+    // `_log_capacity` tx_registry_stm trucates the prefix.
+    int64_t _processed{0};
+    config::binding<int16_t> _log_capacity;
+    model::offset _next_snapshot{-1};
+
+    bool _is_truncating{false};
+};
+
+} // namespace cluster

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -991,6 +991,16 @@ std::ostream& operator<<(std::ostream& o, const find_coordinator_reply& r) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const describe_tx_registry_request&) {
+    fmt::print(o, "{{}}");
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const describe_tx_registry_reply& r) {
+    fmt::print(o, "{{ec: {}}}", r.ec);
+    return o;
+}
+
 std::ostream&
 operator<<(std::ostream& o, const configuration_update_request& cr) {
     fmt::print(o, "{{broker: {} target_node: {}}}", cr.node, cr.target_node);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -13,6 +13,7 @@
 
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
+#include "cluster/tx_hash_ranges.h"
 #include "kafka/types.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
@@ -1064,6 +1065,30 @@ struct find_coordinator_request
     operator<<(std::ostream& o, const find_coordinator_request& r);
 
     auto serde_fields() { return std::tie(tid); }
+};
+
+struct describe_tx_registry_reply {
+    repartitioning_id id;
+    absl::flat_hash_map<model::partition_id, hosted_txs> mapping;
+    tx_errc ec{};
+
+    describe_tx_registry_reply() noexcept = default;
+
+    describe_tx_registry_reply(tx_errc ec)
+      : ec(ec) {}
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const describe_tx_registry_reply& r);
+};
+
+struct describe_tx_registry_request {
+    using reply = describe_tx_registry_reply;
+    static constexpr const std::string_view name = "describe_tx_registry";
+
+    describe_tx_registry_request() noexcept = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const describe_tx_registry_request& r);
 };
 
 struct join_node_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3945,6 +3945,7 @@ static const ss::sstring archival_stm_snapshot = "archival_metadata.snapshot";
 static const ss::sstring rm_stm_snapshot = "tx.snapshot";
 static const ss::sstring tm_stm_snapshot = "tx.coordinator.snapshot";
 static const ss::sstring id_allocator_snapshot = "id.snapshot";
+static const ss::sstring tx_registry_snapshot = "tx_registry.snapshot";
 
 /**
  * Create/update a (Wasm) plugin.

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -185,35 +185,6 @@ enum class partition_removal_mode : uint8_t {
     global = 1
 };
 
-struct try_abort_request
-  : serde::
-      envelope<try_abort_request, serde::version<0>, serde::compat_version<0>> {
-    model::partition_id tm;
-    model::producer_identity pid;
-    model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout{};
-
-    try_abort_request() noexcept = default;
-
-    try_abort_request(
-      model::partition_id tm,
-      model::producer_identity pid,
-      model::tx_seq tx_seq,
-      model::timeout_clock::duration timeout)
-      : tm(tm)
-      , pid(pid)
-      , tx_seq(tx_seq)
-      , timeout(timeout) {}
-
-    friend bool operator==(const try_abort_request&, const try_abort_request&)
-      = default;
-
-    friend std::ostream&
-    operator<<(std::ostream& o, const try_abort_request& r);
-
-    auto serde_fields() { return std::tie(tm, pid, tx_seq, timeout); }
-};
-
 struct try_abort_reply
   : serde::
       envelope<try_abort_reply, serde::version<0>, serde::compat_version<0>> {
@@ -248,6 +219,38 @@ struct try_abort_reply
     }
 
     auto serde_fields() { return std::tie(commited, aborted, ec); }
+};
+
+struct try_abort_request
+  : serde::
+      envelope<try_abort_request, serde::version<0>, serde::compat_version<0>> {
+    using reply = try_abort_reply;
+    static constexpr const std::string_view name = "try_abort";
+
+    model::partition_id tm;
+    model::producer_identity pid;
+    model::tx_seq tx_seq;
+    model::timeout_clock::duration timeout{};
+
+    try_abort_request() noexcept = default;
+
+    try_abort_request(
+      model::partition_id tm,
+      model::producer_identity pid,
+      model::tx_seq tx_seq,
+      model::timeout_clock::duration timeout)
+      : tm(tm)
+      , pid(pid)
+      , tx_seq(tx_seq)
+      , timeout(timeout) {}
+
+    friend bool operator==(const try_abort_request&, const try_abort_request&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const try_abort_request& r);
+
+    auto serde_fields() { return std::tie(tm, pid, tx_seq, timeout); }
 };
 
 struct init_tm_tx_request

--- a/src/v/config/base_property.cc
+++ b/src/v/config/base_property.cc
@@ -56,8 +56,8 @@ std::string_view to_string_view(visibility v) {
 void base_property::assert_live_settable() const {
     vassert(
       _meta.needs_restart == needs_restart::no,
-      "Property must be be marked as "
-      "needs_restart::no");
+      "Property {} must be be marked as needs_restart::no",
+      name());
 }
 
 }; // namespace config

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -428,6 +428,12 @@ configuration::configuration()
       "Time to wait state catch up before rejecting a request",
       {.visibility = visibility::user},
       10s)
+  , tx_registry_sync_timeout_ms(
+      *this,
+      "tx_registry_sync_timeout_ms",
+      "Time to wait state catch up before rejecting a request",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10s)
   , tm_violation_recovery_policy(*this, "tm_violation_recovery_policy")
   , rm_sync_timeout_ms(
       *this,
@@ -1001,11 +1007,18 @@ configuration::configuration()
        .visibility = visibility::tunable},
       2,
       {.min = 1})
+  , tx_registry_log_capacity(
+      *this,
+      "tx_registry_log_capacity",
+      "Capacity of the tx_registry log in number of batches. "
+      "Once it reached tx_registry_stm truncates log's prefix.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100)
   , id_allocator_log_capacity(
       *this,
       "id_allocator_log_capacity",
-      "Capacity of the id_allocator log in number of messages. "
-      "Once it reached id_allocator_stm should compact the log.",
+      "Capacity of the id_allocator log in number of batches. "
+      "Once it reached id_allocator_stm truncates log's prefix.",
       {.visibility = visibility::tunable},
       100)
   , id_allocator_batch_size(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -113,6 +113,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> metadata_dissemination_retry_delay_ms;
     property<int16_t> metadata_dissemination_retries;
     property<std::chrono::milliseconds> tm_sync_timeout_ms;
+    property<std::chrono::milliseconds> tx_registry_sync_timeout_ms;
     deprecated_property tm_violation_recovery_policy;
     property<std::chrono::milliseconds> rm_sync_timeout_ms;
     property<std::chrono::milliseconds> find_coordinator_timeout_ms;
@@ -208,6 +209,7 @@ struct configuration final : public config_store {
     property<bool> storage_ignore_cstore_hints;
     bounded_property<int16_t> storage_reserve_min_segments;
 
+    property<int16_t> tx_registry_log_capacity;
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3125,11 +3125,12 @@ group::do_try_abort_old_tx(model::producer_identity pid) {
               "pid {} doesn't exist in current transactions data",
               pid);
         }
-        auto r = co_await _tx_frontend.local().try_abort(
-          tm,
-          pid,
-          tx_seq,
-          config::shard_local_cfg().rm_sync_timeout_ms.value());
+        auto r = co_await _tx_frontend.local().route_globally(
+          cluster::try_abort_request(
+            tm,
+            pid,
+            tx_seq,
+            config::shard_local_cfg().rm_sync_timeout_ms.value()));
         if (r.ec != cluster::tx_errc::none) {
             co_return r.ec;
         }

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -361,6 +361,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::prefix_truncate";
     case record_batch_type::plugin_update:
         return o << "batch_type::plugin_update";
+    case record_batch_type::tx_registry:
+        return o << "batch_type::tx_registry";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -44,7 +44,8 @@ enum class record_batch_type : int8_t {
     tx_tm_hosted_trasactions = 24,   // tx_tm_hosted_trasactions_batch_type
     prefix_truncate = 25,            // log prefix truncation type
     plugin_update = 26,              // Wasm plugin update
-    MAX = plugin_update
+    tx_registry = 27,                // tx_registry_batch_type
+    MAX = tx_registry
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/redpanda/admin/api-doc/transaction.json
+++ b/src/v/redpanda/admin/api-doc/transaction.json
@@ -26,6 +26,21 @@
             ]
         },
         {
+            "path": "/v1/tx_registry",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get tx registry state",
+                    "type": "describe_tx_registry_reply",
+                    "nickname": "describe_tx_registry",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/transaction/{transactional_id}/find_coordinator",
             "operations": [
                 {
@@ -95,6 +110,54 @@
         }
     ],
     "models": {
+        "hash_range": {
+            "id": "hash_range",
+            "description": "Hash range",
+            "properties": {
+                "first": {
+                    "type": "long",
+                    "description": "first"
+                },
+                "last": {
+                    "type": "long",
+                    "description": "last"
+                }
+            }
+        },
+        "tx_mapping_entry": {
+            "id": "tx_mapping_entry",
+            "description": "tx_mapping_entry",
+            "properties": {
+                "partition_id": {
+                    "type": "int",
+                    "description": "partition_id"
+                },
+                "hosted_txs": {
+                    "type": "hosted_txs",
+                    "description": "hosted transactions"
+                }
+            }
+        },
+        "describe_tx_registry_reply": {
+            "id": "describe_tx_registry_reply",
+            "description": "tx registry state",
+            "properties": {
+                "ec": {
+                    "type": "long"
+                },
+                "version": {
+                    "type": "long",
+                    "description": "repartitioning_id"
+                },
+                "tx_mapping": {
+                    "type": "array",
+                    "items": {
+                        "type": "tx_mapping_entry"
+                    },
+                    "description": "tx_mapping"
+                }
+            }
+        },
         "ntp": {
             "id": "ntp",
             "description": "NTP",
@@ -226,6 +289,30 @@
                         "type": "group"
                     },
                     "description": "Consumer groups for transaction"
+                }
+            }
+        },
+        "hosted_txs": {
+            "id": "hosted_txs",
+            "description": "hosted_txs",
+            "properties": {
+                "excluded_transactions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "included_transactions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hash_ranges": {
+                    "type": "array",
+                    "items": {
+                        "type": "hash_range"
+                    }
                 }
             }
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3604,6 +3604,47 @@ admin_server::find_tx_coordinator_handler(
 }
 
 ss::future<ss::json::json_return_type>
+admin_server::describe_tx_registry_handler(
+  std::unique_ptr<ss::http::request> req) {
+    if (need_redirect_to_leader(model::tx_registry_ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, model::tx_registry_ntp);
+    }
+
+    ss::httpd::transaction_json::describe_tx_registry_reply reply;
+    auto r = co_await _tx_registry_frontend.local().route_locally(
+      cluster::describe_tx_registry_request());
+    if (r.ec != cluster::tx_errc::none) {
+        reply.ec = static_cast<int>(r.ec);
+        co_return ss::json::json_return_type(std::move(reply));
+    }
+    reply.ec = 0;
+
+    reply.version = r.id();
+    for (auto& [partition, hosted] : r.mapping) {
+        ss::httpd::transaction_json::tx_mapping_entry entry;
+        entry.partition_id = partition();
+
+        ss::httpd::transaction_json::hosted_txs hosted_txs;
+        for (auto tx_id : hosted.excluded_transactions) {
+            hosted_txs.excluded_transactions.push(tx_id());
+        }
+        for (auto tx_id : hosted.included_transactions) {
+            hosted_txs.included_transactions.push(tx_id());
+        }
+        for (auto range : hosted.hash_ranges.ranges) {
+            ss::httpd::transaction_json::hash_range hash_range;
+            hash_range.first = range.first;
+            hash_range.last = range.last;
+            hosted_txs.hash_ranges.push(hash_range);
+        }
+        entry.hosted_txs = hosted_txs;
+        reply.tx_mapping.push(entry);
+    }
+
+    co_return ss::json::json_return_type(std::move(reply));
+}
+
+ss::future<ss::json::json_return_type>
 admin_server::delete_partition_handler(std::unique_ptr<ss::http::request> req) {
     auto& tx_frontend = _partition_manager.local().get_tx_frontend();
     if (!tx_frontend.local_is_initialized()) {
@@ -3674,6 +3715,12 @@ void admin_server::register_transaction_routes() {
       ss::httpd::transaction_json::find_coordinator,
       [this](std::unique_ptr<ss::http::request> req) {
           return find_tx_coordinator_handler(std::move(req));
+      });
+
+    register_route<user>(
+      ss::httpd::transaction_json::describe_tx_registry,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return describe_tx_registry_handler(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -424,6 +424,8 @@ private:
     ss::future<ss::json::json_return_type>
       delete_partition_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
+      describe_tx_registry_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
       find_tx_coordinator_handler(std::unique_ptr<ss::http::request>);
 
     /// Cluster routes

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1446,8 +1446,7 @@ void application::wire_up_redpanda_services(
       .get();
 
     syschecks::systemd_message("Creating tx coordinator mapper").get();
-    construct_service(
-      tx_coordinator_ntp_mapper, std::ref(metadata_cache), model::tx_manager_nt)
+    construct_service(tx_coordinator_ntp_mapper, std::ref(metadata_cache))
       .get();
 
     syschecks::systemd_message("Creating id allocator frontend").get();

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -672,6 +672,24 @@ class Admin:
         path = f"transaction/{tid}/find_coordinator"
         return self._request('get', path, node=node).json()
 
+    def describe_tx_registry(self, node=None):
+        """
+        describe_tx_registry
+        """
+        path = f"tx_registry"
+        info = self._request('get', path, node=node).json()
+        mapping = {
+            x["partition_id"]: x["hosted_txs"]
+            for x in info["tx_mapping"]
+        }
+        for key in mapping:
+            if "excluded_transactions" not in mapping[key]:
+                mapping[key]["excluded_transactions"] = []
+            if "included_transactions" not in mapping[key]:
+                mapping[key]["included_transactions"] = []
+        info["tx_mapping"] = mapping
+        return info
+
     def set_partition_replicas(self,
                                topic,
                                partition,

--- a/tests/rptest/tests/tx_registry_test.py
+++ b/tests/rptest/tests/tx_registry_test.py
@@ -1,0 +1,82 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.util import wait_until_result
+from rptest.clients.types import TopicSpec
+
+import random
+
+from ducktape.mark import parametrize
+from ducktape.utils.util import wait_until
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+import confluent_kafka as ck
+
+
+class TransactionsMixin:
+    def on_delivery_passes(self, err, msg):
+        assert err == None, msg
+
+    def on_delivery_fails(self, err, msg):
+        assert err != None, err
+
+
+class TxRegistryTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1, replication_factor=3),
+              TopicSpec(partition_count=1, replication_factor=3))
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_leader_balancer": False,
+            "partition_autobalancing_mode": "off",
+        }
+
+        super(TxRegistryTest, self).__init__(test_context=test_context,
+                                             extra_rp_conf=extra_rp_conf,
+                                             log_level="trace")
+
+        self.input_t = self.topics[0]
+        self.output_t = self.topics[1]
+        self.max_records = 100
+        self.admin = Admin(self.redpanda)
+
+    @cluster(num_nodes=3)
+    def find_coordinator_inits_tx_registry_test(self):
+        def find_tx_coordinator_passes():
+            r = self.admin.find_tx_coordinator(
+                "tx0", node=random.choice(self.redpanda.started_nodes()))
+            return r["ec"] == 0
+
+        def describe_tx_registry():
+            state = self.admin.describe_tx_registry()
+            return state["ec"] != 11, state
+
+        wait_until(find_tx_coordinator_passes, timeout_sec=10, backoff_sec=1)
+
+        info = wait_until_result(describe_tx_registry,
+                                 timeout_sec=10,
+                                 backoff_sec=1)
+        assert info["ec"] == 0
+        assert info["version"] == 0
+        partitions = set()
+        ranges = list()
+        for (partition_id, hosted_txs) in info["tx_mapping"].items():
+            partitions.add(partition_id)
+            for hash_range in hosted_txs["hash_ranges"]:
+                ranges.append(hash_range)
+        assert len(partitions) > 0
+        assert max(partitions) + 1 == len(partitions)
+        assert min(partitions) == 0
+        assert len(ranges) > 0
+        ranges = sorted(ranges, key=lambda x: x["first"])
+        assert ranges[0]["first"] == 0
+        assert ranges[-1]["last"] == 4294967295
+        for i in range(1, len(ranges)):
+            assert ranges[i - 1]["last"] + 1 == ranges[i]["first"]


### PR DESCRIPTION
Add and initialize tx_registry_stm on the first request

Fixes #10754

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none