### PR TITLE
test: rpk cloud login test using rpk.yaml

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -833,11 +833,12 @@ class RpkTool:
         ]
         return self._execute(cmd)
 
-    def _execute(self, cmd, stdin=None, timeout=None):
+    def _execute(self, cmd, stdin=None, timeout=None, log_cmd=True):
         if timeout is None:
             timeout = DEFAULT_TIMEOUT
 
-        self._redpanda.logger.debug("Executing command: %s", cmd)
+        if log_cmd:
+            self._redpanda.logger.debug("Executing command: %s", cmd)
 
         p = subprocess.Popen(cmd,
                              stdout=subprocess.PIPE,
@@ -856,7 +857,8 @@ class RpkTool:
             self._redpanda.logger.error(error)
             raise RpkException(
                 'command %s returned %d, output: %s' %
-                (' '.join(cmd), p.returncode, output), error, p.returncode)
+                (' '.join(cmd) if log_cmd else '[redacted]', p.returncode,
+                 output), error, p.returncode)
 
         return output
 
@@ -1052,7 +1054,7 @@ class RpkTool:
         if path:
             cmd += ["--path", path]
 
-        return self._execute(cmd)
+        return self._execute(cmd, log_cmd=False)
 
     def license_info(self):
 
@@ -1179,3 +1181,25 @@ class RpkTool:
                                    int(size)))
 
         return result
+
+    def cloud_login_cc(self, id, secret):
+
+        cmd = [
+            self._rpk_binary(), "cloud", "login", "--client-id", id,
+            "--client-secret", secret
+        ]
+
+        self._redpanda.logger.debug(
+            "Executing command: %s cloud login --client-id %s --client-secret [redacted]",
+            self._rpk_binary(), id)
+
+        return self._execute(cmd, log_cmd=False)
+
+    def cloud_logout(self, clear_credentials=True):
+
+        cmd = [self._rpk_binary(), "cloud", "logout"]
+
+        if clear_credentials:
+            cmd += ["--clear-credentials"]
+
+        return self._execute(cmd)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -692,6 +692,7 @@ class RedpandaServiceBase(Service):
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
     NODE_CONFIG_FILE = "/etc/redpanda/redpanda.yaml"
     CLUSTER_BOOTSTRAP_CONFIG_FILE = "/etc/redpanda/.bootstrap.yaml"
+    RPK_CONFIG_FILE = "/root/.config/rpk/rpk.yaml"
     TLS_SERVER_KEY_FILE = "/etc/redpanda/server.key"
     TLS_SERVER_CRT_FILE = "/etc/redpanda/server.crt"
     TLS_CA_CRT_FILE = "/etc/redpanda/ca.crt"

--- a/tests/rptest/tests/rpk_cloud_test.py
+++ b/tests/rptest/tests/rpk_cloud_test.py
@@ -1,0 +1,71 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+import tempfile
+import yaml
+
+from rptest.services.cluster import cluster
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import RedpandaService
+from rptest.clients.rpk import RpkTool
+
+
+def get_ci_env_var(env_var):
+    out = os.environ.get(env_var, None)
+    if out is None:
+        is_ci = os.environ.get("CI", "false")
+        if is_ci == "true":
+            raise RuntimeError(
+                f"Expected {env_var} variable to be set in this environment")
+
+    return out
+
+
+def read_rpk_cfg(node):
+    with tempfile.TemporaryDirectory() as d:
+        node.account.copy_from(RedpandaService.RPK_CONFIG_FILE, d)
+        with open(os.path.join(d, 'rpk.yaml')) as f:
+            return yaml.full_load(f.read())
+
+
+class RpkCloudTest(RedpandaTest):
+    def __init__(self, ctx):
+        super(RpkCloudTest, self).__init__(test_context=ctx)
+        self._ctx = ctx
+        self._rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=1)
+    def test_cloud_login_logout_cc(self):
+        """
+        Test login to cloud via rpk using client
+        credentials, make sure we store the token and
+        then delete it when we logout.
+        """
+        id = get_ci_env_var("RPK_TEST_CLIENT_ID")
+        secret = get_ci_env_var("RPK_TEST_CLIENT_SECRET")
+        if id is None or secret is None:
+            self.logger.warn(
+                "Skipping test, client credentials env vars not found")
+            return
+
+        output = self._rpk.cloud_login_cc(id, secret)
+        assert "Successfully logged in" in output
+
+        # Check for a token present in file.
+        node = self.redpanda.get_node(0)
+        rpk_yaml = read_rpk_cfg(node)
+        assert rpk_yaml["cloud_auth"][0]["auth_token"] is not None
+
+        # Check that the token is not there anymore.
+        output = self._rpk.cloud_logout()
+        assert "You are now logged out" in output
+        rpk_yaml = read_rpk_cfg(node)
+        assert rpk_yaml["cloud_auth"][0]["auth_token"] is None


### PR DESCRIPTION
This test will try to login and logout from cloud but using Client Credentials.

And we check that we write to the newly introduced rpk.yaml

Draft until we merge the infra PR (vtools #1835)
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required
- [ ] none - issue does not exist in previous branches

## Release Notes
* none

