### PR TITLE
Update `abort_old_txes` of the consumer group to use locks

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -49,6 +49,7 @@ group::group(
   kafka::group_id id,
   group_state s,
   config::configuration& conf,
+  ss::lw_shared_ptr<ssx::rwlock> catchup_lock,
   ss::lw_shared_ptr<cluster::partition> partition,
   model::term_id term,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
@@ -62,6 +63,7 @@ group::group(
   , _num_members_joining(0)
   , _new_member_added(false)
   , _conf(conf)
+  , _catchup_lock(std::move(catchup_lock))
   , _partition(std::move(partition))
   , _probe(_members, _static_members, _offsets)
   , _ctxlog(klog, *this)
@@ -84,6 +86,7 @@ group::group(
   kafka::group_id id,
   group_metadata_value& md,
   config::configuration& conf,
+  ss::lw_shared_ptr<ssx::rwlock> catchup_lock,
   ss::lw_shared_ptr<cluster::partition> partition,
   model::term_id term,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
@@ -103,6 +106,7 @@ group::group(
   , _leader(md.leader)
   , _new_member_added(false)
   , _conf(conf)
+  , _catchup_lock(std::move(catchup_lock))
   , _partition(std::move(partition))
   , _probe(_members, _static_members, _offsets)
   , _ctxlog(klog, *this)
@@ -3229,6 +3233,11 @@ void group::maybe_rearm_timer() {
 }
 
 ss::future<> group::do_abort_old_txes() {
+    auto unit = _catchup_lock->attempt_read_lock();
+    if (!unit) {
+        co_return;
+    }
+
     std::vector<model::producer_identity> pids;
     for (auto& [id, _] : _prepared_txs) {
         pids.push_back(id);

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -29,6 +29,7 @@
 #include "model/timestamp.h"
 #include "seastarx.h"
 #include "utils/mutex.h"
+#include "utils/rwlock.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -202,6 +203,7 @@ public:
       kafka::group_id id,
       group_state s,
       config::configuration& conf,
+      ss::lw_shared_ptr<ssx::rwlock> catchup_lock,
       ss::lw_shared_ptr<cluster::partition> partition,
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
@@ -214,6 +216,7 @@ public:
       kafka::group_id id,
       group_metadata_value& md,
       config::configuration& conf,
+      ss::lw_shared_ptr<ssx::rwlock> catchup_lock,
       ss::lw_shared_ptr<cluster::partition> partition,
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
@@ -916,6 +919,7 @@ private:
     ss::timer<clock_type> _join_timer;
     bool _new_member_added;
     config::configuration& _conf;
+    ss::lw_shared_ptr<ssx::rwlock> _catchup_lock;
     ss::lw_shared_ptr<cluster::partition> _partition;
     absl::node_hash_map<
       model::topic_partition,

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -403,7 +403,7 @@ ss::future<> group_manager::do_detach_partition(model::ntp ntp) {
         co_return;
     }
     auto p = it->second;
-    auto units = co_await p->catchup_lock.hold_write_lock();
+    auto units = co_await p->catchup_lock->hold_write_lock();
 
     // Becasue shutdown group is async operation we should run it after
     // rehash for groups map
@@ -562,8 +562,7 @@ group_manager::gc_partition_state(ss::lw_shared_ptr<attached_partition> p) {
      * since this operation is destructive for partitions group we hold a
      * catchup write lock
      */
-
-    auto units = co_await p->catchup_lock.hold_write_lock();
+    auto units = co_await p->catchup_lock->hold_write_lock();
 
     // Becasue shutdown group is async operation we should run it after rehash
     // for groups map
@@ -623,8 +622,8 @@ ss::future<> group_manager::handle_partition_leader_change(
      * is rarely contended we take a writer lock only when leadership
      * changes (infrequent event)
      */
-    return p->catchup_lock.hold_write_lock()
-      .then([this, term, timeout, p](ss::basic_rwlock<>::holder unit) {
+    return p->catchup_lock->hold_write_lock().then(
+      [this, term, timeout, p](ss::basic_rwlock<>::holder unit) {
           return inject_noop(p->partition, timeout)
             .then([this, term, timeout, p] {
                 /*
@@ -663,8 +662,7 @@ ss::future<> group_manager::handle_partition_leader_change(
                   });
             })
             .finally([unit = std::move(unit)] {});
-      })
-      .finally([p] {});
+      });
 }
 
 /*
@@ -723,6 +721,7 @@ ss::future<> group_manager::do_recover_group(
               group_id,
               group_stm.get_metadata(),
               _conf,
+              p->catchup_lock,
               p->partition,
               term,
               _tx_frontend,
@@ -923,6 +922,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
           r.data.group_id,
           group_state::empty,
           _conf,
+          it->second->catchup_lock,
           p,
           it->second->term,
           _tx_frontend,
@@ -1039,7 +1039,7 @@ group_manager::leave_group(leave_group_request&& r) {
 ss::future<txn_offset_commit_response>
 group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
     auto p = get_attached_partition(r.ntp);
-    if (!p || !p->catchup_lock.try_read_lock()) {
+    if (!p || !p->catchup_lock->try_read_lock()) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1049,9 +1049,9 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
           txn_offset_commit_response(
             r, error_code::coordinator_load_in_progress));
     }
-    p->catchup_lock.read_unlock();
+    p->catchup_lock->read_unlock();
 
-    return p->catchup_lock.hold_read_lock().then(
+    return p->catchup_lock->hold_read_lock().then(
       [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
           // TODO: use correct key instead of offset_commit_api::key
           // check other txn places
@@ -1064,13 +1064,14 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
 
           auto group = get_group(r.data.group_id);
           if (!group) {
-              // <kafka>the group is not relying on Kafka for group management,
-              // so allow the commit</kafka>
+              // <kafka>the group is not relying on Kafka for group
+              // management, so allow the commit</kafka>
 
               group = ss::make_lw_shared<kafka::group>(
                 r.data.group_id,
                 group_state::empty,
                 _conf,
+                p->catchup_lock,
                 p->partition,
                 p->term,
                 _tx_frontend,
@@ -1089,7 +1090,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
 ss::future<cluster::commit_group_tx_reply>
 group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
     auto p = get_attached_partition(r.ntp);
-    if (!p || !p->catchup_lock.try_read_lock()) {
+    if (!p || !p->catchup_lock->try_read_lock()) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1098,10 +1099,10 @@ group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
         return ss::make_ready_future<cluster::commit_group_tx_reply>(
           make_commit_tx_reply(cluster::tx_errc::coordinator_load_in_progress));
     }
-    p->catchup_lock.read_unlock();
+    p->catchup_lock->read_unlock();
 
-    return p->catchup_lock.hold_read_lock().then(
-      [this, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
+    return p->catchup_lock->hold_read_lock().then(
+      [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
           auto error = validate_group_status(
             r.ntp, r.group_id, offset_commit_api::key);
           if (error != error_code::none) {
@@ -1128,7 +1129,7 @@ group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
 ss::future<cluster::begin_group_tx_reply>
 group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
     auto p = get_attached_partition(r.ntp);
-    if (!p || !p->catchup_lock.try_read_lock()) {
+    if (!p || !p->catchup_lock->try_read_lock()) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1137,9 +1138,9 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
         return ss::make_ready_future<cluster::begin_group_tx_reply>(
           make_begin_tx_reply(cluster::tx_errc::coordinator_load_in_progress));
     }
-    p->catchup_lock.read_unlock();
+    p->catchup_lock->read_unlock();
 
-    return p->catchup_lock.hold_read_lock().then(
+    return p->catchup_lock->hold_read_lock().then(
       [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
           auto error = validate_group_status(
             r.ntp, r.group_id, offset_commit_api::key);
@@ -1157,6 +1158,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
                 r.group_id,
                 group_state::empty,
                 _conf,
+                p->catchup_lock,
                 p->partition,
                 p->term,
                 _tx_frontend,
@@ -1175,7 +1177,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
 ss::future<cluster::prepare_group_tx_reply>
 group_manager::prepare_tx(cluster::prepare_group_tx_request&& r) {
     auto p = get_attached_partition(r.ntp);
-    if (!p || !p->catchup_lock.try_read_lock()) {
+    if (!p || !p->catchup_lock->try_read_lock()) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1185,10 +1187,10 @@ group_manager::prepare_tx(cluster::prepare_group_tx_request&& r) {
           make_prepare_tx_reply(
             cluster::tx_errc::coordinator_load_in_progress));
     }
-    p->catchup_lock.read_unlock();
+    p->catchup_lock->read_unlock();
 
-    return p->catchup_lock.hold_read_lock().then(
-      [this, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
+    return p->catchup_lock->hold_read_lock().then(
+      [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
           auto error = validate_group_status(
             r.ntp, r.group_id, offset_commit_api::key);
           if (error != error_code::none) {
@@ -1213,7 +1215,7 @@ group_manager::prepare_tx(cluster::prepare_group_tx_request&& r) {
 ss::future<cluster::abort_group_tx_reply>
 group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
     auto p = get_attached_partition(r.ntp);
-    if (!p || !p->catchup_lock.try_read_lock()) {
+    if (!p || !p->catchup_lock->try_read_lock()) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1222,10 +1224,10 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
         return ss::make_ready_future<cluster::abort_group_tx_reply>(
           make_abort_tx_reply(cluster::tx_errc::coordinator_load_in_progress));
     }
-    p->catchup_lock.read_unlock();
+    p->catchup_lock->read_unlock();
 
-    return p->catchup_lock.hold_read_lock().then(
-      [this, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
+    return p->catchup_lock->hold_read_lock().then(
+      [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
           auto error = validate_group_status(
             r.ntp, r.group_id, offset_commit_api::key);
           if (error != error_code::none) {
@@ -1265,6 +1267,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
               r.data.group_id,
               group_state::empty,
               _conf,
+              p->catchup_lock,
               p->partition,
               p->term,
               _tx_frontend,

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -52,6 +52,7 @@ static group get() {
       group_state::empty,
       conf,
       nullptr,
+      nullptr,
       model::term_id(),
       fr,
       feature_table,

--- a/src/v/utils/rwlock.h
+++ b/src/v/utils/rwlock.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "seastarx.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/rwlock.hh>
+
+namespace ssx {
+
+class rwlock;
+
+class rwlock_unit {
+    rwlock* _lock;
+    bool _is_write_lock{false};
+
+public:
+    rwlock_unit(rwlock* lock, bool is_write_lock) noexcept
+      : _lock(lock)
+      , _is_write_lock(is_write_lock) {}
+    rwlock_unit(rwlock_unit&& token) noexcept
+      : _lock(token._lock)
+      , _is_write_lock(token._is_write_lock) {
+        token._lock = nullptr;
+    }
+    rwlock_unit(const rwlock_unit&) = delete;
+    rwlock_unit(const rwlock_unit&&) = delete;
+    rwlock_unit() = delete;
+
+    rwlock_unit& operator=(rwlock_unit&& other) noexcept {
+        if (this != &other) {
+            other._lock = nullptr;
+        }
+        return *this;
+    }
+
+    ~rwlock_unit() noexcept;
+};
+
+class rwlock : public ss::basic_rwlock<> {
+public:
+    std::optional<rwlock_unit> attempt_read_lock() {
+        bool locked = try_read_lock();
+
+        if (!locked) {
+            return std::nullopt;
+        }
+
+        return rwlock_unit(this, false);
+    }
+
+    std::optional<rwlock_unit> attempt_write_lock() {
+        bool locked = try_write_lock();
+
+        if (!locked) {
+            return std::nullopt;
+        }
+
+        return rwlock_unit(this, true);
+    }
+};
+
+inline rwlock_unit::~rwlock_unit() noexcept {
+    if (_lock) {
+        if (_is_write_lock) {
+            _lock->write_unlock();
+        } else {
+            _lock->read_unlock();
+        }
+    }
+}
+
+} // namespace ssx

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ rp_test(
     retry_chain_node_test.cc
     seastar_histogram_test.cc
     timed_mutex_test.cc
+    rwlock_test.cc
     token_bucket_test.cc
     uuid_test.cc
     vint_test.cc

--- a/src/v/utils/tests/rwlock_test.cc
+++ b/src/v/utils/tests/rwlock_test.cc
@@ -1,0 +1,53 @@
+#include "seastarx.h"
+#include "ssx/semaphore.h"
+#include "utils/rwlock.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+SEASTAR_THREAD_TEST_CASE(test_rwlock_r_blocks_w) {
+    ssx::rwlock rwlock;
+    auto runit = rwlock.attempt_read_lock();
+    BOOST_REQUIRE(runit);
+    auto wunit = rwlock.attempt_write_lock();
+    BOOST_REQUIRE(!wunit);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_rwlock_w_blocks_r) {
+    ssx::rwlock rwlock;
+    auto wunit = rwlock.attempt_write_lock();
+    BOOST_REQUIRE(wunit);
+    auto runit = rwlock.attempt_read_lock();
+    BOOST_REQUIRE(!runit);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_rwlock_r_permits_r) {
+    ssx::rwlock rwlock;
+    auto unit1 = rwlock.attempt_read_lock();
+    BOOST_REQUIRE(unit1);
+    auto unit2 = rwlock.attempt_read_lock();
+    BOOST_REQUIRE(unit2);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_rwlock_w_blocks_w) {
+    ssx::rwlock rwlock;
+    auto unit1 = rwlock.attempt_write_lock();
+    BOOST_REQUIRE(unit1);
+    auto unit2 = rwlock.attempt_write_lock();
+    BOOST_REQUIRE(!unit2);
+}
+
+void some_processing(ssx::rwlock_unit&& unit) {
+    ssx::rwlock_unit unit3(std::move(unit));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_rwlock_unit_move) {
+    ssx::rwlock rwlock;
+    auto unit1 = rwlock.attempt_write_lock();
+    BOOST_REQUIRE(unit1);
+    some_processing(std::move(unit1.value()));
+
+    auto unit2 = rwlock.attempt_write_lock();
+    BOOST_REQUIRE(unit2);
+}


### PR DESCRIPTION
An execution of abort_old_txes could span multiple terms so the so the method could modify new state assuming it's the old state resulting in undefined behavior.

This commit is the rewrite of the reverted [f7fc026f](https://github.com/redpanda-data/redpanda/commit/f7fc026f3203da167acc0e4c95b86f2e7e082dec) in [11474](https://github.com/redpanda-data/redpanda/pull/11474). The problem was caused by:

  - do_detach_partition got blocked
  - RP ignored blocked do_detach_partition and attempted next op leading double registration of the consumer groups ntp

The op was blocked by a deadlock:

  - do_abort_old_txes was waiting for read lock while holding _gate
  - do_detach_partition was holding write lock while waiting to the gate to be closed

This version doesn't wait for the read lock to become available and exit do_abort_old_txes releasing the _gate.

It still isn't clear why RP ignored a blocked op

Fixes #11562

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none