### PR TITLE
cloud_storage: run partition finalize in background

### DIFF
--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -455,6 +455,11 @@ public:
       const model::topic& topic,
       const model::initial_revision_id rev);
 
+    // If you need to spawn a background task that relies on
+    // this object staying alive, spawn it with this gate.
+    seastar::gate& gate() { return _gate; };
+    ss::abort_source& as() { return _as; }
+
 private:
     ss::future<upload_result> delete_objects_sequentially(
       const cloud_storage_clients::bucket_name& bucket,

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -131,8 +131,9 @@ public:
     ss::future<std::vector<model::tx_range>>
     aborted_transactions(offset_range offsets);
 
-    /// Flush metadata to object storage, prior to a topic deletion
-    ss::future<> finalize(ss::abort_source&);
+    /// Do background flush metadata to object storage, prior to a topic
+    /// deletion
+    void finalize();
 
     enum class erase_result { erased, failed };
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -997,7 +997,7 @@ ss::future<> partition::finalize_remote_partition(ss::abort_source& as) {
               clusterlog.debug,
               "Finalizing remote metadata on partition delete {}",
               ntp());
-            co_await _cloud_storage_partition->finalize(as);
+            _cloud_storage_partition->finalize();
         }
     }
 }


### PR DESCRIPTION
Previously, any blocking of the remote storage requests involved in doing the final upload of metadata would result in stalling the controller's backend loop, stopping unrelated actions such as topic creations from proceeding.

While issues with timeouts on remote requests should also be resolved, we can change the structure of this to avoid the risk of any remote storage issues causing controller-wide stalls, by bundling up the state required for finalize, and copying it into a background fiber so that teardown of remote_partition can proceed unimpeded.

Fixes https://github.com/redpanda-data/redpanda/issues/11863

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
