### PR TITLE
cloud_storage: allow STM retention to proceed and more archive retention fixes

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1925,6 +1925,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
 
     auto cursor = std::move(backlog.value());
 
+    using eof = cloud_storage::async_manifest_view_cursor::eof;
     while (cursor->get_status()
            == cloud_storage::async_manifest_view_cursor_status::
              materialized_spillover) {
@@ -1978,7 +1979,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
               "Failed to load next spillover manifest: {}",
               res.error());
             break;
-        } else if (res.value() == false) {
+        } else if (res.value() == eof::yes) {
             // End of stream
             break;
         }

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -708,9 +708,9 @@ FIXTURE_TEST(test_archival_stm_spillover, archival_metadata_stm_fixture) {
         model::offset{0}, 0, ss::lowres_clock::now() + 10s, never_abort)
       .get();
     BOOST_REQUIRE_EQUAL(
-      archival_stm->manifest().get_archive_start_offset(), model::offset(0));
+      archival_stm->manifest().get_archive_start_offset(), model::offset{});
     BOOST_REQUIRE_EQUAL(
-      archival_stm->manifest().get_archive_clean_offset(), model::offset(0));
+      archival_stm->manifest().get_archive_clean_offset(), model::offset{});
 
     // unaligned spillover command shouldn't remove segment
     archival_stm

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -648,6 +648,9 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
     }).get();
     fut.get();
 
+    BOOST_REQUIRE_EQUAL(
+      part->archival_meta_stm()->manifest().get_spillover_map().size(), 0);
+
     ss::sstring delete_payloads;
     for (const auto& [url, req] : get_targets()) {
         if (req.has_q_delete) {

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -634,14 +634,17 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
     auto fut = archiver.garbage_collect_archive();
     tests::cooperative_spin_wait_with_timeout(5s, [this, part]() mutable {
         const auto& manifest = part->archival_meta_stm()->manifest();
-        bool archive_clean_moved = manifest.get_archive_clean_offset()
-                                   == model::offset{2000};
+        bool archive_clean_offset_reset = manifest.get_archive_clean_offset()
+                                          == model::offset{};
+        bool archive_start_offset_reset = manifest.get_archive_start_offset()
+                                          == model::offset{};
         bool deletes_sent = std::count_if(
                               get_targets().begin(),
                               get_targets().end(),
                               [](auto it) { return it.second.has_q_delete; })
                             == 2;
-        return archive_clean_moved && deletes_sent;
+        return archive_clean_offset_reset && archive_start_offset_reset
+               && deletes_sent;
     }).get();
     fut.get();
 

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -229,7 +229,7 @@ ss::future<result<bool, error_outcome>> async_manifest_view_cursor::next() {
         co_return manifest.as_failure();
     }
     if (unlikely(!manifest_in_range(manifest.value()))) {
-        co_return false;
+        co_return error_outcome::out_of_range;
     }
     _current = manifest.value();
     _timer.rearm(_idle_timeout + ss::lowres_clock::now());
@@ -241,8 +241,8 @@ ss::future<ss::stop_iteration> async_manifest_view_cursor::next_iter() {
     if (res.has_failure()) {
         throw std::system_error(res.error());
     }
-    co_return res.value() == true ? ss::stop_iteration::yes
-                                  : ss::stop_iteration::no;
+    co_return res.value() == false ? ss::stop_iteration::yes
+                                   : ss::stop_iteration::no;
 }
 
 std::optional<std::reference_wrapper<const partition_manifest>>

--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -95,7 +95,9 @@ public:
     ///       available.
     ss::future<
       result<std::unique_ptr<async_manifest_view_cursor>, error_outcome>>
-    get_cursor(async_view_search_query_t q) noexcept;
+    get_cursor(
+      async_view_search_query_t q,
+      std::optional<model::offset> end_inclusive = std::nullopt) noexcept;
 
     /// Get inactive spillover manifests which are waiting for
     /// retention

--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -256,7 +256,8 @@ public:
     async_manifest_view_cursor_status get_status() const;
 
     /// Move to the next manifest or fail
-    ss::future<result<bool, error_outcome>> next();
+    using eof = ss::bool_class<struct eof_tag>;
+    ss::future<result<eof, error_outcome>> next();
 
     /// Shortcut to use with Seastar's future utils.
     ///

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -659,7 +659,15 @@ void partition_manifest::set_archive_clean_offset(
         return;
     }
     if (_archive_clean_offset < start_rp_offset) {
-        _archive_clean_offset = start_rp_offset;
+        if (start_rp_offset == _start_offset) {
+            // If we've truncated up to the start offset of the STM manifest,
+            // the archive is completely removed.
+            _archive_clean_offset = model::offset{};
+            _archive_start_offset = model::offset{};
+            _archive_start_offset_delta = model::offset_delta{};
+        } else {
+            _archive_clean_offset = start_rp_offset;
+        }
         if (_archive_size_bytes >= size_bytes) {
             _archive_size_bytes -= size_bytes;
         } else {

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -692,12 +692,43 @@ void partition_manifest::set_archive_clean_offset(
           start_rp_offset,
           _archive_clean_offset);
     }
+
+    // Prefix truncate to get rid of the spillover manifests
+    // that have fallen below the clean offset.
+    const auto previous_spillover_manifests_size = _spillover_manifests.size();
+    if (_archive_clean_offset == model::offset{}) {
+        // Handle the case where the entire archive was removed.
+        _spillover_manifests = {};
+    } else {
+        std::optional<model::offset> truncation_point;
+        for (const auto& spill : _spillover_manifests) {
+            if (spill.base_offset >= _archive_clean_offset) {
+                break;
+            }
+            truncation_point = spill.base_offset;
+        }
+
+        if (truncation_point) {
+            vassert(
+              _archive_clean_offset >= *truncation_point,
+              "Attempt to prefix truncate the spillover manifest list above "
+              "the "
+              "archive clean offest: {} > {}",
+              *truncation_point,
+              _archive_clean_offset);
+            _spillover_manifests.prefix_truncate(*truncation_point);
+        }
+    }
+
     vlog(
       cst_log.info,
-      "{} archive clean offset moved to {} archive size set to {}",
+      "{} archive clean offset moved to {} archive size set to {}; count of "
+      "spillover manifests {} -> {}",
       _ntp,
       _archive_clean_offset,
-      _archive_size_bytes);
+      _archive_size_bytes,
+      previous_spillover_manifests_size,
+      _spillover_manifests.size());
 }
 
 bool partition_manifest::advance_start_kafka_offset(

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -563,14 +563,16 @@ FIXTURE_TEST(test_async_manifest_view_retention, async_manifest_view_fixture) {
     model::offset prefix_base_offset;
     model::offset_delta prefix_delta;
     for (const auto& meta : expected) {
-        prefix_size += meta.size_bytes;
         prefix_timestamp = meta.base_timestamp;
         prefix_base_offset = meta.base_offset;
         prefix_delta = meta.delta_offset;
-        quota--;
+
         if (quota == 0) {
             break;
         }
+
+        prefix_size += meta.size_bytes;
+        quota--;
     }
 
     vlog(

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -35,6 +35,7 @@
 #include <numeric>
 
 using namespace cloud_storage;
+using eof = async_manifest_view_cursor::eof;
 
 static ss::logger test_log("async_manifest_view_log");
 static const model::initial_revision_id manifest_rev(111);
@@ -279,7 +280,7 @@ FIXTURE_TEST(test_async_manifest_view_iter, async_manifest_view_fixture) {
                 actual.push_back(meta);
             }
         });
-    } while (cursor->next().get().value());
+    } while (cursor->next().get().value() != eof::yes);
     print_diff(actual, expected);
     BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
     BOOST_REQUIRE(expected == actual);
@@ -329,7 +330,7 @@ FIXTURE_TEST(test_async_manifest_view_truncate, async_manifest_view_fixture) {
                 actual.push_back(meta);
             }
         });
-    } while (cursor->next().get().value());
+    } while (cursor->next().get().value() != eof::yes);
     print_diff(actual, expected);
     BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
     BOOST_REQUIRE(expected == actual);
@@ -351,7 +352,7 @@ FIXTURE_TEST(test_async_manifest_view_truncate, async_manifest_view_fixture) {
                 actual.push_back(meta);
             }
         });
-    } while (cursor->next().get().value());
+    } while (cursor->next().get().value() != eof::yes);
     print_diff(actual, removed);
     BOOST_REQUIRE_EQUAL(removed.size(), actual.size());
     BOOST_REQUIRE(removed == actual);
@@ -378,7 +379,7 @@ FIXTURE_TEST(test_async_manifest_view_truncate, async_manifest_view_fixture) {
                 actual.push_back(meta);
             }
         });
-    } while (cursor->next().get().value());
+    } while (cursor->next().get().value() != eof::yes);
     print_diff(actual, removed);
     BOOST_REQUIRE_EQUAL(removed.size(), actual.size());
     BOOST_REQUIRE(removed == actual);
@@ -449,7 +450,7 @@ FIXTURE_TEST(
                 actual.push_back(meta);
             }
         });
-    } while (cursor->next().get().value());
+    } while (cursor->next().get().value() != eof::yes);
     print_diff(actual, expected);
     BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
     BOOST_REQUIRE(expected == actual);
@@ -479,7 +480,7 @@ FIXTURE_TEST(
                 actual.push_back(meta);
             }
         });
-    } while (cursor->next().get().value());
+    } while (cursor->next().get().value() != eof::yes);
     print_diff(actual, removed);
     BOOST_REQUIRE_EQUAL(removed.size(), actual.size());
     BOOST_REQUIRE(removed == actual);

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -194,6 +194,11 @@ scan_remote_partition_incrementally_with_reuploads(
 /// This test scans the entire range of offsets
 FIXTURE_TEST(
   test_remote_partition_scan_translate_full_random, cloud_storage_fixture) {
+    vlog(
+      test_log.info,
+      "Seed used for read workload: {}",
+      random_generators::internal::seed);
+
     constexpr int num_segments = 1000;
     const auto [batch_types, num_data_batches] = generate_segment_layout(
       num_segments, 42);
@@ -217,6 +222,11 @@ FIXTURE_TEST(
 
 FIXTURE_TEST(
   test_remote_partition_scan_incrementally_random, cloud_storage_fixture) {
+    vlog(
+      test_log.info,
+      "Seed used for read workload: {}",
+      random_generators::internal::seed);
+
     constexpr int num_segments = 1000;
     const auto [batch_types, num_data_batches] = generate_segment_layout(
       num_segments, 42);
@@ -242,6 +252,11 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   test_remote_partition_scan_incrementally_random_with_overlaps,
   cloud_storage_fixture) {
+    vlog(
+      test_log.info,
+      "Seed used for read workload: {}",
+      random_generators::internal::seed);
+
     constexpr int num_segments = 1000;
     const auto [batch_types, num_data_batches] = generate_segment_layout(
       num_segments, 42);
@@ -272,6 +287,11 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   test_remote_partition_scan_incrementally_random_with_tx_fence,
   cloud_storage_fixture) {
+    vlog(
+      test_log.info,
+      "Seed used for read workload: {}",
+      random_generators::internal::seed);
+
     constexpr int num_segments = 1000;
     const auto [segment_layout, num_data_batches] = generate_segment_layout(
       num_segments, 42, false);
@@ -306,6 +326,11 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   test_remote_partition_scan_incrementally_random_with_reuploads,
   cloud_storage_fixture) {
+    vlog(
+      test_log.info,
+      "Seed used for read workload: {}",
+      random_generators::internal::seed);
+
     constexpr int num_segments = 1000;
     const auto [batch_types, num_data_batches] = generate_segment_layout(
       num_segments, 42);

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -28,8 +28,11 @@ inline std::random_device::result_type get_seed() {
     auto seed = rd();
     return seed;
 }
+
+static const auto seed = get_seed();
+
 // NOLINTNEXTLINE
-static thread_local std::default_random_engine gen(internal::get_seed());
+static thread_local std::default_random_engine gen(internal::seed);
 } // namespace internal
 
 bytes get_bytes(size_t n = 128 * 1024);


### PR DESCRIPTION
This PR fixes a number of issues with retention within the archive.
I've tested this with a custom version of CloudArchiveRetentionTest which asserts that
the precise number of segments was deleted. That requires a kgo-verfier patch and some
further fixes, so it'll come as a separate PR.

Firstly, the archive start and clean offsets are reset when retention has removed the entire archive.
This allows the retention in the STM region to proceed. The list of spillover manifests is also truncated
when the clean offset is advanced.

Secondly, fixes are included for the truncation point search for retention within the archive:
Incorrect truncation point search for size based retention. Cosider the example below:
```
A      B C      D E      F G      H
[------] [------] [------] [------] ....
   10B      10B      10B   |  10B
                           |
                           |
---------------------------|-------
       Archive                STM
```
There's three segments in the archive and multiple in the STM region.

2.1 Assume we have to remove 20B to satisfy the retention policy. The
new start offset of the archive should be E. Previously, we'd pick C as
the truncation point. This is due to the fact that we were only updating
the truncation point when the segment was collected. The fix is
to update the truncation point each time (until breaking).

2.2. Now assume we have to remove 35B to satisfy the retention policy.
The trunaction point should be G (the start of the STM manifest).
Previously, we'd pick E instead because `eof` was not true after the
last spill manifest. The fix is to specify the end offset of the
archive, (G-1) in this case, such that the cursor returns an EOF when
trying to step in the STM region. If the cursor returns EOF, then the
entire archive was consumed and the start offset needs to be advanced to
the STM start offset.

Note: I've also updated the time based retention to work in the same
style with regards to EOF.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
