### PR TITLE
tests: disable minio console

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       MINIO_REGION_NAME: panda-region
       MINIO_ROOT_PASSWORD: panda-secret
       MINIO_ROOT_USER: panda-user
+      MINIO_BROWSER: off
     expose:
     - '9000'
     healthcheck:


### PR DESCRIPTION
The console port is high numbered and has been seen to occasionally collide with some other program in the CI environment.  We do not use the console anything, so simply switch it off.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
