### PR TITLE
Enhance trace logging in members reconciliation path

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -330,6 +330,7 @@ ss::future<std::error_code> members_backend::reconcile() {
     }
 
     // process one update at a time
+    vassert(!_updates.empty(), "_updates was empty");
     auto& meta = _updates.front();
 
     // leadership changed, drop not yet requested reallocations to make sure


### PR DESCRIPTION

 Additional logging on members reconciliation path
 
 This path involves a lot of logic and we've seen in the past cases
 where reconciliation is either not succeeding or not apparently
 making forward process. This change adds trace-level logging to the
 cluster log to help diagnose these cases.

We also add an assert before referencing a vector front().
 
 Issue redpanda-data/core-internal#472.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none