### PR TITLE
tests: bump local truncation timeout in upgrade tests

### DIFF
--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -453,7 +453,7 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
                                         topic,
                                         target_bytes=local_retention_bytes +
                                         segment_bytes,
-                                        timeout_sec=30)
+                                        timeout_sec=60)
 
         # Restart 2/3 nodes, leave last node on old version
         new_version_nodes = self.redpanda.nodes[:-1]
@@ -526,7 +526,7 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
                 topic,
                 partition_idx=newdata_p,
                 target_bytes=local_retention_bytes + segment_bytes,
-                timeout_sec=30)
+                timeout_sec=60)
 
         # Move leadership to the old version node and check the partition is readable
         # from there.
@@ -556,7 +556,7 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
                                         partition_idx=newdata_p,
                                         target_bytes=local_retention_bytes +
                                         segment_bytes,
-                                        timeout_sec=30)
+                                        timeout_sec=60)
 
 
 class RedpandaInstallerTest(RedpandaTest):


### PR DESCRIPTION
For local truncation to happen, we need all the nodes to come up, and object store uploads to finish, and a manifest to upload, and storage-gc interval to tick around.  30 seconds wasn't always enough.

We could just reduce some intervals in the redpanda config, but these tests are intrinsically somewhat time consuming so let's prioritize keeping them
authentic.

Fixes https://github.com/redpanda-data/redpanda/issues/9756

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none
