### PR TITLE
storage: add cache target estimates and space management control loop skeleton

### DIFF
--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -158,6 +158,12 @@ public:
     void evict_reader(std::unique_ptr<remote_segment_batch_reader> reader);
     void evict_segment(ss::lw_shared_ptr<remote_segment> segment);
 
+    // Compute cache usage statistics. This method uses information from the
+    // most recent segment to determine target cache size needs. The results
+    // depend on if the partition appears to be able to use chunk-based storage
+    // vs segment-based storage in the cache.
+    cache_usage_target get_cache_usage_target() const;
+
 private:
     friend struct materialized_segment_state;
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1466,4 +1466,12 @@ std::exception_ptr hydration_loop_state::current_error() {
     return _current_error;
 }
 
+std::pair<size_t, bool> remote_segment::min_cache_cost() const {
+    if (is_legacy_mode_engaged()) {
+        return std::make_pair(_size, false);
+    } else {
+        return std::make_pair(_chunk_size, true);
+    }
+}
+
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -179,6 +179,11 @@ public:
         return _fallback_mode == fallback_mode::yes;
     }
 
+    // returns the minimum space required by this segment in the cloud storage
+    // cache. if ret.second is false then the returned size is based on segment
+    // granularity, otherwise the size is chunk granularity.
+    std::pair<size_t, bool> min_cache_cost() const;
+
 private:
     /// get a file offset for the corresponding kafka offset
     /// if the index is available

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -533,6 +533,16 @@ FIXTURE_TEST(test_remote_segment_chunk_read, cloud_storage_fixture) {
     stream.close().get();
 
     BOOST_REQUIRE(!segment.is_fallback_engaged());
+
+    /*
+     * when fallback mode is NOT engaged, the estimated min cache cost for the
+     * segment should be the size of a single chunk.
+     */
+    BOOST_REQUIRE(
+      segment.min_cache_cost()
+      == std::make_pair(
+        config::shard_local_cfg().cloud_storage_cache_chunk_size(), true));
+
     segment.stop().get();
 
     BOOST_REQUIRE_EQUAL(downloaded.size_bytes(), segment_bytes.size_bytes());
@@ -571,6 +581,14 @@ FIXTURE_TEST(test_remote_segment_chunk_read_fallback, cloud_storage_fixture) {
     stream.close().get();
 
     BOOST_REQUIRE(segment.is_fallback_engaged());
+
+    /*
+     * when fallback mode IS engaged, the estimated min cache cost for the
+     * segment should be the size of the segment itself.
+     */
+    BOOST_REQUIRE(
+      segment.min_cache_cost()
+      == std::make_pair(segment_bytes.size_bytes(), false));
 
     std::regex log_file_expr{".*-.*log(\\.\\d+)?$"};
 

--- a/src/v/cloud_storage/tests/util.h
+++ b/src/v/cloud_storage/tests/util.h
@@ -563,7 +563,8 @@ auto setup_s3_imposter(
   cloud_storage_fixture& fixture,
   int num_segments,
   int num_batches_per_segment,
-  manifest_inconsistency inject = manifest_inconsistency::none) {
+  manifest_inconsistency inject = manifest_inconsistency::none,
+  segment_name_format sname_format = segment_name_format::v3) {
     vassert(
       inject == manifest_inconsistency::none
         || inject == manifest_inconsistency::truncated_segments,
@@ -572,7 +573,11 @@ auto setup_s3_imposter(
     auto segments = make_segments(num_segments, num_batches_per_segment);
     cloud_storage::partition_manifest manifest(manifest_ntp, manifest_revision);
     auto expectations = make_imposter_expectations(
-      manifest, segments, inject == manifest_inconsistency::truncated_segments);
+      manifest,
+      segments,
+      inject == manifest_inconsistency::truncated_segments,
+      model::offset_delta(0),
+      sname_format);
     fixture.set_expectations_and_listen(expectations);
     return segments;
 }

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -251,6 +251,29 @@ inline std::error_code make_error_code(error_outcome e) noexcept {
     return {static_cast<int>(e), error_category()};
 }
 
+// target_min_bytes: the minimum number of bytes that the cache should
+// reserve in order to maintain proper functionality.
+//
+// target_bytes: the minimum number of bytes that the cache should reserve
+// in order to maining "good" functionality, for some definition of good.
+// this may include heuristics to avoid too much thrashing, as well as
+// allowing read-ahead optimizations to be effective.
+struct cache_usage_target {
+    size_t target_min_bytes{0};
+    size_t target_bytes{0};
+    bool chunked{false};
+
+    friend cache_usage_target
+    operator+(cache_usage_target lhs, const cache_usage_target& rhs) {
+        lhs.target_min_bytes += rhs.target_min_bytes;
+        lhs.target_bytes += rhs.target_bytes;
+        // if we have one case of chunked storage, then continue to estimate
+        // as if chunked storage is used.
+        lhs.chunked = lhs.chunked || rhs.chunked;
+        return lhs;
+    }
+};
+
 } // namespace cloud_storage
 
 namespace std {

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -193,6 +193,13 @@ public:
      */
     ss::future<size_t> non_log_disk_size_bytes() const;
 
+    /*
+     * Accumulates the target cache usage for all remote partitions. The result
+     * reflects partitions across all shards.
+     */
+    ss::future<cloud_storage::cache_usage_target>
+    get_cloud_cache_disk_usage_target() const;
+
 private:
     /// Download log if partition_recovery_manager is initialized.
     ///

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1840,6 +1840,13 @@ configuration::configuration()
       "the data directory. Redpanda will refuse to start if it is not found.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , enable_storage_space_manager(
+      *this,
+      "enable_storage_space_manager",
+      "Enable the storage space manager that coordinates and control space "
+      "usage between log data and the cloud storage cache.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      true)
   , memory_abort_on_alloc_failure(
       *this,
       "memory_abort_on_alloc_failure",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -363,6 +363,7 @@ struct configuration final : public config_store {
     bounded_property<size_t> storage_space_alert_free_threshold_bytes;
     bounded_property<size_t> storage_min_free_bytes;
     property<bool> storage_strict_data_init;
+    property<bool> enable_storage_space_manager;
 
     // memory related settings
     property<bool> memory_abort_on_alloc_failure;

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -53,6 +53,7 @@ v_cc_library(
     v::pandaproxy_rest
     v::pandaproxy_schema_registry
     v::migrations
+    v::storage_resource_mgmt
   )
 
 add_subdirectory(tests)

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1351,6 +1351,13 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
           .get();
     }
 
+    construct_single_service(
+      space_manager,
+      config::shard_local_cfg().enable_storage_space_manager.bind(),
+      &storage,
+      &shadow_index_cache,
+      &partition_manager);
+
     // group membership
     syschecks::systemd_message("Creating kafka group manager").get();
     construct_service(
@@ -2240,6 +2247,8 @@ void application::start_runtime_services(
     for (const auto& m : _migrators) {
         m->start(controller->get_abort_source().local());
     }
+
+    space_manager->start().get();
 }
 
 /**

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -138,6 +138,7 @@ public:
     ss::sharded<storage::api> storage;
     ss::sharded<storage::node_api> storage_node;
     ss::sharded<cluster::node::local_monitor> local_monitor;
+    std::unique_ptr<storage::disk_space_manager> space_manager;
 
     std::unique_ptr<cluster::controller> controller;
     std::unique_ptr<coproc::api> coprocessing;

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -2,6 +2,13 @@ v_cc_library(
   NAME resource_mgmt
   SRCS
     available_memory.cc
+  DEPS
+    Seastar::seastar
+  )
+
+v_cc_library(
+  NAME storage_resource_mgmt
+  SRCS
     storage.cc
   DEPS
     Seastar::seastar

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -11,21 +11,125 @@
 
 #include "storage.h"
 
+#include "cluster/partition_manager.h"
+#include "vlog.h"
+
+#include <seastar/util/log.hh>
+
+static ss::logger rlog("resource_mgmt");
+
 namespace storage {
 
-std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
-    switch (d) {
-    case disk_space_alert::ok:
-        o << "ok";
-        break;
-    case disk_space_alert::low_space:
-        o << "low_space";
-        break;
-    case disk_space_alert::degraded:
-        o << "degraded";
-        break;
+disk_space_manager::disk_space_manager(
+  config::binding<bool> enabled,
+  ss::sharded<storage::api>* storage,
+  ss::sharded<cloud_storage::cache>* cache,
+  ss::sharded<cluster::partition_manager>* pm)
+  : _enabled(std::move(enabled))
+  , _storage(storage)
+  , _cache(cache->local_is_initialized() ? cache : nullptr)
+  , _pm(pm) {
+    _enabled.watch([this] {
+        vlog(
+          rlog.info,
+          "{} disk space manager control loop",
+          _enabled() ? "Enabling" : "Disabling");
+        _control_sem.signal();
+    });
+}
+
+ss::future<> disk_space_manager::start() {
+    vlog(
+      rlog.info,
+      "Starting disk space manager service ({})",
+      _enabled() ? "enabled" : "disabled");
+    ssx::spawn_with_gate(_gate, [this] { return run_loop(); });
+    co_return;
+}
+
+ss::future<> disk_space_manager::stop() {
+    vlog(rlog.info, "Stopping disk space manager service");
+    _control_sem.broken();
+    co_await _gate.close();
+}
+
+ss::future<> disk_space_manager::run_loop() {
+    /*
+     * we want the code here to actually run a little, but the final shape of
+     * configuration options is not yet known.
+     */
+    constexpr auto frequency = std::chrono::seconds(30);
+
+    while (true) {
+        try {
+            if (_enabled()) {
+                co_await _control_sem.wait(
+                  frequency, std::max(_control_sem.current(), size_t(1)));
+            } else {
+                co_await _control_sem.wait();
+            }
+        } catch (const ss::semaphore_timed_out&) {
+            // time for some controlling
+        }
+
+        if (!_enabled()) {
+            continue;
+        }
+
+        /*
+         * Collect cache and logs storage usage information. These accumulate
+         * across all shards (despite the local() accessor). If a failure occurs
+         * we wait rather than operate with a reduced set of information.
+         */
+        cloud_storage::cache_usage_target cache_usage_target;
+        try {
+            cache_usage_target
+              = co_await _pm->local().get_cloud_cache_disk_usage_target();
+        } catch (...) {
+            vlog(
+              rlog.info,
+              "Unable to collect cloud cache usage: {}",
+              std::current_exception());
+            continue;
+        }
+
+        storage::usage_report logs_usage;
+        try {
+            logs_usage = co_await _storage->local().disk_usage();
+        } catch (...) {
+            vlog(
+              rlog.info,
+              "Unable to collect log storage usage: {}",
+              std::current_exception());
+            continue;
+        }
+
+        vlog(
+          rlog.debug,
+          "Cloud storage cache target minimum size {} nice to have {}",
+          cache_usage_target.target_min_bytes,
+          cache_usage_target.target_bytes);
+
+        vlog(
+          rlog.debug,
+          "Log storage usage total {} - data {} index {} compaction {}",
+          logs_usage.usage.total(),
+          logs_usage.usage.data,
+          logs_usage.usage.index,
+          logs_usage.usage.compaction);
+
+        vlog(
+          rlog.debug,
+          "Log storage usage available for reclaim local {} total {}",
+          logs_usage.reclaim.retention,
+          logs_usage.reclaim.available);
+
+        vlog(
+          rlog.debug,
+          "Log storage usage target minimum size {} nice to have {}",
+          logs_usage.target.min_capacity,
+          logs_usage.target.min_capacity_wanted);
     }
-    return o;
 }
 
 } // namespace storage

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -11,9 +11,25 @@
 
 #pragma once
 
+#include "config/property.h"
+#include "seastarx.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/sharded.hh>
+
 #include <iostream>
 
+namespace cloud_storage {
+class cache;
+}
+
+namespace cluster {
+class partition_manager;
+}
+
 namespace storage {
+
+class api;
 
 enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
 
@@ -21,6 +37,50 @@ inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
     return std::max(a, b);
 }
 
-std::ostream& operator<<(std::ostream& o, const storage::disk_space_alert d);
+inline std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
+    switch (d) {
+    case disk_space_alert::ok:
+        o << "ok";
+        break;
+    case disk_space_alert::low_space:
+        o << "low_space";
+        break;
+    case disk_space_alert::degraded:
+        o << "degraded";
+        break;
+    }
+    return o;
+}
+
+/*
+ *
+ */
+class disk_space_manager {
+public:
+    disk_space_manager(
+      config::binding<bool> enabled,
+      ss::sharded<storage::api>* storage,
+      ss::sharded<cloud_storage::cache>* cache,
+      ss::sharded<cluster::partition_manager>* pm);
+
+    disk_space_manager(disk_space_manager&&) noexcept = delete;
+    disk_space_manager& operator=(disk_space_manager&&) noexcept = delete;
+    disk_space_manager(const disk_space_manager&) = delete;
+    disk_space_manager& operator=(const disk_space_manager&) = delete;
+    ~disk_space_manager() = default;
+
+    ss::future<> start();
+    ss::future<> stop();
+
+private:
+    config::binding<bool> _enabled;
+    ss::sharded<storage::api>* _storage;
+    ss::sharded<cloud_storage::cache>* _cache;
+    ss::sharded<cluster::partition_manager>* _pm;
+
+    ss::gate _gate;
+    ss::future<> run_loop();
+    ssx::semaphore _control_sem{0, "resource_mgmt::space_manager"};
+};
 
 } // namespace storage


### PR DESCRIPTION
Adds a cloud cache interface for estimating the target minimum for storage size, as well as a control loop skeleton which will be used to manage disk space to be added in subsequent PR.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

