### PR TITLE
ducktape: Change condition for upload check to pass when all segments are uploaded

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -473,7 +473,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             f"Waiting for {local_seg_count - 1} segments to be uploaded to the cloud"
         )
         # Wait for everything to be uploaded to the cloud.
-        wait_until(lambda: cloud_log_segment_count() == local_seg_count - 1,
+        wait_until(lambda: cloud_log_segment_count() >= local_seg_count - 1,
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Segments not uploaded")


### PR DESCRIPTION
The condition for the test checks if the number of segments uploaded is exactly equal to one minus the local segment count. 

Since the max upload interval is set we can end up uploading all segments to the cloud including the open segment(as seen in CI failures). This change adjusts the success condition to include the case where all segments are uploaded.

Fixes https://github.com/redpanda-data/redpanda/issues/9587

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none
