### PR TITLE
tests: log system load and log error on debug mode test writing lots of data

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3704,6 +3704,22 @@ class RedpandaService(RedpandaServiceBase):
                     f"Oversized controller log detected!  {max_length} records"
                 )
 
+    def estimate_bytes_written(self):
+        try:
+            samples = self.metrics_sample(
+                "vectorized_io_queue_total_write_bytes_total",
+                nodes=self.started_nodes())
+        except Exception as e:
+            self.logger.warn(
+                f"Cannot check metrics, did a test finish with all nodes down? ({e})"
+            )
+            return None
+
+        if samples is not None and samples.samples:
+            return sum(s.value for s in samples.samples)
+        else:
+            return None
+
 
 def make_redpanda_service(context, num_brokers, **kwargs):
     """Factory function for instatiating the appropriate RedpandaServiceBase subclass."""


### PR DESCRIPTION

commit 1bdc5432f1bb4b1d42a00ef40f6da5e9971d09d5 (HEAD -> debug-data-size, jcsp/debug-data-size-2)
Author: John Spray <jcs@redpanda.com>
Date:   Wed May 24 17:11:50 2023 +0100

    tests: log system load at end of tests
    
    This is for debugging when a test appears to have
    run very slowly.
    
    Also log an error if a debug mode test appearse to have
    written a lot of data to disk, to make it easy to search
    for badly behaved tests that might overload a shared test
    runner.

commit 892a64dfd57385dbd2170aa0b12a46bc93fc3caa
Author: John Spray <jcs@redpanda.com>
Date:   Thu May 25 09:59:49 2023 +0100

    tests/services: make metrics_sample more robust
    
    Previously, if you passed in your started nodes,
    then that list could be empty, metrics_sample
    would replace it with self.nodes, and then
    metrics() would assert out because it was trying
    to run on non-started nodes.
    
    Instead, if the incoming list is empty, tolerate
    that, and just return an empty result.


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
