### PR TITLE
cmake: use list FILTER since cmake version greater than 3.5 now

### DIFF
--- a/cmake/v_library.cmake
+++ b/cmake/v_library.cmake
@@ -62,15 +62,11 @@ function(v_cc_library)
   set(_NAME "v_${V_CC_LIB_NAME}")
 
   # Check if this is a header-only library
-  # Note that as of February 2019, many popular OS's (for example, Ubuntu
-  # 16.04 LTS) only come with cmake 3.5 by default.  For this reason, we can't
-  # use list(FILTER...)
+  # We now have cmake minimum required version 3.12.0.
+  # For this reason, we now use list(FILTER...) rather 
+  # than list(REMOVE_ITEM ...)
   set(V_CC_SRCS "${V_CC_LIB_SRCS}")
-  foreach(src_file IN LISTS V_CC_SRCS)
-    if(${src_file} MATCHES ".*\\.(h|inc)")
-      list(REMOVE_ITEM V_CC_SRCS "${src_file}")
-    endif()
-  endforeach()
+  list(FILTER V_CC_SRCS EXCLUDE REGEX ".*\\.(h|inc)")
   if("${V_CC_SRCS}" STREQUAL "")
     set(V_CC_LIB_IS_INTERFACE 1)
   else()


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Motivation

For compatibility reasons, we use `list(REMOVE_ITEM ...)` with cmake version 3.5.   

But now we require cmake minimum version 3.12 in root [CMakeLists.txt](https://github.com/redpanda-data/redpanda/blob/dev/CMakeLists.txt), it's time to turn to list(FILTER ...).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
