### PR TITLE
ducktape/test_simple_live_change: wait for all nodes

### DIFF
--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -378,7 +378,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         patch_result = self.admin.patch_cluster_config(
             upsert=dict([norestart_new_setting]))
         new_version = patch_result['config_version']
-        wait_for_version_sync(self.admin, self.redpanda, new_version)
+        wait_for_version_status_sync(self.admin, self.redpanda, new_version)
 
         assert self.admin.get_cluster_config()[
             norestart_new_setting[0]] == norestart_new_setting[1]


### PR DESCRIPTION
The test is checking config status, but it is not waiting for the status object to have content for all the expected nodes.

Fixes #10977

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

Not seen on v23.1.x in the last 14d / 55 runs.

## Release Notes

* none
