### PR TITLE
[feature_table] Replace set with unordered_set.

### DIFF
--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <string_view>
+#include <unordered_set>
 
 // cluster classes that we will make friends of the feature_table
 namespace cluster {
@@ -75,7 +76,7 @@ enum class feature : std::uint64_t {
 //
 // retired does *not* mean the functionality is gone: it just means it
 // is no longer guarded by a feature flag.
-inline const std::set<std::string_view> retired_features = {
+inline const std::unordered_set<std::string_view> retired_features = {
   "central_config",
   "consumer_offsets",
   "maintenance_mode",


### PR DESCRIPTION
Ideally a perfect hashing scheme with constexpr support would be used to use minimum memory with guaranteed O(1) lookups, but std::unordered_set is still [better](https://quick-bench.com/q/yo8MP1nByPrdHkPnPekK3tAe2iM) than std::set.

## Release Notes
* none

### Improvements

* The check for unsupported features now has amortized `O(1)` complexity vs previous `O(log(N))`.