### PR TITLE
fix compilation error

### DIFF
--- a/src/v/utils/stable_iterator_adaptor.h
+++ b/src/v/utils/stable_iterator_adaptor.h
@@ -71,7 +71,7 @@ private:
         }
     }
 
-    void advance(base::difference_type diff) {
+    void advance(typename base::difference_type diff) {
         validate_revision();
         std::advance(this->base_reference(), diff);
     }
@@ -81,7 +81,7 @@ private:
         this->base_reference()++;
     }
 
-    base::reference dereference() const {
+    typename base::reference dereference() const {
         validate_revision();
         return *(this->base_reference());
     }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

It's possible my local environment is different than what's expected, since it seems like this was merged days ago and it doesn't build for me. If so ignore me. :)

```
redpanda/src/v/utils/stable_iterator_adaptor.h:74:18: error: missing 'typename' prior to dependent type name 'base::difference_type'
    void advance(base::difference_type diff) {
                 ^~~~~~~~~~~~~~~~~~~~~
                 typename
redpanda/src/v/utils/stable_iterator_adaptor.h:84:5: error: missing 'typename' prior to dependent type name 'base::reference'
    base::reference dereference() const {
    ^~~~~~~~~~~~~~~
    typename
2 errors generated.
```

```
clang++ --version
clang version 15.0.7
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```