### PR TITLE
treewide: Mark all probes as immovable

### DIFF
--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -32,6 +32,11 @@ namespace archival {
 class ntp_level_probe {
 public:
     ntp_level_probe(per_ntp_metrics_disabled disabled, const model::ntp& ntp);
+    ntp_level_probe(const ntp_level_probe&) = delete;
+    ntp_level_probe& operator=(const ntp_level_probe&) = delete;
+    ntp_level_probe(ntp_level_probe&&) = delete;
+    ntp_level_probe& operator=(ntp_level_probe&&) = delete;
+    ~ntp_level_probe() = default;
 
     void setup_ntp_metrics(const model::ntp& ntp);
 
@@ -101,6 +106,12 @@ class upload_housekeeping_probe {
 
 public:
     upload_housekeeping_probe();
+    upload_housekeeping_probe(const upload_housekeeping_probe&) = delete;
+    upload_housekeeping_probe& operator=(const upload_housekeeping_probe&)
+      = delete;
+    upload_housekeeping_probe(upload_housekeeping_probe&&) = delete;
+    upload_housekeeping_probe& operator=(upload_housekeeping_probe&&) = delete;
+    ~upload_housekeeping_probe() = default;
 
     // These metrics are updated by the service
     void housekeeping_rounds(uint64_t add) { _housekeeping_rounds += add; }

--- a/src/v/cloud_roles/probe.h
+++ b/src/v/cloud_roles/probe.h
@@ -24,6 +24,13 @@ public:
     void fetch_success() { ++_successful_fetches; }
     void fetch_failed() { ++_fetch_errors; }
 
+    auth_refresh_probe() = default;
+    auth_refresh_probe(const auth_refresh_probe&) = delete;
+    auth_refresh_probe& operator=(const auth_refresh_probe&) = delete;
+    auth_refresh_probe(auth_refresh_probe&&) = delete;
+    auth_refresh_probe& operator=(auth_refresh_probe&&) = delete;
+    ~auth_refresh_probe() = default;
+
 private:
     uint64_t _successful_fetches{0};
     uint64_t _fetch_errors{0};

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -160,7 +160,7 @@ private:
     ss::abort_source& _as;
     credentials_update_cb_t _credentials_update;
     aws_region_name _region;
-    auth_refresh_probe _probe;
+    std::unique_ptr<auth_refresh_probe> _probe;
 };
 
 std::ostream& operator<<(std::ostream& os, const refresh_credentials& rc);

--- a/src/v/cloud_storage/probe.h
+++ b/src/v/cloud_storage/probe.h
@@ -29,6 +29,11 @@ public:
       remote_metrics_disabled disabled,
       remote_metrics_disabled public_disabled,
       materialized_segments&);
+    remote_probe(const remote_probe&) = delete;
+    remote_probe& operator=(const remote_probe&) = delete;
+    remote_probe(remote_probe&&) = delete;
+    remote_probe& operator=(remote_probe&&) = delete;
+    ~remote_probe() = default;
 
     /// Register topic manifest upload
     void topic_manifest_upload() { _cnt_topic_manifest_uploads++; }

--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -29,6 +29,11 @@ public:
     explicit group_offset_probe(model::offset& offset) noexcept
       : _offset(offset)
       , _public_metrics(ssx::metrics::public_metrics_handle) {}
+    group_offset_probe(const group_offset_probe&) = delete;
+    group_offset_probe& operator=(const group_offset_probe&) = delete;
+    group_offset_probe(group_offset_probe&&) = delete;
+    group_offset_probe& operator=(group_offset_probe&&) = delete;
+    ~group_offset_probe() = default;
 
     void setup_metrics(
       const kafka::group_id& group_id, const model::topic_partition& tp) {
@@ -102,6 +107,12 @@ public:
       , _static_members(static_members)
       , _offsets(offsets)
       , _public_metrics(ssx::metrics::public_metrics_handle) {}
+
+    group_probe(const group_probe&) = delete;
+    group_probe& operator=(const group_probe&) = delete;
+    group_probe(group_probe&&) = delete;
+    group_probe& operator=(group_probe&&) = delete;
+    ~group_probe() = default;
 
     void setup_public_metrics(const kafka::group_id& group_id) {
         namespace sm = ss::metrics;

--- a/src/v/kafka/latency_probe.h
+++ b/src/v/kafka/latency_probe.h
@@ -21,6 +21,13 @@
 namespace kafka {
 class latency_probe {
 public:
+    latency_probe() = default;
+    latency_probe(const latency_probe&) = delete;
+    latency_probe& operator=(const latency_probe&) = delete;
+    latency_probe(latency_probe&&) = delete;
+    latency_probe& operator=(latency_probe&&) = delete;
+    ~latency_probe() = default;
+
     void setup_metrics() {
         namespace sm = ss::metrics;
 

--- a/src/v/kafka/server/handlers/handler_probe.h
+++ b/src/v/kafka/server/handlers/handler_probe.h
@@ -23,6 +23,11 @@ namespace kafka {
 class handler_probe {
 public:
     explicit handler_probe();
+    handler_probe(const handler_probe&) = delete;
+    handler_probe& operator=(const handler_probe&) = delete;
+    handler_probe(handler_probe&&) = delete;
+    handler_probe& operator=(handler_probe&&) = delete;
+    ~handler_probe() = default;
     void setup_metrics(ss::metrics::metric_groups&, api_key);
 
     void sample_in_progress();

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -138,6 +138,7 @@ server::server(
         cfg->local().max_service_memory_per_core
         * config::shard_local_cfg().kafka_memory_share_for_fetch()),
       "kafka/server-mem-fetch")
+  , _probe(std::make_unique<class latency_probe>())
   , _thread_worker(tw)
   , _replica_selector(
       std::make_unique<rack_aware_replica_selector>(_metadata_cache.local()))
@@ -150,8 +151,8 @@ server::server(
         _qdc_mon.emplace(*qdc_config);
     }
     setup_metrics();
-    _probe.setup_metrics();
-    _probe.setup_public_metrics();
+    _probe->setup_metrics();
+    _probe->setup_public_metrics();
 }
 
 void server::setup_metrics() {

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -70,7 +70,7 @@ public:
     ~server() noexcept override = default;
     server(const server&) = delete;
     server& operator=(const server&) = delete;
-    server(server&&) noexcept = default;
+    server(server&&) noexcept = delete;
     server& operator=(server&&) noexcept = delete;
 
     std::string_view name() const final { return "kafka rpc protocol"; }
@@ -158,7 +158,7 @@ public:
         return _gssapi_principal_mapper;
     }
 
-    latency_probe& latency_probe() { return _probe; }
+    latency_probe& latency_probe() { return *_probe; }
 
     ssx::thread_worker& thread_worker() { return _thread_worker; }
 
@@ -218,8 +218,8 @@ private:
     ssx::semaphore _memory_fetch_sem;
 
     handler_probe_manager _handler_probes;
-    class latency_probe _probe;
     ss::metrics::metric_groups _metrics;
+    std::unique_ptr<class latency_probe> _probe;
     ssx::thread_worker& _thread_worker;
     std::unique_ptr<replica_selector> _replica_selector;
     const std::unique_ptr<pandaproxy::schema_registry::api>& _schema_registry;

--- a/src/v/net/client_probe.h
+++ b/src/v/net/client_probe.h
@@ -22,6 +22,13 @@
 namespace net {
 class client_probe {
 public:
+    client_probe() = default;
+    client_probe(const client_probe&) = delete;
+    client_probe& operator=(const client_probe&) = delete;
+    client_probe(client_probe&&) = delete;
+    client_probe& operator=(client_probe&&) = delete;
+    ~client_probe() = default;
+
     void request() {
         ++_requests;
         ++_requests_pending;

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -129,7 +129,7 @@ public:
     virtual std::string_view name() const = 0;
     virtual ss::future<> apply(ss::lw_shared_ptr<net::connection>) = 0;
 
-    server_probe& probe() { return _probe; }
+    server_probe& probe() { return *_probe; }
     ssx::semaphore& memory() { return _memory; }
     ss::gate& conn_gate() { return _conn_gate; }
     hdr_hist& hist() { return _hist; }
@@ -163,7 +163,7 @@ private:
     ss::abort_source _as;
     ss::gate _conn_gate;
     hdr_hist _hist;
-    server_probe _probe;
+    std::unique_ptr<server_probe> _probe;
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics;
 

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -21,6 +21,13 @@ namespace net {
 
 class server_probe {
 public:
+    server_probe() = default;
+    server_probe(const server_probe&) = delete;
+    server_probe& operator=(const server_probe&) = delete;
+    server_probe(server_probe&&) = delete;
+    server_probe& operator=(server_probe&&) = delete;
+    ~server_probe() = default;
+
     void connection_established() {
         ++_connects;
         ++_connections;

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -84,7 +84,7 @@ protected:
     ss::input_stream<char> _in;
     net::batched_output_stream _out;
     ss::gate _dispatch_gate;
-    client_probe _probe;
+    std::unique_ptr<client_probe> _probe;
 
 private:
     ss::future<> do_connect(clock_type::time_point);

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -61,6 +61,11 @@ class probe {
 public:
     probe(
       ss::httpd::path_description& path_desc, const ss::sstring& group_name);
+    probe(const probe&) = delete;
+    probe& operator=(const probe&) = delete;
+    probe(probe&&) = delete;
+    probe& operator=(probe&&) = delete;
+    ~probe() = default;
     auto auto_measure() { return _request_metrics.auto_measure(); }
 
 private:

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -382,7 +382,7 @@ public:
 
     model::offset read_last_applied() const;
 
-    probe& get_probe() { return _probe; };
+    probe& get_probe() { return *_probe; };
 
     storage::log& log() { return _log; }
 
@@ -743,7 +743,7 @@ private:
     mutex _snapshot_lock;
     /// used for notifying when commits happened to log
     event_manager _event_manager;
-    probe _probe;
+    std::unique_ptr<probe> _probe;
     ctx_log _ctxlog;
     ss::condition_variable _commit_index_updated;
 

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -20,6 +20,13 @@
 namespace raft {
 class probe {
 public:
+    probe() = default;
+    probe(const probe&) = delete;
+    probe& operator=(const probe&) = delete;
+    probe(probe&&) = delete;
+    probe& operator=(probe&&) = delete;
+    ~probe() = default;
+
     void vote_request() { ++_vote_requests; }
     void append_request() { ++_append_requests; }
 

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -509,7 +509,7 @@ clock_type::time_point recovery_stm::append_entries_timeout() {
 
 ss::future<result<append_entries_reply>> recovery_stm::dispatch_append_entries(
   append_entries_request&& r, std::vector<ssx::semaphore_units> units) {
-    _ptr->_probe.recovery_append_request();
+    _ptr->_probe->recovery_append_request();
 
     rpc::client_opts opts(append_entries_timeout());
     opts.resource_units = ss::make_foreign(

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -318,7 +318,7 @@ ss::future<> replicate_batcher::do_flush(
   std::vector<ssx::semaphore_units> u,
   absl::flat_hash_map<vnode, follower_req_seq> seqs) {
     auto needs_flush = req.is_flush_required();
-    _ptr->_probe.replicate_batch_flushed();
+    _ptr->_probe->replicate_batch_flushed();
     auto stm = ss::make_lw_shared<replicate_entries_stm>(
       _ptr, std::move(req), std::move(seqs));
     try {

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -52,7 +52,7 @@ ss::future<result<vote_reply>> vote_stm::do_dispatch_one(vnode n) {
     vlog(_ctxlog.info, "Sending vote request to {} with timeout {}", n, tout);
 
     auto r = _req;
-    _ptr->_probe.vote_request_sent();
+    _ptr->_probe->vote_request_sent();
     r.target_node_id = n;
     return _ptr->_client_protocol
       .vote(n.id(), std::move(r), rpc::client_opts(tout))

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -343,7 +343,7 @@ transport::send_typed_versioned(
   transport_version version) {
     using ret_t = result<result_context<Output>>;
     using ctx_t = result<std::unique_ptr<streaming_context>>;
-    _probe.request();
+    _probe->request();
 
     auto b = std::make_unique<rpc::netbuf>();
     b->set_compression(opts.compression);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -99,13 +99,13 @@ public:
     // maybe_call interface which enforces sizing policies.
     ss::future<> force_roll(ss::io_priority_class);
 
-    probe& get_probe() { return _probe; }
+    probe& get_probe() { return *_probe; }
     model::term_id term() const;
     segment_set& segments() { return _segs; }
     const segment_set& segments() const { return _segs; }
     size_t bytes_left_before_roll() const;
 
-    size_t size_bytes() const override { return _probe.partition_size(); }
+    size_t size_bytes() const override { return _probe->partition_size(); }
     uint64_t size_bytes_after_offset(model::offset o) const override;
     ss::future<> update_configuration(ntp_config::default_overrides) final;
 
@@ -222,7 +222,7 @@ private:
     // method.
     mutex _start_offset_lock;
     lock_manager _lock_mngr;
-    storage::probe _probe;
+    std::unique_ptr<storage::probe> _probe;
     failure_probes _failure_probes;
     std::optional<eviction_monitor> _eviction_monitor;
     size_t _max_segment_size;

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -37,6 +37,13 @@ public:
 
     const disk_metrics& get_disk_metrics() const { return _disk; }
 
+    node_probe() = default;
+    node_probe(const node_probe&) = delete;
+    node_probe& operator=(const node_probe&) = delete;
+    node_probe(node_probe&&) = delete;
+    node_probe& operator=(node_probe&&) = delete;
+    ~node_probe() = default;
+
 private:
     disk_metrics _disk;
     ss::metrics::metric_groups _public_metrics{
@@ -46,6 +53,13 @@ private:
 // Per-NTP probe.
 class probe {
 public:
+    probe() = default;
+    probe(const probe&) = delete;
+    probe& operator=(const probe&) = delete;
+    probe(probe&&) = delete;
+    probe& operator=(probe&&) = delete;
+    ~probe() = default;
+
     void add_bytes_written(uint64_t written) {
         _partition_bytes += written;
         _bytes_written += written;


### PR DESCRIPTION
Probes register metrics by capturing `this`, and it's not save to move
them after that. In a lot of places this is safe because their lifetime
is directly tied to a service which lives the whole program's lifetime,
but any small move of that object even during initialization can break
things (see #11155, #11095, #11107).

This takes a big hammer approach to removing this foot gun by making all
probes immovable and wrapping them in `std::unique_ptr`.


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
