### PR TITLE
ducky: increase test_tx timeout for debug builds

### DIFF
--- a/tests/rptest/tests/compacted_verifier_test.py
+++ b/tests/rptest/tests/compacted_verifier_test.py
@@ -45,6 +45,10 @@ class CompactedVerifierTest(RedpandaTest):
         verifier.remote_start_consumer()
         verifier.remote_wait_consumer()
 
+    @property
+    def tx100_timeout_s(self):
+        return 60 if self.debug_mode else 30
+
     @cluster(num_nodes=4)
     def test_tx(self):
         verifier = CompactedVerifier(self.test_context, self.redpanda,
@@ -54,7 +58,7 @@ class CompactedVerifierTest(RedpandaTest):
         verifier.remote_start_producer(self.redpanda.brokers(), self.topic,
                                        self.partition_count)
         self.logger.info(f"Waiting for 100 writes")
-        verifier.ensure_progress(100, 30)
+        verifier.ensure_progress(100, self.tx100_timeout_s)
         self.logger.info(f"Done")
         verifier.remote_stop_producer()
         verifier.remote_wait_producer()
@@ -70,7 +74,7 @@ class CompactedVerifierTest(RedpandaTest):
         verifier.remote_start_producer(self.redpanda.brokers(), self.topic,
                                        self.partition_count)
         self.logger.info(f"Waiting for 100 writes")
-        verifier.ensure_progress(100, 30)
+        verifier.ensure_progress(100, self.tx100_timeout_s)
         self.logger.info(f"Done")
         verifier.remote_stop_producer()
         verifier.remote_wait_producer()


### PR DESCRIPTION
Debug builds are slower than release and sometimes they time out. Fixing the flakiness by increasing the progress timeout for the debug builds only.

Fixes #11065

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none