### PR TITLE
[v22.2.x] Fixed querying for the node in decommission test

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -309,7 +309,7 @@ class NodesDecommissioningTest(EndToEndTest):
                    backoff_sec=2)
 
         # stop decommissioned node
-        self.redpanda.stop_node(self.redpanda.get_node(to_decommission))
+        self.redpanda.stop_node(self.redpanda.get_node_by_id(to_decommission))
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=90)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11903
Fixes: https://github.com/redpanda-data/redpanda/issues/11908,