### PR TITLE
t/full_disk_test: longer timeout in debug_mode

### DIFF
--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -246,10 +246,11 @@ class FullDiskTest(EndToEndTest):
             self.full_disk.trigger_low_space()
 
             # confirm we were blocked from producing
-            not_producing = RateTarget(max_total_sec=40,
-                                       target_sec=5,
-                                       target_min_rate=0,
-                                       target_max_rate=1)
+            not_producing = RateTarget(
+                max_total_sec=40 if not self.debug_mode else 100,
+                target_sec=5,
+                target_min_rate=0,
+                target_max_rate=1)
             self.bytes_prod.expect_rate(not_producing)
 
             self.full_disk.clear_low_space()


### PR DESCRIPTION
The collection of metrics needed by this test takes more time in debug mode. this pr increases the timeout accordingly

one issue with debug_mode is the increase in latency in acquiring the metrics.

for example:

this is a failure with a debug build.
The test could only do one loop over the metrics and it exhausted the timeout.
```
➜ rg expect_rate vbuild/ducktape/results/2023-07-11--001/FullDiskTest/test_full_disk_no_produce/1/test_log.debug 
486:[DEBUG - 2023-07-11 13:34:57,026 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 181813.0
488:[INFO  - 2023-07-11 13:35:21,601 - expect_rate - expect_rate - lineno:96]: Rate target met: 16630.3 bytes/sec over the last 24.575 sec.
502:[DEBUG - 2023-07-11 13:35:27,834 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 979520.0
504:[DEBUG - 2023-07-11 13:35:33,303 - expect_rate - expect_rate - lineno:101]: rate: 11925.9 for 5.469
506:[INFO  - 2023-07-11 13:35:39,177 - expect_rate - expect_rate - lineno:96]: Rate target met: 0.0 bytes/sec over the last 5.873 sec.
522:[DEBUG - 2023-07-11 13:35:44,078 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 1044743.0
524:[INFO  - 2023-07-11 13:35:52,810 - expect_rate - expect_rate - lineno:96]: Rate target met: 5716.3 bytes/sec over the last 8.732 sec.
538:[DEBUG - 2023-07-11 13:36:13,143 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 1240215.0
540:[DEBUG - 2023-07-11 13:36:35,667 - expect_rate - expect_rate - lineno:101]: rate: 1616.3 for 22.524
551:    self.bytes_prod.expect_rate(not_producing)
552:  File "/root/tests/rptest/utils/expect_rate.py", line 111, in expect_rate
574:    self.bytes_prod.expect_rate(not_producing)
575:  File "/root/tests/rptest/utils/expect_rate.py", line 111, in expect_rate
732:    self.bytes_prod.expect_rate(not_producing)
733:  File "/root/tests/rptest/utils/expect_rate.py", line 111, in expect_rate
```

meanwhile in release mode multiple loops can be done in a shorter amount of time
```
andrea  $     ~/redpanda/redpanda   issue/11362/test_full_disk_no_produce 
➜ rg expect_rate vbuild/ducktape/results/2023-07-11--002/FullDiskTest/test_full_disk_no_produce/1/test_log.debug 
449:[DEBUG - 2023-07-11 14:05:41,876 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 99283.0
451:[DEBUG - 2023-07-11 14:05:42,994 - expect_rate - expect_rate - lineno:104]: (waiting, 1.1/5 sec) bytes: 130499.0
453:[DEBUG - 2023-07-11 14:05:44,129 - expect_rate - expect_rate - lineno:104]: (waiting, 2.3/5 sec) bytes: 157638.0
455:[DEBUG - 2023-07-11 14:05:45,260 - expect_rate - expect_rate - lineno:104]: (waiting, 3.4/5 sec) bytes: 184942.0
457:[DEBUG - 2023-07-11 14:05:46,390 - expect_rate - expect_rate - lineno:104]: (waiting, 4.5/5 sec) bytes: 210569.0
459:[INFO  - 2023-07-11 14:05:47,509 - expect_rate - expect_rate - lineno:96]: Rate target met: 24509.5 bytes/sec over the last 5.633 sec.
473:[DEBUG - 2023-07-11 14:05:48,182 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 253698.0
475:[DEBUG - 2023-07-11 14:05:49,322 - expect_rate - expect_rate - lineno:104]: (waiting, 1.1/5 sec) bytes: 282267.0
477:[DEBUG - 2023-07-11 14:05:50,454 - expect_rate - expect_rate - lineno:104]: (waiting, 2.3/5 sec) bytes: 310671.0
479:[DEBUG - 2023-07-11 14:05:51,565 - expect_rate - expect_rate - lineno:104]: (waiting, 3.4/5 sec) bytes: 339418.0
481:[DEBUG - 2023-07-11 14:05:52,682 - expect_rate - expect_rate - lineno:104]: (waiting, 4.5/5 sec) bytes: 360927.0
483:[DEBUG - 2023-07-11 14:05:53,809 - expect_rate - expect_rate - lineno:101]: rate: 19056.2 for 5.627
485:[DEBUG - 2023-07-11 14:05:54,950 - expect_rate - expect_rate - lineno:101]: rate: 13979.0 for 5.627
487:[DEBUG - 2023-07-11 14:05:56,086 - expect_rate - expect_rate - lineno:101]: rate: 8923.3 for 5.632
489:[DEBUG - 2023-07-11 14:05:57,198 - expect_rate - expect_rate - lineno:101]: rate: 3818.4 for 5.633
491:[INFO  - 2023-07-11 14:05:58,355 - expect_rate - expect_rate - lineno:96]: Rate target met: 0.0 bytes/sec over the last 5.673 sec.
506:[DEBUG - 2023-07-11 14:05:59,023 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 360927.0
508:[DEBUG - 2023-07-11 14:06:00,157 - expect_rate - expect_rate - lineno:104]: (waiting, 1.1/5 sec) bytes: 360927.0
510:[DEBUG - 2023-07-11 14:06:01,287 - expect_rate - expect_rate - lineno:104]: (waiting, 2.3/5 sec) bytes: 360927.0
513:[DEBUG - 2023-07-11 14:06:02,427 - expect_rate - expect_rate - lineno:104]: (waiting, 3.4/5 sec) bytes: 360927.0
515:[DEBUG - 2023-07-11 14:06:03,558 - expect_rate - expect_rate - lineno:104]: (waiting, 4.5/5 sec) bytes: 388597.0
517:[INFO  - 2023-07-11 14:06:04,683 - expect_rate - expect_rate - lineno:96]: Rate target met: 9891.3 bytes/sec over the last 5.660 sec.
531:[DEBUG - 2023-07-11 14:06:05,360 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 433364.0
533:[DEBUG - 2023-07-11 14:06:06,520 - expect_rate - expect_rate - lineno:104]: (waiting, 1.2/5 sec) bytes: 461698.0
535:[DEBUG - 2023-07-11 14:06:07,657 - expect_rate - expect_rate - lineno:104]: (waiting, 2.3/5 sec) bytes: 485771.0
537:[DEBUG - 2023-07-11 14:06:08,792 - expect_rate - expect_rate - lineno:104]: (waiting, 3.4/5 sec) bytes: 485771.0
539:[DEBUG - 2023-07-11 14:06:09,937 - expect_rate - expect_rate - lineno:104]: (waiting, 4.6/5 sec) bytes: 485771.0
541:[DEBUG - 2023-07-11 14:06:11,079 - expect_rate - expect_rate - lineno:101]: rate: 9163.7 for 5.719
543:[DEBUG - 2023-07-11 14:06:12,226 - expect_rate - expect_rate - lineno:101]: rate: 4218.9 for 5.706
545:[INFO  - 2023-07-11 14:06:13,350 - expect_rate - expect_rate - lineno:96]: Rate target met: 0.0 bytes/sec over the last 5.693 sec.
560:[DEBUG - 2023-07-11 14:06:13,999 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 485771.0
562:[DEBUG - 2023-07-11 14:06:15,136 - expect_rate - expect_rate - lineno:104]: (waiting, 1.1/5 sec) bytes: 485771.0
564:[DEBUG - 2023-07-11 14:06:16,264 - expect_rate - expect_rate - lineno:104]: (waiting, 2.3/5 sec) bytes: 485771.0
567:[DEBUG - 2023-07-11 14:06:17,393 - expect_rate - expect_rate - lineno:104]: (waiting, 3.4/5 sec) bytes: 485771.0
569:[DEBUG - 2023-07-11 14:06:18,562 - expect_rate - expect_rate - lineno:104]: (waiting, 4.6/5 sec) bytes: 512407.0
571:[INFO  - 2023-07-11 14:06:19,692 - expect_rate - expect_rate - lineno:96]: Rate target met: 9563.0 bytes/sec over the last 5.693 sec.
585:[DEBUG - 2023-07-11 14:06:20,398 - expect_rate - expect_rate - lineno:104]: (waiting, 0.0/5 sec) bytes: 558130.0
587:[DEBUG - 2023-07-11 14:06:21,533 - expect_rate - expect_rate - lineno:104]: (waiting, 1.1/5 sec) bytes: 586839.0
589:[DEBUG - 2023-07-11 14:06:22,665 - expect_rate - expect_rate - lineno:104]: (waiting, 2.3/5 sec) bytes: 609789.0
591:[DEBUG - 2023-07-11 14:06:23,813 - expect_rate - expect_rate - lineno:104]: (waiting, 3.4/5 sec) bytes: 609789.0
593:[DEBUG - 2023-07-11 14:06:24,952 - expect_rate - expect_rate - lineno:104]: (waiting, 4.6/5 sec) bytes: 609789.0
595:[DEBUG - 2023-07-11 14:06:26,088 - expect_rate - expect_rate - lineno:101]: rate: 9078.9 for 5.690
597:[DEBUG - 2023-07-11 14:06:27,247 - expect_rate - expect_rate - lineno:101]: rate: 4016.5 for 5.714
599:[INFO  - 2023-07-11 14:06:28,381 - expect_rate - expect_rate - lineno:96]: Rate target met: 0.0 bytes/sec over the last 5.716 sec.
andrea  $     ~/redpanda/redpanda   issue/11362/test_full_disk_no_produce 

```

Fixes #11362

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none