### PR TITLE
Using `node_status_table` to determine node unavailability in partition balancer

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -14,6 +14,7 @@
 #include "cluster/controller_probe.h"
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
+#include "cluster/node_status_table.h"
 #include "cluster/scheduling/leader_balancer.h"
 #include "model/fundamental.h"
 #include "raft/fwd.h"
@@ -42,7 +43,8 @@ public:
       ss::sharded<node::local_monitor>& local_monitor,
       ss::sharded<raft::group_manager>&,
       ss::sharded<features::feature_table>&,
-      ss::sharded<cloud_storage::remote>&);
+      ss::sharded<cloud_storage::remote>&,
+      ss::sharded<node_status_table>&);
 
     model::node_id self() { return _raft0->self().id(); }
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }
@@ -234,6 +236,7 @@ private:
     ss::gate _gate;
     consensus_ptr _raft0;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
+    ss::sharded<node_status_table>& _node_status_table;
     controller_probe _probe;
     ss::sharded<bootstrap_backend> _bootstrap_backend; // single instance
     bool _is_ready = false;

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -22,6 +22,8 @@
 
 #include <seastar/core/sharded.hh>
 
+#include <chrono>
+
 namespace cluster {
 
 class partition_balancer_backend {
@@ -45,6 +47,7 @@ public:
       config::binding<double>&& moves_drop_threshold,
       config::binding<size_t>&& segment_fallocation_step,
       config::binding<std::optional<size_t>> min_partition_size_threshold,
+      config::binding<std::chrono::milliseconds> node_status_interval,
       config::binding<size_t> raft_learner_recovery_rate);
 
     void start();
@@ -93,6 +96,7 @@ private:
     config::binding<double> _concurrent_moves_drop_threshold;
     config::binding<size_t> _segment_fallocation_step;
     config::binding<std::optional<size_t>> _min_partition_size_threshold;
+    config::binding<std::chrono::milliseconds> _node_status_interval;
     config::binding<size_t> _raft_learner_recovery_rate;
 
     model::term_id _last_leader_term;

--- a/src/v/cluster/partition_balancer_state.cc
+++ b/src/v/cluster/partition_balancer_state.cc
@@ -13,6 +13,7 @@
 #include "cluster/controller_snapshot.h"
 #include "cluster/logger.h"
 #include "cluster/members_table.h"
+#include "cluster/node_status_table.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "config/configuration.h"
 #include "prometheus/prometheus_sanitize.h"
@@ -27,10 +28,12 @@ namespace cluster {
 partition_balancer_state::partition_balancer_state(
   ss::sharded<topic_table>& topic_table,
   ss::sharded<members_table>& members_table,
-  ss::sharded<partition_allocator>& pa)
+  ss::sharded<partition_allocator>& pa,
+  ss::sharded<node_status_table>& nst)
   : _topic_table(topic_table.local())
   , _members_table(members_table.local())
   , _partition_allocator(pa.local())
+  , _node_status(nst.local())
   , _probe(*this) {}
 
 void partition_balancer_state::handle_ntp_update(

--- a/src/v/cluster/partition_balancer_state.h
+++ b/src/v/cluster/partition_balancer_state.h
@@ -28,11 +28,14 @@ public:
     partition_balancer_state(
       ss::sharded<topic_table>&,
       ss::sharded<members_table>&,
-      ss::sharded<partition_allocator>&);
+      ss::sharded<partition_allocator>&,
+      ss::sharded<node_status_table>&);
 
     topic_table& topics() const { return _topic_table; }
 
     members_table& members() const { return _members_table; }
+
+    node_status_table& node_status() const { return _node_status; }
 
     const absl::btree_set<model::ntp>&
     ntps_with_broken_rack_constraint() const {
@@ -66,6 +69,7 @@ private:
     topic_table& _topic_table;
     members_table& _members_table;
     partition_allocator& _partition_allocator;
+    node_status_table& _node_status;
     absl::btree_set<model::ntp> _ntps_with_broken_rack_constraint;
     probe _probe;
 };

--- a/src/v/cluster/tests/partition_balancer_bench.cc
+++ b/src/v/cluster/tests/partition_balancer_bench.cc
@@ -28,12 +28,12 @@ PERF_TEST_C(partition_balancer_planner_fixture, unavailable_nodes) {
     auto hr = create_health_report({}, {}, local_partition_size);
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    co_await populate_node_status_table(unavailable_nodes);
 
     auto planner = make_planner();
 
     perf_tests::start_measuring_time();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
     perf_tests::stop_measuring_time();
 
     const auto& reassignments = plan_data.reassignments;

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -13,6 +13,7 @@
 
 #include "cluster/commands.h"
 #include "cluster/members_table.h"
+#include "cluster/node_status_table.h"
 #include "cluster/partition_balancer_planner.h"
 #include "cluster/partition_balancer_state.h"
 #include "cluster/tests/utils.h"
@@ -105,7 +106,8 @@ struct partition_balancer_planner_fixture {
             .movement_disk_size_batch = reallocation_batch_size,
             .max_concurrent_actions = max_concurrent_actions,
             .node_availability_timeout_sec = std::chrono::minutes(1),
-            .segment_fallocation_step = 16},
+            .segment_fallocation_step = 16,
+            .node_responsiveness_timeout = std::chrono::seconds(10)},
           workers.state.local(),
           workers.allocator.local());
     }
@@ -275,27 +277,25 @@ struct partition_balancer_planner_fixture {
         dispatch_command(std::move(cmd));
     }
 
-    std::vector<raft::follower_metrics>
-    create_follower_metrics(const std::set<size_t>& unavailable_nodes = {}) {
-        std::vector<raft::follower_metrics> metrics;
-        metrics.reserve(last_node_idx);
+    ss::future<>
+    populate_node_status_table(std::set<size_t> unavailable_nodes = {}) {
+        std::vector<cluster::node_status> status_updates;
+        status_updates.reserve(last_node_idx + 1);
         for (size_t i = 0; i < last_node_idx; ++i) {
+            auto last_seen = raft::clock_type::now();
             if (unavailable_nodes.contains(i)) {
-                metrics.push_back(raft::follower_metrics{
-                  .id = model::node_id(i),
-                  .last_heartbeat = raft::clock_type::now()
-                                    - node_unavailable_timeout,
-                  .is_live = false,
-                });
-            } else {
-                metrics.push_back(raft::follower_metrics{
-                  .id = model::node_id(i),
-                  .last_heartbeat = raft::clock_type::now(),
-                  .is_live = true,
-                });
+                last_seen = last_seen - node_unavailable_timeout;
             }
+            status_updates.push_back(cluster::node_status{
+              .node_id = model::node_id(i),
+              .last_seen = last_seen,
+            });
         }
-        return metrics;
+
+        co_await workers.node_status_table.invoke_on_all(
+          [status_updates](cluster::node_status_table& nts) {
+              nts.update_peers(status_updates);
+          });
     }
 
     cluster::cluster_health_report create_health_report(

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -65,13 +65,20 @@ public:
             config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
             config::mock_binding<bool>(true))
           .get();
+        // use node status that is not used in test as self is always available
+        node_status_table.start_single(model::node_id{123}).get();
         state
-          .start_single(std::ref(table), std::ref(members), std::ref(allocator))
+          .start_single(
+            std::ref(table),
+            std::ref(members),
+            std::ref(allocator),
+            std::ref(node_status_table))
           .get();
     }
 
     ~controller_workers() {
         state.stop().get();
+        node_status_table.stop().get();
         table.stop().get();
         allocator.stop().get();
         members.stop().get();
@@ -82,6 +89,7 @@ public:
     ss::sharded<cluster::topic_table> table;
     ss::sharded<cluster::partition_leaders_table> leaders;
     ss::sharded<cluster::partition_balancer_state> state;
+    ss::sharded<cluster::node_status_table> node_status_table;
     cluster::topic_updates_dispatcher dispatcher;
 };
 

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -69,10 +69,10 @@ FIXTURE_TEST(test_stable, partition_balancer_planner_fixture) {
     create_topic("topic-1", 1, 3);
 
     auto hr = create_health_report();
-    auto fm = create_follower_metrics();
+    populate_node_status_table().get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
     check_violations(plan_data, {}, {});
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
 }
@@ -99,10 +99,10 @@ FIXTURE_TEST(test_node_down, partition_balancer_planner_fixture) {
     auto hr = create_health_report();
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, {});
 
@@ -137,10 +137,10 @@ FIXTURE_TEST(test_no_quorum_for_partition, partition_balancer_planner_fixture) {
     auto hr = create_health_report();
 
     std::set<size_t> unavailable_nodes = {0, 1};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
 }
 
@@ -171,10 +171,10 @@ FIXTURE_TEST(
     auto hr = create_health_report({}, nearly_full_nodes);
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, {});
 
@@ -210,10 +210,10 @@ FIXTURE_TEST(
     auto hr = create_health_report({}, nearly_full_nodes);
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, {});
 
@@ -249,10 +249,10 @@ FIXTURE_TEST(
     auto hr = create_health_report(full_nodes);
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, full_nodes);
 
@@ -281,10 +281,10 @@ FIXTURE_TEST(test_move_from_full_node, partition_balancer_planner_fixture) {
     std::set<size_t> full_nodes = {0};
     auto hr = create_health_report(full_nodes);
 
-    auto fm = create_follower_metrics();
+    populate_node_status_table().get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, {}, full_nodes);
 
@@ -322,10 +322,10 @@ FIXTURE_TEST(
     auto hr = create_health_report();
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, {});
 
@@ -370,10 +370,10 @@ FIXTURE_TEST(
 
     std::set<size_t> full_nodes = {0, 1, 2};
     auto hr = create_health_report(full_nodes);
-    auto fm = create_follower_metrics();
+    populate_node_status_table().get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
     check_violations(plan_data, {}, full_nodes);
 
     const auto& reassignments = plan_data.reassignments;
@@ -417,10 +417,10 @@ FIXTURE_TEST(
     auto hr = create_health_report(full_nodes);
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
     check_violations(plan_data, unavailable_nodes, full_nodes);
 
     const auto& reassignments = plan_data.reassignments;
@@ -464,14 +464,14 @@ FIXTURE_TEST(test_move_part_of_replicas, partition_balancer_planner_fixture) {
     std::set<size_t> full_nodes = {0, 1, 2};
     auto hr = create_health_report(full_nodes);
 
-    auto fm = create_follower_metrics();
+    populate_node_status_table().get();
 
     // Set order of full nodes
     hr.node_reports[1].local_state.data_disk.free -= 1_MiB;
     hr.node_reports[2].local_state.data_disk.free -= 2_MiB;
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, {}, full_nodes);
 
@@ -509,7 +509,7 @@ FIXTURE_TEST(
 
     std::set<size_t> full_nodes = {0, 1};
     auto hr = create_health_report(full_nodes);
-    auto fm = create_follower_metrics();
+    populate_node_status_table().get();
 
     // Set order of full nodes
     hr.node_reports[0].local_state.data_disk.free -= 1_MiB;
@@ -529,7 +529,7 @@ FIXTURE_TEST(
     }
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, {}, full_nodes);
 
@@ -576,10 +576,10 @@ FIXTURE_TEST(test_lot_of_partitions, partition_balancer_planner_fixture) {
     auto hr = create_health_report({}, {}, local_partition_size);
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
     check_violations(plan_data, unavailable_nodes, {});
 
     const auto& reassignments = plan_data.reassignments;
@@ -635,10 +635,10 @@ FIXTURE_TEST(test_node_cancelation, partition_balancer_planner_fixture) {
     auto hr = create_health_report();
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto planner_result = planner.plan_actions(hr, fm);
+    auto planner_result = planner.plan_actions(hr);
 
     BOOST_REQUIRE_EQUAL(planner_result.reassignments.size(), 1);
 
@@ -658,9 +658,9 @@ FIXTURE_TEST(test_node_cancelation, partition_balancer_planner_fixture) {
     hr = create_health_report();
 
     unavailable_nodes = {0, 3};
-    fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
-    planner_result = planner.plan_actions(hr, fm);
+    planner_result = planner.plan_actions(hr);
     BOOST_REQUIRE(planner_result.reassignments.size() == 0);
     BOOST_REQUIRE(planner_result.cancellations.size() == 1);
     BOOST_REQUIRE(planner_result.cancellations.front() == ntp);
@@ -696,10 +696,10 @@ FIXTURE_TEST(test_rack_awareness, partition_balancer_planner_fixture) {
       = hr.node_reports[3].local_state.data_disk.free - 10_MiB;
 
     std::set<size_t> unavailable_nodes = {0};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, {});
 
@@ -729,12 +729,12 @@ FIXTURE_TEST(
 
     std::set<size_t> unavailable_nodes{0};
     auto hr = create_health_report();
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     set_maintenance_mode(model::node_id{3});
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, {});
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
@@ -760,11 +760,11 @@ FIXTURE_TEST(
 
     std::set<size_t> unavailable_nodes{0};
     auto hr = create_health_report();
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
     set_decommissioning(model::node_id{3});
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, {});
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
@@ -789,12 +789,12 @@ FIXTURE_TEST(
 
     std::set<size_t> unavailable_nodes{3};
     auto hr = create_health_report();
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     set_decommissioning(model::node_id{0});
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, unavailable_nodes, {});
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 1);
@@ -863,10 +863,10 @@ FIXTURE_TEST(test_rack_awareness_repair, partition_balancer_planner_fixture) {
     allocator_register_nodes(1, {"rack_C"});
 
     auto hr = create_health_report();
-    auto fm = create_follower_metrics({});
+    populate_node_status_table().get();
 
     auto planner = make_planner();
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, {}, {});
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 2);
@@ -894,10 +894,10 @@ FIXTURE_TEST(balancing_modes, partition_balancer_planner_fixture) {
     auto hr = create_health_report(full_nodes);
 
     std::set<size_t> unavailable_nodes = {1};
-    auto fm = create_follower_metrics(unavailable_nodes);
+    populate_node_status_table(unavailable_nodes).get();
 
     auto planner = make_planner(model::partition_autobalancing_mode::node_add);
-    auto plan_data = planner.plan_actions(hr, fm);
+    auto plan_data = planner.plan_actions(hr);
 
     check_violations(plan_data, {}, {});
     BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1178,6 +1178,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
 
     construct_service(cp_partition_manager, std::ref(storage)).get();
 
+    construct_service(node_status_table, node_id).get();
     // controller
     syschecks::systemd_message("Creating cluster::controller").get();
 
@@ -1191,7 +1192,8 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       local_monitor,
       std::ref(raft_group_manager),
       std::ref(feature_table),
-      std::ref(cloud_storage_api));
+      std::ref(cloud_storage_api),
+      std::ref(node_status_table));
     controller->wire_up().get0();
 
     if (archival_storage_enabled()) {
@@ -1239,8 +1241,6 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(self_test_backend),
       std::ref(_connection_cache))
       .get();
-
-    construct_service(node_status_table, node_id).get();
 
     construct_single_service_sharded(
       node_status_backend,


### PR DESCRIPTION
Using `node_status_table` last heartbeat timestamps to determine if a
node is unavailable. Previously `partition_balancer_planner` was using
follower state coming from the controller raft group.

Fixes: #7218 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none