### PR TITLE
cloud_storage: Fix remote segment index generation

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1175,6 +1175,7 @@ ntp_archiver::make_segment_index(
 
     vlog(ctxlog.debug, "creating remote segment index: {}", index_path);
     auto builder = cloud_storage::make_remote_segment_index_builder(
+      _ntp,
       std::move(stream),
       ix,
       base_rp_offset - base_kafka_offset,

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -391,6 +391,7 @@ void segment_matcher<Fixture>::verify_index(
       cloud_storage::remote_segment_sampling_step_bytes};
 
     auto builder = cloud_storage::make_remote_segment_index_builder(
+      ntp,
       reader_handle.take_stream(),
       ix,
       meta->delta_offset,

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -347,6 +347,7 @@ ss::future<uint64_t> remote_segment::put_segment_in_cache_and_create_index(
       remote_segment_sampling_step_bytes);
     auto [sparse, sput] = input_stream_fanout<2>(std::move(s), 1);
     auto parser = make_remote_segment_index_builder(
+      get_ntp(),
       std::move(sparse),
       tmpidx,
       _base_offset_delta,

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -166,6 +166,7 @@ public:
     using stop_parser = storage::batch_consumer::stop_parser;
 
     remote_segment_index_builder(
+      const model::ntp& ntp,
       offset_index& ix,
       model::offset_delta initial_delta,
       size_t sampling_step);
@@ -192,17 +193,19 @@ private:
     model::offset_delta _running_delta;
     size_t _window{0};
     size_t _sampling_step;
+    std::vector<model::record_batch_type> _filter;
 };
 
 inline ss::lw_shared_ptr<storage::continuous_batch_parser>
 make_remote_segment_index_builder(
+  const model::ntp& ntp,
   ss::input_stream<char> stream,
   offset_index& ix,
   model::offset_delta initial_delta,
   size_t sampling_step) {
     auto parser = ss::make_lw_shared<storage::continuous_batch_parser>(
       std::make_unique<remote_segment_index_builder>(
-        ix, initial_delta, sampling_step),
+        ntp, ix, initial_delta, sampling_step),
       storage::segment_reader_handle(std::move(stream)));
     return parser;
 }

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -25,6 +25,9 @@
 
 using namespace cloud_storage;
 
+static const model::ntp test_ntp(
+  model::kafka_namespace, model::topic("test-topic"), model::partition_id(0));
+
 BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     // This value is a power of two - 1 on purpose. This way we
     // will read from the compressed part and from the buffer of
@@ -133,7 +136,7 @@ SEASTAR_THREAD_TEST_CASE(test_remote_segment_index_builder) {
     auto is = make_iobuf_input_stream(std::move(segment));
     offset_index ix(base_offset, kbase_offset, 0, 0);
     auto parser = make_remote_segment_index_builder(
-      std::move(is), ix, model::offset_delta(0), 0);
+      test_ntp, std::move(is), ix, model::offset_delta(0), 0);
     auto result = parser->consume().get();
     BOOST_REQUIRE(result.has_value());
     BOOST_REQUIRE(result.value() != 0);
@@ -174,7 +177,7 @@ SEASTAR_THREAD_TEST_CASE(test_remote_segment_build_coarse_index) {
     auto is = make_iobuf_input_stream(std::move(segment));
     offset_index ix(base_offset, kbase_offset, 0, 0);
     auto parser = make_remote_segment_index_builder(
-      std::move(is), ix, model::offset_delta(0), 0);
+      test_ntp, std::move(is), ix, model::offset_delta(0), 0);
     auto pclose = ss::defer([&parser] { parser->close().get(); });
     auto result = parser->consume().get();
     BOOST_REQUIRE(result.has_value());
@@ -254,7 +257,7 @@ SEASTAR_THREAD_TEST_CASE(
     auto is = make_iobuf_input_stream(std::move(segment));
     offset_index ix(base_offset, kbase_offset, 0, 0);
     auto parser = make_remote_segment_index_builder(
-      std::move(is), ix, model::offset_delta(0), 0);
+      test_ntp, std::move(is), ix, model::offset_delta(0), 0);
     auto pclose = ss::defer([&parser] { parser->close().get(); });
     auto result = parser->consume().get();
     BOOST_REQUIRE(result.has_value());

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -173,6 +173,7 @@ void upload_index(
       remote_segment_sampling_step_bytes};
 
     auto builder = make_remote_segment_index_builder(
+      manifest_ntp,
       make_iobuf_input_stream(segment_bytes.copy()),
       ix,
       meta.delta_offset,


### PR DESCRIPTION
Previoiusly, the set of batch types for offset translation was hardcoded in the index builder code. This commit fixes this by using function that returns list of record batch types that participate in offset translation.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none