### PR TITLE
[v23.1.x] c/leader_balancer: use btree_map as a group to revision index

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer_types.h
+++ b/src/v/cluster/scheduling/leader_balancer_types.h
@@ -41,7 +41,7 @@ using index_type = absl::node_hash_map<
   absl::btree_map<raft::group_id, std::vector<model::broker_shard>>>;
 
 using group_id_to_topic_revision_t
-  = absl::flat_hash_map<raft::group_id, model::revision_id>;
+  = absl::btree_map<raft::group_id, model::revision_id>;
 
 /*
  * Leaders per shard.


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11706
Fixes https://github.com/redpanda-data/redpanda/issues/11730,