### PR TITLE
Update start timeout for `leadership_transfer_test` on debug builds

### DIFF
--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -186,7 +186,14 @@ class MultiTopicAutomaticLeadershipBalancingTest(RedpandaTest):
         # optimizations
         time.sleep(60)
 
-        self.redpanda.start_node(node)
+        start_timeout = None
+        if self.debug_mode:
+            # Due to the high partition count in this test Redpanda
+            # can take longer than the default 20s to start on a debug
+            # release.
+            start_timeout = 60
+        self.redpanda.start_node(node, timeout=start_timeout)
+
         self.logger.info("stabilization post start")
         wait_until(lambda: topic_leadership_evenly_distributed(),
                    timeout_sec=300,


### PR DESCRIPTION
This PR updates the node start timeout of this test to 60 seconds for debug builds. The need for this change comes from the 500+ partitions this test creates which leads to the node starting up 6 times slower compared to an empty node when on a debug build. This change wasn't needed originally, however, with the update to clang-16 there seems to be a slight performance regression in our debug builds causing the node start time to be right around 20s.

Fixes #11044 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
