### PR TITLE
Server side schema id validation: metrics

### DIFF
--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -28,6 +28,7 @@ public:
         virtual void add_records_fetched(uint64_t) = 0;
         virtual void add_bytes_produced(uint64_t) = 0;
         virtual void add_bytes_fetched(uint64_t) = 0;
+        virtual void add_schema_id_validation_failed() = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
         virtual ~impl() noexcept = default;
     };
@@ -54,6 +55,10 @@ public:
         return _impl->add_bytes_fetched(bytes);
     }
 
+    void add_schema_id_validation_failed() {
+        _impl->add_schema_id_validation_failed();
+    }
+
 private:
     std::unique_ptr<impl> _impl;
 };
@@ -67,6 +72,9 @@ public:
     void add_records_produced(uint64_t cnt) final { _records_produced += cnt; }
     void add_bytes_fetched(uint64_t cnt) final { _bytes_fetched += cnt; }
     void add_bytes_produced(uint64_t cnt) final { _bytes_produced += cnt; }
+    void add_schema_id_validation_failed() final {
+        ++_schema_id_validation_records_failed;
+    };
 
 private:
     void setup_public_metrics(const model::ntp&);
@@ -78,6 +86,7 @@ private:
     uint64_t _records_fetched{0};
     uint64_t _bytes_produced{0};
     uint64_t _bytes_fetched{0};
+    uint64_t _schema_id_validation_records_failed{0};
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics;
 };

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -343,8 +343,9 @@ static partition_produce_stages produce_topic_partition(
                       source_shard);
                 }
 
+                auto probe = std::addressof(partition->probe());
                 return pandaproxy::schema_registry::maybe_validate_schema_id(
-                         std::move(validator), std::move(reader))
+                         std::move(validator), std::move(reader), probe)
                   .then([ntp{std::move(ntp)},
                          partition{std::move(partition)},
                          dispatch = std::move(dispatch),

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -13,6 +13,7 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf_parser.h"
 #include "cluster/controller.h"
+#include "cluster/partition_probe.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "features/feature_table.h"
@@ -470,13 +471,20 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
     return std::nullopt;
 }
 
-ss::future<schema_id_validator::result>
-schema_id_validator::operator()(model::record_batch_reader&& rbr) {
+ss::future<schema_id_validator::result> schema_id_validator::operator()(
+  model::record_batch_reader&& rbr, cluster::partition_probe* probe) {
     using futurator = ss::futurize<schema_id_validator::result>;
-    return (*_impl)(std::move(rbr)).handle_exception([](std::exception_ptr e) {
-        vlog(plog.warn, "Invalid record due to exception: {}", e);
-        return futurator::convert(kafka::error_code::invalid_record);
-    });
+    return (*_impl)(std::move(rbr))
+      .handle_exception([](std::exception_ptr e) {
+          vlog(plog.warn, "Invalid record due to exception: {}", e);
+          return futurator::convert(kafka::error_code::invalid_record);
+      })
+      .then([probe](futurator::value_type res) {
+          if (!res.has_value()) {
+              probe->add_schema_id_validation_failed();
+          }
+          return futurator::convert(std::move(res));
+      });
 }
 
 } // namespace pandaproxy::schema_registry


### PR DESCRIPTION
* Add a metric for schema id validation failure - Fixes #11501
* Convert exceptions into failed result - Fixes #11526

### Notes to reviewer:
* I put these in the same PR since I found the latter whilst fixing the former, and they'd just collide anyway.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none