### PR TITLE
archival/idle_timer: avoid arming an armed timer

### DIFF
--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -75,7 +75,7 @@ upload_housekeeping_service::upload_housekeeping_service(
 
         _idle_jittery_timeout = simple_time_jitter<ss::lowres_clock>(
           _idle_timeout(), 100ms);
-        _idle_timer.arm(_idle_jittery_timeout.next_duration());
+        rearm_idle_timer();
     });
 
     _epoch_duration.watch(


### PR DESCRIPTION
When idle timeout changes, the timer may already be armed. rearm it instead of arming it to avoid an assertion.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes #11938

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
