### PR TITLE
gitignore usertasks.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,7 @@ vbuild/
 /Taskfile.yml
 /.dockerignore
 /.task/
+/usertasks.yml
 
 # helm chart dependencies
 *.tgz


### PR DESCRIPTION
After https://github.com/redpanda-data/vtools/pull/1855 we support custom tasks, we need to gitignore that file too.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
