### PR TITLE
archival: wait for gc future completion in unit test

### DIFF
--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -631,7 +631,7 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
 
     // Trigger garbage collection within the archive. This should
     // remove segments in the [0, 2000) offset interval.
-    ssx::background = archiver.garbage_collect_archive();
+    auto fut = archiver.garbage_collect_archive();
     tests::cooperative_spin_wait_with_timeout(5s, [this, part]() mutable {
         const auto& manifest = part->archival_meta_stm()->manifest();
         bool archive_clean_moved = manifest.get_archive_clean_offset()
@@ -643,6 +643,7 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
                             == 2;
         return archive_clean_moved && deletes_sent;
     }).get();
+    fut.get();
 
     ss::sstring delete_payloads;
     for (const auto& [url, req] : get_targets()) {


### PR DESCRIPTION
Previously, the archive gc future was backgrounded, but that may race with the stopping of the async_manifest_view.

Fixes https://github.com/redpanda-data/redpanda/issues/11626

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
