### PR TITLE
[v23.1.x] raft/recovery_throttle: use total available capacity

### DIFF
--- a/src/v/raft/coordinated_recovery_throttle.cc
+++ b/src/v/raft/coordinated_recovery_throttle.cc
@@ -48,7 +48,7 @@ void coordinated_recovery_throttle::token_bucket::reset_capacity(
     vlog(
       raftlog.debug,
       "Throttler bucket capacity reset to: {}, waiting bytes: {}",
-      _sem.current(),
+      new_capacity,
       _waiting_bytes);
 }
 

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -433,4 +433,7 @@ def wait_for_recovery_throttle_rate(redpanda, new_rate: int):
         assert filtered
         return all([check_throttle_rate(n) for n in filtered])
 
-    wait_until(wait_for_throttle_update, timeout_sec=90, backoff_sec=1)
+    wait_until(wait_for_throttle_update,
+               timeout_sec=90,
+               backoff_sec=1,
+               err_msg=f"Timed out waiting recovery rate to reach: {new_rate}")


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11625
Fixes https://github.com/redpanda-data/redpanda/issues/11727,