### PR TITLE
rpc/transport: fix temporary dispatch loop stalls

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -133,8 +133,7 @@ transport::send(netbuf b, rpc::client_opts opts) {
 }
 
 ss::future<result<std::unique_ptr<streaming_context>>>
-transport::make_response_handler(
-  netbuf& b, rpc::client_opts& opts) {
+transport::make_response_handler(netbuf& b, rpc::client_opts& opts) {
     if (_correlations.find(_correlation_idx + 1) != _correlations.end()) {
         _probe.client_correlation_error();
         vlog(
@@ -169,50 +168,48 @@ transport::make_response_handler(
         throw std::logic_error(
           fmt::format("Tried to reuse correlation id: {}", idx));
     }
-    handler_raw_ptr->with_timeout(
-      opts.timeout, [this, method = b.name(), idx] {
-          auto format_ms = [](clock_type::duration d) {
-              auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                d);
-              return fmt::format("{} ms", ms.count());
-          };
+    handler_raw_ptr->with_timeout(opts.timeout, [this, method = b.name(), idx] {
+        auto format_ms = [](clock_type::duration d) {
+            auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(d);
+            return fmt::format("{} ms", ms.count());
+        };
 
-          auto from_now =
-            [now = timing_info::clock_type::now(), format_ms](
-              timing_info::clock_type::time_point earlier) -> std::string {
-              if (earlier == timing_info::unset) {
-                  return "unset";
-              }
-              return format_ms(now - earlier);
-          };
-          auto it = _correlations.find(idx);
-          // The timeout may race with the completion of the request (and
-          // removal from _correlations map) in which case we treat this as a
-          // not-timed-out request.
-          if (likely(it != _correlations.end())) {
-              auto& timing = it->second->timing;
-              vlog(
-                rpclog.info,
-                "RPC timeout ({}) to {}, method: {}, correlation id: {}, {} "
-                "in flight, time since: {{init: {}, enqueue: {}, "
-                "memory_reserved: {} dispatch: "
-                "{}, written: {}}}, flushed: {}",
-                format_ms(timing.timeout.timeout_period),
-                server_address(),
-                method,
-                idx,
-                _correlations.size(),
-                from_now(
-                  timing.timeout.timeout_at() - timing.timeout.timeout_period),
-                from_now(timing.enqueued_at),
-                from_now(timing.memory_reserved_at),
-                from_now(timing.dispatched_at),
-                from_now(timing.written_at),
-                timing.flushed);
-              _probe.request_timeout();
-              _correlations.erase(it);
-          }
-      });
+        auto from_now =
+          [now = timing_info::clock_type::now(), format_ms](
+            timing_info::clock_type::time_point earlier) -> std::string {
+            if (earlier == timing_info::unset) {
+                return "unset";
+            }
+            return format_ms(now - earlier);
+        };
+        auto it = _correlations.find(idx);
+        // The timeout may race with the completion of the request (and
+        // removal from _correlations map) in which case we treat this as a
+        // not-timed-out request.
+        if (likely(it != _correlations.end())) {
+            auto& timing = it->second->timing;
+            vlog(
+              rpclog.info,
+              "RPC timeout ({}) to {}, method: {}, correlation id: {}, {} "
+              "in flight, time since: {{init: {}, enqueue: {}, "
+              "memory_reserved: {} dispatch: "
+              "{}, written: {}}}, flushed: {}",
+              format_ms(timing.timeout.timeout_period),
+              server_address(),
+              method,
+              idx,
+              _correlations.size(),
+              from_now(
+                timing.timeout.timeout_at() - timing.timeout.timeout_period),
+              from_now(timing.enqueued_at),
+              from_now(timing.memory_reserved_at),
+              from_now(timing.dispatched_at),
+              from_now(timing.written_at),
+              timing.flushed);
+            _probe.request_timeout();
+            _correlations.erase(it);
+        }
+    });
 
     return response_future;
 }

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -134,7 +134,7 @@ transport::send(netbuf b, rpc::client_opts opts) {
 
 ss::future<result<std::unique_ptr<streaming_context>>>
 transport::make_response_handler(
-  netbuf& b, rpc::client_opts& opts, sequence_t seq) {
+  netbuf& b, rpc::client_opts& opts) {
     if (_correlations.find(_correlation_idx + 1) != _correlations.end()) {
         _probe.client_correlation_error();
         vlog(
@@ -170,7 +170,7 @@ transport::make_response_handler(
           fmt::format("Tried to reuse correlation id: {}", idx));
     }
     handler_raw_ptr->with_timeout(
-      opts.timeout, [this, method = b.name(), idx, seq] {
+      opts.timeout, [this, method = b.name(), idx] {
           auto format_ms = [](clock_type::duration d) {
               auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 d);
@@ -185,7 +185,6 @@ transport::make_response_handler(
               }
               return format_ms(now - earlier);
           };
-          _requests_queue.erase(seq);
           auto it = _correlations.find(idx);
           // The timeout may race with the completion of the request (and
           // removal from _correlations map) in which case we treat this as a
@@ -224,13 +223,12 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
     // hold invariant of always having a valid connection _and_ a working
     // dispatch gate where we can wait for async futures
     if (!is_valid() || _dispatch_gate.is_closed()) {
-        _last_seq = std::max(_last_seq, seq);
         return ss::make_ready_future<ret_t>(errc::disconnected_endpoint);
     }
     return ss::with_gate(
       _dispatch_gate,
       [this, b = std::move(b), opts = std::move(opts), seq]() mutable {
-          auto f = make_response_handler(b, opts, seq);
+          auto f = make_response_handler(b, opts);
 
           // send
           auto sz = b.buffer().size_bytes();
@@ -254,27 +252,35 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
               [this, f = std::move(f), seq, corr](
                 ssx::semaphore_units units,
                 ss::scattered_message<char> scattered_message) mutable {
-                  // Check that the request hasn't been finished yet.
-                  // If it has (due to timeout or disconnect), we don't need to
-                  // send it.
-                  if (_correlations.contains(corr)) {
-                      auto e = entry{
-                        .scattered_message
-                        = std::make_unique<ss::scattered_message<char>>(
-                          std::move(scattered_message)),
-                        .correlation_id = corr};
+                  auto e = entry{
+                    .scattered_message
+                    = std::make_unique<ss::scattered_message<char>>(
+                      std::move(scattered_message)),
+                    .correlation_id = corr};
 
-                      _requests_queue.emplace(
-                        seq, std::make_unique<entry>(std::move(e)));
-                      dispatch_send();
-                  }
+                  _requests_queue.emplace(
+                    seq, std::make_unique<entry>(std::move(e)));
+                  // By this point the request may already have timed out but
+                  // we still do dispatch_send where it is handled. This is
+                  // needed for two reasons:
+                  // - Monotonic updates to _last_seq
+                  // - Draining of the request_queue which could otherwise be
+                  //   stalled by missing sequence number.
+                  dispatch_send();
                   return std::move(f).finally([u = std::move(units)] {});
               })
-            .finally([this, seq] {
-                // update last sequence to make progress, for successfull
-                // dispatches this will be noop, as _last_seq was already update
-                // before sending data
-                _last_seq = std::max(_last_seq, seq);
+            .handle_exception([this, seq, corr](std::exception_ptr eptr) {
+                // This is unlikely but may potentially mean dispatch_send()
+                // is not called, stalling the sequence number.
+                vlog(
+                  rpclog.error,
+                  "Exception {} dispatching rpc with sequence: {}, "
+                  "correlation_idx: {}, last_seq: {}",
+                  eptr,
+                  seq,
+                  corr,
+                  _last_seq);
+                return ss::make_exception_future<ret_t>(eptr);
             });
       });
 }

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -70,6 +70,13 @@ struct timing_info {
     time_point enqueued_at = unset;
 
     /**
+     * Moment in time the semaphore units needed for request buffer are
+     * reserved. The request is not dispatched until the required units are
+     * acquired.
+     */
+    time_point memory_reserved_at = unset;
+
+    /**
      * The moment in time we dispatched the request: that is, it was the next
      * request to be sent and we called .write on the output stream: note that
      * this does not perform the write (since that's an async method), but it

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -163,7 +163,7 @@ private:
     void dispatch_send();
 
     ss::future<result<std::unique_ptr<streaming_context>>>
-    make_response_handler(netbuf&, rpc::client_opts&, sequence_t);
+    make_response_handler(netbuf&, rpc::client_opts&);
 
     ssx::semaphore _memory;
 


### PR DESCRIPTION
Currently the way the code is structured can result in temporary
dispatch stalls timing out a bunch of requests.

Consider a request queue of sequence numbers [5, 6, 7, 8]

Lets assume seq=6 dispatch got delayed. This can happen if timeout is
low or there is an unknown delay by the scheduler (eg: debug builds).

_last_seq=4, queue = [5, 7, 8] - 5 is dispatched right away
_last_seq=5, queue = [7,8] -- out of order.

Dispatch of 7, 8 doesn't happen right away due to out of order sequence
and we never do a dispatch with seq=6 because we detect it already
timed out.

Now it takes a new RPC request to clear the stalled queue but
that may not happen for a while  (eg: until the queued RPCs are timed out) and
meanwhile seq=7/8 timeout for no fault of theirs.

This patch does two main things.

* Consolidates _last_seq tracking. Currently it is not monotonic and can
jump all over the place. This is confusing. Now we only update it in a
centralized place in dispatch_send().

* ^^ Requires that dispatch_send() is called in all cases which also
avoids dispatch loop stalls. For example, a timed out request will clear
the stalled queue right away (which is not the case before).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
