### PR TITLE
Linearizable barrier improvements

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -634,7 +634,7 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
           meta(),
           model::make_memory_record_batch_reader(
             ss::circular_buffer<model::record_batch>{}),
-          flush_after_append::no);
+          flush_after_append::yes);
         auto seq = next_follower_sequence(target);
         sequences.emplace(target, seq);
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1899,19 +1899,25 @@ consensus::do_append_entries(append_entries_request&& r) {
             return ss::make_ready_future<append_entries_reply>(
               std::move(reply));
         }
+        auto f = ss::now();
+        if (r.is_flush_required() && lstats.dirty_offset > _flushed_offset) {
+            f = flush_log();
+        }
         auto last_visible = std::min(
           lstats.dirty_offset, request_metadata.last_visible_index);
         // on the follower leader control visibility of entries in the log
         maybe_update_last_visible_index(last_visible);
         _last_leader_visible_offset = std::max(
           request_metadata.last_visible_index, _last_leader_visible_offset);
-        return maybe_update_follower_commit_idx(
-                 model::offset(request_metadata.commit_index))
-          .then([reply = std::move(reply)]() mutable {
-              reply.result = append_entries_reply::status::success;
-              return ss::make_ready_future<append_entries_reply>(
-                std::move(reply));
-          });
+        return f.then([this, reply, request_metadata] {
+            return maybe_update_follower_commit_idx(
+                     model::offset(request_metadata.commit_index))
+              .then([this, reply]() mutable {
+                  reply.last_flushed_log_index = _flushed_offset;
+                  reply.result = append_entries_reply::status::success;
+                  return reply;
+              });
+        });
     }
 
     // section 3

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -162,7 +162,23 @@ ss::future<> state_machine::write_last_applied(model::offset o) {
 
 ss::future<result<model::offset>> state_machine::insert_linearizable_barrier(
   model::timeout_clock::time_point timeout) {
-    return ss::with_timeout(timeout, _raft->linearizable_barrier())
+    /**
+     * Inject leader barrier and wait until returned offset is applied
+     */
+    return ss::with_timeout(
+             timeout,
+             _raft->linearizable_barrier().then(
+               [this, timeout](result<model::offset> r) {
+                   if (!r) {
+                       return ss::make_ready_future<result<model::offset>>(
+                         r.error());
+                   }
+
+                   // wait for the returned offset to be applied
+                   return wait(r.value(), timeout).then([r] {
+                       return result<model::offset>(r.value());
+                   });
+               }))
       .handle_exception_type([](const ss::timed_out_error&) {
           return result<model::offset>(errc::timeout);
       });

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -21,6 +21,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/shared_future.hh>
 #include <seastar/util/log.hh>
 
 namespace raft {
@@ -143,6 +144,13 @@ private:
     model::offset _next;
     ss::abort_source _as;
     model::offset _bootstrap_last_applied;
+    /**
+     * Shared promise used to propagate barrier result to all the waiters. The
+     * shared promise allow us to share the result of ongoing linearizable
+     * barrier request with multiple callers.
+     */
+    using barrier_promise_t = ss::shared_promise<result<model::offset>>;
+    std::optional<barrier_promise_t> _barrier_promise;
 };
 
 } // namespace raft


### PR DESCRIPTION
Improved the way how linearizable barrier is handled

Fixes: #11062
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- Made linearizable barrier semantics more strict. 