### PR TITLE
Revert "txn: update abort_old_txes to use locks"

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -49,7 +49,7 @@ group::group(
   kafka::group_id id,
   group_state s,
   config::configuration& conf,
-  ss::lw_shared_ptr<attached_partition> p,
+  ss::lw_shared_ptr<cluster::partition> partition,
   model::term_id term,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
   ss::sharded<features::feature_table>& feature_table,
@@ -62,8 +62,7 @@ group::group(
   , _num_members_joining(0)
   , _new_member_added(false)
   , _conf(conf)
-  , _p(p)
-  , _partition(p != nullptr ? p->partition : nullptr)
+  , _partition(std::move(partition))
   , _probe(_members, _static_members, _offsets)
   , _ctxlog(klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
@@ -85,7 +84,7 @@ group::group(
   kafka::group_id id,
   group_metadata_value& md,
   config::configuration& conf,
-  ss::lw_shared_ptr<attached_partition> p,
+  ss::lw_shared_ptr<cluster::partition> partition,
   model::term_id term,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
   ss::sharded<features::feature_table>& feature_table,
@@ -104,8 +103,7 @@ group::group(
   , _leader(md.leader)
   , _new_member_added(false)
   , _conf(conf)
-  , _p(p)
-  , _partition(p->partition)
+  , _partition(std::move(partition))
   , _probe(_members, _static_members, _offsets)
   , _ctxlog(klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
@@ -1667,9 +1665,6 @@ void group::fail_offset_commit(
 }
 
 void group::reset_tx_state(model::term_id term) {
-    // must be invoked under catchup_lock.hold_write_lock()
-    // all other tx methods should use catchup_lock.hold_read_lock()
-    // to avoid modifying the state of the executing tx methods
     _term = term;
     _volatile_txs.clear();
     _prepared_txs.clear();
@@ -3234,8 +3229,6 @@ void group::maybe_rearm_timer() {
 }
 
 ss::future<> group::do_abort_old_txes() {
-    auto units = co_await _p->catchup_lock.hold_read_lock();
-
     std::vector<model::producer_identity> pids;
     for (auto& [id, _] : _prepared_txs) {
         pids.push_back(id);

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -50,19 +50,6 @@ struct configuration;
 namespace kafka {
 struct group_log_group_metadata;
 
-struct attached_partition {
-    bool loading;
-    ssx::semaphore sem{1, "k/group-mgr"};
-    ss::abort_source as;
-    ss::lw_shared_ptr<cluster::partition> partition;
-    ss::basic_rwlock<> catchup_lock;
-    model::term_id term{-1};
-
-    explicit attached_partition(ss::lw_shared_ptr<cluster::partition> p)
-      : loading(true)
-      , partition(std::move(p)) {}
-};
-
 /**
  * \defgroup kafka-groups Kafka group membership API
  *
@@ -215,7 +202,7 @@ public:
       kafka::group_id id,
       group_state s,
       config::configuration& conf,
-      ss::lw_shared_ptr<attached_partition>,
+      ss::lw_shared_ptr<cluster::partition> partition,
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
       ss::sharded<features::feature_table>&,
@@ -227,7 +214,7 @@ public:
       kafka::group_id id,
       group_metadata_value& md,
       config::configuration& conf,
-      ss::lw_shared_ptr<attached_partition>,
+      ss::lw_shared_ptr<cluster::partition> partition,
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
       ss::sharded<features::feature_table>&,
@@ -929,7 +916,6 @@ private:
     ss::timer<clock_type> _join_timer;
     bool _new_member_added;
     config::configuration& _conf;
-    ss::lw_shared_ptr<attached_partition> _p;
     ss::lw_shared_ptr<cluster::partition> _partition;
     absl::node_hash_map<
       model::topic_partition,

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -723,7 +723,7 @@ ss::future<> group_manager::do_recover_group(
               group_id,
               group_stm.get_metadata(),
               _conf,
-              p,
+              p->partition,
               term,
               _tx_frontend,
               _feature_table,
@@ -918,7 +918,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
             return group::join_group_stages(
               make_join_error(r.data.member_id, error_code::not_coordinator));
         }
-        auto p = it->second;
+        auto p = it->second->partition;
         group = ss::make_lw_shared<kafka::group>(
           r.data.group_id,
           group_state::empty,
@@ -1071,7 +1071,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
                 r.data.group_id,
                 group_state::empty,
                 _conf,
-                p,
+                p->partition,
                 p->term,
                 _tx_frontend,
                 _feature_table,
@@ -1157,7 +1157,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
                 r.group_id,
                 group_state::empty,
                 _conf,
-                p,
+                p->partition,
                 p->term,
                 _tx_frontend,
                 _feature_table,
@@ -1265,7 +1265,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
               r.data.group_id,
               group_state::empty,
               _conf,
-              p,
+              p->partition,
               p->term,
               _tx_frontend,
               _feature_table,

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -203,6 +203,19 @@ private:
     void detach_partition(const model::ntp&);
     ss::future<> do_detach_partition(model::ntp);
 
+    struct attached_partition {
+        bool loading;
+        ssx::semaphore sem{1, "k/group-mgr"};
+        ss::abort_source as;
+        ss::lw_shared_ptr<cluster::partition> partition;
+        ss::basic_rwlock<> catchup_lock;
+        model::term_id term{-1};
+
+        explicit attached_partition(ss::lw_shared_ptr<cluster::partition> p)
+          : loading(true)
+          , partition(std::move(p)) {}
+    };
+
     cluster::notification_id_type _leader_notify_handle;
     cluster::notification_id_type _topic_table_notify_handle;
 


### PR DESCRIPTION
The commit is correlated with the new ci-failures. Rolling it back. It's ok to rollback only a single commit from the [PR](https://github.com/redpanda-data/redpanda/pull/11110) because its other commits don't depend on it.

Fixes:
 - https://github.com/redpanda-data/redpanda/issues/11372
 - https://github.com/redpanda-data/redpanda/issues/11452
 - https://github.com/redpanda-data/redpanda/issues/11344

This reverts commit f7fc026f3203da167acc0e4c95b86f2e7e082dec.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none