### PR TITLE
tests: reinstate drop_lifecycle_marker_test

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -64,6 +64,29 @@ class KgoVerifierService(Service):
     def __del__(self):
         self._release_port()
 
+    @classmethod
+    def oneshot(cls, *args, **kwargs):
+        """
+        Convenience method for constructing, running and releasing node.
+
+        Invoke with the same arguments as constructor, and optionally also
+        `timeout_sec` if you would like to configure the wait timeout.
+
+        Returns the finished instance, so that one can read its status methods
+        to verify message counts etc
+        """
+
+        if 'timeout_sec' in kwargs:
+            timeout_kwargs = {'timeout_sec': kwargs.pop('timeout_sec')}
+        else:
+            timeout_kwargs = {}
+
+        inst = cls(*args, **kwargs)
+        inst.start()
+        inst.wait(**timeout_kwargs)
+        inst.free()
+        return inst
+
     def _release_port(self):
         for node in self.nodes:
             port_map = getattr(node, "kgo_verifier_ports", dict())
@@ -432,17 +455,18 @@ class ConsumerStatus:
 
 
 class KgoVerifierSeqConsumer(KgoVerifierService):
-    def __init__(self,
-                 context,
-                 redpanda,
-                 topic,
-                 msg_size,
-                 max_msgs=None,
-                 max_throughput_mb=None,
-                 nodes=None,
-                 debug_logs=False,
-                 trace_logs=False,
-                 loop=True):
+    def __init__(
+            self,
+            context,
+            redpanda,
+            topic,
+            msg_size=None,  # TODO: redundant, remove
+            max_msgs=None,
+            max_throughput_mb=None,
+            nodes=None,
+            debug_logs=False,
+            trace_logs=False,
+            loop=True):
         super(KgoVerifierSeqConsumer,
               self).__init__(context, redpanda, topic, msg_size, nodes,
                              debug_logs, trace_logs)

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from ducktape.utils.util import wait_until
 
-from ducktape.mark import matrix, parametrize, ok_to_fail
+from ducktape.mark import matrix, parametrize
 from requests.exceptions import HTTPError
 
 from rptest.utils.mode_checks import skip_debug_mode
@@ -513,7 +513,6 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         self._validate_topic_deletion(self.topic, CloudStorageType.S3)
 
-    @ok_to_fail
     @cluster(
         num_nodes=4,
         log_allow_list=[

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -252,8 +252,13 @@ def wait_for_local_storage_truncate(redpanda,
             # removal would exceed the retention target. so for the comparison
             # to determine if we reached the goal we subtract off the size of
             # the oldest segment
-            first_segment = min(node_partition.segments.values(),
-                                key=lambda s: s.offset)
+            try:
+                first_segment = min(node_partition.segments.values(),
+                                    key=lambda s: s.offset)
+            except ValueError:
+                # Segment list is empty
+                first_segment = None
+
             first_segment_size = first_segment.size if first_segment.size else 0
             sizes.append(total_size - first_segment_size)
 


### PR DESCRIPTION
Make this test better behaved and remove ok_to_fail

Also opportunistically make some other improvements to the deletion test class, including removing use of the KafkaCliTools.produce helper, which can hide issues (https://github.com/redpanda-data/redpanda/issues/11689)

Fixes https://github.com/redpanda-data/redpanda/issues/11232

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

