### PR TITLE
cloud_storage: Add metrics for chunk hydration

### DIFF
--- a/src/v/cloud_storage/partition_probe.cc
+++ b/src/v/cloud_storage/partition_probe.cc
@@ -98,6 +98,15 @@ partition_probe::partition_probe(const model::ntp& ntp) {
           sm::description(
             "Spillover manifest materialization latency histogram"),
           labels),
+
+        sm::make_histogram(
+          "chunk_hydration_latency",
+          [this] {
+              return ssx::metrics::report_default_histogram(
+                _chunk_hydration_latency);
+          },
+          sm::description("Chunk hydration latency histogram"),
+          labels),
       });
 }
 

--- a/src/v/cloud_storage/partition_probe.cc
+++ b/src/v/cloud_storage/partition_probe.cc
@@ -107,6 +107,11 @@ partition_probe::partition_probe(const model::ntp& ntp) {
           },
           sm::description("Chunk hydration latency histogram"),
           labels),
+        sm::make_gauge(
+          "chunk_size",
+          [this] { return _chunk_size; },
+          sm::description("Size of chunk downloaded from cloud storage"),
+          labels),
       });
 }
 

--- a/src/v/cloud_storage/partition_probe.h
+++ b/src/v/cloud_storage/partition_probe.h
@@ -50,6 +50,10 @@ public:
         return _spillover_mat_latency.auto_measure();
     }
 
+    auto chunk_hydration_latency() {
+        return _chunk_hydration_latency.auto_measure();
+    }
+
 private:
     uint64_t _bytes_read = 0;
     uint64_t _records_read = 0;
@@ -65,6 +69,8 @@ private:
     int64_t _spillover_manifest_hydrated = 0;
     /// Spillover manifest materialization latency
     hdr_hist _spillover_mat_latency;
+
+    hdr_hist _chunk_hydration_latency;
 
     ss::metrics::metric_groups _metrics;
 };

--- a/src/v/cloud_storage/partition_probe.h
+++ b/src/v/cloud_storage/partition_probe.h
@@ -54,6 +54,8 @@ public:
         return _chunk_hydration_latency.auto_measure();
     }
 
+    void chunk_size(uint64_t size) { _chunk_size = size; }
+
 private:
     uint64_t _bytes_read = 0;
     uint64_t _records_read = 0;
@@ -71,6 +73,8 @@ private:
     hdr_hist _spillover_mat_latency;
 
     hdr_hist _chunk_hydration_latency;
+
+    uint64_t _chunk_size = 0;
 
     ss::metrics::metric_groups _metrics;
 };

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -130,6 +130,20 @@ remote_probe::remote_probe(
               "spillover_manifest_downloads",
               [this] { return get_spillover_manifest_downloads(); },
               sm::description("Number of spillover manifest downloads")),
+            sm::make_histogram(
+              "client_acquisition_latency",
+              [this] {
+                  return ssx::metrics::report_default_histogram(
+                    _client_acquisition_latency);
+              },
+              sm::description("Client acquisition latency histogram")),
+            sm::make_histogram(
+              "segment_download_latency",
+              [this] {
+                  return ssx::metrics::report_default_histogram(
+                    _segment_download_latency);
+              },
+              sm::description("Segment download latency histogram")),
           });
     }
 

--- a/src/v/cloud_storage/probe.h
+++ b/src/v/cloud_storage/probe.h
@@ -207,6 +207,12 @@ public:
 
     void index_download() { ++_cnt_index_downloads; }
 
+    auto client_acquisition() {
+        return _client_acquisition_latency.auto_measure();
+    }
+
+    auto segment_download() { return _segment_download_latency.auto_measure(); }
+
 private:
     /// Number of topic manifest uploads
     uint64_t _cnt_topic_manifest_uploads{0};
@@ -260,6 +266,9 @@ private:
     uint64_t _cnt_spillover_manifest_uploads{0};
     /// Number of spillover manifest downloads
     uint64_t _cnt_spillover_manifest_downloads{0};
+
+    hdr_hist _client_acquisition_latency;
+    hdr_hist _segment_download_latency;
 
     ss::metrics::metric_groups _metrics;
     ss::metrics::metric_groups _public_metrics;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -96,6 +96,7 @@ public:
             auto dsi = std::make_unique<bounded_stream>(stream, bytes_to_read);
             auto stream_upto = ss::input_stream<char>{
               ss::data_source{std::move(dsi)}};
+            _segment._probe.chunk_size(bytes_to_read);
             co_await _segment.put_chunk_in_cache(
               reservation, std::move(stream_upto), start);
         }

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -967,9 +967,12 @@ ss::future<> remote_segment::hydrate_chunk(segment_chunk_range range) {
     const auto end = range.last_offset().value_or(_size - 1);
     auto consumer = split_segment_into_chunk_range_consumer{
       *this, std::move(range)};
+
+    auto measurement = _probe.chunk_hydration_latency();
     auto res = co_await _api.download_segment(
       _bucket, _path, std::move(consumer), rtc, std::make_pair(start, end));
     if (res != download_result::success) {
+        measurement->set_trace(false);
         throw download_exception{res, _path};
     }
 }

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -165,7 +165,8 @@ remote_segment::remote_segment(
   const remote_segment_path& path,
   const model::ntp& ntp,
   const segment_meta& meta,
-  retry_chain_node& parent)
+  retry_chain_node& parent,
+  partition_probe& probe)
   : _api(r)
   , _cache(c)
   , _bucket(std::move(bucket))
@@ -192,7 +193,8 @@ remote_segment::remote_segment(
   // segment in chunks at the same time. In the first case roughly half the
   // segment may be hydrated at a time.
   , _chunks_in_segment(
-      std::max(static_cast<uint64_t>(ceil(_size / _chunk_size)), 1UL)) {
+      std::max(static_cast<uint64_t>(ceil(_size / _chunk_size)), 1UL))
+  , _probe(probe) {
     if (
       meta.sname_format == segment_name_format::v3
       && meta.metadata_size_hint == 0) {

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -79,7 +79,8 @@ public:
       const remote_segment_path& path,
       const model::ntp& ntp,
       const segment_meta& meta,
-      retry_chain_node& parent);
+      retry_chain_node& parent,
+      partition_probe& probe);
 
     remote_segment(const remote_segment&) = delete;
     remote_segment(remote_segment&&) = delete;
@@ -301,6 +302,7 @@ private:
 
     std::optional<segment_chunks> _chunks_api;
     std::optional<offset_index::coarse_index_t> _coarse_index;
+    partition_probe& _probe;
 
     friend class split_segment_into_chunk_range_consumer;
 };

--- a/src/v/cloud_storage/segment_state.cc
+++ b/src/v/cloud_storage/segment_state.cc
@@ -35,7 +35,7 @@ materialized_segment_state::materialized_segment_state(
   , parent(p.weak_from_this())
   , _units(std::move(u)) {
     segment = ss::make_lw_shared<remote_segment>(
-      p._api, p._cache, p._bucket, path, p.get_ntp(), meta, p._rtc);
+      p._api, p._cache, p._bucket, path, p.get_ntp(), meta, p._rtc, p._probe);
     p.materialized().register_segment(*this);
 }
 

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -104,6 +104,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE(upl_res == upload_result::success);
     m.add(meta);
 
+    partition_probe probe{manifest_ntp};
     remote_segment segment(
       api.local(),
       cache.local(),
@@ -111,7 +112,8 @@ FIXTURE_TEST(
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     auto reader_handle
       = segment.data_stream(0, ss::default_priority_class()).get();
@@ -145,6 +147,7 @@ FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
 
     retry_chain_node fib(never_abort, 100ms, 20ms);
     auto meta = *m.get(name);
+    partition_probe probe{manifest_ntp};
     remote_segment segment(
       api.local(),
       cache.local(),
@@ -152,7 +155,8 @@ FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     BOOST_REQUIRE_THROW(
       segment.data_stream(0, ss::default_priority_class()).get(),
@@ -228,6 +232,7 @@ FIXTURE_TEST(
     storage::log_reader_config reader_config(
       model::offset(1), model::offset(1), ss::default_priority_class());
 
+    partition_probe probe(manifest_ntp);
     auto segment = ss::make_lw_shared<remote_segment>(
       api.local(),
       cache.local(),
@@ -235,9 +240,9 @@ FIXTURE_TEST(
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
-    partition_probe probe(manifest_ntp);
     remote_segment_batch_reader reader(
       segment, reader_config, probe, ssx::semaphore_units());
     storage::offset_translator_state ot_state(m.get_ntp());
@@ -328,6 +333,7 @@ void test_remote_segment_batch_reader(
       begin, end, ss::default_priority_class());
     reader_config.max_bytes = std::numeric_limits<size_t>::max();
 
+    partition_probe probe(manifest_ntp);
     auto segment = ss::make_lw_shared<remote_segment>(
       fixture.api.local(),
       fixture.cache.local(),
@@ -335,9 +341,9 @@ void test_remote_segment_batch_reader(
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
-    partition_probe probe(manifest_ntp);
     remote_segment_batch_reader reader(
       segment, reader_config, probe, ssx::semaphore_units());
     storage::offset_translator_state ot_state(m.get_ntp());
@@ -436,6 +442,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE(upl_res == upload_result::success);
     m.add(meta);
 
+    partition_probe probe(manifest_ntp);
     auto segment = ss::make_lw_shared<remote_segment>(
       api.local(),
       cache.local(),
@@ -443,9 +450,9 @@ FIXTURE_TEST(
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
-    partition_probe probe(manifest_ntp);
     remote_segment_batch_reader reader(
       segment,
       storage::log_reader_config(
@@ -545,6 +552,7 @@ FIXTURE_TEST(test_remote_segment_chunk_read, cloud_storage_fixture) {
 
     auto m = chunk_read_baseline(*this, key, fib, segment_bytes.copy());
     auto meta = *m.get(key);
+    partition_probe probe(manifest_ntp);
     remote_segment segment(
       api.local(),
       cache.local(),
@@ -552,7 +560,8 @@ FIXTURE_TEST(test_remote_segment_chunk_read, cloud_storage_fixture) {
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     // The offset data stream uses an implementation which will iterate over all
     // chunks in the segment.
@@ -605,6 +614,7 @@ FIXTURE_TEST(test_remote_segment_chunk_read_fallback, cloud_storage_fixture) {
       *this, key, fib, segment_bytes.copy(), upload_index_t::no);
 
     auto meta = *m.get(key);
+    partition_probe probe(manifest_ntp);
     remote_segment segment(
       api.local(),
       cache.local(),
@@ -612,7 +622,8 @@ FIXTURE_TEST(test_remote_segment_chunk_read_fallback, cloud_storage_fixture) {
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     auto stream = segment
                     .offset_data_stream(
@@ -684,6 +695,7 @@ FIXTURE_TEST(test_chunks_initialization, cloud_storage_fixture) {
     auto m = chunk_read_baseline(*this, key, fib, segment_bytes.copy());
 
     auto meta = *m.get(key);
+    partition_probe probe(manifest_ntp);
     remote_segment segment(
       api.local(),
       cache.local(),
@@ -691,7 +703,8 @@ FIXTURE_TEST(test_chunks_initialization, cloud_storage_fixture) {
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     segment_chunks chunk_api{segment, segment.max_hydrated_chunks()};
 
@@ -742,6 +755,7 @@ FIXTURE_TEST(test_chunk_hydration, cloud_storage_fixture) {
     auto m = chunk_read_baseline(*this, key, fib, segment_bytes.copy());
 
     auto meta = *m.get(key);
+    partition_probe probe(manifest_ntp);
     remote_segment segment(
       api.local(),
       cache.local(),
@@ -749,7 +763,8 @@ FIXTURE_TEST(test_chunk_hydration, cloud_storage_fixture) {
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     segment_chunks chunk_api{segment, segment.max_hydrated_chunks()};
 
@@ -822,6 +837,7 @@ FIXTURE_TEST(test_chunk_future_reader_stats, cloud_storage_fixture) {
     auto m = chunk_read_baseline(*this, key, fib, segment_bytes.copy());
 
     auto meta = *m.get(key);
+    partition_probe probe(manifest_ntp);
     remote_segment segment(
       api.local(),
       cache.local(),
@@ -829,7 +845,8 @@ FIXTURE_TEST(test_chunk_future_reader_stats, cloud_storage_fixture) {
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     segment_chunks chunk_api{segment, segment.max_hydrated_chunks()};
     auto close_segment = ss::defer([&segment] { segment.stop().get(); });
@@ -870,6 +887,9 @@ FIXTURE_TEST(test_chunk_multiple_readers, cloud_storage_fixture) {
 
     auto m = chunk_read_baseline(*this, key, fib, segment_bytes.copy());
     auto meta = *m.get(key);
+
+    partition_probe probe(manifest_ntp);
+
     auto segment = ss::make_lw_shared<remote_segment>(
       api.local(),
       cache.local(),
@@ -877,7 +897,8 @@ FIXTURE_TEST(test_chunk_multiple_readers, cloud_storage_fixture) {
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     segment_chunks chunk_api{*segment, segment->max_hydrated_chunks()};
     auto close_segment = ss::defer([&segment] { segment->stop().get(); });
@@ -890,8 +911,6 @@ FIXTURE_TEST(test_chunk_multiple_readers, cloud_storage_fixture) {
     storage::log_reader_config reader_config(
       model::offset{1}, model::offset{1000000}, ss::default_priority_class());
     reader_config.max_bytes = std::numeric_limits<size_t>::max();
-
-    partition_probe probe(manifest_ntp);
 
     std::vector<std::unique_ptr<remote_segment_batch_reader>> readers{};
     readers.reserve(10);
@@ -943,6 +962,7 @@ FIXTURE_TEST(test_chunk_prefetch, cloud_storage_fixture) {
 
     const auto m = chunk_read_baseline(*this, key, fib, segment_bytes.copy());
     const auto meta = *m.get(key);
+    partition_probe probe(manifest_ntp);
     remote_segment segment(
       api.local(),
       cache.local(),
@@ -950,7 +970,8 @@ FIXTURE_TEST(test_chunk_prefetch, cloud_storage_fixture) {
       m.generate_segment_path(meta),
       m.get_ntp(),
       meta,
-      fib);
+      fib,
+      probe);
 
     segment_chunks chunk_api{segment, segment.max_hydrated_chunks()};
 

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -226,7 +226,7 @@ def wait_for_local_storage_truncate(redpanda,
         timeout_sec = 120
 
     redpanda.logger.debug(
-        "Waiting for local storage to be truncated to {target_bytes} bytes")
+        f"Waiting for local storage to be truncated to {target_bytes} bytes")
 
     sizes: list[int] = []
 


### PR DESCRIPTION
Metrics are introduced to measure chunk hydration with this change. 

1. Histogram for chunk hydration latency
2. Histogram for client acquisition during segment download
3. Histogram for segment download
4. Gauge for chunk size (labelled by ntp)

The first measurement is roughly the sum of the second and third measurements, so may be redundant.

A couple of tests are changed to use the chunk size metric in their assertions.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none
