### PR TITLE
rpk: avoid mentioning old flags in help text, fix -X defaults.no_default_cluster

### DIFF
--- a/src/go/rpk/pkg/cli/acl/user/create.go
+++ b/src/go/rpk/pkg/cli/acl/user/create.go
@@ -112,7 +112,7 @@ acl help text for more info.
 	cmd.Flags().StringVarP(&newPass, "new-password", "p", "", "")
 	cmd.Flags().MarkHidden("new-password")
 
-	cmd.Flags().StringVar(&mechanism, "mechanism", strings.ToLower(admin.ScramSha256), "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive); not to be confused with the global flag --sasl-mechanism which is used for authenticating the rpk client")
+	cmd.Flags().StringVar(&mechanism, "mechanism", strings.ToLower(admin.ScramSha256), "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive)")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/acl/user/update.go
+++ b/src/go/rpk/pkg/cli/acl/user/update.go
@@ -40,7 +40,7 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&newPass, "new-password", "", "New user's password.")
-	cmd.Flags().StringVar(&mechanism, "mechanism", admin.ScramSha256, "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive); not to be confused with the global flag --sasl-mechanism which is used for authenticating the rpk client")
+	cmd.Flags().StringVar(&mechanism, "mechanism", admin.ScramSha256, "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive)")
 	cmd.MarkFlagRequired("new-password")
 
 	return cmd

--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -433,14 +433,14 @@ func renderClusterInteract(nodes []*common.NodeState) {
 	m := `
 You can use rpk to interact with this cluster. E.g:
 
-    rpk cluster info --brokers %s
-    rpk cluster health --api-urls %s
+    rpk cluster info -X brokers=%s
+    rpk cluster health -X admin.hosts=%s
 
 You may also set an environment variable with the comma-separated list of
 broker and admin API addresses:
 
-    export REDPANDA_BROKERS="%s"
-    export REDPANDA_API_ADMIN_ADDRS="%s"
+    export RPK_BROKERS="%s"
+    export RPK_ADMIN_HOSTS="%s"
     rpk cluster info
     rpk cluster health
 


### PR DESCRIPTION

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none