### PR TITLE
old-backports action: use the correct variable name. [skip-ci]

### DIFF
--- a/.github/workflows/old-backports.yml
+++ b/.github/workflows/old-backports.yml
@@ -16,6 +16,6 @@ jobs:
       uses: slackapi/slack-github-action@v1.24.0
       with:
         channel-id: "C05DHDW4VCL"
-        slack-message: "Test: ${{env.MESSAGE }}"
+        slack-message: "Test: ${{ env.OUTPUT }}"
       env:
         SLACK_BOT_TOKEN: ${{ secrets.VBOTBUILDOVICH_SLACK_BOT_TOKEN }}


### PR DESCRIPTION

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
