### PR TITLE
cloud_storage: more exhaustive cache trim when fast trim doesn't free enough space

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -180,6 +180,23 @@ private:
     /// them until cache size <= _cache_size_low_watermark * max_bytes
     ss::future<> trim();
 
+    struct trim_result {
+        uint64_t deleted_size{0};
+        size_t deleted_count{0};
+    };
+
+    /// Ordinary trim: prioritze trimming data chunks, only delete indices etc
+    /// if all their chunks are dropped.
+    ss::future<trim_result> trim_fast(
+      const fragmented_vector<file_list_item>& candidates,
+      uint64_t target_size,
+      size_t target_objects);
+
+    /// Exhaustive trim: walk all files including indices, remove whatever is
+    /// least recently accessed.
+    ss::future<trim_result>
+    trim_exhaustive(uint64_t target_size, size_t target_objects);
+
     /// If trimming may proceed immediately, return nullopt.  Else return
     /// how long the caller should wait before trimming to respect the
     /// rate limit.

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -189,13 +189,13 @@ private:
     /// if all their chunks are dropped.
     ss::future<trim_result> trim_fast(
       const fragmented_vector<file_list_item>& candidates,
-      uint64_t target_size,
-      size_t target_objects);
+      uint64_t delete_bytes,
+      size_t delete_objects);
 
     /// Exhaustive trim: walk all files including indices, remove whatever is
     /// least recently accessed.
     ss::future<trim_result>
-    trim_exhaustive(uint64_t target_size, size_t target_objects);
+    trim_exhaustive(uint64_t delete_bytes, size_t delete_objects);
 
     /// If trimming may proceed immediately, return nullopt.  Else return
     /// how long the caller should wait before trimming to respect the

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -44,6 +44,14 @@ error_outcome handle_client_transport_error(
 
     try {
         std::rethrow_exception(current_exception);
+    } catch (const std::filesystem::filesystem_error& e) {
+        if (e.code() == std::errc::no_such_file_or_directory) {
+            vlog(logger.warn, "File removed during download: ", e.path1());
+            outcome = error_outcome::retry;
+        } else {
+            vlog(logger.error, "Filesystem error {}", e);
+            outcome = error_outcome::fail;
+        }
     } catch (const std::system_error& cerr) {
         // The system_error is type erased and not convenient for selective
         // handling. The following errors should be retried:

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       MINIO_REGION_NAME: panda-region
       MINIO_ROOT_PASSWORD: panda-secret
       MINIO_ROOT_USER: panda-user
-      MINIO_BROWSER: off
+      MINIO_BROWSER: "off"
     expose:
     - '9000'
     healthcheck:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3185,6 +3185,10 @@ class RedpandaService(RedpandaServiceBase):
 
         return None
 
+    @property
+    def cache_dir(self):
+        return os.path.join(RedpandaService.DATA_DIR, "cloud_storage_cache")
+
     def node_storage(self,
                      node,
                      sizes: bool = False,
@@ -3200,9 +3204,8 @@ class RedpandaService(RedpandaServiceBase):
 
         self.logger.debug(
             f"Starting storage checks for {node.name} sizes={sizes}")
-        store = NodeStorage(
-            node.name, RedpandaService.DATA_DIR,
-            os.path.join(RedpandaService.DATA_DIR, "cloud_storage_cache"))
+        store = NodeStorage(node.name, RedpandaService.DATA_DIR,
+                            self.cache_dir)
         script_path = inject_remote_script(node, "compute_storage.py")
         cmd = [
             "python3", script_path, f"--data-dir={RedpandaService.DATA_DIR}"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -880,13 +880,13 @@ class RedpandaServiceBase(Service):
     def add_extra_rp_conf(self, conf):
         self._extra_rp_conf = {**self._extra_rp_conf, **conf}
 
-    def get_node_memory_mb(self):
+    def get_node_memory_mb(self) -> int:
         pass
 
-    def get_node_cpu_count(self):
+    def get_node_cpu_count(self) -> int:
         pass
 
-    def get_node_disk_free(self):
+    def get_node_disk_free(self) -> int:
         pass
 
     def lsof_node(self, node: ClusterNode, filter: Optional[str] = None):


### PR DESCRIPTION
This fixes cases where the primary trim doesn't clear up .tx and .index files, when there is no chunk/segment file for the segment.

Rather than make the existing trim slower by having it consider all files individually, the existing trim behavior is retained in `trim_fast()`, and a `trim_exhaustive()` function is introduced to do a more expensive "inspect every file" trim.  This can clean up:
- .tx and .index files where there is no corresponding data file
- Abandoned .part files (which shouldn't exist, but could if there is a bug in the download path)
- Any other files in the cache directory, e.g. if a user mistakenly put some files in here, or if there were files from an old Redpanda version that we no longer use/need.

Note that the trim still only happens when it is necessary to enable a put() operation: if the cache size/objects limit is not reached, none of this happens.  In practice, this means that systems with large caches may build up a commensurately large quantity of cruft, but this cruft should be cleaned up promptly as soon as the cache is filled, to let tiered storage reads proceed.

It would be useful to continue this work to a more comprehensive de-crufting mechanism that runs in the background, including cleaning up "dead" data from deleted topics and/or beyond-retention segments: https://github.com/redpanda-data/redpanda/issues/11859

## Backports Required

Need to form an opinion about what to do with 22.3 and 23.1, their cache logic is different but may have similar issues when run for a long time.  The issue becomes more noticeable with 23.2 because we have a max objects limit that highlights situations where very many tiny files have been leaked.

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none