### PR TITLE
Update .gitignore for dev-cluster data dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,9 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# default data dir for dev-cluster.py script
+/tools/data
+
 # mypy
 .mypy_cache/
 .ycm_extra_conf.py


### PR DESCRIPTION
dev-cluster.py will by default create a data directory in the tools/data directory, which will fill with files that show in git unless we ignore them. So do that.

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

