### PR TITLE
cloud storage: Check cache status before hydrating remote segments

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -84,7 +84,8 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    /// Get cached value as a stream if it exists on disk ///
+    /// Get cached value as a stream if it exists on disk
+    ///
     /// \param key is a cache key
     ss::future<std::optional<cache_item>> get(std::filesystem::path key);
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -888,6 +888,11 @@ ss::future<> remote_segment::hydrate_chunk(
     retry_chain_node rtc{
       cache_hydration_timeout, cache_hydration_backoff, &_rtc};
 
+    auto cache_status = co_await _cache.is_cached(get_path_to_chunk(start));
+    if (cache_status == cache_element_status::available) {
+        co_return;
+    }
+
     const auto space_required = end.value_or(_size - 1) - start + 1;
     const auto reserved = co_await _cache.reserve_space(space_required);
 


### PR DESCRIPTION
We currently ignore cache status and always read from cloud storage with chunked reads. This fixes that and noops the chunked read in this case as the read from cache will succeed during materialization.

Fixes: https://github.com/redpanda-data/redpanda/issues/10938

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
