### PR TITLE
[v22.3.x] net/batched_output_stream: call `close()` in a finally block

### DIFF
--- a/src/v/net/batched_output_stream.cc
+++ b/src/v/net/batched_output_stream.cc
@@ -81,7 +81,7 @@ ss::future<> batched_output_stream::stop() {
     }
 
     return ss::with_semaphore(*_write_sem, 1, [this] {
-        return do_flush().then([this] { return _out.close(); });
+        return do_flush().finally([this] { return _out.close(); });
     });
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11586
Fixes https://github.com/redpanda-data/redpanda/issues/11600,