### PR TITLE
cloud_storage: Use chunked storage in tests

### DIFF
--- a/src/v/cloud_storage/tests/util.h
+++ b/src/v/cloud_storage/tests/util.h
@@ -503,7 +503,7 @@ std::vector<cloud_storage_fixture::expectation> make_imposter_expectations(
   const std::vector<in_memory_segment>& segments,
   bool truncate_segments = false,
   model::offset_delta delta = model::offset_delta(0),
-  segment_name_format sname_format = segment_name_format::v2) {
+  segment_name_format sname_format = segment_name_format::v3) {
     std::vector<cloud_storage_fixture::expectation> results;
 
     for (const auto& s : segments) {
@@ -531,7 +531,8 @@ std::vector<cloud_storage_fixture::expectation> make_imposter_expectations(
           .delta_offset = segment_delta,
           .ntp_revision = m.get_revision_id(),
           .delta_offset_end = model::offset_delta(delta)
-                              + model::offset_delta(s.num_config_records)};
+                              + model::offset_delta(s.num_config_records),
+          .sname_format = sname_format};
 
         m.add(s.sname, meta);
         delta = delta


### PR DESCRIPTION
Enable chunked storage by using latest sname format when making segments in remote partition tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
