### PR TITLE
cluster: harden lifecycle marker purge path

### DIFF
--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -319,6 +319,8 @@ scrubber::run(retry_chain_node& parent_rtc, run_quota_t quota) {
                   "scrub",
                   nt_revision.nt,
                   errc.message());
+            } else {
+                vlog(archival_log.info, "Topic {} purge complete", nt_revision);
             }
         }
     }

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -311,13 +311,14 @@ scrubber::run(retry_chain_node& parent_rtc, run_quota_t quota) {
             auto purge_result = co_await _topics_frontend.local().purged_topic(
               nt_revision, 5s);
             if (purge_result.ec != cluster::errc::success) {
+                auto errc = cluster::make_error_code(purge_result.ec);
                 // Just log: this will get retried next time the scrubber runs
                 vlog(
                   archival_log.info,
                   "Failed to mark topic {} purged: {}, will retry on next "
                   "scrub",
                   nt_revision.nt,
-                  purge_result.ec);
+                  errc.message());
             }
         }
     }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -191,7 +191,9 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
             // This is harmless but should not happen and indicates a bug.
             vlog(
               clusterlog.error,
-              "Unexpected request to drop non-existent lifecycle marker {} {}",
+              "Unexpected record at offset {} to drop non-existent lifecycle "
+              "marker {} {}",
+              offset,
               soft_del.topic.nt,
               soft_del.topic.initial_revision_id);
             return ss::make_ready_future<std::error_code>(

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -160,7 +160,7 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
     _last_applied_revision_id = model::revision_id(offset);
 
     if (soft_del.mode == topic_lifecycle_transition_mode::pending_gc) {
-        // Create tombstone
+        // Create a lifecycle marker
         auto tp = _topics.find(soft_del.topic.nt);
         if (tp == _topics.end()) {
             return ss::make_ready_future<std::error_code>(
@@ -175,14 +175,14 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
         _lifecycle_markers.emplace(soft_del.topic, tombstone);
         vlog(
           clusterlog.debug,
-          "Created tombstone for topic {} {}",
+          "Created lifecycle marker for topic {} {}",
           soft_del.topic.nt,
           soft_del.topic.initial_revision_id);
     } else if (soft_del.mode == topic_lifecycle_transition_mode::drop) {
         if (_lifecycle_markers.contains(soft_del.topic)) {
             vlog(
               clusterlog.debug,
-              "Purged tombstone for {} {}",
+              "Purged lifecycle marker for {} {}",
               soft_del.topic.nt,
               soft_del.topic.initial_revision_id);
             _lifecycle_markers.erase(soft_del.topic);
@@ -191,7 +191,7 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
             // This is harmless but should not happen and indicates a bug.
             vlog(
               clusterlog.error,
-              "Unexpected request to drop non-existent tombstone {} {}",
+              "Unexpected request to drop non-existent lifecycle marker {} {}",
               soft_del.topic.nt,
               soft_del.topic.initial_revision_id);
             return ss::make_ready_future<std::error_code>(


### PR DESCRIPTION
It's not entirely clear what's causing duplicate purge messages for a lifecycle marker in https://github.com/redpanda-data/redpanda/issues/11090 because it's a run without debug logs, but there are some changes we can make defensively:
- If topics_frontend sees a redundant purge RPC, ignore it
- Clearer INFO-level logging around topic deletion and lifecycle marker purge

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
