### PR TITLE
archival: remove archive once fully truncated and cleaned

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -659,7 +659,15 @@ void partition_manifest::set_archive_clean_offset(
         return;
     }
     if (_archive_clean_offset < start_rp_offset) {
-        _archive_clean_offset = start_rp_offset;
+        if (start_rp_offset == _start_offset) {
+            // If we've truncated up to the start offset of the STM manifest,
+            // the archive is completely removed.
+            _archive_clean_offset = model::offset{};
+            _archive_start_offset = model::offset{};
+            _archive_start_offset_delta = model::offset_delta{};
+        } else {
+            _archive_clean_offset = start_rp_offset;
+        }
         if (_archive_size_bytes >= size_bytes) {
             _archive_size_bytes -= size_bytes;
         } else {


### PR DESCRIPTION
It doesn't appear that housekeeping can currently reset the archive start offset to model::offset{}. This is important because model::offset{} is used to indicate the absence of an archive (e.g. see ntp_archiver::stm_retention_needed()).

This adds a check to partition_manifest::set_archive_clean_offset() that will reset the manifest upon being truncated to the start of the STM manifest.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
