### PR TITLE
cloud_storage: add timestamps to remote segment index

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1092,7 +1092,11 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
 
     auto index_path = make_index_path(path);
     auto make_idx_fut = make_segment_index(
-      candidate.starting_offset, _rtclog, index_path, std::move(stream_index));
+      candidate.starting_offset,
+      candidate.base_timestamp,
+      _rtclog,
+      index_path,
+      std::move(stream_index));
 
     auto [upload_res, idx_res] = co_await ss::when_all_succeed(
       std::move(upload_fut), std::move(make_idx_fut));
@@ -1222,6 +1226,7 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_tx(
 ss::future<std::optional<ntp_archiver::make_segment_index_result>>
 ntp_archiver::make_segment_index(
   model::offset base_rp_offset,
+  model::timestamp base_timestamp,
   retry_chain_logger& ctxlog,
   std::string_view index_path,
   ss::input_stream<char> stream) {
@@ -1232,7 +1237,8 @@ ntp_archiver::make_segment_index(
       base_rp_offset,
       base_kafka_offset,
       0,
-      cloud_storage::remote_segment_sampling_step_bytes};
+      cloud_storage::remote_segment_sampling_step_bytes,
+      base_timestamp};
 
     vlog(ctxlog.debug, "creating remote segment index: {}", index_path);
     cloud_storage::segment_record_stats stats{};

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -494,6 +494,7 @@ private:
     /// \return An index on success, nullopt on failure
     ss::future<std::optional<make_segment_index_result>> make_segment_index(
       model::offset base_rp_offset,
+      model::timestamp base_timestamp,
       retry_chain_logger& ctxlog,
       std::string_view index_path,
       ss::input_stream<char> stream);

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -263,6 +263,7 @@ private:
     model::offset _base_rp_offset;
     model::offset_delta _base_offset_delta;
     model::offset _max_rp_offset;
+    model::timestamp _base_timestamp;
 
     // The expected size according to the manifest entry for the segment
     size_t _size{0};

--- a/src/v/cloud_storage/remote_segment_index.cc
+++ b/src/v/cloud_storage/remote_segment_index.cc
@@ -22,7 +22,8 @@ offset_index::offset_index(
   model::offset initial_rp,
   kafka::offset initial_kaf,
   int64_t initial_file_pos,
-  int64_t file_pos_step)
+  int64_t file_pos_step,
+  model::timestamp initial_time)
   : _rp_offsets{}
   , _kaf_offsets{}
   , _file_offsets{}
@@ -31,9 +32,11 @@ offset_index::offset_index(
   , _initial_rp(initial_rp)
   , _initial_kaf(initial_kaf)
   , _initial_file_pos(initial_file_pos)
+  , _initial_time(initial_time)
   , _rp_index(initial_rp)
   , _kaf_index(initial_kaf)
   , _file_index(initial_file_pos, delta_delta_t(file_pos_step))
+  , _time_index(initial_time.value())
   , _min_file_pos_step(file_pos_step) {}
 
 void offset_index::add(

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -56,8 +56,11 @@ public:
       int64_t file_pos_step);
 
     /// Add new tuple to the index.
-    void
-    add(model::offset rp_offset, kafka::offset kaf_offset, int64_t file_offset);
+    void add(
+      model::offset rp_offset,
+      kafka::offset kaf_offset,
+      int64_t file_offset,
+      model::timestamp);
 
     struct find_result {
         model::offset rp_offset;
@@ -142,10 +145,12 @@ private:
     std::array<int64_t, buffer_depth> _rp_offsets;
     std::array<int64_t, buffer_depth> _kaf_offsets;
     std::array<int64_t, buffer_depth> _file_offsets;
+    std::array<int64_t, buffer_depth> _time_offsets;
     uint64_t _pos;
     model::offset _initial_rp;
     kafka::offset _initial_kaf;
     int64_t _initial_file_pos;
+    model::timestamp _initial_time;
 
     using encoder_t = deltafor_encoder<int64_t>;
     using decoder_t = deltafor_decoder<int64_t>;
@@ -156,6 +161,7 @@ private:
     encoder_t _rp_index;
     encoder_t _kaf_index;
     foffset_encoder_t _file_index;
+    encoder_t _time_index;
     int64_t _min_file_pos_step;
 
     friend class offset_index_accessor;

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -53,7 +53,8 @@ public:
       model::offset initial_rp,
       kafka::offset initial_kaf,
       int64_t initial_file_pos,
-      int64_t file_pos_step);
+      int64_t file_pos_step,
+      model::timestamp initial_time);
 
     /// Add new tuple to the index.
     void add(

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -43,15 +43,18 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     std::vector<model::offset> rp_offsets;
     std::vector<kafka::offset> kaf_offsets;
     std::vector<size_t> file_offsets;
+    std::vector<model::timestamp> timestamps;
     int64_t rp = segment_base_rp_offset();
     int64_t kaf = segment_base_kaf_offset();
     size_t fpos = random_generators::get_int(1000, 2000);
+    model::timestamp timestamp{123456};
     bool is_config = false;
     for (size_t i = 0; i < segment_num_batches; i++) {
         if (!is_config) {
             rp_offsets.push_back(model::offset(rp));
             kaf_offsets.push_back(kafka::offset(kaf));
             file_offsets.push_back(fpos);
+            timestamps.push_back(timestamp);
         }
         // The test queries every element using the key that matches the element
         // exactly and then it queries the element using the key which is
@@ -63,6 +66,7 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
         rp += batch_size;
         kaf += is_config ? batch_size - 1 : batch_size;
         fpos += random_generators::get_int(1000, 2000);
+        timestamp = model::timestamp(timestamp.value() + 1);
     }
 
     offset_index tmp_index(
@@ -71,7 +75,11 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     kafka::offset klast;
     size_t flast;
     for (size_t i = 0; i < rp_offsets.size(); i++) {
-        tmp_index.add(rp_offsets.at(i), kaf_offsets.at(i), file_offsets.at(i));
+        tmp_index.add(
+          rp_offsets.at(i),
+          kaf_offsets.at(i),
+          file_offsets.at(i),
+          timestamps.at(i));
         last = rp_offsets.at(i);
         klast = kaf_offsets.at(i);
         flast = file_offsets.at(i);

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -70,7 +70,11 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     }
 
     offset_index tmp_index(
-      segment_base_rp_offset, segment_base_kaf_offset, 0U, 1000);
+      segment_base_rp_offset,
+      segment_base_kaf_offset,
+      0U,
+      1000,
+      model::timestamp{0xdeadbeef});
     model::offset last;
     kafka::offset klast;
     size_t flast;
@@ -86,7 +90,11 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
     }
 
     offset_index index(
-      segment_base_rp_offset, segment_base_kaf_offset, 0U, 1000);
+      segment_base_rp_offset,
+      segment_base_kaf_offset,
+      0U,
+      1000,
+      model::timestamp{0xdeadbeef});
     auto buf = tmp_index.to_iobuf();
     index.from_iobuf(std::move(buf));
 
@@ -144,7 +152,8 @@ SEASTAR_THREAD_TEST_CASE(test_remote_segment_index_builder) {
     }
     auto segment = generate_segment(base_offset, batches);
     auto is = make_iobuf_input_stream(std::move(segment));
-    offset_index ix(base_offset, kbase_offset, 0, 0);
+    offset_index ix(
+      base_offset, kbase_offset, 0, 0, model::timestamp{0xdeadbeef});
     auto parser = make_remote_segment_index_builder(
       test_ntp, std::move(is), ix, model::offset_delta(0), 0);
     auto result = parser->consume().get();
@@ -192,7 +201,8 @@ SEASTAR_THREAD_TEST_CASE(test_remote_segment_build_coarse_index) {
                              expected_conf_records + expected_data_records - 1);
     auto segment = generate_segment(base_offset, batches);
     auto is = make_iobuf_input_stream(std::move(segment));
-    offset_index ix(base_offset, kbase_offset, 0, 0);
+    offset_index ix(
+      base_offset, kbase_offset, 0, 0, model::timestamp{0xdeadbeef});
     segment_record_stats stats{};
     auto parser = make_remote_segment_index_builder(
       test_ntp, std::move(is), ix, model::offset_delta(0), 0, std::ref(stats));
@@ -278,7 +288,8 @@ SEASTAR_THREAD_TEST_CASE(
     }
     auto segment = generate_segment(base_offset, batches);
     auto is = make_iobuf_input_stream(std::move(segment));
-    offset_index ix(base_offset, kbase_offset, 0, 0);
+    offset_index ix(
+      base_offset, kbase_offset, 0, 0, model::timestamp{0xdeadbeef});
     auto parser = make_remote_segment_index_builder(
       test_ntp, std::move(is), ix, model::offset_delta(0), 0);
     auto pclose = ss::defer([&parser] { parser->close().get(); });

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -170,7 +170,8 @@ void upload_index(
       meta.base_offset,
       meta.base_kafka_offset(),
       0,
-      remote_segment_sampling_step_bytes};
+      remote_segment_sampling_step_bytes,
+      meta.base_timestamp};
 
     auto builder = make_remote_segment_index_builder(
       manifest_ntp,


### PR DESCRIPTION
This is a prerequisite to make timequeries seek
to the proper chunk, instead of reading from the
start of segments.

The timestamp we care about is the batch max timestamp, because timequeries will want to find a batch that is definitely before the target timestamp, to start their scan from there.

Related: https://github.com/redpanda-data/redpanda/issues/11801

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
