### PR TITLE
cluster: fix result error handling

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -206,14 +206,8 @@ ss::future<std::error_code> partition::prefix_truncate(
       kafka_start_offset);
     auto res = co_await _log_eviction_stm->truncate(
       rp_start_offset, kafka_start_offset, deadline, _as);
-    if (res.has_failure()) {
-        if (res.has_error()) {
-            co_return res.error();
-        }
-        // An exception was thrown.
-        vlog(
-          clusterlog.error, "Truncation failed: {}", std::current_exception());
-        co_return errc::replication_error;
+    if (res.has_error()) {
+        co_return res.error();
     }
     if (_archival_meta_stm) {
         // The archival metadata stm also listens for prefix_truncate batches.


### PR DESCRIPTION
When I wrote this, I expected exceptions to be returned from the underlying result type, but it turns out that has_exception() always returns false for the basic_result class[1]:

```
bool has_exception() const noexcept
Always returns false for basic_result. Constexpr, never throws.
```

1. https://www.boost.org/doc/libs/1_71_0/libs/outcome/doc/html/reference/types/basic_result.html

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
