### PR TITLE
Add support for delete-records to the admin ops fuzzer

### DIFF
--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -231,6 +231,10 @@ class KCL:
 
         kcl admin delete-records foo:p0,o120 foo:p1,o3888 ...
         """
+        def validate_offsets(args):
+            offsets = flat_map(lambda x: list(x.values()), args.values())
+            return all([x >= 0 for x in offsets])
+
         def unfold(x):
             topic, partitions_offsets = x
             return [
@@ -240,6 +244,11 @@ class KCL:
 
         if len(topic_partitions_offsets) == 0:
             return []
+
+        if validate_offsets(topic_partitions_offsets) is False:
+            raise RuntimeError(
+                f'Negative offset passed to delete-records: {topic_partitions_offsets}'
+            )
 
         cmd = ['-X', f'timeout_ms={timeout_ms}', 'admin', 'delete-records'
                ] + flat_map(unfold, topic_partitions_offsets.items())

--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -237,7 +237,7 @@ class DeleteRecordsTest(RedpandaTest):
                     segment_boundaries[random_seg] + 1,
                     segment_boundaries[random_seg + 1] - 1)
             elif truncate_point == "at_segment_boundary":
-                random_seg = random.randint(0, len(segment_boundaries) - 1)
+                random_seg = random.randint(1, len(segment_boundaries) - 1)
                 truncate_offset = segment_boundaries[random_seg] - 1
             else:
                 assert False, "unknown test parameter encountered"


### PR DESCRIPTION
This PR will add delete-records to the set of supported admin ops commands that will be used in tests that invoke the admin ops fuzzer.

## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
