### PR TITLE
rptest: fix S3 bucket deletion

### DIFF
--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -122,8 +122,7 @@ class S3Client:
             f"Bucket {name} didn't become visible to ListObjectsvv2 requests")
 
     def empty_and_delete_bucket(self, name, parallel=False):
-        failed_deletions = self.cloud_storage_client.empty_bucket(
-            self._si_settings.cloud_storage_bucket, parallel=parallel)
+        failed_deletions = self.empty_bucket(name, parallel=parallel)
 
         assert len(failed_deletions) == 0
         self.delete_bucket(name)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2844,7 +2844,15 @@ class RedpandaService(RedpandaServiceBase):
     def clean(self, **kwargs):
         super().clean(**kwargs)
         if self.cloud_storage_client:
-            self.delete_bucket_from_si()
+            try:
+                self.delete_bucket_from_si()
+            except Exception as e:
+                self.logger.error(
+                    f"Failed to remove bucket {self._si_settings.cloud_storage_bucket}."
+                    f" This may cause running out of quota in the cloud env. Please investigate: {e}"
+                )
+
+                raise e
 
     def clean_node(self,
                    node,


### PR DESCRIPTION
A previous refactor of the code around emptying the bucket and deletion was buggy. This resulted in tests not cleaning up their buckets properly. This patch fixes the issue and adds an appropriately scary error log.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

