### PR TITLE
cloud_storage: Read offset arrays when creating coarse index

### DIFF
--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -155,6 +155,8 @@ private:
     encoder_t _kaf_index;
     foffset_encoder_t _file_index;
     int64_t _min_file_pos_step;
+
+    friend class offset_index_accessor;
 };
 
 class remote_segment_index_builder : public storage::batch_consumer {


### PR DESCRIPTION
When creating coarse index, in addition to reading the index fields, we also read the offset fields. This ensures that in cases where the index is very small and all the data is contained in the offset fields, a mini index can still be generated.

Additionally the calculation of offsets to add in the index is changed so that we do not end up skipping offsets when the mod of current offset is unchanged, which is a bug that the previous iteration of the code was susceptible to.

Fixes https://github.com/redpanda-data/redpanda/issues/11703

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
