### PR TITLE
schema_registry: Schema id validation - config checking

### DIFF
--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -457,9 +457,16 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
   const model::topic& topic,
   const cluster::topic_properties& props) {
     auto mode = config::shard_local_cfg().enable_schema_id_validation();
-    return api != nullptr && should_validate_schema_id(props, mode)
-             ? std::make_optional<schema_id_validator>(api, topic, props, mode)
-             : std::nullopt;
+    if (should_validate_schema_id(props, mode)) {
+        if (!api) {
+            vlog(
+              plog.error,
+              "{} requires schema_registry to be enabled in redpanda.yaml",
+              config::shard_local_cfg().enable_schema_id_validation.name());
+        }
+        return std::make_optional<schema_id_validator>(api, topic, props, mode);
+    }
+    return std::nullopt;
 }
 
 ss::future<schema_id_validator::result>

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -63,6 +63,7 @@
 #include "net/dns.h"
 #include "pandaproxy/rest/api.h"
 #include "pandaproxy/schema_registry/api.h"
+#include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "raft/types.h"
 #include "redpanda/admin/api-doc/broker.json.h"
 #include "redpanda/admin/api-doc/cluster.json.h"
@@ -86,6 +87,7 @@
 #include "security/scram_credential.h"
 #include "ssx/future-util.h"
 #include "ssx/metrics.h"
+#include "ssx/sformat.h"
 #include "utils/fragmented_vector.h"
 #include "utils/string_switch.h"
 #include "utils/utf8.h"
@@ -1242,6 +1244,7 @@ join_properties(const std::vector<std::reference_wrapper<
  */
 void config_multi_property_validation(
   ss::sstring const& username,
+  pandaproxy::schema_registry::api* schema_registry,
   cluster::config_update_request const& req,
   config::configuration const& updated_config,
   std::map<ss::sstring, ss::sstring>& errors) {
@@ -1334,6 +1337,14 @@ void config_multi_property_validation(
                 }
             }
         }
+    }
+    if (
+      updated_config.enable_schema_id_validation
+        != pandaproxy::schema_registry::schema_id_validation_mode::none
+      && !schema_registry) {
+        auto name = updated_config.enable_schema_id_validation.name();
+        errors[ss::sstring(name)] = ssx::sformat(
+          "{} requires schema_registry to be enabled in redpanda.yaml", name);
     }
 }
 
@@ -1540,7 +1551,7 @@ admin_server::patch_cluster_config_handler(
         // After checking each individual property, check for
         // any multi-property validation errors
         config_multi_property_validation(
-          auth_state.get_username(), update, cfg, errors);
+          auth_state.get_username(), _schema_registry, update, cfg, errors);
 
         if (!errors.empty()) {
             json::StringBuffer buf;


### PR DESCRIPTION
* Prevent enabling schema ID validation checks if schema registry is disabled
* If schema registry becomes disabled, reject records and log an error

The documentation may need improving to make it clear that server-side-schema-validation requires the `schema_registry` to be enabled in `redpanda.yaml`.

Fixes #11116

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
