### PR TITLE
[v23.1.x] k/proto: use log-level warn for missmatch crc

### DIFF
--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -123,7 +123,7 @@ void kafka_batch_adapter::verify_crc(int32_t expected_crc, iobuf_parser in) {
     if (unlikely((uint32_t)expected_crc != crc.value())) {
         valid_crc = false;
         vlog(
-          klog.error,
+          klog.warn,
           "Cannot validate Kafka record batch. Missmatching CRC. Expected:{}, "
           "Got:{}",
           expected_crc,

--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -162,14 +162,7 @@ class CloudStorageCompactionTest(EndToEndTest):
                    timeout_sec=30,
                    backoff_sec=5)
 
-    # Permit transient CRC errors, to protect this test from incidences of
-    # https://github.com/redpanda-data/redpanda/issues/6631
-    # TODO: remove this low allow-list when that issue is resolved.
-    @cluster(num_nodes=9,
-             log_allow_list=[
-                 "Cannot validate Kafka record batch. Missmatching CRC",
-                 "batch has invalid CRC"
-             ])
+    @cluster(num_nodes=9)
     @parametrize(cloud_storage_type=CloudStorageType.AUTO)
     def test_read_from_replica(self, cloud_storage_type):
         self.start_workload()


### PR DESCRIPTION
Backport https://github.com/redpanda-data/redpanda/pull/11324 into v23.1.x

Fixes: https://github.com/redpanda-data/redpanda/issues/11331

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none