### PR TITLE
tests: skip service self-tests in debug mode

### DIFF
--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -36,6 +36,7 @@ class OpenBenchmarkSelfTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, num_brokers=3, **kwargs)
 
+    @skip_debug_mode  # Sends meaningful traffic, and not intended to test Redpanda
     @cluster(num_nodes=6)
     @matrix(driver=["SIMPLE_DRIVER"], workload=["SIMPLE_WORKLOAD"])
     def test_default_omb_configuration(self, driver, workload):
@@ -54,6 +55,7 @@ class KgoRepeaterSelfTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, num_brokers=3, **kwargs)
 
+    @skip_debug_mode  # Sends meaningful traffic, and not intended to test Redpanda
     @cluster(num_nodes=4)
     def test_kgo_repeater(self):
         topic = 'test'
@@ -78,6 +80,7 @@ class KgoVerifierSelfTest(PreallocNodesTest):
                          *args,
                          **kwargs)
 
+    @skip_debug_mode  # Sends meaningful traffic, and not intended to test Redpanda
     @cluster(num_nodes=4)
     def test_kgo_verifier(self):
         topic = 'test'


### PR DESCRIPTION
These mostly involve sending some amount of traffic, which tends to be flaky in debug mode.  These tests don't exist to test Redpanda, they're just smoke tests for the services themselves, so we don't gain much by running against debug binaries.

Fixes https://github.com/redpanda-data/redpanda/issues/10865

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
