### PR TITLE
c/leader_balancer: use btree_map as a group to revision index

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer_types.h
+++ b/src/v/cluster/scheduling/leader_balancer_types.h
@@ -41,7 +41,7 @@ using index_type = absl::node_hash_map<
   absl::btree_map<raft::group_id, std::vector<model::broker_shard>>>;
 
 using group_id_to_topic_revision_t
-  = absl::flat_hash_map<raft::group_id, model::revision_id>;
+  = absl::btree_map<raft::group_id, model::revision_id>;
 
 /*
  * Leaders per shard.


### PR DESCRIPTION
In a system where there is a lot of raft groups using `absl::flat_hash_map` to store mapping from `raft::group_id` to `model::revision_id` might lead to large contiguous allocation.

Replaced `flat_hash_map` with `btree_map` as the code is not performance critical.

Fixes: #11670

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none