### PR TITLE
storage: manage free space for cloud cache

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -937,12 +937,17 @@ ss::future<> cache::initialize(std::filesystem::path cache_dir) {
 
 uint64_t cache::max_bytes() const {
     vassert(ss::this_shard_id() == 0, "Called on wrong shard");
-    return target_max_bytes();
+    return _max_bytes_override.value_or(target_max_bytes());
 }
 
 uint64_t cache::target_max_bytes() const {
     vassert(ss::this_shard_id() == 0, "Called on wrong shard");
     return _max_bytes();
+}
+
+void cache::set_max_bytes_override(std::optional<uint64_t> val) {
+    vassert(ss::this_shard_id() == 0, "Called on wrong shard");
+    _max_bytes_override = val;
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -138,6 +138,12 @@ public:
       uint64_t free_space,
       storage::disk_space_alert alert);
 
+    // Shard 0 only. The effective max bytes configuration.
+    uint64_t max_bytes() const;
+
+    // Shard 0 only. The target max bytes configuration.
+    uint64_t target_max_bytes() const;
+
 private:
     /// Load access time tracker from file
     ss::future<> load_access_time_tracker();

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -144,6 +144,10 @@ public:
     // Shard 0 only. The target max bytes configuration.
     uint64_t target_max_bytes() const;
 
+    // Shard 0 only. Set or clear the effecitve max bytes. When cleared, the
+    // cache's target max bytes setting becomes the effective max bytes.
+    void set_max_bytes_override(std::optional<uint64_t> val = std::nullopt);
+
 private:
     /// Load access time tracker from file
     ss::future<> load_access_time_tracker();
@@ -198,6 +202,7 @@ private:
 
     std::filesystem::path _cache_dir;
     config::binding<uint64_t> _max_bytes;
+    std::optional<uint64_t> _max_bytes_override;
 
     ss::abort_source _as;
     ss::gate _gate;

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -138,6 +138,10 @@ public:
       uint64_t free_space,
       storage::disk_space_alert alert);
 
+    // Space management interface. The following sub-section of interfaces are
+    // used by the free space management control loop. This loop may adjust the
+    // maximum cache size and trigger trimming when free disk spsace is low.
+public:
     // Shard 0 only. The effective max bytes configuration.
     uint64_t max_bytes() const;
 
@@ -147,6 +151,16 @@ public:
     // Shard 0 only. Set or clear the effecitve max bytes. When cleared, the
     // cache's target max bytes setting becomes the effective max bytes.
     void set_max_bytes_override(std::optional<uint64_t> val = std::nullopt);
+
+    // Shard 0 only. Return the current amount of data in the cache.
+    uint64_t current_size() const;
+
+    // Shard 0 only. The effective maximum cache size that would cause cache put
+    // operations to trigger trimming action to free space.
+    uint64_t max_bytes_trim_threshold() const;
+
+    // Shard 0 only. Trim the cache.
+    ss::future<> trim();
 
 private:
     /// Load access time tracker from file
@@ -161,7 +175,7 @@ private:
 
     /// Triggers directory walker, creates a list of files to delete and deletes
     /// them until cache size <= _cache_size_low_watermark * max_bytes
-    ss::future<> trim();
+    ss::future<> do_trim();
 
     /// Invoke trim, waiting if not enough time passed since the last trim
     ss::future<> trim_throttled();

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -206,9 +206,11 @@ ss::future<> local_monitor::update_disk_metrics() {
     co_await _storage_node_api.invoke_on_all(
       &storage::node::set_disk_metrics,
       storage::node::disk_type::data,
-      _state.data_disk.total,
-      _state.data_disk.free,
-      _state.data_disk.alert);
+      storage::node::disk_space_info{
+        .total = _state.data_disk.total,
+        .free = _state.data_disk.free,
+        .alert = _state.data_disk.alert,
+      });
 
     // Always notify for cache disk, even if it's the same underlying drive:
     // subscribers to updates on cache disk space still need to get updates.
@@ -216,9 +218,11 @@ ss::future<> local_monitor::update_disk_metrics() {
     co_await _storage_node_api.invoke_on_all(
       &storage::node::set_disk_metrics,
       storage::node::disk_type::cache,
-      cache_disk.total,
-      cache_disk.free,
-      cache_disk.alert);
+      storage::node::disk_space_info{
+        .total = cache_disk.total,
+        .free = cache_disk.free,
+        .alert = cache_disk.alert,
+      });
 }
 
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -54,10 +54,6 @@ public:
       = "storage space alert"; // for those who grep the logs..
 
 private:
-    // helpers
-    static size_t
-    alert_percent_in_bytes(unsigned alert_percent, size_t bytes_available);
-
     /// Periodically check node status until stopped by abort source
     ss::future<> _update_loop();
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1357,6 +1357,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       space_manager,
       config::shard_local_cfg().enable_storage_space_manager.bind(),
       &storage,
+      &storage_node,
       &shadow_index_cache,
       &partition_manager);
 

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -13,6 +13,7 @@ v_cc_library(
     storage.cc
   DEPS
     Seastar::seastar
+    v::cloud_storage
   )
 
 add_subdirectory(tests)

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -13,6 +13,7 @@
 
 #include "cloud_storage/cache_service.h"
 #include "cluster/partition_manager.h"
+#include "utils/human.h"
 #include "vlog.h"
 
 #include <seastar/util/log.hh>
@@ -46,11 +47,26 @@ ss::future<> disk_space_manager::start() {
       rlog.info,
       "Starting disk space manager service ({})",
       _enabled() ? "enabled" : "disabled");
+
+    /*
+     * the space manager currently only controls the cache disk, which is not
+     * runtime configurable. so if the cache isn't enabled, there is not point
+     * in starting the control loop.
+     */
+    if (_cache == nullptr) {
+        vlog(
+          rlog.info,
+          "Cloud cache is not enabled. Disk space manager will have no effect");
+        co_return;
+    }
+
     if (ss::this_shard_id() == run_loop_core) {
         ssx::spawn_with_gate(_gate, [this] { return run_loop(); });
         _cache_disk_nid = _storage_node->local().register_disk_notification(
-          node::disk_type::cache,
-          [this](node::disk_space_info info) { _cache_disk_info = info; });
+          node::disk_type::cache, [this](node::disk_space_info info) {
+              _cache_disk_info = info;
+              maybe_signal_run_loop();
+          });
     }
     co_return;
 }
@@ -65,16 +81,44 @@ ss::future<> disk_space_manager::stop() {
     co_await _gate.close();
 }
 
+void disk_space_manager::maybe_signal_run_loop() {
+    /*
+     * in low free space or degraded state wake up the control loop immediately
+     * to deal with the situation.
+     */
+    if (_cache_disk_info.alert != disk_space_alert::ok) {
+        _control_sem.signal();
+        return;
+    }
+
+    /*
+     * no active disk disk space alert is positive, but if we had placed
+     * restrictions on the cache that are no longer necessarily we should lift
+     * those to allow its capacity to increase towards its target.
+     */
+    if (_cache->local().max_bytes() < _cache->local().target_max_bytes()) {
+        _control_sem.signal();
+        return;
+    }
+}
+
 ss::future<> disk_space_manager::run_loop() {
     vassert(ss::this_shard_id() == run_loop_core, "Run on wrong core");
 
     /*
-     * we want the code here to actually run a little, but the final shape of
-     * configuration options is not yet known.
+     * the run loop will wake up this frequency. right now this is intended for
+     * reporting and fail-safe. low-disk alert currently drives urgent changes.
      */
     constexpr auto frequency = std::chrono::seconds(30);
 
+    /*
+     * size of reduction applied to the maximum size of the cache. with default
+     * configurations this will roughly result in a step_size_bytes / sec rate.
+     */
+    constexpr auto max_bytes_step_size = 512_MiB;
+
     while (true) {
+        auto log_level = ss::log_level::debug;
         try {
             if (_enabled()) {
                 co_await _control_sem.wait(
@@ -82,12 +126,179 @@ ss::future<> disk_space_manager::run_loop() {
             } else {
                 co_await _control_sem.wait();
             }
+            // we were explicitly signaled, which means important.
+            log_level = ss::log_level::info;
         } catch (const ss::semaphore_timed_out&) {
             // time for some controlling
         }
 
         if (!_enabled()) {
             continue;
+        }
+
+        if (_cache_disk_info.alert == disk_space_alert::ok) {
+            /*
+             * there is no longer an active alert, but if the cache's effective
+             * max size is less than the target, try to raise it back up.
+             */
+            if (
+              _cache->local().max_bytes()
+              >= _cache->local().target_max_bytes()) {
+                continue;
+            }
+
+            if (_cache_disk_info.free < _cache_disk_info.low_space_threshold) {
+                // don't do anything--system may have _just_ entered into a
+                // low-disk space situation.
+                vlog(
+                  rlog.debug,
+                  "no active alert, but free space {} is below threshold {}. "
+                  "retrying.",
+                  human::bytes(_cache_disk_info.free),
+                  human::bytes(_cache_disk_info.low_space_threshold));
+                continue;
+            }
+
+            // the amount of free space remaining before low space alert
+            const auto space_before_alert
+              = _cache_disk_info.free - _cache_disk_info.low_space_threshold;
+
+            if (space_before_alert > _cache->local().target_max_bytes()) {
+                vlogl(
+                  rlog,
+                  log_level,
+                  "cache disk health ok resetting max size to target {} from "
+                  "{}",
+                  human::bytes(_cache->local().target_max_bytes()),
+                  human::bytes(_cache->local().max_bytes()));
+                _cache->local().set_max_bytes_override();
+                continue;
+            }
+
+            // don't decrease the cache size here. that'll be handled if
+            // necessary by an alert being raised.
+            if (space_before_alert <= _cache->local().max_bytes()) {
+                continue;
+            }
+
+            // don't announce micro adjustments
+            const auto ll = (space_before_alert - _cache->local().max_bytes())
+                                > 1_MiB
+                              ? log_level
+                              : ss::log_level::debug;
+            vlogl(
+              rlog,
+              ll,
+              "cache disk health ok resetting max size to alert threshold {} "
+              "from {} (target {})",
+              human::bytes(space_before_alert),
+              human::bytes(_cache->local().max_bytes()),
+              human::bytes(_cache->local().target_max_bytes()));
+            _cache->local().set_max_bytes_override(space_before_alert);
+            continue;
+        }
+
+        vlogl(
+          rlog,
+          log_level,
+          "cache disk capacity {} free {} thresholds low {} degraded {}",
+          human::bytes(_cache_disk_info.total),
+          human::bytes(_cache_disk_info.free),
+          human::bytes(_cache_disk_info.low_space_threshold),
+          human::bytes(_cache_disk_info.degraded_threshold));
+
+        /*
+         * fetch updated must-have and nice-to-have cache capacity targets
+         */
+        auto cache_targets
+          = co_await _pm->local().get_cloud_cache_disk_usage_target();
+
+        vlogl(
+          rlog,
+          log_level,
+          "cache size {} effective max {} target {} capacity wanted {} "
+          "required {}",
+          human::bytes(_cache->local().current_size()),
+          human::bytes(_cache->local().max_bytes()),
+          human::bytes(_cache->local().target_max_bytes()),
+          human::bytes(cache_targets.target_bytes),
+          human::bytes(cache_targets.target_min_bytes));
+
+        /*
+         * the first knob we can adjust in a low free space state.
+         *
+         * the cache may not contain enough data available for removal that
+         * will take the system out of the alert state, but we can still play
+         * nice by not allowing the cache to use any additional free space.
+         *
+         * the max_bytes_tirm_threshold value is the effective maximum size of
+         * cache that achives this. this is like a "shrink_to_fit" operation.
+         */
+        const auto cache_max_trim_threshold
+          = _cache->local().max_bytes_trim_threshold();
+        vlogl(
+          rlog,
+          log_level,
+          "cache effective max size set to trim threshold {}",
+          human::bytes(cache_max_trim_threshold));
+        _cache->local().set_max_bytes_override(cache_max_trim_threshold);
+
+        // amount of additional free space needed to clear the alert
+        const auto free_space_needed = _cache_disk_info.low_space_threshold
+                                       - _cache_disk_info.free;
+
+        // the size by which the cache may be reduced without violating the
+        // current must-have space requirement.
+        const auto max_reduction = _cache->local().max_bytes()
+                                   - std::min(
+                                     cache_targets.target_min_bytes,
+                                     _cache->local().max_bytes());
+
+        vlogl(
+          rlog,
+          log_level,
+          "cache disk needs {} freed {} available in cache service",
+          human::bytes(free_space_needed),
+          human::bytes(max_reduction));
+
+        /*
+         * the second knob to adjust.
+         *
+         * reduce the amount of data in the cache. the reduction is applied
+         * incrementally to both smooth out the behavior as well as avoid nuking
+         * a ton of data if the reduction is due to a temporary blip.
+         */
+        if (max_reduction > 0) {
+            const auto step = std::min(max_reduction, max_bytes_step_size);
+            const auto new_max_bytes = _cache->local().max_bytes() - step;
+            vlogl(
+              rlog,
+              log_level,
+              "cache disk max size reduced by {} to {}",
+              human::bytes(step),
+              human::bytes(new_max_bytes));
+            _cache->local().set_max_bytes_override(new_max_bytes);
+            co_await _cache->local().trim();
+        }
+
+        /*
+         * In an extreme case there might not be much data in the cache, and
+         * when we clamp to the current size to prevent further expansion in a
+         * low-disk situation then we may already have fell below the must-have
+         * threshold. in this case, let's still warn as we aren't in good shape.
+         */
+        if (_cache->local().max_bytes() < cache_targets.target_min_bytes) {
+            vlog(
+              rlog.warn,
+              "cache max size {} is less than target minimum size {}",
+              human::bytes(_cache->local().max_bytes()),
+              human::bytes(cache_targets.target_min_bytes));
+        } else if (_cache->local().max_bytes() < cache_targets.target_bytes) {
+            vlog(
+              rlog.warn,
+              "cache max size {} is less than target size {}",
+              human::bytes(_cache->local().max_bytes()),
+              human::bytes(cache_targets.target_bytes));
         }
     }
 }

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -89,60 +89,6 @@ ss::future<> disk_space_manager::run_loop() {
         if (!_enabled()) {
             continue;
         }
-
-        /*
-         * Collect cache and logs storage usage information. These accumulate
-         * across all shards (despite the local() accessor). If a failure occurs
-         * we wait rather than operate with a reduced set of information.
-         */
-        cloud_storage::cache_usage_target cache_usage_target;
-        try {
-            cache_usage_target
-              = co_await _pm->local().get_cloud_cache_disk_usage_target();
-        } catch (...) {
-            vlog(
-              rlog.info,
-              "Unable to collect cloud cache usage: {}",
-              std::current_exception());
-            continue;
-        }
-
-        storage::usage_report logs_usage;
-        try {
-            logs_usage = co_await _storage->local().disk_usage();
-        } catch (...) {
-            vlog(
-              rlog.info,
-              "Unable to collect log storage usage: {}",
-              std::current_exception());
-            continue;
-        }
-
-        vlog(
-          rlog.debug,
-          "Cloud storage cache target minimum size {} nice to have {}",
-          cache_usage_target.target_min_bytes,
-          cache_usage_target.target_bytes);
-
-        vlog(
-          rlog.debug,
-          "Log storage usage total {} - data {} index {} compaction {}",
-          logs_usage.usage.total(),
-          logs_usage.usage.data,
-          logs_usage.usage.index,
-          logs_usage.usage.compaction);
-
-        vlog(
-          rlog.debug,
-          "Log storage usage available for reclaim local {} total {}",
-          logs_usage.reclaim.retention,
-          logs_usage.reclaim.available);
-
-        vlog(
-          rlog.debug,
-          "Log storage usage target minimum size {} nice to have {}",
-          logs_usage.target.min_capacity,
-          logs_usage.target.min_capacity_wanted);
     }
 }
 

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -48,12 +48,19 @@ ss::future<> disk_space_manager::start() {
       _enabled() ? "enabled" : "disabled");
     if (ss::this_shard_id() == run_loop_core) {
         ssx::spawn_with_gate(_gate, [this] { return run_loop(); });
+        _cache_disk_nid = _storage_node->local().register_disk_notification(
+          node::disk_type::cache,
+          [this](node::disk_space_info info) { _cache_disk_info = info; });
     }
     co_return;
 }
 
 ss::future<> disk_space_manager::stop() {
     vlog(rlog.info, "Stopping disk space manager service");
+    if (ss::this_shard_id() == run_loop_core) {
+        _storage_node->local().unregister_disk_notification(
+          node::disk_type::cache, _cache_disk_nid);
+    }
     _control_sem.broken();
     co_await _gate.close();
 }

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -11,6 +11,7 @@
 
 #include "storage.h"
 
+#include "cloud_storage/cache_service.h"
 #include "cluster/partition_manager.h"
 #include "vlog.h"
 
@@ -23,10 +24,12 @@ namespace storage {
 disk_space_manager::disk_space_manager(
   config::binding<bool> enabled,
   ss::sharded<storage::api>* storage,
+  ss::sharded<storage::node>* storage_node,
   ss::sharded<cloud_storage::cache>* cache,
   ss::sharded<cluster::partition_manager>* pm)
   : _enabled(std::move(enabled))
   , _storage(storage)
+  , _storage_node(storage_node)
   , _cache(cache->local_is_initialized() ? cache : nullptr)
   , _pm(pm) {
     _enabled.watch([this] {

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -14,6 +14,7 @@
 #include "config/property.h"
 #include "seastarx.h"
 #include "ssx/semaphore.h"
+#include "storage/node.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -30,27 +31,7 @@ class partition_manager;
 namespace storage {
 
 class api;
-
-enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
-
-inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
-    return std::max(a, b);
-}
-
-inline std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
-    switch (d) {
-    case disk_space_alert::ok:
-        o << "ok";
-        break;
-    case disk_space_alert::low_space:
-        o << "low_space";
-        break;
-    case disk_space_alert::degraded:
-        o << "degraded";
-        break;
-    }
-    return o;
-}
+class node;
 
 /*
  *
@@ -60,6 +41,7 @@ public:
     disk_space_manager(
       config::binding<bool> enabled,
       ss::sharded<storage::api>* storage,
+      ss::sharded<storage::node>* storage_node,
       ss::sharded<cloud_storage::cache>* cache,
       ss::sharded<cluster::partition_manager>* pm);
 
@@ -75,6 +57,7 @@ public:
 private:
     config::binding<bool> _enabled;
     ss::sharded<storage::api>* _storage;
+    ss::sharded<storage::node>* _storage_node;
     ss::sharded<cloud_storage::cache>* _cache;
     ss::sharded<cluster::partition_manager>* _pm;
 

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -37,6 +37,8 @@ class node;
  *
  */
 class disk_space_manager {
+    static constexpr ss::shard_id run_loop_core = 0;
+
 public:
     disk_space_manager(
       config::binding<bool> enabled,

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -67,6 +67,7 @@ private:
     // details from last disk notification
     node::disk_space_info _cache_disk_info;
 
+    void maybe_signal_run_loop();
 
     ss::gate _gate;
     ss::future<> run_loop();

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -63,6 +63,11 @@ private:
     ss::sharded<cloud_storage::cache>* _cache;
     ss::sharded<cluster::partition_manager>* _pm;
 
+    node::notification_id _cache_disk_nid;
+    // details from last disk notification
+    node::disk_space_info _cache_disk_info;
+
+
     ss::gate _gate;
     ss::future<> run_loop();
     ssx::semaphore _control_sem{0, "resource_mgmt::space_manager"};

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -38,11 +38,17 @@ void node::set_disk_metrics(
   uint64_t free_bytes,
   disk_space_alert alert) {
     if (t == disk_type::data) {
-        _data_watchers.notify(
-          uint64_t(total_bytes), uint64_t(free_bytes), alert);
+        _data_watchers.notify(disk_space_info{
+          .total = total_bytes,
+          .free = free_bytes,
+          .alert = alert,
+        });
     } else if (t == disk_type::cache) {
-        _cache_watchers.notify(
-          uint64_t(total_bytes), uint64_t(free_bytes), alert);
+        _cache_watchers.notify(disk_space_info{
+          .total = total_bytes,
+          .free = free_bytes,
+          .alert = alert,
+        });
     }
     _probe.set_disk_metrics(total_bytes, free_bytes, alert);
 }

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -32,25 +32,21 @@ ss::future<> node::start() {
 
 ss::future<> node::stop() { co_return; }
 
-void node::set_disk_metrics(
-  disk_type t,
-  uint64_t total_bytes,
-  uint64_t free_bytes,
-  disk_space_alert alert) {
+void node::set_disk_metrics(disk_type t, disk_space_info info) {
     if (t == disk_type::data) {
         _data_watchers.notify(disk_space_info{
-          .total = total_bytes,
-          .free = free_bytes,
-          .alert = alert,
+          .total = info.total,
+          .free = info.free,
+          .alert = info.alert,
         });
     } else if (t == disk_type::cache) {
         _cache_watchers.notify(disk_space_info{
-          .total = total_bytes,
-          .free = free_bytes,
-          .alert = alert,
+          .total = info.total,
+          .free = info.free,
+          .alert = info.alert,
         });
     }
-    _probe.set_disk_metrics(total_bytes, free_bytes, alert);
+    _probe.set_disk_metrics(info.total, info.free, info.alert);
 }
 
 node::notification_id

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -10,6 +10,8 @@
  */
 #include "storage/node.h"
 
+#include <seastar/core/reactor.hh>
+
 namespace storage {
 
 node::node(ss::sstring data_directory, ss::sstring cache_directory)

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -34,17 +34,9 @@ ss::future<> node::stop() { co_return; }
 
 void node::set_disk_metrics(disk_type t, disk_space_info info) {
     if (t == disk_type::data) {
-        _data_watchers.notify(disk_space_info{
-          .total = info.total,
-          .free = info.free,
-          .alert = info.alert,
-        });
+        _data_watchers.notify(info);
     } else if (t == disk_type::cache) {
-        _cache_watchers.notify(disk_space_info{
-          .total = info.total,
-          .free = info.free,
-          .alert = info.alert,
-        });
+        _cache_watchers.notify(info);
     }
     _probe.set_disk_metrics(info.total, info.free, info.alert);
 }

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -10,9 +10,9 @@
  */
 #pragma once
 
-#include "resource_mgmt/storage.h"
 #include "seastarx.h"
 #include "storage/probe.h"
+#include "storage/types.h"
 #include "utils/named_type.h"
 #include "utils/notification_list.h"
 

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -30,9 +30,14 @@ class node {
 public:
     static constexpr ss::shard_id work_shard = 0;
 
+    struct disk_space_info {
+        size_t total;
+        size_t free;
+        disk_space_alert alert;
+    };
+
     using notification_id = named_type<int32_t, struct notification_id_t>;
-    using disk_cb_t
-      = ss::noncopyable_function<void(uint64_t, uint64_t, disk_space_alert)>;
+    using disk_cb_t = ss::noncopyable_function<void(disk_space_info)>;
 
     enum class disk_type { data, cache };
 

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -34,6 +34,8 @@ public:
         size_t total;
         size_t free;
         disk_space_alert alert;
+        size_t degraded_threshold;
+        size_t low_space_threshold;
     };
 
     using notification_id = named_type<int32_t, struct notification_id_t>;

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -46,11 +46,7 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    void set_disk_metrics(
-      disk_type t,
-      uint64_t total_bytes,
-      uint64_t free_bytes,
-      disk_space_alert alert);
+    void set_disk_metrics(disk_type t, disk_space_info);
 
     notification_id register_disk_notification(disk_type t, disk_cb_t cb);
     void unregister_disk_notification(disk_type t, notification_id id);

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -16,7 +16,6 @@
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
-#include "resource_mgmt/storage.h"
 #include "storage/file_sanitizer_types.h"
 #include "storage/fwd.h"
 #include "tristate.h"
@@ -33,6 +32,27 @@
 namespace storage {
 using log_clock = ss::lowres_clock;
 using jitter_percents = named_type<int, struct jitter_percents_tag>;
+
+enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
+
+inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
+    return std::max(a, b);
+}
+
+inline std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
+    switch (d) {
+    case disk_space_alert::ok:
+        o << "ok";
+        break;
+    case disk_space_alert::low_space:
+        o << "low_space";
+        break;
+    case disk_space_alert::degraded:
+        o << "degraded";
+        break;
+    }
+    return o;
+}
 
 struct disk
   : serde::envelope<disk, serde::version<1>, serde::compat_version<0>> {


### PR DESCRIPTION
The core piece of this PR is in the final commit. Prior commits are primarily refactoring in support.

The last commit introduces a control loop for tracking and managing the size of the cloud cache in response to disk space pressure. Roughly when the disk begins to fill up the cache's size will be reduced and the cache will be trimmed. Once the the low free space scenario is mitigated the size of the cache will increase again. The goal is to take pressure off the system and avoid blocking puts by entering into a degraded state.

Note that the only control knob here is the cache itself. So the control loop most directly is applicable to a dedicated cache drive. However, the general structure of this loop is representative of how we will likely tackle the shared drive scenario as well in a later PR.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features

* Short description of the feature. Explain how to configure.

