### PR TITLE
rpk: add labels to rpk generate prometheus-config

### DIFF
--- a/src/go/rpk/pkg/cli/generate/prometheus_test.go
+++ b/src/go/rpk/pkg/cli/generate/prometheus_test.go
@@ -1,0 +1,68 @@
+package generate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		expInt map[string]string
+		expPub map[string]string
+		expErr bool
+	}{
+		{
+			name:   "parse single label",
+			labels: []string{"hello=world"},
+			expInt: map[string]string{"hello": "world"},
+			expPub: map[string]string{"hello": "world"},
+		},
+		{
+			name:   "parse 2 labels with metric target",
+			labels: []string{"internal:foo=bar", "public:hello=world"},
+			expInt: map[string]string{"foo": "bar"},
+			expPub: map[string]string{"hello": "world"},
+		},
+		{
+			name:   "parse 1 label with metric target",
+			labels: []string{"internal:foo=bar"},
+			expInt: map[string]string{"foo": "bar"},
+			expPub: map[string]string{},
+		},
+		{
+			name:   "incorrect label",
+			labels: []string{"what"},
+			expErr: true,
+		},
+		{
+			name:   "incorrect metric target",
+			labels: []string{"mid:foo=bar"},
+			expErr: true,
+		},
+		{
+			name:   "err if more than 1 label per metric",
+			labels: []string{"internal:foo=bar", "public:hello=world", "public:color=blue"},
+			expErr: true,
+		},
+		{
+			name:   "err if more than 1 label per metric - no target",
+			labels: []string{"foo:bar", "hello:world"},
+			expErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInt, gotPub, err := parseLabels(tt.labels)
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expInt, gotInt)
+			require.Equal(t, tt.expPub, gotPub)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a new flag '--labels' which
lets the user add a common label for the targets
in the rpk-generated scrape-config.

Fixes #5548

### Example:

Common tag
```yaml
$ rpk generate prometheus-config --job-name redpanda-metrics-test --node-addrs 'localhost:9644,localhost:9645' --internal-metrics --labels "hello=world" 
- job_name: redpanda-metrics-test
  static_configs:
    - targets:
        - localhost:9644
        - localhost:9645
      labels:
        hello: world
  metrics_path: /public_metrics
- job_name: redpanda-metrics-test
  static_configs:
    - targets:
        - localhost:9644
        - localhost:9645
      labels:
        hello: world
  metrics_path: /metrics
```
Different tags per job
```yaml
$ rpk generate prometheus-config --job-name redpanda-metrics-test --node-addrs 'localhost:9644,localhost:9645' --internal-metrics --labels "internal:foo=bar,public:hello=world"
- job_name: redpanda-metrics-test
  static_configs:
    - targets:
        - localhost:9644
        - localhost:9645
      labels:
        hello: world
  metrics_path: /public_metrics
- job_name: redpanda-metrics-test
  static_configs:
    - targets:
        - localhost:9644
        - localhost:9645
      labels:
        foo: bar
  metrics_path: /metrics
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix

## Release Notes
### Improvements

* now you can specify labels in the rpk-generated Prometheus config via the `labels` flag.
