### PR TITLE
Logging at server creation

### DIFF
--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -34,7 +34,10 @@ server::server(server_configuration c, ss::logger& log)
   , _log(log)
   , _memory{size_t{static_cast<size_t>(cfg.max_service_memory_per_core)}, "net/server-mem"}
   , _probe(std::make_unique<server_probe>())
-  , _public_metrics(ssx::metrics::public_metrics_handle) {}
+  , _public_metrics(ssx::metrics::public_metrics_handle) {
+    vlog(
+      _log.info, "Creating net::server for {} with config {}", cfg.name, cfg);
+}
 
 server::server(ss::sharded<server_configuration>* s, ss::logger& log)
   : server(s->local(), log) {}
@@ -363,7 +366,11 @@ std::ostream& operator<<(std::ostream& o, const server_configuration& c) {
         o << a;
     }
     o << ", max_service_memory_per_core: " << c.max_service_memory_per_core
-      << ", metrics_enabled:" << !c.disable_metrics;
+      << ", metrics_enabled:" << !c.disable_metrics
+      << ", listen_backlog:" << c.listen_backlog
+      << ", tcp_recv_buf:" << c.tcp_recv_buf
+      << ", tcp_send_buf:" << c.tcp_send_buf
+      << ", stream_recv_buf:" << c.stream_recv_buf;
     return o << "}";
 }
 


### PR DESCRIPTION
net::server objects are at the core of the wire layer for Redpanda, so let's log key information about server objects when they are created.

This also fills out operator<< for the server configuration object to include most fields as it was pretty threadbare before.

Issue redpanda-data/core-internal#472.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
