### PR TITLE
miscellaneous improvements to s3_imposter

### DIFF
--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -1,3 +1,16 @@
+v_cc_library(
+  NAME
+    s3_imposter
+  HDRS
+    "s3_imposter.h"
+  SRCS
+    "s3_imposter.cc"
+  DEPS
+    v::config
+    v::http
+    v::http_test_utils
+    v::model
+)
 
 # Regular unit tests that don't open ports and run on a single core
 rp_test(

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -617,8 +617,7 @@ FIXTURE_TEST(test_list_bucket, remote_fixture) {
         auto result
           = remote.local().list_objects(bucket, fib, prefix, '/').get();
         BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE_EQUAL(
-          result.value().contents.size(), first * second * third);
+        BOOST_REQUIRE(result.value().contents.empty());
         BOOST_REQUIRE_EQUAL(result.value().common_prefixes.size(), first);
     }
     {
@@ -633,7 +632,7 @@ FIXTURE_TEST(test_list_bucket, remote_fixture) {
         auto result
           = remote.local().list_objects(bucket, fib, prefix, '/').get();
         BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE_EQUAL(result.value().contents.size(), second * third);
+        BOOST_REQUIRE(result.value().contents.empty());
         BOOST_REQUIRE_EQUAL(result.value().common_prefixes.size(), second);
     }
 }

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -61,11 +61,13 @@ ss::sstring list_objects_resp(
             continue;
         }
         vlog(fixt_log.trace, "{} matches prefix {}", key, prefix);
-        content_key_to_size.emplace(
-          key,
-          expectation.body.has_value() ? expectation.body.value().size() : 0);
         if (delimiter.empty()) {
-            // No delimiter, no need to find prefixes.
+            // No delimiter, we just need to return the content and not
+            // prefixes.
+            content_key_to_size.emplace(
+              key,
+              expectation.body.has_value() ? expectation.body.value().size()
+                                           : 0);
             continue;
         }
         auto delimiter_pos = key.find(delimiter, prefix.size());


### PR DESCRIPTION
A couple things I found while writing tests for cluster metadata uploads:
- it's useful to have s3_imposter outside of the cloud_storage library
- it shouldn't return contents when a delimiter is passed

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
