### PR TITLE
c/types: Add tests for Schema ID Validation properties

### DIFF
--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -11,6 +11,7 @@
 #include "cluster/controller_snapshot.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/metadata_dissemination_types.h"
+#include "cluster/tests/randoms.h"
 #include "cluster/tests/utils.h"
 #include "cluster/types.h"
 #include "compat/check.h"
@@ -2069,6 +2070,61 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
               cluster::partition_move_direction::all}),
         };
         roundtrip_test(request);
+    }
+    {
+        // Test schema ID validation topic_create
+        auto key_validation = tests::random_bool();
+        auto key_strategy = model::random_subject_name_strategy();
+        auto val_validation = tests::random_bool();
+        auto val_strategy = model::random_subject_name_strategy();
+
+        cluster::topic_properties props{};
+
+        props.record_key_schema_id_validation = tests::random_optional(
+          [=] { return key_validation; });
+        props.record_key_schema_id_validation_compat = tests::random_optional(
+          [=] { return key_validation; });
+        props.record_key_subject_name_strategy = tests::random_optional(
+          [=] { return key_strategy; });
+        props.record_key_subject_name_strategy_compat = tests::random_optional(
+          [=] { return key_strategy; });
+        props.record_value_schema_id_validation = tests::random_optional(
+          [=] { return val_validation; });
+        props.record_value_schema_id_validation_compat = tests::random_optional(
+          [=] { return val_validation; });
+        props.record_value_subject_name_strategy = tests::random_optional(
+          [=] { return val_strategy; });
+        props.record_value_subject_name_strategy_compat
+          = tests::random_optional([=] { return val_strategy; });
+
+        roundtrip_test(props);
+    }
+    {
+        // Test schema ID validation incremental_topic_updates
+        auto key_validation = tests::random_bool();
+        auto key_strategy = model::random_subject_name_strategy();
+        auto val_validation = tests::random_bool();
+        auto val_strategy = model::random_subject_name_strategy();
+
+        cluster::incremental_topic_updates updates{
+          .record_key_schema_id_validation = random_property_update(
+            tests::random_optional([=] { return key_validation; })),
+          .record_key_schema_id_validation_compat = random_property_update(
+            tests::random_optional([=] { return key_validation; })),
+          .record_key_subject_name_strategy = random_property_update(
+            tests::random_optional([=] { return key_strategy; })),
+          .record_key_subject_name_strategy_compat = random_property_update(
+            tests::random_optional([=] { return key_strategy; })),
+          .record_value_schema_id_validation = random_property_update(
+            tests::random_optional([=] { return val_validation; })),
+          .record_value_schema_id_validation_compat = random_property_update(
+            tests::random_optional([=] { return val_validation; })),
+          .record_value_subject_name_strategy = random_property_update(
+            tests::random_optional([=] { return val_strategy; })),
+          .record_value_subject_name_strategy_compat = random_property_update(
+            tests::random_optional([=] { return val_strategy; }))};
+
+        roundtrip_test(updates);
     }
 }
 

--- a/src/v/cluster/tests/topic_configuration_compat_test.cc
+++ b/src/v/cluster/tests/topic_configuration_compat_test.cc
@@ -13,6 +13,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "reflection/adl.h"
 #include "test_utils/randoms.h"
 #include "test_utils/rpc.h"
@@ -752,6 +753,34 @@ T make_incremental_topic_properties() {
     if constexpr (std::is_same<T, cluster::incremental_topic_updates>::value) {
         upd.shadow_indexing.op = cluster::incremental_update_operation::set;
         upd.shadow_indexing.value = model::shadow_indexing_mode::archival;
+        upd.record_key_schema_id_validation.op
+          = cluster::incremental_update_operation::set;
+        upd.record_key_schema_id_validation.value = true;
+        upd.record_key_schema_id_validation_compat.op
+          = cluster::incremental_update_operation::set;
+        upd.record_key_schema_id_validation_compat.value = true;
+        upd.record_key_subject_name_strategy.op
+          = cluster::incremental_update_operation::set;
+        upd.record_key_subject_name_strategy.value = pandaproxy::
+          schema_registry::subject_name_strategy::topic_record_name;
+        upd.record_key_subject_name_strategy_compat.op
+          = cluster::incremental_update_operation::set;
+        upd.record_key_subject_name_strategy_compat.value = pandaproxy::
+          schema_registry::subject_name_strategy::topic_record_name;
+        upd.record_value_schema_id_validation.op
+          = cluster::incremental_update_operation::set;
+        upd.record_value_schema_id_validation.value = true;
+        upd.record_value_schema_id_validation_compat.op
+          = cluster::incremental_update_operation::set;
+        upd.record_value_schema_id_validation_compat.value = true;
+        upd.record_value_subject_name_strategy.op
+          = cluster::incremental_update_operation::set;
+        upd.record_value_subject_name_strategy.value
+          = pandaproxy::schema_registry::subject_name_strategy::record_name;
+        upd.record_value_subject_name_strategy_compat.op
+          = cluster::incremental_update_operation::set;
+        upd.record_value_subject_name_strategy_compat.value
+          = pandaproxy::schema_registry::subject_name_strategy::record_name;
     }
     if constexpr (std::is_same<T, old::incremental_topic_updates_1>::value) {
         upd.data_policy.op = cluster::incremental_update_operation::set;
@@ -783,6 +812,54 @@ void compare_incremental_topic_updates(const UpdIn& upd, const UpdOut& res) {
                     value) {
         BOOST_REQUIRE(upd.shadow_indexing.op == res.shadow_indexing.op);
         BOOST_REQUIRE(upd.shadow_indexing.value == res.shadow_indexing.value);
+        BOOST_REQUIRE(
+          upd.record_key_schema_id_validation.op
+          == res.record_key_schema_id_validation.op);
+        BOOST_REQUIRE(
+          upd.record_key_schema_id_validation.value
+          == res.record_key_schema_id_validation.value);
+        BOOST_REQUIRE(
+          upd.record_key_schema_id_validation_compat.op
+          == res.record_key_schema_id_validation_compat.op);
+        BOOST_REQUIRE(
+          upd.record_key_schema_id_validation_compat.value
+          == res.record_key_schema_id_validation_compat.value);
+        BOOST_REQUIRE(
+          upd.record_key_subject_name_strategy.op
+          == res.record_key_subject_name_strategy.op);
+        BOOST_REQUIRE(
+          upd.record_key_subject_name_strategy.value
+          == res.record_key_subject_name_strategy.value);
+        BOOST_REQUIRE(
+          upd.record_key_subject_name_strategy_compat.op
+          == res.record_key_subject_name_strategy_compat.op);
+        BOOST_REQUIRE(
+          upd.record_key_subject_name_strategy_compat.value
+          == res.record_key_subject_name_strategy_compat.value);
+        BOOST_REQUIRE(
+          upd.record_value_schema_id_validation.op
+          == res.record_value_schema_id_validation.op);
+        BOOST_REQUIRE(
+          upd.record_value_schema_id_validation.value
+          == res.record_value_schema_id_validation.value);
+        BOOST_REQUIRE(
+          upd.record_value_schema_id_validation_compat.op
+          == res.record_value_schema_id_validation_compat.op);
+        BOOST_REQUIRE(
+          upd.record_value_schema_id_validation_compat.value
+          == res.record_value_schema_id_validation_compat.value);
+        BOOST_REQUIRE(
+          upd.record_value_subject_name_strategy.op
+          == res.record_value_subject_name_strategy.op);
+        BOOST_REQUIRE(
+          upd.record_value_subject_name_strategy.value
+          == res.record_value_subject_name_strategy.value);
+        BOOST_REQUIRE(
+          upd.record_value_subject_name_strategy_compat.op
+          == res.record_value_subject_name_strategy_compat.op);
+        BOOST_REQUIRE(
+          upd.record_value_subject_name_strategy_compat.value
+          == res.record_value_subject_name_strategy_compat.value);
     }
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1934,15 +1934,7 @@ void adl<cluster::topic_properties>::to(
       p.shadow_indexing,
       p.read_replica,
       p.read_replica_bucket,
-      p.remote_topic_properties,
-      p.record_key_schema_id_validation,
-      p.record_key_schema_id_validation_compat,
-      p.record_key_subject_name_strategy,
-      p.record_key_subject_name_strategy_compat,
-      p.record_value_schema_id_validation,
-      p.record_value_schema_id_validation_compat,
-      p.record_value_subject_name_strategy,
-      p.record_value_subject_name_strategy_compat);
+      p.remote_topic_properties);
 }
 
 cluster::topic_properties

--- a/src/v/model/tests/randoms.h
+++ b/src/v/model/tests/randoms.h
@@ -16,6 +16,7 @@
 #include "model/metadata.h"
 #include "model/record.h"
 #include "model/timestamp.h"
+#include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "random/generators.h"
 #include "test_utils/randoms.h"
 
@@ -161,6 +162,15 @@ inline model::broker_shard random_broker_shard() {
       tests::random_named_int<model::node_id>(),
       random_generators::get_int(std::numeric_limits<uint32_t>::max()),
     };
+}
+
+inline pandaproxy::schema_registry::subject_name_strategy
+random_subject_name_strategy() {
+    return random_generators::random_choice(
+      std::vector<pandaproxy::schema_registry::subject_name_strategy>{
+        pandaproxy::schema_registry::subject_name_strategy::topic_name,
+        pandaproxy::schema_registry::subject_name_strategy::record_name,
+        pandaproxy::schema_registry::subject_name_strategy::topic_record_name});
 }
 
 } // namespace model


### PR DESCRIPTION
* Add `adl` tests for `incremental_property_update`
* Remove `adl` serailization for `topic_properties`
* Add serde tests for `topic_properties` and `incremental_topic_updates`

Fixes #11112

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
