### PR TITLE
Fix counts rebalancing simulation test problems

### DIFF
--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -267,8 +267,16 @@ public:
               double(total_replicas) * capacity / total_capacity);
             logger.info(
               "node {} has {} replicas, expected: {}", id, replicas, expected);
-            BOOST_REQUIRE_GE(replicas, expected - ceil(max_skew * expected));
-            BOOST_REQUIRE_LE(replicas, expected + ceil(max_skew * expected));
+            auto expected_min = expected - ceil(max_skew * expected);
+            auto expected_max = expected + ceil(max_skew * expected);
+            if (replicas < expected_min || replicas > expected_max) {
+                print_replica_map();
+                BOOST_REQUIRE_MESSAGE(
+                  false,
+                  "node " << id << ": unexpected replicas count: " << replicas
+                          << "(expected interval: [" << expected_min << ", "
+                          << expected_max << "]");
+            }
         }
     }
 
@@ -691,6 +699,7 @@ FIXTURE_TEST(test_counts_rebalancing, partition_balancer_sim_fixture) {
         }
     }
 
+    print_state();
     validate_even_replica_distribution();
     validate_even_topic_distribution();
 }

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -319,10 +319,12 @@ public:
                   id,
                   expected_replicas,
                   total_replicas);
+                // Expected variance should be proportional to
+                // sqrt(expected_replicas). Assert that it is not more than 3x
+                // that.
                 auto err = std::abs(expected_replicas - replicas_on_node)
-                           / expected_replicas;
-                // assert that the skew is smaller than 50%
-                BOOST_REQUIRE_LE(err, 0.5);
+                           / sqrt(expected_replicas);
+                BOOST_REQUIRE_LE(err, 3.0);
             }
         }
     }

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -680,9 +680,9 @@ FIXTURE_TEST(test_counts_rebalancing, partition_balancer_sim_fixture) {
           100_MiB);
     }
 
-    add_node(model::node_id{3}, 100_GiB, 4);
+    add_node(model::node_id{3}, 1000_GiB, 4);
     add_node_to_rebalance(model::node_id{3});
-    add_node(model::node_id{4}, 100_GiB, 8);
+    add_node(model::node_id{4}, 1000_GiB, 8);
     add_node_to_rebalance(model::node_id{4});
 
     print_state();


### PR DESCRIPTION
* Fix even topic partition distribution check - expect variance to be proportional to sqrt(expected)
* Fix node disk sizes (prevent disk overflow on target nodes)

Fixes https://github.com/redpanda-data/redpanda/issues/11538

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
