### PR TITLE
throughput control groups: fixed zero byte dumped to the log by noname group

### DIFF
--- a/src/v/config/throughput_control_group.cc
+++ b/src/v/config/throughput_control_group.cc
@@ -121,7 +121,7 @@ operator<<(std::ostream& os, const throughput_control_group& tcg) {
       os,
       "{{group_name: {}, client_id: {}, throughput_limit_node_in_bps: {}, "
       "throughput_limit_node_out_bps: {}}}",
-      tcg.name,
+      tcg.is_noname() ? ""s : fmt::format("{{{}}}", tcg.name),
       tcg.client_id_matcher,
       tcg.throughput_limit_node_in_bps,
       tcg.throughput_limit_node_out_bps);


### PR DESCRIPTION
Introduced in #10755

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
