### PR TITLE
cloud_storage: Destroy client_pool probe in stop()

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -44,6 +44,7 @@ ss::future<> client_pool::stop() {
     }
 
     vlog(pool_log.info, "Stopped client pool");
+    _probe = nullptr;
 }
 
 void client_pool::shutdown_connections() {


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/11285


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
