### PR TITLE
tls: Prefer faster ciphers and use server preference

### DIFF
--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -80,6 +80,7 @@ public:
             return ss::do_with(
               ss::tls::credentials_builder{},
               [this](ss::tls::credentials_builder& builder) {
+                  builder.set_priority_string("PERFORMANCE:%SERVER_PRECEDENCE");
                   builder.set_dh_level(ss::tls::dh_params::level::MEDIUM);
                   if (_require_client_auth) {
                       builder.set_client_auth(ss::tls::client_auth::REQUIRE);


### PR DESCRIPTION
Makes `tls_config::get_credentials_builder` set gnutls priority strings to chose CPU friendlier ciphers which should help with TLS performance. We were already doing this for the cloud clients (see `build_tls_credentials` in `configuration.cc`) but not in `tls_config::get_credentials_builder` which is used for all API TLS endpoints.

This results in chosen ciphers as follows:

Before:

```
stephan@rp:~$ nmap -Pn --script ssl-enum-ciphers -p 9092 35.86.175.191
Starting Nmap 7.93 ( https://nmap.org ) at 2023-06-02 16:39 BST
Nmap scan report for ec2-35-86-175-191.us-west-2.compute.amazonaws.com
(35.86.175.191)
Host is up (0.13s latency).

PORT     STATE SERVICE
9092/tcp open  XmlIpcRegSvc
| ssl-enum-ciphers:
|   TLSv1.0:
|     ciphers:
|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|     compressors:
|       NULL
|     cipher preference: client
|   TLSv1.1:
|     ciphers:
|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|     compressors:
|       NULL
|     cipher preference: client
|   TLSv1.2:
|     ciphers:
|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_128_CCM (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_CCM (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
|       TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (dh 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_CCM (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CCM (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
|     compressors:
|       NULL
|     cipher preference: client
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_128_CCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|     cipher preference: client
|_  least strength: A
```

After:

```
stephan@rp:~/build/redpanda$ nmap -Pn --script ssl-enum-ciphers -p 9092
35.86.175.191
Starting Nmap 7.93 ( https://nmap.org ) at 2023-06-02 17:32 BST
Nmap scan report for ec2-35-86-175-191.us-west-2.compute.amazonaws.com
(35.86.175.191)
Host is up (0.13s latency).

PORT     STATE SERVICE
9092/tcp open  XmlIpcRegSvc
| ssl-enum-ciphers:
|   TLSv1.0:
|     ciphers:
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
|     compressors:
|       NULL
|     cipher preference: server
|   TLSv1.1:
|     ciphers:
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
|     compressors:
|       NULL
|     cipher preference: server
|   TLSv1.2:
|     ciphers:
|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_CCM (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CCM (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
|       TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_128_CCM (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_CCM (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
|     compressors:
|       NULL
|     cipher preference: server
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_128_CCM_SHA256 (secp256r1) - A
|     cipher preference: server
|_  least strength: A
```

Two important differences.

First, we see that the GCM based ciphers are now at the top in TLS1.2/1.3. GCM is a lot faster than CBC/CCM as shown below in the gnutls bench.

Second, we now follow server preference. This means that the server priority list will actually be used by the server to choose which cipher to use and not follow the client priority list.

For reference gnutls bench on my local machine:

```
stephan@rp:~/build/redpanda$
vbuild/release/clang/rp_deps_install/bin/gnutls-cli --benchmark-tls-ciphers aes-128-gcm
Testing throughput in cipher/MAC combinations (payload: 1400 bytes)
                   AES-128-GCM - TLS1.2  2.62 GB/sec
                   AES-128-GCM - TLS1.3  2.31 GB/sec
                   AES-128-CCM - TLS1.2  0.55 GB/sec
                   AES-128-CCM - TLS1.3  0.54 GB/sec
             CHACHA20-POLY1305 - TLS1.2  0.39 GB/sec
             CHACHA20-POLY1305 - TLS1.3  0.39 GB/sec
                   AES-128-CBC - TLS1.0  0.72 GB/sec
              CAMELLIA-128-CBC - TLS1.0  129.61 MB/sec
           GOST28147-TC26Z-CNT - TLS1.2  36.25 MB/sec

Testing throughput in cipher/MAC combinations (payload: 16384 bytes)
                   AES-128-GCM - TLS1.2  4.45 GB/sec
                   AES-128-GCM - TLS1.3  4.16 GB/sec
                   AES-128-CCM - TLS1.2  0.59 GB/sec
                   AES-128-CCM - TLS1.3  0.59 GB/sec
             CHACHA20-POLY1305 - TLS1.2  0.43 GB/sec
             CHACHA20-POLY1305 - TLS1.3  0.43 GB/sec
                   AES-128-CBC - TLS1.0  0.90 GB/sec
              CAMELLIA-128-CBC - TLS1.0  134.66 MB/sec
           GOST28147-TC26Z-CNT - TLS1.2  36.76 MB/sec
```

Issue https://github.com/redpanda-data/core-internal/issues/522

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Choose more CPU friendly TLS ciphers to reduce TLS overhead

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
