### PR TITLE
tests: fix test_delete_records_segment_deletion

### DIFF
--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -206,7 +206,7 @@ class DeleteRecordsTest(RedpandaTest):
 
         def get_segment_boundaries(node):
             def to_final_indicies(seg):
-                if self.data_file is not None:
+                if seg.data_file is not None:
                     return int(seg.data_file.split('-')[0])
                 else:
                     # A segment with no data file indicates that an index or


### PR DESCRIPTION
This was broken in 0570d19d6225ea59e79e197dca2d96ed72f3aa9c

Fixes https://github.com/redpanda-data/redpanda/issues/11871

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none