### PR TITLE
tests: add separate test suite to run partition tests

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -884,12 +884,12 @@ class ManyPartitionsTest(PreallocNodesTest):
 
     # TODO: re-enable once infra has stabilitized
     # https://github.com/redpanda-data/redpanda/issues/9569
-    # @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8777
-    # @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    # @matrix(compacted=[False])  # FIXME: run with compaction
-    # def test_many_partitions_tiered_storage(self, compacted):
-    #     self._test_many_partitions(compacted=compacted,
-    #                                tiered_storage_enabled=True)
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/8777
+    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @matrix(compacted=[False])  # FIXME: run with compaction
+    def test_many_partitions_tiered_storage(self, compacted):
+        self._test_many_partitions(compacted=compacted,
+                                   tiered_storage_enabled=True)
 
     @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_omb(self):

--- a/tests/rptest/test_many_partitions.yml
+++ b/tests/rptest/test_many_partitions.yml
@@ -1,0 +1,9 @@
+# TODO work in progress getting clustered mode issues worked out
+partitions:
+  included:
+    - scale_tests/many_partitions_test.py
+
+  excluded:
+    - scale_tests/many_partitions_test.py::ManyPartitionsTest.test_many_partitions
+    - scale_tests/many_partitions_test.py::ManyPartitionsTest.test_many_partitions_compacted
+    - scale_tests/many_partitions_test.py::ManyPartitionsTest.test_omb

--- a/tests/rptest/test_suite_ec2.yml
+++ b/tests/rptest/test_suite_ec2.yml
@@ -8,3 +8,4 @@ ec2:
     - tests/librdkafka_test.py # normally disabled
     - tests/e2e_iam_role_test.py # use static credentials
     - tests/consumer_group_recovery_tool_test.py # use script available in dockerfile
+    - scale_tests/many_partitions_test.py::ManyPartitionsTest.test_many_partitions_tiered_storage # time consuming in main suite


### PR DESCRIPTION
- Uncommented test_many_partitions_tiered_storage so it can be run
- Added separate suite to run tests
- Excluded tiered test from main ec2 run

## Release Notes

* none