### PR TITLE
rpk: update virtual auth token

### DIFF
--- a/src/go/rpk/pkg/oauth/load.go
+++ b/src/go/rpk/pkg/oauth/load.go
@@ -48,5 +48,7 @@ func LoadFlow(ctx context.Context, fs afero.Fs, cfg *config.Config, cl Client) (
 	}
 	authAct.ClientID = authVir.ClientID
 	authAct.AuthToken = resp.AccessToken
+
+	authVir.AuthToken = resp.AccessToken
 	return resp.AccessToken, yAct.Write(fs)
 }


### PR DESCRIPTION
The oauth.login flow only updated the actual
auth token and left the virtual auth token empty.

This will cause that users with no previous
authorizations (saved to disk) couldn't use the
cloud api calls.



## Backports Required

- [ ] none - issue does not exist in previous branches


## Release Notes

* none

