### PR TITLE
Improved `rm_stm` resource management.

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -16,6 +16,7 @@
 #include "kafka/protocol/wire.h"
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "model/timestamp.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
@@ -2515,8 +2516,10 @@ void rm_stm::apply_data(model::batch_identity bid, model::offset last_offset) {
               rm_stm::clear_type::idempotent_pids);
         }
 
-        seq_it->second.entry.last_write_timestamp = bid.first_timestamp.value();
-        _oldest_session = std::min(_oldest_session, bid.first_timestamp);
+        seq_it->second.entry.last_write_timestamp = bid.max_timestamp.value();
+        if (bid.max_timestamp != model::timestamp::missing()) {
+            _oldest_session = std::min(_oldest_session, bid.max_timestamp);
+        }
     }
 
     if (bid.is_transactional) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -314,7 +314,6 @@ rm_stm::rm_stm(
                          .abort_timed_out_transactions_interval_ms.value())
   , _abort_index_segment_size(
       config::shard_local_cfg().abort_index_segment_size.value())
-  , _seq_table_min_size(config::shard_local_cfg().seq_table_min_size.value())
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.value())
   , _is_tx_enabled(config::shard_local_cfg().enable_transactions.value())

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2895,16 +2895,30 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
               });
         });
     }
-
-    return f.then([this]() mutable {
-        return ss::do_with(iobuf{}, [this](iobuf& tx_ss_buf) mutable {
+    kafka::offset start_kafka_offset = from_log_offset(start_offset);
+    return f.then([this, start_kafka_offset]() mutable {
+        return ss::do_with(iobuf{}, [this, start_kafka_offset](iobuf& tx_ss_buf) mutable {
             auto version = active_snapshot_version();
             auto fut_serialize = ss::now();
             if (version == tx_snapshot::version) {
                 tx_snapshot tx_ss;
                 fill_snapshot_wo_seqs(tx_ss);
                 for (const auto& entry : _log_state.seq_table) {
-                    tx_ss.seqs.push_back(entry.second.entry.copy());
+                    /**
+                     * Only store those producer id sequences which offset is
+                     * greater than log start offset. This way a snapshot will
+                     * not retain producers ids for which all the batches were
+                     * removed with log cleanup policy.
+                     *
+                     * Note that we are not removing producer ids from the in
+                     * memory state but rather relay on the expiration policy
+                     * to do it, however when recovering state from the
+                     * snapshot removed producers will be gone.
+                     */
+                    if (
+                    entry.second.entry.last_offset >= start_kafka_offset) {
+                        tx_ss.seqs.push_back(entry.second.entry.copy());
+                    }
                 }
                 tx_ss.offset = _insync_offset;
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1155,24 +1155,16 @@ ss::future<result<kafka_result>> rm_stm::do_replicate(
   model::record_batch_reader b,
   raft::replicate_options opts,
   ss::lw_shared_ptr<available_promise<>> enqueued) {
-    return _state_lock.hold_read_lock().then(
-      [this, enqueued, bid, opts, b = std::move(b)](
-        ss::basic_rwlock<>::holder unit) mutable {
-          if (bid.is_transactional) {
-              auto pid = bid.pid.get_id();
-              return get_tx_lock(pid)
-                ->with([this, bid, b = std::move(b)]() mutable {
-                    return replicate_tx(bid, std::move(b));
-                })
-                .finally([u = std::move(unit)] {});
-          } else if (bid.has_idempotent()) {
-              return replicate_seq(bid, std::move(b), opts, enqueued)
-                .finally([u = std::move(unit)] {});
-          }
+    auto unit = co_await _state_lock.hold_read_lock();
+    if (bid.is_transactional) {
+        auto pid = bid.pid.get_id();
+        auto tx_units = co_await get_tx_lock(pid)->get_units();
+        co_return co_await replicate_tx(bid, std::move(b));
+    } else if (bid.has_idempotent()) {
+        co_return co_await replicate_seq(bid, std::move(b), opts, enqueued);
+    }
 
-          return replicate_msg(std::move(b), opts, enqueued)
-            .finally([u = std::move(unit)] {});
-      });
+    co_return co_await replicate_msg(std::move(b), opts, enqueued);
 }
 
 ss::future<> rm_stm::stop() {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2897,113 +2897,116 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
     }
     kafka::offset start_kafka_offset = from_log_offset(start_offset);
     return f.then([this, start_kafka_offset]() mutable {
-        return ss::do_with(iobuf{}, [this, start_kafka_offset](iobuf& tx_ss_buf) mutable {
-            auto version = active_snapshot_version();
-            auto fut_serialize = ss::now();
-            if (version == tx_snapshot::version) {
-                tx_snapshot tx_ss;
-                fill_snapshot_wo_seqs(tx_ss);
-                for (const auto& entry : _log_state.seq_table) {
-                    /**
-                     * Only store those producer id sequences which offset is
-                     * greater than log start offset. This way a snapshot will
-                     * not retain producers ids for which all the batches were
-                     * removed with log cleanup policy.
-                     *
-                     * Note that we are not removing producer ids from the in
-                     * memory state but rather relay on the expiration policy
-                     * to do it, however when recovering state from the
-                     * snapshot removed producers will be gone.
-                     */
-                    if (
-                    entry.second.entry.last_offset >= start_kafka_offset) {
-                        tx_ss.seqs.push_back(entry.second.entry.copy());
-                    }
-                }
-                tx_ss.offset = _insync_offset;
+        return ss::do_with(
+          iobuf{}, [this, start_kafka_offset](iobuf& tx_ss_buf) mutable {
+              auto version = active_snapshot_version();
+              auto fut_serialize = ss::now();
+              if (version == tx_snapshot::version) {
+                  tx_snapshot tx_ss;
+                  fill_snapshot_wo_seqs(tx_ss);
+                  for (const auto& entry : _log_state.seq_table) {
+                      /**
+                       * Only store those producer id sequences which offset is
+                       * greater than log start offset. This way a snapshot will
+                       * not retain producers ids for which all the batches were
+                       * removed with log cleanup policy.
+                       *
+                       * Note that we are not removing producer ids from the in
+                       * memory state but rather relay on the expiration policy
+                       * to do it, however when recovering state from the
+                       * snapshot removed producers will be gone.
+                       */
+                      if (
+                        entry.second.entry.last_offset >= start_kafka_offset) {
+                          tx_ss.seqs.push_back(entry.second.entry.copy());
+                      }
+                  }
+                  tx_ss.offset = _insync_offset;
 
-                for (const auto& entry : _log_state.current_txes) {
-                    tx_ss.tx_data.push_back(tx_snapshot::tx_data_snapshot{
-                      .pid = entry.first,
-                      .tx_seq = entry.second.tx_seq,
-                      .tm = entry.second.tm_partition});
-                }
+                  for (const auto& entry : _log_state.current_txes) {
+                      tx_ss.tx_data.push_back(tx_snapshot::tx_data_snapshot{
+                        .pid = entry.first,
+                        .tx_seq = entry.second.tx_seq,
+                        .tm = entry.second.tm_partition});
+                  }
 
-                for (const auto& entry : _log_state.expiration) {
-                    tx_ss.expiration.push_back(tx_snapshot::expiration_snapshot{
-                      .pid = entry.first, .timeout = entry.second.timeout});
-                }
+                  for (const auto& entry : _log_state.expiration) {
+                      tx_ss.expiration.push_back(
+                        tx_snapshot::expiration_snapshot{
+                          .pid = entry.first, .timeout = entry.second.timeout});
+                  }
 
-                fut_serialize = reflection::async_adl<tx_snapshot>{}.to(
-                  tx_ss_buf, std::move(tx_ss));
-            } else if (version == tx_snapshot_v3::version) {
-                tx_snapshot_v3 tx_ss;
-                fill_snapshot_wo_seqs(tx_ss);
-                for (const auto& entry : _log_state.seq_table) {
-                    tx_ss.seqs.push_back(entry.second.entry.copy());
-                }
-                tx_ss.offset = _insync_offset;
+                  fut_serialize = reflection::async_adl<tx_snapshot>{}.to(
+                    tx_ss_buf, std::move(tx_ss));
+              } else if (version == tx_snapshot_v3::version) {
+                  tx_snapshot_v3 tx_ss;
+                  fill_snapshot_wo_seqs(tx_ss);
+                  for (const auto& entry : _log_state.seq_table) {
+                      tx_ss.seqs.push_back(entry.second.entry.copy());
+                  }
+                  tx_ss.offset = _insync_offset;
 
-                for (const auto& entry : _log_state.current_txes) {
-                    tx_ss.tx_seqs.push_back(tx_snapshot_v3::tx_seqs_snapshot{
-                      .pid = entry.first, .tx_seq = entry.second.tx_seq});
-                }
+                  for (const auto& entry : _log_state.current_txes) {
+                      tx_ss.tx_seqs.push_back(tx_snapshot_v3::tx_seqs_snapshot{
+                        .pid = entry.first, .tx_seq = entry.second.tx_seq});
+                  }
 
-                for (const auto& entry : _log_state.expiration) {
-                    tx_ss.expiration.push_back(tx_snapshot::expiration_snapshot{
-                      .pid = entry.first, .timeout = entry.second.timeout});
-                }
+                  for (const auto& entry : _log_state.expiration) {
+                      tx_ss.expiration.push_back(
+                        tx_snapshot::expiration_snapshot{
+                          .pid = entry.first, .timeout = entry.second.timeout});
+                  }
 
-                fut_serialize = reflection::async_adl<tx_snapshot_v3>{}.to(
-                  tx_ss_buf, std::move(tx_ss));
-            } else if (version == tx_snapshot_v2::version) {
-                tx_snapshot_v2 tx_ss;
-                fill_snapshot_wo_seqs(tx_ss);
-                for (const auto& entry : _log_state.seq_table) {
-                    tx_ss.seqs.push_back(entry.second.entry.copy());
-                }
-                tx_ss.offset = _insync_offset;
-                fut_serialize = reflection::async_adl<tx_snapshot_v2>{}.to(
-                  tx_ss_buf, std::move(tx_ss));
-            } else if (version == tx_snapshot_v1::version) {
-                tx_snapshot_v1 tx_ss;
-                fill_snapshot_wo_seqs(tx_ss);
-                for (const auto& it : _log_state.seq_table) {
-                    auto& entry = it.second.entry;
-                    seq_entry_v1 seqs;
-                    seqs.pid = entry.pid;
-                    seqs.seq = entry.seq;
-                    try {
-                        seqs.last_offset = to_log_offset(entry.last_offset);
-                    } catch (...) {
-                        // ignoring outside the translation range errors
-                        continue;
-                    }
-                    seqs.last_write_timestamp = entry.last_write_timestamp;
-                    seqs.seq_cache.reserve(seqs.seq_cache.size());
-                    for (auto& item : entry.seq_cache) {
-                        try {
-                            seqs.seq_cache.push_back(seq_cache_entry_v1{
-                              .seq = item.seq,
-                              .offset = to_log_offset(item.offset)});
-                        } catch (...) {
-                            // ignoring outside the translation range errors
-                            continue;
-                        }
-                    }
-                    tx_ss.seqs.push_back(std::move(seqs));
-                }
-                tx_ss.offset = _insync_offset;
-                fut_serialize = reflection::async_adl<tx_snapshot_v1>{}.to(
-                  tx_ss_buf, std::move(tx_ss));
-            } else {
-                vassert(false, "unsupported tx_snapshot version {}", version);
-            }
-            return fut_serialize.then([version, &tx_ss_buf, this]() {
-                return stm_snapshot::create(
-                  version, _insync_offset, std::move(tx_ss_buf));
-            });
-        });
+                  fut_serialize = reflection::async_adl<tx_snapshot_v3>{}.to(
+                    tx_ss_buf, std::move(tx_ss));
+              } else if (version == tx_snapshot_v2::version) {
+                  tx_snapshot_v2 tx_ss;
+                  fill_snapshot_wo_seqs(tx_ss);
+                  for (const auto& entry : _log_state.seq_table) {
+                      tx_ss.seqs.push_back(entry.second.entry.copy());
+                  }
+                  tx_ss.offset = _insync_offset;
+                  fut_serialize = reflection::async_adl<tx_snapshot_v2>{}.to(
+                    tx_ss_buf, std::move(tx_ss));
+              } else if (version == tx_snapshot_v1::version) {
+                  tx_snapshot_v1 tx_ss;
+                  fill_snapshot_wo_seqs(tx_ss);
+                  for (const auto& it : _log_state.seq_table) {
+                      auto& entry = it.second.entry;
+                      seq_entry_v1 seqs;
+                      seqs.pid = entry.pid;
+                      seqs.seq = entry.seq;
+                      try {
+                          seqs.last_offset = to_log_offset(entry.last_offset);
+                      } catch (...) {
+                          // ignoring outside the translation range errors
+                          continue;
+                      }
+                      seqs.last_write_timestamp = entry.last_write_timestamp;
+                      seqs.seq_cache.reserve(seqs.seq_cache.size());
+                      for (auto& item : entry.seq_cache) {
+                          try {
+                              seqs.seq_cache.push_back(seq_cache_entry_v1{
+                                .seq = item.seq,
+                                .offset = to_log_offset(item.offset)});
+                          } catch (...) {
+                              // ignoring outside the translation range errors
+                              continue;
+                          }
+                      }
+                      tx_ss.seqs.push_back(std::move(seqs));
+                  }
+                  tx_ss.offset = _insync_offset;
+                  fut_serialize = reflection::async_adl<tx_snapshot_v1>{}.to(
+                    tx_ss_buf, std::move(tx_ss));
+              } else {
+                  vassert(false, "unsupported tx_snapshot version {}", version);
+              }
+              return fut_serialize.then([version, &tx_ss_buf, this]() {
+                  return stm_snapshot::create(
+                    version, _insync_offset, std::move(tx_ss_buf));
+              });
+          });
     });
 }
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -15,6 +15,7 @@
 #include "cluster/tx_utils.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "config/property.h"
 #include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/record.h"
@@ -673,6 +674,10 @@ private:
             if (it == seq_table.end()) {
                 return;
             }
+            erase_seq(it);
+        }
+
+        void erase_seq(seq_map::const_iterator it) {
             unlink_lru_pid(it->second);
             seq_table.erase(it);
         }
@@ -913,6 +918,9 @@ private:
     ss::future<> maybe_log_tx_stats();
     void log_tx_stats();
 
+    bool
+    is_producer_expired(model::timestamp now, const seq_entry& entry) const;
+
     // Defines the commit offset range for the stm bootstrap.
     // Set on first apply upcall and used to identify if the
     // stm is still replaying the log.
@@ -942,7 +950,6 @@ private:
     std::chrono::milliseconds _tx_timeout_delay;
     std::chrono::milliseconds _abort_interval_ms;
     uint32_t _abort_index_segment_size;
-    uint32_t _seq_table_min_size;
     std::chrono::milliseconds _transactional_id_expiration;
     bool _is_autoabort_enabled{true};
     bool _is_autoabort_active{false};

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -689,6 +689,7 @@ private:
             for (const auto& entry : seq_table) {
                 unlink_lru_pid(entry.second);
             }
+            seq_table.clear();
             // Checks the 1:1 invariant between seq_table entries and
             // lru_idempotent_pids If every element from seq_table is unlinked,
             // the resulting intrusive list should be empty.

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -444,12 +444,7 @@ configuration::configuration()
       "Time to wait for a response from tx_registry",
       {.visibility = visibility::user},
       2000ms)
-  , seq_table_min_size(
-      *this,
-      "seq_table_min_size",
-      "Minimum size of the seq table non affected by compaction",
-      {.visibility = visibility::user},
-      1000)
+  , seq_table_min_size(*this, "seq_table_min_size")
   , tx_timeout_delay_ms(
       *this,
       "tx_timeout_delay_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -116,7 +116,7 @@ struct configuration final : public config_store {
     deprecated_property tm_violation_recovery_policy;
     property<std::chrono::milliseconds> rm_sync_timeout_ms;
     property<std::chrono::milliseconds> find_coordinator_timeout_ms;
-    property<uint32_t> seq_table_min_size;
+    deprecated_property seq_table_min_size;
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
     deprecated_property rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -562,7 +562,7 @@ struct batch_identity {
           .last_seq = increment_sequence(
             hdr.base_sequence, hdr.last_offset_delta),
           .record_count = hdr.record_count,
-          .first_timestamp = hdr.first_timestamp,
+          .max_timestamp = hdr.max_timestamp,
           .is_transactional = hdr.attrs.is_transactional()};
     }
 
@@ -570,7 +570,7 @@ struct batch_identity {
     int32_t first_seq{0};
     int32_t last_seq{0};
     int32_t record_count;
-    timestamp first_timestamp;
+    timestamp max_timestamp;
     bool is_transactional{false};
 
     bool has_idempotent() { return pid.id >= 0; }

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from collections import defaultdict
 from rptest.services.cluster import cluster
 from rptest.util import wait_until_result
 from rptest.clients.types import TopicSpec
@@ -603,6 +604,110 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                 total += len(self.consume(consumer))
 
         consume_records(consumer, 200)
+
+    @cluster(num_nodes=3)
+    def check_sequence_table_cleaning_after_eviction_test(self):
+        segment_size = 1024 * 1024
+        topic_spec = TopicSpec(partition_count=1, segment_bytes=segment_size)
+        topic = topic_spec.name
+
+        # make segments small
+        self.client().create_topic(topic_spec)
+
+        producers_count = 20
+
+        message_size = 128
+        segments_per_producer = 5
+        message_count = int(segments_per_producer * segment_size /
+                            message_size)
+        msg_body = random.randbytes(message_size)
+
+        producers = []
+        self.logger.info(f"producing {message_count} messages per producer")
+        for i in range(producers_count):
+            p = ck.Producer({
+                'bootstrap.servers': self.redpanda.brokers(),
+                'enable.idempotence': True,
+            })
+            producers.append(p)
+            for m in range(message_count):
+                p.produce(topic,
+                          str(f"p-{i}-{m}"),
+                          msg_body,
+                          partition=0,
+                          on_delivery=self.on_delivery)
+            p.flush()
+
+        def get_tx_metrics():
+            return self.redpanda.metrics_sample(
+                "tx_mem_tracker_consumption_bytes",
+                self.redpanda.started_nodes())
+
+        metrics = get_tx_metrics()
+        consumed_per_node = defaultdict(int)
+        for m in metrics.samples:
+            id = self.redpanda.node_id(m.node)
+            consumed_per_node[id] += int(m.value)
+        self.logger.info(
+            f"Bytes consumed by transactional subsystem: {consumed_per_node}")
+
+        self.client().alter_topic_config(
+            topic=topic, key=TopicSpec.PROPERTY_RETENTION_BYTES, value=128)
+        self.client().alter_topic_config(
+            topic=topic,
+            key=TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,
+            value=128)
+
+        def segments_removed():
+            removed_per_node = defaultdict(int)
+            metric_sample = self.redpanda.metrics_sample(
+                "log_segments_removed", self.redpanda.started_nodes())
+            metric = metric_sample.label_filter(
+                dict(namespace="kafka", topic=topic))
+            for m in metric.samples:
+                removed_per_node[m.node] += m.value
+            return all([v > 0 for v in removed_per_node.values()])
+
+        wait_until(segments_removed, timeout_sec=60, backoff_sec=1)
+        # produce until next segment roll
+        #
+        # TODO: change this when we will implement cleanup on current,
+        # not the next eviction
+        last_producer = ck.Producer({
+            'bootstrap.servers':
+            self.redpanda.brokers(),
+            'enable.idempotence':
+            False,
+        })
+
+        message_count_to_roll_segment = int(
+            message_count / segments_per_producer) + 100
+        # produce enough data to roll the single segment
+        for m in range(message_count_to_roll_segment):
+            last_producer.produce(topic,
+                                  str(f"last-mile-{m}"),
+                                  msg_body,
+                                  partition=0,
+                                  on_delivery=self.on_delivery)
+            last_producer.flush()
+        # restart redpanda to make sure rm_stm recovers state from snapshot,
+        # which should be now cleaned and do not contain expired producer ids
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        metrics = get_tx_metrics()
+        consumed_per_node_after = defaultdict(int)
+        for m in metrics.samples:
+            id = self.redpanda.node_id(m.node)
+            consumed_per_node_after[id] += int(m.value)
+
+        self.logger.info(
+            f"Bytes consumed by transactional subsystem before eviction: {consumed_per_node}, after eviction: {consumed_per_node_after}"
+        )
+
+        assert all([
+            consumed_bytes > consumed_per_node_after[n]
+            for n, consumed_bytes in consumed_per_node.items()
+        ])
 
     @cluster(num_nodes=3)
     def check_pids_overflow_test(self):


### PR DESCRIPTION
Changed the way how expired producer ids are cleaned up in `rm_stm`. Previously an `rm_stm` was incorrectly using the `transactional.ix.expiration.ms` to expire producer ids. Changed the producer id expiration timeout to be separate property and aligned it with Kafka behavior. 

Fixes: https://github.com/redpanda-data/core-internal/issues/640
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixed `rm_stm` resource leak 