### PR TITLE
rpk profile: more

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/logdirs.go
+++ b/src/go/rpk/pkg/cli/cluster/logdirs.go
@@ -79,7 +79,7 @@ where revision is a Redpanda internal concept.
 				listed, err := adm.ListTopics(context.Background(), topics...)
 				out.MaybeDie(err, "unable to describe topics: %v", err)
 				listed.EachError(func(d kadm.TopicDetail) {
-					fmt.Fprintf(os.Stderr, "unable to discover the partitions on topic %q: %v", d.Topic, d.Err)
+					fmt.Fprintf(os.Stderr, "unable to discover the partitions on topic %q: %v\n", d.Topic, d.Err)
 				})
 				s = listed.TopicsSet()
 			}

--- a/src/go/rpk/pkg/cli/profile/clear.go
+++ b/src/go/rpk/pkg/cli/profile/clear.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package profile
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newClearCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear",
+		Short: "Clear the current profile",
+		Long: `Clear the current profile
+
+This small command clears the current profile, which can be useful to unset an
+prod cluster profile.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, args []string) {
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+			y, ok := cfg.ActualRpkYaml()
+			if !ok {
+				return
+			}
+			y.CurrentProfile = ""
+			y.Write(fs)
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/profile/current.go
+++ b/src/go/rpk/pkg/cli/profile/current.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package profile
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newCurrentCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var noNewline bool
+	cmd := &cobra.Command{
+		Use:   "current",
+		Short: "Print the current profile name",
+		Long: `Print the current profile name.
+
+This is a tiny command that simply prints the current profile name, which may
+be useful in scripts, or a PS1, or to confirm what you have selected.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, args []string) {
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			if !noNewline {
+				defer fmt.Println()
+			}
+			y, ok := cfg.ActualRpkYaml()
+			if !ok {
+				return
+			}
+			fmt.Print(y.CurrentProfile)
+		},
+	}
+	cmd.Flags().BoolVarP(&noNewline, "no-newline", "n", false, "Do not print a newline after the profile name")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/profile/delete.go
+++ b/src/go/rpk/pkg/cli/profile/delete.go
@@ -29,7 +29,7 @@ was the selected profile, rpk will use in-memory defaults until a new profile
 is selected.
 `,
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: validProfiles(fs, p),
+		ValidArgsFunction: ValidProfiles(fs, p),
 		Run: func(_ *cobra.Command, args []string) {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/profile/edit.go
+++ b/src/go/rpk/pkg/cli/profile/edit.go
@@ -63,7 +63,7 @@ can use the --raw flag.
 			out.MaybeDieErr(err)
 
 			var renamed, updatedCurrent bool
-			if update.Name != name {
+			if update.Name != name && update.Name != "" {
 				renamed = true
 				if y.CurrentProfile == name {
 					updatedCurrent = true

--- a/src/go/rpk/pkg/cli/profile/edit.go
+++ b/src/go/rpk/pkg/cli/profile/edit.go
@@ -35,7 +35,7 @@ If you want to edit the current raw profile as it exists in rpk.yaml, you
 can use the --raw flag.
 `,
 		Args:              cobra.MaximumNArgs(1),
-		ValidArgsFunction: validProfiles(fs, p),
+		ValidArgsFunction: ValidProfiles(fs, p),
 		Run: func(_ *cobra.Command, args []string) {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/profile/edit_defaults.go
+++ b/src/go/rpk/pkg/cli/profile/edit_defaults.go
@@ -1,0 +1,47 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package profile
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newEditDefaultsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edit-defaults",
+		Short: "Edit rpk defaults",
+		Long: `Edit rpk defaults.
+
+This command opens your default editor to edit the specified profile, or
+the current profile if no profile is specified.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(*cobra.Command, []string) {
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+			y, err := cfg.ActualRpkYamlOrEmpty()
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			y.Defaults, err = rpkos.EditTmpYAMLFile(fs, y.Defaults)
+			out.MaybeDieErr(err)
+
+			err = y.Write(fs)
+			out.MaybeDie(err, "unable to write rpk.yaml: %v", err)
+			fmt.Println("Defaults updated successfully.")
+		},
+	}
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/profile/print.go
+++ b/src/go/rpk/pkg/cli/profile/print.go
@@ -32,7 +32,7 @@ variables applied. If you wish to print the current raw profile as it exists
 in rpk.yaml, you can use the --raw flag.
 `,
 		Args:              cobra.MaximumNArgs(1),
-		ValidArgsFunction: validProfiles(fs, p),
+		ValidArgsFunction: ValidProfiles(fs, p),
 		Run: func(_ *cobra.Command, args []string) {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/profile/print_defaults.go
+++ b/src/go/rpk/pkg/cli/profile/print_defaults.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package profile
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func newPrintDefaultsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:   "print-defaults",
+		Short: "Print rpk default",
+		Long:  `Print rpk defaults.`,
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, args []string) {
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			y := cfg.VirtualRpkYaml()
+			m, err := yaml.Marshal(y.Defaults)
+			out.MaybeDie(err, "unable to encode profile: %v", err)
+			fmt.Println(string(m))
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/profile/profile.go
+++ b/src/go/rpk/pkg/cli/profile/profile.go
@@ -37,11 +37,14 @@ your configuration in one place.
 		newCurrentCommand(fs, p),
 		newDeleteCommand(fs, p),
 		newEditCommand(fs, p),
+		newEditDefaultsCommand(fs, p),
 		newListCommand(fs, p),
 		newPrintCommand(fs, p),
+		newPrintDefaultsCommand(fs, p),
 		newPromptCommand(fs, p),
 		newRenameToCommand(fs, p),
 		newSetCommand(fs, p),
+		newSetDefaultsCommand(fs, p),
 		newUseCommand(fs, p),
 	)
 

--- a/src/go/rpk/pkg/cli/profile/profile.go
+++ b/src/go/rpk/pkg/cli/profile/profile.go
@@ -33,6 +33,8 @@ your configuration in one place.
 
 	cmd.AddCommand(
 		newCreateCommand(fs, p),
+		newClearCommand(fs, p),
+		newCurrentCommand(fs, p),
 		newDeleteCommand(fs, p),
 		newEditCommand(fs, p),
 		newListCommand(fs, p),

--- a/src/go/rpk/pkg/cli/profile/profile.go
+++ b/src/go/rpk/pkg/cli/profile/profile.go
@@ -39,6 +39,7 @@ your configuration in one place.
 		newEditCommand(fs, p),
 		newListCommand(fs, p),
 		newPrintCommand(fs, p),
+		newPromptCommand(fs, p),
 		newRenameToCommand(fs, p),
 		newSetCommand(fs, p),
 		newUseCommand(fs, p),

--- a/src/go/rpk/pkg/cli/profile/profile.go
+++ b/src/go/rpk/pkg/cli/profile/profile.go
@@ -51,7 +51,7 @@ your configuration in one place.
 	return cmd
 }
 
-func validProfiles(fs afero.Fs, p *config.Params) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func ValidProfiles(fs afero.Fs, p *config.Params) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		cfg, err := p.Load(fs)
 		if err != nil {

--- a/src/go/rpk/pkg/cli/profile/prompt.go
+++ b/src/go/rpk/pkg/cli/profile/prompt.go
@@ -1,0 +1,283 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package profile
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newPromptCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var validate bool
+	cmd := &cobra.Command{
+		Use:   "prompt",
+		Short: "Prompt a profile name formatted for a PS1 prompt",
+		Long: `Prompt a profile name formatted for a PS1 prompt.
+
+This command prints ANSI-escaped text per your current profile's "prompt"
+field. If the current profile does not have a prompt, this prints nothing.
+If the prompt is invalid, this exits 0 with no message. To validate the
+current prompt, use the --validate flag.
+
+This command may introduce other % variables in the future, if you want to
+print a % directly, use %% to escape it.
+
+To use this in zsh, be sure to add setopt PROMPT_SUBST to your .zshrc.
+To edit your PS1, use something like PS1='$(rpk profile prompt)' in your
+shell rc file.
+
+FORMAT
+
+The "prompt" field supports space or comma separated modifiers and a quoted
+string that is be modified. Inside the string, the variable %p or %n refers to
+the profile name. As a few examples:
+
+    prompt: hi-white, bg-red, bold, "[%p]"
+    prompt: hi-red  "PROD"
+    prompt: white, "dev-%n
+
+If you want to have multiple formats, you can wrap each formatted section in
+parentheses.
+
+    prompt: ("--") (hi-white bg-red bold "[%p]")
+
+COLORS
+
+All ANSI colors are supported, with names matching the color name:
+"black", "red", "green", "yellow", "blue", "magenta", "cyan", "white".
+
+The "hi-" prefix indicates a high-intensity color: "hi-black", "hi-red", etc.
+The "bg-" prefix modifies the background color: "bg-black", "bg-hi-red", etc.
+
+MODIFIERS
+
+Four modifiers are supported, "bold", "faint", "underline", and "invert".
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, args []string) {
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			var errmsg string
+			if validate {
+				defer func() {
+					if errmsg != "" {
+						out.DieString(errmsg)
+					}
+				}()
+			}
+
+			y, ok := cfg.ActualRpkYaml()
+			if !ok {
+				errmsg = fmt.Sprintf("rpk.yaml file is missing or cannot be loaded")
+				return
+			}
+			p := y.Profile(y.CurrentProfile)
+			if p == nil {
+				errmsg = fmt.Sprintf("current profile %q does not exist", y.CurrentProfile)
+				return
+			}
+
+			parens, err := splitPromptParens(p.Prompt)
+			if err != nil {
+				errmsg = err.Error()
+				return
+			}
+
+			var sb strings.Builder
+			for _, g := range parens {
+				text, attrs, err := parsePrompt(g, p.Name)
+				if err != nil {
+					errmsg = err.Error()
+					return
+				}
+				c := color.New(attrs...)
+				c.EnableColor()
+				sb.WriteString(c.Sprint(text))
+			}
+			if validate {
+				fmt.Print("Prompt ok! Output:\nvvv\n")
+				defer fmt.Print("\n^^^\n")
+			}
+			fmt.Print(sb.String())
+		},
+	}
+	cmd.Flags().BoolVar(&validate, "validate", false, "Exit with an error message if the prompt is invalid")
+	return cmd
+}
+
+func parsePrompt(s string, name string) (string, []color.Attribute, error) {
+	var (
+		b       = make([]byte, 0, 16) // current text or attribute buffer
+		text    []byte                // if non nil, this has been initialized; we cannot have multiple quoted strings
+		attrs   []color.Attribute
+		inQuote bool
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '\\':
+			if !inQuote {
+				return "", nil, errors.New("backslash is only allowed inside a quoted string")
+			}
+			if len(s) > i+1 {
+				b = append(b, s[i+1])
+				i++
+			}
+		case '"':
+			if inQuote {
+				text = append(text, b...)
+				b = b[:0]
+				inQuote = false
+			} else if text != nil {
+				return "", nil, errors.New("only one quoted string can appear in a prompt, we saw a second")
+			} else {
+				b = bytes.TrimSpace(b)
+				if len(b) > 0 {
+					return "", nil, fmt.Errorf("unexpected text %q before quoted string", string(b))
+				}
+				inQuote = true
+			}
+		case ' ', '\t', ',':
+			if inQuote {
+				b = append(b, c)
+				continue
+			}
+			b = bytes.TrimSpace(b)
+			if len(b) == 0 {
+				continue
+			}
+			attr, ok := out.ParseColor(string(b))
+			if !ok {
+				return "", nil, fmt.Errorf("invalid color or attribute %q", string(b))
+			}
+			attrs = append(attrs, attr)
+			b = b[:0]
+		default:
+			b = append(b, c)
+		}
+	}
+
+	// If b is non-empty, the prompt either ended in unneeded spaces or it
+	// ended in an attr -- any ending quote is handled in the above block.
+	if b = bytes.TrimSpace(b); len(b) > 0 {
+		attr, ok := out.ParseColor(string(b))
+		if !ok {
+			return "", nil, fmt.Errorf("invalid color or attribute %q", string(b))
+		}
+		attrs = append(attrs, attr)
+	}
+
+	output := make([]byte, 0, len(s)+len(text))
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		switch c {
+		case '%':
+			if len(text) > i+1 {
+				switch text[i+1] {
+				case 'p', 'n':
+					output = append(output, name...)
+					i++
+				case '%':
+					output = append(output, '%')
+					i++
+				default:
+					return "", nil, fmt.Errorf("unknown escape %%%c", text[i+1])
+				}
+			}
+		default:
+			output = append(output, c)
+		}
+	}
+	return string(output), attrs, nil
+}
+
+func splitPromptParens(s string) ([]string, error) {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return nil, nil
+	}
+
+	var (
+		parens    []string
+		current   []byte
+		onlyParen = s[0] != '('
+		inParen   = onlyParen
+		inQuote   bool
+		inEsc     bool
+	)
+
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+
+		if !inParen {
+			switch c {
+			case ' ', '\t', ',':
+				continue
+			case '(':
+				inParen = true
+				continue
+			default:
+				return nil, fmt.Errorf("unexpected character %c while looking for paren group", c)
+			}
+		}
+
+		if inEsc {
+			inEsc = false
+			current = append(current, c)
+			continue
+		}
+
+		if inQuote {
+			if c == '\\' {
+				inEsc = true
+			} else if c == '"' {
+				inQuote = false
+			}
+			current = append(current, c)
+			continue
+		}
+
+		switch c {
+		case '\\':
+			inEsc = true
+		case '"':
+			inQuote = true
+		case ')':
+			if onlyParen {
+				return nil, errors.New("unexpected closing paren )")
+			}
+			inParen = false
+			current = bytes.TrimSpace(current)
+			if len(current) > 0 {
+				parens = append(parens, string(current))
+			}
+			current = current[:0]
+			continue
+		}
+		current = append(current, c)
+	}
+	if onlyParen {
+		if len(current) > 0 {
+			parens = append(parens, string(current))
+		}
+	} else if len(current) > 0 {
+		return nil, errors.New("prompt is missing closing paren")
+	}
+	return parens, nil
+}

--- a/src/go/rpk/pkg/cli/profile/prompt.go
+++ b/src/go/rpk/pkg/cli/profile/prompt.go
@@ -93,7 +93,12 @@ Four modifiers are supported, "bold", "faint", "underline", and "invert".
 				return
 			}
 
-			parens, err := splitPromptParens(p.Prompt)
+			prompt := cfg.VirtualRpkYaml().Defaults.Prompt
+			if p.Prompt != "" {
+				prompt = p.Prompt
+			}
+
+			parens, err := splitPromptParens(prompt)
 			if err != nil {
 				errmsg = err.Error()
 				return

--- a/src/go/rpk/pkg/cli/profile/prompt.go
+++ b/src/go/rpk/pkg/cli/profile/prompt.go
@@ -84,7 +84,7 @@ Four modifiers are supported, "bold", "faint", "underline", and "invert".
 
 			y, ok := cfg.ActualRpkYaml()
 			if !ok {
-				errmsg = fmt.Sprintf("rpk.yaml file is missing or cannot be loaded")
+				errmsg = "rpk.yaml file is missing or cannot be loaded"
 				return
 			}
 			p := y.Profile(y.CurrentProfile)

--- a/src/go/rpk/pkg/cli/profile/prompt_test.go
+++ b/src/go/rpk/pkg/cli/profile/prompt_test.go
@@ -1,0 +1,86 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package profile
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+func TestSplitPromptParens(t *testing.T) {
+	for _, test := range []struct {
+		in     string
+		exp    []string
+		expErr bool
+	}{
+		{"", nil, false},
+		{"()", nil, false},
+		{" ( ) ", nil, false},
+		{" ", nil, false},
+		{` blue red ,gr\een,\"text"`, []string{`blue red ,gr\een,\"text"`}, false}, // we just parse parens, not contents
+		{` unexpected end paren) `, nil, true},
+		{` (unclosed open paren`, nil, true},
+		{` ("\)")`, []string{`"\)"`}, false},
+		{` ( ) asdf `, nil, true},
+		{` ( ) (red blue  green ) (bog)`, []string{"red blue  green", "bog"}, false},
+	} {
+		t.Run(test.in, func(t *testing.T) {
+			got, err := splitPromptParens(test.in)
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("got err? %v (%v), exp %v", gotErr, err, test.expErr)
+				return
+			}
+			if !reflect.DeepEqual(got, test.exp) {
+				t.Errorf("got %v != exp %v", got, test.exp)
+			}
+		})
+	}
+}
+
+func TestParsePrompt(t *testing.T) {
+	const name = "foo"
+	for _, test := range []struct {
+		in      string
+		expText string
+		expAttr []color.Attribute
+		expErr  bool
+	}{
+		{"", "", nil, false}, // empty is ok
+		{`blue , green , bg-hi-blue, "%n"`, "foo", []color.Attribute{color.FgBlue, color.FgGreen, color.BgHiBlue}, false}, // somewhat complete
+		{`\"blue\"`, "", nil, true},          // backslash only allowed in quoted str
+		{` "prompt" `, "prompt", nil, false}, // simple
+		{`unknown-thing `, "", nil, true},    // unknown keyword stripped
+		{`blue	green red, bg-hi-blue`, "", []color.Attribute{color.FgBlue, color.FgGreen, color.FgRed, color.BgHiBlue}, false}, // attr at end is kept
+		{` " %n " `, " foo ", nil, false},   // name swapped in
+		{`"\\\%%%%n"`, "\\%%n", nil, false}, // escaping works, and %% works
+		{`"text1" "text2"`, "", nil, true},  // one quoted string
+		{`b"text"`, "", nil, true},          // unexpected text before quote
+		{`blue unknown`, "", nil, true},     // unknown attr at end
+		{`"%u"`, "", nil, true},             // unknown % escape
+	} {
+		t.Run(test.in, func(t *testing.T) {
+			gotText, gotAttr, err := parsePrompt(test.in, name)
+			gotErr := err != nil
+			if gotErr != test.expErr {
+				t.Errorf("got err? %v (%v), exp %v", gotErr, err, test.expErr)
+				return
+			}
+			if gotText != test.expText {
+				t.Errorf("got text %v != exp %v", gotText, test.expText)
+			}
+			if !reflect.DeepEqual(gotAttr, test.expAttr) {
+				t.Errorf("got attr %v != exp %v", gotAttr, test.expAttr)
+			}
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/profile/set_defaults.go
+++ b/src/go/rpk/pkg/cli/profile/set_defaults.go
@@ -1,0 +1,90 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package profile
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newSetDefaultsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-defaults [KEY=VALUE]+",
+		Short: "Set rpk default fields",
+		Long: `Set rpk default fields.
+
+This command takes a list of key=value pairs to write to the defaults section
+of rpk.yaml. The defaults section contains a set of settings that apply to all
+profiles and changes the way that rpk acts. For a list of default flags and
+what they mean, check 'rpk -X help' and look for any key that begins with
+"defaults".
+
+This command supports autocompletion of valid keys. You can also use the
+format 'set key value' if you intend to only set one key.
+`,
+
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: validSetDefaultsArgs,
+		Run: func(_ *cobra.Command, args []string) {
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			// Other set commands are `set key value`, if people
+			// use that older form by force of habit, we support
+			// it.
+			if len(args) == 2 && !strings.Contains(args[0], "=") {
+				args = []string{args[0] + "=" + args[1]}
+			}
+
+			y, err := cfg.ActualRpkYamlOrEmpty()
+			out.MaybeDie(err, "unable to load rpk.yaml: %v", err)
+
+			err = doSetDefaults(y, args)
+			out.MaybeDieErr(err)
+			err = y.Write(fs)
+			out.MaybeDieErr(err)
+			fmt.Println("rpk.yaml updated successfully.")
+		},
+	}
+}
+
+func doSetDefaults(y *config.RpkYaml, set []string) error {
+	for _, kv := range set {
+		split := strings.SplitN(kv, "=", 2)
+		if len(split) != 2 {
+			return fmt.Errorf("invalid key=value pair %q", kv)
+		}
+		k, v := split[0], split[1]
+		if y, ok := config.XFlagYamlPath(k); ok {
+			k = y
+		}
+		err := config.Set(&y, k, v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validSetDefaultsArgs(_ *cobra.Command, _ []string, toComplete string) (ps []string, d cobra.ShellCompDirective) {
+	var possibilities []string
+	_, ypaths := config.XRpkDefaultsFlags()
+	for _, p := range ypaths {
+		if strings.HasPrefix(p, toComplete) {
+			possibilities = append(possibilities, p+"=")
+		}
+	}
+	return possibilities, cobra.ShellCompDirectiveNoSpace
+}

--- a/src/go/rpk/pkg/cli/profile/use.go
+++ b/src/go/rpk/pkg/cli/profile/use.go
@@ -23,7 +23,7 @@ func newUseCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:               "use [NAME]",
 		Short:             "Select the rpk profile to use",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: validProfiles(fs, p),
+		ValidArgsFunction: ValidProfiles(fs, p),
 		Run: func(_ *cobra.Command, args []string) {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -76,8 +76,7 @@ func Execute() {
 	pf := root.PersistentFlags()
 	pf.StringVar(&p.ConfigFlag, "config", "", "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml")
 	pf.StringArrayVarP(&p.FlagOverrides, "config-opt", "X", nil, "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail")
-	pf.StringVarP(&p.LogLevel, "verbose", "v", "none", "Log level (none, error, warn, info, debug)")
-	pf.Lookup("verbose").NoOptDefVal = "info"
+	pf.BoolVarP(&p.DebugLogs, "verbose", "v", false, "Enable verbose logging")
 
 	root.RegisterFlagCompletionFunc("config-opt", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		var opts []string

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -75,6 +75,7 @@ func Execute() {
 	}
 	pf := root.PersistentFlags()
 	pf.StringVar(&p.ConfigFlag, "config", "", "Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml")
+	pf.StringVar(&p.Profile, "profile", "", "rpk profile to use")
 	pf.StringArrayVarP(&p.FlagOverrides, "config-opt", "X", nil, "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail")
 	pf.BoolVarP(&p.DebugLogs, "verbose", "v", false, "Enable verbose logging")
 
@@ -92,6 +93,7 @@ func Execute() {
 		}
 		return opts, cobra.ShellCompDirectiveNoSpace
 	})
+	root.RegisterFlagCompletionFunc("profile", profile.ValidProfiles(fs, p))
 
 	root.AddCommand(
 		acl.NewCommand(fs, p),

--- a/src/go/rpk/pkg/cli/topic/describe.go
+++ b/src/go/rpk/pkg/cli/topic/describe.go
@@ -385,7 +385,7 @@ func listStartEndOffsets(cl *kgo.Client, topic string, numPartitions int, stable
 
 	// Finally, the HWM.
 	shards = cl.RequestSharded(context.Background(), req)
-	allFailed = kafka.EachShard(req, shards, func(shard kgo.ResponseShard) {
+	kafka.EachShard(req, shards, func(shard kgo.ResponseShard) {
 		resp := shard.Resp.(*kmsg.ListOffsetsResponse)
 		if len(resp.Topics) > 0 {
 			for _, partition := range resp.Topics[0].Partitions {

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -367,8 +367,9 @@ func XCloudAuthFlags() (xs, yamlPaths []string) {
 	return
 }
 
-// XRpkDefaultsFlags returns all X flags that modify rpk defaults, and
-// their corresponding yaml paths.
+// XRpkDefaultsFlags returns all X flags that modify rpk defaults, and their
+// corresponding yaml paths. Note that for rpk defaults, the X flags always
+// have the same name as the yaml path and always begin with "defaults.".
 func XRpkDefaultsFlags() (xs, yamlPaths []string) {
 	for k, v := range xflags {
 		if v.kind == xkindDefault {

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -581,7 +581,17 @@ func (p *Params) InstallKafkaFlags(cmd *cobra.Command) {
 	pf.StringVar(&p.password, "password", "", "SASL password to be used for authentication")
 	pf.StringVar(&p.saslMechanism, "sasl-mechanism", "", "The authentication mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512)")
 
+	pf.MarkHidden("brokers")
+	pf.MarkHidden(FlagSASLUser)
+	pf.MarkHidden("password")
+	pf.MarkHidden("sasl-mechanism")
+
 	p.InstallTLSFlags(cmd)
+
+	pf.MarkHidden(FlagEnableTLS)
+	pf.MarkHidden(FlagTLSCA)
+	pf.MarkHidden(FlagTLSCert)
+	pf.MarkHidden(FlagTLSKey)
 }
 
 // InstallTLSFlags adds the original rpk Kafka API TLS set of flags to this
@@ -610,6 +620,14 @@ func (p *Params) InstallAdminFlags(cmd *cobra.Command) {
 	pf.StringVar(&p.adminCAFile, "admin-api-tls-truststore", "", "The CA certificate  to be used for TLS communication with the admin API")
 	pf.StringVar(&p.adminCertFile, "admin-api-tls-cert", "", "The certificate to be used for TLS authentication with the admin API")
 	pf.StringVar(&p.adminKeyFile, "admin-api-tls-key", "", "The certificate key to be used for TLS authentication with the admin API")
+
+	pf.MarkHidden("api-urls")
+	pf.MarkHidden("hosts")
+	pf.MarkHidden("admin-url")
+	pf.MarkHidden("admin-api-tls-enabled")
+	pf.MarkHidden("admin-api-tls-truststore")
+	pf.MarkHidden("admin-api-tls-cert")
+	pf.MarkHidden("admin-api-tls-key")
 }
 
 // InstallCloudFlags adds the --client-id and --client-secret flags that

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -829,11 +829,11 @@ func readFile(fs afero.Fs, path string) (string, []byte, error) {
 	return abs, file, err
 }
 
-func (p *Params) backcompatOldCloudYaml(fs afero.Fs) error {
+func (*Params) backcompatOldCloudYaml(fs afero.Fs) error {
 	def, err := DefaultRpkYamlPath()
 	if err != nil {
-		// This error only happens if the user unset $HOME, and if they
-		// do that, we will avoid failing / avoid backcompat here.
+		//nolint:nilerr // This error only happens if the user unset $HOME, and
+		// if they do that, we will avoid failing / avoid backcompat here.
 		return nil
 	}
 
@@ -913,7 +913,7 @@ func (p *Params) readRpkConfig(fs afero.Fs, c *Config) error {
 	if p.ConfigFlag != "" {
 		path = p.ConfigFlag
 	} else if err != nil {
-		// If $HOME is unset, we do not read any file. If the user
+		//nolint:nilerr // If $HOME is unset, we do not read any file. If the user
 		// eventually tries to write, we fail in Write. Allowing
 		// $HOME to not exists allows rpk to work in CI settings
 		// where all config flags are being specified.

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -754,9 +754,9 @@ func (p *Params) SugarLogger() *zap.SugaredLogger {
 // Logger parses returns the corresponding zap logger or a NopLogger.
 func (p *Params) Logger() *zap.Logger {
 	p.loggerOnce.Do(func() {
-		var level zapcore.Level
-		if p.DebugLogs {
-			level = zap.DebugLevel
+		if !p.DebugLogs {
+			p.logger = zap.NewNop()
+			return
 		}
 
 		// Now the zap config. We want to to the console and make the logs
@@ -765,7 +765,7 @@ func (p *Params) Logger() *zap.Logger {
 		// level to three letters, and we only add color if this is a
 		// terminal.
 		zcfg := zap.NewProductionConfig()
-		zcfg.Level = zap.NewAtomicLevelAt(level)
+		zcfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 		zcfg.DisableCaller = true
 		zcfg.DisableStacktrace = true
 		zcfg.Sampling = nil

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -393,9 +393,10 @@ func XFlagYamlPath(x string) (string, bool) {
 // Params contains rpk-wide configuration parameters.
 type Params struct {
 	// ConfigFlag is any flag-specified config path.
-	//
-	// This is unused until step (2) in the refactoring process.
 	ConfigFlag string
+
+	// Profile is any flag-specified profile name.
+	Profile string
 
 	// DebugLogs opts into debug logging.
 	//
@@ -404,8 +405,6 @@ type Params struct {
 	DebugLogs bool
 
 	// FlagOverrides are any flag-specified config overrides.
-	//
-	// This is unused until step (2) in the refactoring process.
 	FlagOverrides []string
 
 	loggerOnce sync.Once
@@ -949,6 +948,13 @@ func (p *Params) readRpkConfig(fs afero.Fs, c *Config) error {
 	}
 	yaml.Unmarshal(file, &c.rpkYamlActual)
 
+	if p.Profile != "" {
+		if c.rpkYaml.Profile(p.Profile) == nil {
+			return fmt.Errorf("selected profile %q does not exist", p.Profile)
+		}
+		c.rpkYaml.CurrentProfile = p.Profile
+		c.rpkYamlActual.CurrentProfile = p.Profile
+	}
 	c.rpkYamlExists = true
 	c.rpkYaml.fileLocation = abs
 	c.rpkYamlActual.fileLocation = abs

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -1056,6 +1056,7 @@ func TestXSetExamples(t *testing.T) {
 	for _, fn := range []func() (xs, yamlPaths []string){
 		XProfileFlags,
 		XCloudAuthFlags,
+		XRpkDefaultsFlags,
 	} {
 		xs, yamlPaths := fn()
 		for i, x := range xs {
@@ -1073,6 +1074,8 @@ func TestXSetExamples(t *testing.T) {
 				err = Set(new(RpkProfile), yamlPath, xf.testExample)
 			case xkindCloudAuth:
 				err = Set(new(RpkCloudAuth), yamlPath, xf.testExample)
+			case xkindDefault:
+				err = Set(new(RpkYaml), yamlPath, xf.testExample)
 			default:
 				t.Errorf("unrecognized xflag kind %v", xf.kind)
 				continue

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -304,21 +304,6 @@ func TestAddUnsetRedpandaDefaults(t *testing.T) {
 		expCfg *RedpandaYaml
 	}{
 		{
-			name:  "default kafka broker and default admin api",
-			inCfg: &RedpandaYaml{},
-			expCfg: &RedpandaYaml{
-				Rpk: RpkNodeConfig{
-					KafkaAPI: RpkKafkaAPI{
-						Brokers: []string{"127.0.0.1:9092"},
-					},
-					AdminAPI: RpkAdminAPI{
-						Addresses: []string{"127.0.0.1:9644"},
-					},
-				},
-			},
-		},
-
-		{
 			name: "rpk configuration left alone if present",
 			inCfg: &RedpandaYaml{
 				Redpanda: RedpandaNodeConfig{

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -1075,3 +1075,15 @@ func TestXSetExamples(t *testing.T) {
 		t.Errorf("xflags still contains keys %v after checking all examples in this test", maps.Keys(m))
 	}
 }
+
+func TestXSetDefaultsPaths(t *testing.T) {
+	xs, paths := XRpkDefaultsFlags()
+	for i, x := range xs {
+		if paths[i] != x {
+			t.Errorf("XRpkDefaultsFlags() returned different xflag %s and path %s", x, paths[i])
+		}
+		if !strings.HasPrefix(x, "defaults.") {
+			t.Errorf("XRpkDefaultsFlags() returned xflag %s that doesn't start with defaults.", x)
+		}
+	}
+}

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -248,6 +248,11 @@ func (p *RpkProfile) SugarLogger() *zap.SugaredLogger {
 	return p.Logger().Sugar()
 }
 
+// Defaults returns the virtual defaults for the rpk.yaml.
+func (p *RpkProfile) Defaults() *RpkDefaults {
+	return &p.c.rpkYaml.Defaults
+}
+
 // HasClientCredentials returns if both ClientID and ClientSecret are empty.
 func (a *RpkCloudAuth) HasClientCredentials() bool {
 	k, _ := a.Kind()

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -35,10 +35,7 @@ func DefaultRpkYamlPath() (string, error) {
 }
 
 func defaultVirtualRpkYaml() (RpkYaml, error) {
-	path, err := DefaultRpkYamlPath()
-	if err != nil {
-		return RpkYaml{}, err
-	}
+	path, _ := DefaultRpkYamlPath() // if err is non-nil, we fail in Write
 	y := RpkYaml{
 		fileLocation: path,
 		Version:      1,

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -323,4 +323,4 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	return err
 }
 
-func (d *Duration) YamlTypeNameForTest() string { return "duration" }
+func (*Duration) YamlTypeNameForTest() string { return "duration" }

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -97,36 +97,36 @@ type (
 	RpkDefaults struct {
 		// Prompt is the prompt to use for all profiles, unless the
 		// profile itself overrides it.
-		Prompt string `yaml:"prompt,omitempty"`
+		Prompt string `yaml:"prompt"`
 
 		// NoDefaultCluster disables localhost:{9092,9644} as a default
 		// profile when no other is selected.
-		NoDefaultCluster bool `yaml:"no_default_cluster,omitempty"`
+		NoDefaultCluster bool `yaml:"no_default_cluster"`
 
 		// DialTimeout is how long we allow for initiating a connection
 		// to brokers for the Admin API and Kafka API.
-		DialTimeout Duration `yaml:"dial_timeout,omitempty"`
+		DialTimeout Duration `yaml:"dial_timeout"`
 
 		// RequestTimeoutOverhead, for Kafka API requests, how long do
 		// we give the request on top of any request's timeout field.
-		RequestTimeoutOverhead Duration `yaml:"request_timeout_overhead,omitempty"`
+		RequestTimeoutOverhead Duration `yaml:"request_timeout_overhead"`
 
 		// RetryTimeout allows us to retry requests. If see we need to
 		// retry before the retry timeout has elapsed, we do -- even if
 		// backing off after we know to retry pushes us past the
 		// timeout.
-		RetryTimeout Duration `yaml:"retry_timeout,omitempty"`
+		RetryTimeout Duration `yaml:"retry_timeout"`
 
 		// FetchMaxWait is how long we give the broker to respond to
 		// fetch requests.
-		FetchMaxWait Duration `yaml:"fetch_max_wait,omitempty"`
+		FetchMaxWait Duration `yaml:"fetch_max_wait"`
 
 		// RedpandaClientID is the client ID to use for the Kafka API.
-		RedpandaClientID string `yaml:"redpanda_client_id,omitempty"`
+		RedpandaClientID string `yaml:"redpanda_client_id"`
 	}
 
 	RpkProfile struct {
-		Name         string           `yaml:"name,omitempty"`
+		Name         string           `yaml:"name"`
 		Description  string           `yaml:"description,omitempty"`
 		Prompt       string           `yaml:"prompt,omitempty"`
 		FromCloud    bool             `yaml:"from_cloud,omitempty"`

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -97,6 +97,7 @@ type (
 	RpkProfile struct {
 		Name         string           `yaml:"name,omitempty"`
 		Description  string           `yaml:"description,omitempty"`
+		Prompt       string           `yaml:"prompt,omitempty"`
 		FromCloud    bool             `yaml:"from_cloud,omitempty"`
 		CloudCluster *RpkCloudCluster `yaml:"cloud_cluster,omitempty"`
 		KafkaAPI     RpkKafkaAPI      `yaml:"kafka_api,omitempty"`

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -119,7 +119,7 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		v1sha = "eb5ffa64ca15ceb04b1189a9f934a95b81577eadc5c8a7b3f60c8116d2799ef8" // 23-06-06
+		v1sha = "2ad0d7eee688f2a38a0ca126c919bbc5af2c42b6c848fa40947dfc6dd5a2fce3" // 23-06-08
 	)
 
 	if shastr != v1sha {

--- a/src/go/rpk/pkg/os/file.go
+++ b/src/go/rpk/pkg/os/file.go
@@ -143,6 +143,9 @@ func EditTmpYAMLFile[T any](fs afero.Fs, v T) (T, error) {
 	if err != nil {
 		return update, fmt.Errorf("unable to edit: %w", err)
 	}
+	if len(read) == 0 || string(read) == "\n" {
+		return update, fmt.Errorf("no changes made")
+	}
 	if err := yaml.Unmarshal(read, &update); err != nil {
 		return update, fmt.Errorf("unable to parse edited file: %w", err)
 	}

--- a/src/go/rpk/pkg/out/color.go
+++ b/src/go/rpk/pkg/out/color.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Redpanda Data, Inc.
+// Copyright 2023 Redpanda Data, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md

--- a/src/go/rpk/pkg/out/color.go
+++ b/src/go/rpk/pkg/out/color.go
@@ -1,0 +1,99 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package out
+
+import (
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// ParseColor parses a string into a color.Attribute. Foreground colors are
+// simply named ("red", "black"), highlights have a "hi-" prefix, and
+// background colors have an additional "bg-" prefix. Bold, faint, underline,
+// and invert attributes are also supported by name directly.
+func ParseColor(c string) (color.Attribute, bool) {
+	switch strings.ToLower(strings.TrimSpace(c)) {
+	case "black":
+		return color.FgBlack, true
+	case "red":
+		return color.FgRed, true
+	case "green":
+		return color.FgGreen, true
+	case "yellow":
+		return color.FgYellow, true
+	case "blue":
+		return color.FgBlue, true
+	case "magenta":
+		return color.FgMagenta, true
+	case "cyan":
+		return color.FgCyan, true
+	case "white":
+		return color.FgWhite, true
+	case "hi-black":
+		return color.FgHiBlack, true
+	case "hi-red":
+		return color.FgHiRed, true
+	case "hi-green":
+		return color.FgHiGreen, true
+	case "hi-yellow":
+		return color.FgHiYellow, true
+	case "hi-blue":
+		return color.FgHiBlue, true
+	case "hi-magenta":
+		return color.FgHiMagenta, true
+	case "hi-cyan":
+		return color.FgHiCyan, true
+	case "hi-white":
+		return color.FgHiWhite, true
+	case "bg-black":
+		return color.BgBlack, true
+	case "bg-red":
+		return color.BgRed, true
+	case "bg-green":
+		return color.BgGreen, true
+	case "bg-yellow":
+		return color.BgYellow, true
+	case "bg-blue":
+		return color.BgBlue, true
+	case "bg-magenta":
+		return color.BgMagenta, true
+	case "bg-cyan":
+		return color.BgCyan, true
+	case "bg-white":
+		return color.BgWhite, true
+	case "bg-hi-black":
+		return color.BgHiBlack, true
+	case "bg-hi-red":
+		return color.BgHiRed, true
+	case "bg-hi-green":
+		return color.BgHiGreen, true
+	case "bg-hi-yellow":
+		return color.BgHiYellow, true
+	case "bg-hi-blue":
+		return color.BgHiBlue, true
+	case "bg-hi-magenta":
+		return color.BgHiMagenta, true
+	case "bg-hi-cyan":
+		return color.BgHiCyan, true
+	case "bg-hi-white":
+		return color.BgHiWhite, true
+	case "bold":
+		return color.Bold, true
+	case "faint":
+		return color.Faint, true
+	case "underline":
+		return color.Underline, true
+	case "invert":
+		return color.ReverseVideo, true
+	default:
+		return 0, false
+	}
+}

--- a/src/go/rpk/pkg/out/out.go
+++ b/src/go/rpk/pkg/out/out.go
@@ -73,6 +73,13 @@ func Die(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
+// DieString is like Die, but does not format the message. This still adds
+// a newline.
+func DieString(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}
+
 // MaybeDie calls Die if err is non-nil.
 func MaybeDie(err error, msg string, args ...interface{}) {
 	if err != nil {

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -74,9 +74,9 @@ class RpkRemoteTool:
         cmd = ["create", name]
         return self._run_profile(cmd)
 
-    def create_profile_simple(self, name, cfg_location):
+    def create_profile_redpanda(self, name, cfg_location):
         return self._run_profile(
-            ['create', name, "--from-simple", cfg_location])
+            ['create', name, "--from-redpanda", cfg_location])
 
     def use_profile(self, name):
         cmd = ["use", name]

--- a/tests/rptest/tests/rpk_profile_test.py
+++ b/tests/rptest/tests/rpk_profile_test.py
@@ -88,9 +88,9 @@ class RpkProfileTest(RedpandaTest):
         assert "no-flag-test" in topic_list
 
     @cluster(num_nodes=3)
-    def test_create_profile_from_simple(self):
+    def test_create_profile_from_redpanda(self):
         """
-        Create redpanda.yaml, use create rpk profile --from simple
+        Create redpanda.yaml, use create rpk profile --from-redpanda
         """
         node = self.redpanda.get_node(0)
         rpk = RpkRemoteTool(self.redpanda, node)
@@ -99,8 +99,8 @@ class RpkProfileTest(RedpandaTest):
         rpk.config_set("rpk.kafka_api.brokers", self.redpanda.brokers_list())
 
         # Then we create the profile based on the redpanda.yaml
-        rpk.create_profile_simple("simple_test",
-                                  RedpandaService.NODE_CONFIG_FILE)
+        rpk.create_profile_redpanda("simple_test",
+                                    RedpandaService.NODE_CONFIG_FILE)
 
         rpk_cfg = read_rpk_cfg(node)
         redpanda_cfg = read_redpanda_cfg(node)


### PR DESCRIPTION
This PRs adds some missing features of rpk profile:

- Adds rpk profile clear: let the user clear the current profile. (Useful to under prod cluster profiles)
- Enable creating a profile from another file that contains a profile (rpk profile create --from-profile)
- Adds rpk profile prompt command: It let's user configure a custom bash prompt via rpk for a specific profile.
- Adds a new flag `--stable` to `rpk topic describe` to only print the `stable` column if the flag is used.
- Fix: allow rpk to be used without setting $HOME
- Revert the `-v` change to default to DEBUG level instead of INFO.
- Hide non -X flags by default.
  - This means users won't see the help text for any of the non -X flags (`brokers`, `api-urls`, `admin-api-tls`, etc...)
- Adds Defaults to rpk.yaml: Global configuration knobs to be used across different profiles.
  - Adds new rpk profile {edit,print,set}-default to modify these configs properties.
- Adds a new flag: `--profile` that let users pick profiles while running a single rpk command.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

