### PR TITLE
rpk: add missing SASL flags for admin api auth.

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/config.go
+++ b/src/go/rpk/pkg/cli/cluster/config/config.go
@@ -48,6 +48,7 @@ different redpanda version that does not recognize certain properties.`,
 		"Include all properties, including tunables",
 	)
 	p.InstallAdminFlags(cmd)
+	p.InstallSASLFlags(cmd)
 
 	cmd.AddCommand(
 		newImportCommand(fs, p, &all),

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -61,6 +61,7 @@ following conditions are met:
 		},
 	}
 	p.InstallAdminFlags(cmd)
+	p.InstallSASLFlags(cmd)
 
 	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "Blocks and writes out all cluster health changes")
 	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "When used with watch, exits after cluster is back in healthy state")

--- a/src/go/rpk/pkg/cli/cluster/license/license.go
+++ b/src/go/rpk/pkg/cli/cluster/license/license.go
@@ -13,6 +13,7 @@ func NewLicenseCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short: "Manage cluster license",
 	}
 	p.InstallAdminFlags(cmd)
+	p.InstallSASLFlags(cmd)
 	cmd.AddCommand(
 		newInfoCommand(fs, p),
 		newSetCommand(fs, p),

--- a/src/go/rpk/pkg/cli/cluster/maintenance/maintenance.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/maintenance.go
@@ -41,7 +41,7 @@ Currently leadership is not transferred for partitions with one replica.
 `,
 	}
 	p.InstallAdminFlags(cmd)
-
+	p.InstallSASLFlags(cmd)
 	cmd.AddCommand(
 		newEnableCommand(fs, p),
 		newDisableCommand(fs, p),

--- a/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
@@ -13,6 +13,7 @@ func NewPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short: "Manage cluster partitions",
 	}
 	p.InstallAdminFlags(cmd)
+	p.InstallSASLFlags(cmd)
 	cmd.AddCommand(
 		newBalancerStatusCommand(fs, p),
 		newMovementCancelCommand(fs, p),

--- a/src/go/rpk/pkg/cli/cluster/selftest/selftest.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/selftest.go
@@ -24,6 +24,7 @@ func NewSelfTestCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 	}
 	p.InstallAdminFlags(cmd)
+	p.InstallSASLFlags(cmd)
 	cmd.AddCommand(
 		newStartCommand(fs, p),
 		newStopCommand(fs, p),

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/recovery.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/recovery.go
@@ -34,6 +34,7 @@ command after it has been started.
 `,
 	}
 	p.InstallAdminFlags(cmd)
+	p.InstallSASLFlags(cmd)
 	cmd.AddCommand(
 		newStartCommand(fs, p),
 		newStatusCommand(fs, p),

--- a/src/go/rpk/pkg/cli/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/admin.go
@@ -27,6 +27,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 	}
 	p.InstallAdminFlags(cmd)
+	p.InstallSASLFlags(cmd)
 	cmd.AddCommand(
 		brokers.NewCommand(fs, p),
 		partitions.NewCommand(fs, p),

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -577,21 +577,29 @@ func (p *Params) InstallKafkaFlags(cmd *cobra.Command) {
 	pf := cmd.PersistentFlags()
 
 	pf.StringSliceVar(&p.brokers, "brokers", nil, "Comma separated list of broker host:ports")
-	pf.StringVar(&p.user, FlagSASLUser, "", "SASL user to be used for authentication")
-	pf.StringVar(&p.password, "password", "", "SASL password to be used for authentication")
-	pf.StringVar(&p.saslMechanism, "sasl-mechanism", "", "The authentication mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512)")
-
 	pf.MarkHidden("brokers")
-	pf.MarkHidden(FlagSASLUser)
-	pf.MarkHidden("password")
-	pf.MarkHidden("sasl-mechanism")
 
+	p.InstallSASLFlags(cmd)
 	p.InstallTLSFlags(cmd)
 
 	pf.MarkHidden(FlagEnableTLS)
 	pf.MarkHidden(FlagTLSCA)
 	pf.MarkHidden(FlagTLSCert)
 	pf.MarkHidden(FlagTLSKey)
+}
+
+// InstallSASLFlags adds the original rpk Kafka SASL flags that are also used
+// by the admin API for authentication.
+func (p *Params) InstallSASLFlags(cmd *cobra.Command) {
+	pf := cmd.PersistentFlags()
+
+	pf.StringVar(&p.user, FlagSASLUser, "", "SASL user to be used for authentication")
+	pf.StringVar(&p.password, "password", "", "SASL password to be used for authentication")
+	pf.StringVar(&p.saslMechanism, "sasl-mechanism", "", "The authentication mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512)")
+
+	pf.MarkHidden(FlagSASLUser)
+	pf.MarkHidden("password")
+	pf.MarkHidden("sasl-mechanism")
 }
 
 // InstallTLSFlags adds the original rpk Kafka API TLS set of flags to this


### PR DESCRIPTION
In the refactoring of the new params, we separated the commands that needed admin-api flags and the
commands that needed kafka-api flags. However, the kafka-api flags contains the SASL user, password,
and mechanism which is used by the Admin API for
authentication.

We will only need to backport the `rpk redpanda admin` flags, in <23.1 all the commands installed the kafka flags as well as the admin API flags.

## Backports Required
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

No release notes for this fix, since it's something that is not in prod yet.
## Release Notes
* none

