### PR TITLE
ducktape/si tests: use auto node_id assignment & multiple seed servers

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1577,7 +1577,7 @@ class RedpandaService(RedpandaServiceBase):
         # stash a copy here so that we can quickly look up e.g. addresses later.
         self._node_configs = {}
 
-        self._seed_servers = [self.nodes[0]] if len(self.nodes) > 0 else []
+        self._seed_servers = self.nodes
 
         self._expect_max_controller_records = 1000
 

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -321,7 +321,9 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
 
         self.redpanda.stop()
         self.redpanda.remove_local_data(self.redpanda.nodes[0])
-        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=True,
+                                    omit_seeds_on_idx_one=False)
         self.redpanda._admin.await_stable_leader("controller",
                                                  partition=0,
                                                  namespace='redpanda',
@@ -383,7 +385,9 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         self.redpanda.stop()
         for n in self.redpanda.nodes:
             self.redpanda.remove_local_data(n)
-        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=True,
+                                    omit_seeds_on_idx_one=False)
         self.redpanda._admin.await_stable_leader("controller",
                                                  partition=0,
                                                  namespace='redpanda',
@@ -732,7 +736,9 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
         node = self.redpanda.nodes[0]
         self.redpanda.stop()
         self.redpanda.remove_local_data(node)
-        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=True,
+                                    omit_seeds_on_idx_one=False)
         self.redpanda._admin.await_stable_leader("controller",
                                                  partition=0,
                                                  namespace='redpanda',

--- a/tests/rptest/tests/node_id_assignment_test.py
+++ b/tests/rptest/tests/node_id_assignment_test.py
@@ -64,7 +64,6 @@ class NodeIdAssignment(RedpandaTest):
         self.admin = self.redpanda._admin
 
     def setUp(self):
-        self.redpanda.set_seed_servers(self.redpanda.nodes)
         self.redpanda.start(auto_assign_node_id=True,
                             omit_seeds_on_idx_one=False)
         self._create_initial_topics()
@@ -152,6 +151,7 @@ class NodeIdAssignmentParallel(RedpandaTest):
 
     def setUp(self):
         # Start just one node so we can add several at the same time.
+        self.redpanda.set_seed_servers([self.redpanda.nodes[0]])
         self.redpanda.start([self.redpanda.nodes[0]],
                             auto_assign_node_id=True,
                             omit_seeds_on_idx_one=False)


### PR DESCRIPTION
When the only founding member of the cluster is restarted with a wiped
off disk, it can create its own cluster with a new cluster ID. This
patch avoids this by using multiple seed servers and auto node id assignment to
force the wiped off node to join the existing cluster instance.

Fixes #11109

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
