### PR TITLE
cloud_storage: check exact segment counts in `CloudArchiveRetentionTest`

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -470,6 +470,7 @@ class KgoVerifierProducer(KgoVerifierService):
                  debug_logs=False,
                  trace_logs=False,
                  fake_timestamp_ms=None,
+                 fake_timestamp_step_ms=None,
                  use_transactions=False,
                  transaction_abort_rate=None,
                  msgs_per_transaction=None,
@@ -482,6 +483,7 @@ class KgoVerifierProducer(KgoVerifierService):
         self._status = ProduceStatus()
         self._batch_max_bytes = batch_max_bytes
         self._fake_timestamp_ms = fake_timestamp_ms
+        self._fake_timestamp_step_ms = fake_timestamp_step_ms
         self._use_transactions = use_transactions
         self._transaction_abort_rate = transaction_abort_rate
         self._msgs_per_transaction = msgs_per_transaction
@@ -548,6 +550,9 @@ class KgoVerifierProducer(KgoVerifierService):
 
         if self._fake_timestamp_ms is not None:
             cmd = cmd + f' --fake-timestamp-ms {self._fake_timestamp_ms}'
+
+        if self._fake_timestamp_step_ms is not None:
+            cmd = cmd + f' --fake-timestamp-step-ms {self._fake_timestamp_step_ms}'
 
         if self._use_transactions:
             cmd = cmd + f' --use-transactions'


### PR DESCRIPTION
The goal of this PR is to tighten up the archive retention tests in `CloudArchiveRetentionTest`.
Previously, the tests did not perform exact checks for the number of
segments deleted by retention. A number of test issues bubbled up when
I did this, but the most significant was that the time based test wasn't
working.

This was due to the fact that segment timestamps were too bunched up and
the precise check couldn't work. To fix that, custom timestamps with a
2 minute delta between records are used. I also had to fix the metric tracking
the number of deleted segments by the archive GC. Previously it treated indices
and tx manifests as segments.

Note that the bugs surfaced by this improved test were fixed in https://github.com/redpanda-data/redpanda/pull/11795.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none

