### PR TITLE
net/tests: Register a BOOST_TEST_MODULE

### DIFF
--- a/src/v/net/tests/connection.cc
+++ b/src/v/net/tests/connection.cc
@@ -8,6 +8,8 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#define BOOST_TEST_MODULE net_connection
+
 #include "net/connection.h"
 
 #include <seastar/core/future.hh>


### PR DESCRIPTION
This prevents:

```
Test setup error: std::runtime_error: No tests registered
```

The error was introduced in https://github.com/redpanda-data/redpanda/pull/11641 which I accidentally merged.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
