### PR TITLE
[v23.1.x] storage/compacted_index_chunk_reader: fix memory calculation

### DIFF
--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -201,9 +201,8 @@ compacted_index_chunk_reader::load_slice(model::timeout_clock::time_point t) {
         _cursor = ss::make_file_input_stream(_handle, 0, _footer->size);
     }
 
-    return ss::do_with(
-      ret_t{}, [this](ret_t& slice) {
-          return ss::do_until(
+    return ss::do_with(ret_t{}, [this](ret_t& slice) {
+        return ss::do_until(
                  [&slice, this] {
                      // stop condition
                      constexpr auto entry_size = sizeof(compacted_index::entry);
@@ -215,34 +214,34 @@ compacted_index_chunk_reader::load_slice(model::timeout_clock::time_point t) {
                      return is_end_of_stream()
                             || next_mem_use > _max_chunk_memory;
                  },
-                   [&slice, this] {
-                       return ::read_iobuf_exactly(*_cursor, sizeof(uint16_t))
-                         .then([this](iobuf b) {
-                             _byte_index += b.size_bytes();
-                             iobuf_parser p(std::move(b));
-                             const size_t entry_size
-                               = reflection::adl<uint16_t>{}.from(p);
-                             return ::read_iobuf_exactly(*_cursor, entry_size);
-                         })
-                         .then([this, &slice](iobuf b) {
-                             _byte_index += b.size_bytes();
-                             iobuf_parser p(std::move(b));
-                             auto type = reflection::adl<uint8_t>{}.from(p);
-                             auto [offset, _1] = p.read_varlong();
-                             auto [delta, _2] = p.read_varlong();
-                             auto bytes = p.read_bytes(p.bytes_left());
-                             auto key = compaction_key(std::move(bytes));
-                             slice.push_back(compacted_index::entry(
-                               compacted_index::entry_type(type),
-                               std::move(key),
-                               model::offset(offset),
-                               delta));
-                         });
-                   })
-            .then([&slice] {
-                return ss::make_ready_future<ret_t>(std::move(slice));
-            });
-      });
+                 [&slice, this] {
+                     return ::read_iobuf_exactly(*_cursor, sizeof(uint16_t))
+                       .then([this](iobuf b) {
+                           _byte_index += b.size_bytes();
+                           iobuf_parser p(std::move(b));
+                           const size_t entry_size
+                             = reflection::adl<uint16_t>{}.from(p);
+                           return ::read_iobuf_exactly(*_cursor, entry_size);
+                       })
+                       .then([this, &slice](iobuf b) {
+                           _byte_index += b.size_bytes();
+                           iobuf_parser p(std::move(b));
+                           auto type = reflection::adl<uint8_t>{}.from(p);
+                           auto [offset, _1] = p.read_varlong();
+                           auto [delta, _2] = p.read_varlong();
+                           auto bytes = p.read_bytes(p.bytes_left());
+                           auto key = compaction_key(std::move(bytes));
+                           slice.push_back(compacted_index::entry(
+                             compacted_index::entry_type(type),
+                             std::move(key),
+                             model::offset(offset),
+                             delta));
+                       });
+                 })
+          .then([&slice] {
+              return ss::make_ready_future<ret_t>(std::move(slice));
+          });
+    });
 }
 
 std::ostream&


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11138
Fixes https://github.com/redpanda-data/redpanda/issues/11162,