### PR TITLE
s/segment: fixed tracking offsets of empty segments

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -429,7 +429,7 @@ ss::future<> segment::do_truncate(
 
 ss::future<bool> segment::materialize_index() {
     vassert(
-      _tracker.base_offset == _tracker.dirty_offset,
+      _tracker.base_offset == model::next_offset(_tracker.dirty_offset),
       "Materializing the index must happen before tracking any data. {}",
       *this);
     return _idx.materialize_index().then([this](bool yn) {

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -45,9 +45,9 @@ public:
         offset_tracker(model::term_id t, model::offset base)
           : term(t)
           , base_offset(base)
-          , committed_offset(base)
-          , dirty_offset(base)
-          , stable_offset(base) {}
+          , committed_offset(model::prev_offset(base))
+          , dirty_offset(model::prev_offset(base))
+          , stable_offset(model::prev_offset(base)) {}
         model::term_id term;
         model::offset base_offset;
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3055,6 +3055,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     append_batch(log, model::term_id(0)); // write single message for final
                                           // segment after last roll
 
+    log.flush().get();
     auto pre_gaps = analyze(*disk_log);
     auto pre_stats = log.offsets();
     BOOST_REQUIRE_EQUAL(


### PR DESCRIPTION
When a segment is rolled due to the `segment.ms` property its base offset is set to the committed offset of last segment plus one. In a segment constructor all segment offset tracker offsets were set to the base offset passed as the constructor argument. This way an empty segment had exactly the same set of offsets as the segment containing single batch containing one record and base offset equal to the segment base offset.

Incorrect offset accounting in empty segments lead to the situation in which eviction driven `log::truncate_prefix` was called with an incorrect offset, leading to the situation in which a log wasn't truncated at the segment boundary. This in the end resulted in the disconnection between the offset translator truncation point and first log segment start offset.

For example:

(we represent segment as `[base_offset,end_offset]`)

In the case of log with segments:

```
[0,10][11,15]
```

After segment ms a new segment is created like this:

```
[0,10][11,15][16,16]
```

When eviction point is established the last offset is checked in this case if all the segments are to be evicted it will be equal to 16. `16` is a last offset that is going to be evicted (last included in raft snapshot). Hence the `log::truncate_prefix` is called with offset `17`.

If some batches are appended to the rolled segment then the log will contain f.e.

```
 [0,10][11,15][16,25]
```

Now if the log is prefix truncated at offset `17` it starts offset is updated to `17` but the underlying segment is kept.

```
[16,25]
```

Now when the reader start reading the log it will request to start from the log start offset which is `17` but it will have to skip over the batch starting at `16`. If a batch at `16` has more than one record it will still be returned to the reader and it will have to translate its base offset to kafka offset space. This is impossible as the offset_translator was already truncated to `16`. i.e. there is no information in the translator to correctly translate the offset.

A fix is setting the empty segment dirty, committed and stable offset to its base_offset minus one. This way all the semantics of log operation holds as the offset returned is equal to previous segment last offset which would be the case if there would be no empty segment at the head of the log.

Fixes: #11403

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes rare situation in which consumer may stuck due to incorrect truncation point