### PR TITLE
memory-sampling: Disable top-n alloc sites logging on low memory

### DIFF
--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -22,13 +22,15 @@ rp_test(
         ARGS "-- -c1 -m1G"
 )
 
-rp_test(
-        UNIT_TEST
-        BINARY_NAME test_memory_sampling_reclaimer
-        SOURCES memory_sampling_reclaimer_test.cc
-        DEFINITIONS BOOST_TEST_DYN_LINK
-        LIBRARIES v::seastar_testing_main v::application
-        LABELS memory_sampling
-        SKIP_BUILD_TYPES "Debug"
-        ARGS "-- -c1 -m1G"
-)
+# Disabled: notification from the batch temporarily removed as it was allocating
+# from reclaim. Will need to be reworked, test disabled until then.
+# rp_test(
+#         UNIT_TEST
+#         BINARY_NAME test_memory_sampling_reclaimer
+#         SOURCES memory_sampling_reclaimer_test.cc
+#         DEFINITIONS BOOST_TEST_DYN_LINK
+#         LIBRARIES v::seastar_testing_main v::application
+#         LABELS memory_sampling
+#         SKIP_BUILD_TYPES "Debug"
+#         ARGS "-- -c1 -m1G"
+# )

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -304,12 +304,6 @@ size_t batch_cache::reclaim(size_t size) {
         }
     });
 
-    // so that memory_sampling service can print top memory allocation sites for
-    // this shard
-    if (_memory_sampling_service.local_is_initialized()) {
-        _memory_sampling_service.local().notify_of_reclaim();
-    }
-
     _last_reclaim = ss::lowres_clock::now();
     _size_bytes -= reclaimed;
     return reclaimed;


### PR DESCRIPTION
We added a condition variable which would notify from the batch cache
whenever a reclaim happened.

This is bad because the signal in the condition variable can potentially
allocate which can lead to recursive reclaim calls.

Disable the notification (and as a consequence the logging when reaching
a lower watermark threshold) until we have a proper fix. We will either
need to use another notification mechanism or notify from the background
reclaimer.

Keeping all the other code in place as we will want to reuse it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none


