### PR TITLE
kafka: Disable use of separate fetch scheduling group

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -516,7 +516,7 @@ configuration::configuration()
       "use_fetch_scheduler_group",
       "Use a separate scheduler group for fetch processing",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      true)
+      false)
   , metadata_status_wait_timeout_ms(
       *this,
       "metadata_status_wait_timeout_ms",


### PR DESCRIPTION
This partially reverts https://github.com/redpanda-data/redpanda/commit/9a93a9c22238e145dfa9d7fe297eb494d7c5f0bf

While the original motiviation isn't invalidated we have now found a
counter example where the extra fetch groups makes things worse overall.

`ManyPartitionTest` fails on ARM with the extra group but passes
without. With the group in use CPU util hits 100% and grinds everything
to halt.

Fetch seems to be a lot slower on ARM. Hence, with the guaranteed share
of the extra group the whole system gets affected and hits CPU limits.

Because this is incredibly hard to reason about and it wasn't the core
fetch optimization we decided to revert back to keeping it disabled by
default.

We still keep the option around as it might be useful potentially in
corner cases.

Fixes https://github.com/redpanda-data/redpanda/issues/10507
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Disable use of fetch scheduling group by default. We found a few cases that were negatively affected.
