### PR TITLE
[cloud_storage] segment hydration failure fix

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -654,15 +654,14 @@ ss::future<bool> remote_segment::maybe_materialize_index() {
               "Failed to materialize index '{}'. Error: {}",
               path,
               std::current_exception());
+            co_return false;
         }
         co_await cache_item->body.close();
+        co_return true;
     } else {
         vlog(_ctxlog.info, "Index '{}' is not available", path);
+        co_return false;
     }
-
-    // TODO (abhijat) start returning false here when the index is required to
-    // be materialized.
-    co_return true;
 }
 
 // NOTE: Aborted transactions handled using tx_range manifests.


### PR DESCRIPTION
Change remote_segment::maybe_materialize_index to return false on failure 

previously, a couple of failure paths would default to true, this is a problem for code after this that assumes the existence of objects after this function

Fixes #11060 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none