### PR TITLE
tests/rpk: auto-retry on SASL auth fail

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -224,7 +224,10 @@ class RpkTool:
                 self._check_stdout_success(output)
                 return (True, output)
             except RpkException as e:
+                self._redpanda.logger.debug(str(e))
                 if "Kafka replied that the controller broker is -1" in str(e):
+                    return False
+                elif "SASL authentication failed" in str(e):
                     return False
                 raise e
 


### PR DESCRIPTION
In tests that enable SASL auth, it is possible for RPK to issue a CreateTopics requests before the user has replicated across the cluster. The solution is to retry the request.

Fixes #11203

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
