### PR TITLE
Fixed `test_partition_balancer_with_many_partitions` setup

### DIFF
--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -121,7 +121,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             message_cnt = 819200
             consumers = 8
             partitions_count = self._max_partition_count(
-                len(self.redpanda.nodes))
+                len(self.redpanda.nodes) - 1)
             timeout = 500
         else:
             message_size = 128 * (2**10)

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -114,6 +114,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             message_cnt = 64000
             consumers = 1
             partitions_count = 16
+            timeout = 120
         elif type == self.MANY_PARTITIONS:
 
             message_size = 128 * (2**10)


### PR DESCRIPTION
Fixed setup of `PartitionBalancerScaleTest::test_partition_balancer_with_many_partitions`. Previously the number of created partitions did not taken into account the node which is stopped during the test. 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Fixes: #9337
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
