### PR TITLE
net: Add GNUTLS_E_INVALID_SESSION to is_reconnect_error

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -32,6 +32,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case GNUTLS_E_PUSH_ERROR:
         case GNUTLS_E_PULL_ERROR:
         case GNUTLS_E_UNEXPECTED_PACKET:
+        case GNUTLS_E_INVALID_SESSION:
         case GNUTLS_E_UNSUPPORTED_VERSION_PACKET:
         case GNUTLS_E_NO_CIPHER_SUITES:
         case GNUTLS_E_PREMATURE_TERMINATION:


### PR DESCRIPTION
Seen in the wild:
```
ERROR 2023-04-11 13:07:58,156 [shard 1] pandaproxy - reply.h:115 - exception_reply:
{"error_code":500,"message":"HTTP 500 Internal Server Error"}
, exception: std::__1::system_error (error GnuTLS:-10, The specified session has been invalidated for some reason.)
WARN 2023-04-11 12:13:47,142 [shard 3] pandaproxy - service.cc:226 - mitigate_error: std::__1::system_error (error GnuTLS:-10, The specified session has been invalidated for some reason.)
```
And also here, but it was having lots of other issues, too.
```
ERROR 2023-05-09 06:38:23,478 [shard 2] rpc - server.cc:139 - kafka rpc protocol - Error[shutting down] remote address: <redacted>:40906 - std::__1::system_error (error GnuTLS:-10, The specified session has been invalidated for some reason.)
ERROR 2023-05-09 06:38:23,478 [shard 2] rpc - server.cc:139 - kafka rpc protocol - Error[applying protocol] remote address: <redacted>:40906 - std::__1::system_error (error GnuTLS:-25, Internal error in memory allocation.)
WARN  2023-05-09 06:38:23,477 [shard 2] kafka - protocol.cc:224 - Error kafka rpc protocol <redacted>:40906: std::__1::system_error (error GnuTLS:-25, Internal error in memory allocation.) (sasl state: complete)
```

Handle `GNUTLS_E_INVALID_SESSION` by reconnecting.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* net: Handle `GNUTLS_E_INVALID_SESSION` by reconnecting.
