### PR TITLE
[v22.3.x] cluster: reject read replica creation when no cloud

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -477,6 +477,12 @@ errc topics_frontend::validate_topic_configuration(
             }
         }
     }
+    if (
+      (assignable_config.is_read_replica()
+       || assignable_config.is_recovery_enabled())
+      && !_cloud_storage_api.local_is_initialized()) {
+        return errc::topic_invalid_config;
+    }
 
     return errc::success;
 }

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -459,3 +459,26 @@ class ReadReplicasUpgradeTest(EndToEndTest):
         wait_until(clusters_report_identical_hwms,
                    timeout_sec=30,
                    backoff_sec=1)
+
+
+class TestMisconfiguredReadReplicaService(EndToEndTest):
+    @cluster(num_nodes=1)
+    def test_create_replica_without_cloud_enabled(self):
+        """
+        Regression test for an issue where creating a read replica when cloud
+        isn't configured crashes the node.
+        """
+        self.start_redpanda(1)
+        rpk = RpkTool(self.redpanda)
+        conf = {
+            'redpanda.remote.readreplica': "dummy_bucket",
+        }
+        topic_name = "no_cloud_no_problems"
+        try:
+            rpk.create_topic(topic_name, replicas=1, config=conf)
+            assert False, "Expected failure"
+        except Exception as e:
+            assert "Configuration is invalid" in str(e), str(e)
+        assert self.redpanda.all_up()
+        topics = rpk.list_topics()
+        assert len(list(topics)) == 0, f"Unexpected partitions: {topics}"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11792
