### PR TITLE
v22.2.x: Downgrade kaf to v0.2.3

### DIFF
--- a/tests/docker/ducktape-deps/kaf
+++ b/tests/docker/ducktape-deps/kaf
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-go get github.com/birdayz/kaf/cmd/kaf
+go get github.com/birdayz/kaf/cmd/kaf@v0.2.3
 mv /root/go/bin/kaf /usr/local/bin/


### PR DESCRIPTION
This avoid a build error with the latest version

Commit https://github.com/redpanda-data/redpanda/commit/e9315cecd927204000b879951cfe22461ce6f670 changed this to not have a specific version.

Fixes #11882

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none