### PR TITLE
tests: only run rpk_cloud_test in CDT

### DIFF
--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -13,3 +13,4 @@ quick:
 
   excluded:
   - tests/rpk_tuner_test.py
+  - tests/rpk_cloud_test.py


### PR DESCRIPTION
Not needed for every single PR, plus, we can save some logins by avoiding running this test every PR.

## Backports Required
- [ ] none - issue does not exist in previous branches


## Release Notes
* none

