### PR TITLE
kafka: downgrade log level for isolated node op

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -160,7 +160,7 @@ static ss::future<metadata_response::topic> create_topic(
   const is_node_isolated_or_decommissioned is_node_isolated) {
     if (is_node_isolated) {
         vlog(
-          klog.error,
+          klog.info,
           "Can not autocreate topic({}) in metadata request, because node is "
           "isolated",
           topic);


### PR DESCRIPTION
This bad log lines doesn't seem to deserve the error level. In particular, there is a natural race here. Clients can send requests at any time to brokers, but the condition in which a node is isolated or being decommissioned is delivered asynchronously.
```
rptest.services.utils.BadLogLines: <BadLogLines nodes=docker-rp-21(19) example="ERROR 2023-06-02 22:26:22,805 [shard 0] kafka - metadata.cc:166
- Can not autocreate topic({topic-ipmhnpwjbc}) in metadata request, because node is isolated">
```

Fixes: https://github.com/redpanda-data/redpanda/issues/11186
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

