### PR TITLE
Adjust maximum value for `memory_share_for_fetch` in `MemoryStressTest.test_fetch_with_many_partitions`

### DIFF
--- a/tests/rptest/tests/memory_stress_test.py
+++ b/tests/rptest/tests/memory_stress_test.py
@@ -40,7 +40,8 @@ class MemoryStressTest(RedpandaTest):
     @skip_debug_mode
     @parametrize(memory_share_for_fetch=0.05)
     @parametrize(memory_share_for_fetch=0.5)
-    @parametrize(memory_share_for_fetch=0.8)
+    @parametrize(memory_share_for_fetch=0.7)
+    # the last one is the maximum at which the test has been checked to not fail in practice
     def test_fetch_with_many_partitions(self, memory_share_for_fetch: float):
         """
         Exhaust memory by consuming from too many partitions in a single Fetch


### PR DESCRIPTION
The failing case is OOM when memory reserved for fetch is 80% of kafka memory, but apparently some knobs in memory control do not reflect what is going on with allocations indeed. For this specific test, the setting should go down gradually until this crash is gone, and that should become the highest recommended setting for now.

Getting it down to 0.7.

Fixes #11458

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
