### PR TITLE
net: `ss::nested_exception` might be a `disconnect_exception`

### DIFF
--- a/src/v/net/tests/CMakeLists.txt
+++ b/src/v/net/tests/CMakeLists.txt
@@ -29,3 +29,13 @@ rp_test(
         ARGS "-- -c 1"
         LABELS net
 )
+
+rp_test(
+        UNIT_TEST
+        BINARY_NAME net_connection
+        SOURCES
+        connection.cc
+        DEFINITIONS BOOST_TEST_DYN_LINK
+        LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::net
+        LABELS net
+)

--- a/src/v/net/tests/connection.cc
+++ b/src/v/net/tests/connection.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "net/connection.h"
+
+#include <seastar/core/future.hh>
+
+#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include <exception>
+#include <system_error>
+
+BOOST_AUTO_TEST_CASE(test_is_disconnect_error) {
+    auto is_a_de = std::system_error(
+      std::make_error_code(std::errc::broken_pipe));
+    auto not_a_de = std::system_error(
+      std::make_error_code(std::errc::is_a_directory));
+
+    BOOST_CHECK(net::is_disconnect_exception(std::make_exception_ptr(is_a_de))
+                  .has_value());
+
+    BOOST_CHECK(!net::is_disconnect_exception(std::make_exception_ptr(not_a_de))
+                   .has_value());
+
+    BOOST_CHECK(
+      net::is_disconnect_exception(
+        std::make_exception_ptr(ss::nested_exception(
+          std::make_exception_ptr(is_a_de), std::make_exception_ptr(not_a_de))))
+        .has_value());
+
+    BOOST_CHECK(
+      net::is_disconnect_exception(
+        std::make_exception_ptr(ss::nested_exception(
+          std::make_exception_ptr(not_a_de), std::make_exception_ptr(is_a_de))))
+        .has_value());
+
+    BOOST_CHECK(!net::is_disconnect_exception(
+                   std::make_exception_ptr(ss::nested_exception(
+                     std::make_exception_ptr(not_a_de),
+                     std::make_exception_ptr(not_a_de))))
+                   .has_value());
+}


### PR DESCRIPTION
Look through an `ss::nested_exception` to see if it's a `disconnect_exception`.
 
Fixes #11617 by changing the log level from `error` to `info`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
