### PR TITLE
rpk: human-readable size in `rpk cluster logdirs describe`

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/logdirs.go
+++ b/src/go/rpk/pkg/cli/cluster/logdirs.go
@@ -207,5 +207,10 @@ where revision is a Redpanda internal concept.
 	cmd.Flags().StringSliceVar(&topics, "topics", nil, "Specific topics to describe")
 	cmd.Flags().StringVar(&aggregateInto, "aggregate-into", "", "If non-empty, what column to aggregate into starting from the partition column (broker, dir, topic)")
 	cmd.Flags().BoolVarP(&human, "human-readable", "H", false, "Print the logdirs size in a human-readable form")
+
+	cmd.RegisterFlagCompletionFunc("aggregate-into", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		opts := []string{"broker", "dir", "topic"}
+		return opts, cobra.ShellCompDirectiveDefault
+	})
 	return cmd
 }


### PR DESCRIPTION
This PR adds autocompletion for `--agregate-into` flag of `rpk cluster logdirs describe` and it introduces the `--human-readable / -H` flag that prints the size of the log dirs in an human-readable format

### Examples:
```
$ rpk cluster logdirs describe -H
BROKER  DIR                     TOPIC               PARTITION  SIZE     ERROR
1       /var/lib/redpanda/data  __consumer_offsets  0          68.58kB  
1       /var/lib/redpanda/data  asdf                0          2.132kB  
1       /var/lib/redpanda/data  asdf                1          2.132kB  
```

```
$ rpk cluster logdirs describe --aggregate-into broker -H
BROKER  SIZE     ERROR
1       203.9kB
```

Fixes #10536

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Improvements

* rpk: now you can print logdirs in a human-readable format with the `--human-readable` flag in `rpk cluster logdirs describe`
