### PR TITLE
[v23.1.x] Update start timeout for `leadership_transfer_test` on debug builds

### DIFF
--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -186,7 +186,14 @@ class MultiTopicAutomaticLeadershipBalancingTest(RedpandaTest):
         # optimizations
         time.sleep(60)
 
-        self.redpanda.start_node(node)
+        start_timeout = None
+        if self.debug_mode:
+            # Due to the high partition count in this test Redpanda
+            # can take longer than the default 20s to start on a debug
+            # release.
+            start_timeout = 60
+        self.redpanda.start_node(node, timeout=start_timeout)
+
         self.logger.info("stabilization post start")
         wait_until(lambda: topic_leadership_evenly_distributed(),
                    timeout_sec=300,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11472
Fixes https://github.com/redpanda-data/redpanda/issues/11478,