### PR TITLE
[cloud_storage] segment_meta_cstore::prefix_truncate fix range of _hints to remove

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -549,7 +549,7 @@ public:
         }
         auto bo = *base_offset_iter;
         auto ix = base_offset_iter.index();
-        auto hint_it = _hints.lower_bound(bo);
+        auto hint_it = _hints.find(bo);
         if (hint_it == _hints.end() || hint_it->second == std::nullopt) {
             return iterators_t(
               _is_compacted.at_index(ix),
@@ -633,7 +633,7 @@ public:
         // belong to it are no longer valid.
         const auto& frame = _base_offset.get_frame_by_element_index(ix).get();
         auto frame_max_offset = frame.last_value();
-        auto it = _hints.upper_bound(frame_max_offset.value_or(bo));
+        auto it = _hints.lower_bound(frame_max_offset.value_or(bo));
 
         // Truncate columns
         std::apply(


### PR DESCRIPTION
`it` should point to the first hint that needs to be removed. Previously it was computed with upper_bound, but this means that it will never point to a value that's equal to frame_max_offset, meaning that that hint value could be left behind, pointing incorrectly at an offset that's no longer valid.

to find the issue, this test was extracted from cloud_storage_basic_rptest suite
https://github.com/andijcr/redpanda/blob/issue/10602/exceptional_future_ignored/src/v/cloud_storage/tests/partition_manifest_outofrange.cc
function ```test_partition_manifest``` repeatedly exercises partition_manifest::truncate, and the high randomized repetition count ensures that the exception is triggered. 
this assertion https://github.com/andijcr/redpanda/blob/issue/10602/exceptional_future_ignored/src/v/cloud_storage/segment_meta_cstore.cc#L646-L648 (not included in this pr) checks that std::prev(it)->first is greater than frame_max_offset, and thus lies after the frame that will be reconstructed. it will be triggered with upper_bound but not with lower_bound 

FIxes #10983 


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None