### PR TITLE
Revert "[v22.3.x] k8s: parse configuration arrays correctly"

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_configuration_test.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -242,33 +241,6 @@ var _ = Describe("RedPandaCluster configuration controller", func() {
 			By("Never restarting the cluster")
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, configMapHashKey), timeoutShort, intervalShort).Should(Equal(hash))
 			Consistently(annotationGetter(key, &appsv1.StatefulSet{}, centralizedConfigurationHashKey), timeoutShort, intervalShort).Should(BeEmpty())
-
-			By("Adding configuration of array type")
-			Expect(k8sClient.Get(context.Background(), key, &cluster)).To(Succeed())
-
-			testAdminAPI.RegisterPropertySchema("kafka_nodelete_topics", admin.ConfigPropertyMetadata{NeedsRestart: false, Type: "array", Items: admin.ConfigPropertyItems{Type: "string"}})
-			cluster.Spec.AdditionalConfiguration["redpanda.kafka_nodelete_topics"] = "[_internal_connectors_configs _internal_connectors_offsets _internal_connectors_status _audit __consumer_offsets _redpanda_e2e_probe _schemas]"
-			Expect(k8sClient.Update(context.Background(), &cluster)).To(Succeed())
-
-			Eventually(testAdminAPI.PropertyGetter("kafka_nodelete_topics")).Should(Equal([]string{
-				"__consumer_offsets",
-				"_audit",
-				"_internal_connectors_configs",
-				"_internal_connectors_offsets",
-				"_internal_connectors_status",
-				"_redpanda_e2e_probe",
-				"_schemas",
-			}))
-
-			patches = testAdminAPI.PatchesGetter()()
-			Expect(patches).NotTo(BeEmpty())
-			expectedPatch := patches[len(patches)-1]
-			Expect(expectedPatch).NotTo(BeNil())
-			arrayInterface := expectedPatch.Upsert["kafka_nodelete_topics"]
-			Expect(arrayInterface).NotTo(BeNil())
-			Expect(reflect.TypeOf(arrayInterface).String()).To(Equal("[]interface {}"))
-			Expect(len(arrayInterface.([]interface{})) == 7).To(BeTrue())
-			Eventually(clusterConfiguredConditionStatusGetter(key), timeout, interval).Should(BeTrue())
 
 			By("Deleting the cluster")
 			Expect(k8sClient.Delete(context.Background(), redpandaCluster, deleteOptions)).Should(Succeed())

--- a/src/go/k8s/pkg/resources/configuration/patch.go
+++ b/src/go/k8s/pkg/resources/configuration/patch.go
@@ -13,14 +13,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
-	"gopkg.in/yaml.v3"
-
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 )
 
@@ -79,8 +76,7 @@ func ThreeWayMerge(
 	}
 	for k, v := range apply {
 		if oldValue, ok := current[k]; !ok || !PropertiesEqual(log, v, oldValue, schema[k]) {
-			metadata := schema[k]
-			patch.Upsert[k] = parseConfigValueBeforeUpsert(log, v, &metadata)
+			patch.Upsert[k] = v
 		}
 	}
 	invalidSet := make(map[string]bool, len(invalidProperties))
@@ -97,44 +93,6 @@ func ThreeWayMerge(
 	}
 	sort.Strings(patch.Remove)
 	return patch
-}
-
-func parseConfigValueBeforeUpsert(log logr.Logger, value interface{}, metadata *admin.ConfigPropertyMetadata) interface{} {
-	tempValue := fmt.Sprintf("%v", value)
-
-	//nolint:gocritic // no need to be a switch case
-	if metadata.Nullable && tempValue == "null" {
-		return nil
-	} else if metadata.Type != "string" && (tempValue == "") {
-		log.Info(fmt.Sprintf("Non-string types that receive an empty string: %v", value))
-		return value
-	} else if metadata.Type == "array" { //nolint:goconst // we wish to be explicit here
-		a, err := convertStringToStringArray(tempValue)
-		if err != nil {
-			log.Info(fmt.Sprintf("could not parse: invalid list syntax: %v", value))
-			return value
-		}
-		return a
-	}
-
-	return value
-}
-
-func convertStringToStringArray(value string) ([]string, error) {
-	a := make([]string, 0)
-	err := yaml.Unmarshal([]byte(value), &a)
-
-	if len(a) == 1 {
-		// it is possible this was not comma separated, so let's make it so and retry unmarshalling
-		b := make([]string, 0)
-		errB := yaml.Unmarshal([]byte(strings.ReplaceAll(value, " ", ",")), &b)
-		if errB == nil && len(b) > len(a) {
-			sort.Strings(b)
-			return b, errB
-		}
-	}
-	sort.Strings(a)
-	return a, err
 }
 
 // PropertiesEqual tries to compare two property values using metadata information about the schema,
@@ -155,14 +113,6 @@ func PropertiesEqual(
 			return i1 == i2
 		}
 		log.Info(schemaMismatchInfoLog, "type", metadata.Type, "v1", v1, "v2", v2)
-	case "array":
-		v1Parsed, errV1 := convertStringToStringArray(fmt.Sprintf("%v", v1))
-		v2Parsed, errV2 := convertStringToStringArray(fmt.Sprintf("%v", v2))
-		if errV1 == nil && errV2 == nil {
-			// must be sorted the same way otherwise the return will be false even though they contain the same items
-			return reflect.DeepEqual(v1Parsed, v2Parsed)
-		}
-		log.Info(fmt.Sprintf("error occurred trying to parse configurations: %s, %s", errV1, errV2), "type", metadata.Type, "v1", v1, "v2", v2)
 	}
 	// Other cases are correctly managed by LooseEqual
 	return LooseEqual(v1, v2)

--- a/src/go/k8s/tests/e2e/additional-configuration/04-update-version_and_config.yaml
+++ b/src/go/k8s/tests/e2e/additional-configuration/04-update-version_and_config.yaml
@@ -10,4 +10,3 @@ spec:
     redpanda.internal_topic_replication_factor: "3" # this is a change
     pandaproxy_client.retries: "11"
     schema_registry.schema_registry_api: "[{'name':'external','address':'0.0.0.0','port':8081}]"
-    redpanda.kafka_nodelete_topics: "[_internal_connectors_configs _internal_connectors_offsets _internal_connectors_status _audit __consumer_offsets _redpanda_e2e_probe _schemas]"


### PR DESCRIPTION
Reverts redpanda-data/redpanda#11013

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none