### PR TITLE
ducktape-deps: fix installing confluent-kafka on arm64

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -164,7 +164,7 @@ RUN /k8s && \
 
 #################################
 
-FROM base as final
+FROM librdkafka as final
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/teleport /
 RUN /teleport && \
@@ -224,8 +224,6 @@ COPY --from=java-verifiers /opt/verifiers /opt/verifiers
 COPY --from=java-verifiers /opt/kafka-serde /opt/kafka-serde
 COPY --from=java-verifiers /root/.m2 /root/.m2
 COPY --from=kafka-tools /opt /opt
-COPY --from=librdkafka /opt/librdkafka /opt/librdkafka
-COPY --from=librdkafka /usr/local/lib /usr/local/lib
 COPY --from=kcat /usr/local/bin/kcat /usr/local/bin/
 COPY --from=sarama-examples /opt/sarama /opt/sarama
 COPY --from=golang-test-clients /opt/redpanda-tests/go /opt/redpanda-tests/go


### PR DESCRIPTION
On arm64 machines, there are no python wheels for confluent-kafka. When attempting to install them with the previous Dockerfile, the librdkafka source was not available. This commit uses the librdkafka intermediate image as the base of the final stage of the ducktape test node image

fixes https://github.com/redpanda-data/vtools/issues/1859

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes
 * none