### PR TITLE
cloud_storage_clients/abs: fix arg count for log

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -340,8 +340,7 @@ ss::future<result<T, error_outcome>> abs_client::send_request(
         } else {
             vlog(
               abs_log.error,
-              "Received [{}] {} unexpected error response for storage account "
-              "{} from ABS: {}",
+              "Received [{}] {} unexpected error response from ABS: {}",
               err.http_code(),
               err.code_string(),
               err.message());


### PR DESCRIPTION
Fix argument count for logging of unexpected errors by abs client.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
