### PR TITLE
tests: skip debug mode on test_get_cpu_profile

### DIFF
--- a/tests/rptest/tests/cpu_profiler_admin_api_test.py
+++ b/tests/rptest/tests/cpu_profiler_admin_api_test.py
@@ -13,6 +13,7 @@ from rptest.services.admin import Admin
 from rptest.services.redpanda import LoggingConfig
 from rptest.clients.types import TopicSpec
 from rptest.services.kgo_repeater_service import repeater_traffic
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class CPUProfilerAdminAPITest(RedpandaTest):
@@ -32,6 +33,7 @@ class CPUProfilerAdminAPITest(RedpandaTest):
         self.admin = Admin(self.redpanda)
 
     @cluster(num_nodes=4)
+    @skip_debug_mode
     def test_get_cpu_profile(self):
         # Provide traffic so there is something to sample.
         with repeater_traffic(context=self.test_context,


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/11790

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
