### PR TITLE
Do not return timeout error in fetch response

### DIFF
--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -47,12 +47,14 @@ public:
             auto error_code = error_code::unknown_server_error;
             if (err.category() == cluster::error_category()) {
                 switch (cluster::errc(err.value())) {
+                    /**
+                     * In the case of timeout and shutting down errors return
+                     * not_leader_for_partition error to force clients retry.
+                     */
                 case cluster::errc::shutting_down:
                 case cluster::errc::not_leader:
-                    error_code = error_code::not_leader_for_partition;
-                    break;
                 case cluster::errc::timeout:
-                    error_code = error_code::request_timed_out;
+                    error_code = error_code::not_leader_for_partition;
                     break;
                 default:
                     error_code = error_code::unknown_server_error;


### PR DESCRIPTION
Some of the error codes are not supported in certain type of Kafka responses. One of such situations is returning a timeout error in Fetch response. This cause client to throw `IvalidStateException` and stop consuming.

Fixes: #8688

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none