### PR TITLE
[v22.2.x] Remove `last_term_start_offset` from `storage::offset_stats`

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -286,8 +286,9 @@ ss::future<bool> persisted_stm::sync(model::timeout_clock::duration timeout) {
     model::offset sync_offset;
     auto log_offsets = _c->log().offsets();
     if (log_offsets.dirty_offset_term == term) {
-        if (log_offsets.last_term_start_offset > model::offset{0}) {
-            sync_offset = log_offsets.last_term_start_offset - model::offset{1};
+        auto last_term_start_offset = _c->log().find_last_term_start_offset();
+        if (last_term_start_offset > model::offset{0}) {
+            sync_offset = last_term_start_offset - model::offset{1};
         } else {
             sync_offset = model::offset{};
         }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -758,6 +758,34 @@ offset_stats disk_log_impl::offsets() const {
     };
 }
 
+model::offset disk_log_impl::find_last_term_start_offset() const {
+    if (_segs.empty()) {
+        return {};
+    }
+
+    segment_set::type end;
+    segment_set::type term_start;
+    for (int i = (int)_segs.size() - 1; i >= 0; --i) {
+        auto& seg = _segs[i];
+        if (!seg->empty()) {
+            if (!end) {
+                end = seg;
+            }
+            // find term start offset
+            if (seg->offsets().term < end->offsets().term) {
+                break;
+            }
+            term_start = seg;
+        }
+    }
+
+    if (!end) {
+        return {};
+    }
+
+    return term_start->offsets().base_offset;
+}
+
 model::timestamp disk_log_impl::start_timestamp() const {
     if (_segs.empty()) {
         return model::timestamp{};

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -714,18 +714,11 @@ offset_stats disk_log_impl::offsets() const {
     // NOTE: we have to do this because ss::circular_buffer<> does not provide
     // with reverse iterators, so we manually find the iterator
     segment_set::type end;
-    segment_set::type term_start;
     for (int i = (int)_segs.size() - 1; i >= 0; --i) {
         auto& seg = _segs[i];
         if (!seg->empty()) {
-            if (!end) {
-                end = seg;
-            }
-            // find term start offset
-            if (seg->offsets().term < end->offsets().term) {
-                break;
-            }
-            term_start = seg;
+            end = seg;
+            break;
         }
     }
     if (!end) {
@@ -740,8 +733,6 @@ offset_stats disk_log_impl::offsets() const {
     // we have valid begin and end
     const auto& bof = _segs.front()->offsets();
     const auto& eof = end->offsets();
-    // term start
-    const auto term_start_offset = term_start->offsets().base_offset;
 
     const auto start_offset = _start_offset() >= 0 ? _start_offset
                                                    : bof.base_offset;
@@ -754,7 +745,6 @@ offset_stats disk_log_impl::offsets() const {
 
       .dirty_offset = eof.dirty_offset,
       .dirty_offset_term = eof.term,
-      .last_term_start_offset = term_start_offset,
     };
 }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -79,6 +79,7 @@ public:
     timequery(timequery_config cfg) final;
     size_t segment_count() const final { return _segs.size(); }
     offset_stats offsets() const final;
+    model::offset find_last_term_start_offset() const final;
     model::timestamp start_timestamp() const final;
     std::optional<model::term_id> get_term(model::offset) const final;
     std::optional<model::offset>

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -70,6 +70,8 @@ public:
 
         virtual size_t segment_count() const = 0;
         virtual storage::offset_stats offsets() const = 0;
+        // Base offset of the first batch in the most recent term stored in log
+        virtual model::offset find_last_term_start_offset() const = 0;
         virtual model::timestamp start_timestamp() const = 0;
         virtual std::ostream& print(std::ostream& o) const = 0;
         virtual std::optional<model::term_id> get_term(model::offset) const = 0;
@@ -153,7 +155,9 @@ public:
     }
 
     storage::offset_stats offsets() const { return _impl->offsets(); }
-
+    model::offset find_last_term_start_offset() const {
+        return _impl->find_last_term_start_offset();
+    }
     std::optional<model::term_id> get_term(model::offset o) const {
         return _impl->get_term(o);
     }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -74,9 +74,9 @@ FIXTURE_TEST(
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
+    auto last_term_start_offset = log.find_last_term_start_offset();
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
     validate_offsets(model::offset(0), headers, batches);
 };
@@ -98,8 +98,8 @@ FIXTURE_TEST(append_twice_to_same_segment, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    auto last_term_start_offset = log.find_last_term_start_offset();
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
 };
@@ -119,8 +119,8 @@ FIXTURE_TEST(test_assigning_offsets_in_multiple_segment, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    auto last_term_start_offset = log.find_last_term_start_offset();
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
     validate_offsets(model::offset(0), headers, batches);
@@ -155,8 +155,8 @@ FIXTURE_TEST(test_single_record_per_segment, storage_test_fixture) {
     info("Flushed log: {}", log);
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    auto last_term_start_offset = log.find_last_term_start_offset();
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
     validate_offsets(model::offset(0), headers, batches);
@@ -194,8 +194,8 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
     info("Flushed log: {}", log);
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
     auto lstats = log.offsets();
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    auto last_term_start_offset = log.find_last_term_start_offset();
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
     validate_offsets(model::offset(0), headers, batches);
@@ -220,8 +220,7 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
     auto new_lstats = log.offsets();
     BOOST_REQUIRE_GE(new_lstats.committed_offset, lstats.committed_offset);
     auto new_batches = read_and_validate_all_batches(log);
-    BOOST_REQUIRE_EQUAL(
-      lstats.last_term_start_offset, batches.front().base_offset());
+    BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(
       new_lstats.committed_offset, new_batches.back().last_offset());
 };
@@ -285,8 +284,8 @@ FIXTURE_TEST(test_rolling_term, storage_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           model::term_id(i),
           log.get_term(current_offset - model::offset(1)).value());
-        auto lstats = log.offsets();
-        BOOST_REQUIRE_EQUAL(lstats.last_term_start_offset, term_start_offset);
+        auto last_term_start_offset = log.find_last_term_start_offset();
+        BOOST_REQUIRE_EQUAL(last_term_start_offset, term_start_offset);
         std::move(part.begin(), part.end(), std::back_inserter(headers));
     }
 

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -139,14 +139,12 @@ std::ostream& operator<<(std::ostream& o, const offset_stats& s) {
     fmt::print(
       o,
       "{{start_offset:{}, committed_offset:{}, "
-      "committed_offset_term:{}, dirty_offset:{}, dirty_offset_term:{}, "
-      "last_term_start_offset:{}}}",
+      "committed_offset_term:{}, dirty_offset:{}, dirty_offset_term:{}}}",
       s.start_offset,
       s.committed_offset,
       s.committed_offset_term,
       s.dirty_offset,
-      s.dirty_offset_term,
-      s.last_term_start_offset);
+      s.dirty_offset_term);
     return o;
 }
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -133,12 +133,6 @@ struct offset_stats {
 
     model::offset dirty_offset;
     model::term_id dirty_offset_term;
-    // Base offset of the first batch in the most recent term stored in log
-    //
-    // The last_term_base offset will be used by the followers to inform the
-    // raft group leader about the next possible index where truncation should
-    // happen while recovering node log.
-    model::offset last_term_start_offset;
 
     friend std::ostream& operator<<(std::ostream&, const offset_stats&);
 };


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11193
