### PR TITLE
Use python generator to read controller log

### DIFF
--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -878,14 +878,13 @@ def decode_record(batch, record, bin_dump: bool):
 
 
 class ControllerLog:
-    def __init__(self, ntp):
+    def __init__(self, ntp, bin_dump: bool):
         self.ntp = ntp
-        self.records = []
+        self.bin_dump = bin_dump
 
-    def decode(self, bin_dump: bool):
+    def __iter__(self):
         for path in self.ntp.segments:
             s = Segment(path)
             for b in s:
                 for r in b:
-                    dec = decode_record(b, r, bin_dump)
-                    self.records.append(decode_record(b, r, bin_dump))
+                    yield decode_record(b, r, self.bin_dump)


### PR DESCRIPTION
Using python generator to decode controller log prevents reading the whole log to memory, this way it is possible to process very large controller logs with offline metadata viewer tool.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
