### PR TITLE
memory-sampling: Reduce reactor count for mem sampling tests

### DIFF
--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -8,6 +8,9 @@ rp_test(
 )
 
 # NB: Some of these rely on global state (low watermark of available_memory) so need to run in a separate binary
+# They use a non-threadsafe logger so we have to run with -c1
+# We set a fixed memory limit which makes them faster and more reliable as they
+# are trying to get below a certain limit
 rp_test(
         UNIT_TEST
         BINARY_NAME test_memory_sampling
@@ -16,6 +19,7 @@ rp_test(
         LIBRARIES v::seastar_testing_main v::application
         LABELS memory_sampling
         SKIP_BUILD_TYPES "Debug"
+        ARGS "-- -c1 -m1G"
 )
 
 rp_test(
@@ -26,4 +30,5 @@ rp_test(
         LIBRARIES v::seastar_testing_main v::application
         LABELS memory_sampling
         SKIP_BUILD_TYPES "Debug"
+        ARGS "-- -c1 -m1G"
 )

--- a/src/v/resource_mgmt/tests/memory_sampling_reclaimer_test.cc
+++ b/src/v/resource_mgmt/tests/memory_sampling_reclaimer_test.cc
@@ -77,6 +77,9 @@ SEASTAR_THREAD_TEST_CASE(reclaim_notifies_memory_sampling) {
         auto view = std::string_view{buf};
         return view.find(needle) != std::string_view::npos;
     }).get(); // will throw if false at timeout
+
+    cache.stop().get();
+    memory_sampling_service.stop().get();
 }
 
 #endif // SEASTAR_DEFAULT_ALLOCATOR

--- a/src/v/resource_mgmt/tests/memory_sampling_tests.cc
+++ b/src/v/resource_mgmt/tests/memory_sampling_tests.cc
@@ -134,6 +134,8 @@ SEASTAR_THREAD_TEST_CASE(test_low_watermark_logging) {
         auto buf = output_buf.str();
         BOOST_REQUIRE_EQUAL(buf.size(), old_size);
     }
+
+    sampling.stop().get();
 }
 
 #endif // SEASTAR_DEFAULT_ALLOCATOR


### PR DESCRIPTION
In those tests we set a `std::stringstream` for the seastar logger so that
we can actually test what is being logged.

However, in contrast to `std::cerr` `std::stringstream` is of course not
threadsafe so if multiple reactors try to log at the same time things go
wrong.

Ideally we could just use `<syncstream>` but libc++ doesn't support that
yet. Hence, just run the tests with only a single reactor thread.

Additionally properly stop the services.

Issue https://github.com/redpanda-data/redpanda/issues/11513

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none


