### PR TITLE
sr: retry create ACLs for the ephemeral principal

### DIFF
--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -20,6 +20,7 @@
 #include "seastarx.h"
 #include "utils/request_auth.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
@@ -71,6 +72,7 @@ private:
     sharded_store& _store;
     ss::sharded<seq_writer>& _writer;
     std::unique_ptr<cluster::controller>& _controller;
+    ss::abort_source _as;
 
     one_shot _ensure_started;
     request_authenticator _auth;

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1365,6 +1365,9 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                                                 partition=0)
             self.logger.info(f"Restarting node: {leader}")
             self.redpanda.restart_nodes(self.redpanda.get_node(leader))
+            admin.await_stable_leader(topic="_schemas",
+                                      partition=0,
+                                      namespace="kafka")
 
         for _ in range(20):
             for n in self.redpanda.nodes:


### PR DESCRIPTION
Previously, two things were occurring in Redpanda:
1. The call to create ACLs in schema registry startup could fail
2. The `security_manager` was storing ephemeral credentials in controller snapshots

Point (1) is a problem because the ephemeral principal needs all permissions on the `_schemas` topic. The solution is to automatically retry the create ACLs request until success with a small backoff. Point (2) is a problem because, upon controller log replay, RP would re-populate the credential store with a credential that has the ephemeral username (a random string) but no principal. This would lead to authorization failures because [this line](https://github.com/redpanda-data/redpanda/blob/b9fbd636a5699175ec7169107ca42aa05c9a02b7/src/v/security/scram_authenticator.cc#L34-L35) in `scram_authenticator` will take the username as the principal when no principal is defined. The solution is to not include ephemeral credentials in snapshots. 

Fixes #11141

Changes from force-push `a64cf5c`, `b580cbe`, `64ed54a`, `12119a7`:
- Convert while loop to `ss::do_until`
- Make `retry_backoff_ms` configurable in ducktape
- (temporary) measure execution time of `_get_subjects` so we can grasp a proper timeout value for the requests library

Changes from force-push `7cc6490` and `4a0eb3c`:
- While loop is OK
- No need to make `retry_backoff_ms` configurable in ducktape
- Edit `security_manager` to not put ephemeral creds into a snapshot
- Modify `test_restarts` to wait for stable leadership of `_schemas` topic

Changes from force-push `64364a4`:
- Add an abort source from shard0
- Construct the error vector directly
- Clean up logging so we don't conflate a principal with a username
- Create the principal acl binding once and reuse it
- Use `ss::sleep_abortable`
- Timeout the create_acls retry loop after some seconds
- Change the log level of some statements

Changes from force-push `725bbed`:
- Do not share an abort source between shards
- Check the gate within the `create_acls` retry loop
- Bound the `create_acls_backoff` by 1s

Changes from force-push `9171667`:
- Put the `create_acls` retry loop in the background

Changes from force-push `e8ddbd9`:
- A regular user does not always have a principal. So make sure those users are added into the snapshot

Changes from force-push `6b0254f`:
- Switch log severity for failed create acls attempts to WARN
- Put the abort source in service.h/.cc

Changes from force-push `755dd91`:
- Check for abort requested in the acls retry loop
- Code clean up for the bug in security manager

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Fixed a bug where ephemeral credentials were stored in controller snapshots
