### PR TITLE
e2e_shadow_indexing_test: bump timeout for workload

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -755,6 +755,7 @@ class RedpandaServiceBase(Service):
     COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT,
                                             "redpanda.profraw")
     DEFAULT_NODE_READY_TIMEOUT_SEC = 20
+    DEFAULT_CLOUD_STORAGE_SCRUB_TIMEOUT_SEC = 60
     DEDICATED_NODE_KEY = "dedicated_nodes"
     RAISE_ON_ERRORS_KEY = "raise_on_error"
     LOG_LEVEL_KEY = "redpanda_log_level"
@@ -1872,7 +1873,8 @@ class RedpandaService(RedpandaServiceBase):
                  skip_if_no_redpanda_log: bool = False,
                  pandaproxy_config: Optional[PandaproxyConfig] = None,
                  schema_registry_config: Optional[SchemaRegistryConfig] = None,
-                 disable_cloud_storage_diagnostics=False):
+                 disable_cloud_storage_diagnostics=False,
+                 cloud_storage_scrub_timeout_s=None):
         super(RedpandaService, self).__init__(
             context,
             num_brokers,
@@ -1893,6 +1895,10 @@ class RedpandaService(RedpandaServiceBase):
         if node_ready_timeout_s is None:
             node_ready_timeout_s = RedpandaService.DEFAULT_NODE_READY_TIMEOUT_SEC
         self.node_ready_timeout_s = node_ready_timeout_s
+
+        if cloud_storage_scrub_timeout_s is None:
+            cloud_storage_scrub_timeout_s = RedpandaService.DEFAULT_CLOUD_STORAGE_SCRUB_TIMEOUT_SEC
+        self.cloud_storage_scrub_timeout_s = cloud_storage_scrub_timeout_s
 
         self._extra_node_conf = {}
         for node in self.nodes:
@@ -4084,7 +4090,8 @@ class RedpandaService(RedpandaServiceBase):
         # flushing data to remote storage.
         self.stop()
 
-        report = self._get_object_storage_report(timeout=run_timeout)
+        scrub_timeout = max(run_timeout, self.cloud_storage_scrub_timeout_s)
+        report = self._get_object_storage_report(timeout=scrub_timeout)
 
         # It is legal for tiered storage to leak objects under
         # certain circumstances: this will remain the case until

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -882,6 +882,8 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
                                        self.topic,
                                        msg_size=1024,
                                        msg_count=10 * 1000 * 1000,
+                                       rate_limit_bps=256 *
+                                       self.small_segment_size,
                                        custom_node=self.preallocated_nodes)
         producer.start()
         try:
@@ -914,6 +916,8 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
                                        self.topic,
                                        msg_size=1024,
                                        msg_count=10 * 1000 * 1000,
+                                       rate_limit_bps=256 *
+                                       self.small_segment_size,
                                        custom_node=self.preallocated_nodes)
         producer.start()
         try:

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -885,8 +885,8 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
         try:
             wait_until(
                 lambda: nodes_report_cloud_segments(self.redpanda, 128 * 200),
-                timeout_sec=120,
-                backoff_sec=3)
+                timeout_sec=300,
+                backoff_sec=5)
         finally:
             producer.stop()
             producer.wait()

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -856,7 +856,9 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
                 'cloud_storage_cache_chunk_size': self.chunk_size,
             },
             environment={'__REDPANDA_TOPIC_REC_DL_CHECK_MILLIS': 5000},
-            si_settings=si_settings)
+            si_settings=si_settings,
+            # These tests write many objects; set a higher scrub timeout.
+            cloud_storage_scrub_timeout_s=120)
         self.kafka_tools = KafkaCliTools(self.redpanda)
 
     def setUp(self):


### PR DESCRIPTION
Empirically, segments may be uploaded ~1/partition/sec, particularly on dockeriszed environments. Thus, the current timeout for the number of segments we want to generate is flaky.

Fixes #11268

Also fixes slow scrubbing, from when there are too many segments to analyze in 30s.

Fixes #11698

Remaining flakiness appears to be fixed by https://github.com/redpanda-data/redpanda/pull/12756
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
