### PR TITLE
k/p/gen: Use `fragmented_vector` for  `fetchable_partition_response`

### DIFF
--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -74,7 +74,7 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
       .aborted{},
       .records{}};
 
-    std::vector<fetch_response::partition_response> responses;
+    small_fragment_vector<fetch_response::partition_response> responses;
     responses.push_back(std::move(pr));
     auto response = fetch_response::partition{.name = tp.topic};
     response.partitions = std::move(responses);

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -213,7 +213,7 @@ struct fetch_response final {
     public:
         using partition_iterator = std::vector<partition>::iterator;
         using partition_response_iterator
-          = std::vector<partition_response>::iterator;
+          = small_fragment_vector<partition_response>::iterator;
 
         struct value_type {
             partition_iterator partition;

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -461,9 +461,11 @@ extra_headers = {
 }
 # yapf: enable
 
-# These types, when they appear as the member type of an array, will use
-# a vector implementation which resists fragmentation.
-enable_fragmentation_resistance = {'metadata_response_partition'}
+# These types, when they appear as the member type of an array, will override
+# the container type from std::vector
+override_member_container = {
+    'metadata_response_partition': 'large_fragment_vector'
+}
 
 
 def make_context_field(path):
@@ -1040,8 +1042,8 @@ class Field:
         yield name
         if isinstance(self._type, ArrayType):
             assert default_value is None  # not supported
-            if name in enable_fragmentation_resistance:
-                yield "large_fragment_vector"
+            if name in override_member_container:
+                yield override_member_container[name]
             else:
                 yield "std::vector"
         if self.nullable():

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -464,7 +464,8 @@ extra_headers = {
 # These types, when they appear as the member type of an array, will override
 # the container type from std::vector
 override_member_container = {
-    'metadata_response_partition': 'large_fragment_vector'
+    'metadata_response_partition': 'large_fragment_vector',
+    'fetchable_partition_response': 'small_fragment_vector'
 }
 
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -926,9 +926,8 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
 
 // insert and reserve space for a new topic in the response
 void op_context::start_response_topic(const fetch_request::topic& topic) {
-    auto& p = response.data.topics.emplace_back(
+    response.data.topics.emplace_back(
       fetchable_topic_response{.name = topic.name});
-    p.partitions.reserve(topic.fetch_partitions.size());
 }
 
 void op_context::start_response_partition(const fetch_request::partition& p) {
@@ -1058,8 +1057,6 @@ ss::future<response_ptr> op_context::send_response() && {
         if (it->is_new_topic) {
             final_response.data.topics.emplace_back(
               fetchable_topic_response{.name = it->partition->name});
-            final_response.data.topics.back().partitions.reserve(
-              it->partition->partitions.size());
         }
 
         fetch_response::partition_response r{

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -338,3 +338,9 @@ private:
  */
 template<typename T>
 using large_fragment_vector = fragmented_vector<T, 32 * 1024>;
+
+/**
+ * An alias for a fragmented_vector using a smaller fragment size.
+ */
+template<typename T>
+using small_fragment_vector = fragmented_vector<T, 1024>;


### PR DESCRIPTION
Avoid oversize allocations by converting `fetchable_partition_response` to ``small_fragment_vector``

Fixes #11017

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Kafka: Avoid very large contiguous allocations during fetch.
