### PR TITLE
tests: ok_to_fail TopicDeleteCloudStorageTest.drop_lifecycle_marker_test

### DIFF
--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from ducktape.utils.util import wait_until
 
-from ducktape.mark import matrix, parametrize
+from ducktape.mark import matrix, parametrize, ok_to_fail
 from requests.exceptions import HTTPError
 
 from rptest.utils.mode_checks import skip_debug_mode
@@ -461,6 +461,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         self._assert_topic_lifecycle_marker_status(
             self.topic, LifecycleMarkerStatus.PURGED)
 
+    @ok_to_fail
     @cluster(
         num_nodes=3,
         log_allow_list=[


### PR DESCRIPTION
Related: https://github.com/redpanda-data/redpanda/issues/11232


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
