### PR TITLE
[WIP] test: Create test suite to test infinite retention [skip-ci]

### DIFF
--- a/src/go/rpk/pkg/cli/topic/describe_storage.go
+++ b/src/go/rpk/pkg/cli/topic/describe_storage.go
@@ -1,0 +1,269 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package topic
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/docker/go-units"
+	"github.com/hashicorp/go-multierror"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+type Status struct {
+	Partition   int32
+	CloudStatus admin.CloudStorageStatus
+}
+
+const (
+	humanSize = "size"
+	humanTime = "time"
+)
+
+func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		all     bool
+		human   bool
+		offset  bool
+		size    bool
+		summary bool
+		syncF   bool // Named syncF (flag) to avoid collision with sync package.
+	)
+	cmd := &cobra.Command{
+		Use:   "describe-storage [TOPIC]",
+		Short: "Describe the topic storage status",
+		Long:  helpDescribeStorage,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			cl, err := kafka.NewAdmin(fs, p)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer cl.Close()
+
+			adminCl, err := admin.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			topic := args[0]
+			listed, err := cl.ListTopics(cmd.Context(), topic)
+			out.MaybeDie(err, "unable to list topic %q metadata: %v", topic, err)
+			listed.EachError(func(d kadm.TopicDetail) {
+				out.Die("unable to discover the partitions on topic %q: %v", d.Topic, d.Err)
+			})
+			topicMeta, ok := listed[topic]
+			if !ok || topicMeta.Err != nil {
+				out.Die("error requesting topic metadata for %q: %v", topic, err)
+			}
+
+			// Get the cloud storage status concurrently for each partition.
+			var (
+				report []Status
+				grp    multierror.Group
+				mu     sync.Mutex
+			)
+			for _, pd := range topicMeta.Partitions {
+				pd := pd
+				grp.Go(func() error {
+					st, err := adminCl.CloudStorageStatus(context.Background(), topic, strconv.Itoa(int(pd.Partition)))
+					if err != nil {
+						return fmt.Errorf("unable to request cloud storage status of topic %q, partition %v. make sure you have tiered storage to use this command: %v", topic, pd.Partition, err)
+					}
+					mu.Lock()
+					report = append(report, Status{pd.Partition, st})
+					mu.Unlock()
+					return nil
+				})
+			}
+			if err := grp.Wait(); err != nil {
+				out.Die(err.Error())
+			}
+			if len(report) == 0 {
+				out.Die("error: could not get any status report from cloud storage.")
+			}
+			sort.Slice(report, func(i, j int) bool {
+				return report[i].Partition < report[j].Partition
+			})
+
+			// By default, if neither are specified, we opt in to
+			// the size section only
+			if !summary && !size && !syncF && !offset {
+				summary, size = true, true
+			}
+			if all {
+				summary, size, syncF, offset = true, true, true, true
+			}
+			var sections int
+			for _, b := range []bool{summary, size, syncF, offset} {
+				if b {
+					sections++
+				}
+			}
+			withSections := sections > 1
+
+			header("SUMMARY", summary, withSections, func() {
+				tw := out.NewTabWriter()
+				defer tw.Flush()
+				tw.PrintColumn("NAME", topic)
+				if topicMeta.IsInternal {
+					tw.PrintColumn("INTERNAL", topicMeta.IsInternal)
+				}
+				tw.PrintColumn("PARTITIONS", len(topicMeta.Partitions))
+				if len(topicMeta.Partitions) > 0 {
+					p0 := topicMeta.Partitions.Sorted()[0]
+					tw.PrintColumn("REPLICAS", len(p0.Replicas))
+				}
+				// We can safely pick the value of the first partition since
+				// the cloud storage mode doesn't change between partitions of
+				// the same topic.
+				tw.PrintColumn("CLOUD-STORAGE-MODE", report[0].CloudStatus.CloudStorageMode)
+
+				lastUpload := getLastUpload(report)
+				tw.PrintColumn("LAST-UPLOAD", humanReadable(lastUpload, human, humanTime))
+			})
+
+			header("OFFSETS", offset, withSections, func() {
+				tw := out.NewTable("PARTITION", "CLOUD-START", "CLOUD-LAST", "LOCAL-START", "LOCAL-LAST")
+				defer tw.Flush()
+				for _, r := range report {
+					tw.Print(
+						r.Partition,
+						r.CloudStatus.CloudLogStartOffset,
+						r.CloudStatus.CloudLogLastOffset,
+						r.CloudStatus.LocalLogStartOffset,
+						r.CloudStatus.LocalLogLastOffset,
+					)
+				}
+			})
+
+			header("SIZE", size, withSections, func() {
+				tw := out.NewTable("PARTITION", "CLOUD-BYTES", "LOCAL-BYTES", "TOTAL-BYTES", "CLOUD-SEGMENTS", "LOCAL-SEGMENTS")
+				defer tw.Flush()
+				for _, r := range report {
+					tw.Print(
+						r.Partition,
+						humanReadable(r.CloudStatus.CloudLogBytes, human, humanSize),
+						humanReadable(r.CloudStatus.LocalLogBytes, human, humanSize),
+						humanReadable(r.CloudStatus.TotalLogBytes, human, humanSize),
+						r.CloudStatus.CloudLogSegmentCount,
+						r.CloudStatus.LocalLogSegmentCount,
+					)
+				}
+			})
+
+			header("SYNC", syncF, withSections, func() {
+				isRrr := report[0].CloudStatus.CloudStorageMode == "read_replica"
+				headers := []string{"PARTITION", "LAST-SEGMENT-UPLOAD", "LAST-MANIFEST-UPLOAD", "METADATA-UPDATE-PENDING"}
+				if isRrr {
+					headers = append(headers, "LAST-MANIFEST-SYNC")
+				}
+				tw := out.NewTable(headers...)
+				defer tw.Flush()
+				for _, r := range report {
+					row := []any{
+						r.Partition,
+						humanReadable(r.CloudStatus.MsSinceLastSegmentUpload, human, humanTime),
+						humanReadable(r.CloudStatus.MsSinceLastManifestUpload, human, humanTime),
+						r.CloudStatus.MetadataUpdatePending,
+					}
+					// If isRrr is true, MsSinceLastManifestSync should be there, this
+					// nil check is possibly redundant, but we want to avoid a
+					// nil pointer dereference.
+					if isRrr && r.CloudStatus.MsSinceLastManifestSync != nil {
+						row = append(row, humanReadable(*r.CloudStatus.MsSinceLastManifestSync, human, humanTime))
+					}
+					tw.Print(row...)
+				}
+			})
+		},
+	}
+	p.InstallAdminFlags(cmd)
+	p.InstallSASLFlags(cmd)
+
+	cmd.Flags().BoolVarP(&all, "print-all", "a", false, "Print all cloud storage status")
+	cmd.Flags().BoolVarP(&summary, "print-summary", "s", false, "Print the summary section")
+	cmd.Flags().BoolVarP(&size, "print-size", "z", false, "Print the log size section")
+	cmd.Flags().BoolVarP(&syncF, "print-sync", "y", false, "Print the sync section")
+	cmd.Flags().BoolVarP(&offset, "print-offset", "o", false, "Print the offset section")
+	cmd.Flags().BoolVarP(&human, "human-readable", "H", false, "Print the times and bytes in a human-readable form")
+
+	return cmd
+}
+
+func getLastUpload(st []Status) int {
+	latest := st[0].CloudStatus.MsSinceLastManifestUpload
+	for _, s := range st {
+		if s.CloudStatus.MsSinceLastManifestUpload < latest {
+			latest = s.CloudStatus.MsSinceLastManifestUpload
+		}
+		if s.CloudStatus.MsSinceLastSegmentUpload < latest {
+			latest = s.CloudStatus.MsSinceLastSegmentUpload
+		}
+	}
+	return latest
+}
+
+func humanReadable(v int, h bool, dataType string) any {
+	if !h {
+		return v
+	}
+	switch dataType {
+	case humanSize:
+		return units.HumanSize(float64(v))
+	case humanTime:
+		return units.HumanDuration(time.Duration(v)*time.Millisecond) + " ago"
+	default:
+		panic("using human readable with an unsupported type")
+	}
+}
+
+const helpDescribeStorage = `Describe the topic storage status.
+
+This commands prints detailed information about the cloud storage status of a
+given topic, the information is divided in 4 sections:
+
+SUMMARY
+
+The summary section contains general information about the topic, the cloud
+storage mode (one of disabled, write_only, read_only, full, and read_replica),
+and the delta in milliseconds since the last upload of either the partition
+manifest or a segment.
+
+OFFSET
+
+The offset section contains the start and last offsets (inclusive) per
+partition of data available in both the cloud and on local disk.
+
+SIZE
+
+The size section contains the total bytes per partition in the cloud and on
+local disk, the total size of the log of each partition (excluding cloud and
+local overlap), and the number of segments in the cloud and on local disk. The
+cloud segment count does not include segments queued for deletion.
+
+SYNC
+
+The sync section contains the state of cloud synchronization: milliseconds
+since the last upload of the partition manifest, milliseconds since the last
+segment upload, milliseconds since the last manifest sync (for read replicas),
+and whether the remote metadata has a pending update to include all uploaded
+segments.
+`

--- a/src/go/rpk/pkg/cli/topic/topic.go
+++ b/src/go/rpk/pkg/cli/topic/topic.go
@@ -28,6 +28,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newCreateCommand(fs, p),
 		newDeleteCommand(fs, p),
 		newDescribeCommand(fs, p),
+		newDescribeStorageCommand(fs, p),
 		newListCommand(fs, p),
 		newProduceCommand(fs, p),
 	)

--- a/src/v/archival/retention_calculator.cc
+++ b/src/v/archival/retention_calculator.cc
@@ -75,9 +75,9 @@ std::optional<retention_calculator> retention_calculator::factory(
     if (ntp_config.retention_bytes()) {
         auto total_retention_bytes = ntp_config.retention_bytes();
 
-        auto cloud_log_size = manifest.cloud_log_size();
-        if (cloud_log_size > *total_retention_bytes) {
-            auto overshot_by = cloud_log_size - *total_retention_bytes;
+        auto stm_region_size = manifest.stm_region_size_bytes();
+        if (stm_region_size > *total_retention_bytes) {
+            auto overshot_by = stm_region_size - *total_retention_bytes;
             strats.push_back(
               std::make_unique<size_based_strategy>(overshot_by));
         }

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -177,8 +177,7 @@ public:
     std::string hexdump(size_t) const;
 
 private:
-    /// \brief trims the back, and appends direct.
-    void prepend_take_ownership(fragment*);
+    void prepend(std::unique_ptr<fragment>);
 
     size_t available_bytes() const;
     void create_new_fragment(size_t);
@@ -231,9 +230,9 @@ inline void iobuf::append(std::unique_ptr<fragment> f) {
     _size += f->size();
     _frags.push_back(*f.release());
 }
-inline void iobuf::prepend_take_ownership(fragment* f) {
+inline void iobuf::prepend(std::unique_ptr<fragment> f) {
     _size += f->size();
-    _frags.push_front(*f);
+    _frags.push_front(*f.release());
 }
 
 inline void iobuf::create_new_fragment(size_t sz) {
@@ -259,8 +258,7 @@ inline void iobuf::reserve_memory(size_t reservation) {
     if (unlikely(!b.size())) {
         return;
     }
-    auto f = new fragment(std::move(b));
-    prepend_take_ownership(f);
+    prepend(std::make_unique<fragment>(std::move(b)));
 }
 [[gnu::always_inline]] void inline iobuf::prepend(iobuf b) {
     oncore_debug_verify(_verify_shard);

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -1009,9 +1009,11 @@ async_manifest_view::hydrate_manifest(
             co_return error_outcome::manifest_download_error;
         }
         auto [str, len] = co_await manifest.serialize();
+        auto reservation = co_await _cache.local().reserve_space(len, 1);
         co_await _cache.local().put(
           manifest.get_manifest_path()(),
           str,
+          reservation,
           priority_manager::local().shadow_indexing_priority());
         _probe.on_spillover_manifest_hydration();
         vlog(

--- a/src/v/cloud_storage/cache_probe.cc
+++ b/src/v/cloud_storage/cache_probe.cc
@@ -78,6 +78,12 @@ cache_probe::cache_probe() {
                   [this] { return _cur_num_files; },
                   sm::description("Number of objects in cache."))
                   .aggregate(aggregate_labels),
+                sm::make_gauge(
+                  "hwm_files",
+                  [this] { return _hwm_num_files; },
+                  sm::description(
+                    "High watermark of number of objects in cache."))
+                  .aggregate(aggregate_labels),
               });
         }
 

--- a/src/v/cloud_storage/cache_probe.h
+++ b/src/v/cloud_storage/cache_probe.h
@@ -30,7 +30,10 @@ public:
         _cur_size_bytes = size;
         _hwm_size_bytes = std::max(_cur_size_bytes, _hwm_size_bytes);
     }
-    void set_num_files(uint64_t num_files) { _cur_num_files = num_files; }
+    void set_num_files(uint64_t num_files) {
+        _cur_num_files = num_files;
+        _hwm_num_files = std::max(_cur_num_files, _hwm_num_files);
+    }
     void put_started() { ++_cur_in_progress_files; }
     void put_ended() { --_cur_in_progress_files; }
 
@@ -43,6 +46,7 @@ private:
     int64_t _cur_size_bytes = 0;
     int64_t _hwm_size_bytes = 0;
     int64_t _cur_num_files = 0;
+    int64_t _hwm_num_files = 0;
     int64_t _cur_in_progress_files = 0;
 
     ss::metrics::metric_groups _metrics;

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -553,6 +553,10 @@ uint64_t partition_manifest::cloud_log_size() const {
     return _cloud_log_size_bytes + _archive_size_bytes;
 }
 
+uint64_t partition_manifest::stm_region_size_bytes() const {
+    return _cloud_log_size_bytes;
+}
+
 uint64_t partition_manifest::archive_size_bytes() const {
     return _archive_size_bytes;
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -305,9 +305,13 @@ public:
     void flush_write_buffer();
 
     // Returns the cached size in bytes of all segments available to clients.
-    // (i.e. all segments after and including the segment that starts at
-    // the current _start_offset).
+    // This includes both the STM region and the archive.
     uint64_t cloud_log_size() const;
+
+    // Returns the cached size in bytes of all segments within the STM region
+    // that are above the start offset. (i.e. all segments after and including
+    // the segment that starts at the current _start_offset).
+    uint64_t stm_region_size_bytes() const;
 
     /// Returns cached size of the archive in bytes.
     ///
@@ -573,6 +577,7 @@ private:
     model::offset _start_offset;
     model::offset _last_uploaded_compacted_offset;
     model::offset _insync_offset;
+    // Size of the segments within the STM region
     size_t _cloud_log_size_bytes{0};
     // First accessible offset of the 'archive' region. Default value means
     // that there is no archive.
@@ -584,7 +589,8 @@ private:
     model::offset _archive_clean_offset;
     // Start kafka offset set by the DeleteRecords request
     kafka::offset _start_kafka_offset;
-    // Total size of the archive (excluding this manifest)
+    // Size of the segments within the archive region (i.e. excluding this
+    // manifest)
     uint64_t _archive_size_bytes{0};
     /// Map of spillover manifests that were uploaded to S3
     spillover_manifest_map _spillover_manifests;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -337,7 +337,9 @@ remote_segment::maybe_get_offsets(kafka::offset kafka_offset) {
  * a GET response: pass the dat through into the cache.
  */
 ss::future<uint64_t> remote_segment::put_segment_in_cache_and_create_index(
-  uint64_t size_bytes, ss::input_stream<char> s) {
+  uint64_t size_bytes,
+  space_reservation_guard& reservation,
+  ss::input_stream<char> s) {
     offset_index tmpidx(
       get_base_rp_offset(),
       get_base_kafka_offset(),
@@ -351,9 +353,10 @@ ss::future<uint64_t> remote_segment::put_segment_in_cache_and_create_index(
       remote_segment_sampling_step_bytes);
     auto fparse = parser->consume().finally(
       [parser] { return parser->close(); });
-    auto fput = _cache.put(_path, sput).finally([sref = std::ref(sput)] {
-        return sref.get().close();
-    });
+    auto fput
+      = _cache.put(_path, sput, reservation).finally([sref = std::ref(sput)] {
+            return sref.get().close();
+        });
     auto [rparse, rput] = co_await ss::when_all(
       std::move(fparse), std::move(fput));
     bool index_prepared = true;
@@ -374,17 +377,24 @@ ss::future<uint64_t> remote_segment::put_segment_in_cache_and_create_index(
         std::rethrow_exception(put_exception);
     }
     if (index_prepared) {
+        auto index_reservation = co_await _cache.reserve_space(
+          storage::segment_index::estimate_size(size_bytes), 1);
         auto index_stream = make_iobuf_input_stream(tmpidx.to_iobuf());
-        co_await _cache.put(generate_index_path(_path), index_stream);
+        co_await _cache.put(
+          generate_index_path(_path), index_stream, index_reservation);
         _index = std::move(tmpidx);
     }
     co_return size_bytes;
 }
 
 ss::future<uint64_t> remote_segment::put_segment_in_cache(
-  uint64_t size_bytes, ss::input_stream<char> s) {
+  uint64_t size_bytes,
+  space_reservation_guard& reservation,
+  ss::input_stream<char> s) {
     try {
-        co_await _cache.put(_path, s).finally([&s] { return s.close(); });
+        co_await _cache.put(_path, s, reservation).finally([&s] {
+            return s.close();
+        });
     } catch (...) {
         auto put_exception = std::current_exception();
         vlog(
@@ -399,10 +409,11 @@ ss::future<uint64_t> remote_segment::put_segment_in_cache(
 
 ss::future<uint64_t> remote_segment::put_chunk_in_cache(
   uint64_t size,
+  space_reservation_guard& reservation,
   ss::input_stream<char> stream,
   chunk_start_offset_t chunk_start) {
     try {
-        co_await _cache.put(get_path_to_chunk(chunk_start), stream)
+        co_await _cache.put(get_path_to_chunk(chunk_start), stream, reservation)
           .finally([&stream] { return stream.close(); });
     } catch (...) {
         auto put_exception = std::current_exception();
@@ -423,17 +434,18 @@ ss::future<> remote_segment::do_hydrate_segment() {
 
     // RAII reservation object represents the disk space this put will consume
     auto reservation = co_await _cache.reserve_space(
-      _size + storage::segment_index::estimate_size(_size));
+      _size + storage::segment_index::estimate_size(_size), 1);
 
     auto res = co_await _api.download_segment(
       _bucket,
       _path,
-      [this](uint64_t size_bytes, ss::input_stream<char> s) {
+      [this, &reservation](uint64_t size_bytes, ss::input_stream<char> s) {
           if (is_legacy_mode_engaged()) {
               return put_segment_in_cache_and_create_index(
-                size_bytes, std::move(s));
+                size_bytes, reservation, std::move(s));
           } else {
-              return put_segment_in_cache(size_bytes, std::move(s));
+              return put_segment_in_cache(
+                size_bytes, reservation, std::move(s));
           }
       },
       local_rtc);
@@ -471,8 +483,9 @@ ss::future<> remote_segment::do_hydrate_index() {
     co_await _chunks_api->start();
     auto buf = _index->to_iobuf();
 
+    auto reservation = co_await _cache.reserve_space(buf.size_bytes(), 1);
     auto str = make_iobuf_input_stream(std::move(buf));
-    co_await _cache.put(_index_path, str).finally([&str] {
+    co_await _cache.put(_index_path, str, reservation).finally([&str] {
         return str.close();
     });
 }
@@ -504,8 +517,8 @@ ss::future<> remote_segment::do_hydrate_txrange() {
         }
 
         auto [stream, size] = co_await manifest.serialize();
-        auto reservation = _cache.reserve_space(size);
-        co_await _cache.put(manifest.get_manifest_path(), stream)
+        auto reservation = co_await _cache.reserve_space(size, 1);
+        co_await _cache.put(manifest.get_manifest_path(), stream, reservation)
           .finally([&s = stream]() mutable { return s.close(); });
     }
 
@@ -878,13 +891,13 @@ ss::future<> remote_segment::hydrate_chunk(
     }
 
     const auto space_required = end.value_or(_size - 1) - start + 1;
-    const auto reserved = co_await _cache.reserve_space(space_required);
+    auto reserved = co_await _cache.reserve_space(space_required, 1);
 
     auto res = co_await _api.download_segment(
       _bucket,
       _path,
-      [this, start](auto size, auto stream) {
-          return put_chunk_in_cache(size, std::move(stream), start);
+      [this, start, &reserved](auto size, auto stream) {
+          return put_chunk_in_cache(size, reserved, std::move(stream), start);
       },
       rtc,
       std::make_pair(start, end.value_or(_size - 1)));

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -206,15 +206,19 @@ private:
     ss::future<> do_hydrate_segment();
 
     /// Helper for do_hydrate_segment
-    ss::future<uint64_t>
-      put_segment_in_cache_and_create_index(uint64_t, ss::input_stream<char>);
+    ss::future<uint64_t> put_segment_in_cache_and_create_index(
+      uint64_t, space_reservation_guard&, ss::input_stream<char>);
 
-    ss::future<uint64_t> put_segment_in_cache(uint64_t, ss::input_stream<char>);
+    ss::future<uint64_t> put_segment_in_cache(
+      uint64_t, space_reservation_guard&, ss::input_stream<char>);
 
     /// Stores a segment chunk in cache. The chunk is stored in a path derived
     /// from the segment path: <segment_path>_chunks/chunk_start_file_offset.
     ss::future<uint64_t> put_chunk_in_cache(
-      uint64_t, ss::input_stream<char>, chunk_start_offset_t chunk_start);
+      uint64_t,
+      space_reservation_guard&,
+      ss::input_stream<char>,
+      chunk_start_offset_t chunk_start);
 
     /// Hydrate tx manifest. Method downloads the manifest file to the cache
     /// dir.

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -92,8 +92,10 @@ public:
         auto path = spm.get_manifest_path();
         if (hydrate) {
             auto stream = spm.serialize().get();
+            auto reservation = cache.local().reserve_space(123, 1).get();
             cache.local()
-              .put(path, stream.stream, ss::default_priority_class())
+              .put(
+                path, stream.stream, reservation, ss::default_priority_class())
               .get();
             stream.stream.close().get();
         }

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -38,10 +38,24 @@ struct cloud_storage_fixture : s3_imposter_fixture {
         cache
           .start(
             tmp_directory.get_path(),
-            config::mock_binding<uint64_t>(1024 * 1024 * 1024))
+            config::mock_binding<uint64_t>(1024 * 1024 * 1024),
+            config::mock_binding<uint32_t>(100000))
           .get();
 
         cache.invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
+          .get();
+
+        // Supply some phony disk stats so that the cache doesn't panic and
+        // think it has zero bytes of space
+        cache
+          .invoke_on(
+            ss::shard_id{0},
+            [](cloud_storage::cache& c) {
+                c.notify_disk_status(
+                  100ULL * 1024 * 1024 * 1024,
+                  50ULL * 1024 * 1024 * 1024,
+                  storage::disk_space_alert::ok);
+            })
           .get();
 
         auto conf = get_configuration();

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -899,6 +899,7 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
       .archive_start_offset = _manifest->get_archive_start_offset(),
       .archive_start_offset_delta = _manifest->get_archive_start_offset_delta(),
       .archive_clean_offset = _manifest->get_archive_clean_offset(),
+      .archive_size_bytes = _manifest->archive_size_bytes(),
       .start_kafka_offset = _manifest->get_start_kafka_offset_override(),
       .spillover_manifests = std::move(spillover)});
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -277,10 +277,14 @@ partition_cloud_storage_status partition::get_cloud_storage_status() const {
           = _archival_meta_stm->get_dirty()
             == archival_metadata_stm::state_dirty::dirty;
         status.cloud_log_size_bytes = manifest.cloud_log_size();
-        status.cloud_log_segment_count = manifest.size();
+        status.stm_region_size_bytes = manifest.stm_region_size_bytes();
+        status.archive_size_bytes = manifest.archive_size_bytes();
+        status.stm_region_segment_count = manifest.size();
 
         if (manifest.size() > 0) {
-            status.cloud_log_start_offset = manifest.get_start_kafka_offset();
+            status.cloud_log_start_offset
+              = manifest.full_log_start_kafka_offset();
+            status.stm_region_start_offset = manifest.get_start_kafka_offset();
             status.cloud_log_last_offset = manifest.get_last_kafka_offset();
         }
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -140,7 +140,7 @@ private:
     bool increment_failure_count();
 
     partition_balancer_planner& _parent;
-    absl::node_hash_map<model::ntp, size_t> _ntp2size;
+    absl::btree_map<model::ntp, size_t> _ntp2size;
     absl::node_hash_map<model::ntp, absl::flat_hash_map<model::node_id, size_t>>
       _moving_ntp2replica_sizes;
     absl::node_hash_map<model::ntp, allocated_partition> _reassignments;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3813,15 +3813,18 @@ struct partition_cloud_storage_status {
 
     size_t total_log_size_bytes{0};
     size_t cloud_log_size_bytes{0};
+    size_t stm_region_size_bytes{0};
+    size_t archive_size_bytes{0};
     size_t local_log_size_bytes{0};
 
-    size_t cloud_log_segment_count{0};
+    size_t stm_region_segment_count{0};
     size_t local_log_segment_count{0};
 
     // Friendlier name for archival_metadata_stm::get_dirty
     bool cloud_metadata_update_pending{false};
 
     std::optional<kafka::offset> cloud_log_start_offset;
+    std::optional<kafka::offset> stm_region_start_offset;
     std::optional<kafka::offset> local_log_last_offset;
 
     std::optional<kafka::offset> cloud_log_last_offset;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -110,6 +110,15 @@ configuration::configuration()
        .example = "31536000000",
        .visibility = visibility::tunable},
       24h * 365)
+  , log_storage_target_size(
+      *this,
+      "log_storage_target_size",
+      "The target size in bytes that log storage will try meet. When no target "
+      "is specified storage usage is unbounded.",
+      {.needs_restart = needs_restart::no,
+       .example = "2147483648000",
+       .visibility = visibility::tunable},
+      std::nullopt)
   , rpc_server_listen_backlog(
       *this,
       "rpc_server_listen_backlog",
@@ -1572,6 +1581,16 @@ configuration::configuration()
       "Max size of archival cache",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       20_GiB)
+  , cloud_storage_cache_max_objects(
+      *this,
+      "cloud_storage_cache_max_objects",
+      "Maximum number of objects that may be held in the tiered storage "
+      "cache.  This applies simultaneously with `cloud_storage_cache_size`, "
+      "and which ever limit is hit first will drive trimming of the cache.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      // Enough for a >1TiB cache of 16MiB objects.  Decrease this in case
+      // of issues with trim performance.
+      100000)
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -54,6 +54,7 @@ struct configuration final : public config_store {
     bounded_property<std::optional<std::chrono::milliseconds>> log_segment_ms;
     property<std::chrono::milliseconds> log_segment_ms_min;
     property<std::chrono::milliseconds> log_segment_ms_max;
+    property<std::optional<uint64_t>> log_storage_target_size;
 
     // Network
     bounded_property<std::optional<int>> rpc_server_listen_backlog;
@@ -317,6 +318,7 @@ struct configuration final : public config_store {
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;
+    property<uint32_t> cloud_storage_cache_max_objects;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
     property<std::optional<uint32_t>> cloud_storage_max_readers_per_shard;
     property<std::optional<uint32_t>>

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -912,6 +912,14 @@
                     "type": "long",
                     "description": "Compaction index"
                 },
+                "cloud_storage_cache_bytes": {
+                    "type": "long",
+                    "description": "Bytes in use by tiered storage cache"
+                },
+                "cloud_storage_cache_objects": {
+                    "type": "long",
+                    "description": "Number of objects in tiered storage cache"
+                },
                 "reclaimable_by_retention": {
                     "type": "long",
                     "description": "Number of bytes currently reclaimable by retention"

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -260,13 +260,21 @@
             "type": "long",
             "description": "Total size of the addressable cloud log for the partition"
         },
+        "stm_region_size_bytes": {
+            "type": "long",
+            "description": "Total size of the addressable segments in the STM region of the log"
+        },
+        "archive_size_bytes": {
+            "type": "long",
+            "description": "Total size of the archive region of the log"
+        },
         "local_log_size_bytes": {
             "type": "long",
             "description": "Total size of the addressable local log for the partition"
         },
-        "cloud_log_segment_count": {
+        "stm_region_segment_count": {
             "type": "long",
-            "description": "Number of segments in the cloud log (does not include segments queued for removal)"
+            "description": "Number of segments in the STM region of the cloud log"
         },
         "local_log_segment_count": {
             "type": "long",
@@ -276,6 +284,11 @@
             "type": "long",
             "nullable": true,
             "description": "The first Kafka offset accessible from the cloud (inclusive)"
+        },
+        "stm_region_start_offset": {
+            "type": "long",
+            "nullable": true,
+            "description": "The first Kafka offset accessible from the cloud in the STM region (inclusive)"
         },
         "cloud_log_last_offset": {
             "type": "long",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -12,6 +12,7 @@
 #include "redpanda/admin_server.h"
 
 #include "archival/ntp_archiver_service.h"
+#include "cloud_storage/cache_service.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote_partition.h"
 #include "cluster/cloud_storage_size_reducer.h"
@@ -212,7 +213,8 @@ admin_server::admin_server(
     topic_recovery_status_frontend,
   ss::sharded<cluster::tx_registry_frontend>& tx_registry_frontend,
   ss::sharded<storage::node>& storage_node,
-  ss::sharded<memory_sampling>& memory_sampling_service)
+  ss::sharded<memory_sampling>& memory_sampling_service,
+  ss::sharded<cloud_storage::cache>& cloud_storage_cache)
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
@@ -235,6 +237,7 @@ admin_server::admin_server(
   , _tx_registry_frontend(tx_registry_frontend)
   , _storage_node(storage_node)
   , _memory_sampling_service(memory_sampling_service)
+  , _cloud_storage_cache(cloud_storage_cache)
   , _default_blocked_reactor_notify(
       ss::engine().get_blocked_reactor_notify_ms()) {
     _server.set_content_streaming(true);
@@ -4343,6 +4346,21 @@ admin_server::get_local_storage_usage_handler(
     ret.target_min_capacity = disk.target.min_capacity;
     ret.target_min_capacity_wanted = disk.target.min_capacity_wanted;
 
+    if (_cloud_storage_cache.local_is_initialized()) {
+        auto [cache_bytes, cache_objects]
+          = co_await _cloud_storage_cache.invoke_on(
+            ss::shard_id{0},
+            [](cloud_storage::cache& cache) -> std::pair<uint64_t, size_t> {
+                return {cache.get_usage_bytes(), cache.get_usage_objects()};
+            });
+
+        ret.cloud_storage_cache_bytes = cache_bytes;
+        ret.cloud_storage_cache_objects = cache_objects;
+    } else {
+        ret.cloud_storage_cache_bytes = 0;
+        ret.cloud_storage_cache_objects = 0;
+    }
+
     co_return ret;
 }
 
@@ -4757,12 +4775,17 @@ map_status_to_json(cluster::partition_cloud_storage_status status) {
 
     json.total_log_size_bytes = status.total_log_size_bytes;
     json.cloud_log_size_bytes = status.cloud_log_size_bytes;
+    json.stm_region_size_bytes = status.stm_region_size_bytes;
+    json.archive_size_bytes = status.archive_size_bytes;
     json.local_log_size_bytes = status.local_log_size_bytes;
-    json.cloud_log_segment_count = status.cloud_log_segment_count;
+    json.stm_region_segment_count = status.stm_region_segment_count;
     json.local_log_segment_count = status.local_log_segment_count;
 
     if (status.cloud_log_start_offset) {
         json.cloud_log_start_offset = status.cloud_log_start_offset.value()();
+    }
+    if (status.stm_region_start_offset) {
+        json.stm_region_start_offset = status.stm_region_start_offset.value()();
     }
     if (status.cloud_log_last_offset) {
         json.cloud_log_last_offset = status.cloud_log_last_offset.value()();

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cloud_storage/fwd.h"
 #include "cluster/fwd.h"
 #include "cluster/types.h"
 #include "config/endpoint_tls_config.h"
@@ -77,7 +78,8 @@ public:
       ss::sharded<cluster::topic_recovery_status_frontend>&,
       ss::sharded<cluster::tx_registry_frontend>&,
       ss::sharded<storage::node>&,
-      ss::sharded<memory_sampling>&);
+      ss::sharded<memory_sampling>&,
+      ss::sharded<cloud_storage::cache>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -522,6 +524,7 @@ private:
     ss::sharded<cluster::tx_registry_frontend>& _tx_registry_frontend;
     ss::sharded<storage::node>& _storage_node;
     ss::sharded<memory_sampling>& _memory_sampling_service;
+    ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;
     ss::timer<> _blocked_reactor_notify_reset_timer;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -854,7 +854,8 @@ void application::configure_admin_server() {
       std::ref(topic_recovery_status_frontend),
       std::ref(tx_registry_frontend),
       std::ref(storage_node),
-      std::ref(_memory_sampling))
+      std::ref(_memory_sampling),
+      std::ref(shadow_index_cache))
       .get();
 }
 
@@ -1300,6 +1301,10 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
           config::node().cloud_storage_cache_path(),
           ss::sharded_parameter([] {
               return config::shard_local_cfg().cloud_storage_cache_size.bind();
+          }),
+          ss::sharded_parameter([] {
+              return config::shard_local_cfg()
+                .cloud_storage_cache_max_objects.bind();
           }))
           .get();
 
@@ -1356,6 +1361,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
     construct_single_service(
       space_manager,
       config::shard_local_cfg().enable_storage_space_manager.bind(),
+      config::shard_local_cfg().log_storage_target_size.bind(),
       &storage,
       &storage_node,
       &shadow_index_cache,

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -13,6 +13,8 @@
 
 #include "cloud_storage/cache_service.h"
 #include "cluster/partition_manager.h"
+#include "storage/disk_log_impl.h"
+#include "utils/human.h"
 #include "vlog.h"
 
 #include <seastar/util/log.hh>
@@ -23,6 +25,7 @@ namespace storage {
 
 disk_space_manager::disk_space_manager(
   config::binding<bool> enabled,
+  config::binding<std::optional<uint64_t>> log_storage_target_size,
   ss::sharded<storage::api>* storage,
   ss::sharded<storage::node>* storage_node,
   ss::sharded<cloud_storage::cache>* cache,
@@ -31,7 +34,8 @@ disk_space_manager::disk_space_manager(
   , _storage(storage)
   , _storage_node(storage_node)
   , _cache(cache->local_is_initialized() ? cache : nullptr)
-  , _pm(pm) {
+  , _pm(pm)
+  , _log_storage_target_size(std::move(log_storage_target_size)) {
     _enabled.watch([this] {
         vlog(
           rlog.info,
@@ -74,10 +78,13 @@ ss::future<> disk_space_manager::run_loop() {
     vassert(ss::this_shard_id() == run_loop_core, "Run on wrong core");
 
     /*
-     * we want the code here to actually run a little, but the final shape of
-     * configuration options is not yet known.
+     * In the short term this frequency should be low enough to provide decent
+     * reactivity to changes in space usage, but not too low as to do an
+     * excessive amount of work. Medium term we want storage to trigger an
+     * upcall to start the monitor loop when it appears that we are getting
+     * close to an important threshold.
      */
-    constexpr auto frequency = std::chrono::seconds(30);
+    constexpr auto frequency = std::chrono::seconds(5);
 
     while (!_gate.is_closed()) {
         try {
@@ -95,60 +102,163 @@ ss::future<> disk_space_manager::run_loop() {
             continue;
         }
 
-        /*
-         * Collect cache and logs storage usage information. These accumulate
-         * across all shards (despite the local() accessor). If a failure occurs
-         * we wait rather than operate with a reduced set of information.
-         */
-        cloud_storage::cache_usage_target cache_usage_target;
-        try {
-            cache_usage_target
-              = co_await _pm->local().get_cloud_cache_disk_usage_target();
-        } catch (...) {
-            vlog(
-              rlog.info,
-              "Unable to collect cloud cache usage: {}",
-              std::current_exception());
-            continue;
+        if (_log_storage_target_size().has_value()) {
+            co_await manage_data_disk(_log_storage_target_size().value());
         }
-
-        storage::usage_report logs_usage;
-        try {
-            logs_usage = co_await _storage->local().disk_usage();
-        } catch (...) {
-            vlog(
-              rlog.info,
-              "Unable to collect log storage usage: {}",
-              std::current_exception());
-            continue;
-        }
-
-        vlog(
-          rlog.debug,
-          "Cloud storage cache target minimum size {} nice to have {}",
-          cache_usage_target.target_min_bytes,
-          cache_usage_target.target_bytes);
-
-        vlog(
-          rlog.debug,
-          "Log storage usage total {} - data {} index {} compaction {}",
-          logs_usage.usage.total(),
-          logs_usage.usage.data,
-          logs_usage.usage.index,
-          logs_usage.usage.compaction);
-
-        vlog(
-          rlog.debug,
-          "Log storage usage available for reclaim local {} total {}",
-          logs_usage.reclaim.retention,
-          logs_usage.reclaim.available);
-
-        vlog(
-          rlog.debug,
-          "Log storage usage target minimum size {} nice to have {}",
-          logs_usage.target.min_capacity,
-          logs_usage.target.min_capacity_wanted);
     }
+}
+
+/*
+ * Attempts to set retention offset for cloud enabled topics such that the
+ * target amount of bytes will be recovered when garbage collection is applied.
+ *
+ * This is greedy approach which will recover as much as possible from each
+ * partition before moving on to the next.
+ */
+static ss::future<size_t>
+set_partition_retention_offsets(cluster::partition_manager& pm, size_t target) {
+    // build a lightweight copy to avoid invalidations during iteration
+    fragmented_vector<ss::lw_shared_ptr<cluster::partition>> partitions;
+    for (const auto& p : pm.partitions()) {
+        if (!p.second->remote_partition()) {
+            continue;
+        }
+        partitions.push_back(p.second);
+    }
+
+    size_t partitions_total = 0;
+    for (const auto& p : partitions) {
+        if (partitions_total >= target) {
+            break;
+        }
+
+        auto log = dynamic_cast<storage::disk_log_impl*>(p->log().get_impl());
+        // make sure housekeeping doesn't delete the log from below us
+        auto gate = log->gate().hold();
+
+        auto segments = log->cloud_gc_eligible_segments();
+        if (segments.empty()) {
+            continue;
+        }
+
+        size_t log_total = 0;
+        auto offset = segments.front()->offsets().committed_offset;
+        for (const auto& seg : segments) {
+            auto usage = co_await seg->persistent_size();
+            log_total += usage.total();
+            if (log_total >= target) {
+                break;
+            }
+        }
+
+        vlog(
+          rlog.info,
+          "Setting retention offset override {} estimated reclaim of {} for "
+          "cloud topic {}",
+          offset,
+          log_total,
+          p->ntp());
+
+        log->set_cloud_gc_offset(offset);
+        partitions_total += log_total;
+    }
+
+    co_return partitions_total;
+}
+
+ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
+    /*
+     * query log storage usage across all cores
+     */
+    storage::usage_report usage;
+    try {
+        usage = co_await _storage->local().disk_usage();
+    } catch (...) {
+        vlog(
+          rlog.info,
+          "Unable to collect log storage usage. Skipping management tick: "
+          "{}",
+          std::current_exception());
+        co_return;
+    }
+
+    /*
+     * how much data from log storage do we need to remove from disk to be able
+     * to stay below the current target size?
+     */
+    const auto target_excess = usage.usage.total() < target_size
+                                 ? 0
+                                 : usage.usage.total() - target_size;
+    if (target_excess <= 0) {
+        vlog(
+          rlog.info,
+          "Log storage usage {} <= target size {}. No work to do.",
+          human::bytes(usage.usage.total()),
+          human::bytes(target_size));
+        co_return;
+    }
+
+    /*
+     * when log storage has exceeded the target usage, then there are some knobs
+     * that can be adjusted to help stay below this target.
+     *
+     * the first knob is to prioritize garbage collection. this is normally a
+     * periodic task performed by the storage layer. if it hasn't run recently,
+     * or it has been spending most of its time doing low impact compaction
+     * work, then we can instead immediately begin applying retention rules.
+     *
+     * the effect of gc is defined entirely by topic configuration and current
+     * state of storage. so in order to turn the first knob we need only trigger
+     * gc across shards.
+     *
+     * however, if current retention is not sufficient to bring usage below the
+     * target, then a second knob must be turned: overriding local retention
+     * targets for cloud-enabled topics, removing data that has been backed up
+     * into the cloud.
+     */
+    if (target_excess > usage.reclaim.retention) {
+        vlog(
+          rlog.info,
+          "Log storage usage {} > target size {} by {}. Garbage collection "
+          "expected to recover {}. Overriding tiered storage retention to "
+          "recover {}. Total estimated available to recover {}",
+          human::bytes(usage.usage.total()),
+          human::bytes(target_size),
+          human::bytes(target_excess),
+          human::bytes(usage.reclaim.retention),
+          human::bytes(target_excess - usage.reclaim.retention),
+          human::bytes(usage.reclaim.available));
+
+        /*
+         * This is a simple greedy approach. It will attempt to reclaim as much
+         * data as possible from each partition on each core, stopping once
+         * enough space has been reclaimed to meet the current target.
+         */
+        size_t total = 0;
+        for (auto shard : ss::smp::all_cpus()) {
+            auto goal = target_excess - total;
+            total += co_await _pm->invoke_on(shard, [goal](auto& pm) {
+                return set_partition_retention_offsets(pm, goal);
+            });
+            if (total >= target_excess) {
+                break;
+            }
+        }
+    } else {
+        vlog(
+          rlog.info,
+          "Log storage usage {} > target size {} by {}. Garbage collection "
+          "expected to recover {}.",
+          human::bytes(usage.usage.total()),
+          human::bytes(target_size),
+          human::bytes(target_excess),
+          human::bytes(usage.reclaim.retention));
+    }
+
+    /*
+     * ask storage across all nodes to apply retention rules asap.
+     */
+    co_await _storage->invoke_on_all([](api& api) { api.trigger_gc(); });
 }
 
 } // namespace storage

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -42,6 +42,7 @@ class disk_space_manager {
 public:
     disk_space_manager(
       config::binding<bool> enabled,
+      config::binding<std::optional<uint64_t>> log_storage_target_size,
       ss::sharded<storage::api>* storage,
       ss::sharded<storage::node>* storage_node,
       ss::sharded<cloud_storage::cache>* cache,
@@ -68,6 +69,9 @@ private:
     // details from last disk notification
     node::disk_space_info _cache_disk_info{};
     node::disk_space_info _data_disk_info{};
+
+    ss::future<> manage_data_disk(uint64_t target_size);
+    config::binding<std::optional<uint64_t>> _log_storage_target_size;
 
     ss::gate _gate;
     ss::future<> run_loop();

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -161,6 +161,7 @@ private:
     ss::future<result<std::unique_ptr<streaming_context>>>
       do_send(sequence_t, netbuf, rpc::client_opts);
     void dispatch_send();
+    ss::future<> do_dispatch_send();
 
     ss::future<result<std::unique_ptr<streaming_context>>>
     make_response_handler(netbuf&, rpc::client_opts&);

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -265,6 +265,17 @@ struct background_t {
 } // namespace detail
 inline constexpr detail::background_t background;
 
+/// \brief Create a new future, handling common shutdown exception types.
+inline seastar::future<>
+ignore_shutdown_exceptions(seastar::future<> fut) noexcept {
+    return std::move(fut)
+      .handle_exception_type([](const seastar::abort_requested_exception&) {})
+      .handle_exception_type([](const seastar::gate_closed_exception&) {})
+      .handle_exception_type([](const seastar::broken_semaphore&) {})
+      .handle_exception_type([](const seastar::broken_promise&) {})
+      .handle_exception_type([](const seastar::broken_condition_variable&) {});
+}
+
 /// \brief Create a future holding a gate, handling common shutdown exception
 /// types.  Returns the resulting future, onto which further exception handling
 /// may be chained.
@@ -279,12 +290,8 @@ inline constexpr detail::background_t background;
 /// noise on shutdown if the caller is logging exceptions.
 template<typename Func>
 inline auto spawn_with_gate_then(seastar::gate& g, Func&& func) noexcept {
-    return seastar::try_with_gate(g, std::forward<Func>(func))
-      .handle_exception_type([](const seastar::abort_requested_exception&) {})
-      .handle_exception_type([](const seastar::gate_closed_exception&) {})
-      .handle_exception_type([](const seastar::broken_semaphore&) {})
-      .handle_exception_type([](const seastar::broken_promise&) {})
-      .handle_exception_type([](const seastar::broken_condition_variable&) {});
+    return ignore_shutdown_exceptions(
+      seastar::try_with_gate(g, std::forward<Func>(func)));
 }
 
 /// \brief Detach a fiber holding a gate, with exception handling to ignore
@@ -377,7 +384,7 @@ seastar::future<T...> with_timeout_abortable(
     auto st = std::make_unique<state>(deadline, as);
     auto result = st->done.get_future();
 
-    (void)f.then_wrapped([st = std::move(st)](auto&& f) {
+    background = f.then_wrapped([st = std::move(st)](auto&& f) {
         bool fired = !st->timer.armed() || !st->sub;
         st->timer.cancel();
         st->sub = seastar::abort_source::subscription{};

--- a/src/v/storage/api.cc
+++ b/src/v/storage/api.cc
@@ -34,4 +34,6 @@ void api::handle_disk_notification(
     }
 }
 
+void api::trigger_gc() { _log_mgr->trigger_gc(); }
+
 } // namespace storage

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -85,6 +85,11 @@ public:
       uint64_t free_space,
       storage::disk_space_alert alert);
 
+    /*
+     * ask local log manager to trigger gc
+     */
+    void trigger_gc();
+
 private:
     storage_resources _resources;
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -777,6 +777,31 @@ ss::future<std::optional<model::offset>> disk_log_impl::do_gc(gc_config cfg) {
 
     cfg = apply_overrides(cfg);
 
+    /*
+     * _cloud_gc_offset is used to communicate the intent to collect
+     * partition data in excess of normal retention settings (and for infinite
+     * retention / no retention settings). it is expected that an external
+     * process such as disk space management drives this process such that after
+     * a round of gc has run the intent flag can be cleared.
+     */
+    if (_cloud_gc_offset.has_value()) {
+        const auto offset = _cloud_gc_offset.value();
+        _cloud_gc_offset.reset();
+
+        vassert(
+          is_cloud_retention_active(), "Expected remote retention active");
+
+        vlog(
+          gclog.info,
+          "[{}] applying 'deletion' log cleanup with remote retention override "
+          "offset {} and config {}",
+          config().ntp(),
+          _cloud_gc_offset,
+          cfg);
+
+        co_return co_await request_eviction_until_offset(offset);
+    }
+
     if (!config().is_collectable()) {
         co_return std::nullopt;
     }
@@ -1919,7 +1944,9 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config cfg) {
           retention_offset.has_value()
           && seg->offsets().dirty_offset <= retention_offset.value()) {
             retention_segments.push_back(seg);
-        } else if (seg->offsets().dirty_offset <= max_collectible) {
+        } else if (
+          is_cloud_retention_active()
+          && seg->offsets().dirty_offset <= max_collectible) {
             available_segments.push_back(seg);
         } else {
             remaining_segments.push_back(seg);
@@ -2178,6 +2205,46 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
       target.min_capacity_wanted, target.min_capacity);
 
     co_return usage_report(usage, reclaim, target);
+}
+
+fragmented_vector<ss::lw_shared_ptr<segment>>
+disk_log_impl::cloud_gc_eligible_segments() {
+    vassert(
+      is_cloud_retention_active(),
+      "Expected {} to have cloud retention enabled",
+      config().ntp());
+
+    // must-have restriction
+    if (_segs.size() <= 2) {
+        return {};
+    }
+
+    /*
+     * for a cloud-backed topic the max collecible offset is the threshold below
+     * which data has been uploaded and can safely be removed from local disk.
+     */
+    const auto max_collectible = stm_manager()->max_collectible_offset();
+
+    // collect eligible segments
+    fragmented_vector<segment_set::type> segments;
+    for (auto remaining = _segs.size() - 2; auto& seg : _segs) {
+        if (seg->offsets().committed_offset <= max_collectible) {
+            segments.push_back(seg);
+        }
+        if (--remaining > 0) {
+            break;
+        }
+    }
+
+    return segments;
+}
+
+void disk_log_impl::set_cloud_gc_offset(model::offset offset) {
+    vassert(
+      is_cloud_retention_active(),
+      "Expected {} to have cloud retention enabled",
+      config().ntp());
+    _cloud_gc_offset = offset;
 }
 
 } // namespace storage

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -232,6 +232,11 @@ public:
 
     void handle_disk_notification(storage::disk_space_alert);
 
+    /*
+     * trigger gc
+     */
+    void trigger_gc();
+
 private:
     using logs_type
       = absl::flat_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;
@@ -248,6 +253,7 @@ private:
     ss::future<> housekeeping();
     ssx::semaphore _housekeeping_sem{0, "log_manager::housekeeping"};
     disk_space_alert _disk_space_alert{disk_space_alert::ok};
+    bool _gc_triggered{false};
 
     std::optional<batch_cache_index> create_cache(with_cache);
 

--- a/tests/rptest/retention/checks.py
+++ b/tests/rptest/retention/checks.py
@@ -1,0 +1,142 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+# noqa: E501
+
+from ast import NodeTransformer, parse, unparse, Constant
+from copy import deepcopy
+
+
+# Credit to blhsing:
+# https://stackoverflow.com/questions/74528551/how-to-substitute-value-of-variables-in-python-expression-but-not-evaluate-the
+class NamesToConstants(NodeTransformer):
+    _args = {}
+
+    def __init__(self, args):
+        self._args = args
+
+    def visit_Name(self, node):
+        # using own dict of vars instead of globals()
+        if node.id in self._args:
+            value = self._args[node.id]
+            # convert value to integer if viable
+            try:
+                value = int(value)
+            except Exception:
+                pass
+            return Constant(value=value)
+        return node
+
+
+class Checks(object):
+    _check_template = {
+        "desc": "check_description",
+        "expr": "check_formula",
+        "expr_text": "",
+        "result": None,
+        "show": True
+    }
+    _calculated = False
+
+    checks = []
+    args = {}
+    summary = None
+
+    def add_arg(self, key, value):
+        self.args[key] = value
+
+    def add_check(self, desc, expression, show=True):
+        _check = deepcopy(self._check_template)
+        _check["desc"] = desc
+        _check["expr"] = expression
+        _check["show"] = show
+
+        self.checks.append(_check)
+
+    def conduct_checks(self):
+        if self._calculated:
+            return
+        else:
+            names2const = NamesToConstants(self.args)
+            for idx in range(len(self.checks)):
+                _item = self.checks[idx]
+                _expr = _item['expr']
+                _parsed = parse(_expr)
+                names2const.visit(_parsed)
+                _item['expr_text'] = unparse(_parsed).strip()
+                _item['result'] = eval(_item['expr_text'], {}, self.args)
+            self._calculated = True
+
+    def get_summary_as_text(self):
+        def format_items(iterator):
+            _fmt = "\n{0}\n-> {1}: {2}\n"
+            _str = ""
+            for item in iterator:
+                # Show in summary only if result is false or show is true
+                if item["show"] or not item['result']:
+                    _str += _fmt.format(
+                        item['expr'],
+                        item['result'],
+                        item['expr_text']
+                    )
+            return _str
+        if not self.summary:
+            _summary = "\n# Summary:"
+
+            _failed = filter(lambda x: not x['result'], self.checks)
+            _failed_summary = format_items(_failed)
+            if len(_failed_summary) > 0:
+                _summary += "\n## Failed checks:"
+                _summary += _failed_summary
+
+            _passed = filter(lambda x: x['result'], self.checks)
+            _passed_summary = format_items(_passed)
+            if len(_passed_summary) > 0:
+                _summary += "\n## Passed checks:"
+                _summary += _passed_summary
+
+            self.summary = _summary
+        return self.summary
+
+    def assert_results(self):
+        _r = filter(lambda x: not x['result'], self.checks)
+        if len(list(_r)) > 0:
+            raise AssertionError(
+                "At least one check failed.\n" + self.get_summary_as_text()
+            )
+        else:
+            return True
+
+
+def main():
+    # this is very simple unittest for Checks :)
+    args = {
+        "a": 5,
+        "b": 6
+    }
+    expr = "a+b*2"
+    parsed_expr = parse(expr)
+    NamesToConstants(args).visit(parsed_expr)
+    expr_values = unparse(parsed_expr).strip()
+    result = eval("a+b*2", {}, args)
+    print(f"Simple check: {expr}")
+    print(f"{expr_values} = {result}")
+
+    chk = Checks()
+    chk.add_arg("value1", 23)
+    chk.add_arg("value2", 56)
+    chk.add_check("Simple formula", "value1 <= value2")
+    chk.conduct_checks()
+    print(chk.get_summary_as_text())
+    if chk.assert_results():
+        print(chk.get_summary_as_text())
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/rptest/retention/checks.py
+++ b/tests/rptest/retention/checks.py
@@ -80,12 +80,10 @@ class Checks(object):
             for item in iterator:
                 # Show in summary only if result is false or show is true
                 if item["show"] or not item['result']:
-                    _str += _fmt.format(
-                        item['expr'],
-                        item['result'],
-                        item['expr_text']
-                    )
+                    _str += _fmt.format(item['expr'], item['result'],
+                                        item['expr_text'])
             return _str
+
         if not self.summary:
             _summary = "\n# Summary:"
 
@@ -107,19 +105,15 @@ class Checks(object):
     def assert_results(self):
         _r = filter(lambda x: not x['result'], self.checks)
         if len(list(_r)) > 0:
-            raise AssertionError(
-                "At least one check failed.\n" + self.get_summary_as_text()
-            )
+            raise AssertionError("At least one check failed.\n" +
+                                 self.get_summary_as_text())
         else:
             return True
 
 
 def main():
     # this is very simple unittest for Checks :)
-    args = {
-        "a": 5,
-        "b": 6
-    }
+    args = {"a": 5, "b": 6}
     expr = "a+b*2"
     parsed_expr = parse(expr)
     NamesToConstants(args).visit(parsed_expr)

--- a/tests/rptest/retention/infinite_retention_test.py
+++ b/tests/rptest/retention/infinite_retention_test.py
@@ -1,0 +1,668 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import time
+
+from ducktape.utils.util import wait_until
+from ducktape.mark import parametrize
+
+from rptest.retention.checks import Checks
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, \
+    KgoVerifierRandomConsumer, KgoVerifierSeqConsumer, \
+    KgoVerifierConsumerGroupConsumer
+from rptest.services.redpanda import SISettings, MetricsEndpoint
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.utils.si_utils import BucketView, quiesce_uploads
+
+
+class InfiniteRetentionTest(PreallocNodesTest):
+    # Initial parameters
+    segment_upload_interval = 30
+    manifest_upload_interval = 10
+    segment_size = 4 * 1024 * 1024  # 64 Mb
+    chunk_size = segment_size * 0.75
+    partition_count = 1000
+    s3_topic_name = "iretention-topic"
+
+    # Calculate other
+    # bitrates
+    produce_byte_rate = 30 * 1024 * 1024
+    limit_consume_rate = False
+    consume_byte_rate = 30 * 1024 * 1024
+
+    # Huge message size to generate a lot of data
+    msg_size = 16384
+
+    # Run an hour
+    total_iterations = 6
+    target_runtime = 600
+    target_stress_start = 30
+    target_stress_delay = 30
+    write_bytes = produce_byte_rate * target_runtime
+    msg_count = write_bytes // msg_size
+
+    # The producer should achieve throughput within this factor
+    # of what we asked for: if this is violated then
+    # it is something wrong with the client or test environment.
+    producer_tolerance = 2
+    expected_producer_duration = (write_bytes //
+                                  produce_byte_rate) * producer_tolerance
+
+    # consumers should receive at least half of the messages
+    # aligned with bitrate
+    recreare_consumer = False
+    consumer_tolerance = 1
+    expected_consumer_duration = (write_bytes //
+                                  consume_byte_rate) * consumer_tolerance
+    consumer_message_count = msg_count // (
+        produce_byte_rate // consume_byte_rate) // consumer_tolerance
+    parallel_consumers = 2
+
+    # Additional configs
+    retention_ms = -1
+    cloud_storage_spillover_manifest_max_segments = 10
+
+    topics = (
+        TopicSpec(
+            retention_ms=retention_ms,
+            replication_factor=3,
+            partition_count=partition_count
+        ),
+    )
+
+    def __init__(self, test_context, *args, **kwargs):
+        self.si_settings = SISettings(
+            test_context=test_context,
+            log_segment_size=self.segment_size,
+        )
+        kwargs['si_settings'] = self.si_settings
+
+        # Use interval uploads so that at end of test we may do an "everything
+        # was uploaded" success condition.
+        kwargs['extra_rp_conf'] = {
+            # We do not intend to do interval-triggered uploads during produce,
+            # but we set this property so that at the end of the test we may
+            # do a simple "everything was uploaded" check after the interval.
+            'cloud_storage_segment_max_upload_interval_sec':
+            self.segment_upload_interval,
+            # The test will assert that the number of manifest uploads does
+            # not exceed what we would expect based on this interval.
+            'cloud_storage_manifest_max_upload_interval_sec':
+            self.manifest_upload_interval,
+            # Default retention is infinite
+            'delete_retention_ms':
+            self.retention_ms,
+            # This causes spillover to hapen more often
+            'cloud_storage_spillover_manifest_max_segments':
+            self.cloud_storage_spillover_manifest_max_segments,
+        }
+        super().__init__(test_context, node_prealloc_count=1, *args, **kwargs)
+
+    def setUp(self):
+        # ensure nodes are clean before the test
+        for node in self.redpanda.nodes:
+            self.redpanda.clean_node(node)
+        super().setUp()
+
+    def tearDown(self):
+        # stop everything
+        for node in self.redpanda.nodes:
+            self.redpanda.stop_node(node)
+        # free nodes
+        self.free_nodes()
+
+        super().tearDown()
+
+    @staticmethod
+    def _calculate_statistic(topics, rpk, bucket):
+        # TODO: Update for multiple topics used
+        _stats = {
+            # Sum of all watermarks from every partition
+            "hwm": 0,
+            # Maximum timestamp among all partitions in a topic
+            "local_ts": 0,
+            # Maximum timestamp among all partitions in a bucket
+            "uploaded_ts": 0,
+            # (offset_delta, segment_count, last_term)
+            "partition_deltas": [],
+        }
+
+        # shortcut for max from list
+        def _check_and_set_max(list, key):
+            if not list:
+                return
+            else:
+                _m = max(list)
+                _stats[key] = _m if _stats[key] < _m else _stats[key]
+
+        for topic in topics:
+            _lts_list = []
+            _uts_list = []
+            for partition in rpk.describe_topic(topic.name):
+                # Add currect high watermark for topic
+                _stats["hwm"] += partition.high_watermark
+
+                # get next max timestamp fot current partition
+                _lts_list += [int(rpk.consume(
+                    topic=topic.name,
+                    n=1,
+                    partition=partition.id,
+                    offset=partition.high_watermark-1,
+                    format="%d\\n"
+                ).strip())]
+
+                # get manifest from bucket
+                _m = bucket.manifest_for_ntp(topic.name, partition.id)
+
+                # get latest timestamp from segments in current partiton
+                if _m['segments']:
+                    _uts_list += [max(s['max_timestamp']
+                                  for s in _m['segments'].values())]
+                    _top_segment = list(_m['segments'].values())[-1]
+                    _stats['partition_deltas'].append([
+                        _m['partition'],
+                        _top_segment['delta_offset_end'],
+                        len(_m['segments']),
+                        _top_segment['segment_term']
+                    ])
+
+            # get latest timestamps
+            _check_and_set_max(_lts_list, "local_ts")
+            _check_and_set_max(_uts_list, "uploaded_ts")
+
+        return _stats
+
+    def metadata_readable(self, rpk):
+        return next(rpk.describe_topic(
+            self.topic, tolerant=True)).high_watermark is not None
+
+    def _create_producer(self):
+        return KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            msg_size=self.msg_size,
+            msg_count=self.msg_count,
+            batch_max_bytes=512 * 1024,
+            rate_limit_bps=self.produce_byte_rate,
+            custom_node=self.preallocated_nodes,
+            debug_logs=True)
+
+    def _create_rnd_consumer(self):
+        return KgoVerifierRandomConsumer(
+                self.test_context,
+                self.redpanda,
+                self.topic,
+                self.msg_size,
+                self.consumer_message_count,
+                self.parallel_consumers,
+                nodes=self.preallocated_nodes,
+                debug_logs=True,
+                trace_logs=True)
+
+    def _create_seq_consumer(self):
+        return KgoVerifierSeqConsumer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            msg_size=self.msg_size,
+            max_msgs=self.consumer_message_count,
+            max_throughput_mb=self.consume_byte_rate,
+            nodes=self.preallocated_nodes,
+            debug_logs=True,
+            trace_logs=True)
+
+    def _create_group_consumer(self):
+        if self.recreare_consumer:
+            _count = self.consumer_message_count
+        else:
+            _count = None
+
+        return KgoVerifierConsumerGroupConsumer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            msg_size=self.msg_size,
+            max_msgs=_count,
+            readers=self.parallel_consumers,
+            nodes=self.preallocated_nodes,
+            debug_logs=True,
+            trace_logs=True)
+
+    @cluster(num_nodes=4)
+    # @parametrize(restart_stress=True)
+    @parametrize(restart_stress=False)
+    def constant_throughput_prolonged_test(self, restart_stress):
+        """
+        Stress the tiered storage upload path on a multiple partitions
+        for a prolonged time. This ensures that there is no skips happen
+        or lost data occurs for additional amounts of time with retention
+        equals to -1. Which is effectively turns it off
+
+        :param restart_stress: if true, additionally restart nodes during
+                               writes, and waive throughput success conditions:
+                               in this mode we are checking for stability and
+                               data durability.
+        """
+
+        rpk = RpkTool(self.redpanda)
+
+        producer = self._create_producer()
+
+        self.logger.info(f"Producing {self.msg_count} msgs ({self.write_bytes} bytes)")
+        produce_start = time.time()
+        producer.start()
+
+        if restart_stress:
+            while producer.produce_status.acked < self.msg_count:
+                # wait for 5 min
+                time.sleep(self.target_stress_start)
+                # restart one with 5 min pause
+                # real world: simulates cluster update
+                for node in self.redpanda.nodes:
+                    time.sleep(self.target_stress_delay)
+                    self.redpanda.restart_nodes(
+                        [node],
+                        start_timeout=180,
+                        stop_timeout=180
+                    )
+
+            # Wait for the cluster to recover after final restart,
+            # so that subsequent post-stress success conditions
+            # can count on their queries succeeding.
+            self.redpanda.wait_until(self.metadata_readable(rpk),
+                                     timeout_sec=60,
+                                     backoff_sec=5)
+
+        producer.wait(timeout_sec=self.expected_producer_duration)
+
+        # calculate rate
+        produce_duration = time.time() - produce_start
+        actual_byte_rate = (self.write_bytes / produce_duration)
+        mbps = int(actual_byte_rate / (1024 * 1024))
+        self.logger.info(
+            f"Produced {self.write_bytes} in {produce_duration}s, {mbps}MiB/s")
+
+        # Dict for all checks
+        chk = Checks()
+
+        # Producer should be within a factor of two of the intended byte rate,
+        # or something is wrong with the test (running on nodes that can't
+        # keep up?) or with Redpanda (some instability interrupted produce?)
+        chk.add_arg("actual_byte_rate", actual_byte_rate)
+        chk.add_arg("produce_byte_rate", self.produce_byte_rate)
+        chk.add_arg("producer_tolerance", self.producer_tolerance)
+        if not restart_stress:
+            chk.add_check(
+                "Producer should be within a factor of two of the intended byte rate, "
+                "or something is wrong with the test (running on nodes that can't "
+                "keep up?) or with Redpanda (some instability interrupted produce?)",
+                "actual_byte_rate > produce_byte_rate / producer_tolerance",
+            )
+        # Check the workload is respecting rate limit
+        chk.add_check(
+            "Check the workload is respecting rate limit",
+            "actual_byte_rate < produce_byte_rate * producer_tolerance",
+        )
+
+        bucket = BucketView(self.redpanda)
+
+        # Read the highest timestamp in local storage
+        self.logger.info("Calculating stats for all partitions")
+        stats = self._calculate_statistic(self.topics, rpk, bucket)
+
+        # Ensure that all messages made it to topic
+        self.logger.info(
+            f"calculated hwm: {stats['hwm']}, message count: {self.msg_count}"
+        )
+        chk.add_arg("sum_high_watermarks", stats['hwm'])
+        chk.add_arg("msg_count", self.msg_count)
+        chk.add_check(
+            "Ensure that all messages made it to topic",
+            "sum_high_watermarks >= msg_count",
+        )
+        # Local timestamp for latest message
+        self.logger.info(f"Max local ts = {stats['local_ts']}")
+
+        # Measure how far behind the tiered storage uploads are:
+        # success condition should be that they are within some
+        # time range of the most recently produced data
+        if not stats['uploaded_ts']:
+            self.logger.warn(
+                "No uploaded segments sound! Check test parameters!"
+            )
+        else:
+            self.logger.info(f"Max uploaded ts = {stats['uploaded_ts']}")
+
+            lag_seconds = (stats['local_ts'] - stats['uploaded_ts']) / 1000.0
+            config_interval = (self.manifest_upload_interval +
+                               (self.segment_size / actual_byte_rate))
+            self.logger.info(
+                f"Upload lag: {lag_seconds}s, "
+                f"Upload interval: {config_interval}")
+            chk.add_arg("lag_seconds", lag_seconds)
+            chk.add_arg("config_interval", config_interval)
+            chk.add_check(
+                "Measure how far behind the tiered storage uploads are: "
+                "success condition should be that they are within some "
+                "time range of the most recently produced data",
+                "lag_seconds < config_interval",
+            )
+
+        # Wait for all uploads to complete: this should take roughly
+        # segment_max_upload_interval_sec plus manifest_max_upload_interval_sec
+        quiesce_uploads(self.redpanda, [self.topic],
+                        timeout_sec=self.manifest_upload_interval +
+                        self.segment_upload_interval)
+
+        # Check manifest upload metrics:
+        #  - we should not have uploaded the manifest more times
+        #    then there were manifest upload intervals in the runtime.
+        manifest_uploads = self.redpanda.metric_sum(
+            metric_name=
+            "redpanda_cloud_storage_partition_manifest_uploads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        segment_uploads = self.redpanda.metric_sum(
+            metric_name="redpanda_cloud_storage_segment_uploads_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        self.logger.info(
+            f"Upload counts: {manifest_uploads} manifests, "
+            f"{segment_uploads} segments"
+        )
+        chk.add_arg("manifest_uploads", manifest_uploads)
+        chk.add_arg("segment_uploads", segment_uploads)
+        chk.add_check(
+            "Non-zero manifest uploads",
+            "manifest_uploads > 0",
+        )
+        chk.add_check(
+            "Non-zero segment uploads",
+            "segment_uploads > 0",
+        )
+
+        # Check the kafka-raft offset delta: this is an indication of how
+        # many extra raft records we wrote for archival_metadata_stm.
+        #
+        # At the maximum, this should be:
+        # - 1 per segment (although could be as low as 1 for every four
+        #   segments due to ntp_archiver::_concurrency)
+        # - 1 per upload round (i.e. per 1-4 segments) for marking the manifest
+        #   clean.
+        # - 1 per raft term, for raft config batches written by new leaders
+        #
+        # This helps to assure us that ntp_archiver and archival_metadata_stm
+        # are doing an efficient job of keeping the state machine up to date.
+
+        # Turned off as per discussion with Andrew W.
+        # for p in stats["partition_deltas"]:
+        #     chk.add_arg(f"p{p[0]}_offset_delta", p[1])
+        #     chk.add_arg(f"p{p[0]}_segment_count", p[2])
+        #     chk.add_arg(f"p{p[0]}_last_term", p[3])
+        #     chk.add_check(
+        #         "Partition offset delta should be less than doubled "
+        #         "segment count added by last term",
+        #         f"p{p[0]}_offset_delta <= (2 * p{p[0]}_segment_count + p{p[0]}_last_term)",
+        #         show=False
+        #     )
+
+        # +3 because:
+        # - 1 empty upload at start
+        # - 1 extra upload from runtime % upload interval
+        # - 1 extra upload after the final interval_sec driven uploads
+        expect_manifest_uploads = (
+            (int(produce_duration) // self.manifest_upload_interval) + 3)
+        self.logger.info(
+            f"Manifests uploads: {manifest_uploads}, "
+            f"Expected not less than: {expect_manifest_uploads}")
+        chk.add_arg("produce_duration", int(produce_duration))
+        chk.add_arg("manifest_upload_interval", self.manifest_upload_interval)
+        chk.add_check(
+            "For spillover active tests manifest uploads should be "
+            "significant",
+            "manifest_uploads > produce_duration // manifest_upload_interval + 3",
+        )
+        # Do all required checks with Redpanda active
+        chk.conduct_checks()
+        # Run rp_storage_tool
+        self.redpanda.stop_and_scrub_object_storage()
+        # Validate checks and generate AssertionError if needed
+        if chk.assert_results():
+            self.logger.info(chk.get_summary_as_text())
+
+    @cluster(num_nodes=6)
+    def long_retention_with_spillover_test(self):
+        rpk = RpkTool(self.redpanda)
+        iteration_count = self.total_iterations
+        iteration = 1
+
+        self.logger.info(
+            "Calculated parameters:\n"
+            f"segment_upload_interval = {self.segment_upload_interval}\n"
+            f"manifest_upload_interval = {self.manifest_upload_interval}\n"
+            f"segment_size = {self.segment_size}\n"
+            f"chunk_size = {self.chunk_size}\n"
+            f"partition_count = {self.partition_count}\n"
+            f"msg_count = {self.msg_count}\n"
+            f"msg_size = {self.msg_size}\n"
+            f"consumer_msg_count = {self.consumer_message_count}\n"
+            f"producer_rate = {self.produce_byte_rate/1024/1024}MB\n"
+            f"producer_tolerance = {self.producer_tolerance}\n"
+            f"consumer_rate = {self.produce_byte_rate/1024/1024}MB\n"
+            f"consumer_tolerance = {self.consumer_tolerance}\n"
+            f"runtime = {self.target_runtime}s\n"
+            f"mb_written = {self.write_bytes/1024/1024}MB\n"
+            f"expected_producer_duration = {self.expected_producer_duration}s\n"
+            f"expected_consumer_duration = {self.expected_consumer_duration}s\n")
+
+        # Producer
+        producer = self._create_producer()
+
+        # Prepare to save timigs
+        iteration_timings = {
+            "high_watermark": {},
+            "manifest_uploads": {},
+            "segment_uploads": {},
+            "produce": {},
+            "consume": {},
+            "checks": {},
+            "restart": {}
+        }
+
+        # Announce scrub_exception
+        scrub_exception = None
+
+        # Start consumer with no limit
+        consumer = self._create_group_consumer()
+        consumer.start(clean=False)
+
+        while iteration <= iteration_count:
+            self.logger.info(f"Starting iteration {iteration}, runtime {self.target_runtime}s")
+            # Consumer are to be created each time and released at the end
+
+            # rand_consumer = self._create_rnd_consumer()
+            # consumer = self._create_seq_consumer()
+            # consumer = self._create_group_consumer()
+
+            # Producer
+            produce_start = time.time()
+            producer.start()
+            producer.wait_for_acks(1000, timeout_sec=60, backoff_sec=10)
+            producer.wait_for_offset_map()
+            # Consumers
+            consume_start = time.time()
+            # consumer.start(clean=False)
+
+            # wait and stop
+            producer.wait(timeout_sec=self.expected_producer_duration)
+            if self.recreare_consumer:
+                consumer.wait(timeout_sec=self.expected_consumer_duration)
+
+            self.logger.info("Stopping services and checking storage")
+            producer.stop()
+
+            # Timing
+            produce_duration = time.time() - produce_start
+            iteration_timings["produce"][iteration] = produce_duration
+
+            # consumer.stop()
+            # consumer.free()
+
+            # Consume timing
+            consume_duration = time.time() - consume_start
+            iteration_timings["consume"][iteration] = consume_duration
+            # Dict for all checks
+            chk = Checks()
+
+            checks_start = time.time()
+
+            # Calculate actual bitrate
+            actual_byte_rate = (self.write_bytes / produce_duration)
+            mbps = int(actual_byte_rate / (1024 * 1024))
+            self.logger.info(
+                f"Produced {self.write_bytes} in {produce_duration}s, {mbps}MiB/s")
+            # Add it for checking
+            chk.add_arg(f"i{iteration}_actual_byte_rate", actual_byte_rate)
+            chk.add_arg("produce_byte_rate", self.produce_byte_rate)
+            chk.add_arg("producer_tolerance", self.producer_tolerance)
+            chk.add_check(
+                "Check the workload is respecting rate limit",
+                f"i{iteration}_actual_byte_rate < produce_byte_rate * producer_tolerance",
+            )
+
+            # Conduct message checks
+            bucket = BucketView(self.redpanda)
+
+            self.logger.info(
+                f"Iteration {iteration}; calculating stats for all partitions"
+            )
+            stats = self._calculate_statistic(self.topics, rpk, bucket)
+
+            # Ensure that all messages made it to topic
+            self.logger.info(
+                f"calculated hwm: {stats['hwm']}, message count: {self.msg_count}"
+            )
+            chk.add_arg(f"i{iteration}_sum_high_watermarks", stats['hwm'])
+            chk.add_arg(f"i{iteration}_msg_count", self.msg_count * iteration)
+            chk.add_check(
+                "Ensure that all messages made it to topic",
+                f"i{iteration}_sum_high_watermarks >= i{iteration}_msg_count",
+            )
+
+            # Check manifest upload metrics:
+            #  - we should not have uploaded the manifest more times
+            #    then there were manifest upload intervals in the runtime.
+            manifest_uploads = self.redpanda.metric_sum(
+                metric_name=
+                "redpanda_cloud_storage_partition_manifest_uploads_total",
+                metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+            segment_uploads = self.redpanda.metric_sum(
+                metric_name="redpanda_cloud_storage_segment_uploads_total",
+                metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+            self.logger.info(
+                f"Upload counts: {manifest_uploads} manifests, "
+                f"{segment_uploads} segments"
+            )
+            chk.add_arg(f"i{iteration}_manifest_uploads", manifest_uploads)
+            chk.add_arg(f"i{iteration}_segment_uploads", segment_uploads)
+            chk.add_check(
+                f"Iteration {iteration}; non-zero manifest uploads",
+                f"i{iteration}_manifest_uploads > 0",
+            )
+            chk.add_check(
+                f"Iteration {iteration}; non-zero segment uploads",
+                f"i{iteration}_segment_uploads > 0",
+            )
+
+            # Run 'rp_storage_tool' to check for anomalies
+            try:
+                self.redpanda.stop_and_scrub_object_storage()
+            except RuntimeError as exc:
+                scrub_exception = exc
+
+            checks_duration = time.time() - checks_start
+            iteration_timings["high_watermark"][iteration] = stats['hwm']
+            iteration_timings["manifest_uploads"][iteration] = manifest_uploads
+            iteration_timings["segment_uploads"][iteration] = segment_uploads
+            iteration_timings["checks"][iteration] = checks_duration
+
+            restart_start = time.time()
+            # restart nodes
+            # random_node = random.choice(self.redpanda.nodes)
+            # self.redpanda.remove_local_data(random_node)
+            for node in self.redpanda.nodes:
+                self.redpanda.restart_nodes(
+                    [node],
+                    start_timeout=180,
+                    stop_timeout=180
+                )
+
+            self.redpanda._admin.await_stable_leader("controller",
+                                                     partition=0,
+                                                     namespace='redpanda',
+                                                     timeout_s=120,
+                                                     backoff_s=10)
+
+            wait_until(lambda: len(set(rpk.list_topics())) == 1,
+                       timeout_sec=120,
+                       backoff_sec=3)
+
+            restart_duration = time.time() - restart_start
+            iteration_timings["restart"][iteration] = restart_duration
+
+            self.logger.info(f"Iteration {iteration} completed. Timings are:")
+            for k, v in iteration_timings.items():
+                self.logger.info(f"{k}={v[iteration]}")
+            if scrub_exception:
+                break
+            else:
+                # do next iteration
+                iteration += 1
+
+        # Cleanup consumer
+        consumer.stop()
+        consumer.free()
+
+        chk.conduct_checks()
+        # Log pretty table of timings
+        # first row
+        lines = []
+        line = " "*18
+        for idx in range(1, iteration_count+1):
+            line += f"{idx:^14}"
+        lines.append(line)
+        # process rows
+        for k, v in iteration_timings.items():
+            line = f"{k:<18}"
+            for idx in range(1, iteration_count+1):
+                if k in [
+                    "high_watermark",
+                    "manifest_uploads",
+                    "segment_uploads"
+                ]:
+                    _t = f"{v[idx]}"
+                else:
+                    _t = f"{v[idx]:.2f}s"
+                line += f"{_t:^14}"
+            lines.append(line)
+
+        # Assert checks and print summary
+        if chk.assert_results():
+            self.logger.info(chk.get_summary_as_text())
+        if scrub_exception:
+            self.logger.info(
+                "rp-storage-tool detected fatal anomaly "
+                f"in iteration {iteration}")
+            raise scrub_exception
+        else:
+            self.logger.info(
+                "All iterations done. Timings:\n{}".format("\n".join(lines)))

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -1,0 +1,112 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import math
+import time
+
+from ducktape.tests.test import TestContext
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import (RESTART_LOG_ALLOW_LIST,
+                                      AdvertisedTierConfig, CloudTierName,
+                                      MetricsEndpoint, SISettings)
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+
+kiB = 1024
+MiB = kiB * kiB
+GiB = kiB * MiB
+
+NoncloudTierConfigs = {
+    #   ingress|          segment size|       partitions max|
+    #             egress|       cloud cache size|connections # limit|
+    #           # of brokers|           partitions min|           memory per broker|
+    "docker-local":
+    AdvertisedTierConfig(3 * MiB, 9 * MiB, 3, 128 * MiB, 20 * GiB, 1, 100, 100,
+                         2 * GiB),
+}
+
+
+class HighThroughputTest2(PreallocNodesTest):
+    def __init__(self, test_ctx: TestContext, *args, **kwargs):
+        self._ctx = test_ctx
+
+        cloud_tier_str = test_ctx.globals.get("cloud_tier", "docker-local")
+        if cloud_tier_str in NoncloudTierConfigs.keys():
+            cloud_tier = None
+            self.tier_config = NoncloudTierConfigs[cloud_tier_str]
+            extra_rp_conf = {
+                'log_segment_size': self.tier_config.segment_size,
+                'cloud_storage_cache_size': self.tier_config.cloud_cache_size,
+                # Disable segment merging: when we create many small segments
+                # to pad out tiered storage metadata, we don't want them to
+                # get merged together.
+                'cloud_storage_enable_segment_merging': False,
+                'disable_batch_cache': True,
+            }
+            num_brokers = self.tier_config.num_brokers
+
+        else:
+            try:
+                cloud_tier = CloudTierName(cloud_tier_str)
+            except ValueError:
+                raise RuntimeError(
+                    f"Unknown cloud tier specified: {cloud_tier_str}. Supported tiers: {CloudTierName.list()+NoncloudTierConfigs.keys()}"
+                )
+            extra_rp_conf = None
+            num_brokers = None
+
+        super(HighThroughputTest2,
+              self).__init__(test_ctx,
+                             1,
+                             *args,
+                             num_brokers=num_brokers,
+                             extra_rp_conf=extra_rp_conf,
+                             cloud_tier=cloud_tier,
+                             disable_cloud_storage_diagnostics=True,
+                             **kwargs)
+
+        if cloud_tier is not None:
+            self.tier_config = self.redpanda.advertised_tier_config
+        test_ctx.logger.info(f"Cloud tier {cloud_tier}: {self.tier_config}")
+
+    @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_throughput_simple(self):
+
+        ingress_rate = self.tier_config.ingress_rate
+        self.topics = [
+            TopicSpec(partition_count=self.tier_config.partitions_min)
+        ]
+        super(HighThroughputTest2, self).setUp()
+
+        target_run_time = 15
+        target_data_size = target_run_time * ingress_rate
+        msg_count = int(math.sqrt(target_data_size) / 2)
+        msg_size = target_data_size // msg_count
+        self.logger.info(
+            f"Producing {msg_count} messages of {msg_size} B, "
+            f"{msg_count*msg_size} B total, target rate {ingress_rate} B/s")
+
+        producer0 = KgoVerifierProducer(self.test_context,
+                                        self.redpanda,
+                                        self.topic,
+                                        msg_size=msg_size,
+                                        msg_count=msg_count)
+        producer0.start()
+        start = time.time()
+
+        producer0.wait()
+        time0 = time.time() - start
+
+        producer0.stop()
+        producer0.free()
+
+        rate0 = msg_count * msg_size / time0
+        self.logger.info(f"Producer: {time0} s, {rate0} B/s")
+        assert rate0 / ingress_rate > 0.5, f"Producer rate is too low. measured: {rate0} B/s, expected: {ingress_rate} B/s"

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -894,7 +894,7 @@ class ManyPartitionsTest(PreallocNodesTest):
     @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_omb(self):
         scale = ScaleParameters(self.redpanda, replication_factor=3)
-        self.redpanda.start(parallel=True)
+        self.redpanda.start()
 
         # We have other OMB benchmark tests, but this one runs at the
         # peak partition count.
@@ -962,7 +962,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             int(scale.expect_bandwidth / len(self.redpanda.nodes) * 3)
         })
 
-        self.redpanda.start(parallel=True)
+        self.redpanda.start()
 
         self.logger.info("Entering topic creation")
         topic_names = [f"scale_{i:06d}" for i in range(0, n_topics)]

--- a/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
@@ -1,0 +1,268 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
+from rptest.services.redpanda import SISettings, MetricsEndpoint, ResourceSettings
+from rptest.services.admin import Admin
+from rptest.clients.rpk import RpkTool
+from rptest.utils.si_utils import quiesce_uploads
+from typing import Optional
+from ducktape.mark import matrix
+import time
+from enum import Enum
+
+
+class LimitMode(str, Enum):
+    bytes = 'bytes'
+    objects = 'objects'
+    both = 'both'
+
+
+class TieredStorageCacheStressTest(RedpandaTest):
+    segment_upload_interval = 30
+    manifest_upload_interval = 10
+
+    def __init__(self, test_context, *args, **kwargs):
+
+        super().__init__(test_context, *args, **kwargs)
+
+    def setUp(self):
+        # defer redpanda startup to the test
+        pass
+
+    def _validate_node_storage(self, node, limit_mode: LimitMode,
+                               size_limit: Optional[int],
+                               max_objects: Optional[int]):
+        admin = Admin(self.redpanda)
+
+        self.logger.info(
+            f"Validating node {node.name} cache vs limits {size_limit}/{max_objects}"
+        )
+
+        # Read logical space usage according to Redpanda
+        usage = admin.get_local_storage_usage(node)
+        self.logger.info(f"Checking cache usage on {node.name}: {usage}")
+
+        # Read physical space usage according to the operating system
+        node_storage = self.redpanda.node_storage(node)
+        self.logger.info(
+            f"Checked physical cache usage on {node.name}: {node_storage.cache}"
+        )
+
+        # Read HWM stats from Redpanda, in case we transiently violated cache size
+        metrics = self.redpanda.metrics(
+            node, metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+        hwm_size = None
+        hwm_objects = None
+        for family in metrics:
+            for sample in family.samples:
+                if sample.name == "redpanda_cloud_storage_cache_space_hwm_size_bytes":
+                    hwm_size = int(sample.value)
+                elif sample.name == "redpanda_cloud_storage_cache_space_hwm_files":
+                    hwm_objects = int(sample.value)
+                #else:
+                #    self.logger.debug(sample.name)
+        assert hwm_size is not None, "Cache HWM metric not found"
+
+        any_cache_usage = (usage['cloud_storage_cache_bytes'] > 0
+                           and usage['cloud_storage_cache_objects'] > 0)
+
+        self.logger.info(
+            f"Admin API cache size[{node.name}]: {usage['cloud_storage_cache_bytes']}/{usage['cloud_storage_cache_objects']}"
+        )
+        self.logger.info(
+            f"Physical cache usage[{node.name}]: {node_storage.cache.bytes}/{node_storage.cache.objects}"
+        )
+        self.logger.info(f"Cache HWM [{node.name}]: {hwm_size}/{hwm_objects}")
+
+        if limit_mode == LimitMode.bytes or limit_mode == LimitMode.both:
+            assert usage['cloud_storage_cache_bytes'] <= size_limit
+            assert node_storage.cache.bytes <= size_limit
+            assert hwm_size <= size_limit
+        elif limit_mode == LimitMode.objects or limit_mode == LimitMode.both:
+            assert usage['cloud_storage_cache_objects'] <= max_objects
+            assert node_storage.cache.objects <= max_objects
+            assert hwm_objects <= max_objects
+        else:
+            raise NotImplementedError(limit_mode)
+
+        return any_cache_usage
+
+    @cluster(num_nodes=4)
+    @matrix(limit_mode=[LimitMode.bytes, LimitMode.objects, LimitMode.both],
+            log_segment_size=[1024 * 1024, 128 * 1024 * 1024])
+    def streaming_cache_test(self, limit_mode, log_segment_size):
+        """
+        Validate that reading data much  larger than the cache proceeds safely
+        and promptly: this exercises the mode where we are reading some data,
+        trimming cache, reading, trimming etc.
+        """
+
+        chunk_size = min(16 * 1024 * 1024, log_segment_size)
+
+        if self.redpanda.dedicated_nodes:
+            partition_count = 128
+
+            # Lowball expectation of bandwidth that should work reliably on
+            # small instance types
+            expect_bandwidth = 100E6
+
+            # Make the cache at least this big (avoid using very small caches when
+            # the segment size is small)
+            at_least_bytes = 20 * 1024 * 1024 * 1024
+        else:
+            # In general, this test should always be run on dedicated nodes: mini-me mode
+            # for developers on fast workstations hacking on the test.
+            partition_count = 16
+            expect_bandwidth = 20E6
+            at_least_bytes = 1 * 1024 * 1024 * 1024
+
+        topic_name = 'streaming-read'
+
+        msg_size = 16384
+
+        # Cache trim interval is 5 seconds.  Cache trim low watermark is 80%.
+        # Effective streaming bandwidth is 20% of cache size every trim period
+        size_limit = max(int((expect_bandwidth * 5) / 0.2),
+                         partition_count * chunk_size)
+        size_limit = max(size_limit, at_least_bytes)
+        # One index per segment, one tx file per segment, one object per chunk bytes
+        max_objects = (size_limit //
+                       log_segment_size) * 2 + size_limit // chunk_size
+
+        if partition_count >= len(self.redpanda.nodes):
+            # If we have multiple partitions then we are spreading load across multiple
+            # nodes, and each node should need a proportionally smaller cache
+            size_limit // len(self.redpanda.nodes)
+
+        # Use interval uploads so that tests can do a "wait til everything uploaded"
+        # check if they want to.
+        extra_rp_conf = {
+            'cloud_storage_segment_max_upload_interval_sec':
+            self.segment_upload_interval,
+            'cloud_storage_manifest_max_upload_interval_sec':
+            self.manifest_upload_interval,
+        }
+
+        si_settings = SISettings(
+            test_context=self.test_context,
+            log_segment_size=log_segment_size,
+        )
+
+        if limit_mode == LimitMode.bytes:
+            si_settings.cloud_storage_cache_size = int(size_limit)
+            si_settings.cloud_storage_cache_max_objects = 2**32 - 1
+        elif limit_mode == LimitMode.objects:
+            si_settings.cloud_storage_cache_size = 2**64 - 1
+            si_settings.cloud_storage_cache_max_objects = int(max_objects)
+        elif limit_mode == LimitMode.both:
+            # This is the normal way of configuring Redpanda, with
+            # safety limits on both data and metadata
+            si_settings.cloud_storage_cache_size = int(size_limit)
+            si_settings.cloud_storage_cache_max_objects = int(max_objects)
+        else:
+            raise NotImplementedError(limit_mode)
+
+        # Write 5x more data than fits in the cache, so that during a consume
+        # cycle we are having to drop+rehydrate it all.
+        data_size = size_limit * 5
+
+        # Write 3x more than one segment size, so that we will be reading from
+        # remote data instead of local data (local retention set to one segment)
+        data_size = max(data_size, log_segment_size * 3 * partition_count)
+
+        msg_count = data_size // msg_size
+
+        # We will run with artificially constrained memory, to minimize use of
+        # the batch cache and ensure that tiered storage reads are not using
+        # egregious amounts of memory.  The memory is within the official system
+        # requirements (2GB per core).  Use a small core count so that if we're
+        # running on a system with plenty of cores, we don't spread out the
+        # partitions such that each core has lots of slack memory.
+        self.redpanda.set_resource_settings(
+            ResourceSettings(memory_mb=4096, num_cpus=2))
+
+        self.redpanda.set_extra_rp_conf(extra_rp_conf)
+        self.redpanda.set_si_settings(si_settings)
+        self.redpanda.start()
+
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(
+            topic_name,
+            partitions=partition_count,
+            replicas=3,
+            config={
+                # Minimal local retention, to send traffic to remote
+                # storage.
+                'retention.local.target.bytes': log_segment_size,
+            })
+
+        self.logger.info(
+            f"Writing {data_size} bytes, will be read using {size_limit}/{max_objects} cache"
+        )
+
+        # Sanity check test parameters against the nodes we are running on
+        disk_space_required = size_limit + data_size
+        assert self.redpanda.get_node_disk_free(
+        ) >= disk_space_required, f"Need at least {disk_space_required} bytes space"
+
+        # Write out the data.  We will write + read in separate phases in order
+        # that this test cleanly exercises the read path.
+        t1 = time.time()
+        KgoVerifierProducer.oneshot(
+            self.test_context,
+            self.redpanda,
+            topic_name,
+            msg_size=msg_size,
+            msg_count=data_size // msg_size,
+            batch_max_bytes=msg_size * 8,
+            timeout_sec=(data_size / expect_bandwidth) * 2)
+        produce_duration = time.time() - t1
+        self.logger.info(
+            f"Produced {data_size} bytes in {produce_duration} seconds, {(data_size/produce_duration)/1000000.0:.2f}MB/s"
+        )
+
+        # Wait for uploads to complete
+        quiesce_uploads(self.redpanda, [topic_name], 30)
+
+        # Read all the data, validate that we read complete and achieve
+        # the streaming bandwidth that we expect
+        t1 = time.time()
+        expect_duration = data_size // expect_bandwidth
+        self.logger.info(
+            f"Consuming, expected duration {expect_duration:.2f}s")
+        consumer = KgoVerifierSeqConsumer.oneshot(self.test_context,
+                                                  self.redpanda,
+                                                  topic_name,
+                                                  loop=False,
+                                                  timeout_sec=expect_duration *
+                                                  2)
+        assert consumer.consumer_status.validator.valid_reads == msg_count
+        assert consumer.consumer_status.validator.invalid_reads == 0
+        assert consumer.consumer_status.validator.out_of_scope_invalid_reads == 0
+        consume_duration = time.time() - t1
+        consume_rate = data_size / consume_duration
+        self.logger.info(
+            f"Consumed {data_size} bytes in {consume_duration} seconds, {consume_rate/1000000.0:.2f}MB/s"
+        )
+
+        # If we are not keeping up, it indicates an issue with trimming logic, such as
+        # backing off too much or not trimming enough each time: there is a generous
+        # 2x margin to make the test robust: if this _still_ fails, something is up.
+        assert consume_rate > expect_bandwidth / 2
+
+        # Validate that the cache end state is within configured limit
+        nodes_cache_used = self.redpanda.for_nodes(
+            self.redpanda.nodes, lambda n: self._validate_node_storage(
+                n, limit_mode, size_limit, max_objects))
+
+        # At least one node should have _something_ in its cache, or something is wrong with our test
+        assert any(nodes_cache_used) is True

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3555,7 +3555,7 @@ class RedpandaService(RedpandaServiceBase):
 
         return wait_until_result(check, timeout_sec=30, backoff_sec=1)
 
-    def stop_and_scrub_object_storage(self):
+    def stop_and_scrub_object_storage(self, run_timeout=60):
         # Before stopping, ensure that all tiered storage partitions
         # have uploaded at least a manifest: we do not require that they
         # have uploaded until the head of their log, just that they have
@@ -3647,7 +3647,7 @@ class RedpandaService(RedpandaServiceBase):
             f"{environment} rp-storage-tool --backend {backend} scan-metadata --source {bucket}",
             combine_stderr=False,
             allow_fail=True,
-            timeout_sec=30)
+            timeout_sec=run_timeout)
 
         try:
             report = json.loads(output)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -55,7 +55,7 @@ from rptest.services import tls
 from rptest.services.admin import Admin
 from rptest.services.redpanda_installer import RedpandaInstaller, VERSION_RE as RI_VERSION_RE, int_tuple as ri_int_tuple
 from rptest.services.rolling_restarter import RollingRestarter
-from rptest.services.storage import ClusterStorage, NodeStorage
+from rptest.services.storage import ClusterStorage, NodeStorage, NodeCacheStorage
 from rptest.services.utils import BadLogLines, NodeCrash
 from rptest.util import inject_remote_script, wait_until_result
 
@@ -358,6 +358,7 @@ class SISettings:
                  cloud_storage_api_endpoint: str = 'minio-s3',
                  cloud_storage_api_endpoint_port: int = 9000,
                  cloud_storage_cache_size: int = 160 * 1000000,
+                 cloud_storage_cache_max_objects: Optional[int] = None,
                  cloud_storage_enable_remote_read: bool = True,
                  cloud_storage_enable_remote_write: bool = True,
                  cloud_storage_max_connections: Optional[int] = None,
@@ -370,6 +371,8 @@ class SISettings:
                      int] = None,
                  bypass_bucket_creation: bool = False,
                  cloud_storage_housekeeping_interval_ms: Optional[int] = None,
+                 cloud_storage_spillover_manifest_max_segments: Optional[
+                     int] = None,
                  fast_uploads=False):
         """
         :param fast_uploads: if true, set low upload intervals to help tests run
@@ -407,6 +410,7 @@ class SISettings:
 
         self.log_segment_size = log_segment_size
         self.cloud_storage_cache_size = cloud_storage_cache_size
+        self.cloud_storage_cache_max_objects = cloud_storage_cache_max_objects
         self.cloud_storage_enable_remote_read = cloud_storage_enable_remote_read
         self.cloud_storage_enable_remote_write = cloud_storage_enable_remote_write
         self.cloud_storage_max_connections = cloud_storage_max_connections
@@ -417,6 +421,7 @@ class SISettings:
         self.endpoint_url = f'http://{self.cloud_storage_api_endpoint}:{self.cloud_storage_api_endpoint_port}'
         self.bypass_bucket_creation = bypass_bucket_creation
         self.cloud_storage_housekeeping_interval_ms = cloud_storage_housekeeping_interval_ms
+        self.cloud_storage_spillover_manifest_max_segments = cloud_storage_spillover_manifest_max_segments
 
         if fast_uploads:
             self.cloud_storage_segment_max_upload_interval_sec = 10
@@ -511,6 +516,10 @@ class SISettings:
         conf["log_segment_size"] = self.log_segment_size
         conf["cloud_storage_enabled"] = True
         conf["cloud_storage_cache_size"] = self.cloud_storage_cache_size
+        if self.cloud_storage_cache_max_objects is not None:
+            conf[
+                "cloud_storage_cache_max_objects"] = self.cloud_storage_cache_max_objects
+
         conf[
             'cloud_storage_enable_remote_read'] = self.cloud_storage_enable_remote_read
         conf[
@@ -540,6 +549,9 @@ class SISettings:
         if self.cloud_storage_housekeeping_interval_ms:
             conf[
                 'cloud_storage_housekeeping_interval_ms'] = self.cloud_storage_housekeeping_interval_ms
+        if self.cloud_storage_spillover_manifest_max_segments:
+            conf[
+                'cloud_storage_spillover_manifest_max_segments'] = self.cloud_storage_spillover_manifest_max_segments
         return conf
 
     def set_expected_damage(self, damage_types: set[str]):
@@ -768,6 +780,8 @@ class RedpandaServiceBase(Service):
                  si_settings: Optional[SISettings] = None,
                  superuser: Optional[SaslCredentials] = None,
                  disable_cloud_storage_diagnostics=True):
+
+        self.advertised_tier_config: AdvertisedTierConfig = None
         super(RedpandaServiceBase, self).__init__(context,
                                                   num_nodes=num_brokers,
                                                   cluster_spec=cluster_spec)
@@ -980,13 +994,7 @@ class RedpandaServiceBase(Service):
     def si_settings(self):
         return self._si_settings
 
-    def _for_nodes(self, nodes, cb: callable, *, parallel: bool) -> list:
-        if not parallel:
-            # Trivial case: just loop and call
-            for n in nodes:
-                cb(n)
-            return list(map(cb, nodes))
-
+    def for_nodes(self, nodes, cb: callable) -> list:
         n_workers = len(nodes)
         if n_workers > 0:
             with concurrent.futures.ThreadPoolExecutor(
@@ -1009,7 +1017,7 @@ class RedpandaServiceBase(Service):
                 f"sed -i -E -e '/TRACE|DEBUG/d' {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
             )
 
-        self._for_nodes(self.nodes, prune, parallel=True)
+        self.for_nodes(self.nodes, prune)
 
     def node_id(self, node, force_refresh=False, timeout_sec=30):
         """
@@ -1744,13 +1752,12 @@ class RedpandaService(RedpandaServiceBase):
             node.account.copy_to(tmpfile, f"/etc/hosts")
 
         # Edit /etc/hosts on Redpanda nodes
-        self._for_nodes(self.nodes, setup_node_dns, parallel=True)
+        self.for_nodes(self.nodes, setup_node_dns)
 
     def start(self,
               nodes=None,
               clean_nodes=True,
               start_si=True,
-              parallel: bool = True,
               expect_fail: bool = False,
               auto_assign_node_id: bool = False,
               omit_seeds_on_idx_one: bool = True,
@@ -1758,12 +1765,6 @@ class RedpandaService(RedpandaServiceBase):
         """
         Start the service on all nodes.
 
-        By default, nodes are started in serial: this makes logs easier to
-        read and simplifies debugging.  For tests starting larger numbers of
-        nodes where serialized startup becomes annoying, pass parallel=True.
-
-        :param parallel: if true, run clean and start operations in parallel
-                         for the nodes being started.
         :param expect_fail: if true, expect redpanda nodes to terminate shortly
                             after starting.  Raise exception if they don't.
         """
@@ -1802,7 +1803,7 @@ class RedpandaService(RedpandaServiceBase):
                     f"Error cleaning node {node.account.hostname}:")
                 raise
 
-        self._for_nodes(to_start, clean_one, parallel=parallel)
+        self.for_nodes(to_start, clean_one)
 
         if first_start:
             self.write_tls_certs()
@@ -1820,7 +1821,7 @@ class RedpandaService(RedpandaServiceBase):
                             override_cfg_params=node_overrides)
 
         try:
-            self._for_nodes(to_start, start_one, parallel=parallel)
+            self.for_nodes(to_start, start_one)
         except TimeoutError as e:
             if expect_fail:
                 raise e
@@ -1965,7 +1966,7 @@ class RedpandaService(RedpandaServiceBase):
             # fall through
             return True
 
-        return all(self._for_nodes(self._started, check_node, parallel=True))
+        return all(self.for_nodes(self._started, check_node))
 
     def wait_until(self, fn, timeout_sec, backoff_sec, err_msg=None):
         """
@@ -2569,11 +2570,12 @@ class RedpandaService(RedpandaServiceBase):
         nodes = [(n, None) for n in self.nodes]
         for _ in range(3):
             retries = []
-            for node, _ in nodes:
-                pct_diff, reclaimable_diff, *deets = inspect_node(node)
+            results = self.for_nodes(nodes, lambda n: (n, inspect_node(n)))
+            for (node, (pct_diff, reclaimable_diff, *deets)) in results:
                 if pct_diff > 0.05 + reclaimable_diff:
                     retries.append(
                         (node, (pct_diff, reclaimable_diff, *deets)))
+
             if not retries:
                 # all good
                 return
@@ -2781,9 +2783,7 @@ class RedpandaService(RedpandaServiceBase):
 
         self.logger.info("%s: stopping service" % self.who_am_i())
 
-        self._for_nodes(self.nodes,
-                        lambda n: self.stop_node(n, **kwargs),
-                        parallel=True)
+        self.for_nodes(self.nodes, lambda n: self.stop_node(n, **kwargs))
 
         self._stop_duration_seconds = time.time() - self._stop_time
 
@@ -3184,7 +3184,9 @@ class RedpandaService(RedpandaServiceBase):
 
         self.logger.debug(
             f"Starting storage checks for {node.name} sizes={sizes}")
-        store = NodeStorage(node.name, RedpandaService.DATA_DIR)
+        store = NodeStorage(
+            node.name, RedpandaService.DATA_DIR,
+            os.path.join(RedpandaService.DATA_DIR, "cloud_storage_cache"))
         script_path = inject_remote_script(node, "compute_storage.py")
         cmd = [
             "python3", script_path, f"--data-dir={RedpandaService.DATA_DIR}"
@@ -3207,8 +3209,24 @@ class RedpandaService(RedpandaServiceBase):
                         continue
                     for segment, data in segments.items():
                         partition.set_segment_size(segment, data["size"])
+
+        if self.si_settings is not None and node.account.exists(
+                store.cache_dir):
+            bytes = int(
+                node.account.ssh_output(
+                    f"du -s \"{store.cache_dir}\"").strip().split()[0])
+            objects = int(
+                node.account.ssh_output(
+                    f"find \"{store.cache_dir}\" -type f | wc -l").strip())
+            indices = int(
+                node.account.ssh_output(
+                    f"find \"{store.cache_dir}\" -type f -name \"*.index\" | wc -l"
+                ).strip())
+            store.set_cache_stats(NodeCacheStorage(bytes, objects, indices))
+
         self.logger.debug(
             f"Finished storage checks for {node.name} sizes={sizes}")
+
         return store
 
     def storage(self, all_nodes: bool = False, sizes: bool = False):
@@ -3227,7 +3245,7 @@ class RedpandaService(RedpandaServiceBase):
             s = self.node_storage(node, sizes=sizes)
             store.add_node(s)
 
-        self._for_nodes(nodes, compute_node_storage, parallel=True)
+        self.for_nodes(nodes, compute_node_storage)
         self.logger.debug(
             f"Finished storage checks all_nodes={all_nodes} sizes={sizes}")
         return store

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -11,6 +11,7 @@ import os
 import re
 import itertools
 from typing import Optional
+from dataclasses import dataclass
 
 
 class Segment:
@@ -154,11 +155,26 @@ class PartitionNotFoundError(Exception):
     pass
 
 
+@dataclass
+class NodeCacheStorage:
+    # Total size of the directory according to `du`
+    bytes: int
+
+    # Total number of non-directory files in the cache dir.  This count
+    # overlaps with subsequent type-specific object counts
+    objects: int
+
+    # Number of .index files
+    indices: int
+
+
 class NodeStorage:
-    def __init__(self, name, data_dir):
+    def __init__(self, name: str, data_dir: str, cache_dir: str):
         self.data_dir = data_dir
+        self.cache_dir = cache_dir
         self.ns = dict()
         self.name = name
+        self.cache = None
 
     def add_namespace(self, ns, path):
         n = Namespace(ns, path)
@@ -182,6 +198,9 @@ class NodeStorage:
             )
 
         return partitions[partition_idx].segments.values()
+
+    def set_cache_stats(self, stats: NodeCacheStorage):
+        self.cache = stats
 
 
 class ClusterStorage:

--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -201,7 +201,7 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
         self._assert_files_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$')
         self._assert_files_in_cache(f'.*kafka/{self.topic}/.*index$')
 
-    @cluster(num_nodes=4)
+    @cluster(num_nodes=4, log_allow_list=["Exceeded cache size limit"])
     def test_read_when_cache_smaller_than_segment_size(self):
         self.si_settings.cloud_storage_cache_size = 1048576 * 4
         self.redpanda.set_si_settings(self.si_settings)

--- a/tests/rptest/tests/cloud_storage_usage_test.py
+++ b/tests/rptest/tests/cloud_storage_usage_test.py
@@ -95,7 +95,8 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
         reported_usage_sliding_window = deque(maxlen=10)
 
         def check():
-            manifest_usage = bucket_view.total_cloud_log_size()
+            manifest_usage = bucket_view.cloud_log_sizes_sum().accessible(
+                no_archive=True)
 
             reported_usage = self.admin.cloud_storage_usage()
             reported_usage_sliding_window.append(reported_usage)
@@ -145,9 +146,7 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
             ntp_remote_size = max(i.size
                                   for i in remote_items) if remote_items else 0
             actual_size = bucket_view.cloud_log_size_for_ntp(
-                ntp.topic,
-                ntp.partition,
-                include_size_below_start_offset=False)
+                ntp.topic, ntp.partition).accessible(no_archive=True)
 
             assert ntp_remote_size == actual_size
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1581,7 +1581,8 @@ class ClusterConfigAzureSharedKey(RedpandaTest):
 
     def get_cloud_log_size(self):
         s3_snapshot = BucketView(self.redpanda, topics=self.topics)
-        return s3_snapshot.cloud_log_size_for_ntp(self.topic, 0)
+        return s3_snapshot.cloud_log_size_for_ntp(self.topic,
+                                                  0).total(no_archive=True)
 
     def wait_for_cloud_uploads(self, initial_count: int, delta: int):
         def segment_uploaded():

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -819,13 +819,11 @@ class EndToEndSpilloverTest(RedpandaTest):
             test_context,
             log_segment_size=1024,
             fast_uploads=True,
-            cloud_storage_housekeeping_interval_ms=10000)
-        super(EndToEndSpilloverTest, self).__init__(
-            test_context=test_context,
-            # Set to minimal value
-            extra_rp_conf=dict(
-                cloud_storage_spillover_manifest_max_segments=10),
-            si_settings=self.si_settings)
+            cloud_storage_housekeeping_interval_ms=10000,
+            cloud_storage_spillover_manifest_max_segments=10)
+        super(EndToEndSpilloverTest,
+              self).__init__(test_context=test_context,
+                             si_settings=self.si_settings)
 
         self.msg_size = 1024 * 256
         self.msg_count = 3000

--- a/tests/rptest/tests/node_id_assignment_test.py
+++ b/tests/rptest/tests/node_id_assignment_test.py
@@ -160,8 +160,7 @@ class NodeIdAssignmentParallel(RedpandaTest):
     def test_assign_multiple_nodes(self):
         self.redpanda.start(self.redpanda.nodes[1:],
                             auto_assign_node_id=True,
-                            omit_seeds_on_idx_one=False,
-                            parallel=True)
+                            omit_seeds_on_idx_one=False)
 
         def check_num_nodes():
             brokers = self.redpanda._admin.get_brokers()

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -404,7 +404,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
         # the bandwidth time for the amount of data we produced, plus the segment
         # upload interval (set to 10s via fast_uploads), plus the manifest upload
         # interval (set to 1s via fast_uploads).
-        wait_until(lambda: cloud_log_size() >= total_bytes,
+        wait_until(lambda: cloud_log_size().total() >= total_bytes,
                    timeout_sec=30,
                    backoff_sec=2,
                    err_msg=f"Segments not uploaded")
@@ -416,7 +416,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
 
         # Test that the size of the cloud log is below the retention threshold
         # by querying the manifest.
-        wait_until(lambda: cloud_log_size() <= retention_bytes,
+        wait_until(lambda: cloud_log_size().total() <= retention_bytes,
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Too many bytes in the cloud")
@@ -563,7 +563,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             return cloud_log_size
 
         # Wait for everything to be uploaded to the cloud.
-        wait_until(lambda: cloud_log_size() >= total_bytes,
+        wait_until(lambda: cloud_log_size().total() >= total_bytes,
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Segments not uploaded")
@@ -574,7 +574,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
 
         # Assert that retention policy has kicked in and with the desired
         # effect, i.e. total bytes is <= retention settings applied
-        wait_until(lambda: cloud_log_size() <= retention_bytes,
+        wait_until(lambda: cloud_log_size().total() <= retention_bytes,
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Too many bytes in the cloud")

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -94,9 +94,7 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # Seed nodes need to be started in parallel because they need to be
         # able to form a quorum before they become ready.
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_with_rpk,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_with_rpk)
         for node in self.redpanda.nodes:
             node_ids.add(self.redpanda.node_id(node))
         assert len(node_ids) == 3, f"Node IDs: {node_ids}"
@@ -125,16 +123,13 @@ class RpkRedpandaStartTest(RedpandaTest):
                     f"{rpk} redpanda config set redpanda.rpc_server " \
                     f"'{{\"address\":\"{node.account.hostname}\",\"port\":33145}}'")
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 config_bootstrap_with_rpk,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, config_bootstrap_with_rpk)
 
         # Run a start with no arguments, as is done when Redpanda is run by a
         # systemd service.
-        self.redpanda._for_nodes(
+        self.redpanda.for_nodes(
             self.redpanda.nodes,
-            lambda n: self.redpanda.start_node_with_rpk(n, clean_node=False),
-            parallel=True)
+            lambda n: self.redpanda.start_node_with_rpk(n, clean_node=False))
         node_ids = set()
         for node in self.redpanda.nodes:
             node_ids.add(self.redpanda.node_id(node))
@@ -265,9 +260,7 @@ class RpkRedpandaStartTest(RedpandaTest):
             # the limits when TLS is enabled.
             node.account.ssh("sysctl fs.inotify.max_user_instances=512")
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 setup_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, setup_cluster)
 
         seeds_str = ",".join(
             [f"{n.account.hostname}" for n in self.redpanda.nodes])
@@ -285,9 +278,7 @@ class RpkRedpandaStartTest(RedpandaTest):
             assert self.redpanda.search_log_node(
                 node, "redpanda.rpc_server_tls:{ enabled: 1")
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_cluster)
 
         # To validate that everything works fine we check that
         # formed a cluster and we can produce and consume from it
@@ -306,9 +297,7 @@ class RpkRedpandaStartTest(RedpandaTest):
             pass
 
         self.redpanda.stop()
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_cluster)
         try:
             for i in range(50, 100):
                 self.rpk.produce(topic, f"k-{i}", f"v-test-{i}", timeout=5)
@@ -337,9 +326,7 @@ class RpkRedpandaStartTest(RedpandaTest):
 
             self.redpanda.start_node_with_rpk(node, clean_node=False)
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 setup_and_start,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, setup_and_start)
 
         # Check that we don't enable rpc and print a warning
         assert self.redpanda.search_log_all(
@@ -368,9 +355,7 @@ class RpkRedpandaStartTest(RedpandaTest):
                            f"[{self.rpc_server_tls()}]")
             node.account.ssh("sysctl fs.inotify.max_user_instances=512")
 
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 setup_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, setup_cluster)
 
         seeds_str = ",".join(
             [f"{n.account.hostname}" for n in self.redpanda.nodes])
@@ -385,9 +370,7 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # On first start we validate that TLS is disabled and produce
         # to a topic.
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_cluster)
         assert self.redpanda.search_log_all(
             "redpanda.rpc_server_tls:{ enabled: 0", self.redpanda.nodes)
 
@@ -414,9 +397,7 @@ class RpkRedpandaStartTest(RedpandaTest):
 
         # Restart and validate rpc_server_tls is enabled.
         self.redpanda.stop()
-        self.redpanda._for_nodes(self.redpanda.nodes,
-                                 start_cluster,
-                                 parallel=True)
+        self.redpanda.for_nodes(self.redpanda.nodes, start_cluster)
         assert self.redpanda.search_log_all(
             "redpanda.rpc_server_tls:{ enabled: 1", self.redpanda.nodes)
 

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -194,10 +194,9 @@ class BucketScrubSelfTest(RedpandaTest):
         # Initially a bucket scrub should pass
         self.logger.info(f"Running baseline scrub")
         self.redpanda.stop_and_scrub_object_storage()
-        self.redpanda._for_nodes(
+        self.redpanda.for_nodes(
             self.redpanda.nodes,
-            lambda n: self.redpanda.start_node(n, first_start=False),
-            parallel=True)
+            lambda n: self.redpanda.start_node(n, first_start=False))
 
         # Go delete a segment: pick one arbitrarily, but it must be one
         # that is linked into a manifest to constitute a corruption.
@@ -230,10 +229,9 @@ class BucketScrubSelfTest(RedpandaTest):
             segment_key,
             validate=True)
 
-        self.redpanda._for_nodes(
+        self.redpanda.for_nodes(
             self.redpanda.nodes,
-            lambda n: self.redpanda.start_node(n, first_start=False),
-            parallel=True)
+            lambda n: self.redpanda.start_node(n, first_start=False))
 
 
 class SimpleSelfTest(Test):

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -825,8 +825,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # compaction may delete segments (which are replaced by merged segments) at any time.
         bucket_view = BucketView(self.redpanda)
         size_before = sum(
-            bucket_view.cloud_log_size_for_ntp(self.topic, i)
-            for i in range(0, self.partition_count))
+            bucket_view.cloud_log_size_for_ntp(self.topic, i).total(
+                no_archive=True) for i in range(0, self.partition_count))
         assert size_before > 0
 
         def get_nodes(partition):
@@ -854,8 +854,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         # Check no remote data was lost
         bucket_view.reset()
         size_after = sum(
-            bucket_view.cloud_log_size_for_ntp(self.topic, i)
-            for i in range(0, self.partition_count))
+            bucket_view.cloud_log_size_for_ntp(self.topic, i).total(
+                no_archive=True) for i in range(0, self.partition_count))
         assert size_after >= size_before
 
         # Check no purging/purged lifecycle marker was written

--- a/tests/rptest/tests/usage_test.py
+++ b/tests/rptest/tests/usage_test.py
@@ -282,7 +282,8 @@ class UsageTestCloudStorageMetrics(RedpandaTest):
 
         def check_usage():
             # Check that the usage reporting system has reported correct values
-            manifest_usage = bucket_view.total_cloud_log_size()
+            manifest_usage = bucket_view.cloud_log_sizes_sum().total(
+                no_archive=True)
             reported_usage = self.admin.get_usage(
                 random.choice(self.redpanda.nodes))
             reported_usages = [

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -257,10 +257,10 @@ def wait_for_local_storage_truncate(redpanda,
                                     key=lambda s: s.offset)
             except ValueError:
                 # Segment list is empty
-                first_segment = None
-
-            first_segment_size = first_segment.size if first_segment.size else 0
-            sizes.append(total_size - first_segment_size)
+                continue
+            else:
+                first_segment_size = first_segment.size if first_segment.size else 0
+                sizes.append(total_size - first_segment_size)
 
         # The segment which is open for appends will differ in Redpanda's internal
         # sizing (exact) vs. what the filesystem reports for a falloc'd file (to the
@@ -407,7 +407,7 @@ def wait_for_recovery_throttle_rate(redpanda, new_rate: int):
                     f"Error getting throttle rate for {node}", exc_info=True)
                 return False
 
-        brokers = redpanda._admin.get_brokers(node=redpanda.controller())
+        brokers = redpanda._admin.get_brokers()
         active_brokers = set([b['node_id'] for b in brokers])
         assert active_brokers
         filtered = [


### PR DESCRIPTION
In order to utilize special procedure to check infinite retention it is needed to create a series of tests that focus on configuring cluster in a way that simulates different client use cases of prolonged use of redpanda without deleting anything from the storage.

fixes https://github.com/redpanda-data/devprod/issues/739
fixes https://github.com/redpanda-data/devprod/issues/744

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

Work in progress on infinite retention tests

### Features

test class of InfiniteRetentionTest should include
- throughput test with long running time (>1h)
- long running test with no stress, (3h)
- all above tests should include occasional node restarts as a failure injection



