### PR TITLE
Support for spillover manifests in `/v1/debug/unsafe_reset_metadata`

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1714,6 +1714,9 @@ void partition_manifest::do_update(partition_manifest_handler&& handler) {
         _replaced = std::move(*handler._replaced);
     }
 
+    if (handler._archive_size_bytes) {
+        _archive_size_bytes = *handler._archive_size_bytes;
+    }
     if (handler._cloud_log_size_bytes) {
         _cloud_log_size_bytes = handler._cloud_log_size_bytes.value();
     } else {

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -554,10 +554,14 @@ private:
     void serialize_segments(serialization_cursor_ptr cursor) const;
     /// Write next chunk of body
     void serialize_replaced(serialization_cursor_ptr cursor) const;
+    /// Write next chunk of body
+    void serialize_spillover(serialization_cursor_ptr cursor) const;
     /// Write epilogue
     void serialize_end(serialization_cursor_ptr cursor) const;
     /// Serialize normal manifest entry
     void serialize_segment_meta(
+      const segment_meta& meta, serialization_cursor_ptr cursor) const;
+    void serialize_spillover_manifest_meta(
       const segment_meta& meta, serialization_cursor_ptr cursor) const;
     /// Serialize removed manifest entry
     void serialize_removed_segment_meta(


### PR DESCRIPTION
### `reset_metadata` command

Previously a `reset_metadata` command was followed up with the commands
setting up the `archival_metadata_stm` state (i.e. partition_manifest).
Since now the manifest is binary serialized and kept small in size it is
possible to serialize it as a part of reset command. This way a reset
command changes the manifest content in `archival_metadata_stm`
simplifying the whole reset operation.

### Rest API

Previously JSON deserializer didn't support the spillover manifests.
Added deserialization support in `partition_manifest_handler`. JSON
deserializtion is used in REST admin API to forcibly reset partition
with handcrafted manifest json.

Force push: 
- using `replace_manifest` command to reset the state
- serialize spillover manifests in an array as segment path is not required

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- support for spillover manifests in reset rest API