### PR TITLE
cloud_storage: perform spillovers in cloud timing stress tests

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2257,6 +2257,15 @@ ss::future<> ntp_archiver::apply_retention() {
         co_return;
     }
 
+    if (manifest().archive_size_bytes() != 0) {
+        vlog(
+          _rtclog.error,
+          "Size of the archive is not 0, but archival and STM start offsets "
+          "are equal ({}). Skipping retention within STM region.",
+          arch_so);
+        co_return;
+    }
+
     auto retention_calculator = retention_calculator::factory(
       manifest(), _parent.get_ntp_config());
     if (!retention_calculator) {

--- a/src/v/archival/retention_calculator.cc
+++ b/src/v/archival/retention_calculator.cc
@@ -75,9 +75,9 @@ std::optional<retention_calculator> retention_calculator::factory(
     if (ntp_config.retention_bytes()) {
         auto total_retention_bytes = ntp_config.retention_bytes();
 
-        auto cloud_log_size = manifest.cloud_log_size();
-        if (cloud_log_size > *total_retention_bytes) {
-            auto overshot_by = cloud_log_size - *total_retention_bytes;
+        auto stm_region_size = manifest.stm_region_size_bytes();
+        if (stm_region_size > *total_retention_bytes) {
+            auto overshot_by = stm_region_size - *total_retention_bytes;
             strats.push_back(
               std::make_unique<size_based_strategy>(overshot_by));
         }

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -553,6 +553,10 @@ uint64_t partition_manifest::cloud_log_size() const {
     return _cloud_log_size_bytes + _archive_size_bytes;
 }
 
+uint64_t partition_manifest::stm_region_size_bytes() const {
+    return _cloud_log_size_bytes;
+}
+
 uint64_t partition_manifest::archive_size_bytes() const {
     return _archive_size_bytes;
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -305,9 +305,13 @@ public:
     void flush_write_buffer();
 
     // Returns the cached size in bytes of all segments available to clients.
-    // (i.e. all segments after and including the segment that starts at
-    // the current _start_offset).
+    // This includes both the STM region and the archive.
     uint64_t cloud_log_size() const;
+
+    // Returns the cached size in bytes of all segments within the STM region
+    // that are above the start offset. (i.e. all segments after and including
+    // the segment that starts at the current _start_offset).
+    uint64_t stm_region_size_bytes() const;
 
     /// Returns cached size of the archive in bytes.
     ///
@@ -573,6 +577,7 @@ private:
     model::offset _start_offset;
     model::offset _last_uploaded_compacted_offset;
     model::offset _insync_offset;
+    // Size of the segments within the STM region
     size_t _cloud_log_size_bytes{0};
     // First accessible offset of the 'archive' region. Default value means
     // that there is no archive.
@@ -584,7 +589,8 @@ private:
     model::offset _archive_clean_offset;
     // Start kafka offset set by the DeleteRecords request
     kafka::offset _start_kafka_offset;
-    // Total size of the archive (excluding this manifest)
+    // Size of the segments within the archive region (i.e. excluding this
+    // manifest)
     uint64_t _archive_size_bytes{0};
     /// Map of spillover manifests that were uploaded to S3
     spillover_manifest_map _spillover_manifests;

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -899,6 +899,7 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
       .archive_start_offset = _manifest->get_archive_start_offset(),
       .archive_start_offset_delta = _manifest->get_archive_start_offset_delta(),
       .archive_clean_offset = _manifest->get_archive_clean_offset(),
+      .archive_size_bytes = _manifest->archive_size_bytes(),
       .start_kafka_offset = _manifest->get_start_kafka_offset_override(),
       .spillover_manifests = std::move(spillover)});
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -277,10 +277,14 @@ partition_cloud_storage_status partition::get_cloud_storage_status() const {
           = _archival_meta_stm->get_dirty()
             == archival_metadata_stm::state_dirty::dirty;
         status.cloud_log_size_bytes = manifest.cloud_log_size();
-        status.cloud_log_segment_count = manifest.size();
+        status.stm_region_size_bytes = manifest.stm_region_size_bytes();
+        status.archive_size_bytes = manifest.archive_size_bytes();
+        status.stm_region_segment_count = manifest.size();
 
         if (manifest.size() > 0) {
-            status.cloud_log_start_offset = manifest.get_start_kafka_offset();
+            status.cloud_log_start_offset
+              = manifest.full_log_start_kafka_offset();
+            status.stm_region_start_offset = manifest.get_start_kafka_offset();
             status.cloud_log_last_offset = manifest.get_last_kafka_offset();
         }
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3813,15 +3813,18 @@ struct partition_cloud_storage_status {
 
     size_t total_log_size_bytes{0};
     size_t cloud_log_size_bytes{0};
+    size_t stm_region_size_bytes{0};
+    size_t archive_size_bytes{0};
     size_t local_log_size_bytes{0};
 
-    size_t cloud_log_segment_count{0};
+    size_t stm_region_segment_count{0};
     size_t local_log_segment_count{0};
 
     // Friendlier name for archival_metadata_stm::get_dirty
     bool cloud_metadata_update_pending{false};
 
     std::optional<kafka::offset> cloud_log_start_offset;
+    std::optional<kafka::offset> stm_region_start_offset;
     std::optional<kafka::offset> local_log_last_offset;
 
     std::optional<kafka::offset> cloud_log_last_offset;

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -260,13 +260,21 @@
             "type": "long",
             "description": "Total size of the addressable cloud log for the partition"
         },
+        "stm_region_size_bytes": {
+            "type": "long",
+            "description": "Total size of the addressable segments in the STM region of the log"
+        },
+        "archive_size_bytes": {
+            "type": "long",
+            "description": "Total size of the archive region of the log"
+        },
         "local_log_size_bytes": {
             "type": "long",
             "description": "Total size of the addressable local log for the partition"
         },
-        "cloud_log_segment_count": {
+        "stm_region_segment_count": {
             "type": "long",
-            "description": "Number of segments in the cloud log (does not include segments queued for removal)"
+            "description": "Number of segments in the STM region of the cloud log"
         },
         "local_log_segment_count": {
             "type": "long",
@@ -276,6 +284,11 @@
             "type": "long",
             "nullable": true,
             "description": "The first Kafka offset accessible from the cloud (inclusive)"
+        },
+        "stm_region_start_offset": {
+            "type": "long",
+            "nullable": true,
+            "description": "The first Kafka offset accessible from the cloud in the STM region (inclusive)"
         },
         "cloud_log_last_offset": {
             "type": "long",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4757,12 +4757,17 @@ map_status_to_json(cluster::partition_cloud_storage_status status) {
 
     json.total_log_size_bytes = status.total_log_size_bytes;
     json.cloud_log_size_bytes = status.cloud_log_size_bytes;
+    json.stm_region_size_bytes = status.stm_region_size_bytes;
+    json.archive_size_bytes = status.archive_size_bytes;
     json.local_log_size_bytes = status.local_log_size_bytes;
-    json.cloud_log_segment_count = status.cloud_log_segment_count;
+    json.stm_region_segment_count = status.stm_region_segment_count;
     json.local_log_segment_count = status.local_log_segment_count;
 
     if (status.cloud_log_start_offset) {
         json.cloud_log_start_offset = status.cloud_log_start_offset.value()();
+    }
+    if (status.stm_region_start_offset) {
+        json.stm_region_start_offset = status.stm_region_start_offset.value()();
     }
     if (status.cloud_log_last_offset) {
         json.cloud_log_last_offset = status.cloud_log_last_offset.value()();

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -370,6 +370,8 @@ class SISettings:
                      int] = None,
                  bypass_bucket_creation: bool = False,
                  cloud_storage_housekeeping_interval_ms: Optional[int] = None,
+                 cloud_storage_spillover_manifest_max_segments: Optional[
+                     int] = None,
                  fast_uploads=False):
         """
         :param fast_uploads: if true, set low upload intervals to help tests run
@@ -417,6 +419,7 @@ class SISettings:
         self.endpoint_url = f'http://{self.cloud_storage_api_endpoint}:{self.cloud_storage_api_endpoint_port}'
         self.bypass_bucket_creation = bypass_bucket_creation
         self.cloud_storage_housekeeping_interval_ms = cloud_storage_housekeeping_interval_ms
+        self.cloud_storage_spillover_manifest_max_segments = cloud_storage_spillover_manifest_max_segments
 
         if fast_uploads:
             self.cloud_storage_segment_max_upload_interval_sec = 10
@@ -540,6 +543,9 @@ class SISettings:
         if self.cloud_storage_housekeeping_interval_ms:
             conf[
                 'cloud_storage_housekeeping_interval_ms'] = self.cloud_storage_housekeeping_interval_ms
+        if self.cloud_storage_spillover_manifest_max_segments:
+            conf[
+                'cloud_storage_spillover_manifest_max_segments'] = self.cloud_storage_spillover_manifest_max_segments
         return conf
 
     def set_expected_damage(self, damage_types: set[str]):

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -77,7 +77,7 @@ def cloud_storage_usage_check(test):
     # what's in the uploaded manifest. For this reason, we wait until the two match.
     wait_until(
         check,
-        timeout_sec=10,
+        timeout_sec=test.check_timeout,
         backoff_sec=0.2,
         err_msg="Reported cloud storage usage did not match the actual usage",
         retry_on_exc=True)
@@ -209,7 +209,7 @@ def cloud_storage_status_endpoint_check(test):
 
     wait_until(
         check,
-        timeout_sec=10,
+        timeout_sec=test.check_timeout,
         backoff_sec=0.2,
         err_msg="Cloud storage partition status did not match the manifest",
         retry_on_exc=True)
@@ -235,6 +235,7 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
     produce_byte_rate_per_ntp = 8 * mib  # 8 MiB
     target_runtime = 60  # seconds
     check_interval = 10  # seconds
+    check_timeout = 10  # seconds
     allow_runtime_overshoot_by = 2
 
     topic_spec = TopicSpec(name="test-topic",
@@ -514,6 +515,8 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
         (e.g. isolate/kill nodes, isolate leader from cloud storage, change cloud storage
         topic/cluster configs on the fly).
         """
+        self.check_timeout = 15  # seconds
+
         self.prologue(cleanup_policy)
 
         partitions = []

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -13,7 +13,7 @@ from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifi
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda import MetricsEndpoint, SISettings
 from rptest.util import firewall_blocked, wait_until_result
-from rptest.utils.si_utils import BucketView
+from rptest.utils.si_utils import BucketView, NTPR
 from rptest.clients.types import TopicSpec
 from rptest.tests.partition_movement import PartitionMovementMixin
 from ducktape.utils.util import wait_until
@@ -43,8 +43,6 @@ class CloudStorageCheck:
 
 
 def cloud_storage_usage_check(test):
-    bucket_view = BucketView(test.redpanda)
-
     # The usage inferred from the uploaded manifest
     # lags behind the actual reported usage. For this reason,
     # we maintain a sliding window of reported usages and check whether
@@ -52,17 +50,25 @@ def cloud_storage_usage_check(test):
     reported_usage_sliding_window = deque(maxlen=10)
 
     def check():
-        manifest_usage = bucket_view.total_cloud_log_size()
+        try:
+            bucket_view = BucketView(test.redpanda)
+            manifest_usage = bucket_view.cloud_log_size_for_ntp(test.topic, 0)
+            test.logger.debug(
+                f"Cloud log usage inferred from manifests: {manifest_usage}")
 
-        reported_usage = test.admin.cloud_storage_usage()
-        reported_usage_sliding_window.append(reported_usage)
+            reported_usage = test.admin.cloud_storage_usage()
+            reported_usage_sliding_window.append(reported_usage)
 
-        test.logger.info(
-            f"Expected {manifest_usage} bytes of cloud storage usage")
-        test.logger.info(
-            f"Reported usages in sliding window: {reported_usage_sliding_window}"
-        )
-        return manifest_usage in reported_usage_sliding_window
+            test.logger.info(
+                f"Expected {manifest_usage.total()} bytes of cloud storage usage"
+            )
+            test.logger.info(
+                f"Reported usages in sliding window: {reported_usage_sliding_window}"
+            )
+            return manifest_usage.total() in reported_usage_sliding_window
+        except Exception as e:
+            test.logger.info(f"usage check exception: {e}")
+            raise e
 
     # Manifests are not immediately uploaded after they are mutated locally.
     # For example, during cloud storage housekeeping, the manifest is not uploaded
@@ -111,7 +117,8 @@ class PartitionStatusValidator:
 
         return len(not_present) == 0
 
-    def _validate_mode(self, status, manifest) -> bool:
+    def _validate_mode(self, status, bucket_view: BucketView,
+                       ntpr: NTPR) -> bool:
         if status["cloud_storage_mode"] != "full":
             self._logger.info(
                 f"Unexpected for cloud_storage_mode: {status['cloud_storage_mode']}"
@@ -122,13 +129,24 @@ class PartitionStatusValidator:
 
     def _validate_cloud_log_size_bytes(self, status, bucket_view: BucketView,
                                        ntpr: NTPR) -> bool:
-        manifest_cloud_log_size = bucket_view.cloud_log_size_for_ntp(
-            ntpr.topic, ntpr.partition, ntpr.ns).accessible(no_archive=True)
+        # bucket_view.evict_ntp(ntpr.to_ntp)
+        cloud_log_size = bucket_view.cloud_log_size_for_ntp(
+            ntpr.topic, ntpr.partition, ntpr.ns)
 
-        reported = status["cloud_log_size_bytes"]
-        if reported != manifest_cloud_log_size:
+        stm_region = cloud_log_size.stm.accessible
+        archive_region = cloud_log_size.archive.total
+
+        reported_stm = status["stm_region_size_bytes"]
+        if reported_stm != stm_region:
             self._logger.info(
-                f"Reported cloud log size does not match manifest: {reported} != {manifest_cloud_log_size}"
+                f"Reported cloud log size for stm region does not match manifest: {reported_stm}!={stm_region}"
+            )
+            return False
+
+        reported_archive = status["archive_size_bytes"]
+        if reported_stm != stm_region:
+            self._logger.info(
+                f"Reported cloud log size for archive region does not match manifest: {reported_archive}!={archive_region}"
             )
             return False
 
@@ -141,21 +159,21 @@ class PartitionStatusValidator:
         if not manifest:
             return "cloud_log_start_offset" not in status and "cloud_log_last_offset" not in status
 
-        manifest_start = BucketView.kafka_start_offset(manifest)
+        cloud_log_start = BucketView.kafka_start_offset(manifest)
         reported_start = status.get("cloud_log_start_offset", None)
 
-        if manifest_start != reported_start:
+        if cloud_log_start != reported_start:
             self._logger.info(
-                f"Reported cloud log start does not match manifest: {reported_start} != {manifest_start}"
+                f"Reported cloud log start does not match manifest: {reported_start} != {cloud_log_start}"
             )
             return False
 
-        manifest_last = BucketView.kafka_last_offset(manifest)
+        cloud_log_last = BucketView.kafka_last_offset(manifest)
         reported_last = status.get("cloud_log_last_offset", None)
 
-        if manifest_last != reported_last:
+        if cloud_log_last != reported_last:
             self._logger.info(
-                f"Reported cloud log end does not match manifest: {reported_last} != {manifest_last}"
+                f"Reported cloud log end does not match manifest: {reported_last} != {cloud_log_last}"
             )
             return False
 
@@ -164,7 +182,7 @@ class PartitionStatusValidator:
 
 def cloud_storage_status_endpoint_check(test):
     bucket_view = BucketView(test.redpanda)
-    reported_status_sliding_window = deque(maxlen=10)
+    reported_status_sliding_window = deque(maxlen=5)
     validator = PartitionStatusValidator(test)
 
     def check():
@@ -179,9 +197,9 @@ def cloud_storage_status_endpoint_check(test):
             ntpr = NTPR(ns="kafka",
                         topic=test.topic,
                         partition=0,
-                        revivions_id=test._initial_revision)
+                        revision=test._initial_revision)
             for status in reported_status_sliding_window:
-                if validator.is_valid(status, manifest, bucket_view, ntpr):
+                if validator.is_valid(status, bucket_view, ntpr):
                     return True
 
             return False
@@ -229,6 +247,7 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             test_context,
             log_segment_size=self.log_segment_size,
             cloud_storage_housekeeping_interval_ms=1000,
+            cloud_storage_spillover_manifest_max_segments=10,
             fast_uploads=True)
 
         extra_rp_conf = dict(
@@ -394,6 +413,10 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
 
         assert self.redpanda.metric_sum(
             "vectorized_cloud_storage_successful_downloads_total") > 0
+
+        assert self.redpanda.metric_sum(
+            "redpanda_cloud_storage_spillover_manifest_uploads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS) > 0
 
         bucket_view = BucketView(self.redpanda)
         bucket_view.assert_segments_deleted(self.topic, partition=0)

--- a/tests/rptest/tests/cloud_storage_usage_test.py
+++ b/tests/rptest/tests/cloud_storage_usage_test.py
@@ -95,7 +95,8 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
         reported_usage_sliding_window = deque(maxlen=10)
 
         def check():
-            manifest_usage = bucket_view.total_cloud_log_size()
+            manifest_usage = bucket_view.cloud_log_sizes_sum().accessible(
+                no_archive=True)
 
             reported_usage = self.admin.cloud_storage_usage()
             reported_usage_sliding_window.append(reported_usage)
@@ -145,9 +146,7 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
             ntp_remote_size = max(i.size
                                   for i in remote_items) if remote_items else 0
             actual_size = bucket_view.cloud_log_size_for_ntp(
-                ntp.topic,
-                ntp.partition,
-                include_size_below_start_offset=False)
+                ntp.topic, ntp.partition).accessible(no_archive=True)
 
             assert ntp_remote_size == actual_size
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1581,7 +1581,8 @@ class ClusterConfigAzureSharedKey(RedpandaTest):
 
     def get_cloud_log_size(self):
         s3_snapshot = BucketView(self.redpanda, topics=self.topics)
-        return s3_snapshot.cloud_log_size_for_ntp(self.topic, 0)
+        return s3_snapshot.cloud_log_size_for_ntp(self.topic,
+                                                  0).total(no_archive=True)
 
     def wait_for_cloud_uploads(self, initial_count: int, delta: int):
         def segment_uploaded():

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -819,13 +819,11 @@ class EndToEndSpilloverTest(RedpandaTest):
             test_context,
             log_segment_size=1024,
             fast_uploads=True,
-            cloud_storage_housekeeping_interval_ms=10000)
-        super(EndToEndSpilloverTest, self).__init__(
-            test_context=test_context,
-            # Set to minimal value
-            extra_rp_conf=dict(
-                cloud_storage_spillover_manifest_max_segments=10),
-            si_settings=self.si_settings)
+            cloud_storage_housekeeping_interval_ms=10000,
+            cloud_storage_spillover_manifest_max_segments=10)
+        super(EndToEndSpilloverTest,
+              self).__init__(test_context=test_context,
+                             si_settings=self.si_settings)
 
         self.msg_size = 1024 * 256
         self.msg_count = 3000

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -404,7 +404,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
         # the bandwidth time for the amount of data we produced, plus the segment
         # upload interval (set to 10s via fast_uploads), plus the manifest upload
         # interval (set to 1s via fast_uploads).
-        wait_until(lambda: cloud_log_size() >= total_bytes,
+        wait_until(lambda: cloud_log_size().total() >= total_bytes,
                    timeout_sec=30,
                    backoff_sec=2,
                    err_msg=f"Segments not uploaded")
@@ -416,7 +416,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
 
         # Test that the size of the cloud log is below the retention threshold
         # by querying the manifest.
-        wait_until(lambda: cloud_log_size() <= retention_bytes,
+        wait_until(lambda: cloud_log_size().total() <= retention_bytes,
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Too many bytes in the cloud")
@@ -563,7 +563,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             return cloud_log_size
 
         # Wait for everything to be uploaded to the cloud.
-        wait_until(lambda: cloud_log_size() >= total_bytes,
+        wait_until(lambda: cloud_log_size().total() >= total_bytes,
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Segments not uploaded")
@@ -574,7 +574,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
 
         # Assert that retention policy has kicked in and with the desired
         # effect, i.e. total bytes is <= retention settings applied
-        wait_until(lambda: cloud_log_size() <= retention_bytes,
+        wait_until(lambda: cloud_log_size().total() <= retention_bytes,
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Too many bytes in the cloud")

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -825,8 +825,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # compaction may delete segments (which are replaced by merged segments) at any time.
         bucket_view = BucketView(self.redpanda)
         size_before = sum(
-            bucket_view.cloud_log_size_for_ntp(self.topic, i)
-            for i in range(0, self.partition_count))
+            bucket_view.cloud_log_size_for_ntp(self.topic, i).total(
+                no_archive=True) for i in range(0, self.partition_count))
         assert size_before > 0
 
         def get_nodes(partition):
@@ -854,8 +854,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # Check no remote data was lost
         bucket_view.reset()
         size_after = sum(
-            bucket_view.cloud_log_size_for_ntp(self.topic, i)
-            for i in range(0, self.partition_count))
+            bucket_view.cloud_log_size_for_ntp(self.topic, i).total(
+                no_archive=True) for i in range(0, self.partition_count))
         assert size_after >= size_before
 
         # Check no purging/purged lifecycle marker was written

--- a/tests/rptest/tests/usage_test.py
+++ b/tests/rptest/tests/usage_test.py
@@ -282,7 +282,8 @@ class UsageTestCloudStorageMetrics(RedpandaTest):
 
         def check_usage():
             # Check that the usage reporting system has reported correct values
-            manifest_usage = bucket_view.total_cloud_log_size()
+            manifest_usage = bucket_view.cloud_log_sizes_sum().total(
+                no_archive=True)
             reported_usage = self.admin.get_usage(
                 random.choice(self.redpanda.nodes))
             reported_usages = [

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -785,6 +785,10 @@ class BucketView:
 
     @staticmethod
     def kafka_start_offset(manifest) -> Optional[int]:
+        if "archive_start_offset" in manifest:
+            return manifest["archive_start_offset"] - manifest[
+                "archive_start_offset_delta"]
+
         if 'segments' not in manifest or len(manifest['segments']) == 0:
             return None
 

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -784,23 +784,6 @@ class BucketView:
         return self._state.partition_manifests
 
     @staticmethod
-    def cloud_log_size_from_ntp_manifest(manifest,
-                                         include_below_start_offset=True
-                                         ) -> int:
-        if 'segments' not in manifest or len(manifest['segments']) == 0:
-            return 0
-
-        start_offset = 0
-        if not include_below_start_offset:
-            start_offset = manifest['start_offset']
-
-        res = sum(seg_meta['size_bytes']
-                  for seg_meta in manifest['segments'].values()
-                  if seg_meta['base_offset'] >= start_offset)
-
-        return res
-
-    @staticmethod
     def kafka_start_offset(manifest) -> Optional[int]:
         if 'segments' not in manifest or len(manifest['segments']) == 0:
             return None

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -60,6 +60,54 @@ class NTPR(NamedTuple):
         return NTP(self.ns, self.topic, self.partition)
 
 
+@dataclass
+class LogRegionSize:
+    total: int = 0
+    accessible: int = 0
+
+    def __iadd__(self, other):
+        self.total += other.total
+        self.accessible += other.accessible
+        return self
+
+
+@dataclass
+class CloudLogSize:
+    stm: LogRegionSize
+    archive: LogRegionSize
+
+    @staticmethod
+    def make_empty():
+        return CloudLogSize(stm=LogRegionSize(), archive=LogRegionSize())
+
+    def __iadd__(self, other):
+        self.stm += other.stm
+        self.archive += other.archive
+        return self
+
+    def accessible(self, no_archive: bool = False) -> int:
+        if no_archive and self.archive.accessible > 0:
+            raise RuntimeError(
+                f"CloudLogSize requested to ignore archive with accessible contents: archive={self.archive}"
+            )
+
+        if no_archive:
+            return self.stm.accessible
+        else:
+            return self.stm.accessible + self.archive.accessible
+
+    def total(self, no_archive: bool = False) -> int:
+        if no_archive and self.archive.total > 0:
+            raise RuntimeError(
+                f"CloudLogSize requested to ignore archive with contents: archive={self.archive}"
+            )
+
+        if no_archive:
+            return self.stm.total
+        else:
+            return self.stm.total + self.archive.total
+
+
 TopicManifestMetadata = namedtuple('TopicManifestMetadata',
                                    ['ntp', 'revision'])
 SegmentMetadata = namedtuple(
@@ -590,7 +638,7 @@ def quiesce_uploads(redpanda, topic_names: list[str], timeout_sec):
             raise RuntimeError(f"Found 0 partitions for topic '{topic_name}'")
 
 
-@dataclass(order=True)
+@dataclass(order=True, frozen=True)
 class SpillMeta:
     base: int
     last: int
@@ -598,37 +646,37 @@ class SpillMeta:
     last_kafka: int
     base_ts: int
     last_ts: int
-
-    path: str
     ntpr: NTPR
+    path: str
 
-    def __init__(self, ntpr: NTPR, path: str):
-        self.path = path.lstrip()
-        self.ntpr = ntpr
+    @staticmethod
+    def make(ntpr: NTPR, path: str):
+        base, last, base_kafka, last_kafka, base_ts, last_ts = SpillMeta._parse_path(
+            ntpr, path)
+        return SpillMeta(base=base,
+                         last=last,
+                         base_kafka=base_kafka,
+                         last_kafka=last_kafka,
+                         base_ts=base_ts,
+                         last_ts=last_ts,
+                         ntpr=ntpr,
+                         path=path)
 
-        self.base, self.last, self.base_kafka, self.last_kafka, self.base_ts, self.last_ts = self.parse_path(
-        )
-
-    def __eq__(self, other):
-        return self.path == other.path
-
-    def __hash__(self):
-        return hash(self.path)
-
-    def parse_path(self) -> list[str]:
+    @staticmethod
+    def _parse_path(ntpr: NTPR, path: str) -> list[str]:
         """
         Extract metadata from spillover manifest path.
         Expected format is:
         {base}.{base_rp_offset}.{last_rp_offest}.{base_kafka_offset}.{last_kafka_offset}.{first_ts}.{last_ts}
         where base = {hash}/meta/{ntpr.ns}/{ntpr.topic}/{ntpr.partition}_{ntpr.revision}/manifest"
         """
-        base = BucketView.gen_manifest_path(self.ntpr)
-        suffix = self.path.removeprefix(f"{base}.")
+        base = BucketView.gen_manifest_path(ntpr)
+        suffix = path.removeprefix(f"{base}.")
 
         split = suffix.split(".")
         if len(split) != 6:
             raise RuntimeError(
-                f"Invalid spillover manifest {self.path=} for {self.ntpr=}")
+                f"Invalid spillover manifest {path=} for {ntpr=}")
 
         return split
 
@@ -792,15 +840,19 @@ class BucketView:
 
         return last_model_offset - delta
 
-    def total_cloud_log_size(self,
-                             include_below_start_offset: bool = False) -> int:
+    def cloud_log_sizes_sum(self) -> CloudLogSize:
+        """
+        Returns the cloud log size summed over all ntps.
+        """
         self._do_listing()
 
-        total = 0
-        for pm in self._state.partition_manifests.values():
-            total += BucketView.cloud_log_size_from_ntp_manifest(
-                pm, include_below_start_offset=include_below_start_offset)
+        total = CloudLogSize.make_empty()
+        for ns, topic, partition in self._state.partition_manifests.keys():
+            val = self.cloud_log_size_for_ntp(topic, partition, ns)
+            self.logger.debug(f"{topic}/{partition} log_size={val}")
+            total += val
 
+        self.logger.debug(f"cloud_log_size_sum()={total}")
         return total
 
     def _ensure_listing(self):
@@ -909,7 +961,7 @@ class BucketView:
         if ntp not in self._state.spillover_manifests:
             self._state.spillover_manifests[ntp] = {}
 
-        meta = SpillMeta(ntpr, path)
+        meta = SpillMeta.make(ntpr, path)
         self._state.spillover_manifests[ntp][meta] = manifest
 
         self.logger.debug(
@@ -942,7 +994,7 @@ class BucketView:
         spill_metas = []
         for manifest_obj in list_res:
             if is_spillover_manifest_path(manifest_obj.key):
-                spill_metas.append(SpillMeta(ntpr, manifest_obj.key))
+                spill_metas.append(SpillMeta.make(ntpr, manifest_obj.key))
 
         return sorted(spill_metas)
 
@@ -1160,20 +1212,65 @@ class BucketView:
 
         return len(manifest['segments'])
 
-    def cloud_log_size_for_ntp(
-            self,
-            topic: str,
-            partition: int,
-            ns: str = 'kafka',
-            include_size_below_start_offset: bool = True) -> int:
+    def stm_region_size_for_ntp(self,
+                                topic: str,
+                                partition: int,
+                                ns: str = "kafka") -> LogRegionSize:
+        size = LogRegionSize()
+
         try:
             manifest = self.manifest_for_ntp(topic, partition, ns)
         except KeyError:
-            return 0
-        else:
-            return BucketView.cloud_log_size_from_ntp_manifest(
-                manifest,
-                include_below_start_offset=include_size_below_start_offset)
+            return size
+
+        if 'segments' not in manifest or len(manifest['segments']) == 0:
+            return size
+
+        so = manifest['start_offset']
+        for seg in manifest['segments'].values():
+            size.total += seg['size_bytes']
+            if seg['base_offset'] >= so:
+                size.accessible += seg['size_bytes']
+
+        return size
+
+    def archive_size_for_ntp(self,
+                             topic: str,
+                             partition: int,
+                             ns: str = "kafka") -> LogRegionSize:
+        size = LogRegionSize()
+
+        try:
+            manifest = self.manifest_for_ntp(topic, partition, ns)
+        except KeyError:
+            return size
+
+        if "archive_clean_offset" not in manifest or "archive_start_offset" not in manifest:
+            return size
+
+        archive_clean_offset = manifest["archive_clean_offset"]
+        archive_start_offset = manifest["archive_start_offset"]
+
+        spills = self.get_spillover_manifests(NTP(ns, topic, partition))
+        if spills is None:
+            return size
+
+        for meta, spill in spills.items():
+            for seg in spill["segments"].values():
+                if seg["base_offset"] >= archive_clean_offset:
+                    size.total += seg["size_bytes"]
+                if seg["base_offset"] >= archive_start_offset:
+                    size.accessible += seg["size_bytes"]
+
+        return size
+
+    def cloud_log_size_for_ntp(self,
+                               topic: str,
+                               partition: int,
+                               ns: str = 'kafka') -> CloudLogSize:
+        return CloudLogSize(
+            stm=self.stm_region_size_for_ntp(topic, partition, ns),
+            archive=self.archive_size_for_ntp(topic, partition, ns))
 
     def assert_at_least_n_uploaded_segments_compacted(self,
                                                       topic: str,


### PR DESCRIPTION
The main goal of this PR is to add spillover operations to CloudStorageTimingStressTest.
A couple other things had to be changed:
* cloud storage status endpoint became spillover aware
* cloud log size utilities became spillover aware  

Also picked up a little fix to the snapshot logic (archive size was not included).
Maybe these tests should perform a read from snapshot somehow.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
