### PR TITLE
Wire-up and enhance disk space notifications that are delivered to space management control loop

### DIFF
--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -206,9 +206,11 @@ ss::future<> local_monitor::update_disk_metrics() {
     co_await _storage_node_api.invoke_on_all(
       &storage::node::set_disk_metrics,
       storage::node::disk_type::data,
-      _state.data_disk.total,
-      _state.data_disk.free,
-      _state.data_disk.alert);
+      storage::node::disk_space_info{
+        .total = _state.data_disk.total,
+        .free = _state.data_disk.free,
+        .alert = _state.data_disk.alert,
+      });
 
     // Always notify for cache disk, even if it's the same underlying drive:
     // subscribers to updates on cache disk space still need to get updates.
@@ -216,9 +218,11 @@ ss::future<> local_monitor::update_disk_metrics() {
     co_await _storage_node_api.invoke_on_all(
       &storage::node::set_disk_metrics,
       storage::node::disk_type::cache,
-      cache_disk.total,
-      cache_disk.free,
-      cache_disk.alert);
+      storage::node::disk_space_info{
+        .total = cache_disk.total,
+        .free = cache_disk.free,
+        .alert = cache_disk.alert,
+      });
 }
 
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -54,10 +54,6 @@ public:
       = "storage space alert"; // for those who grep the logs..
 
 private:
-    // helpers
-    static size_t
-    alert_percent_in_bytes(unsigned alert_percent, size_t bytes_available);
-
     /// Periodically check node status until stopped by abort source
     ss::future<> _update_loop();
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1308,12 +1308,9 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         auto cloud_storage_cache_disk_notification
           = storage_node.local().register_disk_notification(
             storage::node::disk_type::cache,
-            [this](
-              uint64_t total_space,
-              uint64_t free_space,
-              storage::disk_space_alert alert) {
+            [this](storage::node::disk_space_info info) {
                 return shadow_index_cache.local().notify_disk_status(
-                  total_space, free_space, alert);
+                  info.total, info.free, info.alert);
             });
         _deferred.emplace_back([this, cloud_storage_cache_disk_notification] {
             storage_node.local().unregister_disk_notification(
@@ -1690,14 +1687,10 @@ void application::wire_up_bootstrap_services() {
     auto storage_disk_notification
       = storage_node.local().register_disk_notification(
         storage::node::disk_type::data,
-        [this](
-          uint64_t total_space,
-          uint64_t free_space,
-          storage::disk_space_alert alert) {
-            return storage.invoke_on_all(
-              [total_space, free_space, alert](storage::api& api) {
-                  api.handle_disk_notification(total_space, free_space, alert);
-              });
+        [this](storage::node::disk_space_info info) {
+            return storage.invoke_on_all([info](storage::api& api) {
+                api.handle_disk_notification(info.total, info.free, info.alert);
+            });
         });
     _deferred.emplace_back([this, storage_disk_notification] {
         storage_node.local().unregister_disk_notification(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1357,6 +1357,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       space_manager,
       config::shard_local_cfg().enable_storage_space_manager.bind(),
       &storage,
+      &storage_node,
       &shadow_index_cache,
       &partition_manager);
 

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -13,6 +13,7 @@ v_cc_library(
     storage.cc
   DEPS
     Seastar::seastar
+    v::cloud_storage
   )
 
 add_subdirectory(tests)

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -48,12 +48,19 @@ ss::future<> disk_space_manager::start() {
       _enabled() ? "enabled" : "disabled");
     if (ss::this_shard_id() == run_loop_core) {
         ssx::spawn_with_gate(_gate, [this] { return run_loop(); });
+        _cache_disk_nid = _storage_node->local().register_disk_notification(
+          node::disk_type::cache,
+          [this](node::disk_space_info info) { _cache_disk_info = info; });
     }
     co_return;
 }
 
 ss::future<> disk_space_manager::stop() {
     vlog(rlog.info, "Stopping disk space manager service");
+    if (ss::this_shard_id() == run_loop_core) {
+        _storage_node->local().unregister_disk_notification(
+          node::disk_type::cache, _cache_disk_nid);
+    }
     _control_sem.broken();
     co_await _gate.close();
 }

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -11,6 +11,7 @@
 
 #include "storage.h"
 
+#include "cloud_storage/cache_service.h"
 #include "cluster/partition_manager.h"
 #include "vlog.h"
 
@@ -23,10 +24,12 @@ namespace storage {
 disk_space_manager::disk_space_manager(
   config::binding<bool> enabled,
   ss::sharded<storage::api>* storage,
+  ss::sharded<storage::node>* storage_node,
   ss::sharded<cloud_storage::cache>* cache,
   ss::sharded<cluster::partition_manager>* pm)
   : _enabled(std::move(enabled))
   , _storage(storage)
+  , _storage_node(storage_node)
   , _cache(cache->local_is_initialized() ? cache : nullptr)
   , _pm(pm) {
     _enabled.watch([this] {

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -63,6 +63,10 @@ private:
     ss::sharded<cloud_storage::cache>* _cache;
     ss::sharded<cluster::partition_manager>* _pm;
 
+    node::notification_id _cache_disk_nid;
+    // details from last disk notification
+    node::disk_space_info _cache_disk_info{};
+
     ss::gate _gate;
     ss::future<> run_loop();
     ssx::semaphore _control_sem{0, "resource_mgmt::space_manager"};

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -14,6 +14,7 @@
 #include "config/property.h"
 #include "seastarx.h"
 #include "ssx/semaphore.h"
+#include "storage/node.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -30,27 +31,7 @@ class partition_manager;
 namespace storage {
 
 class api;
-
-enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
-
-inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
-    return std::max(a, b);
-}
-
-inline std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
-    switch (d) {
-    case disk_space_alert::ok:
-        o << "ok";
-        break;
-    case disk_space_alert::low_space:
-        o << "low_space";
-        break;
-    case disk_space_alert::degraded:
-        o << "degraded";
-        break;
-    }
-    return o;
-}
+class node;
 
 /*
  *
@@ -60,6 +41,7 @@ public:
     disk_space_manager(
       config::binding<bool> enabled,
       ss::sharded<storage::api>* storage,
+      ss::sharded<storage::node>* storage_node,
       ss::sharded<cloud_storage::cache>* cache,
       ss::sharded<cluster::partition_manager>* pm);
 
@@ -75,6 +57,7 @@ public:
 private:
     config::binding<bool> _enabled;
     ss::sharded<storage::api>* _storage;
+    ss::sharded<storage::node>* _storage_node;
     ss::sharded<cloud_storage::cache>* _cache;
     ss::sharded<cluster::partition_manager>* _pm;
 

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -37,6 +37,8 @@ class node;
  *
  */
 class disk_space_manager {
+    static constexpr ss::shard_id run_loop_core = 0;
+
 public:
     disk_space_manager(
       config::binding<bool> enabled,

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -38,11 +38,17 @@ void node::set_disk_metrics(
   uint64_t free_bytes,
   disk_space_alert alert) {
     if (t == disk_type::data) {
-        _data_watchers.notify(
-          uint64_t(total_bytes), uint64_t(free_bytes), alert);
+        _data_watchers.notify(disk_space_info{
+          .total = total_bytes,
+          .free = free_bytes,
+          .alert = alert,
+        });
     } else if (t == disk_type::cache) {
-        _cache_watchers.notify(
-          uint64_t(total_bytes), uint64_t(free_bytes), alert);
+        _cache_watchers.notify(disk_space_info{
+          .total = total_bytes,
+          .free = free_bytes,
+          .alert = alert,
+        });
     }
     _probe.set_disk_metrics(total_bytes, free_bytes, alert);
 }

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -32,25 +32,21 @@ ss::future<> node::start() {
 
 ss::future<> node::stop() { co_return; }
 
-void node::set_disk_metrics(
-  disk_type t,
-  uint64_t total_bytes,
-  uint64_t free_bytes,
-  disk_space_alert alert) {
+void node::set_disk_metrics(disk_type t, disk_space_info info) {
     if (t == disk_type::data) {
         _data_watchers.notify(disk_space_info{
-          .total = total_bytes,
-          .free = free_bytes,
-          .alert = alert,
+          .total = info.total,
+          .free = info.free,
+          .alert = info.alert,
         });
     } else if (t == disk_type::cache) {
         _cache_watchers.notify(disk_space_info{
-          .total = total_bytes,
-          .free = free_bytes,
-          .alert = alert,
+          .total = info.total,
+          .free = info.free,
+          .alert = info.alert,
         });
     }
-    _probe.set_disk_metrics(total_bytes, free_bytes, alert);
+    _probe.set_disk_metrics(info.total, info.free, info.alert);
 }
 
 node::notification_id

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -10,6 +10,8 @@
  */
 #include "storage/node.h"
 
+#include <seastar/core/reactor.hh>
+
 namespace storage {
 
 node::node(ss::sstring data_directory, ss::sstring cache_directory)

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -34,17 +34,9 @@ ss::future<> node::stop() { co_return; }
 
 void node::set_disk_metrics(disk_type t, disk_space_info info) {
     if (t == disk_type::data) {
-        _data_watchers.notify(disk_space_info{
-          .total = info.total,
-          .free = info.free,
-          .alert = info.alert,
-        });
+        _data_watchers.notify(info);
     } else if (t == disk_type::cache) {
-        _cache_watchers.notify(disk_space_info{
-          .total = info.total,
-          .free = info.free,
-          .alert = info.alert,
-        });
+        _cache_watchers.notify(info);
     }
     _probe.set_disk_metrics(info.total, info.free, info.alert);
 }

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -10,9 +10,9 @@
  */
 #pragma once
 
-#include "resource_mgmt/storage.h"
 #include "seastarx.h"
 #include "storage/probe.h"
+#include "storage/types.h"
 #include "utils/named_type.h"
 #include "utils/notification_list.h"
 

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -30,9 +30,14 @@ class node {
 public:
     static constexpr ss::shard_id work_shard = 0;
 
+    struct disk_space_info {
+        size_t total;
+        size_t free;
+        disk_space_alert alert;
+    };
+
     using notification_id = named_type<int32_t, struct notification_id_t>;
-    using disk_cb_t
-      = ss::noncopyable_function<void(uint64_t, uint64_t, disk_space_alert)>;
+    using disk_cb_t = ss::noncopyable_function<void(disk_space_info)>;
 
     enum class disk_type { data, cache };
 

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -34,6 +34,8 @@ public:
         size_t total;
         size_t free;
         disk_space_alert alert;
+        size_t degraded_threshold;
+        size_t low_space_threshold;
     };
 
     using notification_id = named_type<int32_t, struct notification_id_t>;

--- a/src/v/storage/node.h
+++ b/src/v/storage/node.h
@@ -46,11 +46,7 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    void set_disk_metrics(
-      disk_type t,
-      uint64_t total_bytes,
-      uint64_t free_bytes,
-      disk_space_alert alert);
+    void set_disk_metrics(disk_type t, disk_space_info);
 
     notification_id register_disk_notification(disk_type t, disk_cb_t cb);
     void unregister_disk_notification(disk_type t, notification_id id);

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -16,7 +16,6 @@
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
-#include "resource_mgmt/storage.h"
 #include "storage/file_sanitizer_types.h"
 #include "storage/fwd.h"
 #include "tristate.h"
@@ -33,6 +32,27 @@
 namespace storage {
 using log_clock = ss::lowres_clock;
 using jitter_percents = named_type<int, struct jitter_percents_tag>;
+
+enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
+
+inline disk_space_alert max_severity(disk_space_alert a, disk_space_alert b) {
+    return std::max(a, b);
+}
+
+inline std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
+    switch (d) {
+    case disk_space_alert::ok:
+        o << "ok";
+        break;
+    case disk_space_alert::low_space:
+        o << "low_space";
+        break;
+    case disk_space_alert::degraded:
+        o << "degraded";
+        break;
+    }
+    return o;
+}
 
 struct disk
   : serde::envelope<disk, serde::version<1>, serde::compat_version<0>> {


### PR DESCRIPTION
Two changes

1. Largely a refactor/clean-up. Adds a struct to hold extra information like computed thresholds for low-space/degraded states to disk space notification handlers.
2. Wires up the space management control loop to receive disk space notifications.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

