### PR TITLE
[v23.1.x] cluster: reject read replica creation when no cloud

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -452,6 +452,12 @@ errc topics_frontend::validate_topic_configuration(
             }
         }
     }
+    if (
+      (assignable_config.is_read_replica()
+       || assignable_config.is_recovery_enabled())
+      && !_cloud_storage_api.local_is_initialized()) {
+        return errc::topic_invalid_config;
+    }
 
     return errc::success;
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11792
