### PR TITLE
Server side schema id validation metrics v2

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -242,6 +242,18 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
            topic_label(ntp.tp.topic()),
            partition_label(ntp.tp.partition())})
           .aggregate({sm::shard_label, partition_label}),
+        sm::make_counter(
+          "records_produced_total",
+          [this] { return _records_produced; },
+          sm::description("Total number of records produced"),
+          labels)
+          .aggregate({sm::shard_label, partition_label}),
+        sm::make_counter(
+          "records_fetched_total",
+          [this] { return _records_fetched; },
+          sm::description("Total number of records fetched"),
+          labels)
+          .aggregate({sm::shard_label, partition_label}),
       });
 }
 

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -255,6 +255,21 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
           labels)
           .aggregate({sm::shard_label, partition_label}),
       });
+    if (
+      config::shard_local_cfg().enable_schema_id_validation()
+      != pandaproxy::schema_registry::schema_id_validation_mode::none) {
+        _public_metrics.add_group(
+          prometheus_sanitize::metrics_name("cluster:partition"),
+          {
+            sm::make_counter(
+              "schema_id_validation_records_failed",
+              [this] { return _schema_id_validation_records_failed; },
+              sm::description(
+                "Number of records that failed schema ID validation"),
+              labels)
+              .aggregate({sm::shard_label, partition_label}),
+          });
+    }
 }
 
 } // namespace cluster

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -23,7 +23,16 @@ namespace cluster {
 replicated_partition_probe::replicated_partition_probe(
   const partition& p) noexcept
   : _partition(p)
-  , _public_metrics(ssx::metrics::public_metrics_handle) {}
+  , _public_metrics(ssx::metrics::public_metrics_handle) {
+    config::shard_local_cfg().enable_schema_id_validation.bind().watch(
+      [this]() { reconfigure_metrics(); });
+}
+
+void replicated_partition_probe::reconfigure_metrics() {
+    _metrics.clear();
+    _public_metrics.clear();
+    setup_metrics(_partition.ntp());
+}
 
 void replicated_partition_probe::setup_metrics(const model::ntp& ntp) {
     setup_internal_metrics(ntp);

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -77,6 +77,7 @@ public:
     };
 
 private:
+    void reconfigure_metrics();
     void setup_public_metrics(const model::ntp&);
     void setup_internal_metrics(const model::ntp&);
 

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -28,6 +28,7 @@ public:
         virtual void add_records_fetched(uint64_t) = 0;
         virtual void add_bytes_produced(uint64_t) = 0;
         virtual void add_bytes_fetched(uint64_t) = 0;
+        virtual void add_schema_id_validation_failed() = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
         virtual ~impl() noexcept = default;
     };
@@ -54,6 +55,10 @@ public:
         return _impl->add_bytes_fetched(bytes);
     }
 
+    void add_schema_id_validation_failed() {
+        _impl->add_schema_id_validation_failed();
+    }
+
 private:
     std::unique_ptr<impl> _impl;
 };
@@ -67,6 +72,9 @@ public:
     void add_records_produced(uint64_t cnt) final { _records_produced += cnt; }
     void add_bytes_fetched(uint64_t cnt) final { _bytes_fetched += cnt; }
     void add_bytes_produced(uint64_t cnt) final { _bytes_produced += cnt; }
+    void add_schema_id_validation_failed() final {
+        ++_schema_id_validation_records_failed;
+    };
 
 private:
     void setup_public_metrics(const model::ntp&);
@@ -78,6 +86,7 @@ private:
     uint64_t _records_fetched{0};
     uint64_t _bytes_produced{0};
     uint64_t _bytes_fetched{0};
+    uint64_t _schema_id_validation_records_failed{0};
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics;
 };

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -343,8 +343,9 @@ static partition_produce_stages produce_topic_partition(
                       source_shard);
                 }
 
+                auto probe = std::addressof(partition->probe());
                 return pandaproxy::schema_registry::maybe_validate_schema_id(
-                         std::move(validator), std::move(reader))
+                         std::move(validator), std::move(reader), probe)
                   .then([ntp{std::move(ntp)},
                          partition{std::move(partition)},
                          dispatch = std::move(dispatch),

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -13,6 +13,7 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf_parser.h"
 #include "cluster/controller.h"
+#include "cluster/partition_probe.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "features/feature_table.h"
@@ -470,13 +471,20 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
     return std::nullopt;
 }
 
-ss::future<schema_id_validator::result>
-schema_id_validator::operator()(model::record_batch_reader&& rbr) {
+ss::future<schema_id_validator::result> schema_id_validator::operator()(
+  model::record_batch_reader&& rbr, cluster::partition_probe* probe) {
     using futurator = ss::futurize<schema_id_validator::result>;
-    return (*_impl)(std::move(rbr)).handle_exception([](std::exception_ptr e) {
-        vlog(plog.warn, "Invalid record due to exception: {}", e);
-        return futurator::convert(kafka::error_code::invalid_record);
-    });
+    return (*_impl)(std::move(rbr))
+      .handle_exception([](std::exception_ptr e) {
+          vlog(plog.warn, "Invalid record due to exception: {}", e);
+          return futurator::convert(kafka::error_code::invalid_record);
+      })
+      .then([probe](futurator::value_type res) {
+          if (!res.has_value()) {
+              probe->add_schema_id_validation_failed();
+          }
+          return futurator::convert(std::move(res));
+      });
 }
 
 } // namespace pandaproxy::schema_registry


### PR DESCRIPTION
* Add a metric for schema id validation failure - Fixes #11501
* Convert exceptions into failed result - Fixes #11526
* Add the metrics also to the public endpoint.
* Reconfigure when enable_schema_id_validation is toggled, so that a restart isn't required to view the metrics.


### Notes to reviewer:
* I put these in the same PR since I found the latter whilst fixing the former, and they'd just collide anyway.

### Note for docs:

New topic-level metrics on `/metrics`:
```
# HELP vectorized_cluster_partition_schema_id_validation_records_failed Number of records that failed schema ID validation
# TYPE vectorized_cluster_partition_schema_id_validation_records_failed counter
```

New topic-level  metrics on `/public_metrics`
```
# HELP redpanda_cluster_partition_schema_id_validation_records_failed Number of records that failed schema ID validation
# TYPE redpanda_cluster_partition_schema_id_validation_records_failed counter

# HELP redpanda_kafka_records_fetched_total Total number of records fetched
# TYPE redpanda_kafka_records_fetched_total counter

# HELP redpanda_kafka_records_produced_total Total number of records produced
# TYPE redpanda_kafka_records_produced_total counter
```

## Backports Required



<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
