### PR TITLE
cloud_storage: tweak test to use default archiver

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -79,10 +79,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
 
     // Upload the closed segment to object storage.
     tests::cooperative_spin_wait_with_timeout(3s, [&archiver] {
-        return archiver.upload_next_candidates().then(
-          [](archival::ntp_archiver::batch_result res) {
-              return res.non_compacted_upload_result.num_succeeded == 1;
-          });
+        return archiver.manifest().size() == 1;
     }).get();
     auto manifest_res = archiver.upload_manifest("test").get();
     BOOST_REQUIRE_EQUAL(manifest_res, cloud_storage::upload_result::success);


### PR DESCRIPTION
We have been noticing failures of test_produce_consume_from_cloud while waiting for the intial segment to be uploaded. Looking at the logs, tuns out that the inlined call into the archiver was racing with the usual upload loop. The wait condition has been changed to check that the manifest contains exactly one segment.

Fixes #11091

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none