### PR TITLE
rpk: generate password automatically in `rpk acl user create`

### DIFF
--- a/src/go/rpk/pkg/cli/acl/user/create.go
+++ b/src/go/rpk/pkg/cli/acl/user/create.go
@@ -10,7 +10,9 @@
 package user
 
 import (
+	"crypto/rand"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
@@ -62,31 +64,21 @@ acl help text for more info.
 				out.Die("missing required username argument")
 			}
 
-			// Redpanda added support for using our Kafka SASL
-			// credentials for basic auth. We use --password on
-			// commands to set the Kafka SASL password, but we also
-			// use --password here to specify the new user
-			// password. Historically, this was fine.
-			//
-			// Now, we support --new-password AND --password
-			// (--new-password was the original flag), and we add
-			// the short form -p to --new-password. Previously, -p
-			// was on --password, which meant -p and --password set
-			// the same value and we could not tell.
-			//
-			// Now, if we detect --user, we require --new-password
-			// (or -p). If we only see --password (i.e. only
-			// "password" is set), we fail.
-			//
-			// See #6360.
-			//
-			// Better long term is for people to use -X.
 			userFlag := cmd.Flag(config.FlagSASLUser).Value.String()
-			if userFlag != "" && newPass == "" {
-				out.Die("unable to create user when using basic auth, use --new-password to specify the new user's password")
+			pass = cmd.Flag("password").Value.String()
+			var generated bool
+			// We either run the command without password:
+			//   rpk acl user create foo
+			// Or we run the command with user/password for basic auth:
+			//   rpk acl user create foo --user my_user --pass my_pass
+			// In both cases, we auto-generate a random password:
+			if (newPass == "" && pass == "") || (newPass == "" && userFlag != "" && pass != "") {
+				gen, err := generatePassword(30)
+				out.MaybeDie(err, "unable to generate a password: %v; you can specify your own password using the '--password' flag", err)
+				pass = gen
+				generated = true
 			}
 
-			pass = cmd.Flag("password").Value.String()
 			if newPass != "" {
 				pass = newPass
 			}
@@ -103,6 +95,11 @@ acl help text for more info.
 			err = cl.CreateUser(cmd.Context(), user, pass, mechanism)
 			out.MaybeDie(err, "unable to create user %q: %v", user, err)
 			fmt.Printf("Created user %q.\n", user)
+			if generated {
+				fmt.Println("Automatically generated password:")
+				// In a new line so it can be easily 'tail -1'-ed
+				fmt.Println(pass)
+			}
 		},
 	}
 
@@ -122,4 +119,24 @@ acl help text for more info.
 	cmd.Flags().StringVar(&mechanism, "mechanism", strings.ToLower(admin.ScramSha256), "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive)")
 
 	return cmd
+}
+
+func generatePassword(passLength int) (string, error) {
+	lowercase := "abcdefghijklmnopqrstuvwxyz"
+	uppercase := strings.ToUpper(lowercase)
+	numbers := "0123456789"
+	special := ".,&_+|[]/-()"
+	allCharSet := lowercase + uppercase + numbers + special
+
+	randSize := big.NewInt(int64(len(allCharSet)))
+	var pass string
+	for i := 0; i < passLength; i++ {
+		r, err := rand.Int(rand.Reader, randSize)
+		if err != nil {
+			return "", fmt.Errorf("unable to generate secure random number: %v", err)
+		}
+		pass += string(allCharSet[r.Int64()])
+	}
+
+	return pass, nil
 }

--- a/src/go/rpk/pkg/cli/acl/user/create.go
+++ b/src/go/rpk/pkg/cli/acl/user/create.go
@@ -125,8 +125,7 @@ func generatePassword(passLength int) (string, error) {
 	lowercase := "abcdefghijklmnopqrstuvwxyz"
 	uppercase := strings.ToUpper(lowercase)
 	numbers := "0123456789"
-	special := ".,&_+|[]/-()"
-	allCharSet := lowercase + uppercase + numbers + special
+	allCharSet := lowercase + uppercase + numbers
 
 	randSize := big.NewInt(int64(len(allCharSet)))
 	var pass string

--- a/src/go/rpk/pkg/cli/acl/user/create.go
+++ b/src/go/rpk/pkg/cli/acl/user/create.go
@@ -83,9 +83,10 @@ acl help text for more info.
 			// Better long term is for people to use -X.
 			userFlag := cmd.Flag(config.FlagSASLUser).Value.String()
 			if userFlag != "" && newPass == "" {
-				out.Die("unable to create user with when using basic auth, use --new-password to specify the new user's password")
+				out.Die("unable to create user when using basic auth, use --new-password to specify the new user's password")
 			}
 
+			pass = cmd.Flag("password").Value.String()
 			if newPass != "" {
 				pass = newPass
 			}
@@ -108,7 +109,13 @@ acl help text for more info.
 	cmd.Flags().StringVar(&userOld, "new-username", "", "")
 	cmd.Flags().MarkHidden("new-username")
 
-	cmd.Flags().StringVar(&pass, "password", "", "New user's password (NOTE: if using --password for the admin API, use --new-password)")
+	// This is needed here in order to show the password flag with a different
+	// usage text for this command only.
+	p.InstallKafkaFlags(cmd)
+	passwordFlag := cmd.PersistentFlags().Lookup("password")
+	passwordFlag.Usage = "New user's password (NOTE: if using --password for the admin API, use --new-password)"
+	passwordFlag.Hidden = false
+
 	cmd.Flags().StringVarP(&newPass, "new-password", "p", "", "")
 	cmd.Flags().MarkHidden("new-password")
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -272,10 +272,33 @@ class RpkTool:
         ]
         return self._run(cmd)
 
-    def sasl_create_user(self, new_username, new_password, mechanism):
-        cmd = ["acl", "user", "create", new_username, "-p", new_password]
+    def _sasl_create_user_cmd(self, new_username, new_password, mechanism):
+        cmd = ["acl", "user", "create", new_username]
         cmd += ["--api-urls", self._redpanda.admin_endpoints()]
         cmd += ["--mechanism", mechanism]
+
+        if new_password != "":
+            cmd += ["-p", new_password]
+
+        return cmd
+
+    def sasl_create_user(self,
+                         new_username,
+                         new_password="",
+                         mechanism="SCRAM-SHA-256"):
+        cmd = self._sasl_create_user_cmd(new_username, new_password, mechanism)
+
+        return self._run(cmd)
+
+    def sasl_create_user_basic(self,
+                               new_username,
+                               auth_user="",
+                               auth_password="",
+                               new_password="",
+                               mechanism="SCRAM-SHA-256"):
+        cmd = self._sasl_create_user_cmd(new_username, new_password, mechanism)
+        cmd += ["--user", auth_user, "--password", auth_password]
+
         return self._run(cmd)
 
     def sasl_update_user(self, user, new_password):

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -74,3 +74,38 @@ class RpkACLTest(RedpandaTest):
 
         # We check that we can list the topics with the new password:
         assert topic in topic_list_two
+
+    @cluster(num_nodes=1)
+    def test_create_user_no_pass(self):
+        # No password
+        out = self._rpk.sasl_create_user(new_username="foo_1",
+                                         mechanism=self.mechanism)
+        assert "Automatically generated password" in out
+
+        # with --new-password
+        out = self._rpk.sasl_create_user(new_username="foo_2",
+                                         new_password="any-pass",
+                                         mechanism=self.mechanism)
+        assert "Automatically generated password" not in out
+
+        # with --user and --password, NO --new-password
+        out = self._rpk.sasl_create_user_basic(new_username="foo_3",
+                                               auth_user="anyUser",
+                                               auth_password="any_pw",
+                                               mechanism=self.mechanism)
+        assert "Automatically generated password" in out
+
+        # with --password AND --new-password, NO --user
+        out = self._rpk.sasl_create_user_basic(new_username="foo_4",
+                                               new_password="my_pass",
+                                               auth_password="any_pw",
+                                               mechanism=self.mechanism)
+        assert "Automatically generated password" not in out
+
+        # with --new-password, --user, and --password
+        out = self._rpk.sasl_create_user_basic(new_username="foo_5",
+                                               new_password="my_pass",
+                                               auth_user="anyUser",
+                                               auth_password="any_pw",
+                                               mechanism=self.mechanism)
+        assert "Automatically generated password" not in out


### PR DESCRIPTION
This PR adds the ability to auto-generate a secure random password when you create an user without providing the password:

### Usage:

```
$ rpk acl user create foo           
Created user "foo".
Automatically generated password:
klyTO)sF80JnkAxaARG+6DN6ro,9XX
```

This behavior matches how it's done in Redpanda Console.

The generated password gets printed to stdout in the last line in case you automate the process you can pipe it to `tail -1`.

You can still select your password using `-p / --new-password` flag.

Fixes #11235 

The first commit also fixes a minor bug when using --password along with --new-password.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features

* rpk now generate a password automatically when running `rpk acl user create` with no password
