### PR TITLE
[v23.1.x] rpk: add sasl flags to rpk redpanda admin commands

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -78,6 +78,29 @@ func AddKafkaFlags(
 	return command
 }
 
+func AddSASLFlags(command *cobra.Command, user, password, saslMechanism *string) *cobra.Command {
+	command.PersistentFlags().StringVar(
+		user,
+		"user",
+		"",
+		"SASL user to be used for authentication",
+	)
+	command.PersistentFlags().StringVar(
+		password,
+		"password",
+		"",
+		"SASL password to be used for authentication",
+	)
+	command.PersistentFlags().StringVar(
+		saslMechanism,
+		config.FlagSASLMechanism,
+		"",
+		"The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512",
+	)
+
+	return command
+}
+
 func AddTLSFlags(
 	command *cobra.Command,
 	enableTLS *bool,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/admin.go
@@ -35,6 +35,9 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		adminCertFile  string
 		adminKeyFile   string
 		adminCAFile    string
+		user           string
+		password       string
+		mechanism      string
 	)
 
 	cmd.PersistentFlags().StringVar(
@@ -59,6 +62,13 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 		&adminCertFile,
 		&adminKeyFile,
 		&adminCAFile,
+	)
+
+	common.AddSASLFlags(
+		cmd,
+		&user,
+		&password,
+		&mechanism,
 	)
 
 	cmd.AddCommand(


### PR DESCRIPTION
These were missing and are needed for admin API
auth.

This is a manual "backport" of https://github.com/redpanda-data/redpanda/pull/11648

## Backports Required
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
### Improvements

* rpk: support SASL flags in `rpk redpanda admin` commands.
