### PR TITLE
Cluster: Eviction stm catch gate_closed on shutdown

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -78,6 +78,14 @@ ss::future<> log_eviction_stm::write_raft_snapshots_in_background() {
               evict_until);
             try {
                 co_await do_write_raft_snapshot(*index_lb);
+            } catch (const ss::abort_requested_exception&) {
+                // ignore abort requested exception, shutting down
+            } catch (const ss::gate_closed_exception&) {
+                // ignore gate closed exception, shutting down
+            } catch (const ss::broken_semaphore&) {
+                // ignore broken sem exception, shutting down
+            } catch (const ss::broken_named_semaphore&) {
+                // ignore broken named sem exception, shutting down
             } catch (const std::exception& e) {
                 vlog(
                   _logger.error,

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -69,24 +69,22 @@ ss::future<> log_eviction_stm::write_raft_snapshots_in_background() {
         }
         auto evict_until = std::max(
           _delete_records_eviction_offset, _storage_eviction_offset);
-        if (evict_until > model::offset{}) {
-            auto index_lb = _raft->log().index_lower_bound(evict_until);
-            if (index_lb) {
-                vassert(
-                  index_lb <= evict_until,
-                  "Calculated boundary {} must be <= effective_start {} ",
-                  index_lb,
-                  evict_until);
-                try {
-                    co_await do_write_raft_snapshot(*index_lb);
-                } catch (const std::exception& e) {
-                    vlog(
-                      _logger.error,
-                      "Error occurred when attempting to write snapshot: "
-                      "{}, ntp: {}",
-                      e,
-                      _raft->ntp());
-                }
+        auto index_lb = _raft->log().index_lower_bound(evict_until);
+        if (index_lb) {
+            vassert(
+              index_lb <= evict_until,
+              "Calculated boundary {} must be <= effective_start {} ",
+              index_lb,
+              evict_until);
+            try {
+                co_await do_write_raft_snapshot(*index_lb);
+            } catch (const std::exception& e) {
+                vlog(
+                  _logger.error,
+                  "Error occurred when attempting to write snapshot: "
+                  "{}, ntp: {}",
+                  e,
+                  _raft->ntp());
             }
         }
     }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1320,6 +1320,9 @@ disk_log_impl::index_lower_bound(model::offset o) const {
     if (unlikely(_segs.empty())) {
         return std::nullopt;
     }
+    if (o == model::offset{}) {
+        return std::nullopt;
+    }
     auto it = _segs.lower_bound(o);
     if (it == _segs.end()) {
         return std::nullopt;


### PR DESCRIPTION
Recent CI failures have triggered an ERROR during shutdown due to an exception handler catching a gate closed exception and logging at the error level. Fix is to catch these exceptions and not log error.

Fixes #11628
Fixes https://github.com/redpanda-data/redpanda/issues/11662

## Backports Required
- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none