### PR TITLE
cloud_storage: Unknown STM command handling

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -793,6 +793,11 @@ ss::future<> archival_metadata_stm::apply(model::record_batch b) {
         case replace_manifest_cmd::key:
             apply_replace_manifest(r.release_value());
             break;
+        default:
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format,
+              "Unknown archival metadata STM command {}",
+              static_cast<int>(key)));
         };
     });
 


### PR DESCRIPTION
Throw exception if the replicated STM command is unknown. Currently, the STM silently drop the command on the floor. This may cause replicas to diverge during the rolling upgrade.

This may cause our upgrade tests to fail if we're not handling rolling upgrades correctly in tiered-storage.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Make tiered-storage metadata handling more strict during rolling upgrades

