### PR TITLE
Fixes for AdminOpsFuzzer failures related to delete-records

### DIFF
--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -36,10 +36,6 @@ KclListPartitionReassignmentsResponse = namedtuple(
     'KclListPartitionReassignmentsResponse',
     ['topic', 'partition', 'replicas', 'adding_replicas', 'removing_replicas'])
 
-KclDeleteRecordsResponse = namedtuple(
-    'KclDeleteRecordsResponse',
-    ['broker', 'topic', 'partition', 'new_low_watermark', 'error'])
-
 
 class KCL:
     def __init__(self, redpanda):
@@ -221,68 +217,6 @@ class KCL:
 
         cmd = ['group', 'offset-delete', "-j", group] + request_args_w_flags
         return json.loads(self._cmd(cmd, attempts=5))
-
-    def delete_records(self,
-                       topic_partitions_offsets: dict[str, dict[int, int]],
-                       timeout_ms=1000):
-        """
-        topic_partitions_offsets: mapping of topic -> mapping of
-          partition_id to desired truncation offset
-
-        kcl admin delete-records foo:p0,o120 foo:p1,o3888 ...
-        """
-        def validate_offsets(args):
-            offsets = flat_map(lambda x: list(x.values()), args.values())
-            return all([x >= 0 for x in offsets])
-
-        def unfold(x):
-            topic, partitions_offsets = x
-            return [
-                f"{topic}:p{partition},o{offset}"
-                for partition, offset in partitions_offsets.items()
-            ]
-
-        if len(topic_partitions_offsets) == 0:
-            return []
-
-        if validate_offsets(topic_partitions_offsets) is False:
-            raise RuntimeError(
-                f'Negative offset passed to delete-records: {topic_partitions_offsets}'
-            )
-
-        cmd = ['-X', f'timeout_ms={timeout_ms}', 'admin', 'delete-records'
-               ] + flat_map(unfold, topic_partitions_offsets.items())
-        # Theres no json output support for this command
-        results = self._cmd(cmd, attempts=5).splitlines()[1:]
-        results = [x for x in results if len(x) > 0]
-
-        heading_regex = re.compile(r"BROKER.*")
-        result_regex = re.compile(r"(\d+)\s+(.*)\s+(\d+)\s+(-?\d+)\s+(.*)")
-        error_regex = re.compile(r"(-?\d+)\s+(.*)")
-
-        response = []
-        for raw_line in results:
-            line = raw_line.strip()
-
-            if heading_regex.match(line) is not None:
-                continue
-            matches = result_regex.match(line)
-            if matches is None:
-                err_matches = error_regex.match(line)
-                if err_matches is None:
-                    raise RuntimeError(f"unexpected kcl output: {line}")
-                entry = KclDeleteRecordsResponse(None, None, None,
-                                                 int(err_matches.group(1)),
-                                                 err_matches.group(2).strip())
-            else:
-                entry = KclDeleteRecordsResponse(int(matches.group(1)),
-                                                 matches.group(2).strip(),
-                                                 int(matches.group(3)),
-                                                 int(matches.group(4)),
-                                                 matches.group(5).strip())
-            response.append(entry)
-
-        return response
 
     def get_user_credentials_cmd(self,
                                  user_cred: Optional[dict[str, str]] = None):

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -504,14 +504,14 @@ class ProduceToTopic(Operation):
 class DeleteRecords(Operation):
     def __init__(self, prefix):
         self.prefix = prefix
-        self.truncate_points = {}
+        self.truncate_point = ()
 
-    def _random_truncate_points(self, ctx) -> Dict[str, Dict[int, int]]:
+    def _random_truncate_point(self, ctx):
         """
-        Returns a mapping of topics to partition offsets:
-        { "foo" : { 0 , 150 } } , will truncate foo partition 0 at offset 150
+        Returns a mapping of topic to partition offset:
+        ( "foo", { 0 , 150 ) ) , will truncate foo partition 0 at offset 150
         """
-        def deletable_topic_partitions(ctx):
+        def deletable_topic_partition(ctx):
             def is_partition_empty(p):
                 return int(p.high_watermark) == 0 or (int(p.start_offset)
                                                       == int(p.high_watermark))
@@ -523,69 +523,66 @@ class DeleteRecords(Operation):
                 return 'delete' in values
 
             deletable_topics = [
-                t for t in ctx.rpk().list_topics()
-                if is_deletable(ctx, t) and t.startswith(self.prefix)
+                t for t in ctx.rpk().list_topics() if is_deletable(ctx, t)
             ]
-            tps_with_data = {
-                t: [
-                    p for p in ctx.rpk().describe_topic(t)
-                    if not is_partition_empty(p)
-                ]
-                for t in deletable_topics
-            }
-            return {t: ps for t, ps in tps_with_data.items() if len(ps) > 0}
+            if len(deletable_topics) == 0:
+                return None
 
-        topic_partitions = deletable_topic_partitions(ctx)
+            deletable_topic = _random_choice(self.prefix, deletable_topics)
+            deletable_partitions = [
+                p for p in ctx.rpk().describe_topic(deletable_topic)
+                if not is_partition_empty(p)
+            ]
+
+            return None if len(deletable_partitions) == 0 else (
+                deletable_topic, random.choice(deletable_partitions))
+
+        topic_partition = deletable_topic_partition(ctx)
+        if topic_partition is None:
+            return ()
 
         def random_truncate_offset(p):
             return random.randint(
                 int(p.start_offset) + 1, int(p.high_watermark))
 
-        return {
-            topic: {int(p.id): random_truncate_offset(p)
-                    for p in partitions}
-            for topic, partitions in topic_partitions.items()
-        }
+        (topic, partition) = topic_partition
+        return (topic, (int(partition.id), random_truncate_offset(partition)))
 
     def execute(self, ctx):
-        self.truncate_points = self._random_truncate_points(ctx)
-        if len(self.truncate_points) == 0:
+        self.truncate_point = self._random_truncate_point(ctx)
+        if len(self.truncate_point) == 0:
             return False
 
         ctx.redpanda.logger.info(
-            f"Issuing DeleteRecords command: {self.truncate_points}")
-        ctx.kcl().delete_records(self.truncate_points)
+            f"Issuing DeleteRecords command: {self.truncate_point}")
+        (topic, partition_offset) = self.truncate_point
+        (partition, offset) = partition_offset
+        ctx.rpk().trim_prefix(topic, offset, partitions=[partition])
         return True
 
     def validate(self, ctx):
-        if len(self.truncate_points) == 0:
+        if len(self.truncate_point) == 0:
             return False
 
         ctx.redpanda.logger.info(
-            f"Validing topic low watermarks, expecting: {self.truncate_points}"
-        )
+            f"Validing topic low watermarks, expecting: {self.truncate_point}")
 
-        topic_partitions_data = {
-            topic: ctx.rpk().describe_topic(topic)
-            for topic in self.truncate_points.keys()
-        }
+        (topic, partition_offset) = self.truncate_point
+        (partition_id, lwm) = partition_offset
 
-        for topic, partition_lwm in self.truncate_points.items():
-            tpt = topic_partitions_data.get(topic, None)
-            if tpt is None:
-                return False
-            partition_map = {int(p.id): p for p in tpt}
-            for partition, lwm in partition_lwm.items():
-                tpp = partition_map.get(int(partition), None)
-                if tpp is None or int(tpp.start_offset) != lwm:
-                    return False
-        return True
+        partitions_info = ctx.rpk().describe_topic(topic)
+        partition_info = [
+            p for p in partitions_info if int(p.id) == partition_id
+        ]
+        assert len(partition_info
+                   ) == 1, f"Expected {topic} with partition {partition_id}"
+        return int(partition_info[0].start_offset) == lwm
 
     def describe(self):
         return {
             "type": "delete_records",
             "properties": {
-                "truncate_points": self.truncate_points
+                "truncate_point": self.truncate_point
             }
         }
 

--- a/tests/rptest/tests/controller_upgrade_test.py
+++ b/tests/rptest/tests/controller_upgrade_test.py
@@ -63,6 +63,13 @@ class ControllerUpgradeTest(EndToEndTest):
         else:
             admin_operations = [o for o in RedpandaAdminOperation]
 
+        # DeleteRecords is not an allowable admin operation until the cluster
+        # has been fully upgraded
+        admin_operations = [
+            o for o in admin_operations
+            if o != RedpandaAdminOperation.DELETE_RECORDS
+        ]
+
         installer.install(self.redpanda.nodes, prev_version)
 
         self.redpanda.start()


### PR DESCRIPTION
The major change is to move to Rpk::delete_records() as this throws on any command errors which triggers retry logic in the main admin ops fuzzer harness.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
