### PR TITLE
node_decommissioning_test: fix order of throttle and decommission

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -584,11 +584,13 @@ class NodesDecommissioningTest(EndToEndTest):
         to_decommission = random.choice(self.redpanda.nodes)
         node_id = self.redpanda.node_id(to_decommission)
 
+        # throttle recovery
+        self._set_recovery_rate(100)
+
         survivor_node = self._not_decommissioned_node(node_id)
         self.logger.info(f"decommissioning node: {node_id}", )
         self._decommission(node_id)
 
-        self._set_recovery_rate(100)
         # wait for some partitions to start moving
         wait_until(lambda: self._partitions_moving(node=survivor_node),
                    timeout_sec=15,


### PR DESCRIPTION
If we throttle after we issue the decom command, decom can finish before the throttling will take effect. The correct order (if we want the partition movements to get stuck) is throttle-then-decom.

Fixes https://github.com/redpanda-data/redpanda/issues/11365

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
