### PR TITLE
cloud_storage: archival retention and garbage collection fixes

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1970,6 +1970,9 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
               "Failed to load next spillover manifest: {}",
               res.error());
             break;
+        } else if (res.value() == false) {
+            // End of stream
+            break;
         }
     }
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1911,6 +1911,13 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
 
     const auto clean_offset = manifest().get_archive_clean_offset();
     const auto start_offset = manifest().get_archive_start_offset();
+
+    vlog(
+      _rtclog.info,
+      "Garbage collecting archive segments in offest range [{}, {})",
+      clean_offset,
+      start_offset);
+
     model::offset new_clean_offset;
     // Value includes segments but doesn't include manifests
     size_t bytes_to_remove = 0;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1950,10 +1950,10 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
                           == cloud_storage::segment_name_format::v3
                         && meta.metadata_size_hint != 0) {
                           segments_to_remove.push_back(
-                            cloud_storage::generate_index_path(path));
+                            cloud_storage::generate_remote_tx_path(path)());
                       }
                       segments_to_remove.push_back(
-                        cloud_storage::generate_remote_tx_path(path)());
+                        cloud_storage::generate_index_path(path));
                   } else {
                       // This indicates that we need to remove only some of the
                       // segments from the manifest. In this case the outer loop

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -559,7 +559,7 @@ FIXTURE_TEST(test_async_manifest_view_retention, async_manifest_view_fixture) {
     model::offset_delta prefix_delta;
     for (const auto& meta : expected) {
         prefix_size += meta.size_bytes;
-        prefix_timestamp = meta.base_timestamp;
+        prefix_timestamp = model::timestamp{meta.base_timestamp.value() - 1};
         prefix_base_offset = meta.base_offset;
         prefix_delta = meta.delta_offset;
         quota--;

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -126,10 +126,13 @@ void http_imposter_fixture::set_routes(ss::httpd::routes& r) {
               when().request(req._url).then_reply_with(req.content);
               repl.set_status(ss::http::reply::status_type::ok);
               return "";
-          }
-          if (req._method == "DELETE") {
+          } else if (req._method == "DELETE") {
               repl.set_status(ss::http::reply::status_type::no_content);
               return "";
+          } else if (
+            req._method == "POST" && req.query_parameters.contains("delete")) {
+              // Delete objects
+              return R"xml(<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>)xml";
           } else {
               auto lookup_r = ri;
               lookup_r.url = remove_query_params(req._url);


### PR DESCRIPTION
This PR fixes a bunch of issues with the archive retention mechanisms. These surfaced
while I was working on including spillover in the timing stress tests.

**Infinite loop**
In order to queue segments up for deletion we iterate over the spillover
manifests and pick the ones below the archive start offset. This
procedure could result in an infinite loop if the archive start offset
equals the start offset of the STM region. Checking if the cursor has
reached the end solves the issue.

**Time based retention in the archive**
1. Timestamp search of spilled manifests is inclusive, so if, for
   example, we have a spillover manifest where all segments are 10
   minutes old and retention limit of 5 minutes, we'd not apply any
   retention since the spillover manifest could not be found. This is
   fixed by using the base timestamp of the first spill manifest if it
   is smaller than the computed retention boundary.
2. Previously, time based retention would only look at one spillover
   manifest, but retention may span more than one manifest.
3. The new start offset was off by one segment. Instead of being the
   start offset of the first segment with a timestamp higher than the
   boundary, it was the segment before that.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none


