### PR TITLE
rpk debug bundle: pass SASL info to admin client

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -198,6 +198,9 @@ func getClusterDomain() string {
 func saveClusterAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, p *config.RpkProfile, adminAddresses []string) step {
 	return func() error {
 		p = &config.RpkProfile{
+			KafkaAPI: config.RpkKafkaAPI{
+				SASL: p.KafkaAPI.SASL,
+			},
 			AdminAPI: config.RpkAdminAPI{
 				Addresses: adminAddresses,
 				TLS:       p.AdminAPI.TLS,
@@ -241,6 +244,9 @@ func saveSingleAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, p
 		for _, a := range adminAddresses {
 			a := a
 			p = &config.RpkProfile{
+				KafkaAPI: config.RpkKafkaAPI{
+					SASL: p.KafkaAPI.SASL,
+				},
 				AdminAPI: config.RpkAdminAPI{
 					Addresses: []string{a},
 					TLS:       p.AdminAPI.TLS,


### PR DESCRIPTION
Since redpanda uses the same SASL information
stored in the rpk's kafka API knob, we need to
pass through this info to the client generated
to gather the admin API information.


## Backports Required
- [x] v23.1.x

## Release Notes
### Improvements

* rpk debug bundle now can be used in clusters with SASL enabled to gather Admin API information.