### PR TITLE
Fixed applying messages to stm when using `acks=0` or `acks=1`

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -800,7 +800,7 @@ ss::future<> archival_metadata_stm::apply(model::record_batch b) {
     _manifest->advance_insync_offset(b.last_offset());
 }
 
-ss::future<> archival_metadata_stm::handle_eviction() {
+ss::future<> archival_metadata_stm::handle_raft_snapshot() {
     cloud_storage::partition_manifest new_manifest{
       _manifest->get_ntp(), _manifest->get_revision_id()};
 

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -237,7 +237,7 @@ private:
     do_replicate_commands(model::record_batch, ss::abort_source&);
 
     ss::future<> apply(model::record_batch batch) override;
-    ss::future<> handle_eviction() override;
+    ss::future<> handle_raft_snapshot() override;
 
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -200,7 +200,7 @@ ss::future<stm_snapshot> id_allocator_stm::take_snapshot() {
       std::logic_error("id_allocator_stm doesn't support snapshots"));
 }
 
-ss::future<> id_allocator_stm::handle_eviction() {
+ss::future<> id_allocator_stm::handle_raft_snapshot() {
     _next_snapshot = _c->start_offset();
     _processed = 0;
     set_next(_next_snapshot);

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -100,7 +100,7 @@ private:
     ss::future<> write_snapshot();
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
-    ss::future<> handle_eviction() override;
+    ss::future<> handle_raft_snapshot() override;
     ss::future<bool> sync(model::timeout_clock::duration);
 
     mutex _lock;

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -336,7 +336,7 @@ ss::future<> log_eviction_stm::apply(model::record_batch batch) {
     }
 }
 
-ss::future<> log_eviction_stm::handle_eviction() {
+ss::future<> log_eviction_stm::handle_raft_snapshot() {
     /// In the case there is a gap detected in the log, the only path
     /// forward is to read the raft snapshot and begin processing from the
     /// raft last_snapshot_index

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -116,7 +116,7 @@ private:
     ss::future<> do_write_raft_snapshot(model::offset);
     ss::future<> write_raft_snapshots_in_background();
     ss::future<> apply(model::record_batch) override;
-    ss::future<> handle_eviction() override;
+    ss::future<> handle_raft_snapshot() override;
 
     ss::future<offset_result> replicate_command(
       model::record_batch batch,

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -3118,7 +3118,7 @@ ss::future<> rm_stm::do_remove_persistent_state() {
     co_return co_await persisted_stm::remove_persistent_state();
 }
 
-ss::future<> rm_stm::handle_eviction() {
+ss::future<> rm_stm::handle_raft_snapshot() {
     return _state_lock.hold_write_lock().then(
       [this]([[maybe_unused]] ss::basic_rwlock<>::holder unit) {
           _log_state.reset();

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -436,7 +436,7 @@ public:
     uint64_t get_snapshot_size() const override;
 
 protected:
-    ss::future<> handle_eviction() override;
+    ss::future<> handle_raft_snapshot() override;
 
 private:
     void setup_metrics();

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -1120,7 +1120,7 @@ tm_stm::expire_tx(model::term_id term, kafka::transactional_id tx_id) {
     co_return r0.error();
 }
 
-ss::future<> tm_stm::handle_eviction() {
+ss::future<> tm_stm::handle_raft_snapshot() {
     return _cache->write_lock().then(
       [this]([[maybe_unused]] ss::basic_rwlock<>::holder unit) {
           _cache->clear_log();

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -205,7 +205,7 @@ public:
     }
 
 protected:
-    ss::future<> handle_eviction() override;
+    ss::future<> handle_raft_snapshot() override;
 
 private:
     std::optional<tm_transaction> find_tx(kafka::transactional_id);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1282,216 +1282,190 @@ ss::future<> consensus::start() {
 }
 
 ss::future<> consensus::do_start() {
-    vlog(_ctxlog.info, "Starting");
-    return _op_lock
-      .with([this] {
-          read_voted_for();
+    try {
+        auto u = co_await _op_lock.get_units();
 
-          /*
-           * temporary workaround:
-           *
-           * if the group's ntp matches the pattern, then do not load the
-           * initial configuration snapshto from the keyvalue store. more info
-           * here:
-           *
-           * https://github.com/redpanda-data/redpanda/issues/1870
-           */
-          const auto& ntp = _log.config().ntp();
-          const auto normalized_ntp = fmt::format(
-            "{}.{}.{}", ntp.ns(), ntp.tp.topic(), ntp.tp.partition());
-          const auto& patterns = config::shard_local_cfg()
-                                   .full_raft_configuration_recovery_pattern();
-          auto initial_state = std::any_of(
-            patterns.cbegin(),
-            patterns.cend(),
-            [&normalized_ntp](const ss::sstring& pattern) {
-                return pattern == "*" || normalized_ntp.starts_with(pattern);
-            });
-          if (!initial_state) {
-              initial_state = is_initial_state();
-          }
+        read_voted_for();
 
-          vlog(
-            _ctxlog.info,
-            "Starting with voted_for {} term {} initial_state {}",
-            _voted_for,
-            _term,
-            initial_state);
+        /*
+         * temporary workaround:
+         *
+         * if the group's ntp matches the pattern, then do not load the
+         * initial configuration snapshot from the keyvalue store. more info
+         * here:
+         *
+         * https://github.com/redpanda-data/redpanda/issues/1870
+         */
+        const auto& ntp = _log.config().ntp();
+        const auto normalized_ntp = fmt::format(
+          "{}.{}.{}", ntp.ns(), ntp.tp.topic(), ntp.tp.partition());
+        const auto& patterns = config::shard_local_cfg()
+                                 .full_raft_configuration_recovery_pattern();
+        auto initial_state = std::any_of(
+          patterns.cbegin(),
+          patterns.cend(),
+          [&normalized_ntp](const ss::sstring& pattern) {
+              return pattern == "*" || normalized_ntp.starts_with(pattern);
+          });
+        if (!initial_state) {
+            initial_state = is_initial_state();
+        }
 
-          return _configuration_manager.start(initial_state, _self.revision())
-            .then([this] {
-                vlog(
-                  _ctxlog.trace,
-                  "Configuration manager started: {}",
-                  _configuration_manager);
-            })
-            .then([this, initial_state] {
-                offset_translator::must_reset must_reset{initial_state};
+        vlog(
+          _ctxlog.info,
+          "Starting with voted_for {} term {} initial_state {}",
+          _voted_for,
+          _term,
+          initial_state);
 
-                absl::btree_map<model::offset, int64_t> offset2delta;
-                for (auto it = _configuration_manager.begin();
-                     it != _configuration_manager.end();
-                     ++it) {
-                    offset2delta.emplace(it->first, it->second.idx());
-                }
+        co_await _configuration_manager.start(initial_state, _self.revision());
 
-                auto bootstrap = offset_translator::bootstrap_state{
-                  .offset2delta = std::move(offset2delta),
-                  .highest_known_offset
-                  = _configuration_manager.get_highest_known_offset(),
-                };
+        vlog(
+          _ctxlog.trace,
+          "Configuration manager started: {}",
+          _configuration_manager);
+        offset_translator::must_reset must_reset{initial_state};
 
-                return _offset_translator.start(
-                  must_reset, std::move(bootstrap));
-            })
-            .then([this] {
-                return _snapshot_lock.with(
-                  [this] { return hydrate_snapshot(); });
-            })
-            .then([this] {
-                vlog(
-                  _ctxlog.debug,
-                  "Starting raft bootstrap from {}",
-                  _configuration_manager.get_highest_known_offset());
-                return details::read_bootstrap_state(
-                  _log,
-                  model::next_offset(
-                    _configuration_manager.get_highest_known_offset()),
-                  _as);
-            })
-            .then([this](configuration_bootstrap_state st) {
-                auto lstats = _log.offsets();
+        absl::btree_map<model::offset, int64_t> offset2delta;
+        for (const auto& it : _configuration_manager) {
+            offset2delta.emplace(it.first, it.second.idx());
+        }
 
-                vlog(_ctxlog.info, "Read bootstrap state: {}", st);
-                vlog(_ctxlog.info, "Current log offsets: {}", lstats);
+        auto bootstrap = offset_translator::bootstrap_state{
+          .offset2delta = std::move(offset2delta),
+          .highest_known_offset
+          = _configuration_manager.get_highest_known_offset(),
+        };
 
-                // if log term is newer than the one comming from voted_for
-                // state, we reset voted_for state
-                if (lstats.dirty_offset_term > _term) {
-                    _term = lstats.dirty_offset_term;
-                    _voted_for = {};
-                }
-                /**
-                 * since we are starting, there were no new writes to the log
-                 * before that point. It is safe to use dirty offset as a
-                 * initial flushed offset since it is equal to last offset that
-                 * exists on disk and was read in log recovery process.
-                 */
-                _flushed_offset = lstats.dirty_offset;
-                /**
-                 * The configuration manager state may be divereged from the log
-                 * state, as log is flushed lazily, we have to make sure that
-                 * the log and configuration manager has exactly the same
-                 * offsets range
-                 */
-                vlog(
-                  _ctxlog.info,
-                  "Truncating configurations at {}",
-                  lstats.dirty_offset);
+        co_await _offset_translator.start(must_reset, std::move(bootstrap));
 
-                auto f = _configuration_manager.truncate(
-                  model::next_offset(lstats.dirty_offset));
+        co_await _snapshot_lock.with([this] { return hydrate_snapshot(); });
 
-                /**
-                 * We read some batches from the log and have to update the
-                 * configuration manager.
-                 */
-                if (st.config_batches_seen() > 0) {
-                    f = f.then([this, st = std::move(st)]() mutable {
-                        return _configuration_manager.add(
-                          std::move(st).release_configurations());
-                    });
-                }
+        vlog(
+          _ctxlog.debug,
+          "Starting raft bootstrap from {}",
+          _configuration_manager.get_highest_known_offset());
+        auto st = co_await details::read_bootstrap_state(
+          _log,
+          model::next_offset(_configuration_manager.get_highest_known_offset()),
+          _as);
 
-                return f.then([this] {
-                    update_follower_stats(_configuration_manager.get_latest());
-                });
-            })
-            .then(
-              [this] { return _offset_translator.sync_with_log(_log, _as); })
-            .then([this] {
-                /**
-                 * fix for incorrectly persisted configuration index. In
-                 * previous version of redpanda due to the issue with
-                 * incorrectly assigned raft configuration indicies
-                 * (https://github.com/redpanda-data/redpanda/issues/2326) there
-                 * may be a persistent corruption in offset translation caused
-                 * by incorrectly persited configuration index. It may cause log
-                 * offset to be negative. Here we check if this problem exists
-                 * and if so apply necessary offset translation.
-                 */
-                const auto so = start_offset();
-                // no prefix truncation was applied we do not need adjustment
-                if (so <= model::offset(0)) {
-                    return ss::now();
-                }
-                auto delta = _configuration_manager.offset_delta(
-                  start_offset());
+        const auto lstats = _log.offsets();
 
-                if (so >= delta) {
-                    return ss::now();
-                }
-                // if start offset is smaller than offset delta we need to apply
-                // adjustment
-                const configuration_manager::configuration_idx new_idx(so());
-                vlog(
-                  _ctxlog.info,
-                  "adjusting configuration index, current start offset: {}, "
-                  "delta: {}, new initial index: {}",
-                  so,
-                  delta,
-                  new_idx);
-                return _configuration_manager.adjust_configuration_idx(new_idx);
-            })
-            .then([this] {
-                auto next_election = clock_type::now();
-                // set last heartbeat timestamp to prevent skipping first
-                // election
-                _hbeat = clock_type::time_point::min();
-                auto conf
-                  = _configuration_manager.get_latest().current_config();
-                if (!conf.voters.empty() && _self == conf.voters.front()) {
-                    // Arm immediate election for single node scenarios
-                    // or for the very first start of the preferred leader
-                    // in a multi-node group.  Otherwise use standard election
-                    // timeout.
-                    if (conf.voters.size() > 1 && _term > model::term_id{0}) {
-                        next_election += _jit.next_duration();
-                    }
-                } else {
-                    // current node is not a preselected leader, add 2x jitter
-                    // to give opportunity to the preselected leader to win
-                    // the first round
-                    next_election += _jit.base_duration()
-                                     + 2 * _jit.next_jitter_duration();
-                }
-                if (!_bg.is_closed()) {
-                    _vote_timeout.rearm(next_election);
-                }
-            })
-            .then([this] {
-                auto last_applied = read_last_applied();
-                if (last_applied > _commit_index) {
-                    _commit_index = last_applied;
-                    maybe_update_last_visible_index(_commit_index);
-                    vlog(
-                      _ctxlog.trace,
-                      "Recovered commit_index: {}",
-                      _commit_index);
-                }
-            })
-            .then([this] { return _event_manager.start(); })
-            .then([this] { _append_requests_buffer.start(); })
-            .then([this] {
-                vlog(
-                  _ctxlog.info,
-                  "started raft, log offsets: {}, term: {}, configuration: {}",
-                  _log.offsets(),
-                  _term,
-                  _configuration_manager.get_latest());
-            });
-      })
-      .handle_exception_type([](const ss::broken_semaphore&) {});
+        vlog(
+          _ctxlog.info,
+          "Current log offsets: {}, read bootstrap state: {}",
+          lstats,
+          st);
+
+        // if log term is newer than the one coming from voted_for
+        // state, we reset voted_for state
+        if (lstats.dirty_offset_term > _term) {
+            _term = lstats.dirty_offset_term;
+            _voted_for = {};
+        }
+        /**
+         * since we are starting, there were no new writes to the log
+         * before that point. It is safe to use dirty offset as a
+         * initial flushed offset since it is equal to last offset that
+         * exists on disk and was read in log recovery process.
+         */
+        _flushed_offset = lstats.dirty_offset;
+        /**
+         * The configuration manager state may be divereged from the log
+         * state, as log is flushed lazily, we have to make sure that
+         * the log and configuration manager has exactly the same
+         * offsets range
+         */
+        vlog(
+          _ctxlog.info, "Truncating configurations at {}", lstats.dirty_offset);
+
+        co_await _configuration_manager.truncate(
+          model::next_offset(lstats.dirty_offset));
+
+        /**
+         * We read some batches from the log and have to update the
+         * configuration manager.
+         */
+        if (st.config_batches_seen() > 0) {
+            co_await _configuration_manager.add(
+              std::move(st).release_configurations());
+        }
+
+        update_follower_stats(_configuration_manager.get_latest());
+
+        co_await _offset_translator.sync_with_log(_log, _as);
+
+        /**
+         * fix for incorrectly persisted configuration index. In
+         * previous version of redpanda due to the issue with
+         * incorrectly assigned raft configuration indicies
+         * (https://github.com/redpanda-data/redpanda/issues/2326) there
+         * may be a persistent corruption in offset translation caused
+         * by incorrectly persited configuration index. It may cause log
+         * offset to be negative. Here we check if this problem exists
+         * and if so apply necessary offset translation.
+         */
+        const auto so = start_offset();
+        const auto delta = _configuration_manager.offset_delta(start_offset());
+        // no prefix truncation was applied we do not need adjustment
+        if (so > model::offset(0) || so < delta) {
+            // if start offset is smaller than offset delta we need to apply
+            // adjustment
+            const configuration_manager::configuration_idx new_idx(so());
+            vlog(
+              _ctxlog.info,
+              "adjusting configuration index, current start offset: {}, "
+              "delta: {}, new initial index: {}",
+              so,
+              delta,
+              new_idx);
+            co_await _configuration_manager.adjust_configuration_idx(new_idx);
+        }
+
+        auto next_election = clock_type::now();
+        // set last heartbeat timestamp to prevent skipping first
+        // election
+        _hbeat = clock_type::time_point::min();
+        auto conf = _configuration_manager.get_latest().current_config();
+        if (!conf.voters.empty() && _self == conf.voters.front()) {
+            // Arm immediate election for single node scenarios
+            // or for the very first start of the preferred leader
+            // in a multi-node group.  Otherwise use standard election
+            // timeout.
+            if (conf.voters.size() > 1 && _term > model::term_id{0}) {
+                next_election += _jit.next_duration();
+            }
+        } else {
+            // current node is not a preselected leader, add 2x jitter
+            // to give opportunity to the preselected leader to win
+            // the first round
+            next_election += _jit.base_duration()
+                             + 2 * _jit.next_jitter_duration();
+        }
+        if (!_bg.is_closed()) {
+            _vote_timeout.rearm(next_election);
+        }
+
+        auto last_applied = read_last_applied();
+        if (last_applied > _commit_index) {
+            _commit_index = last_applied;
+            maybe_update_last_visible_index(_commit_index);
+            vlog(_ctxlog.trace, "Recovered commit_index: {}", _commit_index);
+        }
+
+        co_await _event_manager.start();
+        _append_requests_buffer.start();
+
+        vlog(
+          _ctxlog.info,
+          "started raft, log offsets: {}, term: {}, configuration: {}",
+          lstats,
+          _term,
+          _configuration_manager.get_latest());
+
+    } catch (ss::broken_semaphore&) {
+    }
 }
 
 ss::future<>

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -33,6 +33,7 @@
 #include "rpc/types.h"
 #include "ssx/future-util.h"
 #include "storage/api.h"
+#include "storage/kvstore.h"
 #include "vlog.h"
 
 #include <seastar/core/condition-variable.hh>
@@ -1447,11 +1448,29 @@ ss::future<> consensus::do_start() {
             _vote_timeout.rearm(next_election);
         }
 
-        auto last_applied = read_last_applied();
-        if (last_applied > _commit_index) {
-            _commit_index = last_applied;
-            maybe_update_last_visible_index(_commit_index);
-            vlog(_ctxlog.trace, "Recovered commit_index: {}", _commit_index);
+        auto const last_applied = read_last_applied();
+        if (last_applied > lstats.dirty_offset) {
+            vlog(
+              _ctxlog.error,
+              "Inconsistency detected between KVStore last_applied offset({}) "
+              "and log end offset ({}).  If the storage directory was not "
+              "modified intentionally, this is a bug. Raft in initial state: "
+              "{}",
+              last_applied,
+              lstats.dirty_offset,
+              initial_state);
+        }
+
+        if (initial_state) {
+            co_await _storage.kvs().remove(
+              storage::kvstore::key_space::consensus, last_applied_key());
+        } else {
+            if (last_applied > _commit_index) {
+                _commit_index = last_applied;
+                maybe_update_last_visible_index(_commit_index);
+                vlog(
+                  _ctxlog.trace, "Recovered commit_index: {}", _commit_index);
+            }
         }
 
         co_await _event_manager.start();

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -163,7 +163,7 @@ private:
 
     ss::future<> apply(model::record_batch b) final;
     ss::future<> do_apply(model::record_batch b);
-    ss::future<> handle_eviction() final;
+    ss::future<> handle_raft_snapshot() final;
 
     // called after a batch is applied
     virtual ss::future<> on_batch_applied() { return ss::now(); }
@@ -424,7 +424,7 @@ ss::future<> mux_state_machine<T...>::do_apply(model::record_batch b) {
 
 template<typename... T>
 requires(State<T>, ...)
-ss::future<> mux_state_machine<T...>::handle_eviction() {
+ss::future<> mux_state_machine<T...>::handle_raft_snapshot() {
     // We end up here if the last applied offset of the state machine is less
     // than the raft log start offset (this can happen during startup or when an
     // out-of-date node re-joins the cluster). To continue making progress the

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -39,7 +39,7 @@ void state_machine::set_next(model::offset offset) {
     _waiters.notify(model::prev_offset(offset));
 }
 
-ss::future<> state_machine::handle_eviction() {
+ss::future<> state_machine::handle_raft_snapshot() {
     vlog(
       _log.warn,
       "{} state_machine should support handle_eviction",
@@ -123,7 +123,7 @@ ss::future<> state_machine::apply() {
       .then([this] {
           auto f = ss::now();
           if (_next < _raft->start_offset()) {
-              f = handle_eviction();
+              f = handle_raft_snapshot();
           }
           return f.then([this] {
               /**

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -79,6 +79,15 @@ state_machine::batch_applicator::operator()(model::record_batch batch) {
           ss::stop_iteration::yes);
     }
 
+    const auto committed_offset = _machine->_raft->committed_offset();
+    vassert(
+      batch.last_offset() <= committed_offset,
+      "Can not apply not committed batches to stm [{}]. Applied batch "
+      "header: {}, raft committed offset: {}",
+      _machine->_raft->ntp(),
+      batch.header(),
+      committed_offset);
+
     auto last_offset = batch.last_offset();
     return _machine->apply(std::move(batch)).then([this, last_offset] {
         _machine->_next = model::next_offset(last_offset);
@@ -127,10 +136,10 @@ ss::future<> state_machine::apply() {
           }
           return f.then([this] {
               /**
-               * Raft make_reader method allows callers reading up to last_visible
-               * index. In order to make the STMs safe and working with the raft
-               * semantics (i.e. what is applied must be comitted) we have to
-               * limit reading to the committed offset.
+               * Raft make_reader method allows callers reading up to
+               * last_visible index. In order to make the STMs safe and working
+               * with the raft semantics (i.e. what is applied must be comitted)
+               * we have to limit reading to the committed offset.
                */
               storage::log_reader_config config(
                 _next, _raft->committed_offset(), _io_prio);

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -112,7 +112,7 @@ public:
 
 protected:
     void set_next(model::offset offset);
-    virtual ss::future<> handle_eviction();
+    virtual ss::future<> handle_raft_snapshot();
 
     model::offset last_applied_offset() const {
         return model::prev_offset(_next);


### PR DESCRIPTION
Since Redpanda stms are using the Raft protocol semantics we must adhere to the same semantics even when using `acks=1` or `acks=0`. This PR protects the STM from reading beyond the `raft::committed_offset()`. Previously it was possible for the STM to read up to visible index. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixed stms interoperation with relaxed consistency semantics
