### PR TITLE
net/batched_output_stream: call `close()` in a finally block

### DIFF
--- a/src/v/net/batched_output_stream.cc
+++ b/src/v/net/batched_output_stream.cc
@@ -81,7 +81,7 @@ ss::future<> batched_output_stream::stop() {
     }
 
     return ss::with_semaphore(*_write_sem, 1, [this] {
-        return do_flush().then([this] { return _out.close(); });
+        return do_flush().finally([this] { return _out.close(); });
     });
 }
 


### PR DESCRIPTION
`close()` must always be called; move it to a finally block.

Prevent `Assertion !_in_batch && "Was this stream properly closed?"` in `seastar::output_stream<char>::~output_stream()`

Fix #11564
Fix #10218 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Bug Fixes

* net: Fix a rare crash during shutdown of a failed connection with outstanding requests

