### PR TITLE
cloud_storage: Improve manifest spillover robustness

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2064,7 +2064,12 @@ ss::future<bool> ntp_archiver::batch_delete(
 ss::future<> ntp_archiver::apply_spillover() {
     const auto manifest_size_limit
       = config::shard_local_cfg().cloud_storage_spillover_manifest_size.value();
-    if (manifest_size_limit.has_value() == false) {
+    const auto manifest_max_segments
+      = config::shard_local_cfg()
+          .cloud_storage_spillover_manifest_max_segments.value();
+    if (
+      manifest_size_limit.has_value() == false
+      && manifest_max_segments.has_value() == false) {
         co_return;
     }
 
@@ -2077,13 +2082,37 @@ ss::future<> ntp_archiver::apply_spillover() {
           .cloud_storage_manifest_upload_timeout_ms.value();
     const auto manifest_upload_backoff
       = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value();
-    vlog(
-      _rtclog.debug,
-      "Manifest size: {}, manifest size limit (x2): {}",
-      manifest().segments_metadata_bytes(),
-      manifest_size_limit.value() * 2);
-    while (manifest().segments_metadata_bytes()
-           > manifest_size_limit.value() * 2) {
+    if (manifest_size_limit.has_value()) {
+        vlog(
+          _rtclog.debug,
+          "Manifest size: {}, manifest size limit (x2): {}",
+          manifest().segments_metadata_bytes(),
+          manifest_size_limit.value() * 2);
+    } else {
+        vlog(
+          _rtclog.debug,
+          "Manifest size: {}, manifest number of segments limit (x2): {}",
+          manifest().segments_metadata_bytes(),
+          manifest_max_segments.value() * 2);
+    }
+    auto stop_condition = [&] {
+        if (manifest_size_limit.has_value()) {
+            return manifest().segments_metadata_bytes()
+                   < manifest_size_limit.value() * 2;
+        }
+        return manifest().size() < manifest_max_segments.value() * 2;
+    };
+    auto spillover_complete = [&](
+                                const cloud_storage::spillover_manifest& tail) {
+        // Don't allow empty spillover manifests even if the limit
+        // is too low.
+        if (manifest_size_limit.has_value()) {
+            return tail.segments_metadata_bytes() >= manifest_size_limit.value()
+                   && tail.size() > 0;
+        }
+        return tail.size() >= manifest_max_segments.value() && tail.size() > 0;
+    };
+    while (!stop_condition()) {
         auto tail = [&]() {
             cloud_storage::spillover_manifest tail(_ntp, _rev);
             for (const auto& meta : manifest()) {
@@ -2091,11 +2120,7 @@ ss::future<> ntp_archiver::apply_spillover() {
                 // No performance impact since all writes here are
                 // sequential.
                 tail.flush_write_buffer();
-                if (
-                  tail.segments_metadata_bytes() >= manifest_size_limit
-                  && tail.size() > 0) {
-                    // Don't allow empty spillover manifests even if the limit
-                    // is too low.
+                if (spillover_complete(tail)) {
                     break;
                 }
             }

--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -95,7 +95,7 @@ public:
     ///       available.
     ss::future<
       result<std::unique_ptr<async_manifest_view_cursor>, error_outcome>>
-    get_active(async_view_search_query_t q) noexcept;
+    get_cursor(async_view_search_query_t q) noexcept;
 
     /// Get inactive spillover manifests which are waiting for
     /// retention
@@ -108,7 +108,7 @@ public:
     const model::ntp& get_ntp() const { return _stm_manifest.get_ntp(); }
 
     /// Return STM manifest
-    const partition_manifest& stm() const { return _stm_manifest; }
+    const partition_manifest& stm_manifest() const { return _stm_manifest; }
 
     /// Structure that describes how the start archive offset has
     /// to be advanced forward.
@@ -137,10 +137,10 @@ private:
     ss::future<> run_bg_loop();
 
     /// Return true if the offset belongs to the archive
-    bool is_archive(async_view_search_query_t o);
+    bool in_archive(async_view_search_query_t o);
 
     /// Returns true if the offset belongs to the archival STM manifest
-    bool is_stm(async_view_search_query_t o);
+    bool in_stm(async_view_search_query_t o);
 
     /// Get spillover manifest by offset/timestamp
     ss::future<result<manifest_section_t, error_outcome>>
@@ -275,7 +275,7 @@ public:
     /// any scheduling point. The reference will be invalidated in this
     /// case.
     template<class Fn>
-    auto manifest(Fn fn) {
+    auto with_manifest(Fn fn) {
         auto ref = manifest();
         vassert(ref.has_value(), "Invalid cursor, {}", _view.get_ntp());
         return fn(ref->get());
@@ -293,8 +293,8 @@ private:
 
     ss::lowres_clock::duration _idle_timeout;
     ss::timer<ss::lowres_clock> _timer;
-    model::offset _begin;
-    model::offset _end;
+    const model::offset _begin;
+    const model::offset _end;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/materialized_manifest_cache.h
+++ b/src/v/cloud_storage/materialized_manifest_cache.h
@@ -42,11 +42,11 @@ struct materialized_manifest
     materialized_manifest(
       const model::ntp& ntp,
       model::initial_revision_id rev,
-      ss::semaphore_units<> u)
+      ssx::semaphore_units u)
       : manifest(ntp, rev)
       , _units(std::move(u)) {}
 
-    materialized_manifest(spillover_manifest manifest, ss::semaphore_units<> u)
+    materialized_manifest(spillover_manifest manifest, ssx::semaphore_units u)
       : manifest(std::move(manifest))
       , _units(std::move(u)) {}
 
@@ -58,7 +58,7 @@ struct materialized_manifest
     materialized_manifest& operator=(materialized_manifest&&) = delete;
 
     spillover_manifest manifest;
-    ss::semaphore_units<> _units;
+    ssx::semaphore_units _units;
     intrusive_list_hook _hook;
     /// Flag which is set to true when the manifest is being evicted
     /// from the cache.
@@ -93,7 +93,7 @@ public:
     /// \param ctxlog logger of the caller
     /// \param timeout is a timeout for the operation
     /// \return future that result in acquired semaphore units
-    ss::future<ss::semaphore_units<>> prepare(
+    ss::future<ssx::semaphore_units> prepare(
       size_t size_bytes,
       retry_chain_logger& ctxlog,
       std::optional<ss::lowres_clock::duration> timeout = std::nullopt);
@@ -117,7 +117,7 @@ public:
     ///       present the manifest won't be added. Semaphore units
     ///       will be returned.
     void put(
-      ss::semaphore_units<> s,
+      ssx::semaphore_units s,
       spillover_manifest manifest,
       retry_chain_logger& ctxlog);
 
@@ -198,7 +198,7 @@ private:
     /// Storage for manifests
     map_t _cache;
     ss::gate _gate;
-    ss::semaphore _sem;
+    ssx::semaphore _sem;
     /// LRU order list (least recently used elements are in the back of the
     /// list)
     access_list_t _access_order;
@@ -211,7 +211,7 @@ private:
     /// from '_reserved'. This solves the problem of static semaphore count
     /// which can't be changed without recreating the semaphore and makes
     /// difficult cache resizing.
-    ss::semaphore_units<> _reserved;
+    ssx::semaphore_units _reserved;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -1140,7 +1140,7 @@ const gauge_col_t& segment_meta_cstore::get_segment_term_column() const {
     return _impl->get_segment_term_column();
 }
 
-const gauge_col_t& segment_meta_cstore::get_archive_term_column() const {
+const gauge_col_t& segment_meta_cstore::get_archiver_term_column() const {
     return _impl->get_archive_term_column();
 }
 

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -938,7 +938,7 @@ public:
     const gauge_col_t& get_max_timestamp_column() const;
     const gauge_col_t& get_delta_offset_column() const;
     const gauge_col_t& get_segment_term_column() const;
-    const gauge_col_t& get_archive_term_column() const;
+    const gauge_col_t& get_archiver_term_column() const;
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -262,6 +262,9 @@ private:
     static fragmented_vector<segment> replaced_segments_from_manifest(
       const cloud_storage::partition_manifest& manifest);
 
+    static fragmented_vector<segment>
+    spillover_from_manifest(const cloud_storage::partition_manifest& manifest);
+
     void apply_add_segment(const segment& segment);
     void apply_truncate(const start_offset& so);
     void apply_cleanup_metadata();

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1476,7 +1476,8 @@ configuration::configuration()
   , cloud_storage_manifest_cache_ttl_ms(
       *this,
       "cloud_storage_materialized_manifest_ttl_ms",
-      "The time interval that determins how long the materialized manifest can "
+      "The time interval that determines how long the materialized manifest "
+      "can "
       "stay in cache under contention. This parameter is used for performance "
       "tuning. "
       "When the spillover manifest is materialized and stored in cache and the "

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1454,6 +1454,18 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt,
       {.min = 4_KiB, .max = 4_MiB})
+  , cloud_storage_spillover_manifest_max_segments(
+      *this,
+      "cloud_storage_spillover_manifest_max_segments",
+      "Maximum number of elements in the spillover manifest that can be "
+      "offloaded to the cloud storage. This property is similar to "
+      "'cloud_storage_spillover_manifest_size' but "
+      "it triggers spillover based on number of segments instead of the size "
+      "of the manifest in bytes. The property exists to simplify testing and "
+      "shouldn't be set in the production "
+      "environment",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
   , cloud_storage_manifest_cache_size(
       *this,
       "cloud_storage_manifest_cache_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -290,6 +290,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_credentials_host;
     bounded_property<std::optional<size_t>>
       cloud_storage_spillover_manifest_size;
+    property<std::optional<size_t>>
+      cloud_storage_spillover_manifest_max_segments;
     bounded_property<size_t> cloud_storage_manifest_cache_size;
     property<std::chrono::milliseconds> cloud_storage_manifest_cache_ttl_ms;
 

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -16,6 +16,7 @@ from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
@@ -24,7 +25,7 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierRandomConsumer, KgoVerifierSeqConsumer
 from rptest.services.metrics_check import MetricCheck
-from rptest.services.redpanda import SISettings, get_cloud_storage_type, make_redpanda_service, CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import SISettings, get_cloud_storage_type, make_redpanda_service, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import Scale, wait_until_segments
@@ -34,7 +35,7 @@ from rptest.util import (
     wait_for_local_storage_truncate,
 )
 from rptest.utils.mode_checks import skip_debug_mode
-from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView
+from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP
 
 
 class EndToEndShadowIndexingBase(EndToEndTest):
@@ -807,3 +808,102 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
 
         producer.wait()
         rand_consumer.wait()
+
+
+class EndToEndSpilloverTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1,
+                        cleanup_policy=TopicSpec.CLEANUP_DELETE), )
+
+    def __init__(self, test_context):
+        self.si_settings = SISettings(
+            test_context,
+            log_segment_size=1024,
+            fast_uploads=True,
+            cloud_storage_housekeeping_interval_ms=10000)
+        super(EndToEndSpilloverTest, self).__init__(
+            test_context=test_context,
+            # Set to minimal value
+            extra_rp_conf=dict(
+                cloud_storage_spillover_manifest_max_segments=10),
+            si_settings=self.si_settings)
+
+        self.s3_port = self.si_settings.cloud_storage_api_endpoint_port
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.msg_size = 1024 * 256
+        self.msg_count = 1000
+
+    def produce(self):
+        topic_name = self.topics[0].name
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       topic_name,
+                                       msg_size=self.msg_size,
+                                       msg_count=self.msg_count)
+
+        producer.start()
+        producer.wait()
+        producer.free()
+
+        def all_partitions_spilled():
+            return self.num_manifests_uploaded() > 0
+
+        wait_until(all_partitions_spilled, timeout_sec=180, backoff_sec=10)
+
+    def consume(self):
+        topic_name = self.topics[0].name
+        consumer = KgoVerifierSeqConsumer(self.test_context,
+                                          self.redpanda,
+                                          topic_name,
+                                          msg_size=self.msg_size,
+                                          debug_logs=True,
+                                          trace_logs=True)
+        consumer.start()
+
+        consumer.wait(timeout_sec=300)
+
+        assert consumer.consumer_status.validator.invalid_reads == 0
+        assert consumer.consumer_status.validator.valid_reads >= self.msg_count
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_spillover(self, cloud_storage_type):
+
+        self.logger.info("Start producer")
+        self.produce()
+
+        self.logger.info("Remove local data")
+        # Enable local retention for the topic to force reading from the 'archive'
+        # section of the log and wait for the housekeeping to finish.
+        rpk = RpkTool(self.redpanda)
+        num_partitions = self.topics[0].partition_count
+        topic_name = self.topics[0].name
+        rpk.alter_topic_config(topic_name, 'retention.local.target.bytes',
+                               0x1000)
+
+        for pix in range(0, num_partitions):
+            wait_for_local_storage_truncate(self.redpanda,
+                                            self.topic,
+                                            target_bytes=0x2000,
+                                            partition_idx=pix,
+                                            timeout_sec=30)
+
+        self.logger.info("Start consumer")
+        self.consume()
+
+    def num_manifests_uploaded(self):
+        s = self.redpanda.metric_sum(
+            metric_name=
+            "redpanda_cloud_storage_spillover_manifest_uploads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        self.logger.info(
+            f"redpanda_cloud_storage_spillover_manifest_uploads = {s}")
+        return s
+
+    def num_manifests_downloaded(self):
+        s = self.redpanda.metric_sum(
+            metric_name=
+            "redpanda_cloud_storage_spillover_manifest_downloads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        self.logger.info(
+            f"redpanda_cloud_storage_spillover_manifest_downloads = {s}")
+        return s


### PR DESCRIPTION
- Add new duck tape test that checks offset for leader epoch request on `archive` part of the log
- Add spillover manifest metadata to the `spillover_cmd` to improve reliability (the command can be validated by the STM)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none