### PR TITLE
cloud_storage: topic deletion follow up

### DIFF
--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -54,10 +54,7 @@ ss::future<scrubber::purge_result> scrubber::purge_partition(
   model::initial_revision_id remote_revision,
   retry_chain_node& parent_rtc) {
     retry_chain_node partition_purge_rtc(
-      partition_purge_timeout,
-      1s /* unused */,
-      retry_strategy::disallow,
-      &parent_rtc);
+      partition_purge_timeout, 100ms, &parent_rtc);
     retry_chain_logger ctxlog(archival_log, partition_purge_rtc);
 
     if (lifecycle_marker.config.is_read_replica()) {

--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -173,7 +173,7 @@ void upload_housekeeping_service::epoch_timer_callback() {
 void upload_housekeeping_service::register_jobs(
   std::vector<std::reference_wrapper<housekeeping_job>> jobs) {
     for (auto ref : jobs) {
-        vlog(_ctxlog.info, "Registering job: {}", ref.get().name());
+        vlog(_ctxlog.debug, "Registering job: {}", ref.get().name());
         _workflow.register_job(ref.get());
     }
 }
@@ -181,7 +181,7 @@ void upload_housekeeping_service::register_jobs(
 void upload_housekeeping_service::deregister_jobs(
   std::vector<std::reference_wrapper<housekeeping_job>> jobs) {
     for (auto ref : jobs) {
-        vlog(_ctxlog.info, "Deregistering job: {}", ref.get().name());
+        vlog(_ctxlog.debug, "Deregistering job: {}", ref.get().name());
         _workflow.deregister_job(ref.get());
     }
 }

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -878,6 +878,18 @@ ss::future<upload_result> remote::delete_objects(
           bucket, keys, fib.get_timeout());
 
         if (res) {
+            if (!res.value().undeleted_keys.empty()) {
+                vlog(
+                  ctxlog.debug,
+                  "{} objects were not deleted by plural delete; first "
+                  "failure: {{key: {}, reason:{}}}",
+                  res.value().undeleted_keys.size(),
+                  res.value().undeleted_keys.front().key,
+                  res.value().undeleted_keys.front().reason);
+
+                co_return upload_result::failed;
+            }
+
             co_return upload_result::success;
         }
 

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -313,6 +313,10 @@ void s3_imposter_fixture::set_routes(
               request._method == "POST"
               && request.query_parameters.contains("delete")) {
                 // Delete objects
+                auto it = expectations.find(request._url);
+                if (it != expectations.end() && it->second.body.has_value()) {
+                    return it->second.body.value();
+                }
                 return R"xml(<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>)xml";
             }
             BOOST_FAIL("Unexpected request");

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -64,6 +64,29 @@ class KgoVerifierService(Service):
     def __del__(self):
         self._release_port()
 
+    @classmethod
+    def oneshot(cls, *args, **kwargs):
+        """
+        Convenience method for constructing, running and releasing node.
+
+        Invoke with the same arguments as constructor, and optionally also
+        `timeout_sec` if you would like to configure the wait timeout.
+
+        Returns the finished instance, so that one can read its status methods
+        to verify message counts etc
+        """
+
+        if 'timeout_sec' in kwargs:
+            timeout_kwargs = {'timeout_sec': kwargs.pop('timeout_sec')}
+        else:
+            timeout_kwargs = {}
+
+        inst = cls(*args, **kwargs)
+        inst.start()
+        inst.wait(**timeout_kwargs)
+        inst.free()
+        return inst
+
     def _release_port(self):
         for node in self.nodes:
             port_map = getattr(node, "kgo_verifier_ports", dict())
@@ -432,17 +455,18 @@ class ConsumerStatus:
 
 
 class KgoVerifierSeqConsumer(KgoVerifierService):
-    def __init__(self,
-                 context,
-                 redpanda,
-                 topic,
-                 msg_size,
-                 max_msgs=None,
-                 max_throughput_mb=None,
-                 nodes=None,
-                 debug_logs=False,
-                 trace_logs=False,
-                 loop=True):
+    def __init__(
+            self,
+            context,
+            redpanda,
+            topic,
+            msg_size=None,  # TODO: redundant, remove
+            max_msgs=None,
+            max_throughput_mb=None,
+            nodes=None,
+            debug_logs=False,
+            trace_logs=False,
+            loop=True):
         super(KgoVerifierSeqConsumer,
               self).__init__(context, redpanda, topic, msg_size, nodes,
                              debug_logs, trace_logs)

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from ducktape.utils.util import wait_until
 
-from ducktape.mark import matrix, parametrize, ok_to_fail
+from ducktape.mark import matrix, parametrize
 from requests.exceptions import HTTPError
 
 from rptest.utils.mode_checks import skip_debug_mode
@@ -513,7 +513,6 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         self._validate_topic_deletion(self.topic, CloudStorageType.S3)
 
-    @ok_to_fail
     @cluster(
         num_nodes=4,
         log_allow_list=[

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -252,8 +252,13 @@ def wait_for_local_storage_truncate(redpanda,
             # removal would exceed the retention target. so for the comparison
             # to determine if we reached the goal we subtract off the size of
             # the oldest segment
-            first_segment = min(node_partition.segments.values(),
-                                key=lambda s: s.offset)
+            try:
+                first_segment = min(node_partition.segments.values(),
+                                    key=lambda s: s.offset)
+            except ValueError:
+                # Segment list is empty
+                first_segment = None
+
             first_segment_size = first_segment.size if first_segment.size else 0
             sizes.append(total_size - first_segment_size)
 


### PR DESCRIPTION
The main goal of this PR is to fix an issue with topic deletion that surfaced in
CDT testing. Previously, the scrubber did not re-send retryable requests. The
intention here was to drop out  if the cloud storage provider is applying
throttling as it is unlikely that much progress would be made.

However, the connection is killed after specific request sequences
(posibly due to htpp client bug). Not retrying means that the scrubber
does not make progress. This patch changes the retry strategy used for
purging partitions to exponential backoff in order to work around the
issue.

Related #11710

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

