### PR TITLE
pandaproxy: Support SCRAM-SHA-512 for basic_auth

### DIFF
--- a/src/v/pandaproxy/auth_utils.h
+++ b/src/v/pandaproxy/auth_utils.h
@@ -34,7 +34,9 @@ inline credential_t maybe_authenticate_request(
         // did not give the authorization header.
         auth_result.require_authenticated();
         user = credential_t{
-          auth_result.get_username(), auth_result.get_password()};
+          auth_result.get_username(),
+          auth_result.get_password(),
+          auth_result.get_sasl_mechanism()};
     }
 
     return user;

--- a/src/v/pandaproxy/kafka_client_cache.cc
+++ b/src/v/pandaproxy/kafka_client_cache.cc
@@ -54,7 +54,7 @@ client_ptr kafka_client_cache::make_client(
     // Set the principal when the request is using HTTP Basic AuthN
     if (authn_method == config::rest_authn_method::http_basic) {
         // Need to specify type or else bad any_cast runtime error
-        cfg.sasl_mechanism.set_value(ss::sstring{"SCRAM-SHA-256"});
+        cfg.sasl_mechanism.set_value(std::move(user.sasl_mechanism));
         cfg.scram_username.set_value(std::move(user.name));
         cfg.scram_password.set_value(std::move(user.pass));
     }

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -258,7 +258,9 @@ public:
                 // did not give the authorization header.
                 auth_result.require_authenticated();
                 user = credential_t{
-                  auth_result.get_username(), auth_result.get_password()};
+                  auth_result.get_username(),
+                  auth_result.get_password(),
+                  auth_result.get_sasl_mechanism()};
             }
         }
 

--- a/src/v/pandaproxy/types.h
+++ b/src/v/pandaproxy/types.h
@@ -54,11 +54,13 @@ struct timestamped_user {
 struct credential_t {
     ss::sstring name;
     ss::sstring pass;
+    ss::sstring sasl_mechanism;
 
     credential_t() = default;
-    credential_t(ss::sstring n, ss::sstring p)
+    credential_t(ss::sstring n, ss::sstring p, ss::sstring sasl_mechanism)
       : name{std::move(n)}
-      , pass{std::move(p)} {}
+      , pass{std::move(p)}
+      , sasl_mechanism{std::move(sasl_mechanism)} {}
 };
 
 } // namespace pandaproxy

--- a/src/v/utils/request_auth.h
+++ b/src/v/utils/request_auth.h
@@ -43,9 +43,11 @@ public:
     request_auth_result(
       security::credential_user username,
       security::credential_password password,
+      ss::sstring sasl_mechanism,
       superuser is_superuser)
       : _username(std::move(username))
       , _password(std::move(password))
+      , _sasl_mechanism(std::move(sasl_mechanism))
       , _authenticated(true)
       , _superuser(is_superuser){};
 
@@ -77,10 +79,12 @@ public:
 
     ss::sstring const& get_username() const { return _username; }
     ss::sstring const& get_password() const { return _password; }
+    ss::sstring const& get_sasl_mechanism() const { return _sasl_mechanism; }
 
 private:
     security::credential_user _username;
     security::credential_password _password;
+    ss::sstring _sasl_mechanism;
     bool _authenticated{false};
     bool _superuser{false};
     bool _checked{false};


### PR DESCRIPTION
User credentials provided by basic auth cannot provide a sasl_mechanism.

During request authorization, both mechanisms are tried, but the mechanism that succeeds was not propagated in the request_auth_result.

This commit propagates the successful mechanism and uses that during the creation of the client when http basic auth is used for requests to Pandaproxy, instead of hardcoding it to SCRAM-SHA-256.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* pandaproxy: Support users with `SCRAM-SHA-512` for `authentication: http_basic`.
