### PR TITLE
tests: fix typo in oversized controller log check

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3676,8 +3676,7 @@ class RedpandaService(RedpandaServiceBase):
         max_length = None
         for node in self.started_nodes():
             try:
-                status = self._admin.get_controller_status(
-                    node=node)['committed_index']
+                status = self._admin.get_controller_status(node=node)
                 node_length = status['committed_index'] - max(
                     0, status['start_offset'] - 1)
             except Exception as e:


### PR DESCRIPTION
I noticed the controller log check complain in my local test runs. Turns out there's a typo.
```
redpanda - validate_controller_log - lineno:3693]: Failed to read controller status from docker-rp-3: 'int' object is not subscriptable
redpanda - validate_controller_log - lineno:3693]: Failed to read controller status from docker-rp-4: 'int' object is not subscriptable
redpanda - validate_controller_log - lineno:3693]: Failed to read controller status from docker-rp-5: 'int' object is not subscriptable
redpanda - validate_controller_log - lineno:3700]: Failed to read controller status from any node, cannot validate record count
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none