### PR TITLE
add cdt script to install dt deps on cdt infra

### DIFF
--- a/tests/docker/cdt_ducktape_deps.sh
+++ b/tests/docker/cdt_ducktape_deps.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ex
+
+REMOTE_FILES_PATH="/tmp" # https://github.com/redpanda-data/vtools/blob/dev/qa/image/packer/aws-ubuntu.pkr.hcl#L79
+
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/java-dev-tools"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/tool-pkgs"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/omb"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/kafka-tools"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/librdkafka"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/kcat"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/golang"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/kaf"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/rust"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/client-swarm"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/sarama-examples"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/franz-bench"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/kcl"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/kgo-verifier"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/addr2line"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/kafka-streams-examples"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/arroyo"
+
+mkdir -p /opt/redpanda-tests/ /opt/remote /opt/scripts
+pushd "$REMOTE_FILES_PATH"
+cp -r tests/* /opt/redpanda-tests/
+cp -r tests/rptest/remote_scripts/* /opt/remote
+cp -r tools/offline_log_viewer /opt/scripts
+cp -r tools/rp_storage_tool /
+popd
+
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/java-verifiers"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/golang-test-clients"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/rp-storage-tool"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/teleport"


### PR DESCRIPTION
install-deps is currently part of the vtools repo [ref](https://github.com/redpanda-data/vtools/blob/1242110a01b367707e2a92b516bab83bf09db501/qa/image/packer/install-deps.sh). CDT is designed to always run tip of vtools dev.
This causes issues when for example a dt dependency exists in redpanda `dev` branch, and not in `v22.3.x` branch. Once we teach install-deps of vtools/dev
to install a ducktape dependency, then it'll expect the same dependency file in all cdt runs, including older branches.

To avoid that, the install-deps should follow the redpanda ducktape dependencies per branch. Additionally, developers could modify/add a ducktape dependency and update cdt at once

ref #redpanda-data/devprod#741

Another PR on vtools will be introduced

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none
