### PR TITLE
cluster: Allow persisted_stm to use the kvstore for snapshots if selected 

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -552,7 +552,7 @@ class archival_metadata_stm_accessor {
 public:
     static ss::future<> persist_snapshot(
       storage::simple_snapshot_manager& mgr, cluster::stm_snapshot&& snapshot) {
-        return archival_metadata_stm::persist_snapshot(
+        return file_backed_stm_snapshot::persist_snapshot(
           mgr, std::move(snapshot));
     }
 };

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -458,7 +458,8 @@ ss::future<> archival_metadata_stm::make_snapshot(
       "archival_metadata.snapshot",
       raft_priority());
 
-    co_await persist_snapshot(tmp_snapshot_mgr, std::move(snapshot));
+    co_await file_backed_stm_snapshot::persist_snapshot(
+      tmp_snapshot_mgr, std::move(snapshot));
 }
 
 archival_metadata_stm::archival_metadata_stm(

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -468,7 +468,7 @@ archival_metadata_stm::archival_metadata_stm(
   features::feature_table& ft,
   ss::logger& logger,
   ss::shared_ptr<util::mem_tracker> partition_mem_tracker)
-  : cluster::persisted_stm<>("archival_metadata.snapshot", logger, raft)
+  : cluster::persisted_stm<>(archival_stm_snapshot, logger, raft)
   , _logger(logger, ssx::sformat("ntp: {}", raft->ntp()))
   , _manifest(ss::make_shared<cloud_storage::partition_manifest>(
       raft->ntp(),

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -468,7 +468,7 @@ archival_metadata_stm::archival_metadata_stm(
   features::feature_table& ft,
   ss::logger& logger,
   ss::shared_ptr<util::mem_tracker> partition_mem_tracker)
-  : cluster::persisted_stm("archival_metadata.snapshot", logger, raft)
+  : cluster::persisted_stm<>("archival_metadata.snapshot", logger, raft)
   , _logger(logger, ssx::sformat("ntp: {}", raft->ntp()))
   , _manifest(ss::make_shared<cloud_storage::partition_manifest>(
       raft->ntp(),

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -87,7 +87,7 @@ private:
 /// This is needed to 1) avoid querying cloud storage on partition startup and
 /// 2) to replicate metadata to raft followers so that they can decide which
 /// segments can be safely evicted.
-class archival_metadata_stm final : public persisted_stm {
+class archival_metadata_stm final : public persisted_stm<> {
     friend class details::archival_metadata_stm_accessor;
 
 public:

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -25,6 +25,15 @@
 
 #include <chrono>
 
+namespace detail {
+
+ss::sstring
+stm_snapshot_key(const ss::sstring& snapshot_name, const model::ntp& ntp) {
+    return ssx::sformat("{}/{}", snapshot_name, ntp);
+}
+
+} // namespace detail
+
 namespace cluster {
 
 std::vector<ss::shard_id>

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -19,6 +19,7 @@
 #include "raft/errc.h"
 #include "rpc/backoff_policy.h"
 #include "rpc/types.h"
+#include "storage/kvstore.h"
 #include "vlog.h"
 
 #include <seastar/core/future.hh>
@@ -30,6 +31,65 @@ namespace detail {
 ss::sstring
 stm_snapshot_key(const ss::sstring& snapshot_name, const model::ntp& ntp) {
     return ssx::sformat("{}/{}", snapshot_name, ntp);
+}
+
+ss::future<> do_move_persistent_stm_state(
+  ss::sstring snapshot_name,
+  model::ntp ntp,
+  ss::shard_id source_shard,
+  ss::shard_id target_shard,
+  ss::sharded<storage::api>& api) {
+    using state_ptr = std::unique_ptr<iobuf>;
+    using state_fptr = ss::foreign_ptr<state_ptr>;
+
+    const auto key_as_str = stm_snapshot_key(snapshot_name, ntp);
+    bytes key;
+    key.append(
+      reinterpret_cast<const uint8_t*>(key_as_str.begin()), key_as_str.size());
+
+    state_fptr snapshot = co_await api.invoke_on(
+      source_shard, [key](storage::api& api) {
+          const auto ks = storage::kvstore::key_space::stms;
+          auto snapshot_data = api.kvs().get(ks, key);
+          auto snapshot_ptr = !snapshot_data ? nullptr
+                                             : std::make_unique<iobuf>(
+                                               std::move(*snapshot_data));
+          return ss::make_foreign<state_ptr>(std::move(snapshot_ptr));
+      });
+
+    if (snapshot) {
+        co_await api.invoke_on(
+          target_shard,
+          [key, snapshot = std::move(snapshot)](storage::api& api) {
+              const auto ks = storage::kvstore::key_space::stms;
+              return api.kvs().put(ks, key, snapshot->copy());
+          });
+
+        co_await api.invoke_on(source_shard, [key](storage::api& api) {
+            const auto ks = storage::kvstore::key_space::stms;
+            return api.kvs().remove(ks, key);
+        });
+    }
+}
+
+ss::future<> move_persistent_stm_state(
+  model::ntp ntp,
+  ss::shard_id source_shard,
+  ss::shard_id target_shard,
+  ss::sharded<storage::api>& api) {
+    static const std::vector<ss::sstring> stm_snapshot_names{
+      cluster::archival_stm_snapshot,
+      cluster::tm_stm_snapshot,
+      cluster::id_allocator_snapshot,
+      cluster::rm_stm_snapshot};
+
+    return ss::parallel_for_each(
+      stm_snapshot_names,
+      [ntp, source_shard, target_shard, &api](
+        const ss::sstring& snapshot_name) {
+          return do_move_persistent_stm_state(
+            snapshot_name, ntp, source_shard, target_shard, api);
+      });
 }
 
 } // namespace detail

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -30,6 +30,8 @@
 
 namespace detail {
 
+ss::sstring stm_snapshot_key(const ss::sstring&, const model::ntp& ntp);
+
 template<typename T, typename Fn>
 std::vector<cluster::topic_result>
 create_topic_results(const std::vector<T>& topics, Fn fn) {

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -32,6 +32,12 @@ namespace detail {
 
 ss::sstring stm_snapshot_key(const ss::sstring&, const model::ntp& ntp);
 
+ss::future<> move_persistent_stm_state(
+  model::ntp ntp,
+  ss::shard_id source_shard,
+  ss::shard_id target_shard,
+  ss::sharded<storage::api>&);
+
 template<typename T, typename Fn>
 std::vector<cluster::topic_result>
 create_topic_results(const std::vector<T>& topics, Fn fn) {

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1447,6 +1447,8 @@ controller_backend::create_partition_from_remote_shard(
               previous_shard,
               ss::this_shard_id(),
               _storage);
+            co_await detail::move_persistent_stm_state(
+              ntp, previous_shard, ss::this_shard_id(), _storage);
         }
 
         auto ec = co_await create_partition(

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -38,7 +38,7 @@ id_allocator_stm::id_allocator_stm(ss::logger& logger, raft::consensus* c)
 
 id_allocator_stm::id_allocator_stm(
   ss::logger& logger, raft::consensus* c, config::configuration& cfg)
-  : persisted_stm("id.snapshot", logger, c)
+  : persisted_stm(id_allocator_snapshot, logger, c)
   , _batch_size(cfg.id_allocator_batch_size.value())
   , _log_capacity(cfg.id_allocator_log_capacity.value()) {}
 

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -31,7 +31,7 @@ namespace cluster {
 
 // id_allocator is a service to generate cluster-wide unique id (int64)
 
-class id_allocator_stm final : public persisted_stm {
+class id_allocator_stm final : public persisted_stm<> {
 public:
     struct stm_allocation_result {
         int64_t id;

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -33,14 +33,14 @@ std::optional<cluster::stm_snapshot_header> read_snapshot_header(
   iobuf_parser& parser, const model::ntp& ntp, const ss::sstring& name) {
     auto version = reflection::adl<int8_t>{}.from(parser);
     vassert(
-      version == cluster::snapshot_version
-        || version == cluster::snapshot_version_v0,
+      version == cluster::stm_snapshot_version
+        || version == cluster::stm_snapshot_version_v0,
       "[{} ({})] Unsupported persisted_stm snapshot_version {}",
       ntp,
       name,
       version);
 
-    if (version == cluster::snapshot_version_v0) {
+    if (version == cluster::stm_snapshot_version_v0) {
         return std::nullopt;
     }
 
@@ -132,7 +132,7 @@ ss::future<> file_backed_stm_snapshot::persist_snapshot(
   storage::simple_snapshot_manager& snapshot_mgr, stm_snapshot&& snapshot) {
     iobuf data_size_buf;
 
-    int8_t version = snapshot_version;
+    int8_t version = stm_snapshot_version;
     int64_t offset = snapshot.header.offset();
     int8_t data_version = snapshot.header.version;
     int32_t data_size = snapshot.header.snapshot_size;
@@ -242,7 +242,7 @@ kvstore_backed_stm_snapshot::load_snapshot() {
       std::move(*snapshot_blob));
     stm_snapshot snapshot;
     snapshot.header = stm_snapshot_header{
-      .version = snapshot_version,
+      .version = stm_snapshot_version,
       .snapshot_size = static_cast<int32_t>(thin_snapshot.data.size_bytes()),
       .offset = thin_snapshot.offset};
     snapshot.data = std::move(thin_snapshot.data);

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -30,8 +30,8 @@
 
 namespace cluster {
 
-static constexpr const int8_t snapshot_version_v0 = 0;
-static constexpr const int8_t snapshot_version = 1;
+static constexpr const int8_t stm_snapshot_version_v0 = 0;
+static constexpr const int8_t stm_snapshot_version = 1;
 
 struct stm_snapshot_header {
     int8_t version{0};

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -30,6 +30,9 @@
 
 namespace cluster {
 
+static constexpr const int8_t snapshot_version_v0 = 0;
+static constexpr const int8_t snapshot_version = 1;
+
 struct stm_snapshot_header {
     int8_t version{0};
     int32_t snapshot_size{0};
@@ -53,6 +56,27 @@ struct stm_snapshot {
 
         return snapshot;
     }
+};
+
+class file_backed_stm_snapshot {
+public:
+    file_backed_stm_snapshot(
+      ss::sstring snapshot_name, prefix_logger& log, raft::consensus* c);
+    ss::future<std::optional<stm_snapshot>> load_snapshot();
+    ss::future<> persist_snapshot(stm_snapshot&&);
+    const ss::sstring& name();
+    ss::sstring store_path() const;
+    ss::future<> remove_persistent_state();
+    size_t get_snapshot_size() const;
+
+    static ss::future<>
+    persist_snapshot(storage::simple_snapshot_manager&, stm_snapshot&&);
+
+private:
+    model::ntp _ntp;
+    prefix_logger& _log;
+    storage::simple_snapshot_manager _snapshot_mgr;
+    size_t _snapshot_size{0};
 };
 
 /**
@@ -83,8 +107,6 @@ class persisted_stm
   : public raft::state_machine
   , public storage::snapshotable_stm {
 public:
-    static constexpr const int8_t snapshot_version_v0 = 0;
-    static constexpr const int8_t snapshot_version = 1;
     explicit persisted_stm(ss::sstring, ss::logger&, raft::consensus*);
 
     void make_snapshot_in_background() final;
@@ -92,9 +114,9 @@ public:
     model::offset max_collectible_offset() override;
     ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
-    const ss::sstring& name() override { return _snapshot_mgr.name(); }
 
     virtual ss::future<> remove_persistent_state();
+    const ss::sstring& name() override { return _snapshot_backend.name(); }
 
     ss::future<> make_snapshot();
     virtual uint64_t get_snapshot_size() const;
@@ -158,10 +180,9 @@ protected:
     bool _is_catching_up{false};
     model::term_id _insync_term;
     model::offset _insync_offset;
-    uint64_t _snapshot_size{0};
     raft::consensus* _c;
-    storage::simple_snapshot_manager _snapshot_mgr;
     prefix_logger _log;
+    file_backed_stm_snapshot _snapshot_backend;
 };
 
 } // namespace cluster

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -79,6 +79,38 @@ private:
     size_t _snapshot_size{0};
 };
 
+class kvstore_backed_stm_snapshot {
+public:
+    kvstore_backed_stm_snapshot(
+      ss::sstring snapshot_name,
+      prefix_logger& log,
+      raft::consensus* c,
+      storage::kvstore& kvstore);
+
+    /// For testing
+    kvstore_backed_stm_snapshot(
+      ss::sstring snapshot_name,
+      prefix_logger& log,
+      model::ntp ntp,
+      storage::kvstore& kvstore);
+
+    ss::future<std::optional<stm_snapshot>> load_snapshot();
+    ss::future<> persist_snapshot(stm_snapshot&&);
+    const ss::sstring& name();
+    ss::sstring store_path() const;
+    ss::future<> remove_persistent_state();
+    size_t get_snapshot_size() const;
+
+private:
+    bytes snapshot_key() const;
+
+    model::ntp _ntp;
+    ss::sstring _name;
+    ss::sstring _snapshot_key;
+    prefix_logger& _log;
+    storage::kvstore& _kvstore;
+};
+
 template<typename T>
 concept supported_stm_snapshot = requires(T s, stm_snapshot&& snapshot) {
     {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -289,7 +289,7 @@ rm_stm::rm_stm(
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
   ss::sharded<features::feature_table>& feature_table,
   config::binding<uint64_t> max_concurrent_producer_ids)
-  : persisted_stm("tx.snapshot", logger, c)
+  : persisted_stm<>("tx.snapshot", logger, c)
   , _tx_locks(
       mt::
         map<absl::flat_hash_map, model::producer_id, ss::lw_shared_ptr<mutex>>(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -289,7 +289,7 @@ rm_stm::rm_stm(
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
   ss::sharded<features::feature_table>& feature_table,
   config::binding<uint64_t> max_concurrent_producer_ids)
-  : persisted_stm<>("tx.snapshot", logger, c)
+  : persisted_stm<>(rm_stm_snapshot, logger, c)
   , _tx_locks(
       mt::
         map<absl::flat_hash_map, model::producer_id, ss::lw_shared_ptr<mutex>>(

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -55,7 +55,7 @@ namespace cluster {
  *   - enforces monotonicity of the sequential numbers
  *   - fences against old epochs
  */
-class rm_stm final : public persisted_stm {
+class rm_stm final : public persisted_stm<> {
 public:
     using clock_type = ss::lowres_clock;
     using time_point_type = clock_type::time_point;

--- a/src/v/cluster/tests/cluster_utils_tests.cc
+++ b/src/v/cluster/tests/cluster_utils_tests.cc
@@ -9,9 +9,13 @@
 
 #include "cluster/cluster_utils.h"
 #include "cluster/members_table.h"
+#include "cluster/persisted_stm.h"
 #include "cluster/types.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
+#include "storage/tests/kvstore_fixture.h"
+#include "test_utils/fixture.h"
+#include "utils/prefix_logger.h"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/net/inet_address.hh>
@@ -168,4 +172,61 @@ SEASTAR_THREAD_TEST_CASE(test_check_result_configuration) {
       members, b_1_add_listener_the_same);
 
     BOOST_REQUIRE(error);
+}
+
+FIXTURE_TEST(persisted_stm_kvstore_test, kvstore_test_fixture) {
+    ss::logger test_logger("test_logger");
+    auto kvstore = make_kvstore();
+    kvstore->start().get();
+    auto make_snapshotter = [&kvstore, &test_logger]() {
+        auto ntp = model::ntp(
+          model::kafka_namespace,
+          model::topic(random_generators::gen_alphanum_string(10)),
+          model::partition_id(0));
+        prefix_logger logger(
+          test_logger, ssx::sformat("[{} ({})]", ntp, "test.snapshot"));
+        return cluster::kvstore_backed_stm_snapshot(
+          "test.snapshot", logger, ntp, *(kvstore.get()));
+    };
+
+    /// Make multiple snapshots to ensure keyspaces are not overlapping
+    std::vector<cluster::kvstore_backed_stm_snapshot> snapshotters;
+    snapshotters.reserve(10);
+    for (auto i = 0; i < 10; ++i) {
+        snapshotters.push_back(make_snapshotter());
+    }
+    /// Make some snapshots, and retrieve from disk asserting validity
+    std::vector<cluster::stm_snapshot> copies;
+    for (auto i = 0; i < 10; ++i) {
+        cluster::stm_snapshot ss;
+        ss.header = cluster::stm_snapshot_header{
+          .version = cluster::snapshot_version,
+          .offset = model::offset(random_generators::get_int(256))};
+        ss.data = random_generators::make_iobuf(
+          random_generators::get_int(256));
+        ss.header.snapshot_size = ss.data.size_bytes();
+        copies.push_back(
+          cluster::stm_snapshot{.header = ss.header, .data = ss.data.copy()});
+        snapshotters[i].persist_snapshot(std::move(ss)).get();
+    }
+    /// Read data from snapshot, asserting all data matches stored copy
+    for (auto i = 0; i < 10; ++i) {
+        auto snapshot = snapshotters[i].load_snapshot().get();
+        auto& copied_snapshot = copies[i];
+        BOOST_CHECK(snapshot);
+        BOOST_CHECK_EQUAL(
+          snapshot->header.offset, copied_snapshot.header.offset);
+        BOOST_CHECK_EQUAL(
+          snapshot->header.version, copied_snapshot.header.version);
+        BOOST_CHECK_EQUAL(
+          snapshot->header.snapshot_size, copied_snapshot.header.snapshot_size);
+        BOOST_CHECK_EQUAL(snapshot->data, copied_snapshot.data);
+    }
+    /// Finally, clear all snapshots assert they do not exist
+    for (auto i = 0; i < 10; ++i) {
+        snapshotters[i].remove_persistent_state().get();
+        auto snapshot = snapshotters[i].load_snapshot().get();
+        BOOST_CHECK(!snapshot);
+    }
+    kvstore->stop().get();
 }

--- a/src/v/cluster/tests/cluster_utils_tests.cc
+++ b/src/v/cluster/tests/cluster_utils_tests.cc
@@ -200,7 +200,7 @@ FIXTURE_TEST(persisted_stm_kvstore_test, kvstore_test_fixture) {
     for (auto i = 0; i < 10; ++i) {
         cluster::stm_snapshot ss;
         ss.header = cluster::stm_snapshot_header{
-          .version = cluster::snapshot_version,
+          .version = cluster::stm_snapshot_version,
           .offset = model::offset(random_generators::get_int(256))};
         ss.data = random_generators::make_iobuf(
           random_generators::get_int(256));

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -114,7 +114,7 @@ tm_stm::tm_stm(
   raft::consensus* c,
   ss::sharded<features::feature_table>& feature_table,
   ss::lw_shared_ptr<cluster::tm_stm_cache> tm_stm_cache)
-  : persisted_stm<>("tx.coordinator.snapshot", logger, c)
+  : persisted_stm<>(tm_stm_snapshot, logger, c)
   , _sync_timeout(config::shard_local_cfg().tm_sync_timeout_ms.value())
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.value())

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -114,7 +114,7 @@ tm_stm::tm_stm(
   raft::consensus* c,
   ss::sharded<features::feature_table>& feature_table,
   ss::lw_shared_ptr<cluster::tm_stm_cache> tm_stm_cache)
-  : persisted_stm("tx.coordinator.snapshot", logger, c)
+  : persisted_stm<>("tx.coordinator.snapshot", logger, c)
   , _sync_timeout(config::shard_local_cfg().tm_sync_timeout_ms.value())
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.value())

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -48,7 +48,7 @@ using use_tx_version_with_last_pid_bool
  * ongoing and executed transactions and maps tx.id to its latest
  * session (producer_identity)
  */
-class tm_stm final : public persisted_stm {
+class tm_stm final : public persisted_stm<> {
 public:
     using clock_type = ss::lowres_system_clock;
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3839,6 +3839,13 @@ std::ostream& operator<<(
       with_assignment.assignments);
     return o;
 }
+
+/// Names of snapshot files used by stm's
+static const ss::sstring archival_stm_snapshot = "archival_metadata.snapshot";
+static const ss::sstring rm_stm_snapshot = "tx.snapshot";
+static const ss::sstring tm_stm_snapshot = "tx.coordinator.snapshot";
+static const ss::sstring id_allocator_snapshot = "id.snapshot";
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -97,6 +97,7 @@ public:
         controller = 3,
         offset_translator = 4,
         usage = 5,
+        stms = 6,
         /* your sub-system here */
     };
 

--- a/src/v/storage/tests/kvstore_fixture.h
+++ b/src/v/storage/tests/kvstore_fixture.h
@@ -1,0 +1,73 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/configuration.h"
+#include "random/generators.h"
+#include "storage/kvstore.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/util/file.hh>
+
+// This fixture manages the dependencies needed to create kvstore instance.
+// It's the responsiblity of the test to stop the kvstore instances created
+// by the fixture.
+class kvstore_test_fixture {
+public:
+    kvstore_test_fixture()
+      : _test_dir(
+        ssx::sformat("kvstore_test_{}", random_generators::get_int(4000)))
+      , _kv_config(prepare_store().get()) {
+        _feature_table.start().get();
+        _feature_table
+          .invoke_on_all(
+            [](features::feature_table& f) { f.testing_activate_all(); })
+          .get();
+    }
+
+    std::unique_ptr<storage::kvstore> make_kvstore() {
+        return std::make_unique<storage::kvstore>(
+          _kv_config, resources, _feature_table);
+    }
+
+    ~kvstore_test_fixture() {
+        _feature_table.stop().get();
+        cleanup_store().get();
+    }
+
+private:
+    /// Call this at end of tests to avoid leaving garbage
+    /// directories behind
+    ss::future<> cleanup_store() {
+        std::filesystem::path dir_path{_test_dir};
+        return ss::recursive_remove_directory(dir_path);
+    }
+
+    /// Remove any existing store at this path, and return a config
+    /// for constructing a new store.
+    ss::future<storage::kvstore_config> prepare_store() {
+        if (co_await ss::file_exists(_test_dir)) {
+            // Tests can fail in mysterious ways if there's already a store
+            // in the location they're trying to use.  Even though tests
+            // clean up on success, they might leave directories behind
+            // on failure.
+            co_await cleanup_store();
+        }
+
+        co_return storage::kvstore_config(
+          8192,
+          config::mock_binding(std::chrono::milliseconds(10)),
+          _test_dir,
+          storage::make_sanitized_file_config());
+    }
+
+    storage::storage_resources resources{};
+    ss::sstring _test_dir;
+    storage::kvstore_config _kv_config;
+    ss::sharded<features::feature_table> _feature_table;
+};

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -11,69 +11,12 @@
 #include "random/generators.h"
 #include "reflection/adl.h"
 #include "storage/kvstore.h"
+#include "storage/tests/kvstore_fixture.h"
 #include "test_utils/fixture.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/file.hh>
-
-// This fixture manages the dependencies needed to create kvstore instance.
-// It's the responsiblity of the test to stop the kvstore instances created
-// by the fixture.
-class kvstore_test_fixture {
-public:
-    kvstore_test_fixture()
-      : _test_dir(
-        ssx::sformat("kvstore_test_{}", random_generators::get_int(4000)))
-      , _kv_config(prepare_store().get()) {
-        _feature_table.start().get();
-        _feature_table
-          .invoke_on_all(
-            [](features::feature_table& f) { f.testing_activate_all(); })
-          .get();
-    }
-
-    std::unique_ptr<storage::kvstore> make_kvstore() {
-        return std::make_unique<storage::kvstore>(
-          _kv_config, resources, _feature_table);
-    }
-
-    ~kvstore_test_fixture() {
-        _feature_table.stop().get();
-        cleanup_store().get();
-    }
-
-private:
-    /// Call this at end of tests to avoid leaving garbage
-    /// directories behind
-    ss::future<> cleanup_store() {
-        std::filesystem::path dir_path{_test_dir};
-        return ss::recursive_remove_directory(dir_path);
-    }
-
-    /// Remove any existing store at this path, and return a config
-    /// for constructing a new store.
-    ss::future<storage::kvstore_config> prepare_store() {
-        if (co_await ss::file_exists(_test_dir)) {
-            // Tests can fail in mysterious ways if there's already a store
-            // in the location they're trying to use.  Even though tests
-            // clean up on success, they might leave directories behind
-            // on failure.
-            co_await cleanup_store();
-        }
-
-        co_return storage::kvstore_config(
-          8192,
-          config::mock_binding(std::chrono::milliseconds(10)),
-          _test_dir,
-          storage::make_sanitized_file_config());
-    }
-
-    storage::storage_resources resources{};
-    ss::sstring _test_dir;
-    storage::kvstore_config _kv_config;
-    ss::sharded<features::feature_table> _feature_table;
-};
 
 template<typename T>
 static void set_configuration(ss::sstring p_name, T v) {


### PR DESCRIPTION
This change adds the ability to the persisted_stm to write its snapshots to the kvstore instead of using the snapshot_manager. This change is necessitated as the new log_eviction_stm (see https://github.com/redpanda-data/redpanda/pull/10061) will be adding yet another checkpoint file that will be periodically written to. With many partitions there are concerns with performance and stability, moving the backing store of the persisted_stm to the kvstore solves this.

Note this not modify existing behavior of the kvstore. These changes make it so that users will opt-in or out of this behavior. The default is to work as it always did, using the snapshot manager as its backing store.

## Backports Required
- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release notes

### Improvements

* Introduces the ability to use kvstore for snapshots for the persisted_stm tool

