### PR TITLE
c/partition_allocator: maintain and use final partition counts

### DIFF
--- a/src/v/cluster/scheduling/allocation_node.cc
+++ b/src/v/cluster/scheduling/allocation_node.cc
@@ -54,6 +54,8 @@ allocation_node::allocate(const partition_allocation_domain domain) {
     (*it)++; // increment the weights
     _allocated_partitions++;
     ++_allocated_domain_partitions[domain];
+    _final_partitions++;
+    ++_final_domain_partitions[domain];
     const ss::shard_id core = std::distance(_weights.begin(), it);
     vlog(
       clusterlog.trace,

--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -99,10 +99,22 @@ public:
         return _allocated_partitions;
     }
 
+    // number of partitions after all in-progress movements are finished
+    allocation_capacity final_partitions() const { return _final_partitions; }
+
     allocation_capacity
     domain_allocated_partitions(partition_allocation_domain domain) const {
         if (auto it = _allocated_domain_partitions.find(domain);
             it != _allocated_domain_partitions.end()) {
+            return it->second;
+        }
+        return allocation_capacity{0};
+    }
+
+    allocation_capacity
+    domain_final_partitions(partition_allocation_domain domain) const {
+        if (auto it = _final_domain_partitions.find(domain);
+            it != _final_domain_partitions.end()) {
             return it->second;
         }
         return allocation_capacity{0};
@@ -129,6 +141,11 @@ private:
     // number of partitions allocated in a specific allocation domain
     absl::flat_hash_map<partition_allocation_domain, allocation_capacity>
       _allocated_domain_partitions;
+    // number of partitions after all movements are finished
+    allocation_capacity _final_partitions{0};
+    absl::flat_hash_map<partition_allocation_domain, allocation_capacity>
+      _final_domain_partitions;
+
     state _state = state::active;
 
     config::binding<uint32_t> _partitions_per_shard;

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -57,6 +57,10 @@ public:
     add_allocation(const model::broker_shard&, partition_allocation_domain);
     void
     remove_allocation(const model::broker_shard&, partition_allocation_domain);
+    void
+    add_final_count(const model::broker_shard&, partition_allocation_domain);
+    void
+    remove_final_count(const model::broker_shard&, partition_allocation_domain);
 
     void rollback(
       const ss::chunked_fifo<partition_assignment>& pa,

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -54,18 +54,18 @@ hard_constraint disk_not_overflowed_by_partition(
     node_disk_reports);
 
 /*
- * scores nodes based on free overall allocation capacity left
+ * scores nodes based on partition count after all moves have been finished
  * returning `0` for fully allocated nodes and `max_capacity` for empty nodes
  */
-soft_constraint least_allocated();
+soft_constraint max_final_capacity();
 
 /*
- * scores nodes based on allocation capacity used by priority partitions
- * returning `0` for nodes fully allocated for priority partitions
- * and `max_capacity` for nodes without any priority partitions
- * non-priority partition allocations are ignored
+ * scores nodes based on partition counts of priority partitions after all moves
+ * have been finished, returning `0` for nodes fully allocated for priority
+ * partitions and `max_capacity` for nodes without any priority partitions.
+ * non-priority partition allocations are ignored.
  */
-soft_constraint least_allocated_in_domain(partition_allocation_domain);
+soft_constraint max_final_capacity_in_domain(partition_allocation_domain);
 
 /*
  * constraint scores nodes on free disk space

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -66,9 +66,9 @@ allocation_constraints partition_allocator::default_constraints(
     req.add(is_active());
 
     if (domain == partition_allocation_domains::common) {
-        req.add(least_allocated());
+        req.add(max_final_capacity());
     } else {
-        req.add(least_allocated_in_domain(domain));
+        req.add(max_final_capacity_in_domain(domain));
     }
     if (_enable_rack_awareness()) {
         req.add(distinct_rack_preferred(_members.local()));

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -112,12 +112,17 @@ public:
       const std::vector<model::broker_shard>&, partition_allocation_domain);
     void remove_allocations(
       const std::vector<model::broker_shard>&, partition_allocation_domain);
+    void add_final_counts(
+      const std::vector<model::broker_shard>&, partition_allocation_domain);
+    void remove_final_counts(
+      const std::vector<model::broker_shard>&, partition_allocation_domain);
 
     void add_allocations_for_new_partition(
       const std::vector<model::broker_shard>& replicas,
       raft::group_id group_id,
       partition_allocation_domain domain) {
         add_allocations(replicas, domain);
+        add_final_counts(replicas, domain);
         _state->update_highest_group_id(group_id);
     }
 

--- a/src/v/cluster/tests/backend_reallocation_strategy_test.cc
+++ b/src/v/cluster/tests/backend_reallocation_strategy_test.cc
@@ -217,7 +217,11 @@ struct strategy_test_fixture {
             // update allocator
             allocator.add_allocations(
               added, cluster::partition_allocation_domains::common);
+            allocator.add_final_counts(
+              added, cluster::partition_allocation_domains::common);
             allocator.remove_allocations(
+              removed, cluster::partition_allocation_domains::common);
+            allocator.remove_final_counts(
               removed, cluster::partition_allocation_domains::common);
 
             auto ec = co_await topics.apply(

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -23,6 +23,8 @@
 #include <absl/container/flat_hash_set.h>
 #include <boost/test/tools/old/interface.hpp>
 
+ss::logger logger{"allocator_test"};
+
 static void validate_replica_set_diversity(
   const std::vector<model::broker_shard>& replicas) {
     if (replicas.size() > 1) {
@@ -568,16 +570,32 @@ FIXTURE_TEST(even_distribution_pri_allocation, partition_allocator_fixture) {
     }
 }
 
-void check_partition_counts(
+void check_allocated_counts(
   const cluster::partition_allocator& allocator,
   const std::vector<size_t>& expected,
   cluster::partition_allocation_domain domain
   = cluster::partition_allocation_domains::common) {
-    for (const auto& node : allocator.state().allocation_nodes()) {
-        model::node_id node_id = node.first;
-        auto count = node.second->domain_allocated_partitions(domain);
-        BOOST_REQUIRE_EQUAL(count(), expected.at(node_id()));
+    std::vector<size_t> counts;
+    for (const auto& [id, node] : allocator.state().allocation_nodes()) {
+        BOOST_REQUIRE(id() == counts.size());
+        counts.push_back(node->domain_allocated_partitions(domain));
     }
+    logger.debug("allocated counts: {}, expected: {}", counts, expected);
+    BOOST_CHECK_EQUAL(counts, expected);
+};
+
+void check_final_counts(
+  const cluster::partition_allocator& allocator,
+  const std::vector<size_t>& expected,
+  cluster::partition_allocation_domain domain
+  = cluster::partition_allocation_domains::common) {
+    std::vector<size_t> counts;
+    for (const auto& [id, node] : allocator.state().allocation_nodes()) {
+        BOOST_REQUIRE(id() == counts.size());
+        counts.push_back(node->domain_final_partitions(domain));
+    }
+    logger.debug("final counts: {}, expected: {}", counts, expected);
+    BOOST_CHECK_EQUAL(counts, expected);
 };
 
 FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
@@ -594,7 +612,8 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
     // add another node to move replicas to and from
     register_node(3, 1);
 
-    check_partition_counts(allocator, {1, 1, 1, 0});
+    check_allocated_counts(allocator, {1, 1, 1, 0});
+    check_final_counts(allocator, {1, 1, 1, 0});
 
     {
         cluster::allocated_partition reallocated
@@ -612,7 +631,8 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{3});
 
-        check_partition_counts(allocator, {1, 1, 1, 1});
+        check_allocated_counts(allocator, {1, 1, 1, 1});
+        check_final_counts(allocator, {0, 1, 1, 1});
 
         // there is no replica on node 0 any more
         auto moved2 = allocator.reallocate_replica(
@@ -629,7 +649,8 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           moved3.error(), cluster::errc::no_eligible_allocation_nodes);
 
-        check_partition_counts(allocator, {1, 1, 1, 1});
+        check_allocated_counts(allocator, {1, 1, 1, 1});
+        check_final_counts(allocator, {0, 1, 1, 1});
 
         // replicas can move to the same place
         auto moved4 = allocator.reallocate_replica(
@@ -639,7 +660,8 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{3});
 
-        check_partition_counts(allocator, {1, 1, 1, 1});
+        check_allocated_counts(allocator, {1, 1, 1, 1});
+        check_final_counts(allocator, {0, 1, 1, 1});
 
         auto moved5 = allocator.reallocate_replica(
           reallocated, model::node_id{2}, cluster::allocation_constraints{});
@@ -648,7 +670,8 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{2});
 
-        check_partition_counts(allocator, {1, 1, 1, 1});
+        check_allocated_counts(allocator, {1, 1, 1, 1});
+        check_final_counts(allocator, {0, 1, 1, 1});
 
         std::vector new_replicas(reallocated.replicas());
         cluster::allocation_constraints not_on_new_nodes;
@@ -663,7 +686,8 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{0});
 
-        check_partition_counts(allocator, {1, 1, 1, 0});
+        check_allocated_counts(allocator, {1, 1, 1, 0});
+        check_final_counts(allocator, {1, 1, 1, 0});
 
         // do another move so that we have something to revert
         auto moved7 = allocator.reallocate_replica(
@@ -674,10 +698,12 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{3});
 
-        check_partition_counts(allocator, {1, 1, 1, 1});
+        check_allocated_counts(allocator, {1, 1, 1, 1});
+        check_final_counts(allocator, {1, 0, 1, 1});
     }
 
-    check_partition_counts(allocator, {1, 1, 1, 0});
+    check_allocated_counts(allocator, {1, 1, 1, 0});
+    check_final_counts(allocator, {1, 1, 1, 0});
 }
 
 FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
@@ -695,7 +721,8 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
     register_node(3, 1);
     register_node(4, 1);
 
-    check_partition_counts(allocator, {1, 1, 1, 0, 0});
+    check_allocated_counts(allocator, {1, 1, 1, 0, 0});
+    check_final_counts(allocator, {1, 1, 1, 0, 0});
 
     cluster::allocation_constraints not_on_old_nodes;
     not_on_old_nodes.add(cluster::distinct_from(original_assignment.replicas));
@@ -717,7 +744,8 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(replicas_set.size(), 4);
         BOOST_REQUIRE(!replicas_set.contains(model::node_id{0}));
 
-        check_partition_counts(allocator, {1, 1, 1, 1, 1});
+        check_allocated_counts(allocator, {1, 1, 1, 1, 1});
+        check_final_counts(allocator, {0, 1, 1, 1, 1});
     }
 
     {
@@ -784,7 +812,8 @@ FIXTURE_TEST(
         replica2shard.emplace(bs.node_id, bs.shard);
     }
 
-    check_partition_counts(allocator, {2, 2, 2, 1});
+    check_allocated_counts(allocator, {2, 2, 2, 1});
+    check_final_counts(allocator, {2, 2, 2, 1});
 
     cluster::allocated_partition reallocated
       = allocator.make_allocated_partition(
@@ -800,7 +829,8 @@ FIXTURE_TEST(
     // more attractive. But replicas on nodes 0, 1, and 2 should still end up on
     // shard 2
     partition_1.reset();
-    check_partition_counts(allocator, {1, 1, 1, 1});
+    check_allocated_counts(allocator, {1, 1, 1, 1});
+    check_final_counts(allocator, {0, 1, 1, 1});
 
     // Reallocate replica on node 1 to itself.
     moved = allocator.reallocate_replica(

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -663,8 +663,13 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         check_allocated_counts(allocator, {1, 1, 1, 1});
         check_final_counts(allocator, {0, 1, 1, 1});
 
+        std::vector node_0(
+          {model::broker_shard{.node_id = model::node_id{0}, .shard = 0}});
+        cluster::allocation_constraints not_on_node0;
+        not_on_node0.add(cluster::distinct_from(node_0));
+
         auto moved5 = allocator.reallocate_replica(
-          reallocated, model::node_id{2}, cluster::allocation_constraints{});
+          reallocated, model::node_id{2}, not_on_node0);
         BOOST_REQUIRE(moved5.has_value());
         BOOST_REQUIRE_EQUAL(moved5.value().node_id, model::node_id{2});
         BOOST_REQUIRE_EQUAL(

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -19,9 +19,18 @@
 #include <cstdint>
 using namespace std::chrono_literals;
 
+ss::logger logger{"dispatcher_test"};
+
 struct topic_table_updates_dispatcher_fixture : topic_table_fixture {
     topic_table_updates_dispatcher_fixture()
       : dispatcher(allocator, table, leaders, pb_state) {}
+
+    template<typename Cmd>
+    void dispatch_command(Cmd cmd) {
+        auto res
+          = dispatcher.apply_update(serde_serialize_cmd(std::move(cmd))).get();
+        BOOST_REQUIRE_EQUAL(res, cluster::errc::success);
+    }
 
     void create_topics() {
         auto cmd_1 = make_create_topic_cmd("test_tp_1", 1, 3);
@@ -37,19 +46,9 @@ struct topic_table_updates_dispatcher_fixture : topic_table_fixture {
         auto cmd_2 = make_create_topic_cmd("test_tp_2", 12, 3);
         auto cmd_3 = make_create_topic_cmd("test_tp_3", 8, 1);
 
-        auto res_1 = dispatcher
-                       .apply_update(serialize_cmd(std::move(cmd_1)).get0())
-                       .get0();
-        auto res_2 = dispatcher
-                       .apply_update(serialize_cmd(std::move(cmd_2)).get0())
-                       .get0();
-        auto res_3 = dispatcher
-                       .apply_update(serialize_cmd(std::move(cmd_3)).get0())
-                       .get0();
-
-        BOOST_REQUIRE_EQUAL(res_1, cluster::errc::success);
-        BOOST_REQUIRE_EQUAL(res_2, cluster::errc::success);
-        BOOST_REQUIRE_EQUAL(res_3, cluster::errc::success);
+        dispatch_command(std::move(cmd_1));
+        dispatch_command(std::move(cmd_2));
+        dispatch_command(std::move(cmd_3));
     }
 
     cluster::topic_updates_dispatcher dispatcher;
@@ -164,4 +163,191 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(
       current_cluster_capacity(allocator.local().state().allocation_nodes()),
       max_cluster_capacity() - (1 * 3 + 12 * 3 + 8 * 1));
+}
+
+FIXTURE_TEST(
+  allocator_partition_counts, topic_table_updates_dispatcher_fixture) {
+    const auto& allocation_nodes = allocator.local().state().allocation_nodes();
+
+    auto check_allocated_counts = [&](std::vector<size_t> expected) {
+        std::vector<size_t> counts;
+        for (const auto& [id, node] : allocation_nodes) {
+            BOOST_REQUIRE(id() == counts.size() + 1); // 1-based node ids
+            counts.push_back(node->allocated_partitions());
+        }
+        logger.debug("allocated counts: {}, expected: {}", counts, expected);
+        BOOST_CHECK_EQUAL(counts, expected);
+    };
+
+    auto check_final_counts = [&](std::vector<size_t> expected) {
+        std::vector<size_t> counts;
+        for (const auto& [id, node] : allocation_nodes) {
+            BOOST_REQUIRE(id() == counts.size() + 1); // 1-based node ids
+            counts.push_back(node->final_partitions());
+        }
+        logger.debug("final counts: {}, expected: {}", counts, expected);
+        BOOST_CHECK_EQUAL(counts, expected);
+    };
+
+    auto create_topic_cmd = make_create_topic_cmd("test_tp_1", 4, 3);
+    logger.info("create topic {}", create_topic_cmd.key);
+    dispatch_command(create_topic_cmd);
+
+    // create a node to move replicas to
+    allocator.local().register_node(
+      create_allocation_node(model::node_id(4), 4));
+
+    check_allocated_counts({4, 4, 4, 0});
+    check_final_counts({4, 4, 4, 0});
+
+    // get data needed to move a partition
+    auto get_partition = [&](size_t id) {
+        model::ntp ntp{
+          create_topic_cmd.key.ns,
+          create_topic_cmd.key.tp,
+          model::partition_id{id}};
+        auto assignment_it = std::next(
+          create_topic_cmd.value.assignments.begin(), id);
+        BOOST_REQUIRE(assignment_it->id() == id);
+
+        auto old_replicas = assignment_it->replicas;
+
+        auto new_replicas = old_replicas;
+        auto it = std::find_if(
+          new_replicas.begin(), new_replicas.end(), [](const auto& bs) {
+              return bs.node_id() == 1;
+          });
+        BOOST_REQUIRE(it != new_replicas.end());
+        it->node_id = model::node_id{4};
+
+        return std::tuple{
+          ntp,
+          old_replicas,
+          new_replicas,
+        };
+    };
+
+    // move + finish
+    {
+        auto [ntp, old_replicas, new_replicas] = get_partition(0);
+
+        logger.info("move ntp {}", ntp);
+        dispatch_command(
+          cluster::move_partition_replicas_cmd{ntp, new_replicas});
+        check_allocated_counts({4, 4, 4, 1});
+        check_final_counts({3, 4, 4, 1});
+
+        logger.info("finish move");
+        dispatch_command(
+          cluster::finish_moving_partition_replicas_cmd{ntp, new_replicas});
+        check_allocated_counts({3, 4, 4, 1});
+        check_final_counts({3, 4, 4, 1});
+    }
+
+    // move + cancel + force_cancel + finish
+    {
+        auto [ntp, old_replicas, new_replicas] = get_partition(1);
+
+        logger.info("move ntp {}", ntp);
+        dispatch_command(
+          cluster::move_partition_replicas_cmd{ntp, new_replicas});
+        check_allocated_counts({3, 4, 4, 2});
+        check_final_counts({2, 4, 4, 2});
+
+        logger.info("cancel move");
+        dispatch_command(cluster::cancel_moving_partition_replicas_cmd{
+          ntp,
+          cluster::cancel_moving_partition_replicas_cmd_data{
+            cluster::force_abort_update{false}}});
+        check_allocated_counts({3, 4, 4, 2});
+        check_final_counts({3, 4, 4, 1});
+
+        logger.info("force-cancel move");
+        dispatch_command(cluster::cancel_moving_partition_replicas_cmd{
+          ntp,
+          cluster::cancel_moving_partition_replicas_cmd_data{
+            cluster::force_abort_update{true}}});
+        check_allocated_counts({3, 4, 4, 2});
+        check_final_counts({3, 4, 4, 1});
+
+        logger.info("finish move");
+        dispatch_command(
+          cluster::finish_moving_partition_replicas_cmd{ntp, old_replicas});
+        check_allocated_counts({3, 4, 4, 1});
+        check_final_counts({3, 4, 4, 1});
+    }
+
+    // move + cancel + revert_cancel
+    {
+        auto [ntp, old_replicas, new_replicas] = get_partition(2);
+
+        logger.info("move ntp {}", ntp);
+        dispatch_command(
+          cluster::move_partition_replicas_cmd{ntp, new_replicas});
+        check_allocated_counts({3, 4, 4, 2});
+        check_final_counts({2, 4, 4, 2});
+
+        logger.info("cancel move");
+        dispatch_command(cluster::cancel_moving_partition_replicas_cmd{
+          ntp,
+          cluster::cancel_moving_partition_replicas_cmd_data{
+            cluster::force_abort_update{false}}});
+        check_allocated_counts({3, 4, 4, 2});
+        check_final_counts({3, 4, 4, 1});
+
+        logger.info("revert_cancel move");
+        dispatch_command(cluster::revert_cancel_partition_move_cmd(
+          int8_t{0},
+          cluster::revert_cancel_partition_move_cmd_data{.ntp = ntp}));
+        check_allocated_counts({2, 4, 4, 2});
+        check_final_counts({2, 4, 4, 2});
+    }
+
+    // force_move
+    {
+        auto [ntp, old_replicas, new_replicas] = get_partition(3);
+
+        // for new_replicas choose a proper subset of old replicas, as required
+        // by force_partition_reconfiguration.
+        auto repl_it = std::find_if(
+          old_replicas.begin(), old_replicas.end(), [](const auto& bs) {
+              return bs.node_id() == 1;
+          });
+        BOOST_REQUIRE(repl_it != old_replicas.end());
+        new_replicas = std::vector({*repl_it});
+
+        logger.info(
+          "force_partition_reconfiguration ntp {} to {}", ntp, new_replicas);
+        dispatch_command(cluster::force_partition_reconfiguration_cmd{
+          ntp,
+          cluster::force_partition_reconfiguration_cmd_data(new_replicas)});
+        check_allocated_counts({2, 4, 4, 2});
+        check_final_counts({2, 3, 3, 2});
+
+        logger.info("finish move");
+        dispatch_command(
+          cluster::finish_moving_partition_replicas_cmd{ntp, new_replicas});
+        check_allocated_counts({2, 3, 3, 2});
+        check_final_counts({2, 3, 3, 2});
+    }
+
+    // move topic + topic delete
+    {
+        // move everything back
+        logger.info("move topic");
+        std::vector<cluster::move_topic_replicas_data> cmd_data;
+        for (const auto& p_as : create_topic_cmd.value.assignments) {
+            cmd_data.emplace_back(p_as.id, p_as.replicas);
+        }
+        dispatch_command(
+          cluster::move_topic_replicas_cmd(create_topic_cmd.key, cmd_data));
+        check_allocated_counts({4, 4, 4, 2});
+        check_final_counts({4, 4, 4, 0});
+
+        logger.info("delete topic");
+        dispatch_command(cluster::delete_topic_cmd(
+          create_topic_cmd.key, create_topic_cmd.key));
+        check_allocated_counts({0, 0, 0, 0});
+        check_final_counts({0, 0, 0, 0});
+    }
 }

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -115,6 +115,11 @@ private:
     void
     add_allocations_for_new_partitions(const T&, partition_allocation_domain);
 
+    void update_allocations_for_reconfiguration(
+      const std::vector<model::broker_shard>& previous,
+      const std::vector<model::broker_shard>& target,
+      partition_allocation_domain);
+
     void deallocate_topic(
       const model::topic_namespace&,
       const assignments_set&,


### PR DESCRIPTION
When moving partitions, partition allocations on old nodes are not removed until the move is finished. This makes sense because partitions remain physically present on old nodes until the very end. But we also use these allocation counts for count-based rebalancing. This is incorrect because after all moves are finished, the distribution won't necessary be uniform.

To fix this, introduce "final counts" - the number of partitions on a node after all currently in-progress moves are finished, maintain it when (re)allocating partitions and in `topic_updates_dispatcher` and use it in placement constraints and partition counts rebalancing in `members_backend`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none