### PR TITLE
rpk: use console URL in virtual clusters profiles

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -109,7 +109,7 @@ func TestAdminAPI(t *testing.T) {
 				}
 			}()
 
-			adminClient, err := NewAdminAPI(urls, BasicCredentials{}, nil)
+			adminClient, err := NewAdminAPI(urls, BasicCredentials{}, nil, "")
 			require.NoError(t, err)
 			err = tt.action(t, adminClient)
 			require.NoError(t, err)

--- a/src/go/rpk/pkg/api/admin/api_cloud_storage_test.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage_test.go
@@ -35,7 +35,7 @@ func TestStartAutomatedRecovery(t *testing.T) {
 		server := httptest.NewServer(test.testFn(t))
 		defer server.Close()
 
-		client, err := NewAdminAPI([]string{server.URL}, BasicCredentials{}, nil)
+		client, err := NewAdminAPI([]string{server.URL}, BasicCredentials{}, nil, "")
 		assert.NoError(t, err)
 
 		response, err := client.StartAutomatedRecovery(context.Background(), ".*")
@@ -106,7 +106,7 @@ func TestPollAutomatedRecoveryStatus(t *testing.T) {
 		server := httptest.NewServer(test.testFn(t))
 		defer server.Close()
 
-		client, err := NewAdminAPI([]string{server.URL}, BasicCredentials{}, nil)
+		client, err := NewAdminAPI([]string{server.URL}, BasicCredentials{}, nil, "")
 		assert.NoError(t, err)
 
 		resp, err := client.PollAutomatedRecoveryStatus(context.Background())


### PR DESCRIPTION
New virtual clusters will use the Console URL as the admin API and rpk will need to pass the auth token as a bearer token in every admin API request when using OIDC from cloud as an authentication mechanism.

## Backports Required

- [ ] none - not a bug fix


## Release Notes

* none

