### PR TITLE
cloud_storage: Copy exception_ptr when handling error

### DIFF
--- a/src/v/cloud_storage/segment_chunk_data_source.cc
+++ b/src/v/cloud_storage/segment_chunk_data_source.cc
@@ -93,9 +93,9 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
     vlog(_ctxlog.debug, "loading stream for chunk starting at {}", chunk_start);
 
     co_await load_chunk_handle(chunk_start)
-      .handle_exception([this](const std::exception_ptr& ex) {
-          return maybe_close_stream().then(
-            [&ex] { std::rethrow_exception(ex); });
+      .handle_exception([this](std::exception_ptr ex) -> ss::future<> {
+          co_await maybe_close_stream();
+          std::rethrow_exception(ex);
       });
 
     // Decrement the required_by_readers_in_future count by 1, we have acquired


### PR DESCRIPTION
When chunk hydration fails, copy the exception pointer instead of using reference to it, so that there are no lifetime related issues when rethrowing the exception after cleanup.

Fixes: https://github.com/redpanda-data/redpanda/issues/11285

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
