### PR TITLE
storage: wrap segment_reader in a unique_ptr

### DIFF
--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -48,37 +48,6 @@ segment_reader::~segment_reader() noexcept {
     _streams.clear();
 }
 
-segment_reader::segment_reader(segment_reader&& rhs) noexcept
-  : _path(std::move(rhs._path))
-  , _data_file(std::move(rhs._data_file))
-  , _data_file_refcount(rhs._data_file_refcount)
-  , _streams(std::move(rhs._streams))
-  , _file_size(rhs._file_size)
-  , _buffer_size(rhs._buffer_size)
-  , _read_ahead(rhs._read_ahead)
-  , _sanitizer_config(std::move(rhs._sanitizer_config))
-  , _gate(std::move(rhs._gate)) {
-    for (auto& i : _streams) {
-        i._parent = this;
-    }
-}
-
-segment_reader& segment_reader::operator=(segment_reader&& rhs) noexcept {
-    _path = std::move(rhs._path);
-    _data_file = std::move(rhs._data_file);
-    _data_file_refcount = rhs._data_file_refcount;
-    _file_size = rhs._file_size;
-    _buffer_size = rhs._buffer_size;
-    _read_ahead = rhs._read_ahead;
-    _sanitizer_config = std::move(rhs._sanitizer_config);
-    _gate = std::move(rhs._gate);
-    _streams = std::move(rhs._streams);
-    for (auto& i : _streams) {
-        i._parent = this;
-    }
-    return *this;
-}
-
 ss::future<> segment_reader::load_size() {
     ss::gate::holder guard{_gate};
 

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -106,6 +106,8 @@ public:
     ~segment_reader_handle() override;
 };
 
+using segment_reader_ptr = std::unique_ptr<segment_reader>;
+
 class segment_reader {
 public:
     segment_reader(
@@ -115,8 +117,8 @@ public:
       std::optional<ntp_sanitizer_config> ntp_sanitizer_config
       = std::nullopt) noexcept;
     ~segment_reader() noexcept;
-    segment_reader(segment_reader&&) noexcept;
-    segment_reader& operator=(segment_reader&&) noexcept;
+    segment_reader(segment_reader&&) = delete;
+    segment_reader& operator=(segment_reader&&) = delete;
     segment_reader(const segment_reader&) = delete;
     segment_reader& operator=(const segment_reader&) = delete;
 
@@ -179,10 +181,6 @@ private:
     friend class segment_reader_handle;
     friend std::ostream& operator<<(std::ostream&, const segment_reader&);
 };
-
-using segment_reader_ptr = ss::lw_shared_ptr<segment_reader>;
-
-std::ostream& operator<<(std::ostream&, segment_reader_ptr);
 
 /**
  * Enables reading from a series of segments sequentially using a single data

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -72,9 +72,9 @@ public:
           base,
           4096,
           _feature_table);
-        auto reader = segment_reader(
+        auto reader = std::make_unique<segment_reader>(
           segment_full_path::mock(base_name), 128_KiB, 10);
-        reader.load_size().get();
+        reader->load_size().get();
         _seg = ss::make_lw_shared<segment>(
           segment::offset_tracker(model::term_id(0), base),
           std::move(reader),


### PR DESCRIPTION
This patch wraps all segment_reader usages into a unique_ptr. Move
semantics for segment_reader are tricky to get right. One of the ways
this could go wrong previously is moving a segment_reader with
outstanding gated operations. Since gate guards hold a pointer to the
underlying gate, a move would create dangling pointers.

A similar strategy is also used for the segment_appender.

Fixes https://github.com/redpanda-data/redpanda/issues/11408

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.1.x
- [X] v22.3.x
- [X] v22.2.x

## Release Notes
### Bug Fixes
* Fix a possible dangling pointer issue in the storage layer
