### PR TITLE
cloud_roles: Fix metrics lifetime

### DIFF
--- a/src/v/cloud_roles/probe.cc
+++ b/src/v/cloud_roles/probe.cc
@@ -17,7 +17,7 @@
 
 namespace cloud_roles {
 
-auth_refresh_probe::auth_refresh_probe() {
+void auth_refresh_probe::setup_metrics() {
     if (config::shard_local_cfg().disable_metrics()) {
         return;
     }

--- a/src/v/cloud_roles/probe.h
+++ b/src/v/cloud_roles/probe.h
@@ -18,7 +18,8 @@ namespace cloud_roles {
 
 class auth_refresh_probe {
 public:
-    auth_refresh_probe();
+    void setup_metrics();
+    void reset() { _metrics.clear(); }
 
     void fetch_success() { ++_successful_fetches; }
     void fetch_failed() { ++_fetch_errors; }

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -50,6 +50,7 @@ refresh_credentials::refresh_credentials(
   , _region{std::move(region)} {}
 
 void refresh_credentials::start() {
+    _probe.setup_metrics();
     ssx::background = ssx::spawn_with_gate_then(
       _gate, [this]() { return do_start(); });
 }
@@ -214,6 +215,7 @@ ss::future<> refresh_credentials::stop() {
         _as.request_abort();
     }
     co_await _gate.close();
+    _probe.reset();
 }
 
 std::chrono::milliseconds


### PR DESCRIPTION
Limit the lifetime of the metrics to the async lifetime of `refresh_credentials`.

Fixes #11095
Fixes #11107

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

