### PR TITLE
storage: introduce max size control over raft storage

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -118,6 +118,16 @@ configuration::configuration()
        .example = "31536000000",
        .visibility = visibility::tunable},
       std::nullopt)
+  , log_storage_max_size_high_watermark(
+      *this,
+      "log_storage_max_size_high_watermark",
+      "The percentage of the max size at which action will be taken to begin "
+      "reducing the amount of storage used in an effort to stay below the "
+      "configured max size.",
+      {.needs_restart = needs_restart::no,
+       .example = "0.8",
+       .visibility = visibility::tunable},
+      0.8)
   , rpc_server_listen_backlog(
       *this,
       "rpc_server_listen_backlog",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -110,6 +110,14 @@ configuration::configuration()
        .example = "31536000000",
        .visibility = visibility::tunable},
       24h * 365)
+  , log_storage_max_size(
+      *this,
+      "log_storage_max_size",
+      "Upper bound target for the amount of space used by log storage.",
+      {.needs_restart = needs_restart::no,
+       .example = "31536000000",
+       .visibility = visibility::tunable},
+      std::nullopt)
   , rpc_server_listen_backlog(
       *this,
       "rpc_server_listen_backlog",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -54,6 +54,7 @@ struct configuration final : public config_store {
     bounded_property<std::optional<std::chrono::milliseconds>> log_segment_ms;
     property<std::chrono::milliseconds> log_segment_ms_min;
     property<std::chrono::milliseconds> log_segment_ms_max;
+    property<std::optional<uint64_t>> log_storage_max_size;
 
     // Network
     bounded_property<std::optional<int>> rpc_server_listen_backlog;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -55,6 +55,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> log_segment_ms_min;
     property<std::chrono::milliseconds> log_segment_ms_max;
     property<std::optional<uint64_t>> log_storage_max_size;
+    property<double> log_storage_max_size_high_watermark;
 
     // Network
     bounded_property<std::optional<int>> rpc_server_listen_backlog;

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -58,6 +58,7 @@ v_cc_library(
     v::kafka_protocol
     v::security
     v::pandaproxy_schema_registry
+    v::storage_resource_mgmt
     absl::flat_hash_map
     absl::flat_hash_set
 )

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -558,7 +558,9 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     produce_request request;
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
-    if (ctx.metadata_cache().should_reject_writes()) {
+    if (
+      ctx.metadata_cache().should_reject_writes()
+      || ctx.space_manager()->should_block_writes()) {
         thread_local static ss::logger::rate_limit rate(despam_interval);
         klog.log(
           ss::log_level::warn,

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -244,6 +244,10 @@ public:
 
     ss::sharded<server>& server() { return _conn->server().container(); }
 
+    const std::unique_ptr<storage::disk_space_manager>& space_manager() const {
+        return _conn->server().space_manager();
+    }
+
 private:
     template<typename ResponseType>
     void update_usage_stats(const ResponseType& r, size_t response_size) {

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -101,7 +101,8 @@ server::server(
   ss::sharded<cluster::tx_registry_frontend>& tx_registry_frontend,
   std::optional<qdc_monitor::config> qdc_config,
   ssx::thread_worker& tw,
-  const std::unique_ptr<pandaproxy::schema_registry::api>& sr) noexcept
+  const std::unique_ptr<pandaproxy::schema_registry::api>& sr,
+  const std::unique_ptr<storage::disk_space_manager>& space_manager) noexcept
   : net::server(cfg, klog)
   , _smp_group(smp)
   , _fetch_scheduling_group(fetch_sg)
@@ -142,7 +143,8 @@ server::server(
   , _thread_worker(tw)
   , _replica_selector(
       std::make_unique<rack_aware_replica_selector>(_metadata_cache.local()))
-  , _schema_registry(sr) {
+  , _schema_registry(sr)
+  , _space_manager(space_manager) {
     vlog(
       klog.debug,
       "Starting kafka server with {} byte limit on fetch requests",

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -65,7 +65,8 @@ public:
       ss::sharded<cluster::tx_registry_frontend>&,
       std::optional<qdc_monitor::config>,
       ssx::thread_worker&,
-      const std::unique_ptr<pandaproxy::schema_registry::api>&) noexcept;
+      const std::unique_ptr<pandaproxy::schema_registry::api>&,
+      const std::unique_ptr<storage::disk_space_manager>&) noexcept;
 
     ~server() noexcept override = default;
     server(const server&) = delete;
@@ -166,6 +167,10 @@ public:
         return _schema_registry;
     }
 
+    const std::unique_ptr<storage::disk_space_manager>& space_manager() {
+        return _space_manager;
+    }
+
     /**
      * \param api_names list of Kafka API names
      * \return std::vector<bool> always sized to index the entire Kafka API key
@@ -223,6 +228,7 @@ private:
     ssx::thread_worker& _thread_worker;
     std::unique_ptr<replica_selector> _replica_selector;
     const std::unique_ptr<pandaproxy::schema_registry::api>& _schema_registry;
+    const std::unique_ptr<storage::disk_space_manager>& _space_manager;
 };
 
 } // namespace kafka

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -49,7 +49,8 @@ struct bootstrap_fixture : raft::simple_record_fixture {
               storage::with_cache::no,
               storage::make_sanitized_file_config());
         },
-        _feature_table) {
+        _feature_table,
+        config::mock_binding<std::optional<uint64_t>>(std::nullopt)) {
         _feature_table.start().get();
         _feature_table
           .invoke_on_all(

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -52,7 +52,8 @@ struct config_manager_fixture {
               ss::default_priority_class(),
               storage::make_sanitized_file_config());
         },
-        _feature_table))
+        _feature_table,
+        config::mock_binding<std::optional<uint64_t>>(std::nullopt)))
       , _logger(
           raft::group_id(1),
           model::ntp(model::ns("t"), model::topic("t"), model::partition_id(0)))

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -61,7 +61,8 @@ struct foreign_entry_fixture {
               ss::default_priority_class(),
               storage::make_sanitized_file_config());
         },
-        _feature_table) {
+        _feature_table,
+        config::mock_binding<std::optional<uint64_t>>(std::nullopt)) {
         _feature_table.start().get();
         _feature_table
           .invoke_on_all(

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -57,7 +57,8 @@ struct mux_state_machine_fixture {
           .start(
             [kv_conf]() { return kv_conf; },
             [this]() { return default_log_cfg(); },
-            std::ref(_feature_table))
+            std::ref(_feature_table),
+            config::mock_binding<std::optional<uint64_t>>(std::nullopt))
           .get0();
         _storage.invoke_on_all(&storage::api::start).get0();
         _as.start().get();

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -54,7 +54,8 @@ struct base_fixture {
           .start(
             [this]() { return make_kv_cfg(); },
             [this]() { return make_log_cfg(); },
-            std::ref(_feature_table))
+            std::ref(_feature_table),
+            config::mock_binding<std::optional<uint64_t>>(std::nullopt))
           .get();
         _api.invoke_on_all(&storage::api::start).get();
     }

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -129,7 +129,8 @@ struct raft_node {
                   ss::default_priority_class(),
                   storage::make_sanitized_file_config());
             },
-            std::ref(feature_table))
+            std::ref(feature_table),
+            config::mock_binding<std::optional<uint64_t>>(std::nullopt))
           .get();
         storage.invoke_on_all(&storage::api::start).get();
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1683,7 +1683,9 @@ void application::wire_up_bootstrap_services() {
             = sched_groups.cache_background_reclaim_sg();
           return log_cfg;
       },
-      std::ref(feature_table))
+      std::ref(feature_table),
+      ss::sharded_parameter(
+        [] { return config::shard_local_cfg().log_storage_max_size.bind(); }))
       .get();
 
     // Hook up local_monitor to update storage_resources when disk state changes

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1620,7 +1620,8 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         std::ref(tx_registry_frontend),
         qdc_config,
         std::ref(*thread_worker),
-        std::ref(_schema_registry))
+        std::ref(_schema_registry),
+        std::ref(space_manager))
       .get();
     construct_service(
       _compaction_controller,

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -151,7 +151,8 @@ public:
             std::ref(app.tx_registry_frontend),
             std::nullopt,
             std::ref(*app.thread_worker),
-            std::ref(app.schema_registry()))
+            std::ref(app.schema_registry()),
+            std::ref(app.space_manager))
           .get();
 
         configs.stop().get();

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -132,4 +132,8 @@ ss::future<> disk_space_manager::run_loop() {
     }
 }
 
+bool disk_space_manager::should_block_writes() const {
+    return _storage->local().max_size_exceeded();
+}
+
 } // namespace storage

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -72,6 +72,8 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    bool should_block_writes() const;
+
 private:
     config::binding<bool> _enabled;
     ss::sharded<storage::api>* _storage;

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -70,6 +70,7 @@ public:
       storage::disk_space_alert alert);
 
     bool max_size_exceeded() const;
+    bool high_watermark_exceeded() const;
 
 private:
     storage_resources _resources;
@@ -94,6 +95,7 @@ private:
     config::binding<std::optional<uint64_t>> _log_storage_max_size;
     // updated lazily by monitor on core 0
     bool _max_size_exceeded{false};
+    bool _high_watermark_exceeded{false};
 };
 
 } // namespace storage

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -33,26 +33,8 @@ public:
       , _log_conf_cb(std::move(log_conf_cb))
       , _feature_table(feature_table) {}
 
-    ss::future<> start() {
-        _kvstore = std::make_unique<kvstore>(
-          _kv_conf_cb(), _resources, _feature_table);
-        return _kvstore->start().then([this] {
-            _log_mgr = std::make_unique<log_manager>(
-              _log_conf_cb(), kvs(), _resources, _feature_table);
-            return _log_mgr->start();
-        });
-    }
-
-    ss::future<> stop() {
-        auto f = ss::now();
-        if (_log_mgr) {
-            f = _log_mgr->stop();
-        }
-        if (_kvstore) {
-            return f.then([this] { return _kvstore->stop(); });
-        }
-        return f;
-    }
+    ss::future<> start();
+    ss::future<> stop();
 
     void set_node_uuid(const model::node_uuid& node_uuid) {
         _node_uuid = node_uuid;

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -243,8 +243,8 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
             co_return;
         }
 
-        // priortize reclaims over compactions in a low space scenario.
-        if (_storage && _storage->local().max_size_exceeded()) {
+        // priortize reclaims over compactions in a low disk space scenario.
+        if (_storage && _storage->local().high_watermark_exceeded()) {
             co_return;
         }
     }
@@ -293,7 +293,7 @@ ss::future<> log_manager::housekeeping() {
          * interface.
          */
         if (
-          (_storage && _storage->local().max_size_exceeded())
+          (_storage && _storage->local().high_watermark_exceeded())
           || _disk_space_alert == disk_space_alert::degraded
           || _disk_space_alert == disk_space_alert::low_space) {
             /*

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -78,7 +78,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
             storage::make_sanitized_file_config());
       },
       [conf]() { return conf; },
-      feature_table);
+      feature_table,
+      config::mock_binding<std::optional<uint64_t>>(std::nullopt));
     store.start().get();
     auto stop_kvstore = ss::defer([&store, &feature_table] {
         store.stop().get();

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -234,13 +234,17 @@ public:
     /// Creates a log manager in test directory
     storage::log_manager make_log_manager(storage::log_config cfg) {
         return storage::log_manager(
-          std::move(cfg), kvstore, resources, feature_table);
+          std::move(cfg), kvstore, resources, feature_table, nullptr);
     }
 
     /// Creates a log manager in test directory with default config
     storage::log_manager make_log_manager() {
         return storage::log_manager(
-          default_log_config(test_dir), kvstore, resources, feature_table);
+          default_log_config(test_dir),
+          kvstore,
+          resources,
+          feature_table,
+          nullptr);
     }
 
     /// \brief randomizes the configuration options

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -32,7 +32,8 @@ disk_log_builder::disk_log_builder(storage::log_config config)
             storage::make_sanitized_file_config());
       },
       [this]() { return _log_config; },
-      _feature_table) {}
+      _feature_table,
+      config::mock_binding<std::optional<uint64_t>>(std::nullopt)) {}
 
 // Batch generation
 ss::future<> disk_log_builder::add_random_batch(

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -56,7 +56,8 @@ static inline ss::future<> persist_log_file(
                   ss::default_priority_class(),
                   storage::make_sanitized_file_config());
             },
-            std::ref(feature_table))
+            std::ref(feature_table),
+            config::mock_binding<std::optional<uint64_t>>(std::nullopt))
           .get();
         storage.invoke_on_all(&storage::api::start).get();
 
@@ -133,7 +134,8 @@ read_log_file(ss::sstring base_dir, model::ntp file_ntp) {
                   ss::default_priority_class(),
                   storage::make_sanitized_file_config());
             },
-            std::ref(feature_table))
+            std::ref(feature_table),
+            config::mock_binding<std::optional<uint64_t>>(std::nullopt))
           .get();
         storage.invoke_on_all(&storage::api::start).get();
         auto& mgr = storage.local().log_mgr();


### PR DESCRIPTION
Introduces a maximum size configuration value which the log/raft storage attempts to stay under. When the max is reached kafka produce api will be blocked. A high watermark threshold is introduced which is less than the maximum and trigger any available process for avoiding reaching the blocking threshold.

Current limitations in this PR are that the local retention target are continued to be respected (i.e. we don't remove data that has been uploaded to cloud storage that violates retention settings). This "knob" will come in a follow-up PR.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
