### PR TITLE
Avoid duplicate group names in the test in snc trhoughput config test

### DIFF
--- a/tests/rptest/tests/throughput_limits_snc_test.py
+++ b/tests/rptest/tests/throughput_limits_snc_test.py
@@ -145,18 +145,27 @@ class ThroughputLimitsSnc(RedpandaTest):
         if prop == self.ConfigProp.THROUGHPUT_CONTROL:
             throughput_control = []
             letters = string.digits + string.ascii_letters + ' '
+            group_names = set()
             for _ in range(self.rnd.randrange(4)):
                 tc_item = {}
+
                 r = self.rnd.randrange(3)
                 if r != 0:
-                    tc_item['name'] = ''.join(
-                        self.rnd.choice(letters)
-                        for _ in range(self.binexp_random(0, 512)))
+                    while True:
+                        new_name = ''.join(
+                            self.rnd.choice(letters)
+                            for _ in range(self.binexp_random(0, 512)))
+                        if new_name not in group_names:
+                            break
+                    tc_item['name'] = new_name
+                    group_names.add(new_name)
+
                 r = self.rnd.randrange(3)
                 if r == 0:
                     tc_item['client_id'] = 'client_id 1'
                 elif r == 2:
                     tc_item['client_id'] = 'client_\d+'
+
                 throughput_control.append(tc_item)
             return throughput_control
 


### PR DESCRIPTION
The test could create two kafka_throughput_control groups with empty names, or other identical names. Group names are required to be unique when present. This change guarantees unique group names provided by the test.

Fixes #11338

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
