### PR TITLE
Add metric to monitor seq table size

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -3271,6 +3271,13 @@ void rm_stm::setup_metrics() {
       prometheus_sanitize::metrics_name("tx:partition"),
       {
         sm::make_gauge(
+          "idempotency_pid_cache_size",
+          [this] { return _log_state.seq_table.size(); },
+          sm::description(
+            "Number of active producers (known producer_id seq number pairs)."),
+          labels)
+          .aggregate(aggregate_labels),
+        sm::make_gauge(
           "idempotency_num_pids_inflight",
           [this] { return _inflight_requests.size(); },
           sm::description(


### PR DESCRIPTION
The commit adds idempotency_num_pids_known metric to monitor when idempotency hits the limit of max pids in seq table.

Fixes #11886

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

* none