### PR TITLE
tests: add delete_records_utils

### DIFF
--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -14,6 +14,7 @@
 #include "bytes/iostream.h"
 #include "bytes/scattered_message.h"
 #include "kafka/protocol/api_versions.h"
+#include "kafka/protocol/delete_records.h"
 #include "kafka/protocol/flex_versions.h"
 #include "kafka/protocol/fwd.h"
 #include "kafka/server/protocol_utils.h"
@@ -205,6 +206,8 @@ public:
             return dispatch(std::move(r), api_version(6));
         } else if constexpr (std::is_same_v<type, sasl_handshake_request>) {
             return dispatch(std::move(r), api_version(1));
+        } else if constexpr (std::is_same_v<type, delete_records_request>) {
+            return dispatch(std::move(r), api_version(2));
         } else if constexpr (std::is_same_v<type, sasl_authenticate_request>) {
             return dispatch(std::move(r), api_version(1));
         }

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -21,8 +21,10 @@ v_cc_library(
   NAME
     kafka_test_utils
   HDRS
+    "delete_records_utils.h"
     "produce_consume_utils.h"
   SRCS
+    "delete_records_utils.cc"
     "produce_consume_utils.cc"
   DEPS
     v::bytes

--- a/src/v/kafka/server/tests/delete_records_utils.cc
+++ b/src/v/kafka/server/tests/delete_records_utils.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "kafka/server/tests/delete_records_utils.h"
+
+#include "kafka/client/transport.h"
+#include "kafka/protocol/delete_records.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/delete_records_request.h"
+#include "kafka/protocol/schemata/delete_records_response.h"
+#include "vlog.h"
+
+#include <seastar/util/log.hh>
+
+namespace tests {
+
+ss::future<kafka_delete_records_transport::pid_to_offset_map_t>
+kafka_delete_records_transport::delete_records(
+  model::topic topic_name,
+  pid_to_offset_map_t offsets_per_partition,
+  std::chrono::milliseconds timeout) {
+    kafka::delete_records_request req;
+    req.data.timeout_ms = timeout;
+    kafka::delete_records_topic tp;
+    tp.name = std::move(topic_name);
+    for (auto& [pid, offset] : offsets_per_partition) {
+        kafka::delete_records_partition p;
+        p.partition_index = pid;
+        p.offset = offset;
+        tp.partitions.emplace_back(std::move(p));
+    }
+    req.data.topics.emplace_back(std::move(tp));
+    auto resp = co_await _transport.dispatch(std::move(req));
+    if (resp.data.topics.size() != 1) {
+        throw std::runtime_error(
+          fmt::format("Expected 1 topic, got {}", resp.data.topics.size()));
+    }
+    pid_to_offset_map_t ret;
+    for (const auto& p_res : resp.data.topics[0].partitions) {
+        // NOTE: offset_out_of_range returns with a low watermark of -1
+        if (
+          p_res.error_code != kafka::error_code::offset_out_of_range
+          && p_res.error_code != kafka::error_code::none) {
+            ret.emplace(p_res.partition_index, p_res.low_watermark);
+        }
+        ret.emplace(p_res.partition_index, p_res.low_watermark);
+    }
+    co_return ret;
+}
+
+} // namespace tests

--- a/src/v/kafka/server/tests/delete_records_utils.h
+++ b/src/v/kafka/server/tests/delete_records_utils.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "kafka/client/transport.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace tests {
+
+// Wrapper around a Kafka transport that encapsulates deleting records.
+//
+// The primary goal of this is to allow tests to delete without dealing
+// explicitly with the Kafka schemata. To that end, it exposes a
+// protocol-agnostic API.
+class kafka_delete_records_transport {
+public:
+    // NOTE: returned offsets are kafka offsets
+    using pid_to_offset_map_t
+      = absl::flat_hash_map<model::partition_id, model::offset>;
+
+    explicit kafka_delete_records_transport(kafka::client::transport&& t)
+      : _transport(std::move(t)) {}
+
+    ss::future<> start() { return _transport.connect(); }
+
+    ss::future<pid_to_offset_map_t> delete_records(
+      model::topic topic_name,
+      pid_to_offset_map_t offsets_per_partition,
+      std::chrono::milliseconds timeout);
+
+    ss::future<model::offset> delete_records_from_partition(
+      model::topic topic_name,
+      model::partition_id pid,
+      model::offset kafka_offset,
+      std::chrono::milliseconds timeout) {
+        pid_to_offset_map_t m;
+        m.emplace(pid, kafka_offset);
+        auto out_map = co_await delete_records(
+          std::move(topic_name), std::move(m), timeout);
+        co_return out_map[pid];
+    }
+
+private:
+    kafka::client::transport _transport;
+};
+
+} // namespace tests


### PR DESCRIPTION
Similar to produce_consume_utils, this wraps the Kafka API in a (mostly) Kafka-agnostic code to allow test authors to make DeleteRecords calls without having to hand-craft Kafka schemata structs.

Here's an example of this in use: https://github.com/andrwng/redpanda/commit/958459f428b6e11c474faa4f6a416bba86dc54d0

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
