### PR TITLE
v23.1.x: rpk minor bugs

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/logdirs.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/logdirs.go
@@ -106,9 +106,14 @@ where revision is a Redpanda internal concept.
 			if len(topics) > 0 {
 				listed, err := adm.ListTopics(context.Background(), topics...)
 				out.MaybeDie(err, "unable to describe topics: %v", err)
+				var exit bool
 				listed.EachError(func(d kadm.TopicDetail) {
-					fmt.Fprintf(os.Stderr, "unable to discover the partitions on topic %q: %v", d.Topic, d.Err)
+					fmt.Fprintf(os.Stderr, "unable to discover the partitions on topic %q: %v\n", d.Topic, d.Err)
+					exit = true
 				})
+				if exit {
+					os.Exit(1)
+				}
 				s = listed.TopicsSet()
 			}
 
@@ -208,7 +213,7 @@ where revision is a Redpanda internal concept.
 			// what we have already ordered and aggregated.
 			if sortBySize {
 				sort.SliceStable(rows, func(i, j int) bool {
-					return rows[i].Size < rows[j].Size
+					return rows[i].Size >= rows[j].Size
 				})
 			}
 

--- a/src/go/rpk/pkg/cli/cmd/group/offset_delete.go
+++ b/src/go/rpk/pkg/cli/cmd/group/offset_delete.go
@@ -72,9 +72,11 @@ topic_b 0
 
 			// For -topic options that didn't include partitions, perform a
 			// lookup for them using a metadata request
-			mdResp, err := adm.Metadata(context.Background(), topicsSet.EmptyTopics()...)
-			out.MaybeDie(err, "unable to make metadata request: %v", err)
-			topicsSet.Merge(mdResp.Topics.TopicsSet())
+			if empty := topicsSet.EmptyTopics(); len(empty) > 0 {
+				mdResp, err := adm.Metadata(context.Background(), empty...)
+				out.MaybeDie(err, "unable to make metadata request: %v", err)
+				topicsSet.Merge(mdResp.Topics.TopicsSet())
+			}
 
 			responses, err := adm.DeleteOffsets(context.Background(), args[0], topicsSet)
 			out.MaybeDieErr(err)
@@ -101,7 +103,7 @@ topic_b 0
 func parseTopicPartitionsArgs(list []string) (kadm.TopicsSet, error) {
 	parsed, err := out.ParseTopicPartitions(list)
 	if err == nil {
-		topicsList := make(kadm.TopicsList, len(parsed))
+		topicsList := make(kadm.TopicsList, 0, len(parsed))
 		for topic, partitions := range parsed {
 			topicsList = append(topicsList, kadm.TopicPartitions{Topic: topic, Partitions: partitions})
 		}

--- a/src/go/rpk/pkg/cli/cmd/topic/consume.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/consume.go
@@ -161,7 +161,7 @@ func (c *consumer) consume() {
 		}
 
 		fs.EachError(func(t string, p int32, err error) {
-			fmt.Fprintf(os.Stderr, "ERR: topic %s partition %d: %v", t, p, err)
+			fmt.Fprintf(os.Stderr, "ERR: topic %s partition %d: %v\n", t, p, err)
 		})
 
 		marks = marks[:0]


### PR DESCRIPTION
This is a manual backport of #11900

Fixes a few bugs noticed while working on other things (so, not user reported). The offset-delete bugs are more important and exist in 23.1, so this should be backported. The logdirs panic is hard to hit (only encountered if the RP request fails) but is also worth backporting. The consume bug is just a display printing bug (errors are collapsed into one line).

## Release Notes

### Bug Fixes

* `rpk group offset-delete` no longer tries to delete offsets for all topics if no empty topics are specified
* `rpk group offset-delete` no longer tries to delete offsets for empty-name topics
* `rpk cluster logdirs` no longer panics if there is an error getting a response from Redpanda
