### PR TITLE
archival: Validate archival_metadata_stm updates

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1609,15 +1609,18 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
                        - (total.num_succeeded + total.num_cancelled);
 
     std::vector<cloud_storage::segment_meta> mdiff;
-    std::optional<model::offset_delta> delta_offset_top;
+    std::optional<model::offset_delta> delta_offset_end;
     std::optional<model::offset> last_offset;
     auto last_segment = manifest().last_segment();
     if (
       last_segment.has_value()
       && last_segment->delta_offset_end != model::offset_delta{}) {
-        delta_offset_top = last_segment->delta_offset_end;
+        delta_offset_end = last_segment->delta_offset_end;
         last_offset = last_segment->committed_offset;
     }
+    const bool checks_disabled
+      = config::shard_local_cfg()
+          .cloud_storage_disable_upload_consistency_checks.value();
     for (size_t i = 0; i < segment_results.size(); i++) {
         if (
           segment_results[i].result()
@@ -1625,7 +1628,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
             break;
         }
         const auto& upload = scheduled[ixupload[i]];
-        if (segment_results[i].has_record_stats()) {
+        if (!checks_disabled && segment_results[i].has_record_stats()) {
             // Validate metadata by comparing it to the segment stats
             // generated during index building process. The stats contains
             // "ground truth" about the uploaded segment because the code that
@@ -1659,25 +1662,25 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
             }
         }
         if (
-          segment_kind == segment_upload_kind::non_compacted
+          !checks_disabled && segment_kind == segment_upload_kind::non_compacted
           && upload.meta.has_value() && last_offset.has_value()
           && upload.meta->base_offset > last_offset.value()) {
             // This code block is executed only for non-compacted uploads
             // which are adding new segments and not replacing existing
             // ones.
             if (
-              delta_offset_top.has_value() && upload.meta.has_value()
-              && upload.meta->delta_offset != delta_offset_top) {
+              delta_offset_end.has_value() && upload.meta.has_value()
+              && upload.meta->delta_offset != delta_offset_end) {
                 vlog(
                   _rtclog.error,
                   "Delta offset of the uploaded segment {} doesn't match "
                   "with expected value of {}",
                   upload.meta->delta_offset,
-                  delta_offset_top);
+                  delta_offset_end);
                 _probe->gap_detected(last_offset.value());
                 break;
             } else {
-                delta_offset_top = upload.meta->delta_offset_end;
+                delta_offset_end = upload.meta->delta_offset_end;
             }
             if (
               last_offset.has_value() && upload.meta.has_value()

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -70,6 +70,58 @@ constexpr auto housekeeping_jit = 5ms;
 
 namespace archival {
 
+ntp_archiver_upload_result::ntp_archiver_upload_result(
+  cloud_storage::upload_result r)
+  : _result(r) {}
+
+// Success result
+ntp_archiver_upload_result::ntp_archiver_upload_result(
+  const cloud_storage::segment_record_stats& m)
+  : _stats(m)
+  , _result(cloud_storage::upload_result::success) {}
+
+ntp_archiver_upload_result ntp_archiver_upload_result::merge(
+  const std::vector<ntp_archiver_upload_result>& results) {
+    vassert(
+      !results.empty(),
+      "list of ntp_archiver_upload_result values can't be empty");
+    auto res = cloud_storage::upload_result::success;
+    std::optional<cloud_storage::segment_record_stats> stats;
+    for (auto& r : results) {
+        if (r.has_record_stats()) {
+            stats = r.record_stats();
+        }
+        if (r.result() != cloud_storage::upload_result::success) {
+            res = r.result();
+        }
+    }
+    if (stats && res == cloud_storage::upload_result::success) {
+        return ntp_archiver_upload_result(stats.value());
+    }
+    vassert(
+      res != cloud_storage::upload_result::success,
+      "success result should have record stats set");
+    return res;
+}
+
+bool ntp_archiver_upload_result::has_record_stats() const {
+    return _stats.has_value();
+}
+
+const cloud_storage::segment_record_stats&
+ntp_archiver_upload_result::record_stats() const {
+    return _stats.value();
+}
+
+cloud_storage::upload_result ntp_archiver_upload_result::result() const {
+    return _result;
+}
+
+cloud_storage::upload_result
+ntp_archiver_upload_result::operator()(cloud_storage::upload_result) const {
+    return _result;
+}
+
 static std::unique_ptr<adjacent_segment_merger>
 maybe_make_adjacent_segment_merger(
   ntp_archiver& self,
@@ -485,7 +537,7 @@ ss::future<> ntp_archiver::upload_until_term_change() {
         } else if (non_compacted_upload_result.num_succeeded != 0) {
             vlog(
               _rtclog.debug,
-              "Successfuly uploaded {} segments",
+              "Successfully uploaded {} segments",
               non_compacted_upload_result.num_succeeded);
         }
 
@@ -1021,7 +1073,7 @@ static ss::sstring make_index_path(const remote_segment_path& segment_path) {
 }
 
 // from offset to offset (by record batch boundary)
-ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
+ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
   model::term_id archiver_term,
   upload_candidate candidate,
   std::vector<ss::rwlock::holder> segment_read_locks,
@@ -1057,10 +1109,12 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
         co_await _remote.upload_object(
           _conf->bucket_name,
           cloud_storage_clients::object_key{index_path},
-          idx_res->to_iobuf(),
+          idx_res->index.to_iobuf(),
           fib,
           _segment_index_tags,
           "segment-index");
+
+        co_return ntp_archiver_upload_result(idx_res->stats);
     } else {
         if (upload_res != cloud_storage::upload_result::success) {
             vlog(
@@ -1079,8 +1133,8 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
               index_path);
         }
     }
-
     co_return upload_res;
+
     // Note on segment locks:
     //
     // We've successfully uploaded the segment. Before we replicate an update
@@ -1134,7 +1188,7 @@ ntp_archiver::get_aborted_transactions(upload_candidate candidate) {
       candidate.starting_offset, candidate.final_offset);
 }
 
-ss::future<cloud_storage::upload_result> ntp_archiver::upload_tx(
+ss::future<ntp_archiver_upload_result> ntp_archiver::upload_tx(
   model::term_id archiver_term,
   upload_candidate candidate,
   fragmented_vector<model::tx_range> tx_range,
@@ -1165,7 +1219,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_tx(
       get_bucket_name(), manifest, fib, _tx_tags);
 }
 
-ss::future<std::optional<cloud_storage::offset_index>>
+ss::future<std::optional<ntp_archiver::make_segment_index_result>>
 ntp_archiver::make_segment_index(
   model::offset base_rp_offset,
   retry_chain_logger& ctxlog,
@@ -1181,12 +1235,15 @@ ntp_archiver::make_segment_index(
       cloud_storage::remote_segment_sampling_step_bytes};
 
     vlog(ctxlog.debug, "creating remote segment index: {}", index_path);
+    cloud_storage::segment_record_stats stats{};
+
     auto builder = cloud_storage::make_remote_segment_index_builder(
       _ntp,
       std::move(stream),
       ix,
       base_rp_offset - base_kafka_offset,
-      cloud_storage::remote_segment_sampling_step_bytes);
+      cloud_storage::remote_segment_sampling_step_bytes,
+      std::ref(stats));
 
     auto res = co_await builder->consume().finally(
       [&builder] { return builder->close(); });
@@ -1200,29 +1257,26 @@ ntp_archiver::make_segment_index(
         co_return std::nullopt;
     }
 
-    co_return ix;
+    co_return make_segment_index_result{.index = std::move(ix), .stats = stats};
 }
 
 // The function turns an array of futures that return an error code into a
 // single future that returns error result of the last failed future or success
 // otherwise.
-static ss::future<cloud_storage::upload_result> aggregate_upload_results(
-  std::vector<ss::future<cloud_storage::upload_result>> upl_vec) {
+static ss::future<ntp_archiver_upload_result> aggregate_upload_results(
+  std::vector<ss::future<ntp_archiver_upload_result>> upl_vec) {
     return ss::when_all(upl_vec.begin(), upl_vec.end()).then([](auto vec) {
-        auto res = cloud_storage::upload_result::success;
+        std::vector<ntp_archiver_upload_result> results;
         for (auto& v : vec) {
             try {
-                auto r = v.get();
-                if (r != cloud_storage::upload_result::success) {
-                    res = r;
-                }
+                results.push_back(v.get());
             } catch (const ss::gate_closed_exception&) {
-                res = cloud_storage::upload_result::cancelled;
+                results.emplace_back(cloud_storage::upload_result::cancelled);
             } catch (...) {
-                res = cloud_storage::upload_result::failed;
+                results.emplace_back(cloud_storage::upload_result::failed);
             }
         }
-        return res;
+        return ntp_archiver_upload_result::merge(results);
     });
 }
 
@@ -1282,7 +1336,7 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
 
     // The upload is successful only if the segment, and tx_range are
     // uploaded.
-    std::vector<ss::future<cloud_storage::upload_result>> all_uploads;
+    std::vector<ss::future<ntp_archiver_upload_result>> all_uploads;
 
     all_uploads.emplace_back(
       upload_segment(upload_ctx.archiver_term, upload, std::move(locks)));
@@ -1485,7 +1539,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
   segment_upload_kind segment_kind,
   bool inline_manifest) {
     ntp_archiver::upload_group_result total{};
-    std::vector<ss::future<cloud_storage::upload_result>> flist;
+    std::vector<ss::future<ntp_archiver_upload_result>> flist;
     std::vector<size_t> ixupload;
     for (size_t ix = 0; ix < scheduled.size(); ix++) {
         if (scheduled[ix].result) {
@@ -1522,7 +1576,8 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
         // _projected_manifest_clean_at if something was uploaded.
         flist.push_back(
           maybe_upload_manifest(concurrent_with_segs_ctx_label).then([](bool) {
-              return cloud_storage::upload_result::success;
+              return ntp_archiver_upload_result{
+                cloud_storage::upload_result::success};
           }));
     }
 
@@ -1544,7 +1599,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
 
     absl::flat_hash_map<cloud_storage::upload_result, size_t> upload_results;
     for (auto result : segment_results) {
-        ++upload_results[result];
+        ++upload_results[result.result()];
     }
 
     total.num_succeeded = upload_results[cloud_storage::upload_result::success];
@@ -1554,11 +1609,92 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
                        - (total.num_succeeded + total.num_cancelled);
 
     std::vector<cloud_storage::segment_meta> mdiff;
+    std::optional<model::offset_delta> delta_offset_top;
+    std::optional<model::offset> last_offset;
+    auto last_segment = manifest().last_segment();
+    if (
+      last_segment.has_value()
+      && last_segment->delta_offset_end != model::offset_delta{}) {
+        delta_offset_top = last_segment->delta_offset_end;
+        last_offset = last_segment->committed_offset;
+    }
     for (size_t i = 0; i < segment_results.size(); i++) {
-        if (segment_results[i] != cloud_storage::upload_result::success) {
+        if (
+          segment_results[i].result()
+          != cloud_storage::upload_result::success) {
             break;
         }
         const auto& upload = scheduled[ixupload[i]];
+        if (segment_results[i].has_record_stats()) {
+            // Validate metadata by comparing it to the segment stats
+            // generated during index building process. The stats contains
+            // "ground truth" about the uploaded segment because the code that
+            // generates it was "looking" at every record batch before it was
+            // sent out.
+            //
+            // By doing this incrementally we can build consistent log metadata
+            // because every such check is based on previous state that was
+            // also validated using the same procedure.
+            auto stats = segment_results[i].record_stats();
+            if (
+              upload.upload_kind == segment_upload_kind::non_compacted
+              && upload.meta.has_value()) {
+                if (
+                  upload.meta->size_bytes != stats.size_bytes
+                  || upload.meta->base_offset != stats.base_rp_offset
+                  || upload.meta->committed_offset != stats.last_rp_offset) {
+                    vlog(
+                      _rtclog.error,
+                      "Metadata of the uploaded segment [size: {}, base: {}, "
+                      "last: {}] doesn't match the segment [size: {}, base: "
+                      "{}, last: {}]",
+                      upload.meta->size_bytes,
+                      upload.meta->base_offset,
+                      upload.meta->committed_offset,
+                      stats.size_bytes,
+                      stats.base_rp_offset,
+                      stats.last_rp_offset);
+                    break;
+                }
+            }
+        }
+        if (
+          segment_kind == segment_upload_kind::non_compacted
+          && upload.meta.has_value() && last_offset.has_value()
+          && upload.meta->base_offset > last_offset.value()) {
+            // This code block is executed only for non-compacted uploads
+            // which are adding new segments and not replacing existing
+            // ones.
+            if (
+              delta_offset_top.has_value() && upload.meta.has_value()
+              && upload.meta->delta_offset != delta_offset_top) {
+                vlog(
+                  _rtclog.error,
+                  "Delta offset of the uploaded segment {} doesn't match "
+                  "with expected value of {}",
+                  upload.meta->delta_offset,
+                  delta_offset_top);
+                _probe->gap_detected(last_offset.value());
+                break;
+            } else {
+                delta_offset_top = upload.meta->delta_offset_end;
+            }
+            if (
+              last_offset.has_value() && upload.meta.has_value()
+              && upload.meta->base_offset
+                   != model::next_offset(last_offset.value())) {
+                vlog(
+                  _rtclog.error,
+                  "Base offset of the uploaded segment {} doesn't align "
+                  "with previous segment with committed offset {}",
+                  upload.meta->base_offset,
+                  model::next_offset(last_offset.value()));
+                _probe->gap_detected(last_offset.value());
+                break;
+            } else {
+                last_offset = upload.meta->committed_offset;
+            }
+        }
 
         if (segment_kind == segment_upload_kind::non_compacted) {
             _probe->uploaded(*upload.delta);
@@ -1570,10 +1706,6 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
             } else {
                 expected_base_offset = manifest().get_last_offset()
                                        + model::offset{1};
-            }
-            if (upload.meta->base_offset > expected_base_offset) {
-                _probe->gap_detected(
-                  upload.meta->base_offset - expected_base_offset);
             }
         }
 
@@ -2606,7 +2738,7 @@ ss::future<bool> ntp_archiver::do_upload_local(
     auto archiver_term = _start_term;
 
     // Upload segments and tx-manifest in parallel
-    std::vector<ss::future<cloud_storage::upload_result>> futures;
+    std::vector<ss::future<ntp_archiver_upload_result>> futures;
     futures.emplace_back(
       upload_segment(archiver_term, upload, std::move(locks), source_rtc));
 
@@ -2624,13 +2756,13 @@ ss::future<bool> ntp_archiver::do_upload_local(
     }
     auto upl_res = co_await aggregate_upload_results(std::move(futures));
 
-    if (tx_ep || upl_res != cloud_storage::upload_result::success) {
-        if (upl_res != cloud_storage::upload_result::success) {
+    if (tx_ep || upl_res.result() != cloud_storage::upload_result::success) {
+        if (upl_res.result() != cloud_storage::upload_result::success) {
             vlog(
               _rtclog.warn,
               "Failed to upload segment: {}, error: {}",
               upload.exposed_name,
-              upl_res);
+              upl_res.result());
         }
         if (tx_ep) {
             vlog(

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -238,6 +238,7 @@ FIXTURE_TEST(test_archival_stm_segment_replace, archival_metadata_stm_fixture) {
     std::vector<cloud_storage::segment_meta> m2;
     m2.push_back(segment_meta{
       .is_compacted = true,
+      .size_bytes = 1024,
       .base_offset = model::offset(0),
       .committed_offset = model::offset(999),
       .archiver_term = model::term_id(1),
@@ -760,21 +761,27 @@ FIXTURE_TEST(
       .committed_offset = model::offset(1999),
       .delta_offset = model::offset_delta(0),
       .archiver_term = model::term_id(1),
-      .segment_term = model::term_id(1)});
+      .segment_term = model::term_id(1),
+      .delta_offset_end = model::offset_delta(0),
+    });
     m.push_back(segment_meta{
       .size_bytes = 2000,
       .base_offset = model::offset(2000),
       .committed_offset = model::offset(2999),
       .delta_offset = model::offset_delta(0),
       .archiver_term = model::term_id(1),
-      .segment_term = model::term_id(1)});
+      .segment_term = model::term_id(1),
+      .delta_offset_end = model::offset_delta(0),
+    });
     m.push_back(segment_meta{
       .size_bytes = 3000,
       .base_offset = model::offset(3000),
       .committed_offset = model::offset(3999),
       .delta_offset = model::offset_delta(0),
       .archiver_term = model::term_id(2),
-      .segment_term = model::term_id(2)});
+      .segment_term = model::term_id(2),
+      .delta_offset_end = model::offset_delta(0),
+    });
 
     // Replicate add_segment_cmd command that adds segment with offset 0
     auto batcher1 = archival_stm->batch_start(

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -327,6 +327,9 @@ public:
     bool add(segment_meta meta);
     bool add(const segment_name& name, const segment_meta& meta);
 
+    /// Return 'true' if the segment meta can be added safely
+    bool safe_segment_meta_to_add(const segment_meta& meta);
+
     /// \brief Truncate the manifest (remove entries from the manifest)
     ///
     /// \note version with parameter advances start offset before truncating

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -13,6 +13,7 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "model/fundamental.h"
+#include "model/record_batch_types.h"
 #include "seastarx.h"
 #include "storage/parser.h"
 #include "units.h"
@@ -160,6 +161,26 @@ private:
     friend class offset_index_accessor;
 };
 
+struct segment_record_stats {
+    // Offset of the first record in the segment
+    model::offset base_rp_offset;
+    // Offset of the last record in the segment
+    model::offset last_rp_offset;
+    // Number of records in all data batches in the segment (this includes tx
+    // batches and all non-data batch types which doesn't participate in offset
+    // translation)
+    size_t total_data_records{0};
+    // Number of records in all config batches in the segment (this includes
+    // raft-configuration, archival and few other batches)
+    size_t total_conf_records{0};
+    // Total size of the segment
+    size_t size_bytes{0};
+    // Base timestamp
+    model::timestamp base_timestamp;
+    // Last timestamp
+    model::timestamp last_timestamp;
+};
+
 class remote_segment_index_builder : public storage::batch_consumer {
 public:
     using consume_result = storage::batch_consumer::consume_result;
@@ -169,7 +190,8 @@ public:
       const model::ntp& ntp,
       offset_index& ix,
       model::offset_delta initial_delta,
-      size_t sampling_step);
+      size_t sampling_step,
+      std::optional<std::reference_wrapper<segment_record_stats>> maybe_stats);
 
     virtual consume_result
     accept_batch_start(const model::record_batch_header&) const;
@@ -194,6 +216,8 @@ private:
     size_t _window{0};
     size_t _sampling_step;
     std::vector<model::record_batch_type> _filter;
+    /// Collected stats
+    std::optional<std::reference_wrapper<segment_record_stats>> _stats;
 };
 
 inline ss::lw_shared_ptr<storage::continuous_batch_parser>
@@ -202,10 +226,12 @@ make_remote_segment_index_builder(
   ss::input_stream<char> stream,
   offset_index& ix,
   model::offset_delta initial_delta,
-  size_t sampling_step) {
+  size_t sampling_step,
+  std::optional<std::reference_wrapper<segment_record_stats>> maybe_stats
+  = std::nullopt) {
     auto parser = ss::make_lw_shared<storage::continuous_batch_parser>(
       std::make_unique<remote_segment_index_builder>(
-        ntp, ix, initial_delta, sampling_step),
+        ntp, ix, initial_delta, sampling_step, maybe_stats),
       storage::segment_reader_handle(std::move(stream)));
     return parser;
 }

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -991,7 +991,10 @@ model::offset archival_metadata_stm::max_collectible_offset() {
 
 void archival_metadata_stm::apply_add_segment(const segment& segment) {
     auto meta = segment.meta;
-    if (!_manifest->safe_segment_meta_to_add(meta)) {
+    bool disable_safe_add
+      = config::shard_local_cfg()
+          .cloud_storage_disable_upload_consistency_checks.value();
+    if (!disable_safe_add && !_manifest->safe_segment_meta_to_add(meta)) {
         auto last = _manifest->last_segment();
         vlog(
           _logger.warn,

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -991,6 +991,15 @@ model::offset archival_metadata_stm::max_collectible_offset() {
 
 void archival_metadata_stm::apply_add_segment(const segment& segment) {
     auto meta = segment.meta;
+    if (!_manifest->safe_segment_meta_to_add(meta)) {
+        auto last = _manifest->last_segment();
+        vlog(
+          _logger.warn,
+          "Can't add segment: {}, previous segment: {}",
+          meta,
+          last);
+        return;
+    }
     if (meta.ntp_revision == model::initial_revision_id{}) {
         // metadata serialized by old versions of redpanda doesn't have the
         // ntp_revision field.

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1549,6 +1549,14 @@ configuration::configuration()
       "Grace period during which the scrubber will refuse to purge the topic.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       30s)
+  , cloud_storage_disable_upload_consistency_checks(
+      *this,
+      "cloud_storage_disable_upload_consistency_checks",
+      "Disable all upload consistency checks. This will allow redpanda to "
+      "upload logs with gaps and replicate metadata with consistency "
+      "violations. Normally, this options should be disabled.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -303,6 +303,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> cloud_storage_manifest_cache_ttl_ms;
     property<std::chrono::milliseconds>
       cloud_storage_topic_purge_grace_period_ms;
+    property<bool> cloud_storage_disable_upload_consistency_checks;
 
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;


### PR DESCRIPTION
Previously we saw several cases in which:
- metadata didn't match the actual uploaded segment;
- metadata was inconsistent next segment didn't connect with the previous one;

This PR solves this by introducing the validation mechanism to the ntp_archiver and archival_metadata_stm.

During the segment upload ntp_archiver calculates the segment stats (base offset, last offset, size, offset translation parameters). This information is considered a 'ground truth' about the upload. It gets propagated up the call chain until the `ntp_archiver` finished uploading the data and produced the `segment_meta` instance that should be added to the STM. The 'segment_meta' is validated against the previous log and the 'ground truth' that we obtained by analyzing the segment.

The `archival_metadata_stm` also validates every update using more simple procedure. It checks that the new pice of metadata connects with the previous one and that it can't replace existing segment in an unsafe mannter.

This PR makes it impossible for the `ntp_archiver` to add a gap to the manifest.

Fixes #10666

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Make it impossible to add inconsistent metadata to the tiered-storage state machine.
* Validate every tiered-storage metadata update to be consistent with the actual uploaded segments.