### PR TITLE
tests: fix AttributeError in delete_records_test

### DIFF
--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -206,7 +206,13 @@ class DeleteRecordsTest(RedpandaTest):
 
         def get_segment_boundaries(node):
             def to_final_indicies(seg):
-                return int(seg.data_file.split('-')[0])
+                if self.data_file is not None:
+                    return int(seg.data_file.split('-')[0])
+                else:
+                    # A segment with no data file indicates that an index or
+                    # compaction index was left behind for a deleted segment, or
+                    # deletion is currently in flight.
+                    return 0
 
             return sorted([to_final_indicies(seg) for seg in node])
 


### PR DESCRIPTION
This test did not account for the case where a storage segment object has no data_file.

Example failure: https://buildkite.com/redpanda/redpanda/builds/32439#01891df7-b751-49dc-afa0-d0c07cf7a46e

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
