### PR TITLE
c/partition_balancer: reduce log level in scale tests

### DIFF
--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -40,6 +40,8 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
                 "raft_learner_recovery_rate": 10 * 1073741824,
                 "group_topic_partitions": self.GROUP_TOPIC_PARTITIONS
             },
+            # If set to trace, these tests produce 10s of GBs of logs
+            log_config=redpanda.LoggingConfig('info'),
             *args,
             **kwargs)
 


### PR DESCRIPTION
After we enabled trace logs in CDT, size of redpanda logs for this test started to exceed 20GB which is unwieldy and sometimes even leads to test failures (bad log lines scans timing out).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none
