### PR TITLE
dt/leadership_transfer_test: Increase timeout

### DIFF
--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -196,7 +196,7 @@ class MultiTopicAutomaticLeadershipBalancingTest(RedpandaTest):
 
         self.logger.info("stabilization post start")
         wait_until(lambda: topic_leadership_evenly_distributed(),
-                   timeout_sec=300,
+                   timeout_sec=600,
                    backoff_sec=10,
                    err_msg="Leadership did not stablize")
 


### PR DESCRIPTION
Increase the timeout to see how random the random hill climb might be.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.
-->

* none

<!--
Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
