### PR TITLE
iobuf: use unique_ptr<fragment> instead of new-allocation

### DIFF
--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -177,8 +177,7 @@ public:
     std::string hexdump(size_t) const;
 
 private:
-    /// \brief trims the back, and appends direct.
-    void prepend_take_ownership(fragment*);
+    void prepend(std::unique_ptr<fragment>);
 
     size_t available_bytes() const;
     void create_new_fragment(size_t);
@@ -231,9 +230,9 @@ inline void iobuf::append(std::unique_ptr<fragment> f) {
     _size += f->size();
     _frags.push_back(*f.release());
 }
-inline void iobuf::prepend_take_ownership(fragment* f) {
+inline void iobuf::prepend(std::unique_ptr<fragment> f) {
     _size += f->size();
-    _frags.push_front(*f);
+    _frags.push_front(*f.release());
 }
 
 inline void iobuf::create_new_fragment(size_t sz) {
@@ -259,8 +258,7 @@ inline void iobuf::reserve_memory(size_t reservation) {
     if (unlikely(!b.size())) {
         return;
     }
-    auto f = new fragment(std::move(b));
-    prepend_take_ownership(f);
+    prepend(std::make_unique<fragment>(std::move(b)));
 }
 [[gnu::always_inline]] void inline iobuf::prepend(iobuf b) {
     oncore_debug_verify(_verify_shard);


### PR DESCRIPTION
Have prepend_take_ownership mirror the append variant.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

