### PR TITLE
[storage] space management bug fixes and logging improvements

### DIFF
--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -84,7 +84,7 @@ ss::future<> disk_space_manager::run_loop() {
      * upcall to start the monitor loop when it appears that we are getting
      * close to an important threshold.
      */
-    constexpr auto frequency = std::chrono::seconds(5);
+    constexpr auto frequency = std::chrono::seconds(20);
 
     while (!_gate.is_closed()) {
         try {

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -160,6 +160,7 @@ set_partition_retention_offsets(cluster::partition_manager& pm, size_t target) {
         for (const auto& seg : segments) {
             auto usage = co_await seg->persistent_size();
             log_total += usage.total();
+            offset = seg->offsets().committed_offset;
             vlog(
               rlog.info,
               "Collecting segment {}:{}-{} estimated to recover {}",

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -126,6 +126,13 @@ set_partition_retention_offsets(cluster::partition_manager& pm, size_t target) {
         partitions.push_back(p.second);
     }
 
+    vlog(
+      rlog.info,
+      "Attempting to recover {} from {} remote partitions on core {}",
+      human::bytes(target),
+      partitions.size(),
+      ss::this_shard_id());
+
     size_t partitions_total = 0;
     for (const auto& p : partitions) {
         if (partitions_total >= target) {
@@ -137,6 +144,13 @@ set_partition_retention_offsets(cluster::partition_manager& pm, size_t target) {
         auto gate = log->gate().hold();
 
         auto segments = log->cloud_gc_eligible_segments();
+
+        vlog(
+          rlog.info,
+          "Remote partition {} reports {} reclaimable segments",
+          p->ntp(),
+          segments.size());
+
         if (segments.empty()) {
             continue;
         }
@@ -146,6 +160,13 @@ set_partition_retention_offsets(cluster::partition_manager& pm, size_t target) {
         for (const auto& seg : segments) {
             auto usage = co_await seg->persistent_size();
             log_total += usage.total();
+            vlog(
+              rlog.info,
+              "Collecting segment {}:{}-{} estimated to recover {}",
+              p->ntp(),
+              seg->offsets().base_offset(),
+              seg->offsets().committed_offset(),
+              human::bytes(usage.total()));
             if (log_total >= target) {
                 break;
             }
@@ -154,10 +175,12 @@ set_partition_retention_offsets(cluster::partition_manager& pm, size_t target) {
         vlog(
           rlog.info,
           "Setting retention offset override {} estimated reclaim of {} for "
-          "cloud topic {}",
+          "cloud topic {}. Total reclaim {} of target {}.",
           offset,
           log_total,
-          p->ntp());
+          p->ntp(),
+          partitions_total,
+          target);
 
         log->set_cloud_gc_offset(offset);
         partitions_total += log_total;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2231,7 +2231,7 @@ disk_log_impl::cloud_gc_eligible_segments() {
         if (seg->offsets().committed_offset <= max_collectible) {
             segments.push_back(seg);
         }
-        if (--remaining > 0) {
+        if (--remaining <= 0) {
             break;
         }
     }

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -593,4 +593,4 @@ class LogStorageMaxSizeSI(RedpandaTest):
             return total < (15 * 2**20 + 2 * self.log_segment_size)
 
         # give it plenty of time. on debug it is hella slow
-        wait_until(target_size_reached, timeout_sec=240, backoff_sec=5)
+        wait_until(target_size_reached, timeout_sec=120, backoff_sec=5)


### PR DESCRIPTION
* Improves logging
* Fixed a bug causing reclaim to run slower than expected
* Decreased control loop frequency which was low because of said bug
* Tighten up the test timeout which was also high because of the bug

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

