### PR TITLE
[clang-tidy] Add seastar shared_ptr types to allowed value param

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,5 +23,7 @@ CheckOptions:
     value:           llvm
   - key:             modernize-use-nullptr.NullMacros
     value:           NULL
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           'seastar::lw_shared_ptr;seastar::shared_ptr'
 ...
 


### PR DESCRIPTION
There are places where we pass around callbacks to `ss::shared_ptr` or use
them to keep the life of an object around during a coroutine, so
clang-tidy saying that they need to be passed by reference often
conflicts with the clang-tidy check to **not** pass by reference in
coroutines.


## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
