### PR TITLE
rptest: allow missing ntp manifest in upgrade test

### DIFF
--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -822,3 +822,7 @@ class CreateTopicUpgradeTest(RedpandaTest):
             assert config["retention.local.target.bytes"] == (
                 "10000", "DYNAMIC_TOPIC_CONFIG")
             assert config["retention.local.target.ms"][1] == "DEFAULT_CONFIG"
+
+        # The ntp manifest may not have been uploaded yet, but that's fine
+        # since this test focuses on the topic config change.
+        self.redpanda.si_settings.set_expected_damage({"ntpr_no_manifest"})


### PR DESCRIPTION
Test test being updated does not wait for the ntp manifsets to be uploaded since that's not its aim. Its therefore fine for the ntp manifest to be missing at the end.

Fixes #10605

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

