### PR TITLE
[v23.1.x] admin_server/get_partition: Avoid oversized allocation

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -92,6 +92,7 @@
 #include <seastar/core/prometheus.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/with_scheduling_group.hh>
@@ -123,6 +124,27 @@
 using namespace std::chrono_literals;
 
 static ss::logger logger{"admin_api_server"};
+
+// Helpers for partition routes
+namespace {
+
+template<typename C>
+class lw_shared_container {
+public:
+    using iterator = typename C::iterator;
+    using value_type = typename C::value_type;
+
+    explicit lw_shared_container(C&& c)
+      : c_{ss::make_lw_shared<C>(std::move(c))} {}
+
+    iterator begin() const { return c_->begin(); }
+    iterator end() const { return c_->end(); }
+
+private:
+    ss::lw_shared_ptr<C> c_;
+};
+
+} // namespace
 
 admin_server::admin_server(
   admin_server_cfg cfg,
@@ -2910,12 +2932,20 @@ void admin_server::register_partition_routes() {
       ss::httpd::partition_json::get_partitions,
       [this](std::unique_ptr<ss::httpd::request>) {
           using summary = ss::httpd::partition_json::partition_summary;
+          static constexpr auto reduce = [](
+                                           fragmented_vector<summary> acc,
+                                           fragmented_vector<summary> update) {
+              std::move(
+                std::make_move_iterator(update.begin()),
+                std::make_move_iterator(update.end()),
+                std::back_inserter(acc));
+              return acc;
+          };
           auto get_summaries =
             [](auto& partition_manager, bool materialized, auto get_leader) {
                 return partition_manager.map_reduce0(
                   [materialized, get_leader](auto& pm) {
-                      std::vector<summary> partitions;
-                      partitions.reserve(pm.partitions().size());
+                      fragmented_vector<summary> partitions;
                       for (const auto& it : pm.partitions()) {
                           summary p;
                           p.ns = it.first.ns;
@@ -2928,11 +2958,8 @@ void admin_server::register_partition_routes() {
                       }
                       return partitions;
                   },
-                  std::vector<summary>{},
-                  [](std::vector<summary> acc, std::vector<summary> update) {
-                      acc.insert(acc.end(), update.begin(), update.end());
-                      return acc;
-                  });
+                  fragmented_vector<summary>{},
+                  reduce);
             };
           auto f1 = get_summaries(_partition_manager, false, [](const auto& p) {
               return p->get_leader_id().value_or(model::node_id(-1))();
@@ -2942,10 +2969,11 @@ void admin_server::register_partition_routes() {
           return ss::when_all_succeed(std::move(f1), std::move(f2))
             .then([](auto summaries) {
                 auto& [partitions, s2] = summaries;
-                for (auto& s : s2) {
-                    partitions.push_back(std::move(s));
-                }
-                return ss::json::json_return_type(std::move(partitions));
+                partitions = reduce(std::move(partitions), std::move(s2));
+                return ss::json::json_return_type(
+                  ss::json::stream_range_as_array(
+                    lw_shared_container{std::move(partitions)},
+                    [](summary const& i) -> summary const& { return i; }));
             });
       });
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11824

Fixes #11924 

Conflicts:
	src/v/redpanda/admin_server.cc

Due to 2cc38ee1a68282dd7a0966961ad64a3bc229963c

I took the opportunity to extract `reduce` and reuse it.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* admin_server/get_partition: Avoid oversized allocation