### PR TITLE
rptest: perform full log reads with KgoVerifierSeqConsumer

### DIFF
--- a/tests/docker/ducktape-deps/kgo-verifier
+++ b/tests/docker/ducktape-deps/kgo-verifier
@@ -2,6 +2,6 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
 cd /opt/kgo-verifier
-git reset --hard 5b1b6b6b802a30962963cca8b364bee148fee515
+git reset --hard 3508c6e64e1b9ef92dc325a27cd62c16b411f0e4
 go mod tidy
 make

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -288,7 +288,8 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
                                    debug_logs=True,
                                    trace_logs=True)
 
-    def _create_consumer(self) -> KgoVerifierSeqConsumer:
+    def _create_consumer(
+            self, producer: KgoVerifierProducer) -> KgoVerifierSeqConsumer:
         bps = self.produce_byte_rate_per_ntp * self.topics[0].partition_count
         bytes_count = bps * self.target_runtime
         msg_count = bytes_count // self.message_size
@@ -302,7 +303,8 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
                                       msg_size=self.message_size,
                                       max_throughput_mb=int(bps // self.mib),
                                       debug_logs=True,
-                                      trace_logs=True)
+                                      trace_logs=True,
+                                      producer=producer)
 
     def _all_uploads_done(self):
         topic_description = self.rpk.describe_topic(self.topic)
@@ -398,7 +400,7 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
                             cloud_storage_status_endpoint_check)
 
         self.producer = self._create_producer()
-        self.consumer = self._create_consumer()
+        self.consumer = self._create_consumer(self.producer)
 
         self.producer.start()
 


### PR DESCRIPTION
Based on https://github.com/redpanda-data/redpanda/pull/11846 

Previously, whenever a KgoVerifierSequentialConsumer and a
KgoVerifierProducer ran in parallel (which a number of tests do), there
was no guarantee that the consumer would read all partitions entirely.
Whenever `wait` is called on the consumer, the `last_pass` command is
triggered without taking into account if the producer has completed.

This is problematic because it can hide stuck consumer issues. This
patch makes use of the enhanced kgo-verifier status which now contains
the high watermark for each partition. When creating a sequential
consumer, a reference to the producer can be provided. If that was the
case, when `wait` is called on the consumer we will wait until the
producer has finished and the high watermarks match.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
