### PR TITLE
[v22.2.x] net: `ss::nested_exception` might be a `disconnect_exception`

### DIFF
--- a/src/v/net/tests/CMakeLists.txt
+++ b/src/v/net/tests/CMakeLists.txt
@@ -18,3 +18,13 @@ rp_test(
         ARGS "-- -c 8"
         LABELS net
 )
+
+rp_test(
+        UNIT_TEST
+        BINARY_NAME net_connection
+        SOURCES
+        connection.cc
+        DEFINITIONS BOOST_TEST_DYN_LINK
+        LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::net
+        LABELS net
+)

--- a/src/v/net/tests/connection.cc
+++ b/src/v/net/tests/connection.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "net/connection.h"
+
+#include <seastar/core/future.hh>
+
+#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include <exception>
+#include <system_error>
+
+BOOST_AUTO_TEST_CASE(test_is_disconnect_error) {
+    auto is_a_de = std::system_error(
+      std::make_error_code(std::errc::broken_pipe));
+    auto not_a_de = std::system_error(
+      std::make_error_code(std::errc::is_a_directory));
+
+    BOOST_CHECK(net::is_disconnect_exception(std::make_exception_ptr(is_a_de))
+                  .has_value());
+
+    BOOST_CHECK(!net::is_disconnect_exception(std::make_exception_ptr(not_a_de))
+                   .has_value());
+
+    BOOST_CHECK(
+      net::is_disconnect_exception(
+        std::make_exception_ptr(ss::nested_exception(
+          std::make_exception_ptr(is_a_de), std::make_exception_ptr(not_a_de))))
+        .has_value());
+
+    BOOST_CHECK(
+      net::is_disconnect_exception(
+        std::make_exception_ptr(ss::nested_exception(
+          std::make_exception_ptr(not_a_de), std::make_exception_ptr(is_a_de))))
+        .has_value());
+
+    BOOST_CHECK(!net::is_disconnect_exception(
+                   std::make_exception_ptr(ss::nested_exception(
+                     std::make_exception_ptr(not_a_de),
+                     std::make_exception_ptr(not_a_de))))
+                   .has_value());
+}

--- a/src/v/net/tests/connection.cc
+++ b/src/v/net/tests/connection.cc
@@ -8,6 +8,8 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#define BOOST_TEST_MODULE net_connection
+
 #include "net/connection.h"
 
 #include <seastar/core/future.hh>


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11619, https://github.com/redpanda-data/redpanda/pull/11711


Small conflict in `CMakeLists.txt` due to #6560 not backported
Small conflict in `connection.cc` due to #6283 not backported