### PR TITLE
[storage] log_manager::remove_orphan_files: error -> trace for ENOENT

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -620,8 +620,13 @@ ss::future<> log_manager::remove_orphan_files(
                 })
                 .handle_exception_type(
                   [](std::filesystem::filesystem_error const& err) {
-                      vlog(
-                        stlog.error,
+                      auto lvl = err.code()
+                                     == std::errc::no_such_file_or_directory
+                                   ? ss::log_level::trace
+                                   : ss::log_level::info;
+                      vlogl(
+                        stlog,
+                        lvl,
                         "Exception while cleaning orphan files {}",
                         err);
                   });


### PR DESCRIPTION
This function can race with segment::close before being able to call orphan_filter. This commit lowers the log level similar to how it is done in segment::close

Fixes #10366 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
