### PR TITLE
cloud_storage: revise read replica sync to work with spilled metadata

### DIFF
--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -70,7 +70,9 @@ public:
       model::offset start_rp_offset, model::offset_delta delta);
     /// Add truncate-archive-commit command to the batch
     command_batch_builder&
+    /// Totally replace the manifest
     cleanup_archive(model::offset start_rp_offset, uint64_t removed_size_bytes);
+    command_batch_builder& replace_manifest(iobuf);
     /// Replicate the configuration batch
     ss::future<std::error_code> replicate();
 
@@ -252,6 +254,7 @@ private:
     struct truncate_archive_commit_cmd;
     struct reset_metadata_cmd;
     struct spillover_cmd;
+    struct replace_manifest_cmd;
     struct snapshot;
 
     friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
@@ -276,6 +279,7 @@ private:
     void apply_update_start_kafka_offset(kafka::offset so);
     void apply_reset_metadata();
     void apply_spillover(const spillover_cmd& so);
+    void apply_replace_manifest(iobuf);
 
 private:
     prefix_logger _logger;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -640,6 +640,16 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
 }
 
 gc_config disk_log_impl::override_retention_config(gc_config cfg) const {
+    // Read replica topics have a different default retention
+    if (config().is_read_replica_mode_enabled()) {
+        cfg.eviction_time = std::max(
+          model::timestamp(
+            model::timestamp::now().value()
+            - ntp_config::read_replica_retention.count()),
+          cfg.eviction_time);
+        return cfg;
+    }
+
     // cloud_retention is disabled, do not override
     if (!is_cloud_retention_active()) {
         return cfg;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -33,6 +33,8 @@ public:
     static constexpr bool default_remote_delete{true};
     static constexpr bool legacy_remote_delete{false};
 
+    static constexpr std::chrono::milliseconds read_replica_retention{3600000};
+
     struct default_overrides {
         // if not set use the log_manager's configuration
         std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -183,6 +185,13 @@ public:
             }
             // If no value set, fall through and use the cluster-wide default.
         }
+
+        if (is_read_replica_mode_enabled()) {
+            // Read replicas have a special hardcoded default, because they do
+            // not retain user data in local raft log, just configuration.
+            return read_replica_retention;
+        }
+
         return config::shard_local_cfg().delete_retention_ms();
     }
 
@@ -232,6 +241,13 @@ public:
             }
             // fall through to server config
         }
+
+        if (is_read_replica_mode_enabled()) {
+            // Read replicas have a special hardcoded default, because they do
+            // not retain user data in local raft log, just configuration.
+            return read_replica_retention;
+        }
+
         return config::shard_local_cfg().log_segment_ms;
     }
 


### PR DESCRIPTION
Rather than add more complexity to try and synchronize the manifest incrementally, just change how it works to do a total replacement of the manifest each time we download it.  Now that manifests are in an efficient binary encoding, the size of the resulting raft writes are bounded (or they will be, once spilling is on by default).

~TODO:~
- [x] Avoid generating the write if the manifests are identical
- [x] Now that we are writing more data, it's a good time to make read replicas automatically set their local retention to something tiny, so that we can dump history immediately whenever we snapshot.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
