### PR TITLE
ducktape: Reduce parallel reads in test

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -228,7 +228,7 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
                                               self.topic,
                                               msg_size=0,
                                               rand_read_msgs=50,
-                                              parallel=50,
+                                              parallel=15,
                                               nodes=self.preallocated_nodes)
         rand_cons.start()
         rand_cons.wait(timeout_sec=300)


### PR DESCRIPTION
The test changed in commit asserts that the read path works when the segment size is smaller than chunk size. The expectations in test are often unmet on debug build in CI, we expect to be able to read 2500 messages total but the test falls marginally short. Since this test is not a load test but simply a check that read path works in this corner case, this change lowers the message count for the test to pass.

Fixes: https://github.com/redpanda-data/redpanda/issues/11151

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
