### PR TITLE
Remove `last_term_start_offset` from `storage::offset_stats`

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -304,8 +304,9 @@ ss::future<bool> persisted_stm::sync(model::timeout_clock::duration timeout) {
     model::offset sync_offset;
     auto log_offsets = _c->log().offsets();
     if (log_offsets.dirty_offset_term == term) {
-        if (log_offsets.last_term_start_offset > model::offset{0}) {
-            sync_offset = log_offsets.last_term_start_offset - model::offset{1};
+        auto last_term_start_offset = _c->log().find_last_term_start_offset();
+        if (last_term_start_offset > model::offset{0}) {
+            sync_offset = last_term_start_offset - model::offset{1};
         } else {
             sync_offset = model::offset{};
         }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -953,6 +953,34 @@ offset_stats disk_log_impl::offsets() const {
     };
 }
 
+model::offset disk_log_impl::find_last_term_start_offset() const {
+    if (_segs.empty()) {
+        return {};
+    }
+
+    segment_set::type end;
+    segment_set::type term_start;
+    for (int i = (int)_segs.size() - 1; i >= 0; --i) {
+        auto& seg = _segs[i];
+        if (!seg->empty()) {
+            if (!end) {
+                end = seg;
+            }
+            // find term start offset
+            if (seg->offsets().term < end->offsets().term) {
+                break;
+            }
+            term_start = seg;
+        }
+    }
+
+    if (!end) {
+        return {};
+    }
+
+    return term_start->offsets().base_offset;
+}
+
 model::timestamp disk_log_impl::start_timestamp() const {
     if (_segs.empty()) {
         return model::timestamp{};

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -909,18 +909,11 @@ offset_stats disk_log_impl::offsets() const {
     // NOTE: we have to do this because ss::circular_buffer<> does not provide
     // with reverse iterators, so we manually find the iterator
     segment_set::type end;
-    segment_set::type term_start;
     for (int i = (int)_segs.size() - 1; i >= 0; --i) {
         auto& seg = _segs[i];
         if (!seg->empty()) {
-            if (!end) {
-                end = seg;
-            }
-            // find term start offset
-            if (seg->offsets().term < end->offsets().term) {
-                break;
-            }
-            term_start = seg;
+            end = seg;
+            break;
         }
     }
     if (!end) {
@@ -935,8 +928,6 @@ offset_stats disk_log_impl::offsets() const {
     // we have valid begin and end
     const auto& bof = _segs.front()->offsets();
     const auto& eof = end->offsets();
-    // term start
-    const auto term_start_offset = term_start->offsets().base_offset;
 
     const auto start_offset = _start_offset() >= 0 ? _start_offset
                                                    : bof.base_offset;
@@ -949,7 +940,6 @@ offset_stats disk_log_impl::offsets() const {
 
       .dirty_offset = eof.dirty_offset,
       .dirty_offset_term = eof.term,
-      .last_term_start_offset = term_start_offset,
     };
 }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -86,6 +86,7 @@ public:
     timequery(timequery_config cfg) final;
     size_t segment_count() const final { return _segs.size(); }
     offset_stats offsets() const final;
+    model::offset find_last_term_start_offset() const final;
     model::timestamp start_timestamp() const final;
     std::optional<model::term_id> get_term(model::offset) const final;
     std::optional<model::offset>

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -76,6 +76,8 @@ public:
 
         virtual size_t segment_count() const = 0;
         virtual storage::offset_stats offsets() const = 0;
+        // Base offset of the first batch in the most recent term stored in log
+        virtual model::offset find_last_term_start_offset() const = 0;
         virtual model::timestamp start_timestamp() const = 0;
         virtual std::ostream& print(std::ostream& o) const = 0;
         virtual std::optional<model::term_id> get_term(model::offset) const = 0;
@@ -160,7 +162,9 @@ public:
     }
 
     storage::offset_stats offsets() const { return _impl->offsets(); }
-
+    model::offset find_last_term_start_offset() const {
+        return _impl->find_last_term_start_offset();
+    }
     std::optional<model::term_id> get_term(model::offset o) const {
         return _impl->get_term(o);
     }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -103,9 +103,9 @@ FIXTURE_TEST(
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
+    auto last_term_start_offset = log.find_last_term_start_offset();
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
     validate_offsets(model::offset(0), headers, batches);
 };
@@ -127,8 +127,8 @@ FIXTURE_TEST(append_twice_to_same_segment, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    auto last_term_start_offset = log.find_last_term_start_offset();
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
 };
@@ -148,8 +148,8 @@ FIXTURE_TEST(test_assigning_offsets_in_multiple_segment, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    auto last_term_start_offset = log.find_last_term_start_offset();
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
     validate_offsets(model::offset(0), headers, batches);
@@ -184,8 +184,8 @@ FIXTURE_TEST(test_single_record_per_segment, storage_test_fixture) {
     info("Flushed log: {}", log);
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    auto last_term_start_offset = log.find_last_term_start_offset();
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
     validate_offsets(model::offset(0), headers, batches);
@@ -223,8 +223,8 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
     info("Flushed log: {}", log);
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    auto last_term_start_offset = log.find_last_term_start_offset();
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
     validate_offsets(model::offset(0), headers, batches);
@@ -249,8 +249,7 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
     auto new_lstats = log.offsets();
     BOOST_REQUIRE_GE(new_lstats.committed_offset, lstats.committed_offset);
     auto new_batches = read_and_validate_all_batches(log);
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(
       new_lstats.committed_offset, new_batches.back().last_offset());
 };
@@ -314,8 +313,8 @@ FIXTURE_TEST(test_rolling_term, storage_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           model::term_id(i),
           log.get_term(current_offset - model::offset(1)).value());
-        auto lstats = log.offsets();
-        BOOST_REQUIRE_EQUAL(lstats.last_term_start_offset, term_start_offset);
+        auto last_term_start_offset = log.find_last_term_start_offset();
+        BOOST_REQUIRE_EQUAL(last_term_start_offset, term_start_offset);
         std::move(part.begin(), part.end(), std::back_inserter(headers));
     }
 

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -146,14 +146,12 @@ std::ostream& operator<<(std::ostream& o, const offset_stats& s) {
     fmt::print(
       o,
       "{{start_offset:{}, committed_offset:{}, "
-      "committed_offset_term:{}, dirty_offset:{}, dirty_offset_term:{}, "
-      "last_term_start_offset:{}}}",
+      "committed_offset_term:{}, dirty_offset:{}, dirty_offset_term:{}}}",
       s.start_offset,
       s.committed_offset,
       s.committed_offset_term,
       s.dirty_offset,
-      s.dirty_offset_term,
-      s.last_term_start_offset);
+      s.dirty_offset_term);
     return o;
 }
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -167,12 +167,6 @@ struct offset_stats {
 
     model::offset dirty_offset;
     model::term_id dirty_offset_term;
-    // Base offset of the first batch in the most recent term stored in log
-    //
-    // The last_term_base offset will be used by the followers to inform the
-    // raft group leader about the next possible index where truncation should
-    // happen while recovering node log.
-    model::offset last_term_start_offset;
 
     friend std::ostream& operator<<(std::ostream&, const offset_stats&);
 };


### PR DESCRIPTION
This PR removes the calculation of `last_term_start_offset` from  `storage::log::offsets()` and adds a separate function to calculate it. 

### Motivation
This value is only ever used in `persisted_stm` on term changes. And the `storage::log::offsets` function that calculates it often shows up on `perf top` and is on the produce path. This PR reduces the time complexity of the function from being linear to the number of segments since term start to being constant in most cases.

Additionally this PR is the first of likely a few to reduce reactor utilization when partitions have many segments. I.e,

Reactor utilization vs number of 128MiB segments on a 500MB/s produce/consume OMB test;
![image](https://github.com/redpanda-data/redpanda/assets/3487600/81eb6814-471f-458c-b8fa-d5c42ed1b346)

Reactor utilization vs number of 3GiB segments on the same OMB test;
![image](https://github.com/redpanda-data/redpanda/assets/3487600/0e593bc7-7bf4-4dae-88ae-59a5bed57b4c)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
