### PR TITLE
tools/rp-storage-tool: validate segments in the archive

### DIFF
--- a/tools/rp_storage_tool/src/remote_types.rs
+++ b/tools/rp_storage_tool/src/remote_types.rs
@@ -888,7 +888,7 @@ pub struct LifecycleMarker {
     // lifecycle_status status;
     cluster_id: String,
     ntr: NTR,
-    status: LifecycleStatus,
+    pub status: LifecycleStatus,
 }
 
 impl RpSerde for LifecycleMarker {


### PR DESCRIPTION
This PR teaches rp-storage-tool to validate the existence of segments mentioned
by archive manifests (same as it does for segments mentioned by the STM manifest).
I've also included some basic parsing and reporting of the lifecycle markers which are
uploaded as part of scrubbing.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

