### PR TITLE
[v22.2.x] ducktape-deps: fix installing confluent-kafka on arm64

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -165,7 +165,7 @@ RUN /k8s && \
 
 #################################
 
-FROM base as final
+FROM librdkafka as final
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/arroyo /
 RUN /arroyo && \
@@ -210,8 +210,6 @@ COPY --from=java-verifiers /opt/compacted-log-verifier /opt/compacted-log-verifi
 COPY --from=java-verifiers /opt/tx-verifier /opt/tx-verifier
 COPY --from=java-verifiers /root/.m2 /root/.m2
 COPY --from=kafka-tools /opt /opt
-COPY --from=librdkafka /opt/librdkafka /opt/librdkafka
-COPY --from=librdkafka /usr/local/lib /usr/local/lib
 COPY --from=kcat /usr/local/bin/kcat /usr/local/bin/
 COPY --from=sarama-examples /opt/sarama /opt/sarama
 COPY --from=golang-test-clients /opt/redpanda-tests/go /opt/redpanda-tests/go


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11220
