### PR TITLE
cloud_storage: Handle expected hydrate errors

### DIFF
--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -48,6 +48,7 @@ private:
     ss::future<> load_stream_for_chunk(chunk_start_offset_t chunk_start);
 
     ss::future<> maybe_close_stream();
+    ss::future<> load_chunk_handle(chunk_start_offset_t chunk_start);
 
     segment_chunks& _chunks;
     remote_segment& _segment;


### PR DESCRIPTION
When chunk hydration fails due to abort request, this change makes sure that exception handling paths are mutually exclusive. There was a bug in the previous code where the abort requested error was handled and then control was handed off to the generic exception handler, resulting in an unexpected error message.

Fixes: https://github.com/redpanda-data/redpanda/issues/10868
Fixes: https://github.com/redpanda-data/redpanda/issues/11088

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
