### PR TITLE
memory-sampling: Make admin api test work on CDT

### DIFF
--- a/tests/rptest/tests/memory_sampling_test.py
+++ b/tests/rptest/tests/memory_sampling_test.py
@@ -38,7 +38,8 @@ class MemorySamplingTestTest(RedpandaTest):
         admin = Admin(self.redpanda)
         profile = admin.get_sampled_memory_profile()
 
-        assert len(profile) == 2
+        num_shards = self.redpanda.shards()[1] + 1
+        assert len(profile) == num_shards
         assert 'shard' in profile[0]
         assert 'allocation_sites' in profile[0]
         assert len(profile[0]['allocation_sites']) > 0


### PR DESCRIPTION
The admin_api memory sampling test was bound to fail as it assumed a
fixed shard count but that obviously depends on the infra and fails on
CDT.

Make the test use the actual shard count to confirm we get results for
all shards.

Fixes https://github.com/redpanda-data/redpanda/issues/11509

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none


