### PR TITLE
Revert "Assert CPU <50% at the end of ducktape tests"

### DIFF
--- a/tests/rptest/k8s_tests/simple_k8s_test.py
+++ b/tests/rptest/k8s_tests/simple_k8s_test.py
@@ -6,7 +6,6 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-import os
 
 from ducktape.tests.test import Test
 from rptest.services.cluster import cluster
@@ -20,15 +19,6 @@ class SimpleK8sTest(Test):
         """
         super(SimpleK8sTest, self).__init__(test_context)
         self.redpanda = RedpandaServiceK8s(test_context, 1)
-
-    @property
-    def debug_mode(self):
-        """
-        Useful for tests that want to change behaviour when running on
-        the much slower debug builds of redpanda, which generally cannot
-        keep up with significant quantities of data or partition counts.
-        """
-        return os.environ.get('BUILD_TYPE', None) == 'debug'
 
     @cluster(num_nodes=1, check_allowed_error_logs=False)
     def test_k8s(self):

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -16,10 +16,7 @@ from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.mark._mark import Mark
 
 
-def cluster(log_allow_list=None,
-            check_allowed_error_logs=True,
-            check_cpu_idle=True,
-            **kwargs):
+def cluster(log_allow_list=None, check_allowed_error_logs=True, **kwargs):
     """
     Drop-in replacement for Ducktape `cluster` that imposes additional
     redpanda-specific checks and defaults.
@@ -75,7 +72,6 @@ def cluster(log_allow_list=None,
             # This decorator will only work on test classes that have a RedpandaService,
             # such as RedpandaTest subclasses
             assert hasattr(self, 'redpanda')
-            assert hasattr(self, 'debug_mode')
 
             t_initial = time.time()
             disk_stats_initial = psutil.disk_io_counters()
@@ -145,10 +141,6 @@ def cluster(log_allow_list=None,
                         except:
                             redpanda.cloud_storage_diagnostics()
                             raise
-
-                    # Don't check CPU in debug mode, as it's consistently very high.
-                    if check_cpu_idle and not self.debug_mode:
-                        redpanda.assert_cpu_not_busy()
 
                     try:
                         redpanda.raise_on_storage_usage_inconsistency()

--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -33,10 +33,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
                             producer_timeout_sec=producer_timeout_sec,
                             consumer_timeout_sec=consumer_timeout_sec)
 
-    # Don't check CPU metrics if a node is down
-    @cluster(num_nodes=5,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_availability_when_one_node_failed(self):
         self.redpanda = make_redpanda_service(
             self.test_context,
@@ -66,9 +63,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
 
         self.validate_records()
 
-    @cluster(num_nodes=5,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_recovery_after_catastrophic_failure(self):
 
         self.redpanda = make_redpanda_service(

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -528,8 +528,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # Should not succeed!
                 assert False
 
-    # Disable cpu check because this test disables metrics, which that check needs
-    @cluster(num_nodes=3, check_cpu_idle=False)
+    @cluster(num_nodes=3)
     def test_valid_settings(self):
         """
         Bulk exercise of all config settings & the schema endpoint:

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -225,7 +225,7 @@ class ClusterMetricsTest(RedpandaTest):
              lambda a, b: a == b == 0)
         ])
 
-    @cluster(num_nodes=3, check_cpu_idle=False)
+    @cluster(num_nodes=3)
     def cluster_metrics_disabled_by_config_test(self):
         """
         Test that the cluster level metrics have the expected values

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -351,9 +351,7 @@ class PartitionBalancerTest(PartitionBalancerService):
                             consumer_timeout_sec=CONSUMER_TIMEOUT)
 
     @skip_debug_mode
-    @cluster(num_nodes=7,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_unavailable_nodes(self):
         self.start_redpanda(num_nodes=5)
 
@@ -404,9 +402,7 @@ class PartitionBalancerTest(PartitionBalancerService):
         wait_for_recovery_throttle_rate(self.redpanda, new_value)
 
     @skip_debug_mode
-    @cluster(num_nodes=6,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_movement_cancellations(self):
         self.start_redpanda(num_nodes=4)
 
@@ -462,9 +458,7 @@ class PartitionBalancerTest(PartitionBalancerService):
             ), f"bad rack placement {racks} for partition id: {p.id} (replicas: {p.replicas})"
 
     @skip_debug_mode
-    @cluster(num_nodes=8,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=8, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_rack_awareness(self):
         extra_rp_conf = self._extra_rp_conf | {"enable_rack_awareness": True}
         self.redpanda = make_redpanda_service(self.test_context,
@@ -571,8 +565,7 @@ class PartitionBalancerTest(PartitionBalancerService):
     @skip_debug_mode
     @cluster(num_nodes=7,
              log_allow_list=CHAOS_LOG_ALLOW_LIST +
-             RACE_BETWEEN_DELETION_AND_ADDING_PARTITION,
-             check_cpu_idle=False)
+             RACE_BETWEEN_DELETION_AND_ADDING_PARTITION)
     def test_fuzz_admin_ops(self):
         self.start_redpanda(num_nodes=5)
 
@@ -747,9 +740,7 @@ class PartitionBalancerTest(PartitionBalancerService):
             assert used_ratio < 0.81
 
     @skip_debug_mode
-    @cluster(num_nodes=7,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @matrix(kill_same_node=[True, False])
     def test_maintenance_mode(self, kill_same_node):
         """
@@ -830,8 +821,7 @@ class PartitionBalancerTest(PartitionBalancerService):
 
     @skip_debug_mode
     @cluster(num_nodes=7,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST + STARTUP_SEQUENCE_ABORTED,
-             check_cpu_idle=False)
+             log_allow_list=CHAOS_LOG_ALLOW_LIST + STARTUP_SEQUENCE_ABORTED)
     @matrix(kill_same_node=[True, False], decommission_first=[True, False])
     def test_decommission(self, kill_same_node, decommission_first):
         """
@@ -948,9 +938,7 @@ class PartitionBalancerTest(PartitionBalancerService):
                             consumer_timeout_sec=CONSUMER_TIMEOUT)
 
     @skip_debug_mode
-    @cluster(num_nodes=4,
-             log_allow_list=CHAOS_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=4, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_transfer_controller_leadership(self):
         """
         Test that unavailability timeout is correctly restarted after controller

--- a/tests/rptest/tests/redpanda_binary_test.py
+++ b/tests/rptest/tests/redpanda_binary_test.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 import re
-import os
 
 from ducktape.tests.test import Test
 from rptest.services.cluster import cluster
@@ -24,16 +23,7 @@ class RedpandaBinaryTest(Test):
         super(RedpandaBinaryTest, self).__init__(test_context=test_context)
         self.redpanda = make_redpanda_service(self.test_context, 1)
 
-    @property
-    def debug_mode(self):
-        """
-        Useful for tests that want to change behaviour when running on
-        the much slower debug builds of redpanda, which generally cannot
-        keep up with significant quantities of data or partition counts.
-        """
-        return os.environ.get('BUILD_TYPE', None) == 'debug'
-
-    @cluster(num_nodes=1, check_allowed_error_logs=False, check_cpu_idle=False)
+    @cluster(num_nodes=1, check_allowed_error_logs=False)
     def test_version(self):
         version_cmd = f"{self.redpanda.find_binary('redpanda')} --version"
         version_lines = [

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -72,15 +72,6 @@ class RedpandaKerberosTestBase(Test):
 
         self.client = KrbClient(test_context, self.kdc, self.redpanda)
 
-    @property
-    def debug_mode(self):
-        """
-        Useful for tests that want to change behaviour when running on
-        the much slower debug builds of redpanda, which generally cannot
-        keep up with significant quantities of data or partition counts.
-        """
-        return os.environ.get('BUILD_TYPE', None) == 'debug'
-
     def setUp(self):
         self.redpanda.logger.info("Starting KDC")
         self.kdc.start()

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -6,7 +6,6 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-import os
 
 from ducktape.mark import matrix
 from ducktape.tests.test import Test
@@ -246,15 +245,6 @@ class SimpleSelfTest(Test):
     def __init__(self, test_context):
         super(SimpleSelfTest, self).__init__(test_context)
         self.redpanda = make_redpanda_service(test_context, 3)
-
-    @property
-    def debug_mode(self):
-        """
-        Useful for tests that want to change behaviour when running on
-        the much slower debug builds of redpanda, which generally cannot
-        keep up with significant quantities of data or partition counts.
-        """
-        return os.environ.get('BUILD_TYPE', None) == 'debug'
 
     def setUp(self):
         self.redpanda.start()

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -885,10 +885,7 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
 
         self.check_consume(2)
 
-    # Don't check CPU idle as that uses public metrics that aren't available on v22
-    @cluster(num_nodes=3,
-             log_allow_list=RESTART_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def upgrade_coordinator_test(self):
         def get_tx_coordinator():
             admin = Admin(self.redpanda)
@@ -899,10 +896,7 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
 
         self.do_upgrade_with_tx(get_tx_coordinator)
 
-    # Don't check CPU idle as that uses public metrics that aren't available on v22
-    @cluster(num_nodes=3,
-             log_allow_list=RESTART_LOG_ALLOW_LIST,
-             check_cpu_idle=False)
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def upgrade_topic_test(self):
         topic_name = self.topics[0].name
 


### PR DESCRIPTION
Reverts redpanda-data/redpanda#10939

Fixes https://github.com/redpanda-data/redpanda/issues/11424

## Backports Required 
  
 <!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. --> 
  
 - [x] none - not a bug fix 
 - [ ] none - this is a backport 
 - [ ] none - issue does not exist in previous branches 
 - [ ] none - papercut/not impactful enough to backport 
 - [ ] v23.1.x 
 - [ ] v22.3.x 
 - [ ] v22.2.x 
  
 ## Release Notes

* none