### PR TITLE
partition_allocator: exclude internal topics from per node partition limit checks

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -104,6 +104,7 @@ ss::future<> controller::wire_up() {
             config::shard_local_cfg().topic_fds_per_partition.bind(),
             config::shard_local_cfg().topic_partitions_per_shard.bind(),
             config::shard_local_cfg().topic_partitions_reserve_shard0.bind(),
+            config::shard_local_cfg().kafka_nodelete_topics.bind(),
             config::shard_local_cfg().enable_rack_awareness.bind());
       })
       .then([this] { return _credentials.start(); })

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -83,7 +83,10 @@ ss::future<bool> health_manager::ensure_partition_replication(model::ntp ntp) {
       ntp.tp.partition, _target_replication_factor);
 
     auto allocation = _allocator.local().reallocate_partition(
-      constraints, *assignment, get_allocation_domain(ntp));
+      model::topic_namespace{ntp.ns, ntp.tp.topic},
+      constraints,
+      *assignment,
+      get_allocation_domain(ntp));
     if (!allocation) {
         vlog(
           clusterlog.warn,

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -31,6 +31,7 @@ void reassign_replicas(
   partition_assignment current_assignment,
   members_backend::partition_reallocation& reallocation) {
     auto res = allocator.reallocate_partition(
+      model::topic_namespace{ntp.ns, ntp.tp.topic},
       reallocation.constraints.value(),
       current_assignment,
       get_allocation_domain(ntp),

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -40,7 +40,7 @@ distinct_from(const absl::flat_hash_set<model::node_id>& nodes) {
           : _nodes(nodes) {}
 
         hard_constraint_evaluator
-        make_evaluator(const replicas_t&) const final {
+        make_evaluator(const model::ntp&, const replicas_t&) const final {
             return [this](const allocation_node& node) {
                 return !_nodes.contains(node.id());
             };
@@ -828,7 +828,7 @@ partition_balancer_planner::reassignable_partition::move_replica(
     if (!_reallocated) {
         _reallocated
           = _ctx._parent._partition_allocator.make_allocated_partition(
-            replicas(), get_allocation_domain(_ntp));
+            _ntp, replicas(), get_allocation_domain(_ntp));
     }
 
     // Verify that we are moving only original replicas. This assumption

--- a/src/v/cluster/scheduling/allocation_node.cc
+++ b/src/v/cluster/scheduling/allocation_node.cc
@@ -20,12 +20,14 @@ allocation_node::allocation_node(
   model::node_id id,
   uint32_t cpus,
   config::binding<uint32_t> partitions_per_shard,
-  config::binding<uint32_t> partitions_reserve_shard0)
+  config::binding<uint32_t> partitions_reserve_shard0,
+  config::binding<std::vector<ss::sstring>> internal_kafka_topics)
   : _id(id)
   , _weights(cpus)
   , _max_capacity((cpus * partitions_per_shard()) - partitions_reserve_shard0())
   , _partitions_per_shard(std::move(partitions_per_shard))
   , _partitions_reserve_shard0(std::move(partitions_reserve_shard0))
+  , _internal_kafka_topics(std::move(internal_kafka_topics))
   , _cpus(cpus) {
     // add extra weights to core 0
     _weights[0] = _partitions_reserve_shard0();

--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -33,9 +33,10 @@ public:
 
     allocation_node(
       model::node_id,
-      uint32_t,
-      config::binding<uint32_t>,
-      config::binding<uint32_t>);
+      uint32_t /*cpus*/,
+      config::binding<uint32_t> /*partitions_per_shard*/,
+      config::binding<uint32_t> /*partitions_reserve_shard0*/,
+      config::binding<std::vector<ss::sstring>> /*internal_kafka_topics*/);
 
     allocation_node(allocation_node&& o) noexcept = default;
     allocation_node& operator=(allocation_node&&) = delete;
@@ -150,6 +151,7 @@ private:
 
     config::binding<uint32_t> _partitions_per_shard;
     config::binding<uint32_t> _partitions_reserve_shard0;
+    config::binding<std::vector<ss::sstring>> _internal_kafka_topics;
     // Keep track of how much weight we applied to shard0,
     // to enable runtime updates
     int32_t _shard0_reserved{0};

--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -124,7 +124,7 @@ public:
     bool empty() const {
         return _allocated_partitions == allocation_capacity{0};
     }
-    bool is_full() const { return _allocated_partitions >= _max_capacity; }
+    bool is_full(const model::ntp&) const;
     ss::shard_id allocate(partition_allocation_domain);
 
 private:

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -59,7 +59,8 @@ void allocation_state::register_node(
       broker.id(),
       broker.properties().cores,
       _partitions_per_shard,
-      _partitions_reserve_shard0);
+      _partitions_reserve_shard0,
+      _internal_kafka_topics);
 
     if (state == allocation_node::state::decommissioned) {
         node->decommission();
@@ -93,7 +94,8 @@ void allocation_state::update_allocation_nodes(
                 b.id(),
                 b.properties().cores,
                 _partitions_per_shard,
-                _partitions_reserve_shard0));
+                _partitions_reserve_shard0,
+                _internal_kafka_topics));
         } else {
             it->second->update_core_count(b.properties().cores);
             // node was added back to the cluster
@@ -114,7 +116,8 @@ void allocation_state::upsert_allocation_node(const model::broker& broker) {
             broker.id(),
             broker.properties().cores,
             _partitions_per_shard,
-            _partitions_reserve_shard0));
+            _partitions_reserve_shard0,
+            _internal_kafka_topics));
     } else {
         it->second->update_core_count(broker.properties().cores);
         // node was added back to the cluster

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -30,9 +30,11 @@ public:
 
     allocation_state(
       config::binding<uint32_t> partitions_per_shard,
-      config::binding<uint32_t> partitions_reserve_shard0)
-      : _partitions_per_shard(partitions_per_shard)
-      , _partitions_reserve_shard0(partitions_reserve_shard0) {}
+      config::binding<uint32_t> partitions_reserve_shard0,
+      config::binding<std::vector<ss::sstring>> internal_kafka_topics)
+      : _partitions_per_shard(std::move(partitions_per_shard))
+      , _partitions_reserve_shard0(std::move(partitions_reserve_shard0))
+      , _internal_kafka_topics(std::move(internal_kafka_topics)) {}
 
     // Allocation nodes
     void register_node(node_ptr);
@@ -84,6 +86,7 @@ private:
 
     config::binding<uint32_t> _partitions_per_shard;
     config::binding<uint32_t> _partitions_reserve_shard0;
+    config::binding<std::vector<ss::sstring>> _internal_kafka_topics;
 
     raft::group_id _highest_group{0};
     underlying_t _nodes;

--- a/src/v/cluster/scheduling/allocation_strategy.cc
+++ b/src/v/cluster/scheduling/allocation_strategy.cc
@@ -42,13 +42,14 @@ inline bool contains_node_already(
 }
 
 std::vector<model::node_id> solve_hard_constraints(
+  const model::ntp& ntp,
   const std::vector<model::broker_shard>& current_replicas,
   const std::vector<hard_constraint_ptr>& constraints,
   const allocation_state::underlying_t& nodes) {
     std::vector<hard_constraint_evaluator> evaluators;
     evaluators.reserve(constraints.size());
     for (auto& c : constraints) {
-        evaluators.push_back(c->make_evaluator(current_replicas));
+        evaluators.push_back(c->make_evaluator(ntp, current_replicas));
     }
 
     // empty hard constraints, all nodes are eligible
@@ -160,6 +161,7 @@ allocation_strategy simple_allocation_strategy() {
     class impl : public allocation_strategy::impl {
     public:
         result<model::node_id> choose_node(
+          const model::ntp& ntp,
           const std::vector<model::broker_shard>& current_replicas,
           const allocation_constraints& request,
           allocation_state& state,
@@ -169,6 +171,7 @@ allocation_strategy simple_allocation_strategy() {
              * evaluate hard constraints
              */
             std::vector<model::node_id> possible_nodes = solve_hard_constraints(
+              ntp,
               current_replicas,
               request.hard_constraints,
               state.allocation_nodes());

--- a/src/v/cluster/scheduling/allocation_strategy.h
+++ b/src/v/cluster/scheduling/allocation_strategy.h
@@ -26,6 +26,7 @@ public:
          * constraints in the specified domain
          */
         virtual result<model::node_id> choose_node(
+          const model::ntp&,
           const replicas_t&,
           const allocation_constraints&,
           allocation_state&,
@@ -39,11 +40,12 @@ public:
       : _impl(std::move(impl)) {}
 
     result<model::node_id> choose_node(
+      const model::ntp& ntp,
       const replicas_t& current_replicas,
       const allocation_constraints& ac,
       allocation_state& state,
       const partition_allocation_domain domain) {
-        return _impl->choose_node(current_replicas, ac, state, domain);
+        return _impl->choose_node(ntp, current_replicas, ac, state, domain);
     }
 
 private:

--- a/src/v/cluster/scheduling/constraints.cc
+++ b/src/v/cluster/scheduling/constraints.cc
@@ -29,7 +29,7 @@ hard_constraint not_fully_allocated() {
     class impl : public hard_constraint::impl {
     public:
         hard_constraint_evaluator
-        make_evaluator(const replicas_t&) const final {
+        make_evaluator(const model::ntp&, const replicas_t&) const final {
             return [](const allocation_node& node) { return !node.is_full(); };
         }
 
@@ -45,7 +45,7 @@ hard_constraint is_active() {
     class impl : public hard_constraint::impl {
     public:
         hard_constraint_evaluator
-        make_evaluator(const replicas_t&) const final {
+        make_evaluator(const model::ntp&, const replicas_t&) const final {
             return [](const allocation_node& node) { return node.is_active(); };
         }
 
@@ -62,7 +62,7 @@ hard_constraint on_node(model::node_id id) {
           : _id(id) {}
 
         hard_constraint_evaluator
-        make_evaluator(const replicas_t&) const final {
+        make_evaluator(const model::ntp&, const replicas_t&) const final {
             return
               [this](const allocation_node& node) { return node.id() == _id; };
         }
@@ -89,7 +89,7 @@ hard_constraint on_nodes(const std::vector<model::node_id>& ids) {
             }
         }
         hard_constraint_evaluator
-        make_evaluator(const replicas_t&) const final {
+        make_evaluator(const model::ntp&, const replicas_t&) const final {
             return [this](const allocation_node& node) {
                 return _ids.contains(node.id());
             };
@@ -125,7 +125,7 @@ hard_constraint distinct_from(const replicas_t& replicas) {
           : _replicas(r) {}
 
         hard_constraint_evaluator
-        make_evaluator(const replicas_t&) const final {
+        make_evaluator(const model::ntp&, const replicas_t&) const final {
             return [this](const allocation_node& node) {
                 return std::all_of(
                   _replicas.begin(),
@@ -150,8 +150,8 @@ hard_constraint distinct_from(const replicas_t& replicas) {
 hard_constraint distinct_nodes() {
     class impl : public hard_constraint::impl {
     public:
-        hard_constraint_evaluator
-        make_evaluator(const replicas_t& current_replicas) const final {
+        hard_constraint_evaluator make_evaluator(
+          const model::ntp&, const replicas_t& current_replicas) const final {
             return [&current_replicas](const allocation_node& node) {
                 return std::all_of(
                   current_replicas.begin(),
@@ -187,7 +187,7 @@ hard_constraint disk_not_overflowed_by_partition(
           , _node_disk_reports(node_disk_reports) {}
 
         hard_constraint_evaluator
-        make_evaluator(const replicas_t&) const final {
+        make_evaluator(const model::ntp&, const replicas_t&) const final {
             return [this](const allocation_node& node) {
                 auto disk_it = _node_disk_reports.find(node.id());
                 if (disk_it == _node_disk_reports.end()) {
@@ -320,32 +320,6 @@ soft_constraint least_disk_filled(
 
     return soft_constraint(
       std::make_unique<impl>(max_disk_usage_ratio, node_disk_reports));
-}
-
-soft_constraint make_soft_constraint(hard_constraint constraint) {
-    class impl : public soft_constraint::impl {
-    public:
-        explicit impl(hard_constraint constraint)
-          : _hard_constraint(std::move(constraint)) {}
-
-        soft_constraint_evaluator
-        make_evaluator(const replicas_t& replicas) const final {
-            auto ev = _hard_constraint.make_evaluator(replicas);
-            return
-              [ev = std::move(ev)](const allocation_node& node) -> uint64_t {
-                  return ev(node) ? soft_constraint::max_score : 0;
-              };
-        }
-
-        ss::sstring name() const final {
-            return ssx::sformat(
-              "soft constraint adapter of ({})", _hard_constraint);
-        }
-
-        const hard_constraint _hard_constraint;
-    };
-
-    return soft_constraint(std::make_unique<impl>(std::move(constraint)));
 }
 
 soft_constraint distinct_rack_preferred(const members_table& members) {

--- a/src/v/cluster/scheduling/constraints.cc
+++ b/src/v/cluster/scheduling/constraints.cc
@@ -29,8 +29,10 @@ hard_constraint not_fully_allocated() {
     class impl : public hard_constraint::impl {
     public:
         hard_constraint_evaluator
-        make_evaluator(const model::ntp&, const replicas_t&) const final {
-            return [](const allocation_node& node) { return !node.is_full(); };
+        make_evaluator(const model::ntp& ntp, const replicas_t&) const final {
+            return [&ntp](const allocation_node& node) {
+                return !node.is_full(ntp);
+            };
         }
 
         ss::sstring name() const final {

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -23,12 +23,6 @@ namespace cluster {
 class allocation_state;
 
 static constexpr std::string_view rack_label = "rack";
-/**
- * make_soft_constraint adapts hard constraint to soft one by returning
- * max score for nodes that matches the soft constraint and 0 for
- * the ones that not
- */
-soft_constraint make_soft_constraint(hard_constraint);
 
 hard_constraint not_fully_allocated();
 hard_constraint is_active();

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -77,6 +77,7 @@ allocation_constraints partition_allocator::default_constraints(
 }
 
 result<allocated_partition> partition_allocator::allocate_new_partition(
+  model::topic_namespace nt,
   partition_constraints p_constraints,
   const partition_allocation_domain domain) {
     vlog(
@@ -94,7 +95,9 @@ result<allocated_partition> partition_allocator::allocate_new_partition(
     auto effective_constraints = default_constraints(domain);
     effective_constraints.add(p_constraints.constraints);
 
-    allocated_partition ret{{}, domain, *_state};
+    model::ntp ntp{
+      std::move(nt.ns), std::move(nt.tp), p_constraints.partition_id};
+    allocated_partition ret{std::move(ntp), {}, domain, *_state};
     for (auto r = 0; r < replicas_to_allocate; ++r) {
         auto replica = do_allocate_replica(
           ret, std::nullopt, effective_constraints);
@@ -271,10 +274,11 @@ partition_allocator::allocate(allocation_request request) {
     intermediate_allocation assignments(
       *_state, request.partitions.size(), request.domain);
 
+    const auto& nt = request._nt;
     for (auto& p_constraints : request.partitions) {
         auto const partition_id = p_constraints.partition_id;
         auto allocated = allocate_new_partition(
-          std::move(p_constraints), request.domain);
+          nt, std::move(p_constraints), request.domain);
         if (!allocated) {
             co_return allocated.error();
         }
@@ -290,6 +294,7 @@ partition_allocator::allocate(allocation_request request) {
 }
 
 result<allocated_partition> partition_allocator::reallocate_partition(
+  model::topic_namespace nt,
   partition_constraints p_constraints,
   const partition_assignment& current_assignment,
   const partition_allocation_domain domain,
@@ -309,7 +314,10 @@ result<allocated_partition> partition_allocator::reallocate_partition(
         return errc::topic_invalid_replication_factor;
     }
 
-    allocated_partition res{current_assignment.replicas, domain, *_state};
+    model::ntp ntp{
+      std::move(nt.ns), std::move(nt.tp), p_constraints.partition_id};
+    allocated_partition res{
+      std::move(ntp), current_assignment.replicas, domain, *_state};
 
     if (num_new_replicas == 0 && replicas_to_reallocate.empty()) {
         // nothing to do
@@ -340,9 +348,11 @@ result<allocated_partition> partition_allocator::reallocate_partition(
 }
 
 allocated_partition partition_allocator::make_allocated_partition(
+  model::ntp ntp,
   std::vector<model::broker_shard> replicas,
   partition_allocation_domain domain) const {
-    return allocated_partition{std::move(replicas), domain, *_state};
+    return allocated_partition{
+      std::move(ntp), std::move(replicas), domain, *_state};
 }
 
 result<reallocation_step> partition_allocator::reallocate_replica(
@@ -381,7 +391,11 @@ result<reallocation_step> partition_allocator::do_allocate_replica(
     });
 
     auto node = _allocation_strategy.choose_node(
-      partition._replicas, effective_constraints, *_state, partition._domain);
+      partition._ntp,
+      partition._replicas,
+      effective_constraints,
+      *_state,
+      partition._domain);
     if (!node) {
         return node.error();
     }

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -32,11 +32,13 @@ public:
     static constexpr ss::shard_id shard = 0;
     partition_allocator(
       ss::sharded<members_table>&,
-      config::binding<std::optional<size_t>>,
-      config::binding<std::optional<int32_t>>,
-      config::binding<uint32_t>,
-      config::binding<uint32_t>,
-      config::binding<bool>);
+      config::binding<std::optional<size_t>> memory_per_partition,
+      config::binding<std::optional<int32_t>> fds_per_partition,
+      config::binding<uint32_t> partitions_per_shard,
+      config::binding<uint32_t> partitions_reserve_shard0,
+      config::binding<std::vector<ss::sstring>>
+        kafka_topics_skipping_allocation,
+      config::binding<bool> enable_rack_awareness);
 
     // Replica placement APIs
 
@@ -200,6 +202,7 @@ private:
     config::binding<std::optional<int32_t>> _fds_per_partition;
     config::binding<uint32_t> _partitions_per_shard;
     config::binding<uint32_t> _partitions_reserve_shard0;
+    config::binding<std::vector<ss::sstring>> _internal_kafka_topics;
     config::binding<bool> _enable_rack_awareness;
 };
 } // namespace cluster

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -51,6 +51,7 @@ public:
     /// replicas to reach the requested replication factor will be allocated
     /// anew.
     result<allocated_partition> reallocate_partition(
+      model::topic_namespace,
       partition_constraints,
       const partition_assignment&,
       partition_allocation_domain,
@@ -59,6 +60,7 @@ public:
     /// Create allocated_partition object from current replicas for use with the
     /// allocate_replica method.
     allocated_partition make_allocated_partition(
+      model::ntp ntp,
       std::vector<model::broker_shard> replicas,
       partition_allocation_domain) const;
 
@@ -178,7 +180,9 @@ private:
     check_cluster_limits(allocation_request const& request) const;
 
     result<allocated_partition> allocate_new_partition(
-      partition_constraints, partition_allocation_domain);
+      model::topic_namespace nt,
+      partition_constraints,
+      partition_allocation_domain);
 
     result<reallocation_step> do_allocate_replica(
       allocated_partition&,

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -19,9 +19,9 @@
 
 namespace cluster {
 
-hard_constraint_evaluator
-hard_constraint::make_evaluator(const replicas_t& current_replicas) const {
-    auto ev = _impl->make_evaluator(current_replicas);
+hard_constraint_evaluator hard_constraint::make_evaluator(
+  const model::ntp& ntp, const replicas_t& current_replicas) const {
+    auto ev = _impl->make_evaluator(ntp, current_replicas);
     return [this, ev = std::move(ev)](const allocation_node& node) {
         auto res = ev(node);
         vlog(clusterlog.trace, "{}({}) = {}", name(), node.id(), res);
@@ -85,10 +85,12 @@ allocation_units::~allocation_units() {
 }
 
 allocated_partition::allocated_partition(
+  model::ntp ntp,
   std::vector<model::broker_shard> replicas,
   partition_allocation_domain domain,
   allocation_state& state)
-  : _replicas(std::move(replicas))
+  : _ntp(std::move(ntp))
+  , _replicas(std::move(replicas))
   , _domain(domain)
   , _state(state.weak_from_this()) {}
 

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -116,7 +116,7 @@ struct partition_allocator_fixture {
     cluster::allocation_request
     make_allocation_request(int partitions, uint16_t replication_factor) {
         cluster::allocation_request req(
-          cluster::partition_allocation_domains::common);
+          tn, cluster::partition_allocation_domains::common);
         req.partitions.reserve(partitions);
         for (int i = 0; i < partitions; ++i) {
             req.partitions.emplace_back(
@@ -125,6 +125,7 @@ struct partition_allocator_fixture {
         return req;
     }
 
+    model::topic_namespace tn{model::kafka_namespace, model::topic{"test"}};
     ss::sharded<cluster::members_table> members;
     cluster::partition_allocator allocator;
 

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -17,6 +17,7 @@
 #include "cluster/scheduling/allocation_strategy.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "config/configuration.h"
+#include "config/mock_property.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
@@ -37,7 +38,7 @@ struct partition_allocator_fixture {
         config::mock_binding<std::optional<int32_t>>(std::nullopt),
         config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
         config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
-        config::mock_binding<std::vector<ss::sstring>>({}),
+        kafka_internal_topics.bind(),
         config::mock_binding<bool>(true)) {
         members.start().get0();
         ss::smp::invoke_on_all([] {
@@ -71,7 +72,7 @@ struct partition_allocator_fixture {
           broker.properties().cores,
           config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
           config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
-          config::mock_binding<std::vector<ss::sstring>>({})));
+          kafka_internal_topics.bind()));
     }
 
     void saturate_all_machines() {
@@ -117,8 +118,13 @@ struct partition_allocator_fixture {
 
     cluster::allocation_request
     make_allocation_request(int partitions, uint16_t replication_factor) {
+        return make_allocation_request(tn, partitions, replication_factor);
+    }
+
+    cluster::allocation_request make_allocation_request(
+      model::topic_namespace tn, int partitions, uint16_t replication_factor) {
         cluster::allocation_request req(
-          tn, cluster::partition_allocation_domains::common);
+          std::move(tn), cluster::partition_allocation_domains::common);
         req.partitions.reserve(partitions);
         for (int i = 0; i < partitions; ++i) {
             req.partitions.emplace_back(
@@ -127,6 +133,7 @@ struct partition_allocator_fixture {
         return req;
     }
 
+    config::mock_property<std::vector<ss::sstring>> kafka_internal_topics{{}};
     model::topic_namespace tn{model::kafka_namespace, model::topic{"test"}};
     ss::sharded<cluster::members_table> members;
     cluster::partition_allocator allocator;

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -37,6 +37,7 @@ struct partition_allocator_fixture {
         config::mock_binding<std::optional<int32_t>>(std::nullopt),
         config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
         config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
+        config::mock_binding<std::vector<ss::sstring>>({}),
         config::mock_binding<bool>(true)) {
         members.start().get0();
         ss::smp::invoke_on_all([] {
@@ -69,7 +70,8 @@ struct partition_allocator_fixture {
           broker.id(),
           broker.properties().cores,
           config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
-          config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0})));
+          config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
+          config::mock_binding<std::vector<ss::sstring>>({})));
     }
 
     void saturate_all_machines() {

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -48,7 +48,8 @@ create_allocation_node(model::node_id nid, uint32_t cores) {
       nid,
       cores,
       config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
-      config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}));
+      config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
+      config::mock_binding<std::vector<ss::sstring>>({}));
 }
 
 struct controller_workers {
@@ -64,6 +65,9 @@ public:
             config::mock_binding<std::optional<int32_t>>(std::nullopt),
             config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
             config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
+            config::mock_binding<std::vector<ss::sstring>>(
+              std::vector<ss::sstring>{
+                {"__audit", "__consumer_offsets", "_schemas"}}),
             config::mock_binding<bool>(true))
           .get();
         // use node status that is not used in test as self is always available

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -59,7 +59,8 @@ public:
             id,
             n_cores,
             config::mock_binding<uint32_t>(1000),
-            config::mock_binding<uint32_t>(0)));
+            config::mock_binding<uint32_t>(0),
+            config::mock_binding<std::vector<ss::sstring>>({})));
 
         // add some random initial used space
         size_t initial_used = random_generators::get_int(

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -97,7 +97,7 @@ struct topic_table_fixture {
           test_ns, model::topic(topic), partitions, replication_factor);
 
         cluster::allocation_request req(
-          cluster::partition_allocation_domains::common);
+          cfg.tp_ns, cluster::partition_allocation_domains::common);
         req.partitions.reserve(partitions);
         for (auto p = 0; p < partitions; ++p) {
             req.partitions.emplace_back(

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -54,6 +54,7 @@ struct topic_table_fixture {
             config::mock_binding<std::optional<int32_t>>(std::nullopt),
             config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
             config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
+            config::mock_binding<std::vector<ss::sstring>>({}),
             config::mock_binding<bool>(false))
           .get0();
         allocator.local().register_node(
@@ -88,7 +89,8 @@ struct topic_table_fixture {
           nid,
           cores,
           config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
-          config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}));
+          config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
+          config::mock_binding<std::vector<ss::sstring>>({}));
     }
 
     cluster::topic_configuration_assignment make_tp_configuration(


### PR DESCRIPTION
Internal topics are now excluded from partition allocator limit checks. This means that a given allocation node can host any number of such internal topic partitions. A topic is considered internal in the following cases:

- It belongs to `redpanda` or `kafka_internal` namespaces or
- It belongs to `kafka` namespace but included in `kafka_nodelete_topics`

The rationale for do so is that these topics can potentially be created lazily, for example transactions related topics are created when a user uses transactions for the first time. This could be problematic if the user has already exhausted `topic_partitions_per_shard` limits and the creation of these internal topics just hangs. To avoid such scenarios we exclude these internal topics from limit checks. This should not be problematic in practice because total number of such internal partitions in a typical deployment is fairly small compared to total number of non internal partitions.

Fixes: https://github.com/redpanda-data/redpanda/issues/10995

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
