### PR TITLE
Do not query decommissioned nodes

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -551,9 +551,13 @@ class AdminOperationsFuzzer():
         try:
             self.attempted += 1
             if self.execute_with_retries(op_type, op):
-                wait_until(validate_result,
-                           timeout_sec=self.operation_timeout,
-                           backoff_sec=1)
+                wait_until(
+                    validate_result,
+                    timeout_sec=self.operation_timeout,
+                    backoff_sec=1,
+                    err_msg=
+                    f"Timeout waiting for {op.describe()} operation validation"
+                )
                 self.executed += 1
                 sleep(self.operations_interval)
                 return True
@@ -563,7 +567,8 @@ class AdminOperationsFuzzer():
                 )
                 return False
         except Exception as e:
-            self.redpanda.logger.debug(f"Operation: {op_type}", exc_info=True)
+            self.redpanda.logger.error(f"Operation: {op.describe()} failed",
+                                       exc_info=True)
             raise e
 
     def execute_with_retries(self, op_type, op):

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -133,15 +133,21 @@ class DeleteTopicOperation(Operation):
         if self.topic is None:
             return False
         ctx.redpanda.logger.info(f"Validating topic {self.topic} deletion")
-
+        try:
+            brokers = ctx.admin().get_brokers()
+        except:
+            return False
         # since metadata in Redpanda and Kafka are eventually consistent
         # we must check all the nodes before proceeding
-        for n in ctx.redpanda.started_nodes():
+        for b in brokers:
+            n = ctx.redpanda.get_node_by_id(b["node_id"])
+            if n not in ctx.redpanda.started_nodes():
+                continue
             # we will check does topic_table contain any info about our topic and partition 0. If not we can assume that topic was deleted
             try:
-                info = ctx.admin().get_partitions(node=n,
-                                                  topic=self.topic,
-                                                  partition=0)
+                ctx.admin().get_partitions(node=n,
+                                           topic=self.topic,
+                                           partition=0)
                 ctx.redpanda.logger.info(
                     f"found deleted topic {self.topic} on node {n.account.hostname}"
                 )
@@ -227,7 +233,14 @@ class AddPartitionsOperation(Operation):
     def _current_partition_count(self, ctx):
 
         per_node_count = set()
-        for n in ctx.redpanda.started_nodes():
+        try:
+            brokers = ctx.admin().get_brokers()
+        except:
+            return None
+        for b in brokers:
+            n = ctx.redpanda.get_node_by_id(b['node_id'])
+            if n not in ctx.redpanda.started_nodes():
+                continue
             node_version = int_tuple(
                 VERSION_RE.findall(ctx.redpanda.get_version(n))[0])
             # do not query nodes with redpanda version prior to v23.1.x


### PR DESCRIPTION
When answering the admin API requests a node should be a cluster member,
otherwise it may returned stalled data which will never converge to the
expected state. 

Made admin operations fuzzer aware of decommissioned node to prevent querying stale state.

Fixes: #11158 
Fixes: #9293

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none