### PR TITLE
cloud_storage: fix a trim bug on small caches

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -305,8 +305,8 @@ ss::future<> cache::trim() {
     uint64_t deleted_size = 0;
     size_t deleted_count = 0;
     if (
-      _current_cache_size >= target_size
-      || _current_cache_objects >= target_objects) {
+      _current_cache_size + _reserved_cache_size >= target_size
+      || _current_cache_objects + _reserved_cache_objects >= target_objects) {
         auto size_to_delete
           = (_current_cache_size + _reserved_cache_size)
             - std::min(target_size, _current_cache_size + _reserved_cache_size);


### PR DESCRIPTION
Where reserved is same order of magnitude as
total cache size, we must include it in our
pre-check for whether to trim at all.

This the same issue that
9f05d78eccec0689565d511cfd6f91d5d5c706db
was addressing: it should have been changed
in that commit.

Fixes https://github.com/redpanda-data/redpanda/issues/11819

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
