### PR TITLE
config: enable cloud_storage_spillover_manifest_size by default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1488,7 +1488,7 @@ configuration::configuration()
       "split the manifest into two parts and one of them will be uploaded to "
       "S3.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      std::nullopt,
+      64_KiB,
       {.min = 4_KiB, .max = 4_MiB})
   , cloud_storage_spillover_manifest_max_segments(
       *this,


### PR DESCRIPTION
Set 64kiB, this is pretty small but enough to handle a typical modest partition's metadata with hourly uploads for a week.

The practical result will be that spilling will kick in for two kinds of partition:
- Partitions with much longer than default retention
- High throughput partitions that write lots of segments because they have lots of data.

This threshold is unlikely to be met by most of our automated tests, so it is still necessary to have explicit testing that triggers spillover by setting smaller than default thresholds.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
