### PR TITLE
[storage]: add interface for lying about disk space stats

### DIFF
--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -395,6 +395,57 @@
               ]
             }
           ]
+        },
+        {
+          "path": "/v1/debug/storage/disk_stat/{type}",
+          "operations": [
+            {
+              "method": "GET",
+              "summary": "Return disk space statistics.",
+              "operationId": "get_disk_stat",
+              "nickname": "get_disk_stat",
+              "type": "disk_stat",
+              "produces": [
+                "application/json"
+              ],
+              "parameters": [
+                {
+                  "name": "type",
+                  "in": "path",
+                  "required": true,
+                  "type": "string"
+                }
+              ],
+              "responseMessages": [
+                {
+                  "code": 200
+                }
+              ]
+            },
+            {
+              "method": "PUT",
+              "summary": "Override disk space statistics.",
+              "operationId": "put_disk_stat",
+              "nickname": "put_disk_stat",
+              "type": "disk_stat_overrides",
+              "produces": [
+                "application/json"
+              ],
+              "parameters": [
+                {
+                  "name": "type",
+                  "in": "path",
+                  "required": true,
+                  "type": "string"
+                }
+              ],
+              "responseMessages": [
+                {
+                  "code": 200
+                }
+              ]
+            }
+          ]
         }
     ],
     "models": {
@@ -808,6 +859,38 @@
                 "target_min_capacity_wanted": {
                     "type": "long",
                     "description": "Target minimum capacity wanted"
+                }
+            }
+        },
+        "disk_stat": {
+            "id": "disk_stat",
+            "description": "Effective disk stat used by redpanda",
+            "properties": {
+                "total_bytes": {
+                    "type": "long",
+                    "description": "Total size of disk in bytes"
+                },
+                "free_bytes": {
+                    "type": "long",
+                    "description": "Free size of disk in bytes"
+                }
+            }
+        },
+        "disk_stat_overrides": {
+            "id": "disk_stat_overrides",
+            "description": "Disk stat overrides",
+            "properties": {
+                "total_bytes": {
+                    "type": "long",
+                    "description": "Total size of disk in bytes"
+                },
+                "free_bytes": {
+                    "type": "long",
+                    "description": "Free size of disk in bytes"
+                },
+                "free_bytes_delta": {
+                    "type": "long",
+                    "description": "Free size adjustment (signed)"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -20,6 +20,7 @@
 #include "pandaproxy/schema_registry/fwd.h"
 #include "rpc/connection_cache.h"
 #include "seastarx.h"
+#include "storage/node.h"
 #include "utils/request_auth.h"
 
 #include <seastar/core/scheduling.hh>
@@ -71,7 +72,8 @@ public:
       pandaproxy::schema_registry::api*,
       ss::sharded<cloud_storage::topic_recovery_service>&,
       ss::sharded<cluster::topic_recovery_status_frontend>&,
-      ss::sharded<cluster::tx_registry_frontend>&);
+      ss::sharded<cluster::tx_registry_frontend>&,
+      ss::sharded<storage::node>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -448,6 +450,10 @@ private:
       get_partition_state_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       get_local_storage_usage_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      get_disk_stat_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      put_disk_stat_handler(std::unique_ptr<ss::http::request>);
 
     // Debug routes
     ss::future<ss::json::json_return_type>
@@ -503,6 +509,7 @@ private:
     ss::sharded<cluster::topic_recovery_status_frontend>&
       _topic_recovery_status_frontend;
     ss::sharded<cluster::tx_registry_frontend>& _tx_registry_frontend;
+    ss::sharded<storage::node>& _storage_node;
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;
     ss::timer<> _blocked_reactor_notify_reset_timer;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -843,7 +843,8 @@ void application::configure_admin_server() {
       _schema_registry.get(),
       std::ref(topic_recovery_service),
       std::ref(topic_recovery_status_frontend),
-      std::ref(tx_registry_frontend))
+      std::ref(tx_registry_frontend),
+      std::ref(storage_node))
       .get();
 }
 

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -55,7 +55,28 @@ public:
 
     ss::future<stat_info> get_statvfs(disk_type);
 
-    void testing_only_set_statvfs(std::function<struct statvfs(ss::sstring)>);
+    /*
+     * total_bytes: size of disk
+     *
+     * free_bytes: free space on disk. if not specified then actual free space
+     * is used so that statvfs reflects dynamic changes on the file system.
+     *
+     * free_bytes_delta: signed value applied to free_bytes, for example to
+     * simulate a separate application taking up / freeing space independent of
+     * redpanda.
+     */
+    struct statvfs_overrides {
+        std::optional<size_t> total_bytes;
+        std::optional<size_t> free_bytes;
+        std::optional<ssize_t> free_bytes_delta;
+
+        bool has_overrides() const {
+            return total_bytes.has_value() || free_bytes.has_value()
+                   || free_bytes_delta.has_value();
+        }
+    };
+
+    void set_statvfs_overrides(disk_type, statvfs_overrides);
 
 private:
     storage::node_probe _probe;
@@ -63,8 +84,8 @@ private:
     notification_list<disk_cb_t, notification_id> _data_watchers;
     notification_list<disk_cb_t, notification_id> _cache_watchers;
 
-    std::function<struct statvfs(ss::sstring)> _statvfs_for_test;
-    std::optional<size_t> _disk_size_for_test;
+    statvfs_overrides _data_overrides;
+    statvfs_overrides _cache_overrides;
 
     ss::sstring _data_directory;
     ss::sstring _cache_directory;

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -28,6 +28,8 @@ namespace storage {
  */
 class node {
 public:
+    static constexpr ss::shard_id work_shard = 0;
+
     using notification_id = named_type<int32_t, struct notification_id_t>;
     using disk_cb_t
       = ss::noncopyable_function<void(uint64_t, uint64_t, disk_space_alert)>;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -963,3 +963,33 @@ class Admin:
         """
         return self._request("get", "debug/local_storage_usage",
                              node=node).json()
+
+    def get_disk_stat(self, disk_type, node):
+        """
+        Get disk_type stat from node.
+        """
+        return self._request("get",
+                             f"debug/storage/disk_stat/{disk_type}",
+                             node=node).json()
+
+    def set_disk_stat_override(self,
+                               disk_type,
+                               node,
+                               *,
+                               total_bytes=None,
+                               free_bytes=None,
+                               free_bytes_delta=None):
+        """
+        Get disk_type stat from node.
+        """
+        json = {}
+        if total_bytes is not None:
+            json["total_bytes"] = total_bytes
+        if free_bytes is not None:
+            json["free_bytes"] = free_bytes
+        if free_bytes_delta is not None:
+            json["free_bytes_delta"] = free_bytes_delta
+        return self._request("put",
+                             f"debug/storage/disk_stat/{disk_type}",
+                             json=json,
+                             node=node)


### PR DESCRIPTION
Lie about disk space stats so that we can do things like avoid having to fill up a disk to simulate low-disk space. This is possible today with an environment variable, but we'd like more control.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

