### PR TITLE
ducktape: Copy allowed log lines before modifying them

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2601,7 +2601,7 @@ class RedpandaService(RedpandaServiceBase):
         if allow_list is None:
             allow_list = DEFAULT_LOG_ALLOW_LIST
         else:
-            combined_allow_list = DEFAULT_LOG_ALLOW_LIST
+            combined_allow_list = DEFAULT_LOG_ALLOW_LIST.copy()
             # Accept either compiled or string regexes
             for a in allow_list:
                 if not isinstance(a, re.Pattern):


### PR DESCRIPTION
Without this the allow list of logs will build up as a process runs.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
