### PR TITLE
rpc/conn_cache: return errc::shutting_down after shutdown

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -355,6 +355,8 @@ cluster::errc map_update_interruption_error_code(std::error_code ec) {
         case rpc::errc::client_request_timeout:
         case rpc::errc::connection_timeout:
             return errc::timeout;
+        case rpc::errc::shutting_down:
+            return errc::shutting_down;
         case rpc::errc::disconnected_endpoint:
         case rpc::errc::exponential_backoff:
         case rpc::errc::missing_node_rpc_client:

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1009,8 +1009,8 @@ ss::future<> admin_server::throw_on_error(
         case rpc::errc::success:
             co_return;
         case rpc::errc::disconnected_endpoint:
-            [[fallthrough]];
         case rpc::errc::exponential_backoff:
+        case rpc::errc::shutting_down:
             throw ss::httpd::base_exception(
               fmt::format("Not ready: {}", ec.message()),
               ss::http::reply::status_type::service_unavailable);

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -76,6 +76,7 @@ ss::future<> connection_cache::remove_all() {
 /// \brief closes all client connections
 ss::future<> connection_cache::do_shutdown() {
     auto units = co_await _mutex.get_units();
+    _shutting_down = true;
     // Exchange ensures the cache is invalidated and concurrent
     // accesses wait on the mutex to populate new entries.
     auto cache = std::exchange(_cache, {});

--- a/src/v/rpc/errc.h
+++ b/src/v/rpc/errc.h
@@ -25,6 +25,7 @@ enum class errc {
     method_not_found,
     version_not_supported,
     connection_timeout,
+    shutting_down,
 
     // Used when receiving an undefined errc (e.g. from a newer version of
     // Redpanda).
@@ -49,6 +50,8 @@ struct errc_category final : public std::error_category {
             return "rpc::errc::version_not_supported";
         case errc::connection_timeout:
             return "rpc::errc::connection_timeout";
+        case errc::shutting_down:
+            return "rpc::errc::shutting_down";
         default:
             return "rpc::errc::unknown(" + std::to_string(c) + ")";
         }


### PR DESCRIPTION
The first step in the shutdown sequence is to empty the local cache. Previously, attempts to get a connection after that returned with errc::missing_node_rpc_client, which is potentially indicative of a bug. Return a more benign error code instead.

Fixes https://github.com/redpanda-data/redpanda/issues/10112

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
