### PR TITLE
Default to reading from the beginning of partition in `ThroughputLimitsSnc.test_consumers`

### DIFF
--- a/tests/rptest/services/kcat_consumer.py
+++ b/tests/rptest/services/kcat_consumer.py
@@ -130,14 +130,14 @@ class KcatConsumer(BackgroundThreadService):
 
         if getattr(self._redpanda, "sasl_enabled", lambda: False)():
             cfg = self._redpanda.security_config()
-            cmd += [
+            self._cmd += [
                 "-X", f"security.protocol={cfg['security_protocol']}", "-X"
                 f"sasl.mechanism={cfg['sasl_mechanism']}", "-X",
                 f"sasl.username={cfg['sasl_plain_username']}", "-X",
                 f"sasl.password={cfg['sasl_plain_password']}"
             ]
             if cfg['sasl_mechanism'] == "GSSAPI":
-                cmd += [
+                self._cmd += [
                     "-X", "sasl.kerberos.service.name=redpanda",
                     '-Xsasl.kerberos.kinit.cmd=kinit client -t /var/lib/redpanda/client.keytab'
                 ]

--- a/tests/rptest/tests/throughput_limits_snc_test.py
+++ b/tests/rptest/tests/throughput_limits_snc_test.py
@@ -288,14 +288,16 @@ class ThroughputLimitsSnc(RedpandaTest):
                                 self.topic,
                                 offset=KcatConsumer.OffsetMeta.beginning,
                                 cgroup_name="cg01",
-                                auto_commit_interval_ms=500
-                                #caption="consumer1"
-                                )
+                                auto_commit_interval_ms=500)
         consumer.set_on_message(on_message)
         consumer.start()
-        wait_until(lambda: consumer.consumed_total >= msg_count // 10,
-                   timeout_sec=10,
-                   backoff_sec=0.001)
+        wait_until(
+            lambda: consumer.consumed_total >= msg_count // 10,
+            timeout_sec=10,
+            backoff_sec=0.001,
+            err_msg=
+            "Timeout waiting for the first consumer to receive 10% of messages"
+        )
 
         consumer2 = KcatConsumer(self.test_context,
                                  self.redpanda,
@@ -303,13 +305,17 @@ class ThroughputLimitsSnc(RedpandaTest):
                                  offset=KcatConsumer.OffsetMeta.stored,
                                  cgroup_name="cg01",
                                  auto_commit_interval_ms=500
-                                 #caption="consumer2"
                                  )
         consumer2.set_on_message(on_message)
         consumer2.start()
         # ensure that the 2nd consumer has connected and joined the cgroup
         # by checking that it has started to consume
-        wait_until(lambda: consumer2.consumed_total > 0, timeout_sec=30)
+        wait_until(
+            lambda: consumer2.consumed_total > 0,
+            timeout_sec=30,
+            err_msg=
+            "Timeout waiting for the second consumer to join the cgroup and consume something"
+        )
 
         producer.stop()
         consumer.stop()

--- a/tests/rptest/tests/throughput_limits_snc_test.py
+++ b/tests/rptest/tests/throughput_limits_snc_test.py
@@ -299,13 +299,14 @@ class ThroughputLimitsSnc(RedpandaTest):
             "Timeout waiting for the first consumer to receive 10% of messages"
         )
 
-        consumer2 = KcatConsumer(self.test_context,
-                                 self.redpanda,
-                                 self.topic,
-                                 offset=KcatConsumer.OffsetMeta.stored,
-                                 cgroup_name="cg01",
-                                 auto_commit_interval_ms=500
-                                 )
+        consumer2 = KcatConsumer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            offset=KcatConsumer.OffsetMeta.stored,
+            offset_default=KcatConsumer.OffsetDefaultMeta.beginning,
+            cgroup_name="cg01",
+            auto_commit_interval_ms=500)
         consumer2.set_on_message(on_message)
         consumer2.start()
         # ensure that the 2nd consumer has connected and joined the cgroup


### PR DESCRIPTION
In `ThroughputLimitsSnc.test_consumers`, by the time the 1st consumer joins the cgroup, the 0th consumer has not fetched any messages from partition 1 yet, and there is no offset stored for that partition. Consumer 1, who was supposed to read from the stored offset, then defaults to reading from the end, and since the producer is already done by that time, does not fetch a single message, thus failing to verify the assertion.

This PR makes the 1st consumer to default to reading from the beginning of partition.

The issue was introduced in #10785

Fixes #11157

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
