### PR TITLE
[v23.1.x] rpk debug bundle: pass SASL info to admin client

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go
@@ -199,6 +199,9 @@ func saveClusterAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, 
 	return func() error {
 		allCfg := &config.Config{
 			Rpk: config.RpkConfig{
+				KafkaAPI: config.RpkKafkaAPI{
+					SASL: cfg.Rpk.KafkaAPI.SASL,
+				},
 				AdminAPI: config.RpkAdminAPI{
 					Addresses: adminAddresses,
 					TLS:       cfg.Rpk.AdminAPI.TLS,
@@ -244,6 +247,9 @@ func saveSingleAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, c
 			a := a
 			c := &config.Config{
 				Rpk: config.RpkConfig{
+					KafkaAPI: config.RpkKafkaAPI{
+						SASL: cfg.Rpk.KafkaAPI.SASL,
+					},
 					AdminAPI: config.RpkAdminAPI{
 						Addresses: []string{a},
 						TLS:       cfg.Rpk.AdminAPI.TLS,


### PR DESCRIPTION
(Manual cherry-pick of 11a8290f812dcfa508b556e8a748cecc80dd26ad)

Since redpanda uses the same SASL information
stored in the kafka API knob, we need to
pass through this info to the client generated
to gather the admin API information.

Fixes #11111

## Backports Required
- [ ] none - this is a backport


## Release Notes

### Improvements

* rpk debug bundle now can be used in clusters with SASL enabled to gather Admin API information.

