### PR TITLE
[v22.3.x] k/proto: use log-level warn for invalid crc

### DIFF
--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -168,7 +168,7 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
 
     verify_crc(header.crc, std::move(crcparser));
     if (unlikely(!valid_crc)) {
-        vlog(klog.error, "batch has invalid CRC: {}", header);
+        vlog(klog.warn, "batch has invalid CRC: {}", header);
         return remainder;
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11384
Fixes https://github.com/redpanda-data/redpanda/issues/11397,