### PR TITLE
test: check for early aborts on start-up failure

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1817,7 +1817,16 @@ class RedpandaService(RedpandaServiceBase):
                             omit_seeds_on_idx_one=omit_seeds_on_idx_one,
                             override_cfg_params=node_overrides)
 
-        self._for_nodes(to_start, start_one, parallel=parallel)
+        try:
+            self._for_nodes(to_start, start_one, parallel=parallel)
+        except TimeoutError as e:
+            if expect_fail:
+                raise e
+            if "failed to start within" in str(e):
+                self.logger.debug(
+                    f"Checking for crashes after start-up error: {e}")
+                self.raise_on_crash()
+            raise e
 
         if expect_fail:
             # If we got here without an exception, it means we failed as expected


### PR DESCRIPTION
If redpanda crashes very early on then it gets reported as a generic thing like "failed to start within 30 seconds". When this happens, let's look to see if a crash happened and report that. Otherwise, we'll just continue to raise the generic error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

