### PR TITLE
ducktape: add teleport as test dependency

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -166,6 +166,11 @@ RUN /k8s && \
 
 FROM base as final
 
+COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/teleport /
+RUN /teleport && \
+    rm /teleport && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/arroyo /
 RUN /arroyo && \
     rm /arroyo

--- a/tests/docker/ducktape-deps/teleport
+++ b/tests/docker/ducktape-deps/teleport
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+curl -SL https://apt.releases.teleport.dev/gpg \
+  -o /usr/share/keyrings/teleport-archive-keyring.asc
+
+source /etc/os-release
+
+# kinetic is not officially supported yet, so this needs to install jammy packages
+# see https://github.com/gravitational/teleport/issues/18679
+
+# hard-code `jammy` instead of referencing ${VERSION_CODENAME}
+echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+https://apt.releases.teleport.dev/${ID?} jammy stable/v13" |
+  tee /etc/apt/sources.list.d/teleport.list >/dev/null
+
+# replace kinetic for jammy since official packages don't support kinetic yet
+sed -i 's/kinetic/jammy/g' /etc/apt/sources.list.d/teleport.list
+
+apt-get update
+apt-get install teleport


### PR DESCRIPTION
part of fix for https://github.com/redpanda-data/vtools/issues/1748

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
