### PR TITLE
Fixed setting max controller log length

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -230,15 +230,17 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             enable_controller_snapshots=[True, False])
     def test_node_operations(self, enable_failures, num_to_upgrade,
                              enable_controller_snapshots):
-        if not enable_controller_snapshots:
-            # Without snapshots, there is not bound on how large
-            # the controller log may grow.
-            self.redpanda.set_expected_controller_records(None)
 
         lock = threading.Lock()
 
         # setup test case scale parameters
         self._setup_test_scale(num_to_upgrade)
+
+        if not enable_controller_snapshots:
+            # Without snapshots, there is not bound on how large
+            # the controller log may grow.
+            self.redpanda.set_expected_controller_records(None)
+
         if self.should_skip:
             cleanup_on_early_exit(self)
             return


### PR DESCRIPTION
Previously a length for tests not using controller snapshots which was set to `None` was overridden in `_setup_test_scale` method

Fixes: #11179
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none