### PR TITLE
memory-sampling: Fix missing newline between stacks in OOM output

### DIFF
--- a/src/v/resource_mgmt/memory_sampling.cc
+++ b/src/v/resource_mgmt/memory_sampling.cc
@@ -61,7 +61,7 @@ memory_sampling::get_oom_diagnostics_callback() {
             auto bytes_written = fmt::format_to_n(
                                    format_buf.begin(),
                                    format_buf.size(),
-                                   "{}",
+                                   "{}\n",
                                    allocation_sites[i])
                                    .size;
 

--- a/src/v/resource_mgmt/tests/memory_sampling_tests.cc
+++ b/src/v/resource_mgmt/tests/memory_sampling_tests.cc
@@ -66,7 +66,7 @@ SEASTAR_THREAD_TEST_CASE(test_no_allocs_in_oom_callback) {
     BOOST_REQUIRE_EQUAL(before.mallocs(), after.mallocs());
 
     // confirm an average allocation site fits into the oom writer line buffer
-    auto allocation_site_needle = fmt::format("{}", allocation_sites[0]);
+    auto allocation_site_needle = fmt::format("{}\n", allocation_sites[0]);
     BOOST_REQUIRE_NE(
       std::string_view(output_buffer.data(), output_buffer.size())
         .find(allocation_site_needle),


### PR DESCRIPTION
Probably got lost in the various revisions.

Add it back and make sure the test catches it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

