### PR TITLE
[v23.1.x] Use `chunked_fifo` to group shard heartbeats

### DIFF
--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -18,6 +18,7 @@
 #include "seastarx.h"
 #include "utils/copy_range.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timed_out_error.hh>
@@ -188,8 +189,10 @@ private:
     using consensus_ptr = seastar::lw_shared_ptr<consensus>;
     using hbeats_t = std::vector<append_entries_request>;
     using hbeats_ptr = ss::foreign_ptr<std::unique_ptr<hbeats_t>>;
+    using groupped_hbeats_ptr = ss::foreign_ptr<
+      std::unique_ptr<ss::chunked_fifo<append_entries_request>>>;
     struct shard_groupped_hbeat_requests {
-        absl::flat_hash_map<ss::shard_id, hbeats_ptr> shard_requests;
+        absl::flat_hash_map<ss::shard_id, groupped_hbeats_ptr> shard_requests;
         std::vector<append_entries_request> group_missing_requests;
     };
 
@@ -253,7 +256,7 @@ private:
     }
 
     ss::future<std::vector<append_entries_reply>>
-    dispatch_hbeats_to_core(ss::shard_id shard, hbeats_ptr requests) {
+    dispatch_hbeats_to_core(ss::shard_id shard, groupped_hbeats_ptr requests) {
         return with_scheduling_group(
           get_scheduling_group(),
           [this, shard, r = std::move(requests)]() mutable {
@@ -267,7 +270,7 @@ private:
     }
 
     ss::future<std::vector<append_entries_reply>>
-    dispatch_hbeats_to_groups(ConsensusManager& m, hbeats_ptr reqs) {
+    dispatch_hbeats_to_groups(ConsensusManager& m, groupped_hbeats_ptr reqs) {
         std::vector<ss::future<append_entries_reply>> futures;
         futures.reserve(reqs->size());
         // dispatch requests in parallel
@@ -306,7 +309,8 @@ private:
                   it,
                   shard,
                   ss::make_foreign(
-                    std::make_unique<std::vector<append_entries_request>>()));
+                    std::make_unique<
+                      ss::chunked_fifo<append_entries_request>>()));
                 it = result;
             }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11015
Fixes https://github.com/redpanda-data/redpanda/issues/11082,