### PR TITLE
slash backport: add pr number to the branch name

### DIFF
--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -40,14 +40,7 @@ git remote add upstream "https://github.com/$TARGET_FULL_REPO.git"
 git fetch --all
 git remote set-url origin "https://$GIT_USER:$GITHUB_TOKEN@github.com/$GIT_USER/$TARGET_REPO.git"
 
-backport_issues_numbers=""
-for issue_url in $fixing_issue_urls; do
-  backport_issues_numbers+=$(echo "$issue_url" | awk -F/ '{print $NF"-"}')
-done
-if [[ $backport_issues_numbers == "" ]]; then
-  backport_issues_numbers="fixes-to-"
-fi
-head_branch=$(echo "backport-$backport_issues_numbers$BACKPORT_BRANCH-$suffix" | sed 's/ /-/g')
+head_branch=$(echo "backport-pr-$PR_NUMBER-$BACKPORT_BRANCH-$suffix" | sed 's/ /-/g')
 git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
 
 if ! git cherry-pick -x $BACKPORT_COMMITS; then


### PR DESCRIPTION
there are some cases where the branch exists in
the vbotbuildovich account. This happens because
the branch name follows the below patterns:

* there is no linked issues to the original PR: `backport-fixes-[BRACNH]-[4_DIGIT_RANDOM]`
* there are linked issues: `backport-[...ISSUES_URLS]-[BRANCH]-[4_DIGIT_NUMBER]`

for the first case, it's likely that the branch name already exists; causing slash backport to fail.
an example is https://github.com/redpanda-data/redpanda/actions/runs/5079464556/jobs/9125226163

This commit changes the branch name to only follow 1 pattern: `backport-pr-[ORIGINAL_PR_NUMBER]-[BRANCH]-[4_DIGIT_RANDOM]`

fixes https://github.com/redpanda-data/devprod/issues/719

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none