### PR TITLE
schema_registry: Schema ID Validation low-level tests

### DIFF
--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ rp_test(
     quota_managers_test.cc
     validator_tests.cc
     fetch_unit_test.cc
+    config_utils_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka v::coproc
   LABELS kafka

--- a/src/v/kafka/server/tests/config_utils_test.cc
+++ b/src/v/kafka/server/tests/config_utils_test.cc
@@ -1,0 +1,83 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/types.h"
+#include "kafka/server/handlers/configs/config_utils.h"
+#include "kafka/types.h"
+
+#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+BOOST_AUTO_TEST_CASE(parse_and_set_optional_bool_alpha_test_set) {
+    using namespace kafka;
+    cluster::property_update<std::optional<bool>> property;
+
+    // Set from 'true'
+    parse_and_set_optional_bool_alpha(
+      property, "true", config_resource_operation::set);
+    BOOST_REQUIRE_EQUAL(property.value, true);
+    BOOST_REQUIRE_EQUAL(
+      property.op, cluster::incremental_update_operation::set);
+
+    // Set from 'false'
+    parse_and_set_optional_bool_alpha(
+      property, "false", config_resource_operation::set);
+    BOOST_REQUIRE_EQUAL(property.value, false);
+    BOOST_REQUIRE_EQUAL(
+      property.op, cluster::incremental_update_operation::set);
+
+    // If no value provided, do nothing
+    property.value = true;
+    property.op = cluster::incremental_update_operation::none;
+    parse_and_set_optional_bool_alpha(
+      property, std::nullopt, config_resource_operation::set);
+    BOOST_REQUIRE_EQUAL(property.value, true);
+    BOOST_REQUIRE_EQUAL(
+      property.op, cluster::incremental_update_operation::none);
+}
+
+BOOST_AUTO_TEST_CASE(parse_and_set_optional_bool_alpha_test_set_invalid) {
+    using namespace kafka;
+    cluster::property_update<std::optional<bool>> property;
+
+    // "0" is invalid (c.f. parse_and_set_bool)
+    BOOST_REQUIRE_THROW(
+      parse_and_set_optional_bool_alpha(
+        property, "0", config_resource_operation::set),
+      boost::bad_lexical_cast);
+
+    // "1" is invalid (c.f. parse_and_set_bool)
+    BOOST_REQUIRE_THROW(
+      parse_and_set_optional_bool_alpha(
+        property, "1", config_resource_operation::set),
+      boost::bad_lexical_cast);
+
+    // An arbitrary string is invalid (c.f. parse_and_set_bool)
+    BOOST_REQUIRE_THROW(
+      parse_and_set_optional_bool_alpha(
+        property, "foo", config_resource_operation::set),
+      boost::bad_lexical_cast);
+}
+
+BOOST_AUTO_TEST_CASE(parse_and_set_optional_bool_alpha_test_remove) {
+    using namespace kafka;
+    cluster::property_update<std::optional<bool>> property;
+
+    // Removing a property results in a remove
+    parse_and_set_optional_bool_alpha(
+      property, std::nullopt, config_resource_operation::remove);
+    BOOST_REQUIRE_EQUAL(
+      property.op, cluster::incremental_update_operation::remove);
+
+    // Removing a property results in a remove, the value is ignored
+    parse_and_set_optional_bool_alpha(
+      property, "ignored", config_resource_operation::remove);
+    BOOST_REQUIRE_EQUAL(
+      property.op, cluster::incremental_update_operation::remove);
+}


### PR DESCRIPTION
Add some tests as an exposition of setting and removing schema id validation properties.

Fixes https://github.com/redpanda-data/redpanda/issues/11115

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
