### PR TITLE
Fixed returning `log_end_offset` for empty local logs

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -489,7 +489,7 @@ result<partition_info> replicated_partition::get_partition_info() const {
     ret.replicas.push_back(replica_info{
       .id = _partition->raft()->self().id(),
       .high_watermark = high_watermark(),
-      .log_end_offset = log_dirty_offset(),
+      .log_end_offset = log_end_offset(),
       .is_alive = true,
     });
 


### PR DESCRIPTION
In Kafka the semantics of `log_end_offset` is defined as a next offset assigned to a record produced to a given partition.

When local log is empty its `dirty_offset` is equal to `start_offset - 1`. In this case a `log_end_offset` should return Kafka offset corresponding to the `start_offset` as this is the next offset assigned to a record produced to given topic partition.

Fixes: #11403 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- gracefully handles listing offsets and fetching from a completely empty log