### PR TITLE
cloud_storage: add TieredStorageReaderStressTest & strictly limit reader concurrency

### DIFF
--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -50,18 +50,18 @@ materialized_resources::materialized_resources()
   , _max_segments_per_shard(
       config::shard_local_cfg()
         .cloud_storage_max_materialized_segments_per_shard.bind())
-  , _reader_units(max_readers(), "cst_reader")
+  , _segment_reader_units(max_readers(), "cst_reader")
   , _segment_units(max_segments(), "cst_segment")
   , _manifest_meta_size(
       config::shard_local_cfg().cloud_storage_manifest_cache_size.bind())
   , _manifest_cache(ss::make_shared<materialized_manifest_cache>(
       config::shard_local_cfg().cloud_storage_manifest_cache_size())) {
     _max_readers_per_shard.watch(
-      [this]() { _reader_units.set_capacity(max_readers()); });
+      [this]() { _segment_reader_units.set_capacity(max_readers()); });
     _max_segments_per_shard.watch(
       [this]() { _segment_units.set_capacity(max_segments()); });
     _max_partitions_per_shard.watch(
-      [this]() { _reader_units.set_capacity(max_readers()); });
+      [this]() { _segment_reader_units.set_capacity(max_readers()); });
     _manifest_meta_size.watch([this] {
         ssx::background = ss::with_gate(_gate, [this] {
             vlog(
@@ -112,8 +112,8 @@ size_t materialized_resources::max_segments() const {
       _max_partitions_per_shard() * default_segment_factor));
 }
 
-size_t materialized_resources::current_readers() const {
-    return _reader_units.outstanding();
+size_t materialized_resources::current_segment_readers() const {
+    return _segment_reader_units.outstanding();
 }
 
 size_t materialized_resources::current_segments() const {
@@ -124,16 +124,16 @@ void materialized_resources::register_segment(materialized_segment_state& s) {
     _materialized.push_back(s);
 }
 
-ssx::semaphore_units materialized_resources::get_reader_units() {
-    if (_reader_units.available_units() <= 0) {
-        trim_readers(max_readers() / 2);
+ssx::semaphore_units materialized_resources::get_segment_reader_units() {
+    if (_segment_reader_units.available_units() <= 0) {
+        trim_segment_readers(max_readers() / 2);
     }
 
     // TOOD: make this function async so that it can wait until we succeed
     // in evicting some readers: trim_readers is not
     // guaranteed to do this, if all readers are in use.
 
-    return _reader_units.take(1).units;
+    return _segment_reader_units.take(1).units;
 }
 
 ssx::semaphore_units materialized_resources::get_segment_units() {
@@ -149,12 +149,12 @@ ssx::semaphore_units materialized_resources::get_segment_units() {
     return _segment_units.take(1).units;
 }
 
-void materialized_resources::trim_readers(size_t target_free) {
+void materialized_resources::trim_segment_readers(size_t target_free) {
     vlog(
       cst_log.debug,
-      "Trimming readers until {} reader slots are free (current {})",
+      "Trimming segment readers until {} reader slots are free (current {})",
       target_free,
-      _reader_units.available_units());
+      _segment_reader_units.available_units());
 
     // We sort segments by their reader count before culling, to avoid unfairly
     // targeting whichever segments happen to be first in the list.
@@ -188,7 +188,8 @@ void materialized_resources::trim_readers(size_t target_free) {
     }
 
     for (auto i = candidates.rbegin();
-         i != candidates.rend() && _reader_units.current() < target_free;
+         i != candidates.rend()
+         && _segment_reader_units.current() < target_free;
          ++i) {
         auto& st = i->second.get();
 
@@ -202,13 +203,14 @@ void materialized_resources::trim_readers(size_t target_free) {
 
         // Readers hold a reference to the segment, so for the
         // segment.owned() check to pass, we need to clear them out.
-        while (!st.readers.empty() && _reader_units.current() < target_free) {
+        while (!st.readers.empty()
+               && _segment_reader_units.current() < target_free) {
             auto partition = st.parent;
             // TODO: consider asserting here instead: it's a bug for
             // 'partition' to be null, since readers outlive the partition, and
             // we can't create new readers if the partition has been shut down.
             if (likely(partition)) {
-                partition->evict_reader(std::move(st.readers.front()));
+                partition->evict_segment_reader(std::move(st.readers.front()));
             }
             st.readers.pop_front();
         }
@@ -332,7 +334,7 @@ void materialized_resources::maybe_trim_segment(
             // we can't create new readers if the partition has been shut down.
             auto partition = st.parent;
             if (likely(partition)) {
-                partition->evict_reader(std::move(st.readers.front()));
+                partition->evict_segment_reader(std::move(st.readers.front()));
             }
             st.readers.pop_front();
         }

--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -149,6 +149,11 @@ ssx::semaphore_units materialized_resources::get_segment_reader_units() {
 
 ss::future<ssx::semaphore_units>
 materialized_resources::get_partition_reader_units(size_t n) {
+    if (_partition_reader_units.available_units() <= 0) {
+        // Update metrics counter if we are trying to acquire units while
+        // saturated saturated
+        _partition_readers_delayed += 1;
+    }
     return _partition_reader_units.get_units(n);
 }
 

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -86,6 +86,12 @@ private:
     /// How many materialized_segment_state instances exist
     size_t current_segments() const;
 
+    /// Counts the number of times when get_partition_reader_units() was
+    /// called and had to sleep because no units were immediately available.
+    uint64_t get_partition_readers_delayed() {
+        return _partition_readers_delayed;
+    }
+
     /// Consume from _eviction_list
     ss::future<> run_eviction_loop();
 
@@ -141,6 +147,9 @@ private:
 
     /// Cache used to store materialized spillover manifests
     ss::shared_ptr<materialized_manifest_cache> _manifest_cache;
+
+    /// Counter that is exposed via probe object.
+    uint64_t _partition_readers_delayed{0};
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -178,9 +178,9 @@ remote_probe::remote_probe(
               .aggregate({sm::shard_label}),
             sm::make_gauge(
               "readers",
-              [&ms] { return ms.current_readers(); },
-              sm::description(
-                "Number of read cursors for hydrated remote log segments"))
+              [&ms] { return ms.current_segment_readers(); },
+              sm::description("Number of segment read cursors for hydrated "
+                              "remote log segments"))
               .aggregate({sm::shard_label}),
             sm::make_counter(
               "segment_index_uploads_total",

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -190,6 +190,13 @@ remote_probe::remote_probe(
                 "fetch/timequery requests reading from tiered storage)"))
               .aggregate({sm::shard_label}),
             sm::make_counter(
+              "partition_readers_delayed",
+              [&ms] { return ms.get_partition_readers_delayed(); },
+              sm::description("How many read requests were delayed due to "
+                              "hitting reader limit.  This indicates cluster "
+                              "is saturated with tiered storage reads."))
+              .aggregate({sm::shard_label}),
+            sm::make_counter(
               "segment_index_uploads_total",
               [this] { return get_index_uploads(); },
               sm::description("Successful segment index uploads"),

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -182,6 +182,13 @@ remote_probe::remote_probe(
               sm::description("Number of segment read cursors for hydrated "
                               "remote log segments"))
               .aggregate({sm::shard_label}),
+            sm::make_gauge(
+              "partition_readers",
+              [&ms] { return ms.current_partition_readers(); },
+              sm::description(
+                "Number of partition reader instances (number of current "
+                "fetch/timequery requests reading from tiered storage)"))
+              .aggregate({sm::shard_label}),
             sm::make_counter(
               "segment_index_uploads_total",
               [this] { return get_index_uploads(); },

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -147,7 +147,8 @@ public:
     void offload_segment(model::offset);
 
     // Place on the eviction queue.
-    void evict_reader(std::unique_ptr<remote_segment_batch_reader> reader);
+    void
+    evict_segment_reader(std::unique_ptr<remote_segment_batch_reader> reader);
     void evict_segment(ss::lw_shared_ptr<remote_segment> segment);
 
     // Compute cache usage statistics. This method uses information from the
@@ -176,13 +177,13 @@ private:
     /// \param config is a reader config
     /// \param offset_key is an key of the segment state in the _segments
     /// \param st is a segment state referenced by offset_key
-    std::unique_ptr<remote_segment_batch_reader> borrow_reader(
+    std::unique_ptr<remote_segment_batch_reader> borrow_segment_reader(
       storage::log_reader_config config,
       kafka::offset offset_key,
       materialized_segment_ptr& st);
 
     /// Return reader back to segment_state
-    void return_reader(std::unique_ptr<remote_segment_batch_reader>);
+    void return_segment_reader(std::unique_ptr<remote_segment_batch_reader>);
 
     /// The result of the borrow_next_reader method
     ///
@@ -200,7 +201,7 @@ private:
     /// find the target. It can find already materialized segment and reuse the
     /// reader. Alternatively, it can materialize the segment and create a
     /// reader.
-    borrow_result_t borrow_next_reader(
+    borrow_result_t borrow_next_segment_reader(
       const partition_manifest& manifest,
       storage::log_reader_config config,
       model::offset hint = {});

--- a/src/v/cloud_storage/segment_state.cc
+++ b/src/v/cloud_storage/segment_state.cc
@@ -20,7 +20,7 @@ namespace cloud_storage {
 void materialized_segment_state::offload(remote_partition* partition) {
     _hook.unlink();
     for (auto&& rs : readers) {
-        partition->evict_reader(std::move(rs));
+        partition->evict_segment_reader(std::move(rs));
     }
     partition->evict_segment(std::move(segment));
     partition->_probe.segment_offloaded();
@@ -70,7 +70,7 @@ materialized_segment_state::borrow_reader(
 
     // Obey budget for concurrent readers: call into materialized_segments
     // to give it an opportunity to free state and make way for us.
-    auto units = parent->materialized().get_reader_units();
+    auto units = parent->materialized().get_segment_reader_units();
 
     return std::make_unique<remote_segment_batch_reader>(
       segment, cfg, probe, std::move(units));

--- a/src/v/utils/adjustable_semaphore.h
+++ b/src/v/utils/adjustable_semaphore.h
@@ -95,6 +95,8 @@ public:
         return _capacity - available_units();
     }
 
+    void broken() noexcept { _sem.broken(); }
+
 private:
     ssx::semaphore _sem;
 

--- a/src/v/utils/adjustable_semaphore.h
+++ b/src/v/utils/adjustable_semaphore.h
@@ -97,8 +97,10 @@ public:
 
     void broken() noexcept { _sem.broken(); }
 
+    uint64_t capacity() { return _capacity; }
+
 private:
     ssx::semaphore _sem;
 
-    uint64_t _capacity;
+    uint64_t _capacity{0};
 };

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 import time
-import signal
 import concurrent.futures
 from collections import Counter
 
@@ -533,7 +532,9 @@ class ManyPartitionsTest(PreallocNodesTest):
         t1 = time.time()
         wait_until(
             lambda: self._node_leadership_balanced(topic_names, n_partitions),
-            expect_leader_transfer_time, 10)
+            expect_leader_transfer_time,
+            10,
+            err_msg="Waiting for leadership balance after restart")
         self.logger.info(
             f"Leaderships balanced in {time.time() - t1:.2f} seconds")
 
@@ -564,7 +565,8 @@ class ManyPartitionsTest(PreallocNodesTest):
             wait_until(
                 lambda: self._all_elections_done(topic_names, n_partitions),
                 timeout_sec=60,
-                backoff_sec=5)
+                backoff_sec=5,
+                err_msg="Waiting for elections to complete after restart")
             self.logger.info(f"Post-restart elections done.")
 
             inter_restart_check()
@@ -624,7 +626,8 @@ class ManyPartitionsTest(PreallocNodesTest):
                 wait_until(lambda: nodes_report_cloud_segments(
                     self.redpanda, target_cloud_segments),
                            timeout_sec=expect_runtime,
-                           backoff_sec=5)
+                           backoff_sec=5,
+                           err_msg="Waiting for cloud segments upload")
             finally:
                 producer.stop()
                 producer.wait(timeout_sec=expect_runtime)
@@ -733,7 +736,8 @@ class ManyPartitionsTest(PreallocNodesTest):
         # checkpoint with valid ranges.
         wait_until(lambda: fast_producer.produce_status.acked > 0,
                    timeout_sec=30,
-                   backoff_sec=1.0)
+                   backoff_sec=1.0,
+                   err_msg="Waiting for producer checkpoint")
 
         rand_ios = 100
         rand_parallel = 100
@@ -993,7 +997,8 @@ class ManyPartitionsTest(PreallocNodesTest):
         self.logger.info(f"Awaiting elections...")
         wait_until(lambda: self._all_elections_done(topic_names, n_partitions),
                    timeout_sec=60,
-                   backoff_sec=5)
+                   backoff_sec=5,
+                   err_msg="Waiting for initial elections")
         self.logger.info(f"Initial elections done.")
 
         for node_name, file_count in self._get_fd_counts():

--- a/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
@@ -1,0 +1,319 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
+from rptest.services.redpanda import SISettings, MetricsEndpoint, ResourceSettings
+from rptest.clients.rpk import RpkTool, RpkException
+import concurrent.futures
+from rptest.utils.si_utils import quiesce_uploads
+import time
+import threading
+
+
+class TieredStorageReaderStressTest(RedpandaTest):
+    segment_upload_interval = 10
+    manifest_upload_interval = 1
+    expect_throughput = 50 * 1024 * 1024
+    runtime_grace_factor = 2.0
+
+    # Make the cache big enough to definitely accomodate disk-saturating throughput,  to avoid
+    # artificially limiting the rate at which we create segment readers and fill their read
+    # buffers: we want maximum memory stress, not readers waiting on cache space.
+    cache_max_throughput = 10 * expect_throughput
+    cache_size = SISettings.cache_size_for_throughput(cache_max_throughput)
+
+    # This is the same as the default at time of writing (v23.2)
+    readers_per_shard = 1000
+
+    # To help reduce runtime by requiring less data to get a given segment count
+    segment_size = 16 * 1024 * 1024
+    chunk_size = 1 * 1024 * 1024
+
+    def __init__(self, test_context, *args, **kwargs):
+        si_settings = SISettings(test_context=test_context,
+                                 log_segment_size=self.segment_size,
+                                 cloud_storage_cache_size=self.cache_size)
+        extra_rp_conf = {
+            "cloud_storage_cache_chunk_size": self.chunk_size,
+            'cloud_storage_segment_max_upload_interval_sec':
+            self.segment_upload_interval,
+            'cloud_storage_manifest_max_upload_interval_sec':
+            self.manifest_upload_interval,
+            'cloud_storage_max_readers_per_shard': self.readers_per_shard
+        }
+        super().__init__(test_context,
+                         *args,
+                         si_settings=si_settings,
+                         extra_rp_conf=extra_rp_conf,
+                         **kwargs)
+
+        # Artificially limit CPUs, so that we concentrate readers on a small, deterministic
+        # number of cores, and have relatively limited memory.  The memory is within the official system
+        # requirements (2GB per core).
+        self.redpanda.set_resource_settings(
+            ResourceSettings(memory_mb=4096, num_cpus=2))
+
+    def _produce_and_quiesce(self, topic_name: str, msg_size: int,
+                             data_size: int, expect_bandwidth: float,
+                             **kwargs):
+        expect_runtime = max(60.0, (data_size / expect_bandwidth) * 2)
+
+        t1 = time.time()
+        timeout = expect_runtime * self.runtime_grace_factor
+
+        self.logger.info(f"Producing {data_size} bytes, timeout = {timeout}")
+        KgoVerifierProducer.oneshot(self.test_context,
+                                    self.redpanda,
+                                    topic_name,
+                                    msg_size=msg_size,
+                                    msg_count=data_size // msg_size,
+                                    batch_max_bytes=msg_size * 8,
+                                    timeout_sec=timeout,
+                                    **kwargs)
+        produce_duration = time.time() - t1
+        self.logger.info(
+            f"Produced {data_size} bytes in {produce_duration} seconds, {(data_size/produce_duration)/1000000.0:.2f}MB/s"
+        )
+
+        quiesce_uploads(
+            self.redpanda, [topic_name],
+            self.manifest_upload_interval + self.segment_upload_interval + 30)
+
+    def _create_topic(self, topic_name: str, partition_count: int,
+                      local_retention: int):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(topic_name,
+                         partitions=partition_count,
+                         replicas=3,
+                         config={
+                             'retention.local.target.bytes': local_retention,
+                         })
+
+    def _get_stats(self):
+        """The stats we care about for reader stress, especially
+        reader count and kafka connection count"""
+
+        results = {}
+        for node in self.redpanda.nodes:
+            metrics = self.redpanda.metrics(
+                node, metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+            segment_reader_count = 0
+            partition_reader_count = 0
+            partition_reader_delay_count = 0
+            connection_count = 0
+            for family in metrics:
+                for sample in family.samples:
+                    if sample.name == "redpanda_cloud_storage_readers":
+                        segment_reader_count += int(sample.value)
+                    if sample.name == "redpanda_cloud_storage_partition_readers":
+                        partition_reader_count += int(sample.value)
+                    if sample.name == "redpanda_cloud_storage_partition_readers_delayed_total":
+                        partition_reader_delay_count += int(sample.value)
+                    elif sample.name == "redpanda_rpc_active_connections":
+                        if sample.labels["redpanda_server"] == "kafka":
+                            connection_count += int(sample.value)
+
+            stats = {
+                "segment_readers": segment_reader_count,
+                "partition_readers": partition_reader_count,
+                "partition_readers_delayed": partition_reader_delay_count,
+                "connections": connection_count
+            }
+            self.logger.debug(f"stats[{node.name}] = {stats}")
+            results[node] = stats
+
+        return results
+
+    @cluster(num_nodes=4)
+    def reader_stress_test(self):
+        """
+        Validate that when Kafka RPCs request far more concurrent readers than we can provide:
+        - we do not leak kafka client connections from long-waiting readers whose
+          originating kafka rpc has long since timed out on the client side
+        - reader limits are respected to within a reasonable bound
+        - the system stays up.
+        - that more reasonable reads are still serviced eventually, after we stop hammering
+          the cluster with unreasonable reads.
+
+        The easiest way to bury a redpanda cluster in tiered storage reads is to issue
+        N time queries across M partitions, where each time query happens to target a
+        different data chunk.
+        """
+
+        # Use interval uploads so that tests can do a "wait til everything uploaded"
+        # check if they want to.
+        topic_name = "reader-stress"
+
+        concurrent_timequeries = 32
+        total_timequeries = concurrent_timequeries * 16
+        partition_count = 128
+        msg_size = 16384
+        data_size = max(
+            # Write enough segments that most of the data falls into remote storage
+            self.segment_size * partition_count * 4,
+            # Write enough data that it won't all remain in cache, so that under stress
+            # we are continually promoting/trimming data for maximum disk and memory stress
+            self.cache_size * 4)
+        msg_count = data_size // msg_size
+
+        # We will use synthetic timestamps, to keep the test somewhat deterministic when we
+        # select timequery points evenly spaced through the range
+        base_fake_ts = 1688562373356
+        max_fake_ts = base_fake_ts + msg_count - 1
+
+        peak_readers = partition_count * concurrent_timequeries
+        peak_readers_per_shard = peak_readers // (len(
+            (self.redpanda.nodes) * self.redpanda.get_node_cpu_count()))
+
+        self._create_topic(topic_name, partition_count, self.segment_size)
+        self._produce_and_quiesce(topic_name,
+                                  msg_size,
+                                  data_size,
+                                  self.expect_throughput,
+                                  fake_timestamp_ms=base_fake_ts)
+
+        rpk = RpkTool(self.redpanda)
+
+        client_timeout = 5
+
+        def tq_at(ts):
+            self.logger.debug(f"starting timequery: {ts}")
+            out = rpk.consume(topic_name,
+                              n=1,
+                              offset=f"@{ts}",
+                              format="%p,%o",
+                              timeout=5)
+            self.logger.debug(f"completed timequery: {ts} -> {out}")
+
+        stats_watcher_stop = threading.Event()
+        stats_hwms = {}
+
+        def stats_watcher():
+            while not stats_watcher_stop.is_set():
+                stats = self._get_stats()
+                for node, node_stats in stats.items():
+                    hwms = stats_hwms.get(node, node_stats)
+                    for k, v in node_stats.items():
+                        if v > hwms[k]:
+                            hwms[k] = v
+                    stats_hwms[node] = hwms
+
+                stats_watcher_stop.wait(0.5)
+
+        # We are running clients locally on the test runner machine
+        self.logger.info(
+            f"Spawning timequery {total_timequeries} client tasks with {concurrent_timequeries}-way concurrency"
+        )
+        any_failed = False
+
+        # How long we expect it to  take for all tasks to execute
+        task_wait_timeout = (total_timequeries // concurrent_timequeries
+                             ) * client_timeout * self.runtime_grace_factor
+        task_initial_time = time.time()
+
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=concurrent_timequeries + 1) as executor:
+            watcher_job = executor.submit(stats_watcher)
+            jobs = []
+            step = msg_count // concurrent_timequeries
+
+            # k is the counter through rounds of concurrent timequery tasks
+            k_iterations = total_timequeries // concurrent_timequeries
+
+            for k in range(0, k_iterations):
+                for i in range(0, concurrent_timequeries):
+                    ts = base_fake_ts + step * i + k * (step // k_iterations)
+                    jobs.append((k, ts, executor.submit(tq_at, ts)))
+
+            for (k, ts, j) in jobs:
+                try:
+                    # Throw and fail the test if our overall runtime for all tasks
+                    # has expired.
+                    timeout = task_wait_timeout - (time.time() -
+                                                   task_initial_time)
+                    j.result(timeout=timeout)
+                except RpkException as e:
+                    # We expect this: timequeries will time out
+                    self.logger.info(
+                        f"timequery task {k}-@{ts} on overloaded cluster failed: {e}"
+                    )
+                    any_failed = True
+                else:
+                    self.logger.info(f"timequery task {k}-@{ts} succeeded")
+
+            stats_watcher_stop.set()
+            watcher_job.result()
+
+        self.logger.info("Finished timequery client tasks")
+
+        assert any_failed, "Expected some timequeries to fail due to overload"
+
+        for node, hwms in stats_hwms.items():
+            self.logger.info(f"hwms[{node.name}]: {hwms}")
+
+            assert hwms['connections'] <= total_timequeries
+            assert hwms[
+                'partition_readers'] <= self.readers_per_shard * self.redpanda.get_node_cpu_count(
+                )
+
+            # Segment reader limit is sloppy, but probabilistically it should not have overshot
+            # by more than a factor of 2 before getting trimmed.
+            assert hwms[
+                'segment_readers'] <= 2 * self.readers_per_shard * self.redpanda.get_node_cpu_count(
+                )
+
+        # TODO: assert on reader HWM once we enforce it more strongly
+
+        # TODO: once we implement abort source driven cancellation of tiered storage
+        # I/O on client disconnect, we should assert here that the connection count
+        # is at zero, and we should assert that no new downloads start after all our
+        # clients have stopped.
+
+        stats = self._get_stats()
+        for node, stats in stats.items():
+            # The stats indicate saturation with tiered storage reads.
+            assert stats['partition_readers_delayed']
+            # There are still some segment readers cached as expected, they shouldn't
+            # all have been trimmed.
+            assert stats['segment_readers']
+
+            # TODO: remove these last assertions once we have clean abort on client timeout:
+            # they are currently asserting that the buggy behavior happens where we have
+            # a backlog of connections due to abandoned kafka RPC dispatch fibers.
+            assert stats['connections']
+            assert stats['partition_readers']
+
+        def connections_closed():
+            for node, stats in self._get_stats().items():
+                if stats['connections'] > 0:
+                    self.logger.debug(
+                        f"Node {node.name} still has {stats['connections']} connections open"
+                    )
+                    return False
+
+            return True
+
+        self.logger.info("Waiting for all Kafka connections to close")
+        # The timeout here has to be set in a way that's aligned with the number of parallel
+        # reads we did: if this timeout is long enough for them all to complete and drain (even
+        # without aborting requests on client timeout), then the test will pass even if
+        # we aren't doing proper aborting on client timeout.
+        # TODO: make this much tighter, and/or an immediate assertion rather than a
+        #       wait_until, once we have aborting of readers on client disconnect.
+        expect_runtime_per_request = 0.5
+        self.redpanda.wait_until(
+            connections_closed,
+            # How long we expect all the timequeries to take to drain if they
+            # are sat there running in orphan rpc fibers
+            # TODO: this reflects the behavior that abort-on-client-timeout should fix.
+            timeout_sec=expect_runtime_per_request * total_timequeries,
+            backoff_sec=1,
+            err_msg="Waiting for Kafka connections to close")

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -178,6 +178,23 @@ class KgoVerifierService(Service):
 
     def wait_node(self, node, timeout_sec=None):
         """
+        Wrapper to catch timeouts on wait, and send a `/print_stack` to the remote
+        process in case it is experiencing a hang bug.
+        """
+        try:
+            return self._do_wait_node(node, timeout_sec)
+        except:
+            try:
+                self._remote(node, "print_stack")
+            except Exception as e:
+                self._redpanda.logger.warn(
+                    f"{self.who_am_i()} failed to print stacks during wait failure: {e}"
+                )
+
+            raise
+
+    def _do_wait_node(self, node, timeout_sec):
+        """
         Wait for the remote process to gracefully finish: if it is a one-shot
         operation this waits for all work to complete, if it is a looping
         operation then we wait for the current iteration of the loop to finish
@@ -201,10 +218,13 @@ class KgoVerifierService(Service):
         # Let the worker fall through to the end of its current iteration
         self.logger.debug(
             f"wait_node {self.who_am_i()}: waiting for worker to complete")
-        self._redpanda.wait_until(lambda: self._status.active is False or self.
-                                  _status_thread.errored,
-                                  timeout_sec=timeout_sec,
-                                  backoff_sec=5)
+        self._redpanda.wait_until(
+            lambda: self._status.active is False or self._status_thread.
+            errored,
+            timeout_sec=timeout_sec,
+            backoff_sec=5,
+            err_msg=
+            f"{self.who_am_i()} didn't complete in {timeout_sec} seconds")
         self._status_thread.raise_on_error()
 
         # Read final status


### PR DESCRIPTION
Previously, our reader concurrency limit applied to segment readers rather than partition readers, and it was a soft limit: it governed trimming behavior, but trimming could only happen if the segment readers weren't actively in use.  Therefore if clients deluged a server with tiered storage read requests (which can be done quite cheaply with time queries), they could create very large numbers of concurrent segment readers.

This is bad because we can OOM (and the new test does indeed OOM without the new limiting in this PR), but also because it leads to splitting available disk bandwidth very widely between all those readers, meaning that each one might well be too slow to complete quickly enough for a client's timeout.

That bad situation is compounded by lack of cancellation of requests on the server when a client gives up and disconnects: we accumulate a pile of connections that doesn't drain until all of them complete their I/O and generate results for clients that long since disconnected.

This PR adds a test that exercises this scenario, and partly fixes it.  The concurrent reader limit is now applied to partition readers as well as segment readers, and it is applied strictly: the tiered storage read path will not proceed until units are acquired.  These blocked requests still have a memory footprint (especially if they are wide fetches which might have buffered data already from some partitions while they wait for other partitions to acquire reader semaphore units), but it is better than spawning an unbounded number of underlying readers.

The next stage to addressing this situation is to abort request fibers when clients disconnect: an opportune place to do this is right after the semaphore get_units that is added in this PR: if we get those units, then find that our request's abort source has fired, we can go ahead and drop out before doing any I/O.

Related: https://github.com/redpanda-data/redpanda/issues/11799

## Backports Required

**Debatable**: one could hand backport the partition concurrency limit, needs prioritization relative to other work.

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Limits on tiered storage read concurrency are enforced more strictly, to improve stability when clients issue very large numbers of concurrent fetches, or do timequeries on topics with large numbers of partitions.