### PR TITLE
storage: balanced eviction and advisory policy

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1611,7 +1611,7 @@ configuration::configuration()
       "the target. When no target is specified storage usage is unbounded.",
       {.needs_restart = needs_restart::no,
        .example = "2147483648000",
-       .visibility = visibility::tunable},
+       .visibility = visibility::user},
       std::nullopt)
   , retention_local_trim_interval(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -110,23 +110,6 @@ configuration::configuration()
        .example = "31536000000",
        .visibility = visibility::tunable},
       24h * 365)
-  , log_storage_target_size(
-      *this,
-      "log_storage_target_size",
-      "The target size in bytes that log storage will try meet. When no target "
-      "is specified storage usage is unbounded.",
-      {.needs_restart = needs_restart::no,
-       .example = "2147483648000",
-       .visibility = visibility::tunable},
-      std::nullopt)
-  , log_storage_max_usage_interval(
-      *this,
-      "log_storage_max_usage_interval",
-      "The maximum amount of time before log storage usage will be calculated",
-      {.needs_restart = needs_restart::no,
-       .example = "31536000000",
-       .visibility = visibility::tunable},
-      30s)
   , rpc_server_listen_backlog(
       *this,
       "rpc_server_listen_backlog",
@@ -1620,6 +1603,26 @@ configuration::configuration()
       "write enabled",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       24h)
+  , retention_local_target_capacity_bytes(
+      *this,
+      "retention_local_target_capacity_bytes",
+      "The target capacity in bytes that log storage will try to use before "
+      "additional retention rules will take over to trim data in order to meet "
+      "the target. When no target is specified storage usage is unbounded.",
+      {.needs_restart = needs_restart::no,
+       .example = "2147483648000",
+       .visibility = visibility::tunable},
+      std::nullopt)
+  , retention_local_trim_interval(
+      *this,
+      "retention_local_trim_interval",
+      "The maximum amount of time before log storage will examine usage to "
+      "determine of the target capacity has been exceeded and additional data "
+      "trimming is required.",
+      {.needs_restart = needs_restart::no,
+       .example = "31536000000",
+       .visibility = visibility::tunable},
+      30s)
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1603,6 +1603,14 @@ configuration::configuration()
       "write enabled",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       24h)
+  , retention_local_is_advisory(
+      *this,
+      "retention_local_is_advisory",
+      "Allow log data to expand past local retention. When enabled, non-local "
+      "retention settings are used, and local retention settings are used to "
+      "inform data removal policies in low-disk space scenarios.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , retention_local_target_capacity_bytes(
       *this,
       "retention_local_target_capacity_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1631,6 +1631,16 @@ configuration::configuration()
        .example = "31536000000",
        .visibility = visibility::tunable},
       30s)
+  , retention_local_trim_overage_coeff(
+      *this,
+      "retention_local_trim_overage_coeff",
+      "The space management control loop will reclaim the overage multiplied "
+      "by this this coefficient in order to compensate for data that is "
+      "written during the idle period between control loop invocations.",
+      {.needs_restart = needs_restart::no,
+       .example = "1.8",
+       .visibility = visibility::tunable},
+      2.0)
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -319,6 +319,7 @@ struct configuration final : public config_store {
     // cloud storage read and write enabled
     property<std::optional<size_t>> retention_local_target_bytes_default;
     property<std::chrono::milliseconds> retention_local_target_ms_default;
+    property<bool> retention_local_is_advisory;
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
     property<std::chrono::milliseconds> retention_local_trim_interval;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -54,8 +54,6 @@ struct configuration final : public config_store {
     bounded_property<std::optional<std::chrono::milliseconds>> log_segment_ms;
     property<std::chrono::milliseconds> log_segment_ms_min;
     property<std::chrono::milliseconds> log_segment_ms_max;
-    property<std::optional<uint64_t>> log_storage_target_size;
-    property<std::chrono::milliseconds> log_storage_max_usage_interval;
 
     // Network
     bounded_property<std::optional<int>> rpc_server_listen_backlog;
@@ -321,6 +319,8 @@ struct configuration final : public config_store {
     // cloud storage read and write enabled
     property<std::optional<size_t>> retention_local_target_bytes_default;
     property<std::chrono::milliseconds> retention_local_target_ms_default;
+    property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
+    property<std::chrono::milliseconds> retention_local_trim_interval;
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -322,6 +322,7 @@ struct configuration final : public config_store {
     property<bool> retention_local_is_advisory;
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
     property<std::chrono::milliseconds> retention_local_trim_interval;
+    property<double> retention_local_trim_overage_coeff;
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1372,7 +1372,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
     construct_single_service(
       space_manager,
       config::shard_local_cfg().enable_storage_space_manager.bind(),
-      config::shard_local_cfg().log_storage_target_size.bind(),
+      config::shard_local_cfg().retention_local_target_capacity_bytes.bind(),
       &storage,
       &storage_node,
       &shadow_index_cache,

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -16,6 +16,7 @@ v_cc_library(
   DEPS
     Seastar::seastar
     v::cloud_storage
+    v::cluster
   )
 
 add_subdirectory(tests)

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -81,7 +81,7 @@ ss::future<> disk_space_manager::run_loop() {
         try {
             if (_enabled()) {
                 co_await _control_sem.wait(
-                  config::shard_local_cfg().log_storage_max_usage_interval(),
+                  config::shard_local_cfg().retention_local_trim_interval(),
                   std::max(_control_sem.current(), size_t(1)));
             } else {
                 co_await _control_sem.wait();

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -206,13 +206,16 @@ ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
                                  ? 0
                                  : usage.usage.total() - target_size;
     if (target_excess <= 0) {
-        vlog(
-          rlog.info,
+        vlogl(
+          rlog,
+          _previous_reclaim ? ss::log_level::info : ss::log_level::debug,
           "Log storage usage {} <= target size {}. No work to do.",
           human::bytes(usage.usage.total()),
           human::bytes(target_size));
+        _previous_reclaim = false;
         co_return;
     }
+    _previous_reclaim = true;
 
     /*
      * when log storage has exceeded the target usage, then there are some knobs

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -147,6 +147,8 @@ public:
     /*
      * create a new schedule containing information about partitions on the
      * system. initially the schedule will contain no eviction decisions.
+     * if the resulting schedule is non-empty then the policy's cursor will be
+     * normalized to the new schedule's size.
      */
     ss::future<schedule> create_new_schedule();
 
@@ -165,6 +167,12 @@ public:
 private:
     ss::sharded<cluster::partition_manager>* _pm;
     ss::sharded<storage::api>* _storage;
+
+    /*
+     * used to approximate round-robin iteration across partitions in a
+     * schedule, such as balanced removal of old segments.
+     */
+    size_t _cursor{0};
 
     /*
      * marks segments for eviction from a scheduling level using a round robin
@@ -219,6 +227,8 @@ private:
 
     ss::future<> manage_data_disk(uint64_t target_size);
     config::binding<std::optional<uint64_t>> _log_storage_target_size;
+
+    eviction_policy _policy;
 
     ss::gate _gate;
     ss::future<> run_loop();

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -167,6 +167,12 @@ public:
     size_t evict_until_low_space_non_hinted(schedule&, size_t);
 
     /*
+     * same as non-hinted variant, but includes partitions with explicitly
+     * configured local retention.
+     */
+    size_t evict_until_low_space_hinted(schedule&, size_t);
+
+    /*
      * install the schedule by applying eviction decisions on all cores.
      */
     ss::future<> install_schedule(schedule);

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -76,6 +76,7 @@ private:
     ss::gate _gate;
     ss::future<> run_loop();
     ssx::semaphore _control_sem{0, "resource_mgmt::space_manager"};
+    bool _previous_reclaim{false};
 };
 
 } // namespace storage

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -46,6 +46,16 @@ public:
     struct partition {
         raft::group_id group;
         reclaimable_offsets offsets;
+
+        /*
+         * used when applying policies to the schedule.
+         *
+         * the offset at which the scheduling policy would like this partition
+         * to be prefix truncated, along with the total amount of space
+         * estimated to be reclaimed.
+         */
+        std::optional<model::offset> decision;
+        size_t total{0};
     };
 
     /*
@@ -105,6 +115,31 @@ public:
          */
         partition* current();
     };
+
+public:
+    eviction_policy(
+      ss::sharded<cluster::partition_manager>* pm,
+      ss::sharded<storage::api>* storage)
+      : _pm(pm)
+      , _storage(storage) {}
+
+    /*
+     * create a new schedule containing information about partitions on the
+     * system. initially the schedule will contain no eviction decisions.
+     */
+    ss::future<schedule> create_new_schedule();
+
+    /*
+     * install the schedule by applying eviction decisions on all cores.
+     */
+    ss::future<> install_schedule(schedule);
+
+private:
+    ss::sharded<cluster::partition_manager>* _pm;
+    ss::sharded<storage::api>* _storage;
+
+    ss::future<fragmented_vector<partition>> collect_reclaimable_offsets();
+    ss::future<size_t> install_schedule(shard_partitions);
 };
 
 /*

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -160,6 +160,13 @@ public:
     size_t evict_until_local_retention(schedule&, size_t);
 
     /*
+     * balanced eviction of segments across all partitions without explicit
+     * local retention settings. eviction does not proceed past the configured
+     * low space level for the partition.
+     */
+    size_t evict_until_low_space_non_hinted(schedule&, size_t);
+
+    /*
      * install the schedule by applying eviction decisions on all cores.
      */
     ss::future<> install_schedule(schedule);

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -173,6 +173,11 @@ public:
     size_t evict_until_low_space_hinted(schedule&, size_t);
 
     /*
+     * balanced eviction until partition active segment is reached.
+     */
+    size_t evict_until_active_segment(schedule&, size_t);
+
+    /*
      * install the schedule by applying eviction decisions on all cores.
      */
     ss::future<> install_schedule(schedule);

--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -22,3 +22,11 @@ rp_test(
         SKIP_BUILD_TYPES "Debug"
         ARGS "-- -c1 -m1G"
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME storage_resource_mgmt
+  SOURCES storage_test.cc
+  LIBRARIES v::seastar_testing_main v::storage_resource_mgmt v::config
+  LABELS resource_mgmt
+)

--- a/src/v/resource_mgmt/tests/storage_test.cc
+++ b/src/v/resource_mgmt/tests/storage_test.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "config/configuration.h"
+#include "config/property.h"
+#include "random/generators.h"
+#include "resource_mgmt/storage.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+using ep = storage::eviction_policy;
+
+SEASTAR_THREAD_TEST_CASE(test_partition_iteration) {
+    // generate unique group ids across all tests
+    int64_t group_id = 0;
+
+    const auto make_schedule = [&](int cores, int partitions) {
+        std::vector<ep::shard_partitions> shards;
+        shards.resize(cores);
+        for (int i = 0; i < partitions; ++i) {
+            auto core = random_generators::get_int(0, cores - 1);
+            shards[core].partitions.push_back(ep::partition{
+              .group = raft::group_id(group_id++),
+            });
+        }
+        return ep::schedule(std::move(shards), partitions);
+    };
+
+    // shared across tests
+    size_t cursor = 0;
+
+    for (int repeat = 0; repeat < 100; ++repeat) {
+        auto schedule = make_schedule(
+          random_generators::get_int(1, 5), random_generators::get_int(1, 20));
+        BOOST_REQUIRE(schedule.sched_size > 0);
+        schedule.seek(cursor);
+
+        // capture the ordering of partitions in the first iteration
+        auto partition = schedule.current();
+        const auto first = partition;
+        std::vector<raft::group_id> first_loop_ordering;
+        for (size_t i = 0; i < schedule.sched_size; ++i) {
+            first_loop_ordering.push_back(partition->group);
+            schedule.next();
+            ++cursor;
+            partition = schedule.current();
+        }
+        BOOST_REQUIRE(partition == first);
+        BOOST_REQUIRE(first_loop_ordering.size() == schedule.sched_size);
+
+        // capture the ordering of partitions in the second iteration
+        std::vector<raft::group_id> second_loop_ordering;
+        for (size_t i = 0; i < schedule.sched_size; ++i) {
+            second_loop_ordering.push_back(partition->group);
+            schedule.next();
+            ++cursor;
+            partition = schedule.current();
+        }
+        BOOST_REQUIRE(partition == first);
+        // the ordering should be the same
+        BOOST_REQUIRE(first_loop_ordering == second_loop_ordering);
+
+        // no duplicates should be in the ordering
+        std::sort(first_loop_ordering.begin(), first_loop_ordering.end());
+        BOOST_REQUIRE(
+          std::adjacent_find(
+            first_loop_ordering.begin(), first_loop_ordering.end())
+          == first_loop_ordering.end());
+    }
+}

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -639,6 +639,16 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
     co_return ret;
 }
 
+bool disk_log_impl::has_local_retention_override() const {
+    if (config().has_overrides()) {
+        const auto& overrides = config().get_overrides();
+        auto bytes = overrides.retention_local_target_bytes;
+        auto time = overrides.retention_local_target_ms;
+        return bytes.is_engaged() || time.is_engaged();
+    }
+    return false;
+}
+
 gc_config disk_log_impl::override_retention_config(gc_config cfg) const {
     // Read replica topics have a different default retention
     if (config().is_read_replica_mode_enabled()) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2308,10 +2308,14 @@ disk_log_impl::cloud_gc_eligible_segments() {
 }
 
 void disk_log_impl::set_cloud_gc_offset(model::offset offset) {
-    vassert(
-      is_cloud_retention_active(),
-      "Expected {} to have cloud retention enabled",
-      config().ntp());
+    if (!is_cloud_retention_active()) {
+        vlog(
+          stlog.debug,
+          "Ignoring request to set GC offset on non-cloud enabled partition "
+          "{}. Configuration may have recently changed.",
+          config().ntp());
+        return;
+    }
     _cloud_gc_offset = offset;
 }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -207,6 +207,7 @@ private:
     // overrides, such as custom topic configs.
     bool has_local_retention_override() const;
 
+    gc_config maybe_override_retention_config(gc_config) const;
     gc_config override_retention_config(gc_config) const;
 
     bool is_cloud_retention_active() const;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -133,6 +133,8 @@ public:
     fragmented_vector<ss::lw_shared_ptr<segment>> cloud_gc_eligible_segments();
     void set_cloud_gc_offset(model::offset);
 
+    ss::future<reclaimable_offsets> get_reclaimable_offsets(gc_config cfg);
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -203,6 +203,10 @@ private:
 
     void wrote_stm_bytes(size_t);
 
+    // returns true if this partition's local retention configuration has
+    // overrides, such as custom topic configs.
+    bool has_local_retention_override() const;
+
     gc_config override_retention_config(gc_config) const;
 
     bool is_cloud_retention_active() const;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -213,6 +213,11 @@ private:
 
     std::optional<model::offset> retention_offset(gc_config);
 
+    // returns retention_offset(cfg) but may also first apply adjustments to
+    // future timestamps if this option is turned on in configuration.
+    ss::future<std::optional<model::offset>>
+    maybe_adjusted_retention_offset(gc_config cfg);
+
     /*
      * total disk usage and the amount of reclaimable space are most efficiently
      * computed together given that use cases often use both together.

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -556,4 +556,26 @@ struct usage_report {
     }
 };
 
+/*
+ * A set of categorized offsets annotated with the amount of data
+ * represented in the log up to the offset, along with any other metadata
+ * necessary to make low-disk reclaim decisions.
+ *
+ * This data structure is co-designed with the implementation of the reclaim
+ * policy in resource_mgmt/storage.cc where the definitive documentation for
+ * this data structure is located.
+ */
+struct reclaimable_offsets {
+    struct offset {
+        model::offset offset;
+        size_t size;
+    };
+
+    ss::chunked_fifo<offset> effective_local_retention;
+    ss::chunked_fifo<offset> low_space_non_hinted;
+    ss::chunked_fifo<offset> low_space_hinted;
+    ss::chunked_fifo<offset> active_segment;
+    std::optional<size_t> force_roll;
+};
+
 } // namespace storage

--- a/tests/rptest/scale_tests/log_storage_target_size_test.py
+++ b/tests/rptest/scale_tests/log_storage_target_size_test.py
@@ -42,8 +42,9 @@ class LogStorageTargetSizeTest(RedpandaTest):
                     self.redpanda.nodes))
 
     @cluster(num_nodes=4)
-    @matrix(log_segment_size=[1024 * 1024, 100 * 1024 * 1024])
-    def streaming_cache_test(self, log_segment_size):
+    @matrix(log_segment_size=[1024 * 1024, 100 * 1024 * 1024],
+            advisory=[True, False])
+    def streaming_cache_test(self, log_segment_size, advisory):
         if self.redpanda.dedicated_nodes:
             partition_count = 64
             rate_limit_bps = int(120E6)
@@ -92,7 +93,19 @@ class LogStorageTargetSizeTest(RedpandaTest):
             'retention_local_trim_interval':
             self.retention_local_trim_interval,
             'retention_local_target_capacity_bytes': target_size,
+            'retention_local_is_advisory': advisory,
         }
+
+        # when local retention is advisory, data can expand past the local
+        # retention and this expanded data will be subject to reclaim first in
+        # the eviction policy. reduce the expiration age from default 24 hours
+        # to 30 seconds in order to make it more likely that we are testing this.
+        if advisory:
+            extra_rp_conf.update({
+                'retention_local_target_ms_default':
+                30 * 1000,
+            })
+
         si_settings = SISettings(test_context=self.test_context,
                                  log_segment_size=log_segment_size)
         self.redpanda.set_extra_rp_conf(extra_rp_conf)

--- a/tests/rptest/scale_tests/log_storage_target_size_test.py
+++ b/tests/rptest/scale_tests/log_storage_target_size_test.py
@@ -24,7 +24,7 @@ import time
 class LogStorageTargetSizeTest(RedpandaTest):
     segment_upload_interval = 30
     manifest_upload_interval = 10
-    log_storage_max_usage_interval = 5
+    retention_local_trim_interval = 5
 
     def __init__(self, test_context, *args, **kwargs):
         super().__init__(test_context, *args, **kwargs)
@@ -63,7 +63,7 @@ class LogStorageTargetSizeTest(RedpandaTest):
         # not immediate. currently a monitoring loop runs periodically, and
         # during this time data may accumulate that is not subject to being
         # removed because the monitor has not run to notice it.
-        accounting_delay_accumulation = rate_limit_bps * self.log_storage_max_usage_interval
+        accounting_delay_accumulation = rate_limit_bps * self.retention_local_trim_interval
 
         # consider the case where all the active segments fill up and roll at
         # the same time, and then a full accounting period passes during which
@@ -89,9 +89,9 @@ class LogStorageTargetSizeTest(RedpandaTest):
             self.segment_upload_interval,
             'cloud_storage_manifest_max_upload_interval_sec':
             self.manifest_upload_interval,
-            'log_storage_max_usage_interval':
-            self.log_storage_max_usage_interval,
-            'log_storage_target_size': target_size,
+            'retention_local_trim_interval':
+            self.retention_local_trim_interval,
+            'retention_local_target_capacity_bytes': target_size,
         }
         si_settings = SISettings(test_context=self.test_context,
                                  log_segment_size=log_segment_size)

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -606,7 +606,7 @@ class LogStorageMaxSizeSI(RedpandaTest):
 
         # set the log storage target size. system will try to meet this target.
         self.redpanda.set_cluster_config(
-            dict(log_storage_target_size=target_size, ))
+            dict(retention_local_target_capacity_bytes=target_size, ))
 
         # now go write another `data_size` bytes
         t1 = time()


### PR DESCRIPTION
This PR introduces two important changes:

1. A configuration option that makes local retention advisory. When enabled, storage is allowed to grow beyond the effective local retention. Normal GC will collect based on the consumable retention configuration (aka cloud retention aka max retention), and relies on space management to select data for removal when log data usage is over the target size.

2. Replaces the greedy selection approach--which culled data down to the max collectible offset--with a balanced (round robin removal of segments) and phased/leveled approach which prioritizes classes of data over others, such as removing data first which has expanded beyond the local retention policy when config from (1) is enabled.

Incoming 💾 🚒. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

