### PR TITLE
Adjust metadata memory estimate for allocation

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -578,7 +578,9 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
 
     // We still add on the default_estimate to handle the size of the request
     // itself and miscellaneous other procesing (this is a small adjustment,
-    // generally ~8000 bytes).
-    return default_memory_estimate(request_size) + size_estimate;
+    // generally ~8000 bytes). Finally, we add max_frag_bytes to account for the
+    // worse-cast overshoot during vector re-allocation.
+    return default_memory_estimate(request_size) + size_estimate
+           + large_fragment_vector<metadata_response_partition>::max_frag_bytes;
 }
 } // namespace kafka


### PR DESCRIPTION
Add max_frag_bytes to the metadata memory estimate to account for the worse-cast overshoot during vector re-allocation.

Issue #5563.

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

### Bug Fixes

Makes the estimate of the memory used by a metadata request more conservative by including the extra allocated but unused space at the end of a fragmented vector.
