### PR TITLE
rptest: bump spillover test consume timeout

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -857,7 +857,7 @@ class EndToEndSpilloverTest(RedpandaTest):
                                           trace_logs=True)
         consumer.start()
 
-        consumer.wait(timeout_sec=100)
+        consumer.wait(timeout_sec=120)
 
         assert consumer.consumer_status.validator.invalid_reads == 0
         assert consumer.consumer_status.validator.valid_reads >= self.msg_count


### PR DESCRIPTION
Consume timed out in a couple of debug tests. The logs indicate that the consumer was not stuck, so bumping the timeout a bit feels ok.

Fixes #11508

## Backports Required
- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
