### PR TITLE
test: fix zero segments handling in wait_for_local_storage_truncate

### DIFF
--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -257,10 +257,10 @@ def wait_for_local_storage_truncate(redpanda,
                                     key=lambda s: s.offset)
             except ValueError:
                 # Segment list is empty
-                first_segment = None
-
-            first_segment_size = first_segment.size if first_segment.size else 0
-            sizes.append(total_size - first_segment_size)
+                continue
+            else:
+                first_segment_size = first_segment.size if first_segment.size else 0
+                sizes.append(total_size - first_segment_size)
 
         # The segment which is open for appends will differ in Redpanda's internal
         # sizing (exact) vs. what the filesystem reports for a falloc'd file (to the


### PR DESCRIPTION
This replaces the previous non-fixing fix in a4d9e4fcdc7a22d193c818cc071df7f18f50b01e

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
