### PR TITLE
Made printing topic partitions and namespaces consistent

### DIFF
--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -47,7 +47,7 @@ void read_nested(
 void write(iobuf& out, timestamp ts) { serde::write(out, ts._v); }
 
 std::ostream& operator<<(std::ostream& os, const topic_partition& tp) {
-    fmt::print(os, "{{topic_partition: {}:{}}}", tp.topic, tp.partition);
+    fmt::print(os, "{{{}/{}}}", tp.topic, tp.partition);
     return os;
 }
 
@@ -57,13 +57,13 @@ std::ostream& operator<<(std::ostream& os, const ntp& n) {
 }
 
 std::ostream& operator<<(std::ostream& o, const model::topic_namespace& tp_ns) {
-    fmt::print(o, "{{ns: {}, topic: {}}}", tp_ns.ns, tp_ns.tp);
+    fmt::print(o, "{{{}/{}}}", tp_ns.ns, tp_ns.tp);
     return o;
 }
 
 std::ostream&
 operator<<(std::ostream& o, const model::topic_namespace_view& tp_ns) {
-    fmt::print(o, "{{ns: {}, topic: {}}}", tp_ns.ns, tp_ns.tp);
+    fmt::print(o, "{{{}/{}}}", tp_ns.ns, tp_ns.tp);
     return o;
 }
 


### PR DESCRIPTION
Made printing `topic_namespace` and `topic_partition` consistent with string representation of `ntp` which is printed as `namespace/topic/partition_id`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- easier to read log entries 
