### PR TITLE
Schema Registry: `GET /schemas/ids/<id>` should return references

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -273,7 +273,7 @@ build_file(pb::DescriptorPool& dp, const pb::FileDescriptorProto& fdp) {
 /// on stack unwind.
 ss::future<const pb::FileDescriptor*> build_file_with_refs(
   pb::DescriptorPool& dp, sharded_store& store, canonical_schema schema) {
-    for (const auto& ref : schema.refs()) {
+    for (const auto& ref : schema.def().refs()) {
         if (dp.FindFileByName(ref.name)) {
             continue;
         }
@@ -282,10 +282,7 @@ ss::future<const pb::FileDescriptor*> build_file_with_refs(
         co_await build_file_with_refs(
           dp,
           store,
-          canonical_schema{
-            subject{ref.name},
-            std::move(dep.schema).def(),
-            std::move(dep.schema).refs()});
+          canonical_schema{subject{ref.name}, std::move(dep.schema).def()});
     }
 
     parser p;
@@ -345,8 +342,9 @@ operator<<(std::ostream& os, const protobuf_schema_definition& def) {
 ss::future<protobuf_schema_definition>
 make_protobuf_schema_definition(sharded_store& store, canonical_schema schema) {
     auto impl = ss::make_shared<protobuf_schema_definition::impl>();
+    auto refs = schema.def().refs();
     impl->fd = co_await import_schema(impl->_dp, store, std::move(schema));
-    co_return protobuf_schema_definition{std::move(impl)};
+    co_return protobuf_schema_definition{std::move(impl), std::move(refs)};
 }
 
 ss::future<canonical_schema_definition>
@@ -362,12 +360,11 @@ make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema) {
     canonical_schema temp{
       std::move(schema).sub(),
       {canonical_schema_definition::raw_string{schema.def().raw()()},
-       schema.def().type()},
-      std::move(schema).refs()};
+       schema.def().type(),
+       schema.def().refs()}};
 
     auto validated = co_await validate_protobuf_schema(store, temp);
-    co_return canonical_schema{
-      std::move(temp).sub(), std::move(validated), std::move(temp).refs()};
+    co_return canonical_schema{std::move(temp).sub(), std::move(validated)};
     // NOLINTEND(bugprone-use-after-move)
 }
 

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
@@ -30,6 +30,21 @@ inline void rjson_serialize(
     }
     w.Key("schema");
     ::json::rjson_serialize(w, res.definition.raw());
+    if (!res.definition.refs().empty()) {
+        w.Key("references");
+        w.StartArray();
+        for (const auto& ref : res.definition.refs()) {
+            w.StartObject();
+            w.Key("name");
+            ::json::rjson_serialize(w, ref.name);
+            w.Key("subject");
+            ::json::rjson_serialize(w, ref.sub);
+            w.Key("version");
+            ::json::rjson_serialize(w, ref.version);
+            w.EndObject();
+        }
+        w.EndArray();
+    }
     w.EndObject();
 }
 

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -37,10 +37,10 @@ inline void rjson_serialize(
         w.Key("schemaType");
         ::json::rjson_serialize(w, to_string_view(type));
     }
-    if (!res.schema.refs().empty()) {
+    if (!res.schema.def().refs().empty()) {
         w.Key("references");
         w.StartArray();
-        for (const auto& ref : res.schema.refs()) {
+        for (const auto& ref : res.schema.def().refs()) {
             w.StartObject();
             w.Key("name");
             ::json::rjson_serialize(w, ref.name);

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -49,7 +49,7 @@ class post_subject_versions_request_handler
         subject sub{invalid_subject};
         unparsed_schema_definition::raw_string def;
         schema_type type{schema_type::avro};
-        unparsed_schema::references refs;
+        unparsed_schema_definition::references refs;
     };
     mutable_schema _schema;
 
@@ -207,8 +207,7 @@ public:
             _state = state::empty;
             result.def = {
               std::move(_schema.sub),
-              {std::move(_schema.def), _schema.type},
-              std::move(_schema.refs)};
+              {std::move(_schema.def), _schema.type, std::move(_schema.refs)}};
             return true;
         }
         case state::reference: {

--- a/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
@@ -23,18 +23,14 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_version_response) {
       R"({\"type\":\"record\",\"name\":\"test\",\"fields\":[{\"type\":\"string\",\"name\":\"field1\"},{\"type\":\"com.acme.Referenced\",\"name\":\"int\"}]})"};
     const pps::canonical_schema_definition schema_def{
       R"({"type":"record","name":"test","fields":[{"type":"string","name":"field1"},{"type":"com.acme.Referenced","name":"int"}]})",
-      pps::schema_type::avro};
+      pps::schema_type::avro,
+      {{{"com.acme.Referenced"},
+        pps::subject{"childSubject"},
+        pps::schema_version{1}}}};
     const pps::subject sub{"imported-ref"};
 
     pps::post_subject_versions_version_response response{
-      .schema{
-        pps::subject{"imported-ref"},
-        schema_def,
-        {{{"com.acme.Referenced"},
-          pps::subject{"childSubject"},
-          pps::schema_version{1}}}},
-      .id{12},
-      .version{2}};
+      .schema{pps::subject{"imported-ref"}, schema_def}, .id{12}, .version{2}};
 
     const ss::sstring expected{
       R"(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -57,6 +57,12 @@ bool check_compatible(const valid_schema& reader, const valid_schema& writer) {
     });
 }
 
+constexpr auto set_accumulator =
+  [](store::schema_id_set acc, store::schema_id_set refs) {
+      acc.insert(refs.begin(), refs.end());
+      return acc;
+  };
+
 } // namespace
 
 ss::future<> sharded_store::start(ss::smp_service_group sg) {
@@ -72,8 +78,7 @@ sharded_store::make_canonical_schema(unparsed_schema schema) {
     case schema_type::avro: {
         co_return canonical_schema{
           std::move(schema.sub()),
-          sanitize_avro_schema_definition(schema.def()).value(),
-          std::move(schema.refs())};
+          sanitize_avro_schema_definition(schema.def()).value()};
     }
     case schema_type::protobuf:
         co_return co_await make_canonical_protobuf_schema(
@@ -220,8 +225,6 @@ ss::future<bool> sharded_store::upsert(
       marker,
       // NOLINTNEXTLINE(bugprone-use-after-move)
       std::move(schema).sub(),
-      // NOLINTNEXTLINE(bugprone-use-after-move)
-      std::move(schema).refs(),
       version,
       id,
       deleted);
@@ -301,7 +304,7 @@ ss::future<subject_schema> sharded_store::get_subject_schema(
       });
 
     co_return subject_schema{
-      .schema = {sub, std::move(def), std::move(v_id.refs)},
+      .schema = {sub, std::move(def)},
       .version = v_id.version,
       .id = v_id.id,
       .deleted = v_id.deleted};
@@ -330,10 +333,21 @@ sharded_store::get_versions(subject sub, include_deleted inc_del) {
 }
 
 ss::future<bool> sharded_store::is_referenced(subject sub, schema_version ver) {
-    auto map = [sub{std::move(sub)}, ver](store& s) {
-        return s.is_referenced(sub, ver);
-    };
-    co_return co_await _store.map_reduce0(map, false, std::logical_or<>{});
+    // Find all the schema that reference this sub-ver
+    auto references = co_await _store.map_reduce0(
+      [sub{std::move(sub)}, ver](store& s) {
+          return s.referenced_by(sub, ver);
+      },
+      store::schema_id_set{},
+      set_accumulator);
+
+    // Find whether any subject version reference any of the schema
+    co_return co_await _store.map_reduce0(
+      [refs{std::move(references)}](store& s) {
+          return s.subject_versions_has_any_of(refs);
+      },
+      false,
+      std::logical_or<>{});
 }
 
 ss::future<std::vector<schema_id>> sharded_store::referenced_by(
@@ -348,17 +362,23 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
         ver = versions.back();
     }
 
-    auto map = [sub{std::move(sub)}, ver](store& s) {
-        return s.referenced_by(sub, ver);
-    };
-    auto reduce = [](std::vector<schema_id> acc, std::vector<schema_id> refs) {
-        acc.insert(acc.end(), refs.begin(), refs.end());
-        return acc;
-    };
+    // Find all the schema that reference this sub-ver
     auto references = co_await _store.map_reduce0(
-      map, std::vector<schema_id>{}, reduce);
-    std::sort(references.begin(), references.end());
-    co_return references;
+      [sub{std::move(sub)}, ver](store& s) {
+          return s.referenced_by(sub, ver);
+      },
+      store::schema_id_set{},
+      set_accumulator);
+
+    // Find all the subject versions that reference any of the schema
+    references = co_await _store.map_reduce0(
+      [refs{std::move(references)}](store& s) {
+          return s.subject_versions_with_any_of(refs);
+      },
+      store::schema_id_set{},
+      set_accumulator);
+
+    co_return std::vector<schema_id>{references.begin(), references.end()};
 }
 
 ss::future<std::vector<schema_version>> sharded_store::delete_subject(
@@ -464,14 +484,12 @@ sharded_store::upsert_schema(schema_id id, canonical_schema_definition def) {
       });
 }
 
-ss::future<sharded_store::insert_subject_result> sharded_store::insert_subject(
-  subject sub, canonical_schema::references refs, schema_id id) {
+ss::future<sharded_store::insert_subject_result>
+sharded_store::insert_subject(subject sub, schema_id id) {
     auto sub_shard{shard_for(sub)};
     auto [version, inserted] = co_await _store.invoke_on(
-      sub_shard,
-      _smp_opts,
-      [sub{std::move(sub)}, refs{std::move(refs)}, id](store& s) mutable {
-          return s.insert_subject(sub, std::move(refs), id);
+      sub_shard, _smp_opts, [sub{std::move(sub)}, id](store& s) mutable {
+          return s.insert_subject(sub, id);
       });
     co_return insert_subject_result{version, inserted};
 }
@@ -479,7 +497,6 @@ ss::future<sharded_store::insert_subject_result> sharded_store::insert_subject(
 ss::future<bool> sharded_store::upsert_subject(
   seq_marker marker,
   subject sub,
-  canonical_schema::references refs,
   schema_version version,
   schema_id id,
   is_deleted deleted) {
@@ -487,14 +504,8 @@ ss::future<bool> sharded_store::upsert_subject(
     co_return co_await _store.invoke_on(
       sub_shard,
       _smp_opts,
-      [marker,
-       sub{std::move(sub)},
-       refs{std::move(refs)},
-       version,
-       id,
-       deleted](store& s) mutable {
-          return s.upsert_subject(
-            marker, std::move(sub), std::move(refs), version, id, deleted);
+      [marker, sub{std::move(sub)}, version, id, deleted](store& s) mutable {
+          return s.upsert_subject(marker, std::move(sub), version, id, deleted);
       });
 }
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -142,13 +142,11 @@ private:
         schema_version version;
         bool inserted;
     };
-    ss::future<insert_subject_result> insert_subject(
-      subject sub, canonical_schema::references refs, schema_id id);
+    ss::future<insert_subject_result> insert_subject(subject sub, schema_id id);
 
     ss::future<bool> upsert_subject(
       seq_marker marker,
       subject sub,
-      canonical_schema::references refs,
       schema_version version,
       schema_id id,
       is_deleted deleted);

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -336,10 +336,10 @@ inline void rjson_serialize(
         w.Key("schemaType");
         ::json::rjson_serialize(w, to_string_view(type));
     }
-    if (!val.schema.refs().empty()) {
+    if (!val.schema.def().refs().empty()) {
         w.Key("references");
         w.StartArray();
-        for (const auto& ref : val.schema.refs()) {
+        for (const auto& ref : val.schema.def().refs()) {
             w.StartObject();
             w.Key("name");
             ::json::rjson_serialize(w, ref.name);
@@ -381,7 +381,7 @@ class schema_value_handler final : public json::base_handler<Encoding> {
         subject sub{invalid_subject};
         typename typed_schema_definition<Tag>::raw_string def;
         schema_type type{schema_type::avro};
-        typename typed_schema<Tag>::references refs;
+        typename typed_schema_definition<Tag>::references refs;
     };
     mutable_schema _schema;
 
@@ -572,8 +572,7 @@ public:
             _state = state::empty;
             result.schema = {
               std::move(_schema.sub),
-              {std::move(_schema.def), _schema.type},
-              std::move(_schema.refs)};
+              {std::move(_schema.def), _schema.type, std::move(_schema.refs)}};
             return true;
         }
         case state::reference: {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -322,7 +322,7 @@ public:
         schema_id_set has_ids;
         for (const auto& s : _subjects) {
             for (const auto& r : s.second.versions) {
-                if (ids.contains(r.id)) {
+                if (!r.deleted && ids.contains(r.id)) {
                     has_ids.insert(r.id);
                 }
             }
@@ -332,8 +332,8 @@ public:
 
     bool subject_versions_has_any_of(const schema_id_set& ids) {
         return absl::c_any_of(_subjects, [&ids](const auto& s) {
-            return absl::c_any_of(s.second.versions, [&ids](const auto& v) {
-                return ids.contains(v.id);
+            return absl::c_any_of(s.second.versions, [&ids, &s](const auto& v) {
+                return !s.second.deleted && ids.contains(v.id);
             });
         });
     }

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -19,6 +19,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <utility>
+
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
 
@@ -63,16 +65,14 @@ bool check_compatible(
     store.insert(
       pandaproxy::schema_registry::canonical_schema{
         pps::subject{"sub"},
-        pps::canonical_schema_definition{writer, pps::schema_type::protobuf},
-        {}},
+        pps::canonical_schema_definition{writer, pps::schema_type::protobuf}},
       pps::schema_version{1});
     return store.store
       .is_compatible(
         pps::schema_version{1},
         pps::canonical_schema{
           pps::subject{"sub"},
-          pps::canonical_schema_definition{reader, pps::schema_type::protobuf},
-          {}})
+          pps::canonical_schema_definition{reader, pps::schema_type::protobuf}})
       .get();
 }
 
@@ -116,7 +116,8 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
     simple_sharded_store store;
 
     auto schema1 = pps::canonical_schema{pps::subject{"simple"}, simple};
-    auto schema2 = pps::canonical_schema{pps::subject{"imported"}, imported};
+    auto schema2 = pps::canonical_schema{
+      pps::subject{"imported"}, imported_no_ref};
 
     store.insert(schema1, pps::schema_version{1});
 
@@ -135,13 +136,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
 
     auto schema1 = pps::canonical_schema{pps::subject{"simple.proto"}, simple};
     auto schema2 = pps::canonical_schema{
-      pps::subject{"imported.proto"},
-      imported,
-      {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}}}};
+      pps::subject{"imported.proto"}, imported};
     auto schema3 = pps::canonical_schema{
-      pps::subject{"imported-again.proto"},
-      imported_again,
-      {{"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}}};
+      pps::subject{"imported-again.proto"}, imported_again};
 
     store.insert(schema1, pps::schema_version{1});
     store.insert(schema2, pps::schema_version{1});
@@ -160,14 +157,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_recursive_reference) {
 
     auto schema1 = pps::canonical_schema{pps::subject{"simple.proto"}, simple};
     auto schema2 = pps::canonical_schema{
-      pps::subject{"imported.proto"},
-      imported,
-      {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}}}};
+      pps::subject{"imported.proto"}, imported};
     auto schema3 = pps::canonical_schema{
-      pps::subject{"imported-twice.proto"},
-      imported_twice,
-      {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}},
-       {"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}}};
+      pps::subject{"imported-twice.proto"}, imported_twice};
 
     store.insert(schema1, pps::schema_version{1});
     store.insert(schema2, pps::schema_version{1});

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
@@ -23,7 +23,7 @@ message Simple {
 })",
   pps::schema_type::protobuf};
 
-const auto imported = pps::canonical_schema_definition{
+const auto imported_no_ref = pps::canonical_schema_definition{
   R"(
 syntax = "proto3";
 
@@ -34,6 +34,18 @@ message Test2 {
 })",
   pps::schema_type::protobuf};
 
+const auto imported = pps::canonical_schema_definition{
+  R"(
+syntax = "proto3";
+
+import "simple";
+
+message Test2 {
+  Simple id =  1;
+})",
+  pps::schema_type::protobuf,
+  {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}}}};
+
 const auto imported_again = pps::canonical_schema_definition{
   R"(
 syntax = "proto3";
@@ -43,7 +55,8 @@ import "imported";
 message Test3 {
   Test2 id =  1;
 })",
-  pps::schema_type::protobuf};
+  pps::schema_type::protobuf,
+  {{"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}}};
 
 const auto imported_twice = pps::canonical_schema_definition{
   R"(
@@ -55,7 +68,9 @@ import "imported";
 message Test3 {
   Test2 id =  1;
 })",
-  pps::schema_type::protobuf};
+  pps::schema_type::protobuf,
+  {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}},
+   {"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}}};
 
 const auto nested = pps::canonical_schema_definition{
   R"(

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -33,14 +33,6 @@
 
 namespace pps = pandaproxy::schema_registry;
 
-const pps::canonical_schema_definition string_def0{
-  pps::sanitize_avro_schema_definition(
-    {R"({"type":"string"})", pps::schema_type::avro})
-    .value()};
-const pps::canonical_schema_definition int_def0{
-  pps::sanitize_avro_schema_definition(
-    {R"({"type": "int"})", pps::schema_type::avro})
-    .value()};
 const pps::subject subject0{"subject0"};
 constexpr pps::topic_key_magic magic0{0};
 constexpr pps::topic_key_magic magic1{1};
@@ -49,6 +41,15 @@ constexpr pps::schema_version version0{0};
 constexpr pps::schema_version version1{1};
 constexpr pps::schema_id id0{0};
 constexpr pps::schema_id id1{1};
+
+const pps::canonical_schema_definition string_def0{
+  pps::sanitize_avro_schema_definition(
+    {R"({"type":"string"})", pps::schema_type::avro})
+    .value()};
+const pps::canonical_schema_definition int_def0{
+  pps::sanitize_avro_schema_definition(
+    {R"({"type": "int"})", pps::schema_type::avro})
+    .value()};
 
 inline model::record_batch make_delete_subject_batch(pps::subject sub) {
     storage::record_batch_builder rb{

--- a/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
+++ b/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
@@ -177,7 +177,7 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
     }
 
     {
-        info("Delete subject int-key, expect failure 42206");
+        info("Delete subject int-key, expect failure 42206 (still referenced)");
         auto res = delete_subject(client, pps::subject{"int-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(),
@@ -193,24 +193,7 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
     }
 
     {
-        info("Delete subject int-key");
-        auto res = delete_subject(client, pps::subject{"int-key"});
-        BOOST_REQUIRE_EQUAL(
-          res.headers.result(),
-          boost::beast::http::status::unprocessable_entity);
-        BOOST_REQUIRE_EQUAL(get_body_error_code(res.body), 42206);
-    }
-
-    {
-        info("Permanantly delete subject reference-key");
-        auto res = delete_subject(
-          client, pps::subject{"reference-key"}, pps::permanent_delete::yes);
-        BOOST_REQUIRE_EQUAL(
-          res.headers.result(), boost::beast::http::status::ok);
-    }
-
-    {
-        info("Delete subject int-key");
+        info("Delete subject int-key (not referenced - soft deleted)");
         auto res = delete_subject(client, pps::subject{"int-key"});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -35,10 +35,10 @@ void rjson_serialize(
         w.Key("schemaType");
         ::json::rjson_serialize(w, to_string_view(r.schema.type()));
     }
-    if (!r.schema.refs().empty()) {
+    if (!r.schema.def().refs().empty()) {
         w.Key("references");
         w.StartArray();
-        for (const auto& ref : r.schema.refs()) {
+        for (const auto& ref : r.schema.def().refs()) {
             w.StartObject();
             w.Key("name");
             ::json::rjson_serialize(w, ref.name);
@@ -539,7 +539,7 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 
     const auto employee_req = request{pps::canonical_schema{
       pps::subject{"employee-value"},
-      pps::canonical_schema_definition(
+      pps::canonical_schema_definition{
         R"({
   "namespace": "com.redpanda",
   "type": "record",
@@ -559,10 +559,10 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
     }
   ]
 })",
-        pps::schema_type::avro),
-      {{"com.redpanda.company",
-        pps::subject{"company-value"},
-        pps::schema_version{1}}}}};
+        pps::schema_type::avro,
+        {{"com.redpanda.company",
+          pps::subject{"company-value"},
+          pps::schema_version{1}}}}}};
 
     info("Connecting client");
     auto client = make_schema_reg_client();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -64,6 +64,10 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
 
     BOOST_REQUIRE_EQUAL(referenced_by.size(), 1);
     BOOST_REQUIRE_EQUAL(referenced_by[0], pps::schema_id{2});
+
+    BOOST_REQUIRE(
+      store.is_referenced(pps::subject{"simple.proto"}, pps::schema_version{1})
+        .get());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_find_unordered) {

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -66,6 +66,26 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     BOOST_REQUIRE(
       store.is_referenced(pps::subject{"simple.proto"}, pps::schema_version{1})
         .get());
+
+    // soft delete subject
+    store
+      .upsert(
+        pps::seq_marker{
+          std::nullopt, std::nullopt, ver1, pps::seq_marker_key_type::schema},
+        importing_schema,
+        pps::schema_id{2},
+        ver1,
+        pps::is_deleted::yes)
+      .get();
+
+    // Soft-deleted should not partake in reference calculations
+    BOOST_REQUIRE(
+      store.referenced_by(pps::subject{"simple.proto"}, pps::schema_version{1})
+        .get()
+        .empty());
+    BOOST_REQUIRE(
+      !store.is_referenced(pps::subject{"simple.proto"}, pps::schema_version{1})
+         .get());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_find_unordered) {

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -45,9 +45,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
 
     // Insert referenced
     auto importing_schema = pps::canonical_schema{
-      pps::subject{"imported.proto"},
-      imported,
-      {{"simple", pps::subject{"simple.proto"}, ver1}}};
+      pps::subject{"imported.proto"}, imported};
 
     store
       .upsert(

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -67,6 +67,13 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
       store.is_referenced(pps::subject{"simple.proto"}, pps::schema_version{1})
         .get());
 
+    auto importing = store.get_schema_definition(pps::schema_id{2}).get();
+    BOOST_REQUIRE_EQUAL(importing.refs().size(), 1);
+    BOOST_REQUIRE_EQUAL(importing.refs()[0].sub, imported.refs()[0].sub);
+    BOOST_REQUIRE_EQUAL(
+      importing.refs()[0].version, imported.refs()[0].version);
+    BOOST_REQUIRE_EQUAL(importing.refs()[0].name, imported.refs()[0].name);
+
     // soft delete subject
     store
       .upsert(

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -53,8 +53,9 @@ const pps::canonical_schema_value avro_schema_value{
   .schema{
     pps::subject{"my-kafka-value"},
     pps::canonical_schema_definition{
-      R"({"type":"string"})", pps::schema_type::avro},
-    {{{"name"}, pps::subject{"subject"}, pps::schema_version{1}}}},
+      R"({"type":"string"})",
+      pps::schema_type::avro,
+      {{{"name"}, pps::subject{"subject"}, pps::schema_version{1}}}}},
   .version{pps::schema_version{1}},
   .id{pps::schema_id{1}},
   .deleted = pps::is_deleted::yes};

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -78,7 +78,7 @@ bool upsert(
   pps::is_deleted deleted) {
     store.upsert_schema(id, std::move(def));
     return store.upsert_subject(
-      pps::seq_marker{}, std::move(sub), {}, version, id, deleted);
+      pps::seq_marker{}, std::move(sub), version, id, deleted);
 }
 
 BOOST_AUTO_TEST_CASE(test_store_upsert_in_order) {
@@ -236,7 +236,6 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subject_versions) {
     s.upsert_subject(
       dummy_marker,
       subject0,
-      {},
       pps::schema_version{1},
       pps::schema_id{1},
       pps::is_deleted::yes);
@@ -599,7 +598,6 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
     BOOST_REQUIRE_NO_THROW(s.upsert_subject(
       dummy_marker,
       subject0,
-      {},
       pps::schema_version{1},
       pps::schema_id{1},
       pps::is_deleted::yes));
@@ -665,7 +663,6 @@ BOOST_AUTO_TEST_CASE(test_store_subject_version_latest) {
     BOOST_REQUIRE_NO_THROW(s.upsert_subject(
       dummy_marker,
       subject0,
-      {},
       pps::schema_version{2},
       pps::schema_id{1},
       pps::is_deleted::yes));
@@ -700,7 +697,6 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_after_delete_version) {
     s.upsert_subject(
       dummy_marker,
       subject0,
-      {},
       pps::schema_version{1},
       pps::schema_id{1},
       pps::is_deleted::yes);

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -44,7 +44,11 @@ std::ostream& operator<<(
   std::ostream& os,
   const typed_schema_definition<unparsed_schema_definition::tag>& def) {
     fmt::print(
-      os, "type: {}, definition: {}", to_string_view(def.type()), def.raw());
+      os,
+      "type: {}, definition: {}, references: {}",
+      to_string_view(def.type()),
+      def.raw(),
+      def.refs());
     return os;
 }
 
@@ -52,7 +56,11 @@ std::ostream& operator<<(
   std::ostream& os,
   const typed_schema_definition<canonical_schema_definition::tag>& def) {
     fmt::print(
-      os, "type: {}, definition: {}", to_string_view(def.type()), def.raw());
+      os,
+      "type: {}, definition: {}, references: {}",
+      to_string_view(def.type()),
+      def.raw(),
+      def.refs());
     return os;
 }
 
@@ -63,14 +71,12 @@ std::ostream& operator<<(std::ostream& os, const schema_reference& ref) {
 }
 
 std::ostream& operator<<(std::ostream& os, const unparsed_schema& ref) {
-    fmt::print(
-      os, "subject: {}, {}, references: {}", ref.sub(), ref.def(), ref.refs());
+    fmt::print(os, "subject: {}, {}", ref.sub(), ref.def());
     return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const canonical_schema& ref) {
-    fmt::print(
-      os, "subject: {}, {}, references: {}", ref.sub(), ref.def(), ref.refs());
+    fmt::print(os, "subject: {}, {}", ref.sub(), ref.def());
     return os;
 }
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -67,6 +67,26 @@ std::ostream& operator<<(std::ostream& os, const schema_type& v);
 using subject = named_type<ss::sstring, struct subject_tag>;
 static const subject invalid_subject{};
 
+///\brief The version of the schema registered with a subject.
+///
+/// A subject may evolve its schema over time. Each version is associated with a
+/// schema_id.
+using schema_version = named_type<int32_t, struct schema_version_tag>;
+static constexpr schema_version invalid_schema_version{-1};
+
+struct schema_reference {
+    friend bool
+    operator==(const schema_reference& lhs, const schema_reference& rhs)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const schema_reference& ref);
+
+    ss::sstring name;
+    subject sub{invalid_subject};
+    schema_version version{invalid_schema_version};
+};
+
 ///\brief Definition of a schema and its type.
 template<typename Tag>
 class typed_schema_definition {
@@ -231,13 +251,6 @@ private:
     impl _impl;
 };
 
-///\brief The version of the schema registered with a subject.
-///
-/// A subject may evolve its schema over time. Each version is associated with a
-/// schema_id.
-using schema_version = named_type<int32_t, struct schema_version_tag>;
-static constexpr schema_version invalid_schema_version{-1};
-
 ///\brief Globally unique identifier for a schema.
 using schema_id = named_type<int32_t, struct schema_id_tag>;
 static constexpr schema_id invalid_schema_id{-1};
@@ -281,20 +294,7 @@ struct seq_marker {
     friend std::ostream& operator<<(std::ostream& os, const seq_marker& v);
 };
 
-struct schema_reference {
-    friend bool
-    operator==(const schema_reference& lhs, const schema_reference& rhs)
-      = default;
-
-    friend std::ostream&
-    operator<<(std::ostream& os, const schema_reference& ref);
-
-    ss::sstring name;
-    subject sub{invalid_subject};
-    schema_version version{invalid_schema_version};
-};
-
-///\brief A schema with its subject and references.
+///\brief A schema with its subject
 template<typename Tag>
 class typed_schema {
 public:


### PR DESCRIPTION
Return `references` for `GET /schemas/ids/<id>`.

Fixes #11194 

### Notes for reviewer:

The `store` has two mappings:
1) `schema_map`: Schema ID to Schema
2) `subject_map`: Subject-Versions to Schema ID

Each of these mappings are then balanced across shards, coordinated by `sharded_store`.

Prior to this change, `references` were attached to the Subject-Versions.

This is an incorrect modelling; Schema should own the references to other schema. This commit does that refactoring by moving references from `typed_schema` to `typed_schema_definition`.

This allows returning the references when querying a schema by ID.

Additionally there is a fix to ignore references when a subject-version has been soft-deleted.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* Schema Registry: Return `references` for `GET /schemas/ids/<id>`.
