### PR TITLE
Expand '~' in --redpanda-cfg

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -600,7 +600,15 @@ ss::app_template::config application::setup_app_config() {
 }
 
 void application::hydrate_config(const po::variables_map& cfg) {
-    std::filesystem::path cfg_path(cfg["redpanda-cfg"].as<std::string>());
+    auto raw_cfg_path = cfg["redpanda-cfg"].as<std::string>();
+    // Expand ~/redpanda.yaml to the full path
+    if (raw_cfg_path.starts_with("~")) {
+        const char* home = std::getenv("HOME");
+        if (home) {
+            raw_cfg_path = fmt::format("{}{}", home, raw_cfg_path.substr(1));
+        }
+    }
+    std::filesystem::path cfg_path(raw_cfg_path);
 
     // Retain the original bytes loaded so that we can hexdump them later
     // if YAML Parse fails.


### PR DESCRIPTION
A small quality of life change: I keep my redpanda.yaml in a seperate
directory that is tuned to my system, so it's useful to just
pass ~/conf/redpanda.yaml instead of remembering to do
$HOME/conf/redpanda.yaml

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
