### PR TITLE
node_status_backend: reset backoff on peer checkin

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -91,12 +91,18 @@ inline std::vector<topic_result> create_topic_results(
       });
 }
 
+inline rpc::backoff_policy default_backoff_policy() {
+    return rpc::make_exponential_backoff_policy<rpc::clock_type>(
+      std::chrono::seconds(1), std::chrono::seconds(15));
+}
+
 ss::future<> add_one_tcp_client(
   ss::shard_id owner,
   ss::sharded<rpc::connection_cache>& clients,
   model::node_id node,
   net::unresolved_address addr,
-  config::tls_config tls_config);
+  config::tls_config tls_config,
+  rpc::backoff_policy backoff_policy = default_backoff_policy());
 
 ss::future<> update_broker_client(
   model::node_id,

--- a/src/v/cluster/node_status_backend.cc
+++ b/src/v/cluster/node_status_backend.cc
@@ -212,7 +212,7 @@ ss::future<result<node_status>> node_status_backend::send_node_status_request(
 
 ss::future<ss::shard_id> node_status_backend::maybe_create_client(
   model::node_id target, net::unresolved_address address) {
-    auto source_shard = target % ss::smp::count;
+    auto source_shard = connection_source_shard(target);
     auto target_shard = rpc::connection_cache::shard_for(
       _self, source_shard, target);
 

--- a/src/v/cluster/node_status_backend.h
+++ b/src/v/cluster/node_status_backend.h
@@ -54,7 +54,8 @@ public:
       ss::sharded<members_table>&,
       ss::sharded<features::feature_table>&,
       ss::sharded<node_status_table>&,
-      config::binding<std::chrono::milliseconds>,
+      config::binding<std::chrono::milliseconds> /* period*/,
+      config::binding<std::chrono::milliseconds> /* max_backoff*/,
       ss::sharded<ss::abort_source>&);
 
     ss::future<> start();
@@ -91,12 +92,20 @@ private:
     ss::shard_id connection_source_shard(model::node_id target) const {
         return target % ss::smp::count;
     }
+
+    rpc::backoff_policy create_backoff_policy() const {
+        static constexpr auto default_backoff_base = 1000ms;
+        return rpc::make_exponential_backoff_policy<rpc::backoff_policy>(
+          std::min(default_backoff_base, _max_reconnect_backoff()),
+          _max_reconnect_backoff());
+    }
     model::node_id _self;
     ss::sharded<members_table>& _members_table;
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<node_status_table>& _node_status_table;
 
     config::binding<std::chrono::milliseconds> _period;
+    config::binding<std::chrono::milliseconds> _max_reconnect_backoff;
     config::tls_config _rpc_tls_config;
     ss::sharded<rpc::connection_cache> _node_connection_cache;
 

--- a/src/v/cluster/node_status_backend.h
+++ b/src/v/cluster/node_status_backend.h
@@ -88,6 +88,9 @@ private:
     };
 
 private:
+    ss::shard_id connection_source_shard(model::node_id target) const {
+        return target % ss::smp::count;
+    }
     model::node_id _self;
     ss::sharded<members_table>& _members_table;
     ss::sharded<features::feature_table>& _feature_table;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1924,6 +1924,13 @@ configuration::configuration()
       "establish liveness status outside of the Raft protocol.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100ms)
+  , node_status_reconnect_max_backoff_ms(
+      *this,
+      "node_status_reconnect_max_backoff_ms",
+      "Maximum backoff (in ms) to reconnect to an unresponsive peer during "
+      "node status liveness checks.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      15s)
   , enable_controller_log_rate_limiting(
       *this,
       "enable_controller_log_rate_limiting",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -387,6 +387,7 @@ struct configuration final : public config_store {
     property<bool> enable_rack_awareness;
 
     property<std::chrono::milliseconds> node_status_interval;
+    property<std::chrono::milliseconds> node_status_reconnect_max_backoff_ms;
     // controller log limitng
     property<bool> enable_controller_log_rate_limiting;
     property<size_t> rps_limit_topic_operations;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1240,6 +1240,10 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       std::ref(node_status_table),
       ss::sharded_parameter(
         [] { return config::shard_local_cfg().node_status_interval.bind(); }),
+      ss::sharded_parameter([] {
+          return config::shard_local_cfg()
+            .node_status_reconnect_max_backoff_ms.bind();
+      }),
       std::ref(_as))
       .get();
 

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -63,6 +63,16 @@ ss::future<> connection_cache::remove(model::node_id n) {
       });
 }
 
+ss::future<> connection_cache::remove_all() {
+    auto units = co_await _mutex.get_units();
+    auto cache = std::exchange(_cache, {});
+    co_await parallel_for_each(cache, [](auto& it) {
+        auto& [_, cli] = it;
+        return cli->stop();
+    });
+    cache.clear();
+}
+
 /// \brief closes all client connections
 ss::future<> connection_cache::do_shutdown() {
     auto units = co_await _mutex.get_units();

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -57,6 +57,9 @@ public:
     /// \brief removes the node *and* closes the connection
     ss::future<> remove(model::node_id n);
 
+    /// \brief similar to remove but removes all nodes.
+    ss::future<> remove_all();
+
     /// \brief closes all connections
     ss::future<> do_shutdown();
     void shutdown();

--- a/tests/rptest/tests/node_status_test.py
+++ b/tests/rptest/tests/node_status_test.py
@@ -77,9 +77,9 @@ class StatusGraph:
         vertex = self.node_to_vertex[node]
         return self.edges[vertex][vertex] == ConnectionStatus.ALIVE
 
-    def check_cluster_status(self):
+    def do_check_cluster_status(self):
         admin = Admin(self.redpanda)
-
+        results = []
         for node, peer, expected_status in self._all_edges():
             if not self.is_node_available(node):
                 # The starting node is unavailable so the request
@@ -88,21 +88,36 @@ class StatusGraph:
 
             self.redpanda.logger.debug(
                 f"Checking status of peer {self.redpanda.idx(peer)} "
-                f"from node {self.redpanda.idx(node)}")
+                f"from node {self.redpanda.idx(node)}, expected status: {expected_status}"
+            )
             peer_status = self._get_peer_status(admin, node, peer)
 
             if expected_status == ConnectionStatus.UNKNOWN:
-                assert peer_status is None, f"Expected no reponse from node {peer.name}"
-            if expected_status == ConnectionStatus.ALIVE:
+                results.append(peer_status is None)
+
+            elif expected_status == ConnectionStatus.ALIVE:
                 ms_since_last_status = peer_status["since_last_status"]
-                assert is_live(
-                    ms_since_last_status
-                ), f"Expected node {peer.name} to be alive, but since_last_status > max_delta: ms_since_last_status={ms_since_last_status}, tolerance={MAX_DELTA}"
+                is_peer_live = is_live(ms_since_last_status)
+                self.redpanda.logger.debug(
+                    f"Node {peer.name} expected status: alive, last status: {ms_since_last_status}, is live: {is_peer_live}"
+                )
+                results.append(is_peer_live)
+
             elif expected_status == ConnectionStatus.DOWN:
                 ms_since_last_status = peer_status["since_last_status"]
-                assert not is_live(
-                    ms_since_last_status
-                ), f"Expected node {peer.name} to be down, but ms_since_last_status <= max_delta: ms_since_last_status={ms_since_last_status}, tolerance={MAX_DELTA}"
+                is_not_live = not is_live(ms_since_last_status)
+                self.redpanda.logger.debug(
+                    f"Node {peer.name} expected status: down, last status: {ms_since_last_status}, is not live: {is_not_live}"
+                )
+        return all(results)
+
+    def check_cluster_status(self):
+        self.redpanda.wait_until(
+            self.do_check_cluster_status,
+            timeout_sec=30,
+            backoff_sec=2,
+            err_msg=
+            "Node status across cluster nodes did not reach the desired state")
 
     def _all_edges(self):
         for start_vertex, end_vertex in np.ndindex(self.shape):

--- a/tests/rptest/tests/node_status_test.py
+++ b/tests/rptest/tests/node_status_test.py
@@ -129,9 +129,15 @@ class NodeStatusTest(RedpandaTest):
             test_context=ctx,
             extra_rp_conf={"node_status_interval": NODE_STATUS_INTERVAL})
 
+    def _update_max_backoff(self):
+        self.redpanda.set_cluster_config(
+            {"node_status_reconnect_max_backoff_ms": 5000})
+
     @cluster(num_nodes=3)
     def test_all_nodes_up(self):
         status_graph = StatusGraph(self.redpanda)
+        status_graph.check_cluster_status()
+        self._update_max_backoff()
         status_graph.check_cluster_status()
 
     @cluster(num_nodes=3)


### PR DESCRIPTION
When a peer restarts and a backoff is applied locally, it needs to be
reset once the peer is available again. Otherwise the transport does not
reconnect until the entire backoff elapses thus marking it unavailable
for downstream consumers like partition balancer.

Fixes https://github.com/redpanda-data/redpanda/issues/5795
Fixes #11307
Fixes https://github.com/redpanda-data/redpanda/issues/11276

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
