### PR TITLE
Sort nodes in health report

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -807,6 +807,9 @@ health_monitor_backend::get_cluster_health_overview(
         }
     }
 
+    std::sort(ret.all_nodes.begin(), ret.all_nodes.end());
+    std::sort(ret.nodes_down.begin(), ret.nodes_down.end());
+
     // The size of the health status must be bounded: if all partitions
     // on a system with 50k partitions are under-replicated, it is not helpful
     // to try and cram all 50k NTPs into a vector here.


### PR DESCRIPTION
It is convenient if the node IDs are sorted in the node health report.

This change sorts the "all nodes" and "nodes down" lists.


## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
