### PR TITLE
kafka: Abort fetch and list_offsets when client disconnects

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -206,7 +206,9 @@ public:
             vlog(_ctxlog.debug, "abort_source is set");
             auto sub = config.abort_source->get().subscribe([this]() noexcept {
                 vlog(_ctxlog.debug, "abort requested via config.abort_source");
-                dispose_current_reader();
+                if (_reader) {
+                    _partition->evict_segment_reader(std::move(_reader));
+                }
             });
             if (sub) {
                 _as_sub = std::move(*sub);

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -204,6 +204,7 @@ public:
     ss::future<> start(storage::log_reader_config config) {
         if (config.abort_source) {
             vlog(_ctxlog.debug, "abort_source is set");
+            _partition_reader_as = config.abort_source;
             auto sub = config.abort_source->get().subscribe([this]() noexcept {
                 vlog(_ctxlog.debug, "abort requested via config.abort_source");
                 if (_reader) {
@@ -266,6 +267,14 @@ public:
 
     bool is_end_of_stream() const override { return _reader == nullptr; }
 
+    void throw_on_external_abort() {
+        _partition->_as.check();
+
+        if (_partition_reader_as) {
+            _partition_reader_as.value().get().check();
+        }
+    }
+
     ss::future<storage_t>
     do_load_slice(model::timeout_clock::time_point deadline) override {
         std::exception_ptr unknown_exception_ptr = nullptr;
@@ -292,6 +301,8 @@ public:
                     co_await set_end_of_stream();
                     co_return storage_t{};
                 }
+
+                throw_on_external_abort();
                 auto reader_delta = _reader->current_delta();
                 if (
                   !_ot_state->empty()
@@ -344,6 +355,8 @@ public:
                 try {
                     auto result = co_await _reader->read_some(
                       deadline, *_ot_state);
+                    throw_on_external_abort();
+
                     if (!result) {
                         vlog(
                           _ctxlog.debug,
@@ -365,6 +378,7 @@ public:
                     }
                     co_return storage_t{std::move(d)};
                 } catch (const stuck_reader_exception& ex) {
+                    throw_on_external_abort();
                     vlog(
                       _ctxlog.warn,
                       "stuck reader: current rp offset: {}, max rp offset: {}",
@@ -656,6 +670,8 @@ private:
     std::unique_ptr<remote_segment_batch_reader> _reader;
     /// Cancellation subscription
     ss::abort_source::subscription _as_sub;
+    /// Reference to the abort source of the partition reader
+    storage::opt_abort_source_t _partition_reader_as;
     /// Guard for the partition gate
     ss::gate::holder _gate_guard;
     model::offset _next_segment_base_offset{};

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1353,6 +1353,7 @@ remote_segment_batch_reader::read_some(
 
 ss::future<std::unique_ptr<storage::continuous_batch_parser>>
 remote_segment_batch_reader::init_parser() {
+    ss::gate::holder h(_gate);
     vlog(
       _ctxlog.debug,
       "remote_segment_batch_reader::init_parser, start_offset: {}",

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -56,6 +56,7 @@ connection_context::connection_context(
     kafka_throughput_controlled_api_keys) noexcept
   : _server(s)
   , conn(conn)
+  , _as()
   , _sasl(std::move(sasl))
   // tests may build a context without a live connection
   , _client_addr(conn ? conn->addr.addr() : ss::net::inet_address{})
@@ -219,7 +220,7 @@ ss::future<> connection_context::handle_auth_v0(const size_t size) {
 }
 
 bool connection_context::is_finished_parsing() const {
-    return conn->input().eof() || _server.abort_requested();
+    return conn->input().eof() || abort_requested();
 }
 
 connection_context::delay_t
@@ -294,7 +295,7 @@ ss::future<session_resources> connection_context::throttle_request(
     auto tracker = std::make_unique<request_tracker>(_server.probe(), h_probe);
     auto fut = ss::now();
     if (delay.enforce > delay_t::clock::duration::zero()) {
-        fut = ss::sleep_abortable(delay.enforce, _server.abort_source());
+        fut = ss::sleep_abortable(delay.enforce, abort_source().local());
     }
     auto track = track_latency(hdr.key);
     return fut
@@ -357,7 +358,7 @@ connection_context::reserve_request_units(api_key key, size_t size) {
 ss::future<>
 connection_context::dispatch_method_once(request_header hdr, size_t size) {
     auto sres_in = co_await throttle_request(hdr, size);
-    if (_server.abort_requested()) {
+    if (abort_requested()) {
         // protect against shutdown behavior
         co_return;
     }
@@ -381,7 +382,7 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
     auto remaining = size - request_header_size - hdr.client_id_buffer.size()
                      - hdr.tags_size_bytes;
     auto buf = co_await read_iobuf_exactly(conn->input(), remaining);
-    if (_server.abort_requested()) {
+    if (abort_requested()) {
         // _server._cntrl etc might not be alive
         co_return;
     }

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -20,6 +20,7 @@
 #include "security/authorizer.h"
 #include "security/mtls.h"
 #include "security/sasl_authentication.h"
+#include "ssx/abort_source.h"
 #include "ssx/semaphore.h"
 #include "utils/log_hist.h"
 #include "utils/named_type.h"
@@ -126,8 +127,18 @@ public:
     connection_context& operator=(const connection_context&) = delete;
     connection_context& operator=(connection_context&&) = delete;
 
+    ss::future<> start() {
+        co_await _as.start(_server.abort_source());
+    }
+
+    ss::future<> stop() {
+        co_await _as.stop();
+    }
+
     /// The instance of \ref kafka::server on the shard serving the connection
     server& server() { return _server; }
+    ssx::sharded_abort_source& abort_source() { return _as; }
+    bool abort_requested() const { return _as.abort_requested(); }
     const ss::sstring& listener() const { return conn->name(); }
     std::optional<security::sasl_server>& sasl() { return _sasl; }
 
@@ -349,6 +360,7 @@ private:
     sequence_id _next_response;
     sequence_id _seq_idx;
     map_t _responses;
+    ssx::sharded_abort_source _as;
     std::optional<security::sasl_server> _sasl;
     const ss::net::inet_address _client_addr;
     const bool _enable_authorizer;

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -17,6 +17,7 @@
 #include "model/fundamental.h"
 #include "model/ktp.h"
 #include "model/metadata.h"
+#include "ssx/abort_source.h"
 #include "utils/intrusive_list_helpers.h"
 #include "utils/log_hist.h"
 
@@ -167,11 +168,13 @@ struct fetch_config {
     bool skip_read{false};
     bool read_from_follower{false};
     std::optional<model::rack_id> consumer_rack_id;
+    std::optional<std::reference_wrapper<ssx::sharded_abort_source>>
+      abort_source;
 
     friend std::ostream& operator<<(std::ostream& o, const fetch_config& cfg) {
         fmt::print(
           o,
-          R"({{"start_offset": {}, "max_offset": {}, "isolation_lvl": {}, "max_bytes": {}, "strict_max_bytes": {}, "skip_read": {}, "current_leader_epoch:" {}, "follower_read:" {}, "consumer_rack_id": {}}})",
+          R"({{"start_offset": {}, "max_offset": {}, "isolation_lvl": {}, "max_bytes": {}, "strict_max_bytes": {}, "skip_read": {}, "current_leader_epoch:" {}, "follower_read:" {}, "consumer_rack_id": {}, "abortable": {}, "aborted": {}}})",
           cfg.start_offset,
           cfg.max_offset,
           cfg.isolation_level,
@@ -180,7 +183,11 @@ struct fetch_config {
           cfg.skip_read,
           cfg.current_leader_epoch,
           cfg.read_from_follower,
-          cfg.consumer_rack_id);
+          cfg.consumer_rack_id,
+          cfg.abort_source.has_value(),
+          cfg.abort_source.has_value()
+            ? cfg.abort_source.value().get().abort_requested()
+            : false);
         return o;
     }
 };

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -109,7 +109,8 @@ struct op_context {
     bool should_stop_fetch() const {
         return !request.debounce_delay() || over_min_bytes()
                || is_empty_request() || contains_preferred_replica
-               || response_error || deadline <= model::timeout_clock::now();
+               || response_error || rctx.abort_requested()
+               || deadline <= model::timeout_clock::now();
     }
 
     bool over_min_bytes() const {

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -132,7 +132,8 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
       timestamp,
       offset,
       kafka_read_priority(),
-      {model::record_batch_type::raft_data}});
+      {model::record_batch_type::raft_data},
+      octx.rctx.abort_source().local()});
     auto id = ktp.get_partition();
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -27,6 +27,7 @@
 #include "pandaproxy/schema_registry/fwd.h"
 #include "seastarx.h"
 #include "security/fwd.h"
+#include "ssx/abort_source.h"
 #include "vlog.h"
 
 #include <seastar/core/future.hh>
@@ -89,6 +90,9 @@ public:
     const request_header& header() const { return _header; }
 
     ss::lw_shared_ptr<connection_context> connection() { return _conn; }
+
+    ssx::sharded_abort_source& abort_source() { return _conn->abort_source(); }
+    bool abort_requested() const { return _conn->abort_requested(); }
 
     protocol::decoder& reader() { return _reader; }
 

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -288,10 +288,18 @@ ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
         .kafka_throughput_controlled_api_keys.bind<std::vector<bool>>(
           &convert_api_names_to_key_bitmap));
 
+    std::exception_ptr eptr;
     try {
+        co_await ctx->start();
         co_await ctx->process();
     } catch (...) {
-        auto eptr = std::current_exception();
+        eptr = std::current_exception();
+    }
+    if (!eptr) {
+        co_return co_await ctx->stop();
+    } else {
+        co_await ctx->abort_source().request_abort_ex(eptr);
+        co_await ctx->stop();
         auto disconnected = net::is_disconnect_exception(eptr);
         if (authn_method == config::broker_authn_method::sasl) {
             /*

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -65,6 +65,10 @@ public:
         return ss::tls::get_dn_information(_fd);
     }
 
+    ss::future<> wait_for_input_shutdown() {
+        return _fd ? _fd.wait_input_shutdown() : ss::make_ready_future<>();
+    }
+
 private:
     boost::intrusive::list<connection>& _hook;
     ss::sstring _name;

--- a/src/v/ssx/abort_source.h
+++ b/src/v/ssx/abort_source.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "oncore.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/sharded.hh>
+
+#include <exception>
+
+namespace ssx {
+
+class sharded_abort_source {
+public:
+    ss::future<> start(ss::abort_source& parent) {
+        return _as.start().then([this, &parent]() {
+            auto dex = parent.get_default_exception();
+            auto sub = parent.subscribe(
+              [this, dex](
+                std::optional<std::exception_ptr> const& ex) mutable noexcept {
+                  dex = ex.value_or(dex);
+                  return _as.invoke_on_all(
+                    [dex](auto& as) { return as.request_abort_ex(dex); });
+              });
+            if (sub) {
+                _sub.emplace(std::move(*sub));
+            }
+        });
+    }
+
+    ss::future<> stop() noexcept {
+        _sub.reset();
+        return request_abort().then([this]() { return _as.stop(); });
+    }
+
+    auto& local() noexcept { return _as.local(); }
+    auto const& local() const noexcept { return _as.local(); }
+
+    template<typename Func>
+    [[nodiscard]] auto subscribe(Func&& func) {
+        return local().subscribe(std::forward<Func>(func));
+    }
+
+    ss::future<> request_abort_ex(std::exception_ptr ex) noexcept {
+        return _as.invoke_on_all(
+          [ex](auto& s) { return s.request_abort_ex(ex); });
+    }
+
+    template<typename Exception>
+    ss::future<> request_abort_ex(Exception&& e) noexcept {
+        return request_abort_ex(std::make_exception_ptr(e));
+    }
+
+    ss::future<> request_abort() noexcept {
+        return request_abort_ex(local().get_default_exception());
+    }
+
+    auto abort_requested() const noexcept { return local().abort_requested(); }
+    auto check() const { return local().check(); }
+
+private:
+    ss::sharded<ss::abort_source> _as;
+    std::optional<ss::abort_source::subscription> _sub;
+};
+
+} // namespace ssx

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -14,6 +14,16 @@ rp_test(
 )
 
 rp_test(
+  UNIT_TEST
+  BINARY_NAME ssx_multi_thread
+  SOURCES
+    abort_source_test.cc
+  LIBRARIES v::seastar_testing_main
+  ARGS "-- -c 2"
+  LABELS ssx
+)
+
+rp_test(
   BENCHMARK_TEST
   BINARY_NAME ssx_bench
   SOURCES

--- a/src/v/ssx/tests/abort_source_test.cc
+++ b/src/v/ssx/tests/abort_source_test.cc
@@ -1,0 +1,122 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/abort_source.h"
+#include "vlog.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/later.hh>
+
+#include <boost/test/unit_test.hpp>
+
+static constexpr auto derived_str = "derived";
+static constexpr auto expected_msg = std::string_view{derived_str};
+
+struct derived_error final : std::runtime_error {
+    derived_error()
+      : std::runtime_error(derived_str) {}
+};
+
+struct fixture {
+    using sub_arg_t = std::optional<std::exception_ptr> const&;
+
+    auto make_incrementor() {
+        ++expected_count;
+        return [this](sub_arg_t) noexcept { ++count; };
+    }
+
+    auto make_async_incrementor() {
+        ++expected_count;
+        return [this](sub_arg_t) noexcept {
+            ++count;
+            return ss::now();
+        };
+    }
+
+    auto make_naive_incrementor() {
+        ++expected_count;
+        return [this]() noexcept { ++count; };
+    }
+
+    auto make_async_naive_incrementor() {
+        ++expected_count;
+        return [this]() noexcept {
+            ++count;
+            return ss::now();
+        };
+    }
+
+    auto start() { return sas.start(as); }
+    auto stop() { return sas.stop(); }
+
+    std::atomic_size_t count{0};
+    std::atomic_size_t expected_count{0};
+
+    ss::abort_source as;
+    ssx::sharded_abort_source sas;
+};
+
+SEASTAR_THREAD_TEST_CASE(ssx_sharded_abort_source_test_abort_parent) {
+    BOOST_REQUIRE(ss::smp::count > 1);
+
+    fixture f;
+    f.start().get();
+
+    auto fas_sub_1 = ss::smp::submit_to(ss::shard_id{1}, [&f]() {
+                         return f.sas.subscribe(f.make_incrementor());
+                     }).get();
+
+    f.as.request_abort_ex(derived_error{});
+
+    // Ensure parent exception is propated
+    BOOST_REQUIRE(f.sas.abort_requested());
+    BOOST_REQUIRE_EXCEPTION(
+      f.sas.check(), derived_error, [](derived_error const& e) {
+          return e.what() == expected_msg;
+      });
+
+    f.stop().get();
+
+    BOOST_REQUIRE_EQUAL(f.count, f.expected_count);
+}
+
+SEASTAR_THREAD_TEST_CASE(ssx_sharded_abort_source_test_no_abort_parent) {
+    BOOST_REQUIRE(ss::smp::count > 1);
+
+    fixture f;
+    f.start().get();
+
+    auto fas_sub_1 = ss::smp::submit_to(ss::shard_id{1}, [&f]() {
+                         return f.sas.subscribe(f.make_incrementor());
+                     }).get();
+
+    BOOST_REQUIRE(!f.sas.abort_requested());
+    BOOST_REQUIRE_NO_THROW(f.sas.check());
+
+    // Ensure stop aborts the subscriptions
+    f.stop().get();
+
+    BOOST_REQUIRE_EQUAL(f.count, f.expected_count);
+}
+
+SEASTAR_THREAD_TEST_CASE(ssx_sharded_abort_source_subscribe_test) {
+    fixture f;
+    f.start().get();
+
+    // Ensure that sync and async functions are called;
+    auto s0 = f.sas.subscribe(f.make_incrementor());
+    auto s1 = f.sas.subscribe(f.make_async_incrementor());
+    auto s2 = f.sas.subscribe(f.make_naive_incrementor());
+    auto s3 = f.sas.subscribe(f.make_async_naive_incrementor());
+
+    f.as.request_abort_ex(derived_error());
+    f.stop().get();
+    BOOST_REQUIRE_EQUAL(f.count, f.expected_count);
+}

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -60,6 +60,11 @@ std::ostream& operator<<(std::ostream& o, const log_reader_config& cfg) {
     o << ", over_budget:" << cfg.over_budget;
     o << ", strict_max_bytes:" << cfg.strict_max_bytes;
     o << ", skip_batch_cache:" << cfg.skip_batch_cache;
+    o << ", abortable:" << cfg.abort_source.has_value();
+    o << ", aborted:"
+      << (cfg.abort_source.has_value()
+            ? cfg.abort_source.value().get().abort_requested()
+            : false);
     return o << "}";
 }
 


### PR DESCRIPTION
kafka: Abort fetch and list_offsets (timequery) when the client disconnects for timely resource cleanup.

* Add an `abort_source` to `connection_context`
  * This needs to be sharded as some requests span arbitrary shards
* Abort the `abort_source` when the socket is disconnected
* Wire up the `abort_source` to the `request_context` and into:
  * `fetch` 
  * `list_offsets` (timequery)

The primary goal is to improve the situation for https://github.com/redpanda-data/redpanda/issues/11799

Testing can be done with something like:
```
kcat -G foo -X fetch.wait.max.ms=60000
```

And the kill the client either gracefully or will `kill -9`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* kafka: Abort `fetch` and `list_offsets` (timequery) when the client disconnects for timely resource cleanup.