### PR TITLE
cloud_storage: fix OffsetForLeaderEpoch when it lands in the cloud log

### DIFF
--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -139,6 +139,13 @@ private:
     ss::future<result<archive_start_offset_advance, error_outcome>>
     offset_based_retention() noexcept;
 
+    // Perform a term upper bound search within the spillover manifest list.
+    // Returns the index of the first spillover manifest that contains a segment
+    // wit term greater than the requested one. If no such spillover manifest
+    // exists, returns std::nullopt.
+    std::optional<size_t>
+    get_spillover_upper_bound_by_term(model::term_id term) noexcept;
+
     ss::future<> run_bg_loop();
 
     /// Return true if the offset belongs to the archive

--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -105,6 +105,9 @@ public:
       result<std::unique_ptr<async_manifest_view_cursor>, error_outcome>>
     get_retention_backlog() noexcept;
 
+    ss::future<result<std::optional<kafka::offset>, error_outcome>>
+    get_term_last_offset(model::term_id term) noexcept;
+
     bool is_empty() const noexcept;
 
     const model::ntp& get_ntp() const { return _stm_manifest.get_ntp(); }

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -720,83 +720,17 @@ ss::future<> remote_partition::serialize_json_manifest_to_output_stream(
 // returns term last kafka offset
 ss::future<std::optional<kafka::offset>>
 remote_partition::get_term_last_offset(model::term_id term) const {
-    const auto& stmm = _manifest_view->stm_manifest();
-    vassert(
-      stmm.size() > 0,
-      "The manifest for {} is not expected to be empty",
-      _manifest_view->get_ntp());
-
-    if (stmm.begin()->segment_term <= term) {
-        // if last segment term is equal to the one we look for return it
-        auto last = stmm.last_segment();
-        vassert(
-          last.has_value(),
-          "The manifest for {} is not expected to be empty",
-          _manifest_view->get_ntp());
-
-        if (last->segment_term == term) {
-            // Fast path, most requests should query the last term
-            co_return last->next_kafka_offset() - kafka::offset(1);
-        } else {
-            // look for first segment in next term, segments are sorted by
-            // base_offset and term
-            for (auto const& p : stmm) {
-                if (p.segment_term > term) {
-                    co_return p.base_kafka_offset() - kafka::offset(1);
-                }
-            }
-        }
-    } else if (stmm.get_archive_start_offset() != model::offset{}) {
-        // Use column-store that contains list of spillover manifests to
-        // find a starting point for the search.
-        const auto& spillover_map
-          = _manifest_view->stm_manifest().get_spillover_map();
-        // This column contains term of the last segment in the manifest
-        const auto& term_col = spillover_map.get_segment_term_column();
-        size_t sp_index = 0;
-        for (auto t : term_col) {
-            if (t > term()) {
-                break;
-            }
-            sp_index++;
-        }
-        auto sp_start = spillover_map.get_base_offset_column().at_index(
-          sp_index);
-        auto res = co_await _manifest_view->get_cursor(
-          sp_start.is_end()
-            ? _manifest_view->stm_manifest().get_archive_start_offset()
-            : model::offset{*sp_start});
-        if (res.has_error()) {
-            vlog(_ctxlog.error, "Failed to scan metadata: {}", res.error());
-            throw std::system_error(res.error());
-        }
-        std::optional<kafka::offset> res_offset;
-        co_await ss::repeat(
-          [this, &res_offset, term, cursor = std::move(res.value())] {
-              const auto& manifest = cursor->manifest()->get();
-              vlog(
-                _ctxlog.debug,
-                "Scanning manifest {} for term {}",
-                manifest.get_manifest_path(),
-                term);
-              for (auto meta : manifest) {
-                  if (meta.segment_term > term) {
-                      res_offset = meta.base_kafka_offset() - kafka::offset(1);
-                      vlog(
-                        _ctxlog.debug,
-                        "Scan found offset {} at term {}",
-                        res_offset.value(),
-                        meta.segment_term);
-                      return ss::make_ready_future<ss::stop_iteration>(
-                        ss::stop_iteration::yes);
-                  }
-              }
-              return cursor->next_iter();
-          });
-
-        co_return res_offset;
+    const auto res = co_await _manifest_view->get_term_last_offset(term);
+    if (res.has_error()) {
+        vlog(
+          _ctxlog.error,
+          "Failed to get last offset from term {}: {}",
+          term,
+          res.error());
+        throw std::system_error(res.error());
+    } else {
+        co_return res.value();
     }
-    co_return std::nullopt;
 }
 
 ss::future<std::vector<model::tx_range>>


### PR DESCRIPTION
This PR fixes a few issues with the handling of OffsetForLeaderEpoch in the cloud log.
The issues manifested in https://github.com/redpanda-data/redpanda/pull/11759 as a stuck consumer.

The following issue is fixed and unit tests are introduced for it:
```
Consider the example below:
        [--------]  [--------]
        ^           ^    ^
Term:   T1          T1   T2
Offset: A           B  X C
                       ^
                       |________ _archive_start_offset

Previously, when looking for the last offset in T1, we'd correctly pick
the second spillover manifest in the diagram and we would attempt to
create a cursor starting at B (i.e. the start of the selected spill
manifest). This request is not fulfilled as the cursor refuses to answer
queries below the archive start offset. The fix here, is to init the
cursor with the start offset of the archive iff that lies within the
same spillover manifest.

3. Previously, the behaviour of OffsetForLeaderEpoch requests was
inconsistent between the cloud and the local log. If the local log does
not know about the term, it returns the start offse of the local log.
This PR teaches the cloud log code path to do the same.
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
