### PR TITLE
[v22.3.x] net: `ss::nested_exception` might be a `disconnect_exception`

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -12,6 +12,8 @@
 #include "net/exceptions.h"
 #include "rpc/service.h"
 
+#include <seastar/core/future.hh>
+
 #include <gnutls/gnutls.h>
 
 namespace net {
@@ -83,6 +85,11 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
         return "parse error";
     } catch (const invalid_request_error& e) {
         return "invalid request";
+    } catch (const ss::nested_exception& e) {
+        if (auto err = is_disconnect_exception(e.inner)) {
+            return err;
+        }
+        return is_disconnect_exception(e.outer);
     } catch (...) {
         // Global catch-all prevents stranded/non-handled exceptional futures.
         // In all other non-explicity handled cases, the exception will not be

--- a/src/v/net/tests/CMakeLists.txt
+++ b/src/v/net/tests/CMakeLists.txt
@@ -18,3 +18,13 @@ rp_test(
         ARGS "-- -c 8"
         LABELS net
 )
+
+rp_test(
+        UNIT_TEST
+        BINARY_NAME net_connection
+        SOURCES
+        connection.cc
+        DEFINITIONS BOOST_TEST_DYN_LINK
+        LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::net
+        LABELS net
+)

--- a/src/v/net/tests/connection.cc
+++ b/src/v/net/tests/connection.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "net/connection.h"
+
+#include <seastar/core/future.hh>
+
+#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include <exception>
+#include <system_error>
+
+BOOST_AUTO_TEST_CASE(test_is_disconnect_error) {
+    auto is_a_de = std::system_error(
+      std::make_error_code(std::errc::broken_pipe));
+    auto not_a_de = std::system_error(
+      std::make_error_code(std::errc::is_a_directory));
+
+    BOOST_CHECK(net::is_disconnect_exception(std::make_exception_ptr(is_a_de))
+                  .has_value());
+
+    BOOST_CHECK(!net::is_disconnect_exception(std::make_exception_ptr(not_a_de))
+                   .has_value());
+
+    BOOST_CHECK(
+      net::is_disconnect_exception(
+        std::make_exception_ptr(ss::nested_exception(
+          std::make_exception_ptr(is_a_de), std::make_exception_ptr(not_a_de))))
+        .has_value());
+
+    BOOST_CHECK(
+      net::is_disconnect_exception(
+        std::make_exception_ptr(ss::nested_exception(
+          std::make_exception_ptr(not_a_de), std::make_exception_ptr(is_a_de))))
+        .has_value());
+
+    BOOST_CHECK(!net::is_disconnect_exception(
+                   std::make_exception_ptr(ss::nested_exception(
+                     std::make_exception_ptr(not_a_de),
+                     std::make_exception_ptr(not_a_de))))
+                   .has_value());
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11619
Fixes https://github.com/redpanda-data/redpanda/issues/11639,

Small conflict in `CMakeLists.txt` due to #6560 not backported