### PR TITLE
[v23.1.x] throughput control groups: fixed zero byte dumped to the log by noname group

### DIFF
--- a/src/v/config/throughput_control_group.cc
+++ b/src/v/config/throughput_control_group.cc
@@ -119,7 +119,7 @@ operator<<(std::ostream& os, const throughput_control_group& tcg) {
       os,
       "{{group_name: {}, client_id: {}, throughput_limit_node_in_bps: {}, "
       "throughput_limit_node_out_bps: {}}}",
-      tcg.name,
+      tcg.is_noname() ? ""s : fmt::format("{{{}}}", tcg.name),
       tcg.client_id_matcher,
       tcg.throughput_limit_node_in_bps,
       tcg.throughput_limit_node_out_bps);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11340
