### PR TITLE
rpk: small improvements for rpk-trim

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
@@ -90,7 +90,7 @@ help text for more details on why.`, broker)
 			err = cl.DecommissionBroker(cmd.Context(), broker)
 			out.MaybeDie(err, "unable to decommission broker: %v", err)
 
-			fmt.Printf("Success, broker %d decommission started.  Use `rpk redpanda admin brokers decommission-status %d` to monitor data movement.`", broker, broker)
+			fmt.Printf("Success, broker %d decommission started.  Use `rpk redpanda admin brokers decommission-status %d` to monitor data movement.\n`", broker, broker)
 		},
 	}
 

--- a/src/go/rpk/pkg/cli/topic/trim.go
+++ b/src/go/rpk/pkg/cli/topic/trim.go
@@ -102,6 +102,9 @@ Trim records from a JSON file
 				}
 				fmt.Println()
 			}
+			if len(o) == 0 {
+				out.Die("there are no records to trim")
+			}
 			drr, err := adm.DeleteRecords(cmd.Context(), o)
 			out.MaybeDie(err, "unable to trim records: %v", err)
 			printDeleteRecordResponse(drr)


### PR DESCRIPTION
This PR:

- Adds a new line in an rpk decommission command.
- Improve error handling for non-existent topics.
- Exit 1 if there was at least an error in the topics that you tried to trim.

## Backports Required

- [ ] none - issue does not exist in previous branches


## Release Notes
* none
