### PR TITLE
net/tests: Register a BOOST_TEST_MODULE

### DIFF
--- a/src/v/net/tests/connection.cc
+++ b/src/v/net/tests/connection.cc
@@ -8,6 +8,8 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#define BOOST_TEST_MODULE net_connection
+
 #include "net/connection.h"
 
 #include <seastar/core/future.hh>


### PR DESCRIPTION
This prevents:

```
Test setup error: std::runtime_error: No tests registered
```

The error was introduced in https://github.com/redpanda-data/redpanda/pull/11687 which I accidentally merged.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
