### PR TITLE
[v23.1.x] k8s: continue console deletion if cluster not configured

### DIFF
--- a/src/go/k8s/controllers/redpanda/console_controller.go
+++ b/src/go/k8s/controllers/redpanda/console_controller.go
@@ -93,6 +93,11 @@ func (r *ConsoleReconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 
+	var consoleIsDeleting bool
+	if !console.GetDeletionTimestamp().IsZero() {
+		consoleIsDeleting = true
+	}
+
 	cluster, err := console.GetCluster(ctx, r.Client)
 	if err != nil {
 		// Create event instead of logging the error, so user can see in Console CR instead of checking logs in operator
@@ -109,7 +114,9 @@ func (r *ConsoleReconciler) Reconcile(
 				corev1.EventTypeWarning, ClusterNotFoundEvent,
 				"Unable to reconcile Console as the referenced Cluster %s is not found or is being deleted", console.GetClusterRef(),
 			)
-		case errors.Is(err, redpandav1alpha1.ErrClusterNotConfigured):
+		case errors.Is(err, redpandav1alpha1.ErrClusterNotConfigured) && consoleIsDeleting:
+			r.Log.Info("cluster %s is not yet configured but console is deleting -> proceeding with the delete.", console.GetClusterRef())
+		case errors.Is(err, redpandav1alpha1.ErrClusterNotConfigured) && !consoleIsDeleting:
 			r.EventRecorder.Eventf(
 				console,
 				corev1.EventTypeWarning, ClusterNotConfiguredEvent,
@@ -117,8 +124,10 @@ func (r *ConsoleReconciler) Reconcile(
 			)
 			// When Cluster will be configured, Console will receive a notification trigger
 			return ctrl.Result{}, nil
+
+		default:
+			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, err
 	}
 
 	r.Log.V(debugLogLevel).Info("console", "observed generation", console.Status.ObservedGeneration, "generation", console.GetGeneration())

--- a/src/go/k8s/controllers/redpanda/console_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/console_controller_test.go
@@ -200,6 +200,43 @@ var _ = Describe("Console controller", func() {
 		})
 	})
 
+	Context("When deleting Console", func() {
+		It("Should delete console if cluster is not configured", func() {
+			ctx := context.Background()
+			brokenKey, _, brokenCluster, ns := getInitialTestCluster(ClusterName)
+			brokenCluster.Spec.Image = "nonexistentimage"
+			var replicas1 int32 = 1
+			brokenCluster.Spec.Replicas = &replicas1
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, brokenCluster)).Should(Succeed())
+			console := &redpandav1alpha1.Console{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "redpanda.vectorized.io/v1alpha1",
+					Kind:       "Console",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deleting-console",
+					Namespace: brokenKey.Namespace,
+				},
+				Spec: redpandav1alpha1.ConsoleSpec{
+					ClusterRef:     redpandav1alpha1.NamespaceNameRef{Namespace: brokenKey.Namespace, Name: brokenKey.Name},
+					SchemaRegistry: redpandav1alpha1.Schema{Enabled: enableSchemaRegistry},
+					Deployment:     redpandav1alpha1.Deployment{Image: deploymentImage},
+					Connect:        redpandav1alpha1.Connect{Enabled: enableConnect},
+				},
+			}
+			Expect(k8sClient.Create(ctx, console)).Should(Succeed())
+			consoleLookupKey := types.NamespacedName{Name: console.Name, Namespace: console.Namespace}
+			Eventually(func() bool {
+				return k8sClient.Get(ctx, consoleLookupKey, &redpandav1alpha1.Console{}) == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(k8sClient.Delete(ctx, console)).Should(Succeed())
+			Eventually(func() bool {
+				return k8sClient.Get(ctx, consoleLookupKey, &redpandav1alpha1.Console{}) != nil
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
 	Context("When updating Console", func() {
 		ctx := context.Background()
 		It("Should not create new ConfigMap if no change on spec", func() {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11026
Fixes https://github.com/redpanda-data/redpanda/issues/11073,