### PR TITLE
tests: avoid unnecessary `du` calls on cache dir

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3198,7 +3198,9 @@ class RedpandaService(RedpandaServiceBase):
         ]
         if sizes:
             cmd.append("--sizes")
-        output = node.account.ssh_output(shlex.join(cmd), timeout_sec=10)
+        output = node.account.ssh_output(shlex.join(cmd),
+                                         combine_stderr=False,
+                                         timeout_sec=10)
         namespaces = json.loads(output)
         for ns, topics in namespaces.items():
             ns_path = os.path.join(store.data_dir, ns)
@@ -3219,14 +3221,16 @@ class RedpandaService(RedpandaServiceBase):
                 store.cache_dir):
             bytes = int(
                 node.account.ssh_output(
-                    f"du -s \"{store.cache_dir}\"").strip().split()[0])
+                    f"du -s \"{store.cache_dir}\"",
+                    combine_stderr=False).strip().split()[0])
             objects = int(
                 node.account.ssh_output(
-                    f"find \"{store.cache_dir}\" -type f | wc -l").strip())
+                    f"find \"{store.cache_dir}\" -type f | wc -l",
+                    combine_stderr=False).strip())
             indices = int(
                 node.account.ssh_output(
-                    f"find \"{store.cache_dir}\" -type f -name \"*.index\" | wc -l"
-                ).strip())
+                    f"find \"{store.cache_dir}\" -type f -name \"*.index\" | wc -l",
+                    combine_stderr=False).strip())
             store.set_cache_stats(NodeCacheStorage(bytes, objects, indices))
 
         self.logger.debug(

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -90,7 +90,7 @@ def wait_until_result(condition, *args, **kwargs):
 
 
 def segments_count(redpanda, topic, partition_idx):
-    storage = redpanda.storage()
+    storage = redpanda.storage(scan_cache=False)
     topic_partitions = storage.partitions("kafka", topic)
 
     return map(
@@ -178,8 +178,9 @@ def wait_for_removal_of_n_segments(redpanda, topic: str, partition_idx: int,
     :param original_snapshot: snapshot of segments to compare against
     """
     def segments_removed():
-        current_snapshot = redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", topic, partition_idx)
+        current_snapshot = redpanda.storage(all_nodes=True,
+                                            scan_cache=False).segments_by_node(
+                                                "kafka", topic, partition_idx)
 
         redpanda.logger.debug(
             f"Current segment snapshot for topic {topic}: {pprint.pformat(current_snapshot, indent=1)}"
@@ -231,7 +232,7 @@ def wait_for_local_storage_truncate(redpanda,
     sizes: list[int] = []
 
     def is_truncated():
-        storage = redpanda.storage(sizes=True)
+        storage = redpanda.storage(sizes=True, scan_cache=False)
         nonlocal sizes
         sizes = []
         for node_partition in storage.partitions("kafka", topic):


### PR DESCRIPTION
For unknown reasons, `du` is failing sometimes when run concurrently with tiered storage reads.

In the contexts where it is used mid-test, we generally do not care about cache sizes, so just avoid doing the check.

Also fix these remote command executions to separate stderr from stdout, so that if they do fail we get a more descriptive error.  Issue https://github.com/redpanda-data/redpanda/issues/11665 also had one of these enigmatic remote command failures where we can't see stderr.

Fixes: https://github.com/redpanda-data/redpanda/issues/11815

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
