### PR TITLE
cloud_metadata: plug upload loop into application

### DIFF
--- a/src/v/cluster/cloud_metadata/manifest_downloads.cc
+++ b/src/v/cluster/cloud_metadata/manifest_downloads.cc
@@ -22,6 +22,9 @@ namespace {
 const std::regex cluster_metadata_manifest_prefix_expr{
   R"REGEX(cluster_metadata/[a-z0-9-]+/manifests/(\d+)/)REGEX"};
 
+const std::regex cluster_metadata_manifest_expr{
+  R"REGEX(cluster_metadata/([a-z0-9-]+)/manifests/(\d+)/cluster_manifest.json)REGEX"};
+
 } // anonymous namespace
 
 namespace cluster::cloud_metadata {
@@ -72,10 +75,14 @@ ss::future<cluster_manifest_result> download_highest_manifest_for_cluster(
         if (!matches_manifest_expr) {
             continue;
         }
+        vassert(
+          matches.size() >= 2,
+          "Unexpected size of regex match",
+          matches.size());
         const auto& meta_id_str = matches[1].str();
         cluster_metadata_id meta_id;
         try {
-            meta_id = cluster_metadata_id(std::stoi(meta_id_str.c_str()));
+            meta_id = cluster_metadata_id(std::stol(meta_id_str.c_str()));
         } catch (...) {
             vlog(
               clusterlog.debug,
@@ -143,6 +150,90 @@ ss::future<std::list<ss::sstring>> list_orphaned_by_manifest(
         ret.emplace_back(std::move(item.key));
     }
     co_return ret;
+}
+
+ss::future<cluster_manifest_result> download_highest_manifest_in_bucket(
+  cloud_storage::remote& remote,
+  const cloud_storage_clients::bucket_name& bucket,
+  retry_chain_node& retry_node) {
+    // Look for unique cluster UUIDs for which we have metadata.
+    constexpr auto cluster_prefix = "cluster_metadata/";
+    vlog(clusterlog.trace, "Listing objects with prefix {}", cluster_prefix);
+    auto list_res = co_await remote.list_objects(
+      bucket,
+      retry_node,
+      cloud_storage_clients::object_key(cluster_prefix),
+      std::nullopt);
+    if (list_res.has_error()) {
+        vlog(clusterlog.debug, "Error downloading manifest", list_res.error());
+        co_return error_outcome::list_failed;
+    }
+    // Examine all cluster metadata in this bucket.
+    auto& cluster_metadata_items = list_res.value().contents;
+    if (cluster_metadata_items.empty()) {
+        vlog(clusterlog.debug, "No manifests found in bucket {}", bucket());
+        co_return error_outcome::no_matching_metadata;
+    }
+
+    // Look through those that look like cluster metadata manifests and find
+    // the one with the highest metadata ID. This will be the returned to the
+    // caller.
+    model::cluster_uuid uuid_with_highest_meta_id{};
+    cluster_metadata_id highest_meta_id{};
+    for (const auto& item : cluster_metadata_items) {
+        std::smatch matches;
+        std::string k = item.key;
+        const auto matches_manifest_expr = std::regex_match(
+          k.cbegin(), k.cend(), matches, cluster_metadata_manifest_expr);
+        if (!matches_manifest_expr) {
+            continue;
+        }
+        const auto& cluster_uuid_str = matches[1].str();
+        const auto& meta_id_str = matches[2].str();
+        cluster_metadata_id meta_id{};
+        model::cluster_uuid cluster_uuid{};
+        try {
+            meta_id = cluster_metadata_id(std::stoi(meta_id_str.c_str()));
+        } catch (...) {
+            vlog(
+              clusterlog.debug,
+              "Ignoring invalid metadata ID: {}",
+              meta_id_str);
+            continue;
+        }
+        try {
+            auto u = boost::lexical_cast<uuid_t::underlying_t>(
+              cluster_uuid_str);
+            std::vector<uint8_t> uuid_vec{u.begin(), u.end()};
+            cluster_uuid = model::cluster_uuid(std::move(uuid_vec));
+        } catch (...) {
+            vlog(
+              clusterlog.debug,
+              "Ignoring invalid cluster UUID: {}",
+              cluster_uuid_str);
+            continue;
+        }
+        if (meta_id > highest_meta_id) {
+            highest_meta_id = meta_id;
+            uuid_with_highest_meta_id = cluster_uuid;
+        }
+    }
+    if (highest_meta_id == cluster_metadata_id{}) {
+        vlog(clusterlog.debug, "No valid manifests in bucket {}", bucket());
+        co_return error_outcome::no_matching_metadata;
+    }
+    cluster_metadata_manifest manifest;
+    auto manifest_res = co_await remote.download_manifest(
+      bucket,
+      cluster_manifest_key(uuid_with_highest_meta_id, highest_meta_id),
+      manifest,
+      retry_node);
+    if (manifest_res != cloud_storage::download_result::success) {
+        vlog(
+          clusterlog.debug, "Manifest download failed with {}", manifest_res);
+        co_return error_outcome::download_failed;
+    }
+    co_return manifest;
 }
 
 } // namespace cluster::cloud_metadata

--- a/src/v/cluster/cloud_metadata/manifest_downloads.h
+++ b/src/v/cluster/cloud_metadata/manifest_downloads.h
@@ -48,4 +48,15 @@ ss::future<std::list<ss::sstring>> list_orphaned_by_manifest(
   const cluster_metadata_manifest& manifest,
   retry_chain_node& retry_node);
 
+// Looks through the given bucket for cluster metadata with the highest
+// metadata ID.
+// - list_failed/download_failed: there was a physical error sending requests
+//   to remote storage, preventing us from returning an accurate result.
+// - no_matching_metadata: we were able to list an sift through the bucket, but
+//   no cluster metadata manifest exists.
+ss::future<cluster_manifest_result> download_highest_manifest_in_bucket(
+  cloud_storage::remote& remote,
+  const cloud_storage_clients::bucket_name& bucket,
+  retry_chain_node& retry_node);
+
 } // namespace cluster::cloud_metadata

--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -20,6 +20,7 @@
 #include "cluster/config_frontend.h"
 #include "cluster/controller_snapshot.h"
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "redpanda/application.h"
 #include "redpanda/tests/fixture.h"
@@ -67,9 +68,23 @@ public:
         auto m_res = co_await download_highest_manifest_for_cluster(
           remote, cluster_uuid, bucket, retry_node);
         if (!m_res.has_value()) {
+            vlog(
+              logger.debug,
+              "Current manifest has id {}, waiting for > {}",
+              -1,
+              initial_meta_id);
             co_return false;
         }
         if (m_res.value().metadata_id <= initial_meta_id) {
+            vlog(
+              logger.debug,
+              "Current manifest has id {}, waiting for > {}",
+              m_res.value(),
+              initial_meta_id);
+            co_return false;
+        }
+        if (m_res.value().controller_snapshot_path.empty()) {
+            vlog(logger.debug, "Missing controller snapshot");
             co_return false;
         }
         *downloaded_manifest = std::move(m_res.value());
@@ -117,12 +132,7 @@ protected:
 
 FIXTURE_TEST(
   test_download_highest_manifest, cluster_metadata_uploader_fixture) {
-    cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(),
-      app.storage.local(),
-      bucket,
-      remote,
-      raft0);
+    auto& uploader = app.controller->metadata_uploader();
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::max(), 10ms);
 
@@ -161,12 +171,7 @@ FIXTURE_TEST(
 
 FIXTURE_TEST(
   test_download_highest_manifest_errors, cluster_metadata_uploader_fixture) {
-    cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(),
-      app.storage.local(),
-      bucket,
-      remote,
-      raft0);
+    auto& uploader = app.controller->metadata_uploader();
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::min(), 10ms);
     auto down_res
@@ -176,12 +181,7 @@ FIXTURE_TEST(
 }
 
 FIXTURE_TEST(test_upload_next_metadata, cluster_metadata_uploader_fixture) {
-    cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(),
-      app.storage.local(),
-      bucket,
-      remote,
-      raft0);
+    auto& uploader = app.controller->metadata_uploader();
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::max(), 10ms);
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
@@ -280,12 +280,7 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
 
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
-    cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(),
-      app.storage.local(),
-      bucket,
-      remote,
-      raft0);
+    auto& uploader = app.controller->metadata_uploader();
     cluster::cloud_metadata::cluster_metadata_id highest_meta_id{0};
 
     // Checks that metadata is uploaded a new term, stepping down in between
@@ -298,13 +293,6 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
 
           // Start uploading in this term.
           auto upload_in_term = uploader.upload_until_term_change();
-          auto defer = ss::defer([&] {
-              uploader.stop_and_wait().get();
-              try {
-                  upload_in_term.get();
-              } catch (...) {
-              }
-          });
 
           // Keep checking the latest manifest for whether the metadata ID is
           // some non-zero value (indicating we've uploaded multiple manifests);
@@ -323,7 +311,6 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
           // Stop the upload loop and continue in a new term.
           raft0->step_down("forced stepdown").get();
           upload_in_term.get();
-          defer.cancel();
       };
     for (int i = 0; i < 3; ++i) {
         check_uploads_in_term_and_stepdown(snap_offset);
@@ -353,22 +340,10 @@ FIXTURE_TEST(
       5s, [this] { return controller_stm.maybe_write_snapshot(); });
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
-    cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(),
-      app.storage.local(),
-      bucket,
-      remote,
-      raft0);
+    auto& uploader = app.controller->metadata_uploader();
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
 
     auto upload_in_term = uploader.upload_until_term_change();
-    auto defer = ss::defer([&] {
-        uploader.stop_and_wait().get();
-        try {
-            upload_in_term.get();
-        } catch (...) {
-        }
-    });
     // Wait for some valid metadata to show up.
     cluster::cloud_metadata::cluster_metadata_manifest manifest;
     RPTEST_REQUIRE_EVENTUALLY(5s, [this, &manifest] {
@@ -404,19 +379,13 @@ FIXTURE_TEST(
 }
 
 FIXTURE_TEST(test_run_loop, cluster_metadata_uploader_fixture) {
+    RPTEST_REQUIRE_EVENTUALLY(
+      5s, [this] { return controller_stm.maybe_write_snapshot(); });
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
-    cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(),
-      app.storage.local(),
-      bucket,
-      remote,
-      raft0);
-    retry_chain_node retry_node(
-      never_abort, ss::lowres_clock::time_point::max(), 10ms);
+    auto& uploader = app.controller->metadata_uploader();
     // Run the upload loop and make sure that new leaders continue to upload.
     uploader.start();
-    auto stop = ss::defer([&] { uploader.stop_and_wait().get(); });
     cluster::cloud_metadata::cluster_metadata_id highest_meta_id{-1};
     for (int i = 0; i < 3; i++) {
         auto initial_meta_id = highest_meta_id;

--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -118,7 +118,11 @@ protected:
 FIXTURE_TEST(
   test_download_highest_manifest, cluster_metadata_uploader_fixture) {
     cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(), cluster_uuid, bucket, remote, raft0);
+      app.raft_group_manager.local(),
+      app.storage.local(),
+      bucket,
+      remote,
+      raft0);
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::max(), 10ms);
 
@@ -158,7 +162,11 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   test_download_highest_manifest_errors, cluster_metadata_uploader_fixture) {
     cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(), cluster_uuid, bucket, remote, raft0);
+      app.raft_group_manager.local(),
+      app.storage.local(),
+      bucket,
+      remote,
+      raft0);
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::min(), 10ms);
     auto down_res
@@ -169,7 +177,11 @@ FIXTURE_TEST(
 
 FIXTURE_TEST(test_upload_next_metadata, cluster_metadata_uploader_fixture) {
     cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(), cluster_uuid, bucket, remote, raft0);
+      app.raft_group_manager.local(),
+      app.storage.local(),
+      bucket,
+      remote,
+      raft0);
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::max(), 10ms);
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
@@ -269,7 +281,11 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
     cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(), cluster_uuid, bucket, remote, raft0);
+      app.raft_group_manager.local(),
+      app.storage.local(),
+      bucket,
+      remote,
+      raft0);
     cluster::cloud_metadata::cluster_metadata_id highest_meta_id{0};
 
     // Checks that metadata is uploaded a new term, stepping down in between
@@ -338,7 +354,11 @@ FIXTURE_TEST(
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
     cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(), cluster_uuid, bucket, remote, raft0);
+      app.raft_group_manager.local(),
+      app.storage.local(),
+      bucket,
+      remote,
+      raft0);
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
 
     auto upload_in_term = uploader.upload_until_term_change();
@@ -387,7 +407,11 @@ FIXTURE_TEST(test_run_loop, cluster_metadata_uploader_fixture) {
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
     cluster::cloud_metadata::uploader uploader(
-      app.raft_group_manager.local(), cluster_uuid, bucket, remote, raft0);
+      app.raft_group_manager.local(),
+      app.storage.local(),
+      bucket,
+      remote,
+      raft0);
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::max(), 10ms);
     // Run the upload loop and make sure that new leaders continue to upload.

--- a/src/v/cluster/cloud_metadata/uploader.h
+++ b/src/v/cluster/cloud_metadata/uploader.h
@@ -15,6 +15,7 @@
 #include "cluster/types.h"
 #include "config/property.h"
 #include "seastarx.h"
+#include "storage/fwd.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/future.hh>
@@ -44,7 +45,7 @@ class uploader {
 public:
     uploader(
       raft::group_manager& group_manager,
-      model::cluster_uuid cluster_uuid,
+      storage::api& storage,
       cloud_storage_clients::bucket_name bucket,
       cloud_storage::remote& remote,
       consensus_ptr raft0);
@@ -111,7 +112,8 @@ private:
     ss::future<bool> term_has_changed(model::term_id);
 
     raft::group_manager& _group_manager;
-    const model::cluster_uuid _cluster_uuid;
+    storage::api& _storage;
+    model::cluster_uuid _cluster_uuid;
     cloud_storage::remote& _remote;
     consensus_ptr _raft0;
     const cloud_storage_clients::bucket_name _bucket;

--- a/src/v/cluster/cloud_metadata/uploader.h
+++ b/src/v/cluster/cloud_metadata/uploader.h
@@ -23,6 +23,10 @@ namespace cloud_storage {
 class remote;
 } // namespace cloud_storage
 
+namespace raft {
+class group_manager;
+} // namespace raft
+
 namespace cluster::cloud_metadata {
 
 // Periodically uploads cluster metadata within a given term.
@@ -39,12 +43,19 @@ namespace cluster::cloud_metadata {
 class uploader {
 public:
     uploader(
+      raft::group_manager& group_manager,
       model::cluster_uuid cluster_uuid,
       cloud_storage_clients::bucket_name bucket,
       cloud_storage::remote& remote,
       consensus_ptr raft0);
 
+    // Begins the upload loop and listens for leadership changes.
+    void start();
+
+    // Stops the upload loop.
     ss::future<> stop_and_wait();
+
+    ss::future<> upload_until_abort();
 
     // Periodically uploads cluster metadata for as long as the local
     // controller replica is the leader.
@@ -99,6 +110,7 @@ private:
     // the input term.
     ss::future<bool> term_has_changed(model::term_id);
 
+    raft::group_manager& _group_manager;
     const model::cluster_uuid _cluster_uuid;
     cloud_storage::remote& _remote;
     consensus_ptr _raft0;
@@ -108,6 +120,14 @@ private:
 
     ss::gate _gate;
     ss::abort_source _as;
+
+    cluster::notification_id_type _leader_cb_id{notification_id_type_invalid};
+
+    // Abort source to stop sleeping if there is a term change.
+    std::optional<std::reference_wrapper<ss::abort_source>> _term_as;
+
+    // Used to wait for leadership. It will be triggered by notify_leadership.
+    ss::condition_variable _leader_cond;
 };
 
 } // namespace cluster::cloud_metadata

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -564,7 +564,9 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             bucket,
             _cloud_storage_api.local(),
             _raft0);
-          _metadata_uploader->start();
+          if (config::shard_local_cfg().enable_cluster_metadata_upload_loop()) {
+              _metadata_uploader->start();
+          }
       });
 }
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -10,6 +10,7 @@
 #include "cluster/controller.h"
 
 #include "cluster/bootstrap_backend.h"
+#include "cluster/cloud_metadata/uploader.h"
 #include "cluster/cluster_discovery.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/config_frontend.h"
@@ -59,6 +60,7 @@
 #include "security/ephemeral_credential_store.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/future.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/util/later.hh>
@@ -95,6 +97,10 @@ controller::controller(
   , _cloud_storage_api(cloud_storage_api)
   , _node_status_table(node_status_table)
   , _probe(*this) {}
+
+// Explicit destructor in the .cc file just to avoid bloating the header with
+// includes for destructors of all its members (e.g. the metadata uploader).
+controller::~controller() = default;
 
 ss::future<> controller::wire_up() {
     return _as.start()
@@ -542,6 +548,23 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
           return _partition_balancer.invoke_on(
             partition_balancer_backend::shard,
             &partition_balancer_backend::start);
+      })
+      .then([this] {
+          auto& bucket_property
+            = cloud_storage::configuration::get_bucket_config();
+          if (
+            !bucket_property.is_overriden() || !bucket_property().has_value()
+            || !_cloud_storage_api.local_is_initialized()) {
+              return;
+          }
+          cloud_storage_clients::bucket_name bucket(bucket_property().value());
+          _metadata_uploader = std::make_unique<cloud_metadata::uploader>(
+            _raft_manager.local(),
+            _storage.local(),
+            bucket,
+            _cloud_storage_api.local(),
+            _raft0);
+          _metadata_uploader->start();
       });
 }
 
@@ -581,6 +604,12 @@ ss::future<> controller::stop() {
                   }
                   return ss::now();
               });
+          })
+          .then([this] {
+              if (_metadata_uploader) {
+                  return _metadata_uploader->stop_and_wait();
+              }
+              return ss::make_ready_future();
           })
           .then([this] { return _partition_balancer.stop(); })
           .then([this] { return _metrics_reporter.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -130,6 +130,10 @@ public:
     }
     ss::sharded<controller_stm>& get_controller_stm() { return _stm; }
 
+    cloud_metadata::uploader& metadata_uploader() {
+        return *_metadata_uploader;
+    }
+
     bool is_raft0_leader() const {
         vassert(
           ss::this_shard_id() == ss::shard_id(0),

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -30,6 +30,10 @@
 
 namespace cluster {
 
+namespace cloud_metadata {
+class uploader;
+} // namespace cloud_metadata
+
 class cluster_discovery;
 
 class controller {
@@ -45,6 +49,8 @@ public:
       ss::sharded<features::feature_table>&,
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<node_status_table>&);
+
+    ~controller();
 
     model::node_id self() { return _raft0->self().id(); }
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }
@@ -242,6 +248,8 @@ private:
     ss::sharded<features::feature_table>& _feature_table; // instance per core
     std::unique_ptr<leader_balancer> _leader_balancer;
     ss::sharded<partition_balancer_backend> _partition_balancer;
+    std::unique_ptr<cloud_metadata::uploader> _metadata_uploader;
+
     ss::gate _gate;
     consensus_ptr _raft0;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1476,6 +1476,14 @@ configuration::configuration()
       "set in production.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , enable_cluster_metadata_upload_loop(
+      *this,
+      "enable_cluster_metadata_upload_loop",
+      "Enables the cluster metadata upload loop.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      // TODO: set to true by default once the feature is ready.
+      // TODO: make this runtime configurable.
+      false)
   , cloud_storage_max_segments_pending_deletion_per_partition(
       *this,
       "cloud_storage_max_segments_pending_deletion_per_partition",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -293,6 +293,7 @@ struct configuration final : public config_store {
     property<bool> cloud_storage_enable_segment_merging;
     property<bool> cloud_storage_disable_upload_loop_for_tests;
     property<bool> cloud_storage_disable_read_replica_loop_for_tests;
+    property<bool> enable_cluster_metadata_upload_loop;
     property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;
     property<bool> cloud_storage_enable_compacted_topic_reupload;
     property<size_t> cloud_storage_recovery_temporary_retention_bytes_default;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -188,6 +188,7 @@ application::application(ss::sstring logger_name)
 application::~application() = default;
 
 void application::shutdown() {
+    storage.invoke_on_all(&storage::api::stop_cluster_uuid_waiters).get();
     // Stop accepting new requests.
     if (_kafka_server.local_is_initialized()) {
         _kafka_server.invoke_on_all(&net::server::shutdown_input).get();

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1904,6 +1904,9 @@ class RedpandaService(RedpandaServiceBase):
             self.write_tls_certs()
             self.write_bootstrap_cluster_config()
 
+        if start_si and self._si_settings is not None:
+            self.start_si()
+
         def start_one(node):
             node_overrides = node_config_overrides[
                 node] if node in node_config_overrides else {}
@@ -1967,9 +1970,6 @@ class RedpandaService(RedpandaServiceBase):
                                          sasl_plain_password=password,
                                          request_timeout_ms=30000,
                                          api_version_auto_timeout_ms=3000)
-
-        if start_si and self._si_settings is not None:
-            self.start_si()
 
     def write_tls_certs(self):
         if not self._security.tls_provider:

--- a/tests/rptest/tests/cluster_metadata_upload_test.py
+++ b/tests/rptest/tests/cluster_metadata_upload_test.py
@@ -1,0 +1,141 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import SISettings, get_cloud_storage_type
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.si_utils import BucketView, ClusterMetadata, parse_controller_snapshot_path
+
+
+def check_cluster_metadata_is_consistent(s3_snapshot: BucketView):
+    """
+    Takes the given snapshot and ensures that the highest manifest available
+    (that would be used in a recovery) only references objects that exist in
+    the bucket.
+    """
+    latest_cluster_metadata = ClusterMetadata(dict(), dict())
+    highest_meta_id = -1
+    cluster_uuid = ""
+    for uuid, meta in s3_snapshot.cluster_metadata.items():
+        for meta_id, _ in meta.cluster_metadata_manifests.items():
+            if meta_id > highest_meta_id:
+                latest_cluster_metadata = meta
+                cluster_uuid = uuid
+                highest_meta_id = meta_id
+    highest_manifest = latest_cluster_metadata.cluster_metadata_manifests[
+        highest_meta_id]
+    assert 'controller_snapshot_path' in highest_manifest, highest_manifest
+    controller_snapshot_path = highest_manifest['controller_snapshot_path']
+    assert len(controller_snapshot_path) > 0, highest_manifest
+
+    _, snap_offset = parse_controller_snapshot_path(controller_snapshot_path)
+    assert snap_offset in latest_cluster_metadata.controller_snapshot_sizes, \
+        f"Couldn't find {snap_offset} in {latest_cluster_metadata.controller_snapshot_sizes}"
+    assert latest_cluster_metadata.controller_snapshot_sizes[snap_offset] > 0
+    return cluster_uuid, highest_meta_id
+
+
+class ClusterMetadataUploadTest(RedpandaTest):
+    topic_name = "oolong"
+    topics = (TopicSpec(name=topic_name, partition_count=10), )
+    segment_size = 1024 * 1024
+
+    def __init__(self, test_context):
+        si_settings = SISettings(test_context,
+                                 log_segment_size=self.segment_size,
+                                 fast_uploads=True)
+        extra_rp_conf = {
+            'controller_snapshot_max_age_sec': 1,
+            'cloud_storage_cluster_metadata_upload_interval_ms': 1000,
+            'enable_cluster_metadata_upload_loop': True,
+        }
+        super().__init__(test_context,
+                         si_settings=si_settings,
+                         num_brokers=3,
+                         extra_rp_conf=extra_rp_conf)
+
+    def bucket_has_metadata(self, at_least: int):
+        """
+        Returns true if at least some metadata exist in the bucket.
+        As new metadata is written, the upload loop may be cleaning up after
+        itself, so ignores exceptions.
+        """
+        try:
+            s3_snapshot = BucketView(self.redpanda, topics=self.topics)
+            num_cluster_metas = 0
+            for _, meta in s3_snapshot.cluster_metadata.items():
+                if len(meta.cluster_metadata_manifests) > 0 and len(
+                        meta.controller_snapshot_sizes) > 0:
+                    num_cluster_metas += 1
+            return num_cluster_metas >= at_least
+        except Exception as e:
+            self.logger.warn(f"Error while populating snapshot: {str(e)}")
+            return False
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_uploads_after_restart(self, cloud_storage_type):
+        """
+        Ensure that metadata uploads proceed after restarting, upholding the
+        invariant that manifest IDs are monotonically increasing.
+        """
+        self.redpanda._admin.put_feature("controller_snapshots",
+                                         {"state": "active"})
+
+        wait_until(lambda: self.bucket_has_metadata(1),
+                   timeout_sec=10,
+                   backoff_sec=1)
+
+        # Stop the cluster so we can check consistency of the bucket without
+        # Redpanda deleting objects beneath us.
+        self.redpanda.stop()
+        s3_snapshot = BucketView(self.redpanda, topics=self.topics)
+        cluster_uuid, orig_highest_manifest_id = check_cluster_metadata_is_consistent(
+            s3_snapshot)
+        orig_lowest_manifest_id = \
+            min(s3_snapshot.cluster_metadata[cluster_uuid].cluster_metadata_manifests.items())
+
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # Wait for the metadata ID to increase, as metadata is written by a
+        # new leader. As we wait, make sure some other invariants are true:
+        # - the metadata ID shouldn't go down
+        # - the highest manifest should always point to existing files
+        def meta_id_has_grown(by_at_least: int):
+            try:
+                # Since Redpanda is running and deleting old metadata, it's
+                # possible that listing the bucket and parsing everything don't
+                # quite match up. Ignore errors until we parse the snapshot
+                # successfully without any NoSuchKey errors.
+                s3_snapshot = BucketView(self.redpanda, topics=self.topics)
+                s3_snapshot._ensure_listing()
+            except Exception as e:
+                self.logger.warn(f"Error while populating snapshot: {str(e)}")
+                return False
+
+            new_lowest_manifest_id = \
+                min(s3_snapshot.cluster_metadata[cluster_uuid].cluster_metadata_manifests.items())
+            assert new_lowest_manifest_id >= orig_lowest_manifest_id, \
+                f"Cluster metadata manifest ID went down from {orig_lowest_manifest_id} to " \
+                "{new_lowest_manifest_id}: {s3_snapshot}"
+            _, new_highest_manifest_id = check_cluster_metadata_is_consistent(
+                s3_snapshot)
+            return new_highest_manifest_id > orig_highest_manifest_id + by_at_least
+
+        wait_until(lambda: meta_id_has_grown(5),
+                   timeout_sec=10,
+                   backoff_sec=0.1)
+        # The topic manifest may not have been uploaded yet, but that's fine
+        # since this test focuses on cluster metadata only.
+        self.redpanda.si_settings.set_expected_damage(
+            {"ntr_no_topic_manifest"})

--- a/tools/rp_storage_tool/src/bucket_reader.rs
+++ b/tools/rp_storage_tool/src/bucket_reader.rs
@@ -1024,7 +1024,7 @@ impl BucketReader {
                 debug!("No manifests for cluster {}", cluster_uuid);
                 continue;
             };
-            if !highest_manifest.controller_snapshot_path.is_empty() {
+            if highest_manifest.controller_snapshot_path.is_empty() {
                 continue;
             }
             if !meta


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR adds the controller uploader into the application:
- Plumbs the uploader into the controller, optionally avoiding the start() call for easier testing and backportability
- Register appropriate callbacks to allow the controller to listen to leadership changes
- Allows the uploader to wait for the cluster UUID to be set in the storage layer

Along the way, in testing, I found that subsequent usage of the same bucket previously resulted in multiple clusters contending with each others metadata IDs. This PR also tweaks the uploader to start its count from a metadata ID that is higher than the highest in the bucket, ensuring a single bucket can be used across multiple recoveries.

Fixes https://github.com/redpanda-data/redpanda/issues/9552

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
