### PR TITLE
c/node_status_backend: fix handling members notification

### DIFF
--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -301,7 +301,7 @@ void members_table::apply_snapshot(
         notify_member_updated(id, model::membership_state::removed);
     }
 
-    // notify for changes in broker state
+    // notify for changes in broker maintenance state
 
     auto maybe_notify = [&](const node_metadata& new_node) {
         model::node_id id = new_node.broker.id();

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -70,6 +70,11 @@ public:
         }
     }
 
+    // NOTE: these are level-triggered (as opposed to edge-triggered)
+    // notifications. So for example if you get a members_updated notification
+    // with membership_state::draining, this means "there is a node and its
+    // current state is draining", not "node state switched to draining".
+
     using maintenance_state_cb_t = ss::noncopyable_function<void(
       model::node_id, model::maintenance_state)>;
 


### PR DESCRIPTION
If the members table update is coming from a controller snapshot, and the node is already being decommissioned, there won't be a notification with status "added", only with status "draining". Node discovery code should handle this case as well.

(partially) fixes https://github.com/redpanda-data/redpanda/issues/9052

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
