### PR TITLE
tests: fix call to quiesce_uploads in topic deletion test

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -406,7 +406,6 @@ class RpkTool:
             self._redpanda.logger.error(f"Missing columns: {missing_columns}")
             raise RpkException(f"Missing columns: {missing_columns}")
 
-        partitions = []
         for row in table.rows:
             obj = dict()
             obj["LAST-STABLE-OFFSET"] = "-"
@@ -440,9 +439,7 @@ class RpkTool:
                                      start_offset=obj["LOG-START-OFFSET"])
 
             if initialized or tolerant:
-                partitions.append(partition)
-
-        return iter(partitions)
+                yield partition
 
     def describe_topic_configs(self, topic):
         cmd = ['describe', topic, '-c']

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -472,7 +472,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         # Wait for everything to be uploaded: this avoids tests potentially trying
         # to delete topics mid-uploads, which can leave orphan segments.
-        quiesce_uploads(self.redpanda, topic_name, timeout_sec=60)
+        quiesce_uploads(self.redpanda, [topic_name], timeout_sec=60)
 
     @skip_debug_mode  # Rely on timely uploads during leader transfers
     @cluster(num_nodes=3,


### PR DESCRIPTION

This was a case of passing `topic_name` instead of `[topic_name]`, python helpfully accepting a string as something to iterate over, rpk topic describe not throwing an error on a missing topic, and `quiesce_uploads` not throwing an error of rpk gives it zero partition descriptions.

Fixes https://github.com/redpanda-data/redpanda/issues/8496
Fixes https://github.com/redpanda-data/redpanda/issues/10655
Fixes https://github.com/redpanda-data/redpanda/issues/9629

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
