### PR TITLE
rpk: fix a few minor bugs

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/logdirs.go
+++ b/src/go/rpk/pkg/cli/cluster/logdirs.go
@@ -81,9 +81,14 @@ where revision is a Redpanda internal concept.
 			if len(topics) > 0 {
 				listed, err := adm.ListTopics(context.Background(), topics...)
 				out.MaybeDie(err, "unable to describe topics: %v", err)
+				var exit bool
 				listed.EachError(func(d kadm.TopicDetail) {
 					fmt.Fprintf(os.Stderr, "unable to discover the partitions on topic %q: %v\n", d.Topic, d.Err)
+					exit = true
 				})
+				if exit {
+					os.Exit(1)
+				}
 				s = listed.TopicsSet()
 			}
 
@@ -190,7 +195,7 @@ where revision is a Redpanda internal concept.
 			// what we have already ordered and aggregated.
 			if sortBySize {
 				sort.SliceStable(rows, func(i, j int) bool {
-					return rows[i].Size < rows[j].Size
+					return rows[i].Size >= rows[j].Size
 				})
 			}
 

--- a/src/go/rpk/pkg/cli/group/offset_delete.go
+++ b/src/go/rpk/pkg/cli/group/offset_delete.go
@@ -71,9 +71,11 @@ topic_b 0
 
 			// For -topic options that didn't include partitions, perform a
 			// lookup for them using a metadata request
-			mdResp, err := adm.Metadata(context.Background(), topicsSet.EmptyTopics()...)
-			out.MaybeDie(err, "unable to make metadata request: %v", err)
-			topicsSet.Merge(mdResp.Topics.TopicsSet())
+			if empty := topicsSet.EmptyTopics(); len(empty) > 0 {
+				mdResp, err := adm.Metadata(context.Background(), empty...)
+				out.MaybeDie(err, "unable to make metadata request: %v", err)
+				topicsSet.Merge(mdResp.Topics.TopicsSet())
+			}
 
 			responses, err := adm.DeleteOffsets(context.Background(), args[0], topicsSet)
 			out.MaybeDieErr(err)
@@ -100,7 +102,7 @@ topic_b 0
 func parseTopicPartitionsArgs(list []string) (kadm.TopicsSet, error) {
 	parsed, err := out.ParseTopicPartitions(list)
 	if err == nil {
-		topicsList := make(kadm.TopicsList, len(parsed))
+		topicsList := make(kadm.TopicsList, 0, len(parsed))
 		for topic, partitions := range parsed {
 			topicsList = append(topicsList, kadm.TopicPartitions{Topic: topic, Partitions: partitions})
 		}

--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -163,7 +163,7 @@ func (c *consumer) consume() {
 		}
 
 		fs.EachError(func(t string, p int32, err error) {
-			fmt.Fprintf(os.Stderr, "ERR: topic %s partition %d: %v", t, p, err)
+			fmt.Fprintf(os.Stderr, "ERR: topic %s partition %d: %v\n", t, p, err)
 		})
 
 		marks = marks[:0]


### PR DESCRIPTION
Fixes a few bugs noticed while working on other things (so, not user reported). The offset-delete bugs are more important and exist in 23.1, so this should be backported. The logdirs panic is hard to hit (only encountered if the RP request fails) but is also worth backporting. The consume bug is just a display printing bug (errors are collapsed into one line).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes


* `rpk group offset-delete` no longer tries to delete offsets for all topics if no empty topics are specified
* `rpk group offset-delete` no longer tries to delete offsets for empty-name topics
* `rpk cluster logdirs` no longer panics if there is an error getting a response from Redpanda
