### PR TITLE
Skip controller log limiting mm2 test in debug mode

### DIFF
--- a/tests/rptest/tests/controller_log_limiting_test.py
+++ b/tests/rptest/tests/controller_log_limiting_test.py
@@ -29,6 +29,8 @@ from rptest.services.cluster import cluster
 from requests.exceptions import HTTPError
 from ducktape.utils.util import wait_until
 
+from rptest.utils.mode_checks import skip_debug_mode
+
 OPERATIONS_LIMIT = 3
 TOO_MANY_REQUESTS_ERROR_CODE = 89
 TOO_MANY_REQUESTS_HTTP_ERROR_CODE = 429
@@ -342,6 +344,7 @@ class ControllerLogLimitMirrorMakerTests(MirrorMakerService):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    @skip_debug_mode
     @cluster(num_nodes=10)
     def test_mirror_maker_with_limits(self):
         # start brokers


### PR DESCRIPTION
Skipping test that requires allocating 10 nodes not to run in debug mode.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none