### PR TITLE
rpk: add `rpk topic trim-prefix` (support for DeleteRecords)

### DIFF
--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -421,9 +421,6 @@ func parseFromToOffset(
 	return
 }
 
-// Until we use go1.17, nano/1e6 converts nanoseconds to milliseconds.
-func unixMilli(nano int64) int64 { return nano / 1e6 }
-
 // Parses the first or second timestamp in a timestamp based offset.
 //
 // The expressions below all end in (?::|$), meaning, a non capturing group for
@@ -529,12 +526,12 @@ func (c *consumer) parseTimeOffset(
 		// If there are no offsets after the requested milli, we get
 		// the default offset -1, which below in NewOffset().At(-1)
 		// actually coincidentally maps to AtEnd(). So it all works.
-		lstart, err := adm.ListOffsetsAfterMilli(context.Background(), unixMilli(startAt.UnixNano()), topics...)
+		lstart, err := adm.ListOffsetsAfterMilli(context.Background(), startAt.UnixMilli(), topics...)
 		if err == nil {
 			err = lstart.Error()
 		}
 		if err != nil {
-			return fmt.Errorf("unable to list offsets after milli %d: %v", unixMilli(startAt.UnixNano()), err)
+			return fmt.Errorf("unable to list offsets after milli %d: %v", startAt.UnixMilli(), err)
 		}
 
 		c.setParts(&c.partStarts, lstart, nil)
@@ -572,12 +569,12 @@ func (c *consumer) parseTimeOffset(
 			return fmt.Errorf("unable to list end offsets: %v", err)
 		}
 	} else {
-		lend, err = adm.ListOffsetsAfterMilli(context.Background(), unixMilli(endAt.UnixNano()), topics...)
+		lend, err = adm.ListOffsetsAfterMilli(context.Background(), endAt.UnixMilli(), topics...)
 		if err == nil {
 			err = lend.Error()
 		}
 		if err != nil {
-			return fmt.Errorf("unable to list offsets after milli %d: %v", unixMilli(endAt.UnixNano()), err)
+			return fmt.Errorf("unable to list offsets after milli %d: %v", endAt.UnixMilli(), err)
 		}
 	}
 	c.setParts(&c.partEnds, lend, nil)

--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -425,7 +425,7 @@ func parseFromToOffset(
 //
 // The expressions below all end in (?::|$), meaning, a non capturing group for
 // the first time followed by a colon or the second time at the end.
-func parseConsumeTimestamp(
+func parseTimestampBasedOffset(
 	half string, baseTimestamp time.Time,
 ) (length int, at time.Time, end bool, fromTimestamp bool, err error) {
 	switch {
@@ -516,7 +516,7 @@ func (c *consumer) parseTimeOffset(
 		err           error
 	)
 	if !strings.HasPrefix(offset, ":") {
-		length, startAt, end, fromTimestamp, err = parseConsumeTimestamp(offset, time.Now())
+		length, startAt, end, fromTimestamp, err = parseTimestampBasedOffset(offset, time.Now())
 		if err != nil {
 			return err
 		} else if end {
@@ -549,9 +549,9 @@ func (c *consumer) parseTimeOffset(
 	offset = offset[1:] // strip start:end delimiting colon
 
 	if fromTimestamp {
-		length, endAt, end, _, err = parseConsumeTimestamp(offset, startAt)
+		length, endAt, end, _, err = parseTimestampBasedOffset(offset, startAt)
 	} else {
-		length, endAt, end, _, err = parseConsumeTimestamp(offset, time.Now())
+		length, endAt, end, _, err = parseTimestampBasedOffset(offset, time.Now())
 	}
 
 	if err != nil {

--- a/src/go/rpk/pkg/cli/topic/consume_test.go
+++ b/src/go/rpk/pkg/cli/topic/consume_test.go
@@ -279,7 +279,7 @@ func TestParseConsumeTimestamp(t *testing.T) {
 			gotErr        bool
 		)
 		test.startAt = test.startAt.UTC()
-		l, startAt, end, fromTimestamp, err = parseConsumeTimestamp(test.in, time.Now())
+		l, startAt, end, fromTimestamp, err = parseTimestampBasedOffset(test.in, time.Now())
 
 		gotErr = err != nil
 		if gotErr != test.expErrFirstHalf {
@@ -310,9 +310,9 @@ func TestParseConsumeTimestamp(t *testing.T) {
 		}
 
 		if fromTimestamp {
-			_, endAt, _, _, err = parseConsumeTimestamp(offset[1:], startAt)
+			_, endAt, _, _, err = parseTimestampBasedOffset(offset[1:], startAt)
 		} else {
-			_, endAt, _, _, err = parseConsumeTimestamp(offset[1:], time.Now())
+			_, endAt, _, _, err = parseTimestampBasedOffset(offset[1:], time.Now())
 		}
 
 		gotErr = err != nil

--- a/src/go/rpk/pkg/cli/topic/topic.go
+++ b/src/go/rpk/pkg/cli/topic/topic.go
@@ -30,6 +30,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newDescribeCommand(fs, p),
 		newDescribeStorageCommand(fs, p),
 		newListCommand(fs, p),
+		newTrimPrefixCommand(fs, p),
 		newProduceCommand(fs, p),
 	)
 	return cmd

--- a/src/go/rpk/pkg/cli/topic/trim.go
+++ b/src/go/rpk/pkg/cli/topic/trim.go
@@ -1,0 +1,279 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package topic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+func newTrimPrefixCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		fromFile   string
+		noConfirm  bool
+		offset     string
+		partitions []int32
+	)
+	cmd := &cobra.Command{
+		Use:     "trim-prefix [TOPIC]",
+		Aliases: []string{"trim"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Trim records from topics",
+		Long: `Trim records from topics
+
+This command allows you to trim records from topics, to trim the topics Redpanda
+sets the LogStartOffset for partitions to the requested offset. All segments
+whose base offset is less then the requested offset are deleted, and any records
+within the segment before the requested offset can no longer be read.
+
+The --offset/-o flag allows you to indicate which index you want to set the
+partition's low watermark (start offset) to. It can be a single integer value
+denoting the offset or a timestamp if you prefix the offset with an '@'. You may
+select which partition you want to trim the offset from with the --partition/-p
+flag.
+
+The --from-file option allows to trim the offsets specified in a text file with
+the following format:
+    [TOPIC] [PARTITION] [OFFSET]
+    [TOPIC] [PARTITION] [OFFSET]
+    ...
+or the equivalent keyed JSON/YAML file.
+
+EXAMPLES
+
+Trim records in 'foo' topic to offset 120 in partition 1
+    rpk topic trim-prefix foo --offset 120 --partition 1
+
+Trim records in all partitions of topic foo previous to an specific timestamp
+    rpk topic trim-prefix foo -o "@1622505600"
+
+Trim records from a JSON file
+    rpk topic trim-prefix --from-file /tmp/to_trim.json
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			var o kadm.Offsets
+			if fromFile != "" {
+				o, err = parseOffsetFile(fs, fromFile, args)
+				out.MaybeDie(err, "unable to parse file %q: %v", fromFile, err)
+			} else {
+				if len(args) == 0 {
+					out.Die("Error: required arg 'topic' not set\n%v", cmd.UsageString())
+				}
+				if offset == "" {
+					out.Die("Error: required flag 'offset' not set\n%v", cmd.UsageString())
+				}
+				topic := args[0]
+				o, err = parseOffsetArgs(cmd.Context(), adm, topic, offset, partitions)
+				out.MaybeDieErr(err)
+			}
+			if !noConfirm {
+				err := printDeleteRecordRequest(cmd.Context(), adm, o)
+				out.MaybeDie(err, "unable to print trimming request: %v", err)
+				fmt.Println()
+				confirmed, err := out.Confirm("Confirm trimming of the above offsets?")
+				out.MaybeDie(err, "unable to confirm: %v", err)
+				if !confirmed {
+					out.Exit("Trimming canceled.")
+				}
+				fmt.Println()
+			}
+			drr, err := adm.DeleteRecords(cmd.Context(), o)
+			out.MaybeDie(err, "unable to trim records: %v", err)
+			printDeleteRecordResponse(drr)
+		},
+	}
+
+	cmd.Flags().StringVarP(&offset, "offset", "o", "", "Offset to set the partition's start offset to (end, 47, @<timestamp>)")
+	cmd.Flags().Int32SliceVarP(&partitions, "partitions", "p", nil, "Comma-separated list of partitions to trim records from (default to all)")
+	cmd.Flags().StringVarP(&fromFile, "from-file", "f", "", "File of topic/partition/offset for which to trim offsets for")
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+
+	cmd.MarkFlagsMutuallyExclusive("from-file", "offset")
+	cmd.MarkFlagsMutuallyExclusive("from-file", "partitions")
+
+	return cmd
+}
+
+// parseOffsetArgs creates the kadm.Offsets based on the passed args via rpk
+// flags. It checks if the topic exists and defaults to all partitions in the
+// case that partitions were not provided.
+func parseOffsetArgs(ctx context.Context, adm *kadm.Client, topic, offset string, partitions []int32) (kadm.Offsets, error) {
+	var (
+		listedOffsets kadm.ListedOffsets
+		parsedOffset  int64
+		err           error
+	)
+	switch {
+	case strings.HasPrefix(offset, "@"):
+		offset = offset[1:] // strip @
+		_, startAt, end, _, err := parseTimestampBasedOffset(offset, time.Now())
+		if err != nil {
+			return nil, err
+		} else if end {
+			return nil, errors.New("invalid offset '@end'; use '--offset end' if you want to trim all")
+		}
+		listedOffsets, err = adm.ListOffsetsAfterMilli(ctx, startAt.UnixMilli(), topic)
+		if err != nil {
+			return nil, fmt.Errorf("unable to list offsets after milli %d: %v", startAt.UnixMilli(), err)
+		}
+	case offset == "end":
+		listedOffsets, err = adm.ListEndOffsets(ctx, topic)
+		if err != nil {
+			return nil, fmt.Errorf("unable to list end offset for topic %q: %v", topic, err)
+		}
+	default:
+		parsedOffset, err = strconv.ParseInt(offset, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing offset %q: %v", offset, err)
+		}
+		// If no partitions are provided, we list the topic and use every
+		// partition.
+		if len(partitions) == 0 {
+			topicDetails, err := adm.ListTopics(ctx, topic)
+			if err != nil {
+				return nil, fmt.Errorf("unable to list topic %q metadata: %v", topic, err)
+			}
+			topicDetails.EachError(func(d kadm.TopicDetail) {
+				err = fmt.Errorf("unable to list the topic %q: %v", topic, d.Err)
+			})
+			if err != nil {
+				return nil, err
+			}
+			topicDetails.EachPartition(func(pd kadm.PartitionDetail) {
+				partitions = append(partitions, pd.Partition)
+			})
+		}
+	}
+	// Same logic as above, but in this case we use the listed offset.
+	if len(partitions) == 0 {
+		listedOffsets.Each(func(lo kadm.ListedOffset) {
+			partitions = append(partitions, lo.Partition)
+		})
+	}
+	o := make(kadm.Offsets)
+	for _, p := range partitions {
+		if listedOffsets != nil {
+			l, ok := listedOffsets.Lookup(topic, p)
+			if !ok {
+				return nil, fmt.Errorf("unable to find offset %q for topic %q in partition %v: %v", offset, topic, p, err)
+			}
+			parsedOffset = l.Offset
+		}
+		o.Add(kadm.Offset{
+			Topic:     topic,
+			Partition: p,
+			At:        parsedOffset,
+		})
+	}
+	return o, nil
+}
+
+// parseOffsetFile parse the given file whether it's a json, yaml or
+// space-delimited text. File content: topic | partition | offset.
+func parseOffsetFile(fs afero.Fs, file string, args []string) (kadm.Offsets, error) {
+	parsed, err := out.ParseFileArray[struct {
+		Topic     string `yaml:"topic" json:"topic"`
+		Partition int32  `yaml:"partition" json:"partition"`
+		Offset    int64  `yaml:"offset" json:"offset"`
+	}](fs, file)
+	if err != nil {
+		// If we fail to parse a 3-column file, we attempt to parse as 2-column.
+		parsed, err := out.ParseFileArray[struct {
+			Partition int32 `yaml:"partition" json:"partition"`
+			Offset    int64 `yaml:"offset" json:"offset"`
+		}](fs, file)
+		o := make(kadm.Offsets)
+		if err != nil {
+			return nil, err
+		}
+		if len(args) == 0 {
+			return nil, fmt.Errorf("unable to get the topic; please provide it via arguments to this command or in the file provided")
+		}
+		for _, element := range parsed {
+			o.Add(kadm.Offset{
+				Topic:     args[0],
+				Partition: element.Partition,
+				At:        element.Offset,
+			})
+		}
+		return o, nil
+	}
+	o := make(kadm.Offsets)
+	for _, element := range parsed {
+		if len(args) > 0 && args[0] != element.Topic {
+			return nil, fmt.Errorf("unable to parse the topic; the file contains the topic %q that is different of the argument provided %q", element.Topic, args[0])
+		}
+		o.Add(kadm.Offset{
+			Topic:     element.Topic,
+			Partition: element.Partition,
+			At:        element.Offset,
+		})
+	}
+	return o, nil
+}
+
+// printDeleteRecordRequest prints the passed kadm.Offsets (used for the
+// deleteRecords request). It finds the start offset so the user can see what's
+// the change that is being done, it also finds the hwm for when the user passes
+// the '--offset end' flag.
+func printDeleteRecordRequest(ctx context.Context, adm *kadm.Client, o kadm.Offsets) (rerr error) {
+	// We get the start Offset for every topic.
+	listStartOffsets, err := adm.ListStartOffsets(ctx, o.TopicsSet().Topics()...)
+	if err == nil {
+		err = listStartOffsets.Error()
+	}
+	if err != nil {
+		return fmt.Errorf("unable to list start offset for the topic(s) %v: %v", o.TopicsSet().Topics(), err)
+	}
+	tw := out.NewTable("TOPIC", "PARTITION", "PRIOR-START-OFFSET", "NEW-START-OFFSET")
+	o.Each(func(offset kadm.Offset) {
+		lso, ok := listStartOffsets.Lookup(offset.Topic, offset.Partition)
+		if !ok {
+			rerr = fmt.Errorf("unable to find the start offset for the topic %q and partition %v", offset.Topic, offset.Partition)
+			return
+		}
+		tw.Print(offset.Topic, offset.Partition, lso.Offset, offset.At)
+	})
+	if rerr == nil {
+		tw.Flush()
+	}
+	return rerr
+}
+
+func printDeleteRecordResponse(drr kadm.DeleteRecordsResponses) {
+	tw := out.NewTable("TOPIC", "PARTITION", "NEW-START-OFFSET", "ERROR")
+	defer tw.Flush()
+
+	drr.Each(func(r kadm.DeleteRecordsResponse) {
+		if r.Err != nil {
+			tw.Print(r.Topic, r.Partition, "-", r.Err)
+		} else {
+			tw.Print(r.Topic, r.Partition, r.LowWatermark, "")
+		}
+	})
+}

--- a/src/go/rpk/pkg/cli/topic/trim_test.go
+++ b/src/go/rpk/pkg/cli/topic/trim_test.go
@@ -1,0 +1,102 @@
+package topic
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+func Test_parseOffsetFile(t *testing.T) {
+	o0 := kadm.Offset{
+		Topic:     "foo",
+		Partition: 0,
+		At:        1,
+	}
+	o2 := kadm.Offset{
+		Topic:     "foo-2",
+		Partition: 2,
+		At:        3,
+	}
+	expBoth := kadm.Offsets{
+		"foo":   map[int32]kadm.Offset{0: o0},
+		"foo-2": map[int32]kadm.Offset{2: o2},
+	}
+	for _, tt := range []struct {
+		name     string
+		fileName string
+		content  string
+		args     []string
+		exp      kadm.Offsets
+		expErr   bool
+	}{
+		{
+			name:     "parse text file - no extension",
+			fileName: "/tmp/noExtension",
+			content:  "foo 0 1\nfoo-2 2 3",
+			exp:      expBoth,
+		},
+		{
+			name:     "parse text file - extension",
+			fileName: "/tmp/noExtension.txt",
+			content:  "foo 0 1\nfoo-2 2 3",
+			exp:      expBoth,
+		},
+		{
+			name:     "parse 2-column text file",
+			fileName: "/tmp/noExtension",
+			args:     []string{"foo"},
+			content:  "0 1\n2 3",
+			exp: kadm.Offsets{
+				"foo": map[int32]kadm.Offset{0: o0, 2: {Topic: "foo", Partition: 2, At: 3}},
+			},
+		},
+		{
+			name:     "parse json file",
+			fileName: "/tmp/in.json",
+			content:  `[{"topic":"foo","partition":0,"offset":1},{ "topic":"foo-2","partition":2,"offset":3}]`,
+			exp:      expBoth,
+		},
+		{
+			name:     "parse yaml file",
+			fileName: "/tmp/in.yaml",
+			content: `
+- topic: foo
+  partition: 0
+  offset: 1
+- topic: foo-2
+  partition: 2
+  offset: 3
+`,
+			exp: expBoth,
+		},
+		{
+			name:     "invalid types",
+			fileName: "/tmp/noExtension",
+			content:  "1 zero 1\nfoo-2 two 3",
+			expErr:   true,
+		},
+		{
+			name:     "err 3-column and mismatch arg",
+			fileName: "/tmp/noExtension",
+			args:     []string{"foo"},
+			content:  "foo 0 1\nfoo-2 2 3",
+			expErr:   true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			err := afero.WriteFile(fs, tt.fileName, []byte(tt.content), 0o777)
+			require.NoError(t, err)
+
+			got, err := parseOffsetFile(fs, tt.fileName, tt.args)
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.exp, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces the new command `rpk topic trim-prefix` that supports the DeleteRecords admin request

Fixes #11781

### Usage and Help Text
**Full Help Text**
```
$ rpk topic trim-prefix --help
Trim records from topics

This command allows you to trim records from topics, to trim the topics Redpanda
sets the LogStartOffset for partitions to the requested offset. All segments 
whose max partition is before the requested offset are deleted, and any records 
within the segment before the requested offset can no longer be read.

The --offset/-o flag allows you to indicate which index you want to set the 
partition's low watermark (start offset) to. It can be a single integer value 
denoting the offset or a timestamp if you prefix the offset with an '@'. You may
select which partition you want to trim the offset from with the --partition/-p 
flag.

The --from-file option allows to trim the offsets specified in a text file with
the following format:
    [TOPIC] [PARTITION] [OFFSET]
    [TOPIC] [PARTITION] [OFFSET]
    ...
or the equivalent keyed JSON/YAML file.

EXAMPLES

Trim records in 'foo' topic to offset 120 in partition 1
    rpk topic trim-prefix foo --offset 120 --partition 1

Trim records in all partitions of topic foo previous to an specific timestamp
    rpk topic trim-prefix foo -o "@1622505600"

Trim records from a JSON file
    rpk topic trim-prefix --from-file /tmp/to_trim.json

Usage:
  rpk topic trim-prefix [TOPIC] [flags]

Aliases:
  trim-prefix, trim

Flags:
  -f, --from-file string   File of topic/partition/offset for which to trim offsets for
  -h, --help               Help for trim-prefix
      --no-confirm         Disable confirmation prompt
  -o, --offset string      Offset to set the partition's low watermark (start offset) to
  -p, --partitions ints    Comma-separated list of partitions to trim records from (default to all)
      --to-hwm             Set the partition's low watermark to the partition's high watermark (trim all)
```

The command prompts for confirmation when a deletion request is issued:
```
$ rpk topic trim-prefix test --offset 50 
TOPIC  PARTITION  PRIOR-START-OFFSET  NEW-START-OFFSET
test   0          48                  50

? Confirm trimming of the above offsets? Yes

TOPIC  PARTITION  NEW-START-OFFSET  ERROR
test   0          50
```

You may use a text/JSON/YAML file to trim multiple topics/offsets/partitions at the same time:
_This example contains an example of error handling when multiple requests are done at the same time_
```
$ cat /tmp/asJson.json
[
    {
        "topic":"test",
        "partition":0,
        "offset":50
    }, 
    {
        "topic":"test-2",
        "partition":0,
        "offset":7
    }
]

$ rpk topic trim-prefix --from-file /tmp/asJson.json
TOPIC   PARTITION  PRIOR-START-OFFSET  NEW-START-OFFSET
test    0          50                  50
test-2  0          6                   7

? Confirm trimming of the above offsets? Yes

TOPIC   PARTITION  NEW-START-OFFSET  ERROR
test-2  0          7                 
test    0          -                 OFFSET_OUT_OF_RANGE: The requested offset is not within the range of offsets maintained by the server.
```

It also supports passing specific timestamps to the`--offset` flag:
```
# Producing to a specific A timestamp
$ echo "k0,v0,1669856400000" | rpk topic produce test -f '%k,%v,%d\n'
Produced to partition 0 at offset 48 with timestamp 1669856400000.

# Producing to a specific B timestamp
$ echo "k0,v0,1669860400000" | rpk topic produce test -f '%k,%v,%d\n'
Produced to partition 0 at offset 49 with timestamp 1669860400000.

# Trimming exactly at A, gives the offset of A
$ rpk topic trim test -o "@1669856400000"
TOPIC  PARTITION  PRIOR-START-OFFSET  NEW-START-OFFSET
test   0          48                  48

# Trimming between A and B, gives the offset of B
$ rpk topic trim test -o "@1669856400002"
TOPIC  PARTITION  PRIOR-START-OFFSET  NEW-START-OFFSET
test   0          48                  49

# Trimming to a recent timestamp where there are no offsets, gives you the high water mark
rpk topic trim test -o "@-2h"          
TOPIC  PARTITION  PRIOR-START-OFFSET  NEW-START-OFFSET
test   0          48                  50
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Features

* rpk: adds `rpk topic trim-prefix`, rpk support for the DeleteRecords request. Now you can trim records to a specific offset in the given topic/partition.