### PR TITLE
build: add missing #include <array>

### DIFF
--- a/src/v/hashing/tests/xx_tests.cc
+++ b/src/v/hashing/tests/xx_tests.cc
@@ -19,6 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <array>
 #include <utility>
 
 BOOST_AUTO_TEST_CASE(incremental_same_as_array) {


### PR DESCRIPTION
When building in debug mode with shared libs I ran into:

[45/968] Building CXX object src/v/hashing/tests/CMakeFiles/xx_hashes_rpunit.dir/xx_tests.cc.o FAILED: src/v/hashing/tests/CMakeFiles/xx_hashes_rpunit.dir/xx_tests.cc.o /usr/bin/ccache /home/andrew/xfs/vbuild/llvm/install/bin/clang++ -DBOOST_TEST_DYN_LINK -DBOOST_TEST_NO_LIB -DXXH_PRIVATE_API -I/home/andrew/Repos/redpanda/src/v -I/home/andrew/xfs/vbuild/debug/clang/src/v -isystem /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/include -fPIC -march=westmere -fuse-ld=lld -mllvm -inline-threshold=2500 -Wno-unused-lambda-capture -Wno-unused-command-line-argument -stdlib=libc++ -fsanitize=undefined -fsanitize=address -fstack-protector-strong -fno-plt -fstack-clash-protection -O0 -g -gdwarf-4 -gsplit-dwarf -fPIE -Wall -std=c++20 -MD -MT src/v/hashing/tests/CMakeFiles/xx_hashes_rpunit.dir/xx_tests.cc.o -MF src/v/hashing/tests/CMakeFiles/xx_hashes_rpunit.dir/xx_tests.cc.o.d -o src/v/hashing/tests/CMakeFiles/xx_hashes_rpunit.dir/xx_tests.cc.o -c /home/andrew/Repos/redpanda/src/v/hashing/tests/xx_tests.cc /home/andrew/Repos/redpanda/src/v/hashing/tests/xx_tests.cc:29:24: error: implicit instantiation of undefined template 'std::array<int, 3>'
    std::array<int, 3> arr = {1, 2, 42};
                       ^
/home/andrew/xfs/vbuild/llvm/install/bin/../include/c++/v1/__tuple:219:64: note: template is declared here template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
/home/andrew/Repos/redpanda/src/v/hashing/tests/xx_tests.cc:41:24: error: implicit instantiation of undefined template 'std::array<int, 3>'
    std::array<int, 3> arr = {1, 2, 42};
                       ^
/home/andrew/xfs/vbuild/llvm/install/bin/../include/c++/v1/__tuple:219:64: note: template is declared here template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
2 errors generated.
[74/968] Building CXX object src/v/utils/CMakeFiles/v_utils.dir/request_auth.cc.o ninja: build stopped: subcommand failed.
task: Failed to run task "rp:build": exit status 1

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none