### PR TITLE
tests: setup tbot for tsh

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -17,81 +17,126 @@ class KubectlTool:
     """
 
     KUBECTL_VERSION = '1.24.10'
+    TELEPORT_DEST_DIR = '/tmp/machine-id'
+    TELEPORT_IDENT_FILE = f'{TELEPORT_DEST_DIR}/identity'
 
-    def __init__(self,
-                 redpanda,
-                 *,
-                 remote_uri=None,
-                 namespace='redpanda',
-                 cluster_id=''):
+    def __init__(
+        self,
+        redpanda,
+        *,
+        remote_uri=None,
+        namespace='redpanda',
+        cluster_id='',
+        tp_proxy=None,
+        tp_token=None,
+    ):
         self._redpanda = redpanda
         self._remote_uri = remote_uri
         self._namespace = namespace
         self._cluster_id = cluster_id
+        self._tp_proxy = tp_proxy
+        self._tp_token = tp_token
         self._kubectl_installed = False
         self._privileged_pod_installed = False
+        self._setup_tbot()
+
+    def _ssh_prefix(self):
+        '''Generate the ssh prefix of a cmd.
+
+        Example output of the 4 types of ssh prefixes:
+         0. # nothing if there is no _remote_uri to run a remote command onto
+         1. ssh target.example.com # for simple ssh
+         2. tsh ssh --proxy=proxy.example.com target.example.com # for local dev that will use github auth by default
+         3. tsh ssh --proxy=proxy.example.com --identity=/tmp/machine-id/identity target.example.com # for headless assuming tbot start
+        '''
+        if self._remote_uri is None:
+            return []
+        if self._tp_proxy is None:
+            return [
+                'ssh',
+                self._remote_uri,
+            ]
+        if self._tp_token is None:
+            return [
+                'tsh',
+                'ssh',
+                f'--proxy={self._tp_proxy}',
+                self._remote_uri,
+            ]
+        return [
+            'tsh',
+            'ssh',
+            f'--proxy={self._tp_proxy}',
+            f'--identity={self.TELEPORT_IDENT_FILE}',
+            self._remote_uri,
+        ]
+
+    def _scp_cmd(self, src, dest):
+        '''Generate the scp cmd.
+
+        Example output of the 4 types of ssh prefixes:
+         0. # nothing if there is no _remote_uri to run a remote command onto
+         1. scp src dest # for simple scp passwordless
+         2. tsh scp --proxy=proxy.example.com src dest # for local dev that will use github auth by default
+         3. tsh scp --proxy=proxy.example.com --identity=/tmp/machine-id/identity src dest # for headless assuming tbot start
+        '''
+        if self._remote_uri is None:
+            # do not copy anything if kubectl is on local machine
+            return []
+        if self._tp_proxy is None:
+            return ['scp', src, dest]
+        if self._tp_token is None:
+            return ['tsh', 'scp', f'--proxy={self._tp_proxy}', src, dest]
+        return [
+            'tsh', 'scp', f'--proxy={self._tp_proxy}',
+            f'--identity={self.TELEPORT_IDENT_FILE}', src, dest
+        ]
 
     def _install(self):
         '''Installs kubectl on a remote target host
         '''
         if not self._kubectl_installed and self._remote_uri is not None:
-            download_cmd = [
-                'tsh', 'ssh', self._remote_uri, 'wget', '-q',
+            ssh_prefix = self._ssh_prefix()
+            download_cmd = ssh_prefix + [
+                'wget', '-q',
                 f'https://dl.k8s.io/release/v{self.KUBECTL_VERSION}/bin/linux/amd64/kubectl',
                 '-O', '/tmp/kubectl'
             ]
-            install_cmd = [
-                'tsh', 'ssh', self._remote_uri, 'sudo', 'install', '-m',
-                '0755', '/tmp/kubectl', '/usr/local/bin/kubectl'
+            install_cmd = ssh_prefix + [
+                'sudo', 'install', '-m', '0755', '/tmp/kubectl',
+                '/usr/local/bin/kubectl'
             ]
-            cleanup_cmd = [
-                'tsh', 'ssh', self._remote_uri, 'rm', '-f', '/tmp/kubectl'
+            cleanup_cmd = ssh_prefix + ['rm', '-f', '/tmp/kubectl']
+            config_cmd = ssh_prefix + [
+                'awscli2', 'eks', 'update-kubeconfig', '--name',
+                f'redpanda-{self._cluster_id}', '--region', 'us-west-2'
             ]
-            config_cmd = [
-                'tsh', 'ssh', self._remote_uri, 'awscli2', 'eks',
-                'update-kubeconfig', '--name', f'redpanda-{self._cluster_id}',
-                '--region', 'us-west-2'
-            ]
-            try:
-                self._redpanda.logger.info(download_cmd)
-                res = subprocess.check_output(download_cmd)
-                self._redpanda.logger.info(install_cmd)
-                res = subprocess.check_output(install_cmd)
-                self._redpanda.logger.info(cleanup_cmd)
-                res = subprocess.check_output(cleanup_cmd)
-                self._redpanda.logger.info(config_cmd)
-                res = subprocess.check_output(config_cmd)
-            except subprocess.CalledProcessError as e:
-                self._redpanda.logger.info("CalledProcessError {}: {}".format(
-                    e.returncode, e.output))
-                exit(1)
+            self._redpanda.logger.info(download_cmd)
+            res = subprocess.check_output(download_cmd)
+            self._redpanda.logger.info(install_cmd)
+            res = subprocess.check_output(install_cmd)
+            self._redpanda.logger.info(cleanup_cmd)
+            res = subprocess.check_output(cleanup_cmd)
+            self._redpanda.logger.info(config_cmd)
+            res = subprocess.check_output(config_cmd)
             self._kubectl_installed = True
         return
 
     def exec(self, remote_cmd):
         self._install()
-        prefix = []
-        if self._remote_uri:
-            prefix = ['tsh', 'ssh', self._remote_uri]
-        cmd = prefix + [
+        ssh_prefix = self._ssh_prefix()
+        cmd = ssh_prefix + [
             'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
             f'rp-{self._cluster_id}-0', '--', 'bash', '-c'
         ] + ['"' + remote_cmd + '"']
-        try:
-            self._redpanda.logger.info(cmd)
-            res = subprocess.check_output(cmd)
-        except subprocess.CalledProcessError as e:
-            self._redpanda.logger.info("CalledProcessError {}: {}".format(
-                e.returncode, e.output))
-            exit(1)
+        self._redpanda.logger.info(cmd)
+        res = subprocess.check_output(cmd)
         return res
 
     def exists(self, remote_path):
         self._install()
-        prefix = []
-        if self._remote_uri:
-            prefix = ['tsh', 'ssh', self._remote_uri]
-        cmd = prefix + [
+        ssh_prefix = self._ssh_prefix()
+        cmd = ssh_prefix + [
             'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
             f'rp-{self._cluster_id}-0', '--', 'stat'
         ] + [remote_path]
@@ -106,10 +151,8 @@ class KubectlTool:
         # ip-10-1-1-26.us-west-2.compute.internal    everything-allowed-exec-pod-bkj4m
         # ip-10-1-1-139.us-west-2.compute.internal   everything-allowed-exec-pod-jxk9j
         # ip-10-1-1-101.us-west-2.compute.internal   everything-allowed-exec-pod-pl8sc
-        cmd = [
-            'tsh',
-            'ssh',
-            self._remote_uri,
+        ssh_prefix = self._ssh_prefix()
+        cmd = prefx + [
             'kubectl',
             'get',
             'pod',
@@ -131,10 +174,8 @@ class KubectlTool:
         # ip-10-1-1-139.us-west-2.compute.internal   rp-ci0motok30vsi89l501g-0
         # ip-10-1-1-101.us-west-2.compute.internal   rp-ci0motok30vsi89l501g-1
         # ip-10-1-1-26.us-west-2.compute.internal    rp-ci0motok30vsi89l501g-2
-        cmd = [
-            'tsh',
-            'ssh',
-            self._remote_uri,
+        ssh_prefix = self._ssh_prefix()
+        cmd = ssh_prefix + [
             'kubectl',
             '-n',
             'redpanda',
@@ -162,36 +203,44 @@ class KubectlTool:
         redpanda_pod = f'rp-{self._cluster_id}-0'
         return redpanda_to_priv_pods[redpanda_pod]
 
+    def _setup_tbot(self):
+        if self._tp_proxy is None or self._tp_token is None:
+            self._redpanda.logger.info(
+                'skipping tbot start to generate identity')
+            return None
+
+        self._redpanda.logger.info('starting tbot to generate identity')
+        cmd = [
+            'tbot', 'start', '--data-dir=/tmp/tbot-data',
+            f'--destination-dir={self.TELEPORT_DEST_DIR}',
+            f'--auth-server={self._tp_proxy}', '--join-method=iam',
+            f'--token={self._tp_token}', '--certificate-ttl=6h',
+            '--renewal-interval=6h', '--oneshot'
+        ]
+        return subprocess.check_output(cmd)
+
     def _setup_privileged_pod(self):
         if not self._privileged_pod_installed and self._remote_uri is not None:
             filename = 'everything-allowed-exec-pod.yml'
             filename_path = os.path.join(os.path.dirname(__file__),
                                          'everything-allowed-exec-pod.yml')
             self._redpanda.logger.info(filename_path)
-            setup_cmd = ['tsh', 'scp', filename_path, f'{self._remote_uri}:']
-            apply_cmd = [
-                'tsh', 'ssh', self._remote_uri, 'kubectl', 'apply', '-f',
-                filename
-            ]
-            try:
+            setup_cmd = self._scp_cmd(filename_path, f'{self._remote_uri}:')
+            ssh_prefix = self._ssh_prefix()
+            apply_cmd = ssh_prefix + ['kubectl', 'apply', '-f', filename]
+            if len(setup_cmd) > 0:
                 self._redpanda.logger.info(setup_cmd)
                 res = subprocess.check_output(setup_cmd)
-                self._redpanda.logger.info(apply_cmd)
-                res = subprocess.check_output(apply_cmd)
-            except subprocess.CalledProcessError as e:
-                self._redpanda.logger.info("CalledProcessError {}: {}".format(
-                    e.returncode, e.output))
-                exit(1)
+            self._redpanda.logger.info(apply_cmd)
+            res = subprocess.check_output(apply_cmd)
             self._privileged_pod_installed = True
 
     def exec_privileged(self, remote_cmd):
         self._setup_privileged_pod()
         priv_pod = self._get_privileged_pod()
-        prefix = []
-        if self._remote_uri:
-            prefix = ['tsh', 'ssh', self._remote_uri]
-        cmd = prefix + ['kubectl', 'exec', priv_pod, '--', 'bash', '-c'
-                        ] + ['"' + remote_cmd + '"']
+        ssh_prefix = self._ssh_prefix()
+        cmd = ssh_prefix + ['kubectl', 'exec', priv_pod, '--', 'bash', '-c'
+                            ] + ['"' + remote_cmd + '"']
         self._redpanda.logger.debug(cmd)
         res = subprocess.run(cmd, capture_output=True, text=True)
         self._redpanda.logger.debug(res.stdout)


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/cloudv2/issues/7088

This PR changes the `KubectlTool` class to use `tbot` to get temp creds for `tsh` to connect to the agent node of a redpanda cloud cluster. This is needed for headless ducktape test execution and only works on EC2 machines that have a tbot IAM role assumed for redpanda testing.

To get the temp creds, `tbot` needs the auth server and bot token set in the duckatpe globals config file, e.g.:
```json
  "cloud_teleport_auth_server": "auth.example.com:443",
  "cloud_teleport_bot_token": "the-token",
```

if the `cloud_teleport_auth_server` is set but `cloud_teleport_bot_token` is unset, `tbot` will be skipped and teleport's default auth via github sso will be used (helpful for local dev env that do not have the tbot IAM role assumed).

No changes to existing test behaviour that does not use redpanda cloud.

Example test output with `cloud_teleport_auth_server` and `cloud_teleport_bot_token` set:
```
...
task: [cdt:run-duckpy] ./duck.py '--cloud-provider=aws' --region us-west-2 run-cloud-tests
Warning: Permanently added '35.81.166.71' (ED25519) to the list of known hosts.
~/tests ~
[INFO:2023-07-10 13:24:58,364]: starting test run with session id 2023-07-10--004...
[INFO:2023-07-10 13:24:58,364]: running 1 tests...
[INFO:2023-07-10 13:24:58,364]: Triggering test 1 of 1...
[INFO:2023-07-10 13:24:58,370]: RunnerClient: Loading test {'directory': '/home/ubuntu/redpanda/tests/rptest/tests', 'file_name': 'services_self_test.py', 'cls_name': 'SimpleSelfTest', 'method_name': 'test_cloud', 'injected_args': None}
[INFO:2023-07-10 13:24:58,374]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Setting up...
[WARNING - 2023-07-10 13:24:58,374 - redpanda - create - lineno:1351]: will not create cluster; already have cluster_id ci0motok30vsi89l501g
WARN [TBOT]      CLI parameters are overriding onboarding config from  config/config.go:460
INFO [TBOT]      Anonymous telemetry is not enabled. Find out more about Machine ID's anonymous telemetry at https://goteleport.com/docs/machine-id/reference/telemetry/ tbot/anonymous_telemetry.go:83
INFO [TBOT]      Successfully loaded bot identity, valid: after=2023-07-10T13:22:08Z, before=2023-07-10T19:23:07Z, duration=6h0m59s | kind=tls, renewable=false, disallow-reissue=false, roles=[bot-buildkite-robot], principals=[-teleport-internal-join], generation=0 tbot/tbot.go:372
WARN [TBOT]      Note: onboarding config ignored as identity was loaded from persistent storage tbot/tbot.go:379
INFO [TBOT]      Beginning renewal loop: ttl=6h0m0s interval=6h0m0s tbot/renew.go:693
INFO [TBOT]      Started watching for CA rotations tbot/ca_rotation.go:173
INFO [TBOT]      Attempting to generate new identity from token tbot/renew.go:479
INFO [AUTH]      Attempting registration via proxy server. auth/register.go:277
INFO [AUTH]      Attempting to register Bot with IAM method using regional STS endpoint auth/register.go:623
INFO [AUTH]      Successfully registered Bot with IAM method using regional STS endpoint auth/register.go:656
INFO [AUTH]      Successfully registered via proxy server. auth/register.go:284
INFO [TBOT]      Successfully renewed bot certificates, valid: after=2023-07-10T13:24:00Z, before=2023-07-10T19:24:59Z, duration=6h0m59s | kind=tls, renewable=false, disallow-reissue=false, roles=[bot-buildkite-robot], principals=[-teleport-internal-join], generation=0 tbot/renew.go:601
INFO [TBOT]      Successfully renewed impersonated certificates for directory /tmp/machine-id, valid: after=2023-07-10T13:24:01Z, before=2023-07-10T19:24:59Z, duration=6h0m58s | kind=tls, renewable=false, disallow-reissue=true, roles=[teleport-admin], principals=[root redpanda {{internal.logins}} -teleport-internal-join], generation=0 tbot/renew.go:664
INFO [TBOT]      Started watching for CA rotations tbot/ca_rotation.go:173
INFO [TBOT]      Persisted certificates successfully. One-shot mode enabled so exiting. tbot/renew.go:747
[INFO:2023-07-10 13:25:03,467]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Running...
[INFO:2023-07-10 13:25:31,362]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: PASS
[INFO:2023-07-10 13:25:31,362]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Tearing down...
[WARNING - 2023-07-10 13:25:31,363 - runner_client - log - lineno:278]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Test requested 3 nodes, used only 0
[WARNING:2023-07-10 13:25:31,363]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Test requested 3 nodes, used only 0
[INFO:2023-07-10 13:25:31,364]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Summary: 
[INFO:2023-07-10 13:25:31,364]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Data: None
test_id:    rptest.tests.services_self_test.SimpleSelfTest.test_cloud
status:     PASS
run time:   32.990 seconds
--------------------------------------------------------------------------------
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-07-10--004
run time:         33.004 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none