### PR TITLE
Using `fragmented_vector` in fetch response 

### DIFF
--- a/src/v/kafka/client/assignment_plans.cc
+++ b/src/v/kafka/client/assignment_plans.cc
@@ -45,10 +45,11 @@ assignment assignment_plan::decode(const bytes& b) const {
         return {};
     }
     protocol::decoder reader(bytes_to_iobuf(b));
-    auto result = reader.read_array([](protocol::decoder& reader) {
+    auto result = reader.read_array<false>([](protocol::decoder& reader) {
         auto topic = model::topic(reader.read_string());
         return std::make_pair(
-          std::move(topic), reader.read_array([](protocol::decoder& reader) {
+          std::move(topic),
+          reader.read_array<false>([](protocol::decoder& reader) {
               return model::partition_id(reader.read_int32());
           }));
     });

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -226,7 +226,7 @@ void consumer::on_leader_join(const join_group_response& res) {
     _subscribed_topics.clear();
     for (auto const& m : res.data.members) {
         protocol::decoder r(bytes_to_iobuf(m.metadata));
-        auto topics = r.read_array([](protocol::decoder& reader) {
+        auto topics = r.read_array<false>([](protocol::decoder& reader) {
             return model::topic(reader.read_string());
         });
         std::copy(

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -76,10 +76,10 @@ struct partition_comp {
 fetch_response
 reduce_fetch_response(fetch_response result, fetch_response val) {
     result.data.throttle_time_ms += val.data.throttle_time_ms;
-    result.data.topics.insert(
-      result.data.topics.end(),
-      std::make_move_iterator(val.data.topics.begin()),
-      std::make_move_iterator(val.data.topics.end()));
+    std::move(
+      val.data.topics.begin(),
+      val.data.topics.end(),
+      std::back_inserter(result.data.topics));
 
     return result;
 };

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -79,7 +79,7 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
     responses.push_back(std::move(pr));
     auto response = fetch_response::partition{.name = tp.topic};
     response.partitions = std::move(responses);
-    std::vector<fetch_response::partition> parts;
+    large_fragment_vector<fetch_response::partition> parts;
     parts.push_back(std::move(response));
     return fetch_response{
       .data = {

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -18,6 +18,7 @@
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastar/core/gate.hh"
+#include "utils/fragmented_vector.h"
 
 namespace kafka::client {
 
@@ -74,7 +75,7 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
       .aborted{},
       .records{}};
 
-    std::vector<fetch_response::partition_response> responses;
+    large_fragment_vector<fetch_response::partition_response> responses;
     responses.push_back(std::move(pr));
     auto response = fetch_response::partition{.name = tp.topic};
     response.partitions = std::move(responses);

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -20,6 +20,7 @@
 #include "model/metadata.h"
 #include "model/timeout_clock.h"
 #include "seastarx.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/future.hh>
 
@@ -213,7 +214,7 @@ struct fetch_response final {
     public:
         using partition_iterator = std::vector<partition>::iterator;
         using partition_response_iterator
-          = std::vector<partition_response>::iterator;
+          = large_fragment_vector<partition_response>::iterator;
 
         struct value_type {
             partition_iterator partition;

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -212,7 +212,7 @@ struct fetch_response final {
      */
     class iterator {
     public:
-        using partition_iterator = std::vector<partition>::iterator;
+        using partition_iterator = large_fragment_vector<partition>::iterator;
         using partition_response_iterator
           = large_fragment_vector<partition_response>::iterator;
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -464,7 +464,8 @@ extra_headers = {
 # These types, when they appear as the member type of an array, will use
 # a vector implementation which resists fragmentation.
 enable_fragmentation_resistance = {
-    'metadata_response_partition', 'fetchable_partition_response'
+    'metadata_response_partition', 'fetchable_partition_response',
+    'fetchable_topic_response'
 }
 
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -463,7 +463,9 @@ extra_headers = {
 
 # These types, when they appear as the member type of an array, will use
 # a vector implementation which resists fragmentation.
-enable_fragmentation_resistance = {'metadata_response_partition'}
+enable_fragmentation_resistance = {
+    'metadata_response_partition', 'fetchable_partition_response'
+}
 
 
 def make_context_field(path):

--- a/src/v/kafka/protocol/tests/field_parser_test.cc
+++ b/src/v/kafka/protocol/tests/field_parser_test.cc
@@ -123,17 +123,18 @@ T read_flex(iobuf buf) {
     } else if constexpr (std::is_same_v<T, bytes>) {
         return reader.read_flex_bytes();
     } else if constexpr (std::is_same_v<T, std::vector<test_struct>>) {
-        return reader.read_flex_array([](kafka::protocol::decoder& reader) {
-            test_struct v;
-            v.field_a = reader.read_flex_string();
-            v.field_b = reader.read_int32();
-            (void)reader.read_tags();
-            return v;
-        });
+        return reader.read_flex_array<false>(
+          [](kafka::protocol::decoder& reader) {
+              test_struct v;
+              v.field_a = reader.read_flex_string();
+              v.field_b = reader.read_int32();
+              (void)reader.read_tags();
+              return v;
+          });
     } else if constexpr (std::is_same_v<
                            T,
                            std::optional<std::vector<test_struct>>>) {
-        return reader.read_nullable_flex_array(
+        return reader.read_nullable_flex_array<false>(
           [](kafka::protocol::decoder& reader) {
               test_struct v;
               v.field_a = reader.read_flex_string();

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -171,7 +171,7 @@ group_metadata_value group_metadata_value::decode(protocol::decoder& reader) {
         ret.state_timestamp = model::timestamp(reader.read_int64());
     }
 
-    ret.members = reader.read_array(
+    ret.members = reader.read_array<false>(
       [](protocol::decoder& reader) { return member_state::decode(reader); });
 
     return ret;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -859,9 +859,6 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
      * decode request and prepare the inital response
      */
     request.decode(rctx.reader(), rctx.header().version);
-    if (likely(!request.data.topics.empty())) {
-        response.data.topics.reserve(request.data.topics.size());
-    }
 
     if (auto delay = request.debounce_delay(); delay) {
         deadline = model::timeout_clock::now() + delay.value();

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -881,9 +881,8 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
 
 // insert and reserve space for a new topic in the response
 void op_context::start_response_topic(const fetch_request::topic& topic) {
-    auto& p = response.data.topics.emplace_back(
+    response.data.topics.emplace_back(
       fetchable_topic_response{.name = topic.name});
-    p.partitions.reserve(topic.fetch_partitions.size());
 }
 
 void op_context::start_response_partition(const fetch_request::partition& p) {
@@ -1002,8 +1001,6 @@ ss::future<response_ptr> op_context::send_response() && {
         if (it->is_new_topic) {
             final_response.data.topics.emplace_back(
               fetchable_topic_response{.name = it->partition->name});
-            final_response.data.topics.back().partitions.reserve(
-              it->partition->partitions.size());
         }
 
         fetch_response::partition_response r{

--- a/src/v/pandaproxy/json/requests/test/fetch.cc
+++ b/src/v/pandaproxy/json/requests/test/fetch.cc
@@ -22,6 +22,7 @@
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
 #include "seastarx.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
@@ -45,7 +46,7 @@ make_record_set(model::offset offset, size_t count) {
 
 auto make_fetch_response(
   std::vector<model::topic_partition> tps, model::offset offset, size_t count) {
-    std::vector<kafka::fetch_response::partition> parts;
+    large_fragment_vector<kafka::fetch_response::partition> parts;
     for (const auto& tp : tps) {
         kafka::fetch_response::partition res{tp.topic};
         res.partitions.push_back(kafka::fetch_response::partition_response{

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -242,6 +242,8 @@ public:
             return tmp;
         }
 
+        pointer operator->() const { return &_vec->operator[](_index); }
+
         iter operator+(difference_type offset) { return iter{*this} += offset; }
         iter operator-(difference_type offset) { return iter{*this} -= offset; }
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -141,6 +141,9 @@ public:
 
     const T& front() const { return _frags.front().front(); }
     const T& back() const { return _frags.back().back(); }
+
+    T& front() { return _frags.front().front(); }
+    T& back() { return _frags.back().back(); }
     bool empty() const noexcept { return _size == 0; }
     size_t size() const noexcept { return _size; }
 


### PR DESCRIPTION
Using fragmented vectors in `fetch_response` to store both `fetchable_topic_response` and `fetchable_partition_response`. Using fragmented containers will prevent memory fragmentation by reducing large contiguous allocations. 
Fixes: #11671 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none