### PR TITLE
Cache values computed in `partition_manifest::full_log_start_kafka_offset`

### DIFF
--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -524,6 +524,8 @@ public:
 private:
     std::optional<kafka::offset> compute_start_kafka_offset_local() const;
 
+    void set_start_offset(model::offset start_offset);
+
     void subtract_from_cloud_log_size(size_t to_subtract);
 
     // Computes the size in bytes of all segments available to clients
@@ -574,6 +576,8 @@ private:
     /// Collection of replaced but not yet removed segments
     replaced_segments_list _replaced;
     model::offset _last_offset;
+    // Note: always set this member with `set_start_offset` as it has cached
+    // values associated with it that need to be invalidated.
     model::offset _start_offset;
     model::offset _last_uploaded_compacted_offset;
     model::offset _insync_offset;
@@ -594,6 +598,11 @@ private:
     uint64_t _archive_size_bytes{0};
     /// Map of spillover manifests that were uploaded to S3
     spillover_manifest_map _spillover_manifests;
+
+    // The starting offset for a Kafka batch in the segment that corresponds
+    // with `_start_offset`. This value is computed from
+    // `compute_start_kafka_offset_local` and is not in the serialized manifest.
+    mutable std::optional<kafka::offset> _cached_start_kafka_offset_local;
 };
 
 } // namespace cloud_storage


### PR DESCRIPTION
`kafka::replicated_partition::start_offset` is called often on the fetch path. And when cloud storage is enabled for a partition this leads to a find operation on `segment_meta_cstore` for every call.

The result of this find doesn't change unless `_start_offset` in `cloud_storage::partition_manifest` has changed. So this commit caches the result of the find and updates it whenever `_start_offset` changes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Partially fixes #11952 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
