### PR TITLE
tests: cloud failure injector

### DIFF
--- a/tests/rptest/clients/everything-allowed-exec-pod.yml
+++ b/tests/rptest/clients/everything-allowed-exec-pod.yml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: everything-allowed-exec-pod
+spec:
+  selector:
+    matchLabels:
+      name: privileged-pod
+  template:
+    metadata:
+      labels:
+        name: privileged-pod
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      nodeSelector:
+        redpanda-node: "true"
+      tolerations:
+      - effect: NoSchedule
+        key: redpanda-node
+        operator: Equal
+        value: "true"
+      containers:
+        - name: everything-allowed-pod
+          image: ubuntu
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host
+              name: noderoot
+          command: [ "/bin/bash" ]
+          tty: true
+          stdin: true
+          env:
+          - name: DOCKER_HOST
+            value: unix:///host/var/run/docker.sock
+          - name: PATH
+            value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/host/usr/local/sbin:/host/usr/local/bin:/host/usr/sbin:/host/usr/bin:/host/sbin:/host/bin:"
+      volumes:
+        - name: noderoot
+          hostPath:
+            path: /

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import os
 import subprocess
 
 
@@ -19,30 +20,37 @@ class KubectlTool:
 
     def __init__(self,
                  redpanda,
-                 cmd_prefix=[],
+                 *,
+                 remote_uri=None,
                  namespace='redpanda',
                  cluster_id=''):
         self._redpanda = redpanda
-        self._cmd_prefix = cmd_prefix
+        self._remote_uri = remote_uri
         self._namespace = namespace
         self._cluster_id = cluster_id
         self._kubectl_installed = False
+        self._privileged_pod_installed = False
 
     def _install(self):
-        if not self._kubectl_installed:
-            download_cmd = self._cmd_prefix + [
-                'wget', '-q',
+        '''Installs kubectl on a remote target host
+        '''
+        if not self._kubectl_installed and self._remote_uri is not None:
+            download_cmd = [
+                'tsh', 'ssh', self._remote_uri, 'wget', '-q',
                 f'https://dl.k8s.io/release/v{self.KUBECTL_VERSION}/bin/linux/amd64/kubectl',
                 '-O', '/tmp/kubectl'
             ]
-            install_cmd = self._cmd_prefix + [
-                'sudo', 'install', '-m', '0755', '/tmp/kubectl',
-                '/usr/local/bin/kubectl'
+            install_cmd = [
+                'tsh', 'ssh', self._remote_uri, 'sudo', 'install', '-m',
+                '0755', '/tmp/kubectl', '/usr/local/bin/kubectl'
             ]
-            cleanup_cmd = self._cmd_prefix + ['rm', '-f', '/tmp/kubectl']
-            config_cmd = self._cmd_prefix + [
-                'awscli2', 'eks', 'update-kubeconfig', '--name',
-                f'redpanda-{self._cluster_id}', '--region', 'us-west-2'
+            cleanup_cmd = [
+                'tsh', 'ssh', self._remote_uri, 'rm', '-f', '/tmp/kubectl'
+            ]
+            config_cmd = [
+                'tsh', 'ssh', self._remote_uri, 'awscli2', 'eks',
+                'update-kubeconfig', '--name', f'redpanda-{self._cluster_id}',
+                '--region', 'us-west-2'
             ]
             try:
                 self._redpanda.logger.info(download_cmd)
@@ -54,7 +62,7 @@ class KubectlTool:
                 self._redpanda.logger.info(config_cmd)
                 res = subprocess.check_output(config_cmd)
             except subprocess.CalledProcessError as e:
-                self._redpanda.logger.info("kubectl error {}: {}".format(
+                self._redpanda.logger.info("CalledProcessError {}: {}".format(
                     e.returncode, e.output))
                 exit(1)
             self._kubectl_installed = True
@@ -62,7 +70,10 @@ class KubectlTool:
 
     def exec(self, remote_cmd):
         self._install()
-        cmd = self._cmd_prefix + [
+        prefix = []
+        if self._remote_uri:
+            prefix = ['tsh', 'ssh', self._remote_uri]
+        cmd = prefix + [
             'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
             f'rp-{self._cluster_id}-0', '--', 'bash', '-c'
         ] + ['"' + remote_cmd + '"']
@@ -70,14 +81,17 @@ class KubectlTool:
             self._redpanda.logger.info(cmd)
             res = subprocess.check_output(cmd)
         except subprocess.CalledProcessError as e:
-            self._redpanda.logger.info("kubectl error {}: {}".format(
+            self._redpanda.logger.info("CalledProcessError {}: {}".format(
                 e.returncode, e.output))
             exit(1)
         return res
 
     def exists(self, remote_path):
         self._install()
-        cmd = self._cmd_prefix + [
+        prefix = []
+        if self._remote_uri:
+            prefix = ['tsh', 'ssh', self._remote_uri]
+        cmd = prefix + [
             'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
             f'rp-{self._cluster_id}-0', '--', 'stat'
         ] + [remote_path]
@@ -86,3 +100,99 @@ class KubectlTool:
             return True
         except subprocess.CalledProcessError as e:
             return False
+
+    def _get_privileged_pod(self):
+        # kubectl get pod -l name=privileged-pod --no-headers -o custom-columns=NODE:.spec.nodeName,NAME:.metadata.name
+        # ip-10-1-1-26.us-west-2.compute.internal    everything-allowed-exec-pod-bkj4m
+        # ip-10-1-1-139.us-west-2.compute.internal   everything-allowed-exec-pod-jxk9j
+        # ip-10-1-1-101.us-west-2.compute.internal   everything-allowed-exec-pod-pl8sc
+        cmd = [
+            'tsh',
+            'ssh',
+            self._remote_uri,
+            'kubectl',
+            'get',
+            'pod',
+            '-l',
+            'name=privileged-pod',
+            '--no-headers',
+            '-o',
+            'custom-columns=NODE:.spec.nodeName,NAME:.metadata.name',
+        ]
+        self._redpanda.logger.info(cmd)
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        ip_to_priv_pods = {}
+        for line in res.stdout.splitlines():
+            s = line.split()
+            ip_to_priv_pods[s[0]] = s[1]
+        self._redpanda.logger.info(ip_to_priv_pods)
+
+        # kubectl -n redpanda get pod -l app.kubernetes.io/name=redpanda --no-headers -o custom-columns=NODE:.spec.nodeName,NAME:.metadata.name
+        # ip-10-1-1-139.us-west-2.compute.internal   rp-ci0motok30vsi89l501g-0
+        # ip-10-1-1-101.us-west-2.compute.internal   rp-ci0motok30vsi89l501g-1
+        # ip-10-1-1-26.us-west-2.compute.internal    rp-ci0motok30vsi89l501g-2
+        cmd = [
+            'tsh',
+            'ssh',
+            self._remote_uri,
+            'kubectl',
+            '-n',
+            'redpanda',
+            'get',
+            'pod',
+            '-l',
+            'app.kubernetes.io/name=redpanda',
+            '--no-headers',
+            '-o',
+            'custom-columns=NODE:.spec.nodeName,NAME:.metadata.name',
+        ]
+        self._redpanda.logger.info(cmd)
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        ip_to_redpanda_pods = {}
+        for line in res.stdout.splitlines():
+            s = line.split()
+            ip_to_redpanda_pods[s[0]] = s[1]
+        self._redpanda.logger.info(ip_to_redpanda_pods)
+
+        redpanda_to_priv_pods = {}
+        for ip, redpanda_pod in ip_to_redpanda_pods.items():
+            redpanda_to_priv_pods[redpanda_pod] = ip_to_priv_pods[ip]
+
+        self._redpanda.logger.info(redpanda_to_priv_pods)
+        redpanda_pod = f'rp-{self._cluster_id}-0'
+        return redpanda_to_priv_pods[redpanda_pod]
+
+    def _setup_privileged_pod(self):
+        if not self._privileged_pod_installed and self._remote_uri is not None:
+            filename = 'everything-allowed-exec-pod.yml'
+            filename_path = os.path.join(os.path.dirname(__file__),
+                                         'everything-allowed-exec-pod.yml')
+            self._redpanda.logger.info(filename_path)
+            setup_cmd = ['tsh', 'scp', filename_path, f'{self._remote_uri}:']
+            apply_cmd = [
+                'tsh', 'ssh', self._remote_uri, 'kubectl', 'apply', '-f',
+                filename
+            ]
+            try:
+                self._redpanda.logger.info(setup_cmd)
+                res = subprocess.check_output(setup_cmd)
+                self._redpanda.logger.info(apply_cmd)
+                res = subprocess.check_output(apply_cmd)
+            except subprocess.CalledProcessError as e:
+                self._redpanda.logger.info("CalledProcessError {}: {}".format(
+                    e.returncode, e.output))
+                exit(1)
+            self._privileged_pod_installed = True
+
+    def exec_privileged(self, remote_cmd):
+        self._setup_privileged_pod()
+        priv_pod = self._get_privileged_pod()
+        prefix = []
+        if self._remote_uri:
+            prefix = ['tsh', 'ssh', self._remote_uri]
+        cmd = prefix + ['kubectl', 'exec', priv_pod, '--', 'bash', '-c'
+                        ] + ['"' + remote_cmd + '"']
+        self._redpanda.logger.debug(cmd)
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        self._redpanda.logger.debug(res.stdout)
+        return res

--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -8,7 +8,7 @@ from ducktape.cluster.cluster import ClusterNode
 from ducktape.utils.util import wait_until
 
 from rptest.services.admin import Admin
-from rptest.services.failure_injector import FailureSpec, FailureInjector
+from rptest.services.failure_injector import FailureSpec, make_failure_injector
 from rptest.services.redpanda import RedpandaService
 
 
@@ -126,7 +126,7 @@ class ProcessKill(DisruptiveAction):
     def __init__(self, redpanda: RedpandaService, config: ActionConfig,
                  admin: Admin):
         super(ProcessKill, self).__init__(redpanda, config, admin)
-        self.failure_injector = FailureInjector(self.redpanda)
+        self.failure_injector = make_failure_injector(self.redpanda)
 
     def max_affected_nodes_reached(self):
         return len(self.affected_nodes) >= self.config.max_affected_nodes

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -12,7 +12,7 @@ import signal
 import threading
 from ducktape.utils.util import wait_until
 from ducktape.errors import TimeoutError
-
+from rptest.clients.kubectl import KubectlTool
 from rptest.services import tc_netem
 
 
@@ -110,7 +110,6 @@ class FailureInjectorBase:
                                                  interval=spec.length)
                     self._in_flight.add(spec)
                     stop_timer.start()
-
 
     def _start_func(self, tp):
         if tp == FailureSpec.FAILURE_KILL:
@@ -300,3 +299,13 @@ class FailureInjector(FailureInjectorBase):
     def _netem_duplicate(self, node):
         op = tc_netem.NetemDuplicate(random.randint(1, 60), correlation=None)
         self._netem(node, op=op)
+
+
+class FailureInjectorCloud(FailureInjectorBase):
+    def __init__(self, redpanda):
+        super(FailureInjectorCloud, self).__init__(redpanda)
+        self._kubectl = KubectlTool(redpanda)
+
+    def _isolate(self, node):
+        self.redpanda.logger.info(f"isolating node {node.account.hostname}")
+        # TODO block port 33145 traffic on a node

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -92,7 +92,14 @@ class FailureInjectorBase:
             return self._netem_duplicate
 
     def _stop_func(self, tp):
-        pass
+        if tp == FailureSpec.FAILURE_KILL or tp == FailureSpec.FAILURE_TERMINATE:
+            return self._start
+        elif tp == FailureSpec.FAILURE_SUSPEND:
+            return self._continue
+        elif tp == FailureSpec.FAILURE_ISOLATE:
+            return self._heal
+        else:
+            return self._delete_netem
 
     def _kill(self, node):
         pass
@@ -187,16 +194,6 @@ class FailureInjector(FailureInjectorBase):
                                                  interval=spec.length)
                     self._in_flight.add(spec)
                     stop_timer.start()
-
-    def _stop_func(self, tp):
-        if tp == FailureSpec.FAILURE_KILL or tp == FailureSpec.FAILURE_TERMINATE:
-            return self._start
-        elif tp == FailureSpec.FAILURE_SUSPEND:
-            return self._continue
-        elif tp == FailureSpec.FAILURE_ISOLATE:
-            return self._heal
-        else:
-            return self._delete_netem
 
     def _kill(self, node):
         self.redpanda.logger.info(

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -59,10 +59,72 @@ class FailureSpec:
         return (self.type, self.length, self.node)
 
 
-class FailureInjector:
+class FailureInjectorBase:
     def __init__(self, redpanda):
         self.redpanda = redpanda
         self._in_flight = set()
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, traceback):
+        pass
+
+    def inject_failure(self, spec):
+        pass
+
+    def _start_func(self, tp):
+        pass
+
+    def _stop_func(self, tp):
+        pass
+
+    def _kill(self, node):
+        pass
+
+    def _isolate(self, node):
+        pass
+
+    def _heal(self, node):
+        pass
+
+    def _delete_netem(self, node):
+        pass
+
+    def _heal_all(self):
+        pass
+
+    def _suspend(self, node):
+        pass
+
+    def _terminate(self, node):
+        pass
+
+    def _continue(self, node):
+        pass
+
+    def _start(self, node):
+        pass
+
+    def _netem(self, node, op):
+        pass
+
+    def _netem_delay(self, node):
+        pass
+
+    def _netem_loss(self, node):
+        pass
+
+    def _netem_corrupt(self, node):
+        pass
+
+    def _netem_duplicate(self, node):
+        pass
+
+
+class FailureInjector(FailureInjectorBase):
+    def __init__(self, redpanda):
+        super(FailureInjector, self).__init__(redpanda)
 
     def __enter__(self):
         return self

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -65,10 +65,10 @@ class FailureInjectorBase:
         self._in_flight = set()
 
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, type, value, traceback):
-        pass
+        self._heal_all()
 
     def inject_failure(self, spec):
         pass
@@ -147,12 +147,6 @@ class FailureInjectorBase:
 class FailureInjector(FailureInjectorBase):
     def __init__(self, redpanda):
         super(FailureInjector, self).__init__(redpanda)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self._heal_all()
 
     def inject_failure(self, spec):
         if spec in self._in_flight:

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -74,7 +74,22 @@ class FailureInjectorBase:
         pass
 
     def _start_func(self, tp):
-        pass
+        if tp == FailureSpec.FAILURE_KILL:
+            return self._kill
+        elif tp == FailureSpec.FAILURE_SUSPEND:
+            return self._suspend
+        elif tp == FailureSpec.FAILURE_TERMINATE:
+            return self._terminate
+        elif tp == FailureSpec.FAILURE_ISOLATE:
+            return self._isolate
+        elif tp == FailureSpec.FAILURE_NETEM_RANDOM_DELAY:
+            return self._netem_delay
+        elif tp == FailureSpec.FAILURE_NETEM_PACKET_LOSS:
+            return self._netem_loss
+        elif tp == FailureSpec.FAILURE_NETEM_PACKET_CORRUPT:
+            return self._netem_corrupt
+        elif tp == FailureSpec.FAILURE_NETEM_PACKET_DUPLICATE:
+            return self._netem_duplicate
 
     def _stop_func(self, tp):
         pass
@@ -172,24 +187,6 @@ class FailureInjector(FailureInjectorBase):
                                                  interval=spec.length)
                     self._in_flight.add(spec)
                     stop_timer.start()
-
-    def _start_func(self, tp):
-        if tp == FailureSpec.FAILURE_KILL:
-            return self._kill
-        elif tp == FailureSpec.FAILURE_SUSPEND:
-            return self._suspend
-        elif tp == FailureSpec.FAILURE_TERMINATE:
-            return self._terminate
-        elif tp == FailureSpec.FAILURE_ISOLATE:
-            return self._isolate
-        elif tp == FailureSpec.FAILURE_NETEM_RANDOM_DELAY:
-            return self._netem_delay
-        elif tp == FailureSpec.FAILURE_NETEM_PACKET_LOSS:
-            return self._netem_loss
-        elif tp == FailureSpec.FAILURE_NETEM_PACKET_CORRUPT:
-            return self._netem_corrupt
-        elif tp == FailureSpec.FAILURE_NETEM_PACKET_DUPLICATE:
-            return self._netem_duplicate
 
     def _stop_func(self, tp):
         if tp == FailureSpec.FAILURE_KILL or tp == FailureSpec.FAILURE_TERMINATE:

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -14,6 +14,7 @@ from ducktape.utils.util import wait_until
 from ducktape.errors import TimeoutError
 from rptest.clients.kubectl import KubectlTool
 from rptest.services import tc_netem
+from rptest.services.redpanda import RedpandaServiceCloud
 
 
 class FailureSpec:
@@ -309,3 +310,11 @@ class FailureInjectorCloud(FailureInjectorBase):
     def _isolate(self, node):
         self.redpanda.logger.info(f"isolating node {node.account.hostname}")
         # TODO block port 33145 traffic on a node
+
+
+def make_failure_injector(redpanda):
+    """Factory function for instatiating the appropriate FailureInjector subclass."""
+    if RedpandaServiceCloud.GLOBAL_CLOUD_API_URL in redpanda.context.globals:
+        return FailureInjectorCloud(redpanda)
+    else:
+        return FailureInjector(redpanda)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3824,9 +3824,7 @@ def make_redpanda_service(context: TestContext,
 
     if RedpandaServiceCloud.GLOBAL_CLOUD_API_URL in context.globals:
         if cloud_tier is None:
-            raise RuntimeError(
-                f"The test cannot be run in the cloud, cloud_tier is not specified"
-            )
+            cloud_tier = CloudTierName.AWS_1
         if extra_rp_conf is not None:
             context.logger.info(
                 f"extra_rp_conf is ignored with RedpandaServiceCloud")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1439,9 +1439,9 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
     def start(self, **kwargs):
         cluster_id = self._cloud_cluster.create()
-        target = f'redpanda@{cluster_id}-agent'
+        remote_uri = f'redpanda@{cluster_id}-agent'
         self._kubectl = KubectlTool(self,
-                                    cmd_prefix=['tsh', 'ssh', target],
+                                    remote_uri=remote_uri,
                                     cluster_id=self._cloud_cluster.cluster_id)
 
     def stop_node(self, node, **kwargs):

--- a/tests/rptest/tests/e2e_finjector.py
+++ b/tests/rptest/tests/e2e_finjector.py
@@ -11,7 +11,7 @@ import random
 import time
 import threading
 
-from rptest.services.failure_injector import FailureInjector, FailureSpec
+from rptest.services.failure_injector import make_failure_injector, FailureSpec
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import Scale
 
@@ -70,7 +70,7 @@ class EndToEndFinjectorTest(EndToEndTest):
         return FailureSpec(node=node, type=f_type, length=length)
 
     def inject_failure(self, spec):
-        f_injector = FailureInjector(self.redpanda)
+        f_injector = make_failure_injector(self.redpanda)
         f_injector.inject_failure(spec)
 
     def _next_failure(self):
@@ -82,7 +82,7 @@ class EndToEndFinjectorTest(EndToEndTest):
     def _failure_injector_loop(self):
 
         while self.enable_failures:
-            f_injector = FailureInjector(self.redpanda)
+            f_injector = make_failure_injector(self.redpanda)
             f_injector.inject_failure(self._next_failure())
 
             delay = self.failure_delay_provier()
@@ -94,4 +94,4 @@ class EndToEndFinjectorTest(EndToEndTest):
         self.enable_failures = False
         if self.finjector_thread:
             self.finjector_thread.join()
-        FailureInjector(self.redpanda)._heal_all()
+        make_failure_injector(self.redpanda)._heal_all()

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -17,7 +17,7 @@ from rptest.util import wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.clients.default import DefaultClient
 from rptest.services.redpanda import make_redpanda_service, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
-from rptest.services.failure_injector import FailureInjector, FailureSpec
+from rptest.services.failure_injector import make_failure_injector, FailureSpec
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 
@@ -212,7 +212,7 @@ class PartitionBalancerService(EndToEndTest):
         """Stop/kill/freeze one node at a time and wait for partition balancer."""
         def __init__(self, test, exclude_unavailable_nodes=False):
             self.test = test
-            self.f_injector = FailureInjector(test.redpanda)
+            self.f_injector = make_failure_injector(test.redpanda)
             self.cur_failure = None
             self.logger = test.logger
             self.exclude_unavailable_nodes = exclude_unavailable_nodes

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -13,7 +13,7 @@ from ducktape.tests.test import Test
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
-
+from rptest.services.failure_injector import FailureSpec, make_failure_injector
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.kgo_repeater_service import repeater_traffic
 from rptest.services.kgo_verifier_services import KgoVerifierRandomConsumer, KgoVerifierSeqConsumer, KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
@@ -263,3 +263,20 @@ class SimpleSelfTest(Test):
 
         node_disk_free = self.redpanda.get_node_disk_free()
         assert node_disk_free > 0
+
+
+class FailureInjectorSelfTest(Test):
+    """
+    Verify instantiation of a FailureInjectorBase subclass through the factory method.
+    """
+    def __init__(self, test_context):
+        super(FailureInjectorSelfTest, self).__init__(test_context)
+        self.redpanda = make_redpanda_service(test_context, 3)
+
+    def setUp(self):
+        self.redpanda.start()
+
+    @cluster(num_nodes=3, check_allowed_error_logs=False)
+    def test_finjector(self):
+        fi = make_failure_injector(self.redpanda)
+        fi.inject_failure(FailureSpec(FailureSpec.FAILURE_ISOLATE, None))


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/devprod/issues/680

No changes to existing test behaviour that does not use redpanda cloud.

This PR adds a factory method `make_failure_injector()` to instantiate object from either the existing behaviour `FailureInjector` class or the newly-added class `FailureInjectorCloud` based on config settings in `ducktape_globals.json` (similar to factory pattern in PR #10521)

A simple test class `FailureInjectorSelfTest` is created in `tests/rptest/tests/services_self_test.py` to test the `_isolate()` method on cloud if cloud is enabled in the globals config file. I verified test passes with a cluster that was created before ducktape was run:
```console
ducktape \
  --debug \
  --globals=/path/to/ducktape_globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/path/to/ducktape_cluster.json \
  --test-runner-timeout=3600000 \
  tests/rptest/tests/services_self_test.py::FailureInjectorSelfTest
```

results:
```
[INFO:2023-06-16 12:15:40,408]: starting test run with session id 2023-06-16--002...
[INFO:2023-06-16 12:15:40,408]: running 1 tests...
[INFO:2023-06-16 12:15:40,408]: Triggering test 1 of 1...
[INFO:2023-06-16 12:15:40,413]: RunnerClient: Loading test {'directory': '/home/a/src/redpanda/tests/rptest/tests', 'file_name': 'services_self_test.py', 'cls_name': 'FailureInjectorSelfTest', 'method_name': 'test_finjector', 'injected_args': None}
[INFO:2023-06-16 12:15:40,417]: RunnerClient: rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector: Setting up...
[WARNING - 2023-06-16 12:15:40,417 - redpanda - create - lineno:1317]: will not create cluster; already have cluster_id ci0motok30vsi89l501g
[INFO:2023-06-16 12:15:40,417]: RunnerClient: rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector: Running...
[INFO:2023-06-16 12:16:13,228]: RunnerClient: rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector: PASS
[INFO:2023-06-16 12:16:13,229]: RunnerClient: rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector: Tearing down...
[WARNING - 2023-06-16 12:16:13,229 - runner_client - log - lineno:278]: RunnerClient: rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector: Test requested 3 nodes, used only 0
[WARNING:2023-06-16 12:16:13,230]: RunnerClient: rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector: Test requested 3 nodes, used only 0
[INFO:2023-06-16 12:16:13,230]: RunnerClient: rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector: Summary: 
[INFO:2023-06-16 12:16:13,230]: RunnerClient: rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector: Data: None
test_id:    rptest.tests.services_self_test.FailureInjectorSelfTest.test_finjector
status:     PASS
run time:   32.813 seconds
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
===========================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-06-16--002
run time:         32.826 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
==========================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none