### PR TITLE
rpk: add `rpk acl user update` and tests

### DIFF
--- a/src/go/rpk/pkg/cli/acl/acl.go
+++ b/src/go/rpk/pkg/cli/acl/acl.go
@@ -12,6 +12,7 @@ package acl
 import (
 	"fmt"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/acl/user"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -38,7 +39,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.AddCommand(newCreateCommand(fs, p))
 	cmd.AddCommand(newDeleteCommand(fs, p))
 	cmd.AddCommand(newListCommand(fs, p))
-	cmd.AddCommand(newUserCommand(fs, p))
+	cmd.AddCommand(user.NewCommand(fs, p))
 	return cmd
 }
 

--- a/src/go/rpk/pkg/cli/acl/user.go
+++ b/src/go/rpk/pkg/cli/acl/user.go
@@ -43,13 +43,6 @@ redpanda section of your redpanda.yaml.
 	return cmd
 }
 
-// UserAPI encapsulates functions needed for a user API.
-type UserAPI interface {
-	CreateUser(username, password string) error
-	DeleteUser(username string) error
-	ListUsers() ([]string, error)
-}
-
 func newCreateUserCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var userOld, pass, newPass, mechanism string
 	cmd := &cobra.Command{

--- a/src/go/rpk/pkg/cli/acl/user/delete.go
+++ b/src/go/rpk/pkg/cli/acl/user/delete.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package user
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newDeleteUserCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var oldUser string
+	cmd := &cobra.Command{
+		Use:   "delete [USER]",
+		Short: "Delete a SASL user",
+		Long: `Delete a SASL user.
+
+This command deletes the specified SASL account from Redpanda. This does not
+delete any ACLs that may exist for this user.
+`,
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			cl, err := admin.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			// Backwards compat: we favor the new format (an
+			// argument), but if that is empty, we use the old
+			// flag. If still empty, we error.
+			var user string
+			if len(args) > 0 {
+				user = args[0]
+			} else if len(oldUser) > 0 {
+				user = oldUser
+			} else {
+				out.Die("missing required username argument")
+			}
+
+			err = cl.DeleteUser(cmd.Context(), user)
+			out.MaybeDie(err, "unable to delete user %q: %s", user, err)
+			fmt.Printf("Deleted user %q.\n", user)
+		},
+	}
+
+	cmd.Flags().StringVar(&oldUser, "delete-username", "", "The user to be deleted")
+	cmd.Flags().MarkDeprecated("delete-username", "The username now does not require a flag")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/acl/user/list.go
+++ b/src/go/rpk/pkg/cli/acl/user/list.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package user
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List SASL users",
+		Run: func(cmd *cobra.Command, _ []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			cl, err := admin.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			users, err := cl.ListUsers(cmd.Context())
+			out.MaybeDie(err, "unable to list users: %v", err)
+
+			tw := out.NewTable("Username")
+			defer tw.Flush()
+			for _, u := range users {
+				tw.Print(u)
+			}
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/acl/user/user.go
+++ b/src/go/rpk/pkg/cli/acl/user/user.go
@@ -34,6 +34,7 @@ redpanda section of your redpanda.yaml.
 		newCreateUserCommand(fs, p),
 		newDeleteUserCommand(fs, p),
 		newListUsersCommand(fs, p),
+		newUpdateCommand(fs, p),
 	)
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/acl/user/user.go
+++ b/src/go/rpk/pkg/cli/acl/user/user.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package user
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "user",
+		Short: "Manage SASL users",
+		Long: `Manage SASL users.
+
+If SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs
+control what your user has access to. See 'rpk acl --help' for more information
+about ACLs, and 'rpk acl user create --help' for more information about
+creating SASL users. Using SASL requires setting "enable_sasl: true" in the
+redpanda section of your redpanda.yaml.
+`,
+	}
+	p.InstallAdminFlags(cmd)
+	p.InstallKafkaFlags(cmd) // old ACL user commands have this, and Kafka SASL creds are used for admin API basic auth
+	cmd.AddCommand(
+		newCreateUserCommand(fs, p),
+		newDeleteUserCommand(fs, p),
+		newListUsersCommand(fs, p),
+	)
+	return cmd
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -275,6 +275,13 @@ class RpkTool:
         cmd += ["--mechanism", mechanism]
         return self._run(cmd)
 
+    def sasl_update_user(self, user, new_password):
+        cmd = [
+            "acl", "user", "update", user, "--new-password", new_password,
+            "-X", "admin.hosts=" + self._redpanda.admin_endpoints()
+        ]
+        return self._run(cmd)
+
     def delete_topic(self, topic):
         cmd = ["delete", topic]
         output = self._run_topic(cmd)

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -1,0 +1,76 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.services.redpanda import SecurityConfig
+from rptest.util import expect_exception
+from ducktape.utils.util import wait_until
+
+
+class RpkACLTest(RedpandaTest):
+    username = "red"
+    password = "panda"
+    mechanism = "SCRAM-SHA-256"
+
+    def __init__(self, test_ctx, *args, **kwargs):
+        self._ctx = test_ctx
+        security = SecurityConfig()
+        security.enable_sasl = True
+        security.endpoint_authn_method = 'sasl'
+        super(RpkACLTest, self).__init__(test_ctx,
+                                         security=security,
+                                         *args,
+                                         **kwargs)
+        self._rpk = RpkTool(redpanda=self.redpanda,
+                            username=self.username,
+                            password=self.password,
+                            sasl_mechanism=self.mechanism)
+        self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
+
+    @cluster(num_nodes=1)
+    def test_create_update(self):
+        topic = "create-update"
+        new_password = "new-pass"
+        self._rpk.sasl_create_user(self.username, self.password,
+                                   self.mechanism)
+        # Only the super user can add ACLs
+        self._rpk.sasl_allow_principal(f'User:{self.username}', ['all'],
+                                       'topic', topic, self.superuser.username,
+                                       self.superuser.password,
+                                       self.superuser.algorithm)
+        self._rpk.create_topic(topic)
+        topic_list = self._rpk.list_topics()
+
+        # We check that we can list the topics:
+        assert topic in topic_list
+
+        out = self._rpk.sasl_update_user(self.username, new_password)
+        assert f'Updated user "{self.username}" successfully' in out
+
+        with expect_exception(
+                RpkException, lambda e:
+                'Invalid credentials: SASL_AUTHENTICATION_FAILED' in str(e)):
+            # the rpk tool instance here will use old credentials so now it
+            # should fail. We wait until it fails because the user update
+            # it's not instant.
+            wait_until(lambda: len(set(self._rpk.list_topics())) == 0,
+                       timeout_sec=60,
+                       backoff_sec=5)
+
+        rpk_two = RpkTool(self.redpanda,
+                          username=self.username,
+                          password=new_password,
+                          sasl_mechanism=self.mechanism)
+        topic_list_two = rpk_two.list_topics()
+
+        # We check that we can list the topics with the new password:
+        assert topic in topic_list_two


### PR DESCRIPTION
This PR adds: 

- a new command that allows the user to update the user's credentials:

```
$ rpk acl user update test-update --new-password test 
Updated user "test-update" successfully.
```

- a ducktape test that creates a user, adds ACL, changes the password, and checks that it was correctly updated.
- split `acl user` codebase into its own directory to keep consistency with the rest of the codebase
Fixes #8252

## Backports Required
- [x] none - not a bug fix


## Release Notes
### Features

* rpk: now you can update user credentials with `rpk acl user update`.
