### PR TITLE
tests/produce_consume_utils: throw on partition error

### DIFF
--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -121,6 +121,10 @@ ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
           "Processing topic {} from the fetch response",
           topic.name);
         for (auto& partition : topic.partitions) {
+            if (partition.error_code != kafka::error_code::none) {
+                throw std::runtime_error(fmt::format(
+                  "fetch partition error: {}", partition.error_code));
+            }
             vlog(
               test_log.trace,
               "Processing ntp {}/{} from the fetch response",


### PR DESCRIPTION
The consume utility was previously not throwing on per-partition errors, which is useful expose in tests.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
