### PR TITLE
cloud_storage: add `cloud_storage_max_partition_readers_per_shard`

### DIFF
--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -45,8 +45,9 @@ materialized_resources::materialized_resources()
   : _stm_jitter(stm_jitter_duration)
   , _max_partitions_per_shard(
       config::shard_local_cfg().topic_partitions_per_shard.bind())
-  , _max_readers_per_shard(
-      config::shard_local_cfg().cloud_storage_max_readers_per_shard.bind())
+  , _max_segment_readers_per_shard(
+      config::shard_local_cfg()
+        .cloud_storage_max_segment_readers_per_shard.bind())
   , _max_segments_per_shard(
       config::shard_local_cfg()
         .cloud_storage_max_materialized_segments_per_shard.bind())
@@ -57,9 +58,9 @@ materialized_resources::materialized_resources()
       config::shard_local_cfg().cloud_storage_manifest_cache_size.bind())
   , _manifest_cache(ss::make_shared<materialized_manifest_cache>(
       config::shard_local_cfg().cloud_storage_manifest_cache_size())) {
-    _max_readers_per_shard.watch(
+    _max_segment_readers_per_shard.watch(
       [this]() { _segment_reader_units.set_capacity(max_readers()); });
-    _max_readers_per_shard.watch(
+    _max_segment_readers_per_shard.watch(
       [this]() { _partition_reader_units.set_capacity(max_readers()); });
     _max_segments_per_shard.watch(
       [this]() { _segment_units.set_capacity(max_segments()); });
@@ -110,7 +111,7 @@ materialized_resources::get_materialized_manifest_cache() {
 }
 
 size_t materialized_resources::max_readers() const {
-    return static_cast<size_t>(_max_readers_per_shard().value_or(
+    return static_cast<size_t>(_max_segment_readers_per_shard().value_or(
       _max_partitions_per_shard() * default_reader_factor));
 }
 

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -72,9 +72,11 @@ private:
 
     config::binding<uint32_t> _max_partitions_per_shard;
     config::binding<std::optional<uint32_t>> _max_segment_readers_per_shard;
+    config::binding<std::optional<uint32_t>> _max_partition_readers_per_shard;
     config::binding<std::optional<uint32_t>> _max_segments_per_shard;
 
-    size_t max_readers() const;
+    size_t max_segment_readers() const;
+    size_t max_partition_readers() const;
     size_t max_segments() const;
 
     /// How many remote_segment_batch_reader instances exist

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -71,7 +71,7 @@ private:
     simple_time_jitter<ss::lowres_clock> _stm_jitter;
 
     config::binding<uint32_t> _max_partitions_per_shard;
-    config::binding<std::optional<uint32_t>> _max_readers_per_shard;
+    config::binding<std::optional<uint32_t>> _max_segment_readers_per_shard;
     config::binding<std::optional<uint32_t>> _max_segments_per_shard;
 
     size_t max_readers() const;

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -39,7 +39,7 @@ scan_remote_partition_incrementally_with_reuploads(
             maybe_max_segments);
     }
     if (maybe_max_readers) {
-        config::shard_local_cfg().cloud_storage_max_readers_per_shard(
+        config::shard_local_cfg().cloud_storage_max_segment_readers_per_shard(
           maybe_max_readers);
     }
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -592,7 +592,7 @@ std::vector<model::record_batch_header> scan_remote_partition_incrementally(
             maybe_max_segments);
     }
     if (maybe_max_readers) {
-        config::shard_local_cfg().cloud_storage_max_readers_per_shard(
+        config::shard_local_cfg().cloud_storage_max_segment_readers_per_shard(
           maybe_max_readers);
     }
     auto manifest = hydrate_manifest(imposter.api.local(), bucket);
@@ -672,7 +672,7 @@ std::vector<model::record_batch_header> scan_remote_partition(
             maybe_max_segments);
     }
     if (maybe_max_readers) {
-        config::shard_local_cfg().cloud_storage_max_readers_per_shard(
+        config::shard_local_cfg().cloud_storage_max_segment_readers_per_shard(
           maybe_max_readers);
     }
     storage::log_reader_config reader_config(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1656,12 +1656,29 @@ configuration::configuration()
   , cloud_storage_max_segment_readers_per_shard(
       *this,
       "cloud_storage_max_segment_readers_per_shard",
-      "Maximum concurrent readers of remote data per CPU core.  If unset, "
-      "value of `topic_partitions_per_shard` is used, i.e. one reader per "
-      "partition if the shard is at its maximum partition capacity.",
+      "Maximum concurrent I/O cursors of materialized remote segments per CPU "
+      "core.  If unset, "
+      "value of `topic_partitions_per_shard` is used, i.e. one segment reader "
+      "per "
+      "partition if the shard is at its maximum partition capacity.  These "
+      "readers are cached"
+      "across Kafka consume requests and store a readahead buffer.",
       {.needs_restart = needs_restart::no,
        .visibility = visibility::tunable,
        .aliases = {"cloud_storage_max_readers_per_shard"}},
+      std::nullopt)
+  , cloud_storage_max_partition_readers_per_shard(
+      *this,
+      "cloud_storage_max_partition_readers_per_shard",
+      "Maximum concurrent partition readers of remote data per CPU core.  If "
+      "unset, "
+      "value of `topic_partitions_per_shard` is used, i.e. one reader per "
+      "partition if the shard is at its maximum partition capacity.  These "
+      "readers have the"
+      "lifetime of a Kafka consume request, so this property controls how many "
+      "consume"
+      "requests to remote data can make progress at the same time.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
   , cloud_storage_max_materialized_segments_per_shard(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1653,13 +1653,15 @@ configuration::configuration()
       "elapsed",
       {.visibility = visibility::tunable},
       5s)
-  , cloud_storage_max_readers_per_shard(
+  , cloud_storage_max_segment_readers_per_shard(
       *this,
-      "cloud_storage_max_readers_per_shard",
+      "cloud_storage_max_segment_readers_per_shard",
       "Maximum concurrent readers of remote data per CPU core.  If unset, "
       "value of `topic_partitions_per_shard` is used, i.e. one reader per "
       "partition if the shard is at its maximum partition capacity.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no,
+       .visibility = visibility::tunable,
+       .aliases = {"cloud_storage_max_readers_per_shard"}},
       std::nullopt)
   , cloud_storage_max_materialized_segments_per_shard(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -327,7 +327,8 @@ struct configuration final : public config_store {
     property<uint64_t> cloud_storage_cache_size;
     property<uint32_t> cloud_storage_cache_max_objects;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
-    property<std::optional<uint32_t>> cloud_storage_max_readers_per_shard;
+    property<std::optional<uint32_t>>
+      cloud_storage_max_segment_readers_per_shard;
     property<std::optional<uint32_t>>
       cloud_storage_max_materialized_segments_per_shard;
     property<uint64_t> cloud_storage_cache_chunk_size;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -330,6 +330,8 @@ struct configuration final : public config_store {
     property<std::optional<uint32_t>>
       cloud_storage_max_segment_readers_per_shard;
     property<std::optional<uint32_t>>
+      cloud_storage_max_partition_readers_per_shard;
+    property<std::optional<uint32_t>>
       cloud_storage_max_materialized_segments_per_shard;
     property<uint64_t> cloud_storage_cache_chunk_size;
     property<double> cloud_storage_hydrated_chunks_per_segment_ratio;

--- a/tests/rptest/scale_tests/tiered_storage_io_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_io_stress_test.py
@@ -63,7 +63,7 @@ class TieredStorageIoStressTest(PreallocNodesTest):
 
         # Set a modest reader concurrency limit to run safely on GB-per-core
         # test environments
-        extra_rp_conf['cloud_storage_max_readers_per_shard'] = 500
+        extra_rp_conf['cloud_storage_max_segment_readers_per_shard'] = 500
 
         super().__init__(test_context=test_context,
                          node_prealloc_count=1,

--- a/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
@@ -47,7 +47,8 @@ class TieredStorageReaderStressTest(RedpandaTest):
             self.segment_upload_interval,
             'cloud_storage_manifest_max_upload_interval_sec':
             self.manifest_upload_interval,
-            'cloud_storage_max_readers_per_shard': self.readers_per_shard
+            'cloud_storage_max_segment_readers_per_shard':
+            self.readers_per_shard
         }
         super().__init__(test_context,
                          *args,

--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -47,7 +47,7 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
         self.extra_rp_conf = {'cloud_storage_cache_chunk_size': 1024 * 256}
         if not self.redpanda.dedicated_nodes:
             self.extra_rp_conf.update(
-                {'cloud_storage_max_readers_per_shard': 10})
+                {'cloud_storage_max_segment_readers_per_shard': 10})
         self.redpanda.set_extra_rp_conf(self.extra_rp_conf)
 
     def setup(self):

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -782,7 +782,7 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
 
         if not self.redpanda.dedicated_nodes:
             self.redpanda.set_extra_rp_conf(
-                {'cloud_storage_max_readers_per_shard': 10})
+                {'cloud_storage_max_segment_readers_per_shard': 10})
 
     def setUp(self):
         # Dedicated nodes refers to non-container nodes such as EC2 instances


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda/pull/11914, strict enforcement of partition reader concurrency was added, but the limit was driven by the existing segment reader config.

A separate property enables configuring the limit on partition readers
independently of the limit on segment readers.  Controlling
partition readers enables limiting tiered storage
read concurrency (e.g. because a drive is bottlenecked) without
limiting the number of segment readers we can cache (the limit
on segment readers is driven by memory)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none