### PR TITLE
partition_allocator: preserve shards for replicas on original nodes

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -8,6 +8,7 @@
 #include "cluster/members_manager.h"
 #include "cluster/members_table.h"
 #include "cluster/scheduling/allocation_strategy.h"
+#include "cluster/scheduling/partition_allocator.h"
 #include "cluster/topic_table.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"

--- a/src/v/cluster/node_isolation_watcher.cc
+++ b/src/v/cluster/node_isolation_watcher.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/node_isolation_watcher.h"
 
+#include "cluster/logger.h"
 #include "cluster/metadata_cache.h"
 #include "config/node_config.h"
 #include "ssx/future-util.h"

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -181,17 +181,13 @@ void allocation_state::remove_allocation(
     }
 }
 
-result<uint32_t> allocation_state::allocate(
+uint32_t allocation_state::allocate(
   model::node_id id, const partition_allocation_domain domain) {
     verify_shard();
-    if (auto it = _nodes.find(id); it != _nodes.end()) {
-        if (it->second->is_full()) {
-            return errc::invalid_node_operation;
-        }
-        return it->second->allocate(domain);
-    }
-
-    return errc::node_does_not_exists;
+    auto it = _nodes.find(id);
+    vassert(
+      it != _nodes.end(), "allocated node with id {} have to be present", id);
+    return it->second->allocate(domain);
 }
 
 void allocation_state::verify_shard() const {

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -48,8 +48,9 @@ public:
     const underlying_t& allocation_nodes() const { return _nodes; }
     int16_t available_nodes() const;
 
-    // choose a shard for a replica and add the corresponding allocation.
-    result<uint32_t> allocate(model::node_id id, partition_allocation_domain);
+    // Choose a shard for a replica and add the corresponding allocation.
+    // node_id is required to belong to an existing node.
+    uint32_t allocate(model::node_id id, partition_allocation_domain);
 
     // Operations on state
     void

--- a/src/v/cluster/scheduling/allocation_strategy.cc
+++ b/src/v/cluster/scheduling/allocation_strategy.cc
@@ -159,11 +159,11 @@ model::node_id find_best_fit(
 allocation_strategy simple_allocation_strategy() {
     class impl : public allocation_strategy::impl {
     public:
-        result<model::broker_shard> allocate_replica(
+        result<model::node_id> choose_node(
           const std::vector<model::broker_shard>& current_replicas,
           const allocation_constraints& request,
           allocation_state& state,
-          const partition_allocation_domain domain) final {
+          const partition_allocation_domain) final {
             const auto& nodes = state.allocation_nodes();
             /**
              * evaluate hard constraints
@@ -186,16 +186,7 @@ allocation_strategy simple_allocation_strategy() {
               possible_nodes,
               nodes);
 
-            auto it = nodes.find(best_fit);
-            vassert(
-              it != nodes.end(),
-              "allocated node with id {} have to be present",
-              best_fit);
-            auto core = (it->second)->allocate(domain);
-            return model::broker_shard{
-              .node_id = it->first,
-              .shard = core,
-            };
+            return best_fit;
         }
     };
     return make_allocation_strategy<impl>();

--- a/src/v/cluster/scheduling/allocation_strategy.h
+++ b/src/v/cluster/scheduling/allocation_strategy.h
@@ -25,7 +25,7 @@ public:
          * Allocates single replica according to set of given allocation
          * constraints in the specified domain
          */
-        virtual result<model::broker_shard> allocate_replica(
+        virtual result<model::node_id> choose_node(
           const replicas_t&,
           const allocation_constraints&,
           allocation_state&,
@@ -38,12 +38,12 @@ public:
     explicit allocation_strategy(std::unique_ptr<impl> impl)
       : _impl(std::move(impl)) {}
 
-    result<model::broker_shard> allocate_replica(
+    result<model::node_id> choose_node(
       const replicas_t& current_replicas,
       const allocation_constraints& ac,
       allocation_state& state,
       const partition_allocation_domain domain) {
-        return _impl->allocate_replica(current_replicas, ac, state, domain);
+        return _impl->choose_node(current_replicas, ac, state, domain);
     }
 
 private:

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -385,14 +385,9 @@ result<model::broker_shard> partition_allocator::do_allocate_replica(
     if (!node) {
         return node.error();
     }
-    model::broker_shard replica{
-      .node_id = node.value(),
-      .shard = _state->allocate(node.value(), partition._domain)};
 
     revert.cancel();
-    partition.add_replica(replica, prev);
-
-    return replica;
+    return partition.add_replica(node.value(), prev);
 }
 
 void partition_allocator::add_allocations(

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -380,14 +380,17 @@ result<model::broker_shard> partition_allocator::do_allocate_replica(
         }
     });
 
-    auto replica = _allocation_strategy.allocate_replica(
+    auto node = _allocation_strategy.choose_node(
       partition._replicas, effective_constraints, *_state, partition._domain);
-    if (!replica) {
-        return replica;
+    if (!node) {
+        return node.error();
     }
+    model::broker_shard replica{
+      .node_id = node.value(),
+      .shard = _state->allocate(node.value(), partition._domain)};
 
     revert.cancel();
-    partition.add_replica(replica.value(), prev);
+    partition.add_replica(replica, prev);
 
     return replica;
 }

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -65,6 +65,10 @@ public:
     /// try to substitute an existing replica with a newly allocated one and add
     /// it to the allocated_partition object. If the request fails,
     /// allocated_partition remains unchanged.
+    ///
+    /// Note: if after reallocation the replica ends up on a node from the
+    /// original replica set (doesn't matter if the same as `previous` or a
+    /// different one), its shard id is preserved.
     result<model::broker_shard> reallocate_replica(
       allocated_partition&, model::node_id previous, allocation_constraints);
 

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -14,6 +14,7 @@
 #include "cluster/controller_snapshot.h"
 #include "cluster/partition_balancer_state.h"
 #include "cluster/partition_leaders_table.h"
+#include "cluster/scheduling/partition_allocator.h"
 #include "cluster/topic_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -12,7 +12,6 @@
 #pragma once
 #include "cluster/commands.h"
 #include "cluster/fwd.h"
-#include "cluster/scheduling/partition_allocator.h"
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"


### PR DESCRIPTION
After one or several reallocations a replica may end up on one of the original nodes. Previously, we chose the shard for this replica anew in this case. This is awkward because the shard could change so the full replica id (i.e. broker_shard) changed even if the reallocation didn't change anything in the grand scheme of things. So this commit makes reallocations preserve the shard of replicas that end up on original nodes.

And of course this change makes it easier in the future to let nodes choose shards for the replicas they host themselves.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none