### PR TITLE
Fixed inter-operation between follower fetching and incremental fetch requests

### DIFF
--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -26,6 +26,7 @@ namespace kafka {
 struct fetch_session_partition {
     model::ktp_with_hash topic_partition;
     int32_t max_bytes;
+    model::offset start_offset;
     model::offset fetch_offset;
     model::offset high_watermark;
     model::offset last_stable_offset;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -955,6 +955,13 @@ bool update_fetch_partition(
         include = true;
         partition.start_offset = model::offset(resp.log_start_offset);
     }
+    /**
+     * Always include partition in a response if it contains information about
+     * the preferred replica
+     */
+    if (resp.preferred_read_replica != -1) {
+        include = true;
+    }
     if (include) {
         return include;
     }

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -951,6 +951,10 @@ bool update_fetch_partition(
         include = true;
         partition.last_stable_offset = model::offset(resp.last_stable_offset);
     }
+    if (partition.start_offset != resp.log_start_offset) {
+        include = true;
+        partition.start_offset = model::offset(resp.log_start_offset);
+    }
     if (include) {
         return include;
     }

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1121,6 +1121,10 @@ std::optional<model::node_id> rack_aware_replica_selector::select_replica(
     std::vector<replica_info> rack_replicas;
     model::offset highest_hw;
     for (auto& replica : p_info.replicas) {
+        // filter out replicas which are not responsive
+        if (!replica.is_alive) {
+            continue;
+        }
         if (
           _md_cache.get_node_rack_id(replica.id) == c_info.rack_id
           && replica.log_end_offset >= c_info.fetch_offset) {

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1024,6 +1024,8 @@ ss::future<response_ptr> op_context::send_response() && {
           .last_stable_offset = it->partition_response->last_stable_offset,
           .log_start_offset = it->partition_response->log_start_offset,
           .aborted = std::move(it->partition_response->aborted),
+          .preferred_read_replica
+          = it->partition_response->preferred_read_replica,
           .records = std::move(it->partition_response->records)};
 
         final_response.data.topics.back().partitions.push_back(std::move(r));

--- a/tests/rptest/tests/consumer_group_balancing_test.py
+++ b/tests/rptest/tests/consumer_group_balancing_test.py
@@ -73,7 +73,7 @@ class ConsumerGroupBalancingTest(RedpandaTest):
                                     consumer_properties, instance_id))
 
     def consumed_at_least(consumers, count):
-        return all([len(c._messages) > count for c in consumers])
+        return all([c._message_cnt > count for c in consumers])
 
     def validate_group_state(self,
                              group,

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -97,10 +97,10 @@ class ConsumerGroupTest(RedpandaTest):
         return consumers
 
     def consumed_at_least(consumers, count):
-        return all([len(c._messages) > count for c in consumers])
+        return all([c._message_cnt > count for c in consumers])
 
     def group_consumed_at_least(consumers, count):
-        return sum([len(c._messages) for c in consumers]) >= count
+        return sum([c._message_cnt for c in consumers]) >= count
 
     def validate_group_state(self, group, expected_state, static_members):
         rpk = RpkTool(self.redpanda)


### PR DESCRIPTION
If partition contain information about preferred replica it MUST be
included in incremental fetch response. Otherwise a client would
indefinitely retry asking leader about preferred replica and
stop making progress.

Fixes: #11767 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes
- fixed not being able to clear consumer backlog when using incremental fetch requests and follower fetching
- fixed returning read replica that may be unavailable from replica selector

