### PR TITLE
cloud_storage: Improve manifest spillover robustness

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1865,8 +1865,9 @@ ss::future<> ntp_archiver::apply_archive_retention() {
     }
 
     if (
-      res.value().offset
-      == _manifest_view->stm_manifest().get_archive_start_offset()) {
+      res.value().offset == model::offset{}
+      || res.value().offset
+           == _manifest_view->stm_manifest().get_archive_start_offset()) {
         co_return;
     }
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2166,13 +2166,15 @@ ss::future<> ntp_archiver::apply_spillover() {
 
         const auto first = *tail.begin();
         const auto last = tail.last_segment();
+        const auto spillover_meta = tail.make_manifest_metadata();
         vassert(last.has_value(), "Spillover manifest can't be empty");
         vlog(
           _rtclog.info,
           "First batch of the spillover manifest: {}, Last batch of the "
-          "spillover manifest: {}",
+          "spillover manifest: {}, spillover metadata: {}",
           first,
-          last);
+          last,
+          spillover_meta);
 
         retry_chain_node upload_rtc(
           manifest_upload_timeout, manifest_upload_backoff, &_rtcnode);
@@ -2194,8 +2196,14 @@ ss::future<> ntp_archiver::apply_spillover() {
         auto deadline = ss::lowres_clock::now() + sync_timeout;
 
         auto batch = _parent.archival_meta_stm()->batch_start(deadline, _as);
-        batch.spillover(model::next_offset(last->committed_offset));
+        batch.spillover(spillover_meta);
         if (manifest().get_archive_start_offset() == model::offset{}) {
+            vlog(
+              _rtclog.debug,
+              "Archive is empty, have to set start archive/clean offset: {}, "
+              "and delta: {}",
+              first.base_offset,
+              first.delta_offset);
             // Enable archive if this is the first spillover manifest. In this
             // case we need to set initial values for
             // archive_start_offset/archive_clean_offset which will be advanced

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -48,6 +48,7 @@ v_cc_library(
     v::rphashing
     v::cloud_roles
     v::segment_meta_cstore
+    v::raft
     # NOTE: do not add v::cloud as a dependency
 )
 add_subdirectory(tests)

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -337,9 +337,19 @@ public:
     ///
     /// \note this works the same way as 'truncate' but the 'archive' size
     ///       gets correctly updated.
-    /// \param starting_rp_offset is a new starting offset of the manifest
-    /// \return manifest that contains only removed segments
-    partition_manifest spillover(model::offset starting_rp_offset);
+    /// \param spillover_manifest_meta is a new spillover manifest to add
+    void spillover(const segment_meta& spillover_manifest_meta);
+
+    /// Pack manifest metadata into the 'segment_meta' struct
+    ///
+    /// This mechanism is used by the 'spillover' mechanism. The 'segment_meta'
+    /// instances that describe spillover manifests are stored using this
+    /// format.
+    segment_meta make_manifest_metadata() const;
+
+    /// Return 'true' if the spillover manifest can be added to
+    /// the manifest without creating a gap
+    bool safe_spillover_manifest(const segment_meta& meta);
 
     /// \brief Set start offset without removing any data from the
     /// manifest.

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -755,10 +755,10 @@ remote_partition::get_term_last_offset(model::term_id term) const {
         const auto& term_col = spillover_map.get_segment_term_column();
         size_t sp_index = 0;
         for (auto t : term_col) {
-            sp_index++;
             if (t > term()) {
                 break;
             }
+            sp_index++;
         }
         auto sp_start = spillover_map.get_base_offset_column().at_index(
           sp_index);

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -17,8 +17,10 @@
 #include "utils/delta_for.h"
 
 #include <bitset>
+#include <exception>
 #include <functional>
 #include <limits>
+#include <stdexcept>
 #include <tuple>
 
 namespace cloud_storage {
@@ -930,6 +932,32 @@ public:
         return _col.last_segment();
     }
 
+    // Add value to the write buffer without replacing
+    // anything.
+    void append_no_flush(const segment_meta& m) {
+        auto it = _write_buffer.find(m.base_offset);
+        if (it != _write_buffer.end()) {
+            throw std::invalid_argument(fmt_with_ctx(
+              fmt::format,
+              "Element with base offset {} is already added, new value: {}, "
+              "existing value: {}",
+              m.base_offset,
+              m,
+              it->second));
+        }
+        _write_buffer.insert_or_assign(m.base_offset, m);
+    }
+
+    // Remove element from the write buffer. The method can
+    // be used to undo previous call to 'append_no_flush'
+    void remove_from_buffer(const segment_meta& m) {
+        auto it = _write_buffer.find(m.base_offset);
+        if (it == _write_buffer.end() || it->second != m) {
+            return;
+        }
+        _write_buffer.erase(it);
+    }
+
     void insert(const segment_meta& m) {
         auto [m_it, _] = _write_buffer.insert_or_assign(m.base_offset, m);
         // the new segment_meta could be a replacement for subsequent entries in
@@ -1108,6 +1136,30 @@ iobuf segment_meta_cstore::to_iobuf() const {
     }
 
     return serde::to_iobuf(std::move(tmp));
+}
+
+segment_meta_cstore::append_tx::append_tx(
+  segment_meta_cstore& cs, const segment_meta& meta)
+  : _meta(meta)
+  , _parent(cs) {
+    _parent._impl->append_no_flush(meta);
+}
+
+segment_meta_cstore::append_tx::~append_tx() {
+    if (std::uncaught_exceptions() > 0) {
+        // NOTE: rollback is idempotent so it's safe to invoke
+        // it here if it was called manually prior to d-tor call.
+        rollback();
+    }
+}
+
+void segment_meta_cstore::append_tx::rollback() noexcept {
+    _parent._impl->remove_from_buffer(_meta);
+}
+
+segment_meta_cstore::append_tx
+segment_meta_cstore::append(const segment_meta& meta) {
+    return append_tx(*this, meta);
 }
 
 void segment_meta_cstore::flush_write_buffer() { _impl->flush_write_buffer(); }

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -918,6 +918,27 @@ public:
 
     void insert(const segment_meta&);
 
+    class [[nodiscard]] append_tx {
+    public:
+        explicit append_tx(segment_meta_cstore&, const segment_meta&);
+        ~append_tx();
+        append_tx(const append_tx&) = delete;
+        append_tx(append_tx&&) = delete;
+        append_tx& operator=(const append_tx&) = delete;
+        append_tx& operator=(append_tx&&) = delete;
+
+        void rollback() noexcept;
+
+    private:
+        segment_meta _meta;
+        segment_meta_cstore& _parent;
+    };
+
+    /// Add element to the c-store without flushing the
+    /// write buffer. The new element can't replace any
+    /// existing element in the write buffer.
+    append_tx append(const segment_meta&);
+
     std::pair<size_t, size_t> inflated_actual_size() const;
 
     /// Removes all values up to the offset. The provided offset is

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -80,11 +80,14 @@ public:
         }
         auto so = model::next_offset(stm_manifest.get_last_offset());
         add_random_segments(stm_manifest, num_segments);
-        auto tmp = stm_manifest.spillover(so);
         spillover_manifest spm(manifest_ntp, manifest_rev);
-        for (const auto& meta : tmp) {
+        for (const auto& meta : stm_manifest) {
+            if (meta.committed_offset >= so) {
+                break;
+            }
             spm.add(meta);
         }
+        stm_manifest.spillover(spm.make_manifest_metadata());
         // update cache
         auto path = spm.get_manifest_path();
         if (hydrate) {

--- a/src/v/cloud_storage/tests/common_def.h
+++ b/src/v/cloud_storage/tests/common_def.h
@@ -14,6 +14,7 @@
 #include "cloud_storage/tests/s3_imposter.h"
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
+#include "model/namespace.h"
 #include "model/record_batch_types.h"
 #include "model/tests/random_batch.h"
 #include "storage/parser.h"
@@ -23,7 +24,7 @@
 #include <boost/test/tools/interface.hpp>
 
 namespace cloud_storage {
-static const auto manifest_namespace = model::ns("test-ns");    // NOLINT
+static const auto manifest_namespace = model::kafka_namespace;  // NOLINT
 static const auto manifest_topic = model::topic("test-topic");  // NOLINT
 static const auto manifest_partition = model::partition_id(42); // NOLINT
 static const auto manifest_ntp = model::ntp(                    // NOLINT
@@ -33,11 +34,11 @@ static const auto manifest_ntp = model::ntp(                    // NOLINT
 static const auto manifest_revision = model::initial_revision_id(0); // NOLINT
 static const auto archiver_term = model::term_id{123};
 static const ss::sstring manifest_url = ssx::sformat( // NOLINT
-  "20000000/meta/{}_{}/manifest.json",
+  "10000000/meta/{}_{}/manifest.json",
   manifest_ntp.path(),
   manifest_revision());
 static const ss::sstring manifest_serde_url = ssx::sformat(
-  "20000000/meta/{}_{}/manifest.bin", manifest_ntp.path(), manifest_revision());
+  "10000000/meta/{}_{}/manifest.bin", manifest_ntp.path(), manifest_revision());
 
 static const auto json_manifest_format_path = std::pair{
   manifest_format::json,

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -1631,7 +1631,7 @@ FIXTURE_TEST(
 FIXTURE_TEST(test_remote_partition_scan_after_recovery, cloud_storage_fixture) {
     const char* manifest_json = R"json({
       "version": 1,
-      "namespace": "test-ns",
+      "namespace": "kafka",
       "topic": "test-topic",
       "partition": 42,
       "revision": 0,

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -64,7 +64,7 @@ public:
     command_batch_builder& truncate(model::offset start_rp_offset);
     command_batch_builder& truncate(kafka::offset start_kafka_offset);
     /// Add spillover command to the batch
-    command_batch_builder& spillover(model::offset start_rp_offset);
+    command_batch_builder& spillover(const cloud_storage::segment_meta& meta);
     /// Add truncate-archive-init command to the batch
     command_batch_builder& truncate_archive_init(
       model::offset start_rp_offset, model::offset_delta delta);
@@ -129,7 +129,7 @@ public:
     /// start_rp_offset forward. The entries are supposed to be moved to archive
     /// by the caller.
     ss::future<std::error_code> spillover(
-      model::offset start_rp_offset,
+      const cloud_storage::segment_meta& manifest_meta,
       ss::lowres_clock::time_point deadline,
       ss::abort_source&);
 
@@ -275,7 +275,7 @@ private:
     apply_truncate_archive_commit(model::offset co, uint64_t bytes_removed);
     void apply_update_start_kafka_offset(kafka::offset so);
     void apply_reset_metadata();
-    void apply_spillover(const start_offset& so);
+    void apply_spillover(const spillover_cmd& so);
 
 private:
     prefix_logger _logger;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -74,7 +74,7 @@ struct fmt::formatter<raft::consensus::vote_state> final
 
 namespace raft {
 
-static std::vector<model::record_batch_type>
+std::vector<model::record_batch_type>
 offset_translator_batch_types(const model::ntp& ntp) {
     if (ntp.ns == model::kafka_namespace) {
         return {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -52,6 +52,10 @@ class replicate_entries_stm;
 class vote_stm;
 class prevote_stm;
 class recovery_stm;
+
+std::vector<model::record_batch_type>
+offset_translator_batch_types(const model::ntp& ntp);
+
 /// consensus for one raft group
 class consensus {
 public:

--- a/tests/rptest/tests/archive_retention_test.py
+++ b/tests/rptest/tests/archive_retention_test.py
@@ -1,0 +1,126 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from time import sleep
+import time
+from ducktape.errors import TimeoutError
+from ducktape.mark import matrix, parametrize
+from ducktape.utils.util import wait_until
+
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import CloudStorageType, SISettings, MetricsEndpoint, get_cloud_storage_type
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import (produce_until_segments, produce_total_bytes,
+                         wait_for_local_storage_truncate, segments_count,
+                         expect_exception)
+from rptest.utils.si_utils import BucketView
+
+
+class CloudArchiveRetentionTest(RedpandaTest):
+    """Test retention with spillover enabled"""
+    def __init__(self, test_context):
+        self.extra_rp_conf = dict(
+            log_compaction_interval_ms=1000,
+            cloud_storage_spillover_manifest_max_segments=5)
+
+        si_settings = SISettings(test_context,
+                                 cloud_storage_housekeeping_interval_ms=1000,
+                                 log_segment_size=4096,
+                                 fast_uploads=True)
+
+        super(CloudArchiveRetentionTest,
+              self).__init__(test_context=test_context,
+                             si_settings=si_settings,
+                             extra_rp_conf=self.extra_rp_conf,
+                             log_level="debug")
+
+        self.rpk = RpkTool(self.redpanda)
+        self.s3_bucket_name = si_settings.cloud_storage_bucket
+
+    def produce(self, topic, msg_count):
+        msg_size = 1024 * 256
+        topic_name = topic.name
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       topic_name,
+                                       msg_size=msg_size,
+                                       msg_count=msg_count)
+
+        producer.start()
+        producer.wait()
+        producer.free()
+
+        def all_partitions_spilled():
+            return self.num_manifests_uploaded() > 0
+
+        wait_until(all_partitions_spilled, timeout_sec=180, backoff_sec=10)
+
+    def num_manifests_uploaded(self):
+        s = self.redpanda.metric_sum(
+            metric_name=
+            "redpanda_cloud_storage_spillover_manifest_uploads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        self.logger.info(
+            f"redpanda_cloud_storage_spillover_manifest_uploads = {s}")
+        return s
+
+    def num_segments_deleted(self):
+        s = self.redpanda.metric_sum(
+            metric_name="redpanda_cloud_storage_deleted_segments_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        self.logger.info(
+            f"redpanda_cloud_storage_deleted_segments_total = {s}")
+        return s
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=get_cloud_storage_type(),
+            retention_type=['retention.ms', 'retention.bytes'])
+    def test_delete(self, cloud_storage_type, retention_type):
+        topic = TopicSpec(redpanda_remote_read=True,
+                          redpanda_remote_write=True,
+                          cleanup_policy=TopicSpec.CLEANUP_DELETE)
+
+        self.client().create_topic(topic)
+
+        def wait_for_topic():
+            wait_until(lambda: len(
+                list(self.client().describe_topic(topic.name))) > 0,
+                       30,
+                       backoff_sec=2)
+
+        def produce_until_spillover():
+            initial_uploaded = self.num_manifests_uploaded()
+
+            def new_manifest_spilled():
+                time.sleep(5)
+                self.produce(topic, 250)
+                num_spilled = self.num_manifests_uploaded()
+                return num_spilled > initial_uploaded
+
+            wait_until(new_manifest_spilled,
+                       timeout_sec=120,
+                       backoff_sec=2,
+                       err_msg="Manifests were not created")
+
+        wait_for_topic()
+        produce_until_spillover()
+
+        # Enable cloud retention for the topic to force deleting data
+        # from the 'archive'
+        wait_for_topic()
+        self.client().alter_topic_config(topic.name, retention_type, 1000)
+
+        wait_until(lambda: self.num_segments_deleted() > 50,
+                   timeout_sec=100,
+                   backoff_sec=5,
+                   err_msg=f"Segments were not removed from the cloud")

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -12,14 +12,16 @@ from rptest.services.cluster import cluster
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.clients.kcl import KCL
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings, MetricsEndpoint
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.util import (
     produce_until_segments,
     wait_for_local_storage_truncate,
+    KafkaCliTools,
 )
 
 
@@ -36,17 +38,26 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
             rpk.produce(topic, f"k-{i}", f"v-{i}")
 
     def __init__(self, test_context):
-        super(OffsetForLeaderEpochArchivalTest, self).__init__(
-            test_context=test_context,
-            extra_rp_conf={
-                'enable_leader_balancer': False,
-                "log_compaction_interval_ms": 1000
-            },
-            si_settings=SISettings(
-                test_context,
-                log_segment_size=OffsetForLeaderEpochArchivalTest.segment_size,
-                cloud_storage_cache_size=5 *
-                OffsetForLeaderEpochArchivalTest.segment_size))
+        self.extra_rp_conf = {
+            'enable_leader_balancer': False,
+            "log_compaction_interval_ms": 1000
+        }
+        self.si_settings = SISettings(
+            test_context,
+            log_segment_size=OffsetForLeaderEpochArchivalTest.segment_size,
+            cloud_storage_cache_size=5 *
+            OffsetForLeaderEpochArchivalTest.segment_size)
+        if test_context.function_name == 'test_querying_archive':
+            self.extra_rp_conf[
+                'cloud_storage_spillover_manifest_max_segments'] = 10
+            self.si_settings.log_segment_size = 1024
+            self.si_settings.fast_uploads = True,
+            self.si_settings.cloud_storage_housekeeping_interval_ms = 10000
+
+        super(OffsetForLeaderEpochArchivalTest,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=self.extra_rp_conf,
+                             si_settings=self.si_settings)
 
     def _alter_topic_retention_with_retry(self, topic):
         rpk = RpkTool(self.redpanda)
@@ -122,3 +133,103 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
                 # and we can't read from cloud storage.
                 assert epoch_end_offset != -1, f"{epoch_end_offset} vs -1"
                 assert epoch_end_offset >= offset, f"{epoch_end_offset} vs {offset}"
+
+    def num_manifests_uploaded(self):
+        s = self.redpanda.metric_sum(
+            metric_name=
+            "redpanda_cloud_storage_spillover_manifest_uploads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        self.logger.info(
+            f"redpanda_cloud_storage_spillover_manifest_uploads = {s}")
+        return s
+
+    def produce(self, topic, msg_count):
+        msg_size = 1024 * 256
+        topic_name = topic.name
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       topic_name,
+                                       msg_size=msg_size,
+                                       msg_count=msg_count)
+
+        producer.start()
+        producer.wait()
+        producer.free()
+
+        def all_partitions_spilled():
+            return self.num_manifests_uploaded() > 0
+
+        wait_until(all_partitions_spilled, timeout_sec=180, backoff_sec=10)
+
+    @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_querying_archive(self):
+        topic = TopicSpec(redpanda_remote_read=True,
+                          redpanda_remote_write=True)
+        epoch_offsets = {}
+
+        self.client().create_topic(topic)
+
+        rpk = RpkTool(self.redpanda)
+
+        def wait_for_topic():
+            wait_until(lambda: len(list(rpk.describe_topic(topic.name))) > 0,
+                       30,
+                       backoff_sec=2)
+
+        def produce_until_spillover():
+            initial_uploaded = self.num_manifests_uploaded()
+
+            def new_manifest_spilled():
+                self.produce(topic, 250)
+                num_spilled = self.num_manifests_uploaded()
+                return num_spilled > initial_uploaded
+
+            wait_until(new_manifest_spilled,
+                       timeout_sec=120,
+                       backoff_sec=2,
+                       err_msg="Manifests were not created")
+
+        for _ in range(0, 8):
+            wait_for_topic()
+            produce_until_spillover()
+            res = list(rpk.describe_topic(topic.name))
+            epoch_offsets[res[0].leader_epoch] = res[0].high_watermark
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # Enable local retention for the topic to force reading from the 'archive'
+        # section of the log and wait for the housekeeping to finish.
+        wait_for_topic()
+        rpk = RpkTool(self.redpanda)
+
+        def topic_config_altered():
+            try:
+                rpk.alter_topic_config(topic.name,
+                                       'retention.local.target.bytes', 0x1000)
+                return True
+            except:
+                return False
+
+        wait_until(topic_config_altered,
+                   timeout_sec=120,
+                   backoff_sec=2,
+                   err_msg="Can't update topic config")
+
+        for pix in range(0, topic.partition_count):
+            wait_for_local_storage_truncate(self.redpanda,
+                                            topic.name,
+                                            target_bytes=0x2000,
+                                            partition_idx=pix,
+                                            timeout_sec=30)
+
+        self.logger.info(f"leader epoch high watermarks: {epoch_offsets}")
+
+        kcl = KCL(self.redpanda)
+
+        for epoch, offset in epoch_offsets.items():
+            self.logger.info(f"querying partition epoch {epoch} end offsets")
+            epoch_end_offset = kcl.offset_for_leader_epoch(
+                topics=topic.name, leader_epoch=epoch)[0].epoch_end_offset
+            self.logger.info(
+                f"epoch {epoch} end_offset: {epoch_end_offset}, expected offset: {offset}"
+            )
+            assert epoch_end_offset == offset, f"{epoch_end_offset} vs {offset}"

--- a/tools/rp_storage_tool/deltafor/src/lib.rs
+++ b/tools/rp_storage_tool/deltafor/src/lib.rs
@@ -161,23 +161,23 @@ pub fn read_index_header(
 pub struct OffsetIndex {
     pub min_file_pos_step: i64,
     pub num_elements: u64,
-    #[serde(rename="base_offset")]
+    #[serde(rename = "base_offset")]
     pub base_rp: i64,
-    #[serde(rename="last_offset")]
+    #[serde(rename = "last_offset")]
     pub last_rp: i64,
-    #[serde(rename="base_kafka_offset")]
+    #[serde(rename = "base_kafka_offset")]
     pub base_kaf: i64,
-    #[serde(rename="last_kafka_offset")]
+    #[serde(rename = "last_kafka_offset")]
     pub last_kaf: i64,
-    #[serde(rename="base_file_offset")]
+    #[serde(rename = "base_file_offset")]
     pub base_file: i64,
-    #[serde(rename="last_file_offset")]
+    #[serde(rename = "last_file_offset")]
     pub last_file: i64,
-    #[serde(rename="redpanda_offsets")]
+    #[serde(rename = "redpanda_offsets")]
     pub rp_offsets: Vec<i64>,
-    #[serde(rename="kafka_offsets")]
+    #[serde(rename = "kafka_offsets")]
     pub kaf_offsets: Vec<i64>,
-    #[serde(rename="file_offsets")]
+    #[serde(rename = "file_offsets")]
     pub file_offsets: Vec<i64>,
 }
 

--- a/tools/rp_storage_tool/src/batch_reader.rs
+++ b/tools/rp_storage_tool/src/batch_reader.rs
@@ -1,10 +1,10 @@
 use crate::batch_crc::batch_body_crc;
+use crate::error::DecodeError;
+use crate::util::from_adl_bytes;
 use log::{debug, info, trace};
 use redpanda_records::{Record, RecordBatchHeader, RecordBatchType};
 use std::io;
 use tokio::io::AsyncReadExt;
-use crate::error::DecodeError;
-use crate::util::from_adl_bytes;
 
 use crate::varint::VarIntDecoder;
 

--- a/tools/rp_storage_tool/src/error.rs
+++ b/tools/rp_storage_tool/src/error.rs
@@ -1,12 +1,9 @@
-
 use std;
 use std::array::TryFromSliceError;
 use std::fmt::{self, Display};
 
 use serde::de::StdError;
 use serde::{de, ser};
-
-
 
 /// General purpose error class for code that does I/O to remote storage.
 /// TODO: clean up naming, this may be used in circumstances other than reading from a bucket

--- a/tools/rp_storage_tool/src/main.rs
+++ b/tools/rp_storage_tool/src/main.rs
@@ -9,8 +9,8 @@ mod fundamental;
 mod ntp_mask;
 mod remote_types;
 mod repair;
-mod varint;
 mod util;
+mod varint;
 
 use log::{debug, error, info, trace, warn};
 use remote_types::RpSerde;

--- a/tools/rp_storage_tool/src/main_unstable.rs
+++ b/tools/rp_storage_tool/src/main_unstable.rs
@@ -11,8 +11,8 @@ mod ntp_mask;
 mod remote_types;
 mod repair;
 mod segment_writer;
-mod varint;
 mod util;
+mod varint;
 
 use crate::segment_writer::SegmentWriter;
 use bytes::Bytes;

--- a/tools/rp_storage_tool/src/remote_types.rs
+++ b/tools/rp_storage_tool/src/remote_types.rs
@@ -1053,8 +1053,11 @@ mod tests {
         assert_eq!(manifest.revision, 8);
         assert_eq!(manifest.segments.len(), 3654);
         // Sanity check some missing field serialization.
-        assert!(offset_has_default_value(&manifest.start_kafka_offset),
-                "{:?}", manifest.start_kafka_offset);
+        assert!(
+            offset_has_default_value(&manifest.start_kafka_offset),
+            "{:?}",
+            manifest.start_kafka_offset
+        );
         let json_manifest = serde_json::to_string(&manifest).unwrap();
         assert_eq!(json_manifest.find("start_kafka_offset"), None);
     }
@@ -1078,8 +1081,11 @@ mod tests {
             1573496
         );
         // Sanity check some missing field serialization.
-        assert!(offset_has_default_value(&manifest.start_kafka_offset),
-                "{:?}", manifest.start_kafka_offset);
+        assert!(
+            offset_has_default_value(&manifest.start_kafka_offset),
+            "{:?}",
+            manifest.start_kafka_offset
+        );
         let json_manifest = serde_json::to_string(&manifest).unwrap();
         assert_eq!(json_manifest.find("start_kafka_offset"), None);
     }

--- a/tools/rp_storage_tool/src/util.rs
+++ b/tools/rp_storage_tool/src/util.rs
@@ -27,8 +27,8 @@ impl<'de, DE: Decoder> Deserializer<'de, DE> {
 /// This isn't a full impl of ADL encoding, but for situations we care about (like
 /// RecordBatchHeader), it is enough.
 pub fn from_adl_bytes<T, C: Config>(slice: &[u8], config: C) -> DecodeResult<T>
-    where
-        T: DeserializeOwned,
+where
+    T: DeserializeOwned,
 {
     let reader = SliceReader::new(slice);
     let mut decoder = bincode::de::DecoderImpl::new(reader, config);
@@ -39,168 +39,170 @@ pub fn from_adl_bytes<T, C: Config>(slice: &[u8], config: C) -> DecodeResult<T>
     Ok(t)
 }
 
-
-
 impl<'a, 'de, DE: Decoder> serde::Deserializer<'de> for Deserializer<'a, DE> {
     type Error = DecodeError;
 
     fn deserialize_any<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_bool<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_i8<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_i8(i8::from_le_bytes(self.take_bytes::<1>()?))
     }
 
     fn deserialize_i16<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_i16(i16::from_le_bytes(self.take_bytes::<2>()?))
     }
 
     fn deserialize_i32<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_i32(i32::from_le_bytes(self.take_bytes::<4>()?))
     }
 
     fn deserialize_i64<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_i64(i64::from_le_bytes(self.take_bytes::<8>()?))
     }
 
     fn deserialize_u8<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_u8(u8::from_le_bytes(self.take_bytes::<1>()?))
     }
 
     fn deserialize_u16<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_u16(u16::from_le_bytes(self.take_bytes::<2>()?))
     }
 
     fn deserialize_u32<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_u32(u32::from_le_bytes(self.take_bytes::<4>()?))
     }
 
     fn deserialize_u64<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_u64(u64::from_le_bytes(self.take_bytes::<8>()?))
     }
 
     fn deserialize_f32<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_f32(f32::from_le_bytes(self.take_bytes::<4>()?))
     }
 
     fn deserialize_f64<V>(mut self, visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_f64(f64::from_le_bytes(self.take_bytes::<8>()?))
     }
 
     fn deserialize_char<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_str<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_string<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_bytes<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_byte_buf<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_option<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_unit<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
-    fn deserialize_newtype_struct<V>(self, _name: &'static str, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> DecodeResult<V::Value>
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_seq<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
@@ -211,15 +213,15 @@ impl<'a, 'de, DE: Decoder> serde::Deserializer<'de> for Deserializer<'a, DE> {
         _len: usize,
         _visitor: V,
     ) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_map<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
@@ -230,8 +232,8 @@ impl<'a, 'de, DE: Decoder> serde::Deserializer<'de> for Deserializer<'a, DE> {
         fields: &'static [&'static str],
         visitor: V,
     ) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         struct Access<'a, 'b, DE: Decoder> {
             deserializer: &'a mut Deserializer<'b, DE>,
@@ -242,8 +244,8 @@ impl<'a, 'de, DE: Decoder> serde::Deserializer<'de> for Deserializer<'a, DE> {
             type Error = DecodeError;
 
             fn next_element_seed<T>(&mut self, seed: T) -> DecodeResult<Option<T::Value>>
-                where
-                    T: DeserializeSeed<'de>,
+            where
+                T: DeserializeSeed<'de>,
             {
                 if self.len > 0 {
                     self.len -= 1;
@@ -277,24 +279,23 @@ impl<'a, 'de, DE: Decoder> serde::Deserializer<'de> for Deserializer<'a, DE> {
         _variants: &'static [&'static str],
         _visitor: V,
     ) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_identifier<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> DecodeResult<V::Value>
-        where
-            V: Visitor<'de>,
+    where
+        V: Visitor<'de>,
     {
         todo!()
     }
 }
-


### PR DESCRIPTION
- Add new duck tape test that checks offset for leader epoch request on `archive` part of the log
- Add spillover manifest metadata to the `spillover_cmd` to improve reliability (the command can be validated by the STM)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none