### PR TITLE
pb_planner: simplify iterator check

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -728,18 +728,14 @@ ss::future<> partition_balancer_planner::request_context::for_each_partition(
          it != topics.topics_iterator_end();
          ++it) {
         const auto& assignments = it->second.get_assignments();
-        for (auto a_it = assignments.begin();
-             // Check iterator validity in each iteration after scheduling
-             // point.
-             (void)it->second,
-                  a_it != assignments.end();
-             a_it++) {
-            auto ntp = model::ntp(it->first.ns, it->first.tp, a_it->id);
-            auto stop = do_with_partition(ntp, a_it->replicas, visitor);
+        for (const auto& assignment : assignments) {
+            auto ntp = model::ntp(it->first.ns, it->first.tp, assignment.id);
+            auto stop = do_with_partition(ntp, assignment.replicas, visitor);
             if (stop == ss::stop_iteration::yes) {
                 co_return;
             }
             co_await maybe_yield();
+            it.check();
         }
     }
 }

--- a/src/v/utils/stable_iterator_adaptor.h
+++ b/src/v/utils/stable_iterator_adaptor.h
@@ -59,6 +59,8 @@ public:
       , _stability_func(std::move(func))
       , _stable_revision(_stability_func()) {}
 
+    void check() const { validate_revision(); }
+
 private:
     void validate_revision() const {
         auto current_revision = _stability_func();


### PR DESCRIPTION
Gets rid of the comma operator in the loop that is expected to throw
when the iterator is invalidated. Instead adds an explicit check that
does the same.

ASAN traces in https://github.com/redpanda-data/redpanda/issues/11664 are ideally not possible because the
freeing stack clearly bumps the topic map revision right after erase
that deallocates the memory, so any subsequent operation on the iterator
should throw right away.

The code is unnecessarily complex with the comma operator, so getting
rid of it in the hopes that there is some sort of miscompilation. If the
issue still reproduces after the patch we can at least eliminate this possibility.

Tests: repeat runs are unable to reproduce the UAF in 600 runs while without the
patch the issue reproduced once in 400 runs. 


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
