### PR TITLE
cluster: Fix for incorrect end_offset reported

### DIFF
--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -168,4 +168,15 @@ ss::future<result<model::offset>> state_machine::insert_linearizable_barrier(
       });
 }
 
+ss::future<model::offset> state_machine::bootstrap_committed_offset() {
+    /// It is useful for some STMs to know what the committed offset is so they
+    /// may do things like block until they have consumed all known committed
+    /// records. To achieve this, this method waits on offset 0, so on the first
+    /// call to `event_manager::notify_commit_index`, it is known that the
+    /// committed offset is in an initialized state.
+    return _raft->events()
+      .wait(model::offset(0), model::no_timeout, _as)
+      .then([this] { return _raft->committed_offset(); });
+}
+
 } // namespace raft

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -87,6 +87,10 @@ public:
      */
     model::offset bootstrap_last_applied() const;
     /**
+     * Return when the committed offset has been established when STM starts.
+     */
+    ss::future<model::offset> bootstrap_committed_offset();
+    /**
      * Store last applied offset. If an offset is persisted it will be used by
      * consensus instance underlying this state machine to recovery committed
      * index on startup


### PR DESCRIPTION
- This change reverts a previous attempt to fix rm_stm reporting invalid_lso (in change 20285dff0f35f07c9b30dbcb5a79907e9696f714), which sets `booststrap_committed_offset` in apply_snapshot() to fix the case where invalid_lso is indefinitely returned on a node that had just restarted, applied a snapshot, but no data was produced onto it.

- The change was however incorrect, as the bootstrap committed offset is expected to be the value of a complete read of the log, and the value of the offset in the rm_stm snapshot at the time of reading it at startup, does not necessarily reflect this.

- The solution is to at startup wait until the consensus later has modified the committed offset.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
