### PR TITLE
Update `abort_old_txes` of the consumer group to use locks

### DIFF
--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -202,6 +202,7 @@ public:
       kafka::group_id id,
       group_state s,
       config::configuration& conf,
+      ss::lw_shared_ptr<ss::basic_rwlock<>> catchup_lock,
       ss::lw_shared_ptr<cluster::partition> partition,
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
@@ -214,6 +215,7 @@ public:
       kafka::group_id id,
       group_metadata_value& md,
       config::configuration& conf,
+      ss::lw_shared_ptr<ss::basic_rwlock<>> catchup_lock,
       ss::lw_shared_ptr<cluster::partition> partition,
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
@@ -916,6 +918,7 @@ private:
     ss::timer<clock_type> _join_timer;
     bool _new_member_added;
     config::configuration& _conf;
+    ss::lw_shared_ptr<ss::basic_rwlock<>> _catchup_lock;
     ss::lw_shared_ptr<cluster::partition> _partition;
     absl::node_hash_map<
       model::topic_partition,

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -52,6 +52,7 @@ static group get() {
       group_state::empty,
       conf,
       nullptr,
+      nullptr,
       model::term_id(),
       fr,
       feature_table,


### PR DESCRIPTION
An execution of abort_old_txes could span multiple terms so the so the method could modify new state assuming it's the old state resulting in undefined behavior.

This commit is the rewrite of the reverted [f7fc026f](https://github.com/redpanda-data/redpanda/commit/f7fc026f3203da167acc0e4c95b86f2e7e082dec) in [11474](https://github.com/redpanda-data/redpanda/pull/11474). The problem was caused by:

  - do_detach_partition got blocked
  - RP ignored blocked do_detach_partition and attempted next op leading double registration of the consumer groups ntp

The op was blocked by a deadlock:

  - do_abort_old_txes was waiting for read lock while holding _gate
  - do_detach_partition was holding write lock while waiting to the gate to be closed

This version doesn't wait for the read lock to become available and exit do_abort_old_txes releasing the _gate.

It still isn't clear why RP ignored a blocked op

Fixes #11562

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none