### PR TITLE
ducktape: testing for chunk read path

### DIFF
--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -209,6 +209,7 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
     mib = 1024 * 1024
     message_size = 32 * 1024  # 32KiB
     log_segment_size = 4 * mib  # 4MiB
+    chunk_size = 1 * mib
     produce_byte_rate_per_ntp = 8 * mib  # 8 MiB
     target_runtime = 60  # seconds
     check_interval = 10  # seconds
@@ -233,7 +234,8 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             cloud_storage_segment_size_target=4 * self.log_segment_size,
             cloud_storage_segment_size_min=2 * self.log_segment_size,
             retention_local_target_bytes_default=10 * self.log_segment_size,
-            cloud_storage_enable_segment_merging=True)
+            cloud_storage_enable_segment_merging=True,
+            cloud_storage_cache_chunk_size=self.chunk_size)
 
         super(CloudStorageTimingStressTest,
               self).__init__(test_context=test_context,


### PR DESCRIPTION
This PR adjusts tests to make sure chunk read paths are covered in existing tests. Setting a chunk size smaller than the segment size in existing tests ensures that the read path uses chunks to download segments.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
