### PR TITLE
[v22.3.x] net: Add GNUTLS_E_INVALID_SESSION to is_reconnect_error

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -32,6 +32,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case GNUTLS_E_PUSH_ERROR:
         case GNUTLS_E_PULL_ERROR:
         case GNUTLS_E_UNEXPECTED_PACKET:
+        case GNUTLS_E_INVALID_SESSION:
         case GNUTLS_E_UNSUPPORTED_VERSION_PACKET:
         case GNUTLS_E_NO_CIPHER_SUITES:
         case GNUTLS_E_PREMATURE_TERMINATION:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11029
