### PR TITLE
cloud_storage: use plural delete for retention

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -839,9 +839,10 @@ ss::future<upload_result> remote::delete_object(
     co_return *result;
 }
 
+template<std::ranges::range Range>
 ss::future<upload_result> remote::delete_objects(
   const cloud_storage_clients::bucket_name& bucket,
-  std::vector<cloud_storage_clients::object_key> keys,
+  Range keys,
   retry_chain_node& parent) {
     ss::gate::holder gh{_gate};
 

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -868,6 +868,18 @@ ss::future<upload_result> remote::delete_objects(
           bucket, keys, fib.get_timeout());
 
         if (res) {
+            if (!res.value().undeleted_keys.empty()) {
+                vlog(
+                  ctxlog.debug,
+                  "{} objects were not deleted by plural delete; first "
+                  "failure: {{key: {}, reason:{}}}",
+                  res.value().undeleted_keys.size(),
+                  res.value().undeleted_keys.front().key,
+                  res.value().undeleted_keys.front().reason);
+
+                co_return upload_result::failed;
+            }
+
             co_return upload_result::success;
         }
 

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -12,7 +12,6 @@
 
 #include "bytes/iostream.h"
 #include "cloud_storage/base_manifest.h"
-#include "cloud_storage/logger.h"
 #include "cloud_storage/materialized_segments.h"
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/client_pool.h"
@@ -35,16 +34,6 @@
 #include <exception>
 #include <utility>
 #include <variant>
-
-namespace {
-// Holds the key and associated retry_chain_node to make it
-// easier to keep objects on heap using do_with, as retry_chain_node
-// cannot be copied or moved.
-struct key_and_node {
-    cloud_storage_clients::object_key key;
-    std::unique_ptr<retry_chain_node> node;
-};
-} // namespace
 
 namespace cloud_storage {
 
@@ -839,21 +828,15 @@ ss::future<upload_result> remote::delete_object(
     co_return *result;
 }
 
-template<std::ranges::range Range>
-ss::future<upload_result> remote::delete_objects(
+ss::future<upload_result> remote::do_delete_objects(
   const cloud_storage_clients::bucket_name& bucket,
-  Range keys,
+  std::vector<cloud_storage_clients::object_key> keys,
   retry_chain_node& parent) {
     ss::gate::holder gh{_gate};
 
     if (keys.empty()) {
         vlog(cst_log.info, "No keys to delete, returning");
         co_return upload_result::success;
-    }
-
-    if (!is_batch_delete_supported()) {
-        co_return co_await delete_objects_sequentially(
-          bucket, std::move(keys), parent);
     }
 
     retry_chain_node fib(&parent);
@@ -926,73 +909,6 @@ ss::future<upload_result> remote::delete_objects(
           *result);
     }
     co_return *result;
-}
-
-ss::future<upload_result> remote::delete_objects_sequentially(
-  const cloud_storage_clients::bucket_name& bucket,
-  std::vector<cloud_storage_clients::object_key> keys,
-  retry_chain_node& parent) {
-    vlog(
-      cst_log.debug,
-      "Backend {} does not support batch delete, falling back to "
-      "sequential deletes",
-      _cloud_storage_backend);
-
-    std::vector<key_and_node> key_nodes;
-    key_nodes.reserve(keys.size());
-
-    std::transform(
-      std::make_move_iterator(keys.begin()),
-      std::make_move_iterator(keys.end()),
-      std::back_inserter(key_nodes),
-      [&parent](auto&& key) {
-          return key_and_node{
-            .key = std::forward<cloud_storage_clients::object_key>(key),
-            .node = std::make_unique<retry_chain_node>(&parent)};
-      });
-
-    auto results = co_await ss::do_with(
-      bucket,
-      std::move(key_nodes),
-      std::vector<upload_result>{},
-      [this](auto& bucket, auto& key_nodes, auto& results) {
-          results.reserve(key_nodes.size());
-          return ss::max_concurrent_for_each(
-                   key_nodes.begin(),
-                   key_nodes.end(),
-                   concurrency(),
-                   [this, &bucket, &results](auto& kn) -> ss::future<> {
-                       vlog(cst_log.trace, "Deleting key {}", kn.key);
-                       return delete_object(bucket, kn.key, *kn.node)
-                         .then([&results](auto result) {
-                             results.push_back(result);
-                         });
-                   })
-            .handle_exception_type([](const std::exception& ex) {
-                vlog(cst_log.error, "Failed to delete keys: {}", ex.what());
-            })
-            .then([&results] { return results; });
-      });
-
-    if (results.empty()) {
-        vlog(cst_log.error, "No keys were deleted");
-        co_return upload_result::failed;
-    }
-
-    // This is not ideal, we lose all non-failures but the first one, but
-    // returning a single result for multiple operations will lose
-    // information.
-    co_return std::reduce(
-      results.begin(),
-      results.end(),
-      upload_result::success,
-      [](auto res_a, auto res_b) {
-          if (res_a != upload_result::success) {
-              return res_a;
-          }
-
-          return res_b;
-      });
 }
 
 ss::future<remote::list_result> remote::list_objects(

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -321,9 +321,10 @@ public:
     ///
     /// \param bucket The bucket to delete from
     /// \param keys A vector of keys which will be deleted
+    template<std::ranges::range Range>
     ss::future<upload_result> delete_objects(
       const cloud_storage_clients::bucket_name& bucket,
-      std::vector<cloud_storage_clients::object_key> keys,
+      Range keys,
       retry_chain_node& parent);
 
     using list_result = result<

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -68,6 +68,14 @@ static constexpr std::string_view manifest_payload = R"json({
     }
 })json";
 
+static constexpr std::string_view plural_delete_error = R"json(
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <Error>
+        <Key>a</Key>
+        <Code>TestFailure</Code>
+    </Error>
+</DeleteResult>)json";
+
 static cloud_storage::lazy_abort_source always_continue{
   []() { return std::nullopt; }};
 
@@ -724,6 +732,27 @@ FIXTURE_TEST(test_delete_objects, remote_fixture) {
       cloud_storage_clients::object_key{"b"}};
     auto result = remote.local().delete_objects(bucket, to_delete, fib).get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
+    auto request = get_requests()[0];
+    BOOST_REQUIRE_EQUAL(request.method, "POST");
+    BOOST_REQUIRE_EQUAL(request.url, "/?delete");
+    BOOST_REQUIRE(request.has_q_delete);
+}
+
+FIXTURE_TEST(test_delete_objects_failure_handling, remote_fixture) {
+    // Test that the failure to delete one key via the plural form
+    // fails the entire operation.
+    set_expectations_and_listen({expectation{
+      .url = "/?delete", .body = ss::sstring(plural_delete_error)}});
+
+    cloud_storage_clients::bucket_name bucket{"test"};
+    retry_chain_node fib(never_abort, 100ms, 20ms);
+
+    std::vector<cloud_storage_clients::object_key> to_delete{
+      cloud_storage_clients::object_key{"a"},
+      cloud_storage_clients::object_key{"b"}};
+    auto result = remote.local().delete_objects(bucket, to_delete, fib).get();
+    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::failed, result);
+
     auto request = get_requests()[0];
     BOOST_REQUIRE_EQUAL(request.method, "POST");
     BOOST_REQUIRE_EQUAL(request.url, "/?delete");

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -308,6 +308,10 @@ void s3_imposter_fixture::set_routes(
               request._method == "POST"
               && request.query_parameters.contains("delete")) {
                 // Delete objects
+                auto it = expectations.find(request._url);
+                if (it != expectations.end() && it->second.body.has_value()) {
+                    return it->second.body.value();
+                }
                 return R"xml(<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>)xml";
             }
             BOOST_FAIL("Unexpected request");


### PR DESCRIPTION
This PR updates the archival housekeeping code to perform retention using
plural delete when available on the back-end.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Improvements
* Use plural delete for cloud retention when available.