### PR TITLE
[v23.1.x] storage/record_batch_builder: Avoid intermediate `std::vector`

### DIFF
--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -26,6 +26,20 @@ record_batch_builder::record_batch_builder(
 
 record_batch_builder::~record_batch_builder() = default;
 
+record_batch_builder& record_batch_builder::add_raw_kv(
+  std::optional<iobuf>&& key, std::optional<iobuf>&& value) {
+    _records.emplace_back(std::move(key), std::move(value));
+    return *this;
+}
+
+record_batch_builder& record_batch_builder::add_raw_kw(
+  std::optional<iobuf>&& key,
+  std::optional<iobuf>&& value,
+  std::vector<model::record_header> headers) {
+    _records.emplace_back(std::move(key), std::move(value), std::move(headers));
+    return *this;
+}
+
 model::record_batch record_batch_builder::build() && {
     int32_t offset_delta = 0;
     if (!_timestamp) {

--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -24,7 +24,7 @@ record_batch_builder::record_batch_builder(
   : _batch_type(bt)
   , _base_offset(base_offset) {}
 
-record_batch_builder::~record_batch_builder() {}
+record_batch_builder::~record_batch_builder() = default;
 
 model::record_batch record_batch_builder::build() && {
     int32_t offset_delta = 0;

--- a/src/v/storage/record_batch_builder.h
+++ b/src/v/storage/record_batch_builder.h
@@ -89,7 +89,8 @@ private:
     int16_t _producer_epoch{-1};
     bool _is_control_type{false};
     bool _transactional_type{false};
-    std::vector<serialized_record> _records;
+    iobuf _records;
+    int32_t _offset_delta{0};
     model::compression _compression{model::compression::none};
     std::optional<model::timestamp> _timestamp;
 };

--- a/src/v/storage/record_batch_builder.h
+++ b/src/v/storage/record_batch_builder.h
@@ -25,18 +25,11 @@ public:
     record_batch_builder& operator=(const record_batch_builder&) = delete;
 
     virtual record_batch_builder&
-    add_raw_kv(std::optional<iobuf>&& key, std::optional<iobuf>&& value) {
-        _records.emplace_back(std::move(key), std::move(value));
-        return *this;
-    }
+    add_raw_kv(std::optional<iobuf>&& key, std::optional<iobuf>&& value);
     virtual record_batch_builder& add_raw_kw(
       std::optional<iobuf>&& key,
       std::optional<iobuf>&& value,
-      std::vector<model::record_header> headers) {
-        _records.emplace_back(
-          std::move(key), std::move(value), std::move(headers));
-        return *this;
-    }
+      std::vector<model::record_header> headers);
     virtual model::record_batch build() &&;
     virtual ~record_batch_builder();
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11837
Fixes: https://github.com/redpanda-data/redpanda/issues/11853,