### PR TITLE
rpc: Handle errors while holding a gate

### DIFF
--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -161,6 +161,7 @@ private:
     ss::future<result<std::unique_ptr<streaming_context>>>
       do_send(sequence_t, netbuf, rpc::client_opts);
     void dispatch_send();
+    ss::future<> do_dispatch_send();
 
     ss::future<result<std::unique_ptr<streaming_context>>>
     make_response_handler(netbuf&, rpc::client_opts&);

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -265,6 +265,17 @@ struct background_t {
 } // namespace detail
 inline constexpr detail::background_t background;
 
+/// \brief Create a new future, handling common shutdown exception types.
+inline seastar::future<>
+ignore_shutdown_exceptions(seastar::future<> fut) noexcept {
+    return std::move(fut)
+      .handle_exception_type([](const seastar::abort_requested_exception&) {})
+      .handle_exception_type([](const seastar::gate_closed_exception&) {})
+      .handle_exception_type([](const seastar::broken_semaphore&) {})
+      .handle_exception_type([](const seastar::broken_promise&) {})
+      .handle_exception_type([](const seastar::broken_condition_variable&) {});
+}
+
 /// \brief Create a future holding a gate, handling common shutdown exception
 /// types.  Returns the resulting future, onto which further exception handling
 /// may be chained.
@@ -279,12 +290,8 @@ inline constexpr detail::background_t background;
 /// noise on shutdown if the caller is logging exceptions.
 template<typename Func>
 inline auto spawn_with_gate_then(seastar::gate& g, Func&& func) noexcept {
-    return seastar::try_with_gate(g, std::forward<Func>(func))
-      .handle_exception_type([](const seastar::abort_requested_exception&) {})
-      .handle_exception_type([](const seastar::gate_closed_exception&) {})
-      .handle_exception_type([](const seastar::broken_semaphore&) {})
-      .handle_exception_type([](const seastar::broken_promise&) {})
-      .handle_exception_type([](const seastar::broken_condition_variable&) {});
+    return ignore_shutdown_exceptions(
+      seastar::try_with_gate(g, std::forward<Func>(func)));
 }
 
 /// \brief Detach a fiber holding a gate, with exception handling to ignore
@@ -377,7 +384,7 @@ seastar::future<T...> with_timeout_abortable(
     auto st = std::make_unique<state>(deadline, as);
     auto result = st->done.get_future();
 
-    (void)f.then_wrapped([st = std::move(st)](auto&& f) {
+    background = f.then_wrapped([st = std::move(st)](auto&& f) {
         bool fired = !st->timer.armed() || !st->sub;
         st->timer.cancel();
         st->sub = seastar::abort_source::subscription{};


### PR DESCRIPTION
Otherwise `this` could be deleted by the time that we handle the errors.

Fixes: #11606


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none
