### PR TITLE
build: add an option to run clang-tidy along side compilation

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -3,6 +3,41 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_compile_options(-Wall)
 
+#
+# When enabled clang-tidy will be invoked along side the compiler, and
+# clang-tidy warnings will be reported as errors.
+#
+option(REDPANDA_RUN_CLANG_TIDY "Enable clang-tidy checks" OFF)
+if(REDPANDA_RUN_CLANG_TIDY)
+    find_program(CLANG_TIDY_COMMAND clang-tidy
+        PATHS ${PROJECT_SOURCE_DIR}/vbuild/llvm/install/bin)
+    if(NOT CLANG_TIDY_COMMAND)
+        message(FATAL_ERROR "Could not find clang-tidy program")
+    endif()
+    set(clang_tidy_checks
+        -*
+        bugprone-use-after-move
+        bugprone-assert-side-effect
+        bugprone-assignment-in-if-condition
+        bugprone-dangling-handle
+        bugprone-sizeof-container
+        bugprone-stringview-nullptr
+        bugprone-unused-return-value
+        bugprone-suspicious-string-compare
+        cppcoreguidelines-rvalue-reference-param-not-moved
+        misc-unused-using-decls
+        misc-unused-alias-decls
+        modernize-redundant-void-arg
+        performance-implicit-conversion-in-loop
+        performance-trivially-destructible
+        performance-no-automatic-move
+    )
+    list(JOIN clang_tidy_checks "," clang_tidy_checks)
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND}
+        -warnings-as-errors=* -checks=${clang_tidy_checks})
+    unset(clang_tidy_checks)
+endif()
+
 # libraries
 add_subdirectory(test_utils)
 add_subdirectory(ssx)

--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -33,8 +33,6 @@ client_probe::client_probe(
   cloud_roles::aws_region_name region,
   endpoint_url endpoint)
   : http::client_probe() {
-    namespace sm = ss::metrics;
-
     std::vector<raw_label> s3_labels = {
       {endpoint_label_key, std::move(endpoint)()},
       {region_label_key, std::move(region)()}};

--- a/src/v/cluster/node_status_table.h
+++ b/src/v/cluster/node_status_table.h
@@ -43,8 +43,8 @@ public:
     }
 
     void update_peers(std::vector<node_status> updates) {
-        for (auto& node_status : updates) {
-            _peers_status[node_status.node_id] = std::move(node_status);
+        for (const auto& node_status : updates) {
+            _peers_status[node_status.node_id] = node_status;
         }
     }
 

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -699,13 +699,13 @@ public:
     using property<std::vector<T>>::property;
 
     bool set_value(YAML::Node n) override {
-        auto value = decode_yaml(std::move(n));
+        auto value = decode_yaml(n);
         return property<std::vector<T>>::update_value(std::move(value));
     }
 
     std::optional<validation_error>
     validate([[maybe_unused]] YAML::Node n) const override {
-        std::vector<T> value = decode_yaml(std::move(n));
+        std::vector<T> value = decode_yaml(n);
         return property<std::vector<T>>::validate(value);
     }
 
@@ -739,14 +739,13 @@ public:
     using property<std::unordered_map<typename T::key_type, T>>::property;
 
     bool set_value(YAML::Node n) override {
-        auto value = decode_yaml(std::move(n));
+        auto value = decode_yaml(n);
         return property<std::unordered_map<typename T::key_type, T>>::
           update_value(std::move(value));
     }
 
     std::optional<validation_error> validate(YAML::Node n) const override {
-        std::unordered_map<typename T::key_type, T> value = decode_yaml(
-          std::move(n));
+        std::unordered_map<typename T::key_type, T> value = decode_yaml(n);
         return property<std::unordered_map<typename T::key_type, T>>::validate(
           value);
     }

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -57,8 +57,6 @@
 #include <memory>
 #include <vector>
 
-namespace kc = kafka::client;
-
 namespace {
 
 std::vector<kafka::offset_fetch_request_topic>

--- a/src/v/kafka/client/test/fetch.cc
+++ b/src/v/kafka/client/test/fetch.cc
@@ -28,8 +28,6 @@
 
 #include <chrono>
 
-namespace kc = kafka::client;
-
 FIXTURE_TEST(fetch, kafka_client_fixture) {
     using namespace std::chrono_literals;
 

--- a/src/v/kafka/client/test/produce.cc
+++ b/src/v/kafka/client/test/produce.cc
@@ -21,8 +21,6 @@
 
 #include <chrono>
 
-namespace kc = kafka::client;
-
 FIXTURE_TEST(produce_reconnect, kafka_client_fixture) {
     using namespace std::chrono_literals;
 

--- a/src/v/kafka/client/test/retry.cc
+++ b/src/v/kafka/client/test/retry.cc
@@ -15,8 +15,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/testing/thread_test_case.hh>
 
-namespace kc = kafka::client;
-
 inline const model::topic_partition unknown_tp{
   model::topic{"unknown"}, model::partition_id{0}};
 

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -81,8 +81,7 @@ public:
       model::topic topic_name,
       model::partition_id pid,
       model::offset kafka_offset_inclusive) {
-        auto m = co_await consume(
-          std::move(topic_name), {pid}, kafka_offset_inclusive);
+        auto m = co_await consume(topic_name, {pid}, kafka_offset_inclusive);
         if (m.empty()) {
             throw std::runtime_error(
               fmt::format("empty fetch {}/{}", topic_name(), pid()));

--- a/src/v/model/adl_serde.cc
+++ b/src/v/model/adl_serde.cc
@@ -37,7 +37,7 @@ model::ns adl<model::ns>::from(iobuf_parser& in) {
 
 void adl<model::topic_partition>::to(iobuf& out, model::topic_partition&& t) {
     auto str = ss::sstring(t.topic);
-    reflection::serialize(out, std::move(str), std::move(t.partition));
+    reflection::serialize(out, std::move(str), t.partition);
 }
 
 model::topic_partition adl<model::topic_partition>::from(iobuf_parser& in) {

--- a/src/v/model/tests/model_serialization_test.cc
+++ b/src/v/model/tests/model_serialization_test.cc
@@ -60,9 +60,11 @@ SEASTAR_THREAD_TEST_CASE(tristate_rt_test) {
     tristate<size_t> empty(std::nullopt);
     tristate<size_t> present(1024);
 
+    // NOLINTBEGIN(performance-move-const-arg)
     auto r_disabled = serialize_roundtrip_rpc(std::move(disabled));
     auto r_empty = serialize_roundtrip_rpc(std::move(empty));
     auto r_present = serialize_roundtrip_rpc(std::move(present));
+    // NOLINTEND(performance-move-const-arg)
 
     BOOST_REQUIRE_EQUAL(r_disabled.is_disabled(), true);
     BOOST_REQUIRE_EQUAL(r_empty.is_disabled(), false);

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -126,7 +126,7 @@ connection::connection(
     if (in_max_buffer_size.has_value()) {
         auto in_config = ss::connected_socket_input_stream_config{};
         in_config.max_buffer_size = in_max_buffer_size.value();
-        _in = _fd.input(std::move(in_config));
+        _in = _fd.input(in_config);
     } else {
         _in = _fd.input();
     }

--- a/src/v/pandaproxy/rest/test/consumer_group.cc
+++ b/src/v/pandaproxy/rest/test/consumer_group.cc
@@ -24,7 +24,6 @@
 
 namespace pp = pandaproxy;
 namespace ppj = pp::json;
-namespace kc = kafka::client;
 
 namespace {
 

--- a/src/v/pandaproxy/rest/test/list_topics.cc
+++ b/src/v/pandaproxy/rest/test/list_topics.cc
@@ -16,8 +16,6 @@
 #include <boost/beast/http/verb.hpp>
 #include <boost/test/tools/old/interface.hpp>
 
-namespace pp = pandaproxy;
-
 FIXTURE_TEST(pandaproxy_list_topics, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
 

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -73,6 +73,7 @@ public:
     /// return the schema_version and schema_id, and whether it's new.
     insert_result insert(canonical_schema schema) {
         auto id = insert_schema(std::move(schema).def()).id;
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         auto [version, inserted] = insert_subject(std::move(schema).sub(), id);
         return {version, id, inserted};
     }

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -161,7 +161,7 @@ struct raft_node {
           .get();
 
         // setup consensus
-        auto self_id = broker.id();
+        auto self_id = this->broker.id();
         consensus = ss::make_lw_shared<raft::consensus>(
           self_id,
           gr_id,

--- a/src/v/raft/vote_stm.h
+++ b/src/v/raft/vote_stm.h
@@ -58,7 +58,7 @@ private:
         };
 
         void set_value(result<vote_reply> r) {
-            value = std::make_unique<result<vote_reply>>(std::move(r));
+            value = std::make_unique<result<vote_reply>>(r);
         }
 
         state get_state() const {

--- a/src/v/rpc/netbuf.cc
+++ b/src/v/rpc/netbuf.cc
@@ -30,7 +30,7 @@ iobuf header_as_iobuf(const header& h) {
 ss::future<ss::scattered_message<char>> netbuf::as_scattered() && {
     // Move object members into coroutine before first supension.
     iobuf out_buf = std::move(_out);
-    auto hdr = std::move(_hdr);
+    auto hdr = _hdr;
 
     if (hdr.correlation_id == 0 || hdr.meta == 0) {
         throw std::runtime_error(

--- a/src/v/rpc/test/serialization_test.cc
+++ b/src/v/rpc/test/serialization_test.cc
@@ -17,7 +17,7 @@
 SEASTAR_THREAD_TEST_CASE(serialize_pod) {
     auto b = iobuf();
     pod it;
-    reflection::serialize(b, std::move(it));
+    reflection::serialize(b, it);
     BOOST_CHECK_EQUAL(b.size_bytes(), pod_bytes());
 }
 
@@ -50,7 +50,7 @@ SEASTAR_THREAD_TEST_CASE(serialize_pod_with_vector) {
 SEASTAR_THREAD_TEST_CASE(serialize_pod_with_array) {
     auto b = iobuf();
     pod_with_array it;
-    reflection::serialize(b, std::move(it));
+    reflection::serialize(b, it);
     BOOST_CHECK_EQUAL(b.size_bytes(), pod_with_arr_bytes());
 }
 

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -36,7 +36,7 @@ namespace rpc {
 struct client_context_impl final : streaming_context {
     client_context_impl(transport& s, header h)
       : _c(std::ref(s))
-      , _h(std::move(h)) {}
+      , _h(h) {}
     ss::future<ssx::semaphore_units> reserve_memory(size_t ask) final {
         auto fut = get_units(_c.get()._memory, ask);
         if (_c.get()._memory.waiters()) {
@@ -380,7 +380,7 @@ ss::future<> transport::do_reads() {
                   fail_outstanding_futures();
                   return ss::make_ready_future<>();
               }
-              return dispatch(std::move(h.value()));
+              return dispatch(h.value());
           });
       });
 }

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -296,7 +296,11 @@ ss::future<result<rpc::client_context<T>>> parse_result(
         return ss::make_ready_future<ret_t>(map_server_error(st));
     }
 
-    return parse_type<T, default_message_codec>(in, sctx->get_header())
+    // use-after-move check doesn't take into account c++17 evaluation order
+    // correctly, so when used before and after `.then` it is a false positive.
+    // https://reviews.llvm.org/D145581
+    auto header = sctx->get_header();
+    return parse_type<T, default_message_codec>(in, header)
       .then_wrapped([sctx = std::move(sctx)](ss::future<T> data_fut) {
           if (data_fut.failed()) {
               const auto ex = data_fut.get_exception();

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -430,7 +430,7 @@ public:
       std::optional<acl_operation> operation,
       std::optional<acl_permission> permission)
       : _principal(std::move(principal))
-      , _host(std::move(host))
+      , _host(host)
       , _operation(operation)
       , _permission(permission) {}
 

--- a/src/v/storage/file_sanitizer.h
+++ b/src/v/storage/file_sanitizer.h
@@ -127,11 +127,12 @@ public:
       std::vector<iovec> iov,
       const ss::io_priority_class& pc) final {
         assert_file_not_closed();
+        auto iov_size = iov.size();
         return with_op(
           ssx::sformat(
             "ss::future<size_t>::write_dma(pos:{}, vector<iovec>:{})",
             pos,
-            iov.size()),
+            iov_size),
           maybe_inject_failure(failable_op_type::write)
             .then([this, pos, iov = std::move(iov), &pc]() {
                 return get_file_impl(_file)

--- a/src/v/storage/fs_utils.h
+++ b/src/v/storage/fs_utils.h
@@ -125,9 +125,9 @@ public:
       , file_part({.base_offset = o, .term = t, .version = v}) {}
 
     segment_full_path(
-      partition_path&& dir_part, segment_path::metadata&& file_part)
+      partition_path&& dir_part, segment_path::metadata file_part)
       : dir_part(std::move(dir_part))
-      , file_part(std::move(file_part)) {}
+      , file_part(file_part) {}
 
     /**
      * Transformations from regular segment paths to the index etc

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -238,7 +238,7 @@ ss::future<> spill_key_index::spill(
 }
 
 ss::future<> spill_key_index::append(compacted_index::entry e) {
-    return ss::try_with_gate(_gate, [this, e = std::move(e)]() {
+    return ss::try_with_gate(_gate, [this, e = std::move(e)]() mutable {
         return ss::do_with(std::move(e), [this](compacted_index::entry& e) {
             return spill(e.type, e.key, value_type{e.offset, e.delta});
         });

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -350,6 +350,8 @@ public:
 
     void append_batch(storage::log log, model::record_batch batch) {
         model::record_batch_reader::data_t buffer;
+        const auto last_offset_delta = model::offset(
+          batch.header().last_offset_delta);
         buffer.push_back(std::move(batch));
         storage::log_append_config append_cfg{
           storage::log_append_config::fsync::no,
@@ -360,8 +362,7 @@ public:
         model::offset base_offset = old_dirty_offset < model::offset(0)
                                       ? model::offset(0)
                                       : old_dirty_offset + model::offset(1);
-        auto expected_offset
-          = base_offset + model::offset{batch.header().last_offset_delta};
+        auto expected_offset = base_offset + last_offset_delta;
 
         auto res = model::make_memory_record_batch_reader(std::move(buffer))
                      .for_each_ref(


### PR DESCRIPTION
The idea here is to (1) replace the separate part of the pipeline that handles this in CI and (2)  provide a simple way for devs to invoke and modify this.

The tree is currently clang-tidy clean w.r.t. to the checks added in this PR.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

