### PR TITLE
[v23.1.x] node_decommissioning_test: fix order of throttle and decommission

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -516,11 +516,13 @@ class NodesDecommissioningTest(EndToEndTest):
         to_decommission = random.choice(self.redpanda.nodes)
         node_id = self.redpanda.node_id(to_decommission)
 
+        # throttle recovery
+        self._set_recovery_rate(100)
+
         survivor_node = self._not_decommissioned_node(node_id)
         self.logger.info(f"decommissioning node: {node_id}", )
         admin.decommission_broker(id=node_id)
 
-        self._set_recovery_rate(100)
         # wait for some partitions to start moving
         wait_until(lambda: self._partitions_moving(node=survivor_node),
                    timeout_sec=15,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11471
Fixes https://github.com/redpanda-data/redpanda/issues/11486,