### PR TITLE
storage: tweak ordering of semaphores in appender

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -477,7 +477,6 @@ void segment_appender::dispatch_background_head_write() {
      * out) synchronously.
      */
     auto pending_write_sem = _pending_head_write;
-    auto units = ss::get_units(*pending_write_sem, 1);
 
     (void)ss::with_semaphore(
       _concurrent_flushes,
@@ -489,9 +488,8 @@ void segment_appender::dispatch_background_head_write() {
        expected,
        src,
        pending_write_sem,
-       units = std::move(units),
        full]() mutable {
-          return units
+          return ss::get_units(*pending_write_sem, 1)
             .then([this, h, w, start_offset, expected, src, full](
                     ssx::semaphore_units u) mutable {
                 return _out

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -58,7 +58,7 @@ segment_appender::segment_appender(ss::file f, options opts)
   : _out(std::move(f))
   , _opts(opts)
   , _concurrent_flushes(ss::semaphore::max_counter(), "s/append-flush")
-  , _prev_head_write(ss::make_lw_shared<ssx::semaphore>(1, head_sem_name))
+  , _pending_head_write(ss::make_lw_shared<ssx::semaphore>(1, head_sem_name))
   , _inactive_timer([this] { handle_inactive_timer(); })
   , _chunk_size(internal::chunks().chunk_size()) {
     const auto alignment = _out.disk_write_dma_alignment();
@@ -75,9 +75,9 @@ segment_appender::~segment_appender() noexcept {
       _bytes_flush_pending == 0 && _closed,
       "Must flush & close before deleting {}",
       *this);
-    if (_prev_head_write) {
+    if (_pending_head_write) {
         vassert(
-          _prev_head_write->available_units() == 1,
+          _pending_head_write->available_units() == 1,
           "Unexpected pending head write {}",
           *this);
     }
@@ -99,7 +99,7 @@ segment_appender::segment_appender(segment_appender&& o) noexcept
   , _bytes_flush_pending(o._bytes_flush_pending)
   , _concurrent_flushes(std::move(o._concurrent_flushes))
   , _head(std::move(o._head))
-  , _prev_head_write(std::move(o._prev_head_write))
+  , _pending_head_write(std::move(o._pending_head_write))
   , _flush_ops(std::move(o._flush_ops))
   , _flushed_offset(o._flushed_offset)
   , _stable_offset(o._stable_offset)
@@ -339,7 +339,7 @@ ss::future<> segment_appender::do_next_adaptive_fallocation() {
              ss::semaphore::max_counter(),
              [this, step]() mutable {
                  vassert(
-                   _prev_head_write->available_units() == 1,
+                   _pending_head_write->available_units() == 1,
                    "Unexpected pending head write {}",
                    *this);
                  // step - compute step rounded to alignment(4096); this is
@@ -472,11 +472,12 @@ void segment_appender::dispatch_background_head_write() {
     auto h = full ? std::exchange(_head, nullptr) : _head;
 
     /*
-     * make sure that when the write is dispatched that is sequenced in-order on
-     * the correct semaphore by grabbing the units synchronously.
+     * make sure that when the write is dispatched that it is sequenced
+     * in-order on the correct semaphore (before _pending_head_write is swapped
+     * out) synchronously.
      */
-    auto prev = _prev_head_write;
-    auto units = ss::get_units(*prev, 1);
+    auto pending_write_sem = _pending_head_write;
+    auto units = ss::get_units(*pending_write_sem, 1);
 
     (void)ss::with_semaphore(
       _concurrent_flushes,
@@ -487,7 +488,7 @@ void segment_appender::dispatch_background_head_write() {
        start_offset,
        expected,
        src,
-       prev,
+       pending_write_sem,
        units = std::move(units),
        full]() mutable {
           return units
@@ -513,7 +514,7 @@ void segment_appender::dispatch_background_head_write() {
                   })
                   .finally([u = std::move(u)] {});
             })
-            .finally([prev] {});
+            .finally([pending_write_sem] {});
       })
       .handle_exception([this](std::exception_ptr e) {
           vassert(false, "Could not dma_write: {} - {}", e, *this);
@@ -525,7 +526,8 @@ void segment_appender::dispatch_background_head_write() {
      * dependency chain is reset for the next head.
      */
     if (full) {
-        _prev_head_write = ss::make_lw_shared<ssx::semaphore>(1, head_sem_name);
+        _pending_head_write = ss::make_lw_shared<ssx::semaphore>(
+          1, head_sem_name);
     }
 }
 
@@ -574,7 +576,7 @@ ss::future<> segment_appender::hard_flush() {
              ss::semaphore::max_counter(),
              [this]() mutable {
                  vassert(
-                   _prev_head_write->available_units() == 1,
+                   _pending_head_write->available_units() == 1,
                    "Unexpected pending head write {}",
                    *this);
                  vassert(

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -140,7 +140,7 @@ private:
     size_t _bytes_flush_pending{0};
     ssx::semaphore _concurrent_flushes;
     ss::lw_shared_ptr<chunk> _head;
-    ss::lw_shared_ptr<ssx::semaphore> _prev_head_write;
+    ss::lw_shared_ptr<ssx::semaphore> _pending_head_write;
 
     struct flush_op {
         explicit flush_op(size_t offset)

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -138,8 +138,16 @@ private:
     size_t _committed_offset{0};
     size_t _fallocation_offset{0};
     size_t _bytes_flush_pending{0};
+
+    // Ensures only a single fallocate at a time, and that writes do not
+    // coincide with a fallocate.
+    // If taken alongside _pending_head_write, take this first.
     ssx::semaphore _concurrent_flushes;
+
     ss::lw_shared_ptr<chunk> _head;
+
+    // Ensures only a single dma_writer at a time.
+    // If taken or checked alongside _concurrent_flushes, take this second.
     ss::lw_shared_ptr<ssx::semaphore> _pending_head_write;
 
     struct flush_op {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

In all cases of taking _concurrent_flushes and accessing
_pending_head_write (even just checking available units, rather than
acquiring the units) together, _concurrent_flushes is taken first,
except when we fallocate.

This seems like a flavor of lock order inversion that can be solved by
consistent ordering of locks. So, this patch tweaks the ordering to be
consistent with other accesses: first taken _concurrent_flushes, then
_pending_head_write.

Fixes https://github.com/redpanda-data/redpanda/issues/5433

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* Fixes a crash that could be seen under load when using slow drives.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
