### PR TITLE
rpk: fix `profile create --from-simple`

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -462,10 +462,6 @@ func saveConfig(ps *stepParams, y *config.RedpandaYaml) step {
 			y.Rpk.KafkaAPI.SASL.User = redacted
 			y.Rpk.KafkaAPI.SASL.Password = redacted
 		}
-		if y.Rpk.SASL != nil {
-			y.Rpk.SASL.User = redacted
-			y.Rpk.SASL.Password = redacted
-		}
 		// We want to redact any blindly decoded parameters.
 		redactOtherMap(y.Other)
 		redactOtherMap(y.Redpanda.Other)

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -199,8 +199,6 @@ func (y *RedpandaYaml) setDevMode() {
 	y.Redpanda.DeveloperMode = true
 	// Defaults to setting all tuners to false
 	y.Rpk = RpkNodeConfig{
-		TLS:                  y.Rpk.TLS,
-		SASL:                 y.Rpk.SASL,
 		KafkaAPI:             y.Rpk.KafkaAPI,
 		AdminAPI:             y.Rpk.AdminAPI,
 		AdditionalStartFlags: y.Rpk.AdditionalStartFlags,

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -584,7 +584,6 @@ func (p *Params) Load(fs afero.Fs) (*Config, error) {
 		return nil, err
 	}
 
-	c.redpandaYaml.backcompat()
 	c.mergeRpkIntoRedpanda(true)     // merge actual rpk.yaml KafkaAPI,AdminAPI,Tuners into redpanda.yaml rpk section
 	c.addUnsetRedpandaDefaults(true) // merge from actual redpanda.yaml redpanda section to rpk section
 	c.ensureRpkProfile()             // ensure Virtual rpk.yaml has a loaded profile
@@ -873,21 +872,6 @@ func (p *Params) readRedpandaConfig(fs afero.Fs, c *Config) error {
 	c.redpandaYaml.fileLocation = location
 	c.redpandaYamlActual.fileLocation = location
 	return nil
-}
-
-// Before we process overrides, we process any backwards compatibility from the
-// loaded file.
-func (y *RedpandaYaml) backcompat() {
-	r := &y.Rpk
-	if r.KafkaAPI.TLS == nil {
-		r.KafkaAPI.TLS = r.TLS
-	}
-	if r.KafkaAPI.SASL == nil {
-		r.KafkaAPI.SASL = r.SASL
-	}
-	if r.AdminAPI.TLS == nil {
-		r.AdminAPI.TLS = r.TLS
-	}
 }
 
 // We merge rpk.yaml files into our Virtual redpanda.yaml rpk section,

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -71,10 +71,10 @@ rpk:
 				c.Rpk.KafkaAPI.Brokers = []string{"127.0.1.1:9647"}
 			},
 			exp: `rpk:
-    tls: {}
     kafka_api:
         brokers:
             - 127.0.1.1:9647
+        tls: {}
 `,
 		},
 		{

--- a/src/go/rpk/pkg/config/redpanda_yaml.go
+++ b/src/go/rpk/pkg/config/redpanda_yaml.go
@@ -139,11 +139,6 @@ type (
 	}
 
 	RpkNodeConfig struct {
-		// Deprecated 2021-07-1
-		TLS *TLS `yaml:"tls,omitempty" json:"tls"`
-		// Deprecated 2021-07-1
-		SASL *SASL `yaml:"sasl,omitempty" json:"sasl,omitempty"`
-
 		KafkaAPI RpkKafkaAPI `yaml:"kafka_api,omitempty" json:"kafka_api"`
 		AdminAPI RpkAdminAPI `yaml:"admin_api,omitempty" json:"admin_api"`
 

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -437,10 +437,18 @@ func (rpkc *RpkNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 		return err
 	}
 
-	rpkc.TLS = internal.TLS
-	rpkc.SASL = internal.SASL
+	// backcompat, immediately convert to new tls
 	rpkc.KafkaAPI = internal.KafkaAPI
 	rpkc.AdminAPI = internal.AdminAPI
+	if rpkc.KafkaAPI.TLS == nil {
+		rpkc.KafkaAPI.TLS = internal.TLS
+	}
+	if rpkc.KafkaAPI.SASL == nil {
+		rpkc.KafkaAPI.SASL = internal.SASL
+	}
+	if rpkc.AdminAPI.TLS == nil {
+		rpkc.AdminAPI.TLS = internal.TLS
+	}
 	rpkc.AdditionalStartFlags = internal.AdditionalStartFlags
 	rpkc.EnableMemoryLocking = bool(internal.EnableMemoryLocking)
 	rpkc.Overprovisioned = bool(internal.Overprovisioned)

--- a/src/go/rpk/pkg/config/weak_test.go
+++ b/src/go/rpk/pkg/config/weak_test.go
@@ -1061,8 +1061,6 @@ rpk:
 					SchemaRegistryReplicationFactor: func() *int { i := 3; return &i }(),
 				},
 				Rpk: RpkNodeConfig{
-					TLS:                  &TLS{KeyFile: "~/certs/key.pem"},
-					SASL:                 &SASL{User: "user", Password: "pass"},
 					AdditionalStartFlags: []string{"--overprovisioned"},
 					KafkaAPI: RpkKafkaAPI{
 						Brokers: []string{"192.168.72.34:9092", "192.168.72.35:9092"},
@@ -1382,8 +1380,6 @@ rpk:
 					SchemaRegistryReplicationFactor: func() *int { i := 3; return &i }(),
 				},
 				Rpk: RpkNodeConfig{
-					TLS:                  &TLS{KeyFile: "~/certs/key.pem"},
-					SASL:                 &SASL{User: "user", Password: "pass"},
 					AdditionalStartFlags: []string{"--overprovisioned"},
 					KafkaAPI: RpkKafkaAPI{
 						Brokers: []string{"192.168.72.34:9092", "192.168.72.35:9092"},


### PR DESCRIPTION
The old deprecated TLS / SASL sections were only decoded in params.Load; moving this into the weak.go UnmarshalYAML allows this same backcompat fix to work in --from-simple.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
