### PR TITLE
ducktape: use pgrep to find the redpanda process

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2870,7 +2870,8 @@ class RedpandaService(RedpandaServiceBase):
 
     def redpanda_pid(self, node):
         try:
-            cmd = "ps ax | grep -i 'redpanda' | grep -v grep | grep -v 'version'| grep -v \"\[redpanda\]\" | awk '{print $1}'"
+            cmd = "pgrep --exact redpanda"
+
             for p in node.account.ssh_capture(cmd,
                                               allow_fail=True,
                                               callback=int,


### PR DESCRIPTION
When debugging #11275, it seems like there is an `apport` process who's
pid is being picked up. Here's a process dump that includes the line.
There are no running redpanda processes, but checking for redpanda
processes times out, leading me to believe that this process is being
picked up.

In that case `stop_node` can fail if the node is already failed in CDT,
as this `apport` process is picked up.

    [DEBUG - 2023-06-12 02:54:07,216 - redpanda - _log_node_process_state - lineno:2215]: root      136962 99.6  6.0 1587948 1452804 ?     R    02:53   0:49 /usr/bin/python3 /usr/shar
    e/apport/apport -p136954 -s5 -c18446744073709551615 -d1 -P136954 -u0 -g0 -- !opt!redpanda_installs!head!libexec!redpanda


Fixes: #11275

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none
