### PR TITLE
Fix fetch latency calculation

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -475,7 +475,7 @@ static void fill_fetch_responses(
         resp_it->set(std::move(resp));
         std::chrono::microseconds fetch_latency
           = std::chrono::duration_cast<std::chrono::microseconds>(
-            start_time - op_context::latency_clock::now());
+            op_context::latency_clock::now() - start_time);
         octx.rctx.probe().record_fetch_latency(fetch_latency);
     }
 }


### PR DESCRIPTION
While changing the way we calculate fetch latency, I reversed the order of "now" and "start time" in the latency calculation, resulting in negative values for this duration. This interacted with the way histograms work in Prometheus to produce large (invalid) latency readings.

This change existed only in 23.2 and not in prior versions so no release note nor backports are required.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

