### PR TITLE
cloud_storage: logging improvements

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1000,12 +1000,17 @@ ss::future<> cache::do_reserve_space(uint64_t bytes, size_t objects) {
                 // stall entirely.
                 vlog(
                   cst_log.warn,
-                  "Failed to trim cache enough to reserve {} bytes (size={} "
-                  "reserved={} pending={})",
+                  "Failed to trim cache enough to reserve {}/{} bytes "
+                  "(size={}/{} "
+                  "reserved={}/{} pending={}/{})",
                   bytes,
+                  objects,
                   _current_cache_size,
+                  _current_cache_objects,
                   _reserved_cache_size,
-                  _reservations_pending);
+                  _reserved_cache_objects,
+                  _reservations_pending,
+                  _reservations_pending_objects);
 
                 // If there is a lot of free space on the disk, and we already
                 // tried our best to trim, then we may exceed the cache size


### PR DESCRIPTION
This is a response to issues seen in manual testing:
-  S3 client warnings don't say the response code or the request type
- Cache "failed to trim" lines don't mention object counts

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
