### PR TITLE
rptest: fix wait for trunction in chunk read test

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -20,7 +20,6 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
         self.si_settings = SISettings(
             test_context=test_context,
             log_segment_size=self.log_segment_size,
-            fast_uploads=True,
         )
         self.si_settings.load_context(self.logger, test_context=test_context)
 
@@ -218,7 +217,6 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
 
     @cluster(num_nodes=4)
     def test_read_when_segment_size_smaller_than_chunk_size(self):
-        self.topics[0].segment_bytes = 512 * 1024
         self._set_params_and_start_redpanda(cloud_storage_cache_chunk_size=16 *
                                             1024 * 1024)
 


### PR DESCRIPTION
Previously, test_read_when_segment_size_smaller_than_chunk_size would not use the correct segment size when waiting for truncation. _produce_baseline used self.log_segment_size, but the test only updated the topic config. The result was that the test could fail due to no chunk reads being performed.

Fixes #11507

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
