### PR TITLE
More strict `last_applied_offset` check

### DIFF
--- a/tests/rptest/tests/controller_erase_test.py
+++ b/tests/rptest/tests/controller_erase_test.py
@@ -87,8 +87,10 @@ class ControllerEraseTest(RedpandaTest):
             bystander_node)["dirty_offset"]
 
         def wait_victim_node_apply_segments():
-            return admin.get_controller_status(victim_node)[
-                "last_applied_offset"] >= bystander_node_dirty_offset
+            status = admin.get_controller_status(victim_node)
+            last_applied = status["last_applied_offset"]
+            dirty_offset = status["dirty_offset"]
+            return dirty_offset == last_applied and last_applied >= bystander_node_dirty_offset
 
         wait_until(
             wait_victim_node_apply_segments,


### PR DESCRIPTION
Wait for all victim node records to be applied. If a victim node contains some of the records that were not applied or about to be truncated the test should wait before selecting segments to trim as in the case if segment contains only dirty records removing it will not cause inconsistency.

Fixes: #8217

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none