### PR TITLE
kafka: fix cloud storage support for delete-records

### DIFF
--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -672,7 +672,8 @@ async_manifest_view::compute_retention(
     }
     if (
       _stm_manifest.get_start_kafka_offset_override() != kafka::offset{}
-      && _stm_manifest.get_start_kafka_offset_override() > result.offset) {
+      && _stm_manifest.get_start_kafka_offset_override()
+           > result.offset - result.delta) {
         // The start kafka offset is placed above the retention boundary. We
         // need to adjust retention boundary to remove all data up to start
         // kafka offset.

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -690,6 +690,10 @@ async_manifest_view::compute_retention(
               r.error());
         }
         result = r.value();
+        vlog(
+          _ctxlog.debug,
+          "Found offset {} to advance start offset to",
+          result.offset);
     }
     co_return result;
 }
@@ -704,7 +708,7 @@ async_manifest_view::offset_based_retention() noexcept {
         if (res.has_failure() && res.error() != error_outcome::out_of_range) {
             vlog(
               _ctxlog.error,
-              "Failed to compute time-based retention {}",
+              "Failed to compute offset-based retention {}",
               res.error());
             co_return res.as_failure();
         }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -368,11 +368,11 @@ public:
     /// \brief Set start kafka offset without removing any data from the
     /// manifest.
     ///
-    /// Allows to move start_kafka_offset forward
-    /// freely. The corresponding start_offset value is moved
-    /// to the closest aligned offset.
-    /// \returns true if start_offset was moved
-    bool advance_start_kafka_offset(kafka::offset start_offset);
+    /// Allows start_kafka_offset to move forward freely, without changing
+    /// start_offset.
+    ///
+    /// \returns true if start_kafka_offset was moved
+    bool advance_start_kafka_offset(kafka::offset new_start_offset);
 
     /// \brief Resets the state of the manifest to the default constructed
     /// state.

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ rp_test(
     remote_partition_test.cc
     topic_recovery_service_test.cc
     cloud_storage_e2e_test.cc
+    delete_records_e2e_test.cc
     async_manifest_view_test.cc
     read_replica_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/ntp_archiver_service.h"
+#include "cloud_storage/spillover_manifest.h"
+#include "cloud_storage/tests/produce_utils.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "config/configuration.h"
+#include "kafka/server/tests/delete_records_utils.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "model/fundamental.h"
+#include "redpanda/tests/fixture.h"
+#include "storage/disk_log_impl.h"
+
+#include <seastar/core/io_priority_class.hh>
+
+#include <absl/container/flat_hash_set.h>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <iterator>
+
+using tests::kafka_consume_transport;
+using tests::kafka_delete_records_transport;
+
+static ss::logger e2e_test_log("delete_records_e2e_test");
+
+namespace {
+
+void check_consume_out_of_range(
+  kafka_consume_transport& consumer,
+  const model::topic& topic_name,
+  const model::partition_id pid,
+  model::offset kafka_offset) {
+    BOOST_REQUIRE_EXCEPTION(
+      consumer.consume_from_partition(topic_name, pid, kafka_offset).get(),
+      std::runtime_error,
+      [](std::runtime_error e) {
+          return std::string(e.what()).find("out_of_range")
+                 != std::string::npos;
+      });
+};
+
+} // namespace
+
+class delete_records_e2e_fixture
+  : public s3_imposter_fixture
+  , public redpanda_thread_fixture
+  , public enable_cloud_storage_fixture {
+public:
+    static constexpr auto segs_per_spill = 10;
+    delete_records_e2e_fixture()
+      : redpanda_thread_fixture(
+        redpanda_thread_fixture::init_cloud_storage_tag{},
+        httpd_port_number()) {
+        // No expectations: tests will PUT and GET organically.
+        set_expectations_and_listen({});
+        wait_for_controller_leadership().get();
+
+        // Apply local retention frequently.
+        config::shard_local_cfg().log_compaction_interval_ms.set_value(
+          std::chrono::duration_cast<std::chrono::milliseconds>(1s));
+        // We'll control uploads ourselves.
+        config::shard_local_cfg()
+          .cloud_storage_enable_segment_merging.set_value(false);
+        config::shard_local_cfg()
+          .cloud_storage_disable_upload_loop_for_tests.set_value(true);
+        // Disable metrics to speed things up.
+        config::shard_local_cfg().enable_metrics_reporter.set_value(false);
+        // Encourage spilling over.
+        config::shard_local_cfg()
+          .cloud_storage_spillover_manifest_max_segments.set_value(
+            std::make_optional<size_t>(segs_per_spill));
+        config::shard_local_cfg()
+          .cloud_storage_spillover_manifest_size.set_value(
+            std::optional<size_t>{});
+
+        topic_name = model::topic("tapioca");
+        ntp = model::ntp(model::kafka_namespace, topic_name, 0);
+
+        // Create a tiered storage topic with very little local retention.
+        cluster::topic_properties props;
+        props.shadow_indexing = model::shadow_indexing_mode::full;
+        props.retention_local_target_bytes = tristate<size_t>(1);
+        props.cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::deletion;
+        add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+        wait_for_leader(ntp).get();
+        partition = app.partition_manager.local().get(ntp).get();
+        log = dynamic_cast<storage::disk_log_impl*>(
+          partition->log().get_impl());
+        auto archiver_ref = partition->archiver();
+        BOOST_REQUIRE(archiver_ref.has_value());
+        archiver = &archiver_ref.value().get();
+    }
+
+    model::topic topic_name;
+    model::ntp ntp;
+    cluster::partition* partition;
+    storage::disk_log_impl* log;
+    archival::ntp_archiver* archiver;
+};
+
+// Test consuming after truncating the STM manifest.
+FIXTURE_TEST(test_delete_from_stm_consume, delete_records_e2e_fixture) {
+    // Create a segment with three distinct batches.
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    BOOST_REQUIRE_EQUAL(
+      9, gen.num_segments(3).batches_per_segment(3).produce().get());
+    BOOST_REQUIRE_EQUAL(3, archiver->manifest().size());
+
+    // Delete in the middle of a segment.
+    kafka_delete_records_transport deleter(make_kafka_client("deleter").get());
+    deleter.start().get();
+    auto lwm = deleter
+                 .delete_records_from_partition(
+                   topic_name, model::partition_id(0), model::offset(1), 5s)
+                 .get();
+    BOOST_CHECK_EQUAL(model::offset(1), lwm);
+    tests::cooperative_spin_wait_with_timeout(3s, [this] {
+        return log->segment_count() == 1;
+    }).get();
+
+    kafka_consume_transport consumer(make_kafka_client().get());
+    consumer.start().get();
+    auto consumed_records = consumer
+                              .consume_from_partition(
+                                topic_name,
+                                model::partition_id(0),
+                                model::offset(1))
+                              .get();
+    BOOST_CHECK_GE(consumed_records.size(), 2);
+    BOOST_CHECK_EQUAL("key1", consumed_records[0].key);
+    BOOST_CHECK_EQUAL("val1", consumed_records[0].val);
+    BOOST_CHECK_EQUAL("key2", consumed_records[1].key);
+    BOOST_CHECK_EQUAL("val2", consumed_records[1].val);
+    check_consume_out_of_range(
+      consumer, topic_name, model::partition_id(0), model::offset(0));
+}
+
+// Test consuming after truncating the archive manifests.
+FIXTURE_TEST(test_delete_from_archive_consume, delete_records_e2e_fixture) {
+    auto partition = app.partition_manager.local().get(ntp);
+    auto& archiver = partition->archiver()->get();
+    archiver.sync_for_tests().get();
+
+    const auto records_per_seg = 5;
+    const auto num_segs = 40;
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto total_records = gen.num_segments(num_segs)
+                           .batches_per_segment(records_per_seg)
+                           .produce()
+                           .get();
+    BOOST_REQUIRE_GE(total_records, 200);
+    archiver.apply_spillover().get();
+    auto& stm_manifest = archiver.manifest();
+    BOOST_REQUIRE_EQUAL(
+      stm_manifest.get_archive_start_offset(), model::offset(0));
+    BOOST_REQUIRE_GT(
+      stm_manifest.get_start_offset(), stm_manifest.get_archive_start_offset());
+    BOOST_REQUIRE_EQUAL(
+      stm_manifest.get_spillover_map().size(), num_segs / segs_per_spill - 1);
+    BOOST_REQUIRE_EQUAL(stm_manifest.size(), segs_per_spill);
+    BOOST_REQUIRE_EQUAL(
+      archiver.upload_manifest("test").get(),
+      cloud_storage::upload_result::success);
+    archiver.flush_manifest_clean_offset().get();
+
+    // Delete at every offset, ensuring we consume properly at each offset.
+    kafka_delete_records_transport deleter(make_kafka_client().get());
+    deleter.start().get();
+    kafka_consume_transport consumer(make_kafka_client().get());
+    consumer.start().get();
+    for (size_t i = 1; i < total_records; i++) {
+        auto lwm = deleter
+                     .delete_records_from_partition(
+                       topic_name, model::partition_id(0), model::offset(i), 5s)
+                     .get();
+        BOOST_REQUIRE_EQUAL(model::offset(i), lwm);
+        check_consume_out_of_range(
+          consumer, topic_name, model::partition_id(0), model::offset(i - 1));
+        auto consumed_records = consumer
+                                  .consume_from_partition(
+                                    topic_name,
+                                    model::partition_id(0),
+                                    model::offset(i))
+                                  .get();
+        BOOST_REQUIRE(!consumed_records.empty());
+        auto key = consumed_records[0].key;
+        BOOST_REQUIRE_EQUAL(key, ssx::sformat("key{}", i));
+    }
+}

--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -27,7 +27,11 @@ public:
       , _partition(partition) {}
 
     remote_segment_generator& num_segments(size_t n) {
-        _num_segs = n;
+        _num_remote_segs = n;
+        return *this;
+    }
+    remote_segment_generator& additional_local_segments(size_t n) {
+        _num_local_segs = n;
         return *this;
     }
     remote_segment_generator& records_per_batch(size_t r) {
@@ -53,7 +57,8 @@ public:
         auto& archiver = _partition.archiver().value().get();
 
         size_t total_records = 0;
-        while (_partition.archival_meta_stm()->manifest().size() < _num_segs) {
+        while (_partition.archival_meta_stm()->manifest().size()
+               < _num_remote_segs) {
             for (size_t i = 0; i < _batches_per_seg; i++) {
                 std::vector<kv_t> records = kv_t::sequence(
                   total_records, _records_per_batch);
@@ -90,13 +95,29 @@ public:
             co_return -1;
         }
         co_await archiver.flush_manifest_clean_offset();
+        for (int i = 0; i < _num_local_segs; i++) {
+            for (size_t i = 0; i < _batches_per_seg; i++) {
+                std::vector<kv_t> records = kv_t::sequence(
+                  total_records, _records_per_batch);
+                total_records += _records_per_batch;
+                co_await _producer.produce_to_partition(
+                  _partition.ntp().tp.topic,
+                  _partition.ntp().tp.partition,
+                  std::move(records));
+            }
+            co_await log->flush();
+            co_await log->force_roll(ss::default_priority_class());
+        }
         co_return total_records;
     }
 
 private:
     kafka_produce_transport _producer;
     cluster::partition& _partition;
-    size_t _num_segs{1};
+    // Number of remote segments to create.
+    size_t _num_remote_segs{1};
+    // Number of additional local segments to create.
+    size_t _num_local_segs{0};
     size_t _records_per_batch{1};
     size_t _batches_per_seg{1};
 };

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -14,6 +14,7 @@
 #include "cloud_storage/tests/produce_utils.h"
 #include "cloud_storage/tests/s3_imposter.h"
 #include "config/configuration.h"
+#include "kafka/server/tests/delete_records_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
 #include "redpanda/tests/fixture.h"
@@ -118,4 +119,98 @@ FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
             next += model::offset(1);
         }
     }
+}
+
+FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.retention_local_target_bytes = tristate<size_t>(1);
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    // Produce records to the source.
+    auto partition = app.partition_manager.local().get(ntp).get();
+    auto& archiver = partition->archiver()->get();
+    BOOST_REQUIRE(archiver.sync_for_tests().get());
+    archiver.upload_topic_manifest().get();
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    BOOST_REQUIRE_EQUAL(
+      30, gen.batches_per_segment(10).num_segments(3).produce().get());
+    BOOST_REQUIRE_EQUAL(3, archiver.manifest().size());
+
+    // NOTE: we're creating the deleter here before starting the read replica
+    // fixture because make_kafka_client() uses global configs that will be
+    // overwritten by the new fixture.
+    tests::kafka_delete_records_transport deleter(make_kafka_client().get());
+
+    auto rr_rp = start_read_replica_fixture();
+    cluster::topic_properties read_replica_props;
+    read_replica_props.shadow_indexing = model::shadow_indexing_mode::fetch;
+    read_replica_props.read_replica = true;
+    read_replica_props.read_replica_bucket = "test-bucket";
+    rr_rp
+      ->add_topic({model::kafka_namespace, topic_name}, 1, read_replica_props)
+      .get();
+    rr_rp->wait_for_leader(ntp).get();
+    auto rr_partition = rr_rp->app.partition_manager.local().get(ntp).get();
+    auto& rr_archiver = rr_partition->archiver()->get();
+
+    // Do an initial sync to download the manifest.
+    BOOST_REQUIRE(rr_archiver.sync_for_tests().get());
+    rr_archiver.sync_manifest().get();
+    BOOST_REQUIRE_EQUAL(3, rr_archiver.manifest().size());
+
+    kafka_consume_transport consumer(rr_rp->make_kafka_client().get());
+    consumer.start().get();
+    auto consumed_records = consumer
+                              .consume_from_partition(
+                                topic_name,
+                                model::partition_id(0),
+                                model::offset(28))
+                              .get();
+    BOOST_REQUIRE(!consumed_records.empty());
+    BOOST_CHECK_EQUAL("key28", consumed_records[0].key);
+    BOOST_CHECK_EQUAL("val28", consumed_records[0].val);
+
+    // DeleteRecords on the source cluster.
+    deleter.start().get();
+    auto new_start = model::offset(29);
+    BOOST_REQUIRE_EQUAL(
+      new_start,
+      deleter
+        .delete_records_from_partition(
+          topic_name, model::partition_id(0), new_start, 5s)
+        .get());
+    BOOST_REQUIRE_EQUAL(
+      cloud_storage::upload_result::success,
+      archiver.upload_manifest("test").get());
+    archiver.flush_manifest_clean_offset().get();
+
+    // Once synced on the read replica, it should fail to be read.
+    BOOST_REQUIRE(rr_archiver.sync_for_tests().get());
+    BOOST_REQUIRE_EQUAL(
+      cloud_storage::download_result::success,
+      rr_archiver.sync_manifest().get());
+    BOOST_REQUIRE_EQUAL(3, rr_archiver.manifest().size());
+    BOOST_REQUIRE_EXCEPTION(
+      consumer
+        .consume_from_partition(
+          topic_name, model::partition_id(0), model::offset(28))
+        .get(),
+      std::runtime_error,
+      [](std::runtime_error e) {
+          return std::string(e.what()).find("out_of_range")
+                 != std::string::npos;
+      });
+    consumed_records = consumer
+                         .consume_from_partition(
+                           topic_name,
+                           model::partition_id(0),
+                           model::offset(29))
+                         .get();
+    BOOST_REQUIRE(!consumed_records.empty());
+    BOOST_CHECK_EQUAL("key29", consumed_records[0].key);
+    BOOST_CHECK_EQUAL("val29", consumed_records[0].val);
 }

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -15,6 +15,7 @@
 #include "cloud_storage/tests/s3_imposter.h"
 #include "config/configuration.h"
 #include "kafka/server/tests/delete_records_utils.h"
+#include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
 #include "redpanda/tests/fixture.h"
@@ -213,4 +214,84 @@ FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
     BOOST_REQUIRE(!consumed_records.empty());
     BOOST_CHECK_EQUAL("key29", consumed_records[0].key);
     BOOST_CHECK_EQUAL("val29", consumed_records[0].val);
+}
+
+FIXTURE_TEST(
+  test_read_replica_delete_records_in_local, read_replica_e2e_fixture) {
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.retention_local_target_bytes = tristate<size_t>(1);
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp).get();
+    auto& archiver = partition->archiver()->get();
+    BOOST_REQUIRE(archiver.sync_for_tests().get());
+    archiver.upload_topic_manifest().get();
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    BOOST_REQUIRE_EQUAL(
+      40,
+      gen.batches_per_segment(10)
+        .num_segments(3)
+        .additional_local_segments(1)
+        .produce()
+        .get());
+    BOOST_REQUIRE_EQUAL(3, archiver.manifest().size());
+    auto highest_kafka_offset_in_cloud
+      = archiver.manifest().get_last_kafka_offset().value();
+
+    // DeleteRecords in the region of the log that hasn't yet been uploaded.
+    tests::kafka_delete_records_transport deleter(make_kafka_client().get());
+    deleter.start().get();
+    auto new_start = model::offset(35);
+    BOOST_REQUIRE_EQUAL(
+      new_start,
+      deleter
+        .delete_records_from_partition(
+          topic_name, model::partition_id(0), new_start, 5s)
+        .get());
+
+    // Persist the deletion to the cloud without uploading the segments.
+    BOOST_REQUIRE_EQUAL(
+      cloud_storage::upload_result::success,
+      archiver.upload_manifest("test").get());
+    archiver.flush_manifest_clean_offset().get();
+
+    tests::kafka_list_offsets_transport lister(make_kafka_client().get());
+    lister.start().get();
+    auto lwm = lister
+                 .start_offset_for_partition(topic_name, model::partition_id(0))
+                 .get();
+    BOOST_REQUIRE_EQUAL(lwm, new_start);
+
+    // A read replica will get the override, but be clamped to the highest
+    // offset in uploaded segments.
+    auto rr_rp = start_read_replica_fixture();
+    cluster::topic_properties read_replica_props;
+    read_replica_props.shadow_indexing = model::shadow_indexing_mode::fetch;
+    read_replica_props.read_replica = true;
+    read_replica_props.read_replica_bucket = "test-bucket";
+    rr_rp
+      ->add_topic({model::kafka_namespace, topic_name}, 1, read_replica_props)
+      .get();
+    rr_rp->wait_for_leader(ntp).get();
+    auto rr_partition = rr_rp->app.partition_manager.local().get(ntp).get();
+    auto& rr_archiver = rr_partition->archiver()->get();
+    rr_archiver.sync_manifest().get();
+
+    tests::kafka_list_offsets_transport rr_lister(make_kafka_client().get());
+    rr_lister.start().get();
+    auto rr_hwm = rr_lister
+                    .high_watermark_for_partition(
+                      topic_name, model::partition_id(0))
+                    .get();
+    BOOST_REQUIRE_EQUAL(
+      rr_hwm,
+      model::next_offset(kafka::offset_cast(highest_kafka_offset_in_cloud)));
+    auto rr_lwm
+      = rr_lister.start_offset_for_partition(topic_name, model::partition_id(0))
+          .get();
+    BOOST_REQUIRE_EQUAL(rr_lwm, rr_hwm);
 }

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -191,6 +191,10 @@ struct segment_meta {
         return model::next_offset(committed_offset) - delta;
     }
 
+    kafka::offset last_kafka_offset() const {
+        return next_kafka_offset() - kafka::offset(1);
+    }
+
     auto operator<=>(const segment_meta&) const = default;
 };
 std::ostream& operator<<(std::ostream& o, const segment_meta& r);

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -267,8 +267,8 @@ command_batch_builder::truncate(model::offset start_rp_offset) {
     return *this;
 }
 
-command_batch_builder&
-command_batch_builder::truncate(kafka::offset start_kafka_offset) {
+command_batch_builder& command_batch_builder::update_start_kafka_offset(
+  kafka::offset start_kafka_offset) {
     iobuf key_buf = serde::to_iobuf(
       archival_metadata_stm::update_start_kafka_offset_cmd::key);
     auto record_val
@@ -528,7 +528,7 @@ ss::future<std::error_code> archival_metadata_stm::truncate(
   ss::lowres_clock::time_point deadline,
   ss::abort_source& as) {
     auto builder = batch_start(deadline, as);
-    builder.truncate(start_kafka_offset);
+    builder.update_start_kafka_offset(start_kafka_offset);
     co_return co_await builder.replicate();
 }
 

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -16,6 +16,7 @@
 #include "cluster/errc.h"
 #include "cluster/logger.h"
 #include "cluster/persisted_stm.h"
+#include "cluster/prefix_truncate_record.h"
 #include "config/configuration.h"
 #include "features/feature_table.h"
 #include "model/fundamental.h"
@@ -708,6 +709,27 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
 }
 
 ss::future<> archival_metadata_stm::apply(model::record_batch b) {
+    if (b.header().type == model::record_batch_type::prefix_truncate) {
+        // Special case handling for prefix_truncate batches: these originate
+        // in log_eviction_stm, but affect the entire partition, local and
+        // cloud storage alike. Despite the record originating elsewhere, note
+        // that the STM is still deterministic, as records are applied in
+        // order and are not allowed to fail.
+        b.for_each_record(
+          [this, base_offset = b.base_offset()](model::record&& r) {
+              _last_dirty_at = base_offset + model::offset{r.offset_delta()};
+              auto key = serde::from_iobuf<uint8_t>(r.release_key());
+              auto val = serde::from_iobuf<prefix_truncate_record>(
+                r.release_value());
+              if (key == prefix_truncate_key) {
+                  // The archival layer can't translate arbitrary redpanda
+                  // offsets, so just pass through the Kafka offset as is.
+                  apply_update_start_kafka_offset(val.kafka_start_offset);
+              }
+          });
+        _insync_offset = b.last_offset();
+        co_return;
+    }
     if (b.header().type != model::record_batch_type::archival_metadata) {
         _insync_offset = b.last_offset();
         co_return;

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -1055,19 +1055,9 @@ void archival_metadata_stm::apply_update_start_kafka_offset(kafka::offset so) {
     if (!_manifest->advance_start_kafka_offset(so)) {
         vlog(
           _logger.error,
-          "Can't truncate manifest up to kafka offset {}, offset out of range, "
-          "current start kafka offset: {}, start offset: {}, archive start "
-          "offset: {}",
+          "Can't apply override to kafka start offset {}, currently {}",
           so,
-          get_start_kafka_offset(),
-          get_start_offset(),
-          get_archive_start_offset());
-    } else {
-        vlog(
-          _logger.debug,
-          "Start kafka offset updated to {}, start offset updated to {}",
-          get_start_kafka_offset(),
-          get_start_offset());
+          manifest().get_start_kafka_offset_override());
     }
 }
 

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -62,7 +62,9 @@ public:
     command_batch_builder& mark_clean(model::offset);
     /// Add truncate command to the batch
     command_batch_builder& truncate(model::offset start_rp_offset);
-    command_batch_builder& truncate(kafka::offset start_kafka_offset);
+    /// Update the kafka start offset override.
+    command_batch_builder&
+    update_start_kafka_offset(kafka::offset start_kafka_offset);
     /// Add spillover command to the batch
     command_batch_builder& spillover(const cloud_storage::segment_meta& meta);
     /// Add truncate-archive-init command to the batch

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -158,7 +158,8 @@ ss::future<> log_eviction_stm::do_write_raft_snapshot(model::offset index_lb) {
 }
 
 ss::future<result<model::offset, std::error_code>>
-log_eviction_stm::sync_effective_start(model::timeout_clock::duration timeout) {
+log_eviction_stm::sync_start_offset_override(
+  model::timeout_clock::duration timeout) {
     /// Call this method to ensure followers have processed up until the
     /// most recent known version of the special batch. This is particularly
     /// useful to know if the start offset is up to date in the case
@@ -171,7 +172,7 @@ log_eviction_stm::sync_effective_start(model::timeout_clock::duration timeout) {
             co_return errc::timeout;
         }
     }
-    co_return effective_start_offset();
+    co_return start_offset_override();
 }
 
 model::offset log_eviction_stm::effective_start_offset() const {

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -85,8 +85,18 @@ public:
 
     /// Ensure followers have processed up until the most recent known version
     /// of the batch representing the start offset
+    /// This only returns the start override, if one exists. It does not take
+    /// into account local storage, and may not even point to an offset that
+    /// exists in local storage (e.g. if we have locally truncated).
     ss::future<result<model::offset, std::error_code>>
-    sync_effective_start(model::timeout_clock::duration timeout);
+    sync_start_offset_override(model::timeout_clock::duration timeout);
+
+    model::offset start_offset_override() const {
+        if (_delete_records_eviction_offset == model::offset{}) {
+            return model::offset{};
+        }
+        return model::next_offset(_delete_records_eviction_offset);
+    }
 
 protected:
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -58,7 +58,8 @@ public:
     /// when read by brokers, will invoke a routine that will perform the
     /// deletion
     ss::future<std::error_code> truncate(
-      model::offset kafka_offset,
+      model::offset rp_start_offset,
+      kafka::offset kafka_start_offset,
       ss::lowres_clock::time_point deadline,
       std::optional<std::reference_wrapper<ss::abort_source>> as
       = std::nullopt);

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -177,8 +177,8 @@ partition::partition(
 partition::~partition() {}
 
 ss::future<std::error_code> partition::prefix_truncate(
-  model::offset truncation_offset,
-  kafka::offset kafka_truncation_offset,
+  model::offset rp_start_offset,
+  kafka::offset kafka_start_offset,
   ss::lowres_clock::time_point deadline) {
     if (!_log_eviction_stm) {
         vlog(
@@ -208,21 +208,26 @@ ss::future<std::error_code> partition::prefix_truncate(
       clusterlog.info,
       "Truncating {} to redpanda offset {} kafka offset {}",
       _raft->ntp(),
-      truncation_offset,
-      kafka_truncation_offset);
-    if (truncation_offset != model::offset{}) {
-        auto err = co_await _log_eviction_stm->truncate(
-          truncation_offset, deadline, _as);
-        if (err) {
-            co_return err;
-        }
+      rp_start_offset,
+      kafka_start_offset);
+    auto err = co_await _log_eviction_stm->truncate(
+      rp_start_offset, kafka_start_offset, deadline, _as);
+    if (err) {
+        co_return err;
     }
-    // TODO(awong): have archival listen on log_eviction_stm.
     if (_archival_meta_stm) {
-        co_return co_await _archival_meta_stm->truncate(
-          kafka_truncation_offset, deadline, _as);
+        // The archival metadata stm also listens for prefix_truncate batches.
+        auto applied = co_await _archival_meta_stm->wait_no_throw(
+          _raft->committed_offset(), deadline, _as);
+        if (applied) {
+            co_return errc::success;
+        }
+        if (_as.abort_requested()) {
+            co_return errc::shutting_down;
+        }
+        co_return errc::timeout;
     }
-    co_return cluster::errc::success;
+    co_return errc::success;
 }
 
 ss::future<std::vector<rm_stm::tx_range>> partition::aborted_transactions_cloud(

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -188,14 +188,6 @@ ss::future<std::error_code> partition::prefix_truncate(
           _raft->ntp());
         co_return make_error_code(errc::topic_invalid_config);
     }
-    if (_archival_meta_stm) {
-        vlog(
-          clusterlog.info,
-          "Cannot prefix-truncate topic/partition {} cloud settings are "
-          "applied",
-          _raft->ntp());
-        co_return make_error_code(errc::topic_invalid_config);
-    }
     if (!feature_table().local().is_active(features::feature::delete_records)) {
         vlog(
           clusterlog.info,

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -94,7 +94,7 @@ public:
 
     ss::future<result<model::offset, std::error_code>>
     sync_kafka_start_offset_override(model::timeout_clock::duration timeout) {
-        if (_log_eviction_stm) {
+        if (_log_eviction_stm && !is_read_replica_mode_enabled()) {
             auto offset_res
               = co_await _log_eviction_stm->sync_start_offset_override(timeout);
             if (offset_res.has_failure()) {
@@ -339,7 +339,7 @@ public:
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
     std::optional<model::offset> kafka_start_offset_override() const {
-        if (_log_eviction_stm) {
+        if (_log_eviction_stm && !is_read_replica_mode_enabled()) {
             auto o = _log_eviction_stm->start_offset_override();
             if (o != model::offset{} && _raft->start_offset() < o) {
                 auto offset_translator_state = get_offset_translator_state();

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -73,8 +73,8 @@ public:
 
     /// Truncate the beginning of the log up until a given offset
     /// Can only be performed on logs that are deletable and non internal
-    ss::future<std::error_code>
-    prefix_truncate(model::offset o, ss::lowres_clock::time_point deadline);
+    ss::future<std::error_code> prefix_truncate(
+      model::offset o, kafka::offset ko, ss::lowres_clock::time_point deadline);
 
     kafka_stages replicate_in_stages(
       model::batch_identity,
@@ -103,8 +103,9 @@ public:
             // The eviction STM only keeps track of DeleteRecords truncations
             // as Raft offsets. Translate if possible.
             auto offset_translator_state = get_offset_translator_state();
-            if (offset_res.value() != model::offset{} &&
-                _raft->start_offset() < offset_res.value()) {
+            if (
+              offset_res.value() != model::offset{}
+              && _raft->start_offset() < offset_res.value()) {
                 auto start_kafka_offset
                   = offset_translator_state->from_log_offset(
                     offset_res.value());

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -93,19 +93,45 @@ public:
     }
 
     ss::future<result<model::offset, std::error_code>>
-    sync_effective_start(model::timeout_clock::duration timeout) {
+    sync_kafka_start_offset_override(model::timeout_clock::duration timeout) {
         if (_log_eviction_stm) {
-            co_return co_await _log_eviction_stm->sync_effective_start(timeout);
+            auto offset_res
+              = co_await _log_eviction_stm->sync_start_offset_override(timeout);
+            if (offset_res.has_failure()) {
+                co_return offset_res.as_failure();
+            }
+            // The eviction STM only keeps track of DeleteRecords truncations
+            // as Raft offsets. Translate if possible.
+            auto offset_translator_state = get_offset_translator_state();
+            if (offset_res.value() != model::offset{} &&
+                _raft->start_offset() < offset_res.value()) {
+                auto start_kafka_offset
+                  = offset_translator_state->from_log_offset(
+                    offset_res.value());
+                co_return start_kafka_offset;
+            }
+            // If a start override is no longer in the offset translator state,
+            // it may have been uploaded and persisted in the manifest.
         }
-        co_return raft_start_offset();
+        if (_archival_meta_stm) {
+            auto term = _raft->term();
+            if (!co_await _archival_meta_stm->sync(timeout)) {
+                if (term != _raft->term()) {
+                    co_return errc::not_leader;
+                } else {
+                    co_return errc::timeout;
+                }
+            }
+            auto start_kafka_offset = _archival_meta_stm->manifest()
+                                        .get_start_kafka_offset_override();
+            if (start_kafka_offset != kafka::offset{}) {
+                co_return kafka::offset_cast(start_kafka_offset);
+            }
+        }
+        co_return model::offset{};
     }
 
-    model::offset raft_start_offset() const {
-        if (_log_eviction_stm) {
-            return _log_eviction_stm->effective_start_offset();
-        }
-        return _raft->start_offset();
-    }
+    model::offset raft_start_offset() const { return _raft->start_offset(); }
 
     /**
      * The returned value of last committed offset should not be used to
@@ -310,6 +336,28 @@ public:
     ss::future<storage::translating_reader> make_cloud_reader(
       storage::log_reader_config config,
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
+
+    std::optional<model::offset> kafka_start_offset_override() const {
+        if (_log_eviction_stm) {
+            auto o = _log_eviction_stm->start_offset_override();
+            if (o != model::offset{} && _raft->start_offset() < o) {
+                auto offset_translator_state = get_offset_translator_state();
+                auto start_kafka_offset
+                  = offset_translator_state->from_log_offset(o);
+                return start_kafka_offset;
+            }
+            // If a start override is no longer in the offset translator state,
+            // it may have been uploaded and persisted in the manifest.
+        }
+        if (_archival_meta_stm) {
+            auto o = _archival_meta_stm->manifest()
+                       .get_start_kafka_offset_override();
+            if (o != kafka::offset{}) {
+                return kafka::offset_cast(o);
+            }
+        }
+        return std::nullopt;
+    }
 
     ss::future<> remove_persistent_state();
     ss::future<> finalize_remote_partition(ss::abort_source& as);

--- a/src/v/cluster/prefix_truncate_record.h
+++ b/src/v/cluster/prefix_truncate_record.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "model/fundamental.h"
+#include "serde/envelope.h"
+
+namespace cluster {
+
+// Key types for log_eviction_stm. These are placed here rather than together
+// with log_eviction_stm to allow other listeners on this key type (e.g.
+// archival_metadata_stm).
+
+static constexpr uint8_t prefix_truncate_key = 0;
+
+// Record data to be used in model::record_batch_type::prefix_truncate batches
+// (e.g. during DeleteRecords API calls).
+struct prefix_truncate_record
+  : public serde::envelope<
+      prefix_truncate_record,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    // May be empty if offset translation state was not available when
+    // replicating the batch (e.g. the corresponding local segments had been
+    // GCed, but the data still exists in cloud).
+    model::offset rp_start_offset{};
+
+    // May not be empty.
+    kafka::offset kafka_start_offset{};
+};
+
+} // namespace cluster

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -17,6 +17,7 @@
 #include "kafka/protocol/delete_records.h"
 #include "kafka/protocol/flex_versions.h"
 #include "kafka/protocol/fwd.h"
+#include "kafka/protocol/offset_for_leader_epoch.h"
 #include "kafka/server/protocol_utils.h"
 #include "kafka/types.h"
 #include "net/transport.h"
@@ -207,6 +208,10 @@ public:
         } else if constexpr (std::is_same_v<type, sasl_handshake_request>) {
             return dispatch(std::move(r), api_version(1));
         } else if constexpr (std::is_same_v<type, delete_records_request>) {
+            return dispatch(std::move(r), api_version(2));
+        } else if constexpr (std::is_same_v<
+                               type,
+                               offset_for_leader_epoch_request>) {
             return dispatch(std::move(r), api_version(2));
         } else if constexpr (std::is_same_v<type, sasl_authenticate_request>) {
             return dispatch(std::move(r), api_version(1));

--- a/src/v/kafka/server/handlers/delete_records.cc
+++ b/src/v/kafka/server/handlers/delete_records.cc
@@ -52,6 +52,9 @@ validate_at_topic_level(request_context& ctx, const delete_records_topic& t) {
         return ctx.authorized(security::acl_operation::remove, t.name);
     };
     const auto is_deletable = [](const cluster::topic_configuration& cfg) {
+        if (cfg.is_read_replica()) {
+            return false;
+        }
         /// Immitates the logic in ntp_config::is_collectible
         if (
           !cfg.properties.has_overrides()

--- a/src/v/kafka/server/handlers/delete_records.cc
+++ b/src/v/kafka/server/handlers/delete_records.cc
@@ -62,10 +62,6 @@ validate_at_topic_level(request_context& ctx, const delete_records_topic& t) {
         return (*bitflags & model::cleanup_policy_bitflags::deletion)
                == model::cleanup_policy_bitflags::deletion;
     };
-    const auto is_cloud_enabled = [](const cluster::topic_configuration& cfg) {
-        const auto& si_flags = cfg.properties.shadow_indexing;
-        return si_flags && *si_flags != model::shadow_indexing_mode::disabled;
-    };
     const auto is_nodelete_topic = [](const delete_records_topic& t) {
         const auto& nodelete_topics
           = config::shard_local_cfg().kafka_nodelete_topics();
@@ -85,7 +81,7 @@ validate_at_topic_level(request_context& ctx, const delete_records_topic& t) {
         return make_partition_errors(t, error_code::topic_authorization_failed);
     } else if (!is_deletable(*cfg)) {
         return make_partition_errors(t, error_code::policy_violation);
-    } else if (is_cloud_enabled(*cfg) || is_nodelete_topic(t)) {
+    } else if (is_nodelete_topic(t)) {
         return make_partition_errors(t, error_code::invalid_topic_exception);
     }
     return {};

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -20,6 +20,7 @@
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
 #include "raft/types.h"
+#include "storage/log_reader.h"
 #include "storage/types.h"
 
 #include <seastar/core/coroutine.hh>
@@ -244,7 +245,43 @@ ss::future<std::optional<storage::timequery_result>>
 replicated_partition::timequery(storage::timequery_config cfg) {
     // cluster::partition::timequery returns a result in Kafka offsets,
     // no further offset translation is required here.
-    return _partition->timequery(cfg);
+    auto res = co_await _partition->timequery(cfg);
+    if (!res.has_value()) {
+        co_return std::nullopt;
+    }
+    const auto kafka_start_override = _partition->kafka_start_offset_override();
+    if (
+      !kafka_start_override.has_value()
+      || kafka_start_override.value() <= res.value().offset) {
+        // The start override doesn't affect the result of the timequery.
+        co_return res;
+    }
+    vlog(
+      klog.debug,
+      "{} timequery result {} clamped by start override, fetching result at "
+      "start {}",
+      ntp(),
+      res->offset,
+      kafka_start_override.value());
+    storage::log_reader_config config(
+      kafka_start_override.value(),
+      cfg.max_offset,
+      0,
+      2048, // We just need one record batch
+      cfg.prio,
+      cfg.type_filter,
+      std::nullopt, // No timestamp, just use the offset
+      cfg.abort_source);
+    auto translating_reader = co_await make_reader(config, std::nullopt);
+    auto ot_state = std::move(translating_reader.ot_state);
+    model::record_batch_reader::storage_t data
+      = co_await model::consume_reader_to_memory(
+        std::move(translating_reader.reader), model::no_timeout);
+    auto& batches = std::get<model::record_batch_reader::data_t>(data);
+    if (batches.empty()) {
+        co_return std::nullopt;
+    }
+    co_return storage::batch_timequery(*(batches.begin()), cfg.time);
 }
 
 ss::future<result<model::offset>> replicated_partition::replicate(

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -216,6 +216,11 @@ private:
           partition_kafka_start_offset(), start_kafka_offset_override);
     }
 
+    // Returns the highest offset in the given term, without considering
+    // overrides of the starting offset.
+    ss::future<std::optional<model::offset>>
+      get_leader_epoch_last_offset_unbounded(kafka::leader_epoch) const;
+
     ss::future<std::vector<cluster::rm_stm::tx_range>>
       aborted_transactions_local(
         cloud_storage::offset_range,

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -26,6 +26,7 @@
 #include <boost/numeric/conversion/cast.hpp>
 
 #include <memory>
+#include <optional>
 #include <system_error>
 
 namespace kafka {
@@ -39,17 +40,10 @@ public:
 
     ss::future<result<model::offset, error_code>>
     sync_effective_start(model::timeout_clock::duration timeout) final {
-        if (
-          _partition->is_read_replica_mode_enabled()
-          && _partition->cloud_data_available()) {
-            // Always assume remote read in this case.
-            co_return _partition->start_cloud_offset();
-        }
-
-        auto synced_local_start_offset
-          = co_await _partition->sync_effective_start(timeout);
-        if (!synced_local_start_offset) {
-            auto err = synced_local_start_offset.error();
+        auto synced_start_offset_override
+          = co_await _partition->sync_kafka_start_offset_override(timeout);
+        if (synced_start_offset_override.has_failure()) {
+            auto err = synced_start_offset_override.error();
             auto error_code = error_code::unknown_server_error;
             if (err.category() == cluster::error_category()) {
                 switch (cluster::errc(err.value())) {
@@ -66,34 +60,17 @@ public:
             }
             co_return error_code;
         }
-        auto local_kafka_start_offset = _translator->from_log_offset(
-          synced_local_start_offset.value());
-        if (
-          _partition->is_remote_fetch_enabled()
-          && _partition->cloud_data_available()
-          && (_partition->start_cloud_offset() < local_kafka_start_offset)) {
-            co_return _partition->start_cloud_offset();
-        }
-        co_return local_kafka_start_offset;
+        co_return std::max(
+          partition_kafka_start_offset(), synced_start_offset_override.value());
     }
 
     model::offset start_offset() const final {
-        if (
-          _partition->is_read_replica_mode_enabled()
-          && _partition->cloud_data_available()) {
-            // Always assume remote read in this case.
-            return _partition->start_cloud_offset();
+        auto start_offset_override = _partition->kafka_start_offset_override();
+        if (!start_offset_override.has_value()) {
+            return partition_kafka_start_offset();
         }
-
-        auto local_kafka_start_offset = _translator->from_log_offset(
-          _partition->raft_start_offset());
-        if (
-          _partition->is_remote_fetch_enabled()
-          && _partition->cloud_data_available()
-          && (_partition->start_cloud_offset() < local_kafka_start_offset)) {
-            return _partition->start_cloud_offset();
-        }
-        return local_kafka_start_offset;
+        return std::max(
+          partition_kafka_start_offset(), start_offset_override.value());
     }
 
     model::offset high_watermark() const final {
@@ -198,6 +175,28 @@ public:
     result<partition_info> get_partition_info() const final;
 
 private:
+    // Returns the Kafka offset corresponding to the lowest offset in the
+    // log, including local and cloud storage. Doesn't take into account any
+    // start offset overrides (see start_offset()).
+    model::offset partition_kafka_start_offset() const {
+        if (
+          _partition->is_read_replica_mode_enabled()
+          && _partition->cloud_data_available()) {
+            // Always assume remote read in this case.
+            return _partition->start_cloud_offset();
+        }
+
+        auto local_kafka_start_offset = _translator->from_log_offset(
+          _partition->raft_start_offset());
+        if (
+          _partition->is_remote_fetch_enabled()
+          && _partition->cloud_data_available()
+          && (_partition->start_cloud_offset() < local_kafka_start_offset)) {
+            return _partition->start_cloud_offset();
+        }
+        return local_kafka_start_offset;
+    }
+
     ss::future<std::vector<cluster::rm_stm::tx_range>>
       aborted_transactions_local(
         cloud_storage::offset_range,

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -22,9 +22,11 @@ v_cc_library(
     kafka_test_utils
   HDRS
     "delete_records_utils.h"
+    "list_offsets_utils.h"
     "produce_consume_utils.h"
   SRCS
     "delete_records_utils.cc"
+    "list_offsets_utils.cc"
     "produce_consume_utils.cc"
   DEPS
     v::bytes

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -23,10 +23,12 @@ v_cc_library(
   HDRS
     "delete_records_utils.h"
     "list_offsets_utils.h"
+    "offset_for_leader_epoch_utils.h"
     "produce_consume_utils.h"
   SRCS
     "delete_records_utils.cc"
     "list_offsets_utils.cc"
+    "offset_for_leader_epoch_utils.cc"
     "produce_consume_utils.cc"
   DEPS
     v::bytes

--- a/src/v/kafka/server/tests/list_offsets_utils.cc
+++ b/src/v/kafka/server/tests/list_offsets_utils.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "kafka/server/tests/list_offsets_utils.h"
+
+#include "kafka/client/transport.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/list_offsets.h"
+#include "kafka/protocol/schemata/list_offset_request.h"
+#include "kafka/protocol/schemata/list_offset_response.h"
+
+namespace tests {
+
+ss::future<kafka_list_offsets_transport::pid_to_offset_map_t>
+kafka_list_offsets_transport::list_offsets(
+  model::topic topic_name, pid_to_timestamp_map_t ts_per_partition) {
+    kafka::list_offsets_request req;
+
+    req.data.topics = {{
+      .name = std::move(topic_name),
+    }};
+    for (const auto& [pid, ts] : ts_per_partition) {
+        req.data.topics[0].partitions.emplace_back(kafka::list_offset_partition{
+          .partition_index = pid, .timestamp = ts});
+    }
+    auto resp = co_await _transport.dispatch(std::move(req));
+    if (resp.data.topics.size() != 1) {
+        throw std::runtime_error(
+          fmt::format("Expected 1 topic, got {}", resp.data.topics.size()));
+    }
+    pid_to_offset_map_t ret;
+    for (const auto& p_res : resp.data.topics[0].partitions) {
+        if (p_res.error_code != kafka::error_code::none) {
+            throw std::runtime_error(fmt::format(
+              "Error for partition {}: {}",
+              p_res.partition_index,
+              p_res.error_code));
+        }
+        ret[p_res.partition_index] = p_res.offset;
+    }
+    co_return ret;
+}
+
+ss::future<model::offset>
+kafka_list_offsets_transport::start_offset_for_partition(
+  model::topic topic_name, model::partition_id pid) {
+    return list_offset_for_partition(
+      std::move(topic_name),
+      pid,
+      kafka::list_offsets_request::earliest_timestamp);
+}
+
+ss::future<model::offset>
+kafka_list_offsets_transport::high_watermark_for_partition(
+  model::topic topic_name, model::partition_id pid) {
+    return list_offset_for_partition(
+      std::move(topic_name),
+      pid,
+      kafka::list_offsets_request::latest_timestamp);
+}
+
+} // namespace tests

--- a/src/v/kafka/server/tests/list_offsets_utils.h
+++ b/src/v/kafka/server/tests/list_offsets_utils.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "kafka/client/transport.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace tests {
+
+// Wrapper around a Kafka transport that encapsulates listing offsets.
+//
+// The primary goal of this is to allow tests to delete without dealing
+// explicitly with the Kafka schemata. To that end, it exposes a
+// protocol-agnostic API.
+class kafka_list_offsets_transport {
+public:
+    // NOTE: returned offsets are kafka offsets
+    using pid_to_timestamp_map_t
+      = absl::flat_hash_map<model::partition_id, model::timestamp>;
+    using pid_to_offset_map_t
+      = absl::flat_hash_map<model::partition_id, model::offset>;
+
+    explicit kafka_list_offsets_transport(kafka::client::transport&& t)
+      : _transport(std::move(t)) {}
+
+    ss::future<> start() { return _transport.connect(); }
+
+    ss::future<model::offset> start_offset_for_partition(
+      model::topic topic_name, model::partition_id pid);
+
+    ss::future<model::offset> high_watermark_for_partition(
+      model::topic topic_name, model::partition_id pid);
+
+    ss::future<pid_to_offset_map_t> list_offsets(
+      model::topic topic_name, pid_to_timestamp_map_t ts_per_partition);
+
+    ss::future<model::offset> list_offset_for_partition(
+      model::topic topic_name, model::partition_id pid, model::timestamp ts) {
+        pid_to_timestamp_map_t m;
+        m.emplace(pid, ts);
+        auto out_map = co_await list_offsets(
+          std::move(topic_name), std::move(m));
+        co_return out_map[pid];
+    }
+
+private:
+    kafka::client::transport _transport;
+};
+
+} // namespace tests

--- a/src/v/kafka/server/tests/offset_for_leader_epoch_utils.cc
+++ b/src/v/kafka/server/tests/offset_for_leader_epoch_utils.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "kafka/server/tests/offset_for_leader_epoch_utils.h"
+
+#include "kafka/client/transport.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/offset_for_leader_epoch.h"
+#include "kafka/protocol/schemata/offset_for_leader_epoch_request.h"
+#include "kafka/protocol/schemata/offset_for_leader_epoch_response.h"
+#include "kafka/protocol/types.h"
+#include "vlog.h"
+
+#include <seastar/util/log.hh>
+
+namespace tests {
+
+ss::future<kafka_offset_for_epoch_transport::pid_to_offset_map_t>
+kafka_offset_for_epoch_transport::offsets_for_leaders(
+  model::topic topic_name, pid_to_term_map_t term_per_partition) {
+    kafka::offset_for_leader_epoch_request req;
+    kafka::offset_for_leader_topic t{topic_name, {}, {}};
+    for (const auto [pid, term] : term_per_partition) {
+        t.partitions.emplace_back(kafka::offset_for_leader_partition{
+          .partition = pid,
+          .current_leader_epoch = kafka::leader_epoch{-1},
+          .leader_epoch = kafka::leader_epoch{term()},
+        });
+    }
+    req.data.topics.emplace_back(std::move(t));
+    auto resp = co_await _transport.dispatch(std::move(req));
+    if (resp.data.topics.size() != 1) {
+        throw std::runtime_error(
+          fmt::format("Expected 1 topic, got {}", resp.data.topics.size()));
+    }
+    pid_to_offset_map_t ret;
+    for (const auto& p_res : resp.data.topics[0].partitions) {
+        // NOTE: offset_out_of_range returns with a low watermark of -1
+        if (p_res.error_code == kafka::error_code::none) {
+            ret.emplace(p_res.partition, p_res.end_offset);
+            continue;
+        }
+        throw std::runtime_error(fmt::format(
+          "Error for partition {}: {}", p_res.partition, p_res.error_code));
+    }
+    co_return ret;
+}
+
+} // namespace tests

--- a/src/v/kafka/server/tests/offset_for_leader_epoch_utils.h
+++ b/src/v/kafka/server/tests/offset_for_leader_epoch_utils.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "kafka/client/transport.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace tests {
+
+// Wrapper around a Kafka transport that encapsulates fetching the latest
+// offset for a given term.
+//
+// The primary goal of this is to allow tests to delete without dealing
+// explicitly with the Kafka schemata. To that end, it exposes a
+// protocol-agnostic API.
+class kafka_offset_for_epoch_transport {
+public:
+    // NOTE: returned offsets are kafka offsets
+    using pid_to_offset_map_t
+      = absl::flat_hash_map<model::partition_id, model::offset>;
+    using pid_to_term_map_t
+      = absl::flat_hash_map<model::partition_id, model::term_id>;
+
+    explicit kafka_offset_for_epoch_transport(kafka::client::transport&& t)
+      : _transport(std::move(t)) {}
+
+    ss::future<> start() { return _transport.connect(); }
+
+    ss::future<pid_to_offset_map_t> offsets_for_leaders(
+      model::topic topic_name, pid_to_term_map_t term_per_partition);
+
+    ss::future<model::offset> offset_for_leader_partition(
+      model::topic topic_name, model::partition_id pid, model::term_id t) {
+        pid_to_term_map_t m;
+        m.emplace(pid, t);
+        auto out_map = co_await offsets_for_leaders(
+          std::move(topic_name), std::move(m));
+        co_return out_map[pid];
+    }
+
+private:
+    kafka::client::transport _transport;
+};
+
+} // namespace tests

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -18,6 +18,7 @@ from ducktape.utils.util import wait_until
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.kcl import KCL
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.action_injector import random_process_kills
@@ -296,9 +297,6 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
     @skip_debug_mode
     @cluster(num_nodes=4)
     def test_recover(self):
-        # Recovery will leave behind results files, which aren't tracked.
-        # TODO: remove when recovery is controller-driven instead of using
-        # results objects.
         self.start_producer()
         produce_until_segments(
             redpanda=self.redpanda,
@@ -336,6 +334,71 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         wait_until(lambda: len(set(rpk.list_topics())) == 1,
                    timeout_sec=30,
                    backoff_sec=1)
+
+    @skip_debug_mode
+    @cluster(num_nodes=4)
+    def test_recover_after_delete_records(self):
+        self.start_producer()
+        produce_until_segments(
+            redpanda=self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+        original_snapshot = self.redpanda.storage(
+            all_nodes=True).segments_by_node("kafka", self.topic, 0)
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES:
+                5 * self.segment_size,
+            },
+        )
+
+        wait_for_removal_of_n_segments(redpanda=self.redpanda,
+                                       topic=self.topic,
+                                       partition_idx=0,
+                                       n=6,
+                                       original_snapshot=original_snapshot)
+        self.producer.stop()
+        kcl = KCL(self.redpanda)
+        new_lwm = 2
+        response = kcl.delete_records({self.topic: {0: new_lwm}})
+        assert len(response) == 1
+        assert response[0].topic == self.topic
+        assert response[0].partition == 0
+        assert response[0].error == 'OK', f"Err msg: {response[0].error}"
+        assert new_lwm == response[0].new_low_watermark, response[
+            0].new_low_watermark
+        rpk = RpkTool(self.redpanda)
+        topics_info = list(rpk.describe_topic(self.topic))
+        assert len(topics_info) == 1
+        assert topics_info[0].start_offset == new_lwm, topics_info
+
+        def manifest_has_start_override():
+            s3_snapshot = BucketView(self.redpanda, topics=self.topics)
+            manifest = s3_snapshot.manifest_for_ntp(self.topic, 0)
+            return "start_kafka_offset" in manifest
+
+        wait_until(manifest_has_start_override, timeout_sec=30, backoff_sec=1)
+
+        self.redpanda.stop()
+        for n in self.redpanda.nodes:
+            self.redpanda.remove_local_data(n)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda._admin.await_stable_leader("controller",
+                                                 partition=0,
+                                                 namespace='redpanda',
+                                                 timeout_s=60,
+                                                 backoff_s=2)
+
+        rpk.cluster_recovery_start(wait=True)
+        wait_until(lambda: len(set(rpk.list_topics())) == 1,
+                   timeout_sec=30,
+                   backoff_sec=1)
+        topics_info = list(rpk.describe_topic(self.topic))
+        assert len(topics_info) == 1
+        assert topics_info[0].start_offset == new_lwm, topics_info
 
 
 class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -6,10 +6,12 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+from re import T
 from typing import NamedTuple, Optional
 from rptest.services.cluster import cluster
 
 from rptest.clients.default import DefaultClient
+from rptest.clients.kcl import KCL
 from rptest.services.redpanda import SISettings
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.types import TopicSpec
@@ -41,6 +43,34 @@ READ_REPLICA_LOG_ALLOW_LIST = [
     "Failed to download partition manifest",
     "Failed to download manifest",
 ]
+
+
+def get_lwm_per_partition(cluster: RedpandaService, topic_name,
+                          partition_count):
+    id_to_lwm = dict()
+    rpk = RpkTool(cluster)
+    for prt in rpk.describe_topic(topic_name):
+        id_to_lwm[prt.id] = prt.start_offset
+    if len(id_to_lwm) != partition_count:
+        return False, None
+    return True, id_to_lwm
+
+
+def lwms_are_identical(logger, src_cluster, dst_cluster, topic_name,
+                       partition_count):
+    # Collect the HWMs for each partition before stopping.
+    src_lwms = wait_until_result(lambda: get_lwm_per_partition(
+        src_cluster, topic_name, partition_count),
+                                 timeout_sec=30,
+                                 backoff_sec=1)
+
+    # Ensure that our HWMs on the destination are the same.
+    rr_lwms = wait_until_result(lambda: get_lwm_per_partition(
+        dst_cluster, topic_name, partition_count),
+                                timeout_sec=30,
+                                backoff_sec=1)
+    logger.info(f"{src_lwms} vs {rr_lwms}")
+    return src_lwms == rr_lwms
 
 
 def get_hwm_per_partition(cluster: RedpandaService, topic_name,
@@ -235,6 +265,62 @@ class TestReadReplicaService(EndToEndTest):
             return BucketUsage(obj_delta, bytes_delta, keys_delta)
         else:
             return None
+
+    @cluster(num_nodes=7, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
+    @matrix(partition_count=[5], cloud_storage_type=[CloudStorageType.S3])
+    def test_identical_lwms_after_delete_records(
+            self, partition_count: int,
+            cloud_storage_type: CloudStorageType) -> None:
+        self._setup_read_replica(partition_count=partition_count,
+                                 num_messages=1000)
+        kcl = KCL(self.redpanda)
+
+        def set_lwm(new_lwm):
+            response = kcl.delete_records({self.topic_name: {0: new_lwm}})
+            assert response[0].error == 'OK', response[0].error
+            assert response[0].new_low_watermark == new_lwm
+
+        rpk = RpkTool(self.redpanda)
+
+        def check_lwm(new_lwm):
+            topics_info = list(rpk.describe_topic(self.topic_name))
+            topic_info = topics_info[0]
+            for t in topics_info:
+                if t.id == 0:
+                    topic_info = t
+                    break
+            assert topic_info.start_offset == new_lwm, topic_info
+
+        check_lwm(0)
+        set_lwm(5)
+        check_lwm(5)
+
+        def clusters_report_identical_lwms():
+            return lwms_are_identical(self.logger, self.redpanda,
+                                      self.second_cluster, self.topic_name,
+                                      partition_count)
+
+        wait_until(clusters_report_identical_lwms,
+                   timeout_sec=30,
+                   backoff_sec=1)
+
+        # As a sanity check, ensure the same is true after a restart.
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        wait_until(clusters_report_identical_lwms,
+                   timeout_sec=30,
+                   backoff_sec=1)
+
+        check_lwm(5)
+        set_lwm(6)
+        check_lwm(6)
+
+        self.second_cluster.restart_nodes(self.second_cluster.nodes)
+        wait_until(clusters_report_identical_lwms,
+                   timeout_sec=30,
+                   backoff_sec=1)
+        check_lwm(6)
+        set_lwm(7)
+        check_lwm(7)
 
     @cluster(num_nodes=8, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
     @matrix(partition_count=[5], cloud_storage_type=[CloudStorageType.S3])


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

The previous implementation of the `_start_kafka_offset` relied on the fact that delete-record requests would fail when called above the max collectible offset. This made it impossible for an offset to be persisted in the manifest that was outside the cloud range. While somewhat easier to reason about, it meant that cloud storage could "forget" about a delete-record request, e.g. if receiving a request on data that has not yet been uploaded. With this PR, such a request will now land in the archival metadata stm, and the cloud storage layer is updated to handle such overrides.

Rather than trying to account for the `_start_kafka_offset` override throughout cloud storage, this PR updates the handling of various start-offset-type methods to ignore the override entirely, instead relying on callers (e.g. the Kafka layer) to consider overrides. A side effect of this is that some cloud storage APIs are updated to be able to take into account a kafka offset lower bound (e.g. timequery).

This PR includes the following changes:
- In cloud storage, we will now rarely consider `_start_kafka_offset`, only applying retention based on it, but otherwise omitting it from calculations of start offset.
- Instead, start offset is computed at in the Kafka layer by bumping up to the `_start_kafka_offset` if the would-be start offset is too low.
- The `archival_metadata_stm` now listens for `prefix_truncate` batches, so delete-records can be done in parallel between `log_eviction_stm` and `archival_metadata_stm`.
- Fixes for handling of the start offset override on read-replicas.
- Bumping of timequeries up to the start override if a result is too low.
- Bumping of `offset_for_leader_epoch` requests up to the start override if a result is too low.
- Some test utilities for getting offsets via the Kafka API.
- Some miscellaneous smaller fixes.
- A couple of short ducktape tests for recovery and read replicas (by no means exhaustive, more will follow).

A previous iteration of this PR had more tests for offset-based retention, but it was discovered that retention doesn't quite work, so I backed them out until fixed so this can be merged sooner.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
