### PR TITLE
schema_registry: Switch Schema ID Validation enablement to cluster config

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -14,6 +14,7 @@
 #include "config/node_config.h"
 #include "config/validators.h"
 #include "model/metadata.h"
+#include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "security/gssapi_principal_mapper.h"
 #include "security/mtls.h"
 #include "storage/chunk_cache.h"
@@ -2100,6 +2101,15 @@ configuration::configuration()
       "that unsafe strings are permitted",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       300s)
+  , enable_schema_id_validation(
+      *this,
+      "enable_schema_id_validation",
+      "Enable Server Side Schema ID Validation.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      pandaproxy::schema_registry::schema_id_validation_mode::none,
+      {pandaproxy::schema_registry::schema_id_validation_mode::none,
+       pandaproxy::schema_registry::schema_id_validation_mode::redpanda,
+       pandaproxy::schema_registry::schema_id_validation_mode::compat})
   , kafka_schema_id_validation_cache_capacity(
       *this,
       "kafka_schema_id_validation_cache_capacity",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -25,6 +25,7 @@
 #include "model/metadata.h"
 #include "model/timestamp.h"
 #include "net/unresolved_address.h"
+#include "pandaproxy/schema_registry/schema_id_validation.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/net/inet_address.hh>
@@ -423,6 +424,8 @@ struct configuration final : public config_store {
     property<std::chrono::seconds> legacy_unsafe_log_warning_interval_sec;
 
     // schema id validation
+    enum_property<pandaproxy::schema_registry::schema_id_validation_mode>
+      enable_schema_id_validation;
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -15,6 +15,7 @@
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "oncore.h"
+#include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "reflection/type_traits.h"
 #include "utils/intrusive_list_helpers.h"
@@ -620,6 +621,11 @@ consteval std::string_view property_type_name() {
                            type,
                            pandaproxy::schema_registry::
                              subject_name_strategy>) {
+        return "string";
+    } else if constexpr (std::is_same_v<
+                           type,
+                           pandaproxy::schema_registry::
+                             schema_id_validation_mode>) {
         return "string";
     } else {
         static_assert(dependent_false<T>::value, "Type name not defined");

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -172,4 +172,10 @@ void rjson_serialize(
     stringize(w, v);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const pandaproxy::schema_registry::schema_id_validation_mode& v) {
+    stringize(w, v);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -19,6 +19,7 @@
 #include "json/json.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
+#include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "seastarx.h"
 
@@ -82,5 +83,9 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const pandaproxy::schema_registry::subject_name_strategy& v);
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const pandaproxy::schema_registry::schema_id_validation_mode& v);
 
 } // namespace json

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -69,8 +69,6 @@ std::string_view to_string_view(feature f) {
         return "transaction_partitioning";
     case feature::force_partition_reconfiguration:
         return "force_partition_reconfiguration";
-    case feature::schema_id_validation:
-        return "schema_id_validation";
     case feature::raft_append_entries_serde:
         return "raft_append_entries_serde";
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -59,7 +59,6 @@ enum class feature : std::uint64_t {
     cloud_storage_manifest_format_v2 = 1ULL << 24U,
     transaction_partitioning = 1ULL << 25U,
     force_partition_reconfiguration = 1ULL << 26U,
-    schema_id_validation = 1ULL << 27U,
     raft_append_entries_serde = 1ULL << 28U,
 
     // Dummy features for testing only
@@ -265,12 +264,6 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{10},
     "force_partition_reconfiguration",
     feature::force_partition_reconfiguration,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
-  feature_spec{
-    cluster::cluster_version{10},
-    "schema_id_validation",
-    feature::schema_id_validation,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -232,8 +232,9 @@ create_topic_properties_update(
                   kafka::config_resource_operation::set);
                 continue;
             }
-            if (ctx.feature_table().local().is_active(
-                  features::feature::schema_id_validation)) {
+            if (
+              config::shard_local_cfg().enable_schema_id_validation()
+              != pandaproxy::schema_registry::schema_id_validation_mode::none) {
                 if (schema_id_validation_config_parser(
                       cfg, kafka::config_resource_operation::set)) {
                     continue;

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -19,8 +19,8 @@
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/request_context.h"
 #include "kafka/types.h"
-#include "model/schema_id_validation.h"
 #include "outcome.h"
+#include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "security/acl.h"
 
@@ -400,7 +400,7 @@ public:
 
         auto matcher = string_switch<std::optional<property_t>>(cfg.name);
         switch (config::shard_local_cfg().enable_schema_id_validation()) {
-        case model::schema_id_validation_mode::compat:
+        case pandaproxy::schema_registry::schema_id_validation_mode::compat:
             matcher
               .match(
                 topic_property_record_key_schema_id_validation_compat,
@@ -415,7 +415,7 @@ public:
                 topic_property_record_value_subject_name_strategy_compat,
                 &props.record_value_subject_name_strategy_compat);
             [[fallthrough]];
-        case model::schema_id_validation_mode::redpanda:
+        case pandaproxy::schema_registry::schema_id_validation_mode::redpanda:
             matcher
               .match(
                 topic_property_record_key_schema_id_validation,
@@ -430,7 +430,7 @@ public:
                 topic_property_record_value_subject_name_strategy,
                 &props.record_value_subject_name_strategy);
             [[fallthrough]];
-        case model::schema_id_validation_mode::none:
+        case pandaproxy::schema_registry::schema_id_validation_mode::none:
             break;
         }
         auto prop = matcher.default_match(std::nullopt);

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -19,6 +19,7 @@
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/request_context.h"
 #include "kafka/types.h"
+#include "model/schema_id_validation.h"
 #include "outcome.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "security/acl.h"
@@ -397,8 +398,10 @@ public:
           decltype(&props.record_key_schema_id_validation),
           decltype(&props.record_key_subject_name_strategy)>;
 
-        auto prop
-          = string_switch<std::optional<property_t>>(cfg.name)
+        auto matcher = string_switch<std::optional<property_t>>(cfg.name);
+        switch (config::shard_local_cfg().enable_schema_id_validation()) {
+        case model::schema_id_validation_mode::compat:
+            matcher
               .match(
                 topic_property_record_key_schema_id_validation_compat,
                 &props.record_key_schema_id_validation_compat)
@@ -410,7 +413,10 @@ public:
                 &props.record_value_schema_id_validation_compat)
               .match(
                 topic_property_record_value_subject_name_strategy_compat,
-                &props.record_value_subject_name_strategy_compat)
+                &props.record_value_subject_name_strategy_compat);
+            [[fallthrough]];
+        case model::schema_id_validation_mode::redpanda:
+            matcher
               .match(
                 topic_property_record_key_schema_id_validation,
                 &props.record_key_schema_id_validation)
@@ -422,8 +428,12 @@ public:
                 &props.record_value_schema_id_validation)
               .match(
                 topic_property_record_value_subject_name_strategy,
-                &props.record_value_subject_name_strategy)
-            .default_match(std::nullopt);
+                &props.record_value_subject_name_strategy);
+            [[fallthrough]];
+        case model::schema_id_validation_mode::none:
+            break;
+        }
+        auto prop = matcher.default_match(std::nullopt);
         if (prop.has_value()) {
             ss::visit(
               prop.value(), [&cfg, op](auto& p) { apply(*p, cfg.value, op); });

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -400,30 +400,30 @@ public:
         auto prop
           = string_switch<std::optional<property_t>>(cfg.name)
               .match(
-                topic_property_record_key_schema_id_validation,
-                &props.record_key_schema_id_validation)
-              .match(
                 topic_property_record_key_schema_id_validation_compat,
                 &props.record_key_schema_id_validation_compat)
-              .match(
-                topic_property_record_key_subject_name_strategy,
-                &props.record_key_subject_name_strategy)
               .match(
                 topic_property_record_key_subject_name_strategy_compat,
                 &props.record_key_subject_name_strategy_compat)
               .match(
-                topic_property_record_value_schema_id_validation,
-                &props.record_value_schema_id_validation)
-              .match(
                 topic_property_record_value_schema_id_validation_compat,
                 &props.record_value_schema_id_validation_compat)
               .match(
-                topic_property_record_value_subject_name_strategy,
-                &props.record_value_subject_name_strategy)
-              .match(
                 topic_property_record_value_subject_name_strategy_compat,
                 &props.record_value_subject_name_strategy_compat)
-              .default_match(std::nullopt);
+              .match(
+                topic_property_record_key_schema_id_validation,
+                &props.record_key_schema_id_validation)
+              .match(
+                topic_property_record_key_subject_name_strategy,
+                &props.record_key_subject_name_strategy)
+              .match(
+                topic_property_record_value_schema_id_validation,
+                &props.record_value_schema_id_validation)
+              .match(
+                topic_property_record_value_subject_name_strategy,
+                &props.record_value_subject_name_strategy)
+            .default_match(std::nullopt);
         if (prop.has_value()) {
             ss::visit(
               prop.value(), [&cfg, op](auto& p) { apply(*p, cfg.value, op); });

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -810,8 +810,9 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 request.data.include_documentation,
                 config::shard_local_cfg().log_segment_ms.desc()));
 
-            if (ctx.feature_table().local().is_active(
-                  features::feature::schema_id_validation)) {
+            if (
+              config::shard_local_cfg().enable_schema_id_validation()
+              != pandaproxy::schema_registry::schema_id_validation_mode::none) {
                 constexpr std::string_view key_validation
                   = "Enable validation of the schema id for keys on a record";
                 constexpr std::string_view val_validation

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -818,19 +818,6 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 constexpr std::string_view val_validation
                   = "Enable validation of the schema id for values on a record";
                 const bool hide_default_override = true;
-                add_topic_config_if_requested(
-                  resource,
-                  result,
-                  topic_property_record_key_schema_id_validation,
-                  ctx.metadata_cache()
-                    .get_default_record_key_schema_id_validation(),
-                  topic_property_record_key_schema_id_validation,
-                  topic_config->properties.record_key_schema_id_validation,
-                  request.data.include_synonyms,
-                  maybe_make_documentation(
-                    request.data.include_documentation, key_validation),
-                  &describe_as_string<bool>,
-                  hide_default_override);
 
                 add_topic_config_if_requested(
                   resource,
@@ -841,6 +828,75 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   topic_property_record_key_schema_id_validation_compat,
                   topic_config->properties
                     .record_key_schema_id_validation_compat,
+                  request.data.include_synonyms,
+                  maybe_make_documentation(
+                    request.data.include_documentation, key_validation),
+                  &describe_as_string<bool>,
+                  hide_default_override);
+
+                add_topic_config_if_requested(
+                  resource,
+                  result,
+                  topic_property_record_key_subject_name_strategy_compat,
+                  ctx.metadata_cache()
+                    .get_default_record_key_subject_name_strategy(),
+                  topic_property_record_key_subject_name_strategy_compat,
+                  topic_config->properties
+                    .record_key_subject_name_strategy_compat,
+                  request.data.include_synonyms,
+                  maybe_make_documentation(
+                    request.data.include_documentation,
+                    fmt::format(
+                      "The subject name strategy for keys if {} is enabled",
+                      topic_property_record_key_schema_id_validation_compat)),
+                  [](auto sns) {
+                      return ss::sstring(to_string_view_compat(sns));
+                  },
+                  hide_default_override);
+
+                add_topic_config_if_requested(
+                  resource,
+                  result,
+                  topic_property_record_value_schema_id_validation_compat,
+                  ctx.metadata_cache()
+                    .get_default_record_value_schema_id_validation(),
+                  topic_property_record_value_schema_id_validation_compat,
+                  topic_config->properties
+                    .record_value_schema_id_validation_compat,
+                  request.data.include_synonyms,
+                  maybe_make_documentation(
+                    request.data.include_documentation, val_validation),
+                  &describe_as_string<bool>,
+                  hide_default_override);
+
+                add_topic_config_if_requested(
+                  resource,
+                  result,
+                  topic_property_record_value_subject_name_strategy_compat,
+                  ctx.metadata_cache()
+                    .get_default_record_value_subject_name_strategy(),
+                  topic_property_record_value_subject_name_strategy_compat,
+                  topic_config->properties
+                    .record_value_subject_name_strategy_compat,
+                  request.data.include_synonyms,
+                  maybe_make_documentation(
+                    request.data.include_documentation,
+                    fmt::format(
+                      "The subject name strategy for values if {} is enabled",
+                      topic_property_record_value_schema_id_validation_compat)),
+                  [](auto sns) {
+                      return ss::sstring(to_string_view_compat(sns));
+                  },
+                  hide_default_override);
+
+                add_topic_config_if_requested(
+                  resource,
+                  result,
+                  topic_property_record_key_schema_id_validation,
+                  ctx.metadata_cache()
+                    .get_default_record_key_schema_id_validation(),
+                  topic_property_record_key_schema_id_validation,
+                  topic_config->properties.record_key_schema_id_validation,
                   request.data.include_synonyms,
                   maybe_make_documentation(
                     request.data.include_documentation, key_validation),
@@ -868,46 +924,11 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 add_topic_config_if_requested(
                   resource,
                   result,
-                  topic_property_record_key_subject_name_strategy_compat,
-                  ctx.metadata_cache()
-                    .get_default_record_key_subject_name_strategy(),
-                  topic_property_record_key_subject_name_strategy_compat,
-                  topic_config->properties
-                    .record_key_subject_name_strategy_compat,
-                  request.data.include_synonyms,
-                  maybe_make_documentation(
-                    request.data.include_documentation,
-                    fmt::format(
-                      "The subject name strategy for keys if {} is enabled",
-                      topic_property_record_key_schema_id_validation_compat)),
-                  [](auto sns) {
-                      return ss::sstring(to_string_view_compat(sns));
-                  },
-                  hide_default_override);
-
-                add_topic_config_if_requested(
-                  resource,
-                  result,
                   topic_property_record_value_schema_id_validation,
                   ctx.metadata_cache()
                     .get_default_record_value_schema_id_validation(),
                   topic_property_record_value_schema_id_validation,
                   topic_config->properties.record_value_schema_id_validation,
-                  request.data.include_synonyms,
-                  maybe_make_documentation(
-                    request.data.include_documentation, val_validation),
-                  &describe_as_string<bool>,
-                  hide_default_override);
-
-                add_topic_config_if_requested(
-                  resource,
-                  result,
-                  topic_property_record_value_schema_id_validation_compat,
-                  ctx.metadata_cache()
-                    .get_default_record_value_schema_id_validation(),
-                  topic_property_record_value_schema_id_validation_compat,
-                  topic_config->properties
-                    .record_value_schema_id_validation_compat,
                   request.data.include_synonyms,
                   maybe_make_documentation(
                     request.data.include_documentation, val_validation),
@@ -930,26 +951,6 @@ ss::future<response_ptr> describe_configs_handler::handle(
                       topic_property_record_value_schema_id_validation)),
                   &describe_as_string<
                     pandaproxy::schema_registry::subject_name_strategy>,
-                  hide_default_override);
-
-                add_topic_config_if_requested(
-                  resource,
-                  result,
-                  topic_property_record_value_subject_name_strategy_compat,
-                  ctx.metadata_cache()
-                    .get_default_record_value_subject_name_strategy(),
-                  topic_property_record_value_subject_name_strategy_compat,
-                  topic_config->properties
-                    .record_value_subject_name_strategy_compat,
-                  request.data.include_synonyms,
-                  maybe_make_documentation(
-                    request.data.include_documentation,
-                    fmt::format(
-                      "The subject name strategy for values if {} is enabled",
-                      topic_property_record_value_schema_id_validation_compat)),
-                  [](auto sns) {
-                      return ss::sstring(to_string_view_compat(sns));
-                  },
                   hide_default_override);
             }
 

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -810,15 +810,15 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 request.data.include_documentation,
                 config::shard_local_cfg().log_segment_ms.desc()));
 
-            if (
-              config::shard_local_cfg().enable_schema_id_validation()
-              != pandaproxy::schema_registry::schema_id_validation_mode::none) {
-                constexpr std::string_view key_validation
-                  = "Enable validation of the schema id for keys on a record";
-                constexpr std::string_view val_validation
-                  = "Enable validation of the schema id for values on a record";
-                const bool hide_default_override = true;
+            constexpr std::string_view key_validation
+              = "Enable validation of the schema id for keys on a record";
+            constexpr std::string_view val_validation
+              = "Enable validation of the schema id for values on a record";
+            constexpr bool validation_hide_default_override = true;
 
+            switch (config::shard_local_cfg().enable_schema_id_validation()) {
+            case pandaproxy::schema_registry::schema_id_validation_mode::
+              compat: {
                 add_topic_config_if_requested(
                   resource,
                   result,
@@ -832,7 +832,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   maybe_make_documentation(
                     request.data.include_documentation, key_validation),
                   &describe_as_string<bool>,
-                  hide_default_override);
+                  validation_hide_default_override);
 
                 add_topic_config_if_requested(
                   resource,
@@ -852,7 +852,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   [](auto sns) {
                       return ss::sstring(to_string_view_compat(sns));
                   },
-                  hide_default_override);
+                  validation_hide_default_override);
 
                 add_topic_config_if_requested(
                   resource,
@@ -867,7 +867,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   maybe_make_documentation(
                     request.data.include_documentation, val_validation),
                   &describe_as_string<bool>,
-                  hide_default_override);
+                  validation_hide_default_override);
 
                 add_topic_config_if_requested(
                   resource,
@@ -887,8 +887,11 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   [](auto sns) {
                       return ss::sstring(to_string_view_compat(sns));
                   },
-                  hide_default_override);
-
+                  validation_hide_default_override);
+                [[fallthrough]];
+            }
+            case pandaproxy::schema_registry::schema_id_validation_mode::
+              redpanda: {
                 add_topic_config_if_requested(
                   resource,
                   result,
@@ -901,7 +904,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   maybe_make_documentation(
                     request.data.include_documentation, key_validation),
                   &describe_as_string<bool>,
-                  hide_default_override);
+                  validation_hide_default_override);
 
                 add_topic_config_if_requested(
                   resource,
@@ -919,7 +922,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                       topic_property_record_key_schema_id_validation)),
                   &describe_as_string<
                     pandaproxy::schema_registry::subject_name_strategy>,
-                  hide_default_override);
+                  validation_hide_default_override);
 
                 add_topic_config_if_requested(
                   resource,
@@ -933,7 +936,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   maybe_make_documentation(
                     request.data.include_documentation, val_validation),
                   &describe_as_string<bool>,
-                  hide_default_override);
+                  validation_hide_default_override);
 
                 add_topic_config_if_requested(
                   resource,
@@ -951,7 +954,11 @@ ss::future<response_ptr> describe_configs_handler::handle(
                       topic_property_record_value_schema_id_validation)),
                   &describe_as_string<
                     pandaproxy::schema_registry::subject_name_strategy>,
-                  hide_default_override);
+                  validation_hide_default_override);
+            }
+            case pandaproxy::schema_registry::schema_id_validation_mode::none: {
+                break;
+            }
             }
 
             break;

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -123,7 +123,7 @@ bool valid_config_resource_operation(uint8_t v) {
 
 checked<cluster::topic_properties_update, resp_resource_t>
 create_topic_properties_update(
-  request_context& ctx, incremental_alter_configs_resource& resource) {
+  request_context&, incremental_alter_configs_resource& resource) {
     model::topic_namespace tp_ns(
       model::kafka_namespace, model::topic(resource.resource_name));
     cluster::topic_properties_update update(tp_ns);
@@ -241,8 +241,9 @@ create_topic_properties_update(
                   update.properties.segment_ms, cfg.value, op);
                 continue;
             }
-            if (ctx.feature_table().local().is_active(
-                  features::feature::schema_id_validation)) {
+            if (
+              config::shard_local_cfg().enable_schema_id_validation()
+              != pandaproxy::schema_registry::schema_id_validation_mode::none) {
                 if (schema_id_validation_config_parser(cfg, op)) {
                     continue;
                 }

--- a/src/v/pandaproxy/schema_registry/schema_id_validation.h
+++ b/src/v/pandaproxy/schema_registry/schema_id_validation.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "utils/string_switch.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <iostream>
+
+namespace pandaproxy::schema_registry {
+
+enum class schema_id_validation_mode {
+    // Disabled
+    none = 0,
+    // Use Redpanda topic properties
+    redpanda,
+    // Use Redpanda and compatible topic properties
+    compat,
+};
+
+constexpr std::string_view to_string_view(schema_id_validation_mode m) {
+    switch (m) {
+    case schema_id_validation_mode::none:
+        return "none";
+    case schema_id_validation_mode::redpanda:
+        return "redpanda";
+    case schema_id_validation_mode::compat:
+        return "compat";
+    }
+}
+
+inline std::ostream& operator<<(std::ostream& o, schema_id_validation_mode m) {
+    return o << to_string_view(m);
+}
+
+inline std::istream& operator>>(std::istream& i, schema_id_validation_mode& m) {
+    seastar::sstring s;
+    i >> s;
+    m = string_switch<schema_id_validation_mode>(s)
+          .match(
+            to_string_view(schema_id_validation_mode::none),
+            schema_id_validation_mode::none)
+          .match(
+            to_string_view(schema_id_validation_mode::redpanda),
+            schema_id_validation_mode::redpanda)
+          .match(
+            to_string_view(schema_id_validation_mode::compat),
+            schema_id_validation_mode::compat);
+    return i;
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -24,6 +24,7 @@
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/protobuf.h"
 #include "pandaproxy/schema_registry/schema_id_cache.h"
+#include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "pandaproxy/schema_registry/seq_writer.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
@@ -357,8 +358,9 @@ public:
             // If Schema Registry is not enabled, the safe default is to reject
             co_return kafka::error_code::invalid_record;
         }
-        if (!_api->_controller->get_feature_table().local().is_active(
-              features::feature::schema_id_validation)) {
+        if (
+          config::shard_local_cfg().enable_schema_id_validation()
+          == pandaproxy::schema_registry::schema_id_validation_mode::none) {
             co_return std::move(rbr);
         }
 

--- a/src/v/pandaproxy/schema_registry/validation.h
+++ b/src/v/pandaproxy/schema_registry/validation.h
@@ -16,6 +16,7 @@
 #include "model/record_batch_reader.h"
 #include "outcome.h"
 #include "pandaproxy/schema_registry/api.h"
+#include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -28,7 +29,8 @@ public:
     schema_id_validator(
       const std::unique_ptr<api>& api,
       const model::topic& topic,
-      const cluster::topic_properties& props);
+      const cluster::topic_properties& props,
+      pandaproxy::schema_registry::schema_id_validation_mode mode);
     schema_id_validator(schema_id_validator&&) noexcept;
     schema_id_validator(const schema_id_validator&) = delete;
     schema_id_validator& operator=(schema_id_validator&&) = delete;

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -556,6 +556,9 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         # Don't enable coproc: it generates log errors if its companion service isn't running
         exclude_settings.add('enable_coproc')
 
+        # Don't enable schema id validation: the interdepedencies are too complex and are tested elsewhere.
+        exclude_settings.add('enable_schema_id_validation')
+
         initial_config = self.admin.get_cluster_config()
 
         for name, p in schema_properties.items():

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -193,14 +193,6 @@ class CreateTopicsTest(RedpandaTest):
         lambda: "true" if random.randint(0, 1) else "false",
         'segment.ms':
         lambda: random.choice([-1, random.randint(10000, 10000000)]),
-        TopicSpec.PROPERTY_RECORD_KEY_SCHEMA_ID_VALIDATION:
-        lambda: "true" if random.randint(0, 1) else "false",
-        TopicSpec.PROPERTY_RECORD_KEY_SUBJECT_NAME_STRATEGY:
-        lambda: random.choice(list(TopicSpec.SubjectNameStrategy)).value,
-        TopicSpec.PROPERTY_RECORD_VALUE_SCHEMA_ID_VALIDATION:
-        lambda: "true" if random.randint(0, 1) else "false",
-        TopicSpec.PROPERTY_RECORD_VALUE_SUBJECT_NAME_STRATEGY:
-        lambda: random.choice(list(TopicSpec.SubjectNameStrategy)).value
     }
 
     def __init__(self, test_context):


### PR DESCRIPTION
#10650 introduced schema ID validation gated behind a feature that was enabled by default.

Instead, gate it on cluster configuration, that is disabled by default. E.g.:
```
rpk cluster config set enable_schema_id_validation redpanda --api-urls=localhost:19644
```

There are three possible configuration options:
* `none`: feature is disabled, checking will not occur, associated topic properties cannot be modified
* `redpanda`: Feature is enabled, redpanda topic properties are accepted
* `compat`: Feature is enabled, redpanda and compatible topic properties are accepted

Closes #11113 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
