### PR TITLE
tests: use spillover in `TieredStorageSinglePartitionTest`

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1990,6 +1990,13 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
         }
     }
 
+    // Drop out if we have no work to do, avoid doing things like the following
+    // manifest flushing unnecessarily.
+    if (segments_to_remove.empty() && manifests_to_remove.empty()) {
+        vlog(_rtclog.debug, "Nothing to remove in archive GC");
+        co_return;
+    }
+
     if (
       _parent.archival_meta_stm()->get_dirty(_projected_manifest_clean_at)
       != cluster::archival_metadata_stm::state_dirty::clean) {

--- a/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
@@ -131,8 +131,9 @@ class TieredStorageCacheStressTest(RedpandaTest):
 
         # Cache trim interval is 5 seconds.  Cache trim low watermark is 80%.
         # Effective streaming bandwidth is 20% of cache size every trim period
-        size_limit = max(int((expect_bandwidth * 5) / 0.2),
-                         partition_count * chunk_size)
+        size_limit = max(
+            SISettings.cache_size_for_throughput(expect_bandwidth),
+            partition_count * chunk_size)
         size_limit = max(size_limit, at_least_bytes)
         # One index per segment, one tx file per segment, one object per chunk bytes
         max_objects = (size_limit //

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -574,6 +574,17 @@ class SISettings:
     def is_damage_expected(self, damage_types: set[str]):
         return (damage_types & self._expected_damage_types) == damage_types
 
+    @classmethod
+    def cache_size_for_throughput(cls, throughput_bytes: int) -> int:
+        """
+        Calculate the cache size required to accomodate a particular
+        streaming throughput for consumers.
+        """
+        # - Cache trim interval is 5 seconds.
+        # - Cache trim low watermark is 80%.
+        # Effective streaming bandwidth is 20% of cache size every trim period
+        return int((throughput_bytes * 5) / 0.2)
+
 
 class TLSProvider:
     """


### PR DESCRIPTION
This shook out a small change to the archiver to avoid doing unnecessary manifest uploads when applying archive GC.

It also includes a change to configure the tiered storage cache large enough for the end-of-test consume to proceed promptly when running on a workstation.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
