### PR TITLE
admin: Stream request bodies

### DIFF
--- a/src/v/cloud_storage/recovery_request.h
+++ b/src/v/cloud_storage/recovery_request.h
@@ -19,13 +19,16 @@ namespace cloud_storage {
 
 class bad_request : public std::invalid_argument {
 public:
-    explicit bad_request(ss::sstring msg)
+    explicit bad_request(const ss::sstring& msg)
       : std::invalid_argument(msg) {}
 };
 
 struct recovery_request {
 public:
-    explicit recovery_request(const ss::http::request&);
+    static ss::future<recovery_request>
+    parse_from_http(const ss::http::request&);
+
+    static recovery_request parse_from_string(const ss::sstring&);
 
     std::optional<ss::sstring> topic_names_pattern() const;
 
@@ -34,9 +37,10 @@ public:
     std::optional<std::chrono::milliseconds> retention_ms() const;
 
 private:
-    void parse_request_body(const ss::http::request&);
+    recovery_request() = default;
 
-private:
+    void parse_request_body(const ss::sstring&);
+
     std::optional<ss::sstring> _topic_names_pattern;
     std::optional<size_t> _retention_bytes;
     std::optional<std::chrono::milliseconds> _retention_ms;

--- a/src/v/cluster/topic_recovery_service.h
+++ b/src/v/cluster/topic_recovery_service.h
@@ -97,7 +97,7 @@ struct topic_recovery_service
     /// recovery process is initiated.
     /// \return A result object with an HTTP status code and a message string,
     /// suitable for being returned as response to an HTTP call.
-    init_recovery_result start_recovery(const ss::http::request&);
+    ss::future<init_recovery_result> start_recovery(const ss::http::request&);
 
     /// \brief Stops the download check task. Intended to be stopped before the
     /// cloud storage API is stopped, so that any HTTP calls are not made using


### PR DESCRIPTION
Currently the seastar framework reads the full request body in for us on
every request: https://github.com/redpanda-data/seastar/blob/245e0ccfa6d58d7e0dca2b4034ce1bc43e39bdc5/src/http/httpd.cc#L202-L210

In our efforts to reduce large contiguous allocations, we probably
shouldn't always do this. Also, in the future there maybe large payloads
we accept (i.e. WASM file uploads) that we certainly don't want to fully
read into memory contiguously. So this gives each caller the ability to determine if
it's safe to read the full stream into contiguous memory.

I don't know if there are any admin server payloads that could
potentially read in large request bodies today, but I essentially inlined
all the places where we read in `req->content` to instead read the full
input stream.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
