### PR TITLE
tools: add a github action for rp-storage-tool tests

### DIFF
--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -1,0 +1,64 @@
+
+on: [push, pull_request]
+
+name: Lint & Test rp-storage-tool
+
+jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      touched: ${{ steps.filter.outputs.touched }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          touched:
+            - 'tools/rp_storage_tool/**'
+    # run only if files in the rp-storage-tool dir were changed
+    - name: workflow tests
+      if: steps.filter.outputs.touched == 'true'
+      run: echo "Files touched in rp_storage_tool"
+
+  check:
+    name: Compile check
+    needs: paths-filter
+    if: needs.paths-filter.outputs.touched == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        working-directory: ./tools/rp_storage_tool
+        with:
+          command: check
+
+  test:
+    name: Unit tests
+    needs: paths-filter
+    if: needs.paths-filter.outputs.touched == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        working-directory: ./tools/rp_storage_tool
+        with:
+          command: test

--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -37,8 +37,8 @@ jobs:
           override: true
       - name: Run cargo check
         uses: actions-rs/cargo@v1
-        working-directory: ./tools/rp_storage_tool
         with:
+          working-directory: ./tools/rp_storage_tool
           command: check
 
   test:
@@ -59,6 +59,6 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
-        working-directory: ./tools/rp_storage_tool
         with:
+          working-directory: ./tools/rp_storage_tool
           command: test


### PR DESCRIPTION
Followup to https://github.com/redpanda-data/redpanda/pull/11223

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
