### PR TITLE
Test existing DeleteRecords ducktape tests against topics with cloud storage enabled

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -236,12 +236,14 @@ ss::future<log_eviction_stm::offset_result> log_eviction_stm::truncate(
     vlog(
       _logger.info,
       "Replicating prefix_truncate command, redpanda start offset: {}, kafka "
-      "start offset: {}"
-      "current last snapshot offset: {}, current last visible offset: {}",
+      "start offset: {} "
+      "current last snapshot offset: {}, current last visible offset: {} for "
+      "ntp: {}",
       val.rp_start_offset,
       val.kafka_start_offset,
       _raft->last_snapshot_index(),
-      _raft->last_visible_index());
+      _raft->last_visible_index(),
+      _raft->ntp());
 
     auto res = co_await replicate_command(std::move(batch), deadline, as);
     if (res.has_failure()) {

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -474,6 +474,47 @@
           ]
         },
         {
+            "path": "/v1/debug/storage/offset_translator/{namespace}/{topic}/{partition}",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Return list of all local offsets translated",
+                    "nickname": "get_local_offsets_translated",
+                    "produces": [
+                       "application/json"
+                    ],
+                    "type": "array",
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "translate_to",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "/v1/debug/cpu_profile",
             "operations": [
                 {
@@ -1023,6 +1064,20 @@
                 "free_bytes_delta": {
                     "type": "long",
                     "description": "Free size adjustment (signed)"
+                }
+            }
+        },
+        "translated_offset": {
+            "id": "translated_offset",
+            "description": "2-tuple of redpanda and kafka offset",
+            "properties": {
+                "rp_offset": {
+                    "type": "long",
+                    "description": "redpanda offset"
+                },
+                "kafka_offset": {
+                    "type": "long",
+                    "description": "kafka offset"
                 }
             }
         }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -472,6 +472,8 @@ private:
     ss::future<ss::json::json_return_type>
       cpu_profile_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
+      get_local_offsets_translated_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
       cloud_storage_usage_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       restart_service_handler(std::unique_ptr<ss::http::request>);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1013,3 +1013,20 @@ class Admin:
         Get the CPU profile of a node.
         """
         return self._request("get", "debug/cpu_profile", node=node).json()
+
+    def get_local_offsets_translated(self,
+                                     offsets,
+                                     topic,
+                                     partition,
+                                     translate_to="kafka",
+                                     node=None):
+        """
+        Query offset translator to translate offsets from one type to another
+
+        Options for param "translate_to" are "kafka" and "redpanda"
+        """
+        return self._request(
+            "get",
+            f"debug/storage/offset_translator/kafka/{topic}/{partition}?translate_to={translate_to}",
+            node=node,
+            json=offsets).json()

--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -267,9 +267,10 @@ class DeleteRecordsTest(RedpandaTest):
                     # A segment with no data file indicates that an index or
                     # compaction index was left behind for a deleted segment, or
                     # deletion is currently in flight.
-                    return 0
+                    return -1
 
             boundaries = sorted([to_final_indicies(seg) for seg in node])
+            boundaries = [idx for idx in boundaries if idx >= 0]
             self.redpanda.logger.debug(f"Local boundaries: {boundaries}")
             return boundaries
 

--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -15,7 +15,7 @@ import threading
 import confluent_kafka as ck
 import ducktape
 
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize, matrix
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
@@ -26,6 +26,8 @@ from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.util import produce_until_segments
 from rptest.util import expect_exception
+from rptest.services.redpanda import SISettings
+from rptest.utils.si_utils import BucketView, NTP
 
 
 class DeleteRecordsTest(RedpandaTest):
@@ -33,14 +35,21 @@ class DeleteRecordsTest(RedpandaTest):
     The purpose of this test is to exercise the delete-records API which
     prefix truncates the log at a user defined offset.
     """
-    topics = (TopicSpec(), )
+
+    log_segment_size = 1048576
+
+    topics = [
+        TopicSpec(name="test-topic-1",
+                  partition_count=1,
+                  replication_factor=3,
+                  retention_bytes=-1,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE)
+    ]
 
     def __init__(self, test_context):
-        extra_rp_conf = dict(
-            enable_leader_balancer=False,
-            log_compaction_interval_ms=5000,
-            log_segment_size=1048576,
-        )
+        extra_rp_conf = dict(enable_leader_balancer=False,
+                             log_compaction_interval_ms=5000,
+                             log_segment_size=self.log_segment_size)
         super(DeleteRecordsTest, self).__init__(test_context=test_context,
                                                 num_brokers=3,
                                                 extra_rp_conf=extra_rp_conf)
@@ -48,6 +57,63 @@ class DeleteRecordsTest(RedpandaTest):
 
         self.rpk = RpkTool(self.redpanda)
         self.admin = Admin(self.redpanda)
+
+    def setUp(self):
+        # Defer cluster startup so we can tweak configs based on the type of
+        # test run.
+        pass
+
+    def _start(self,
+               cloud_storage_enabled,
+               start_with_data=True,
+               apply_retention_settings=True):
+        # Tests will invoke this method to start redpanda with the correctly
+        # applied test settings
+        if cloud_storage_enabled:
+            si_settings = SISettings(
+                self._ctx,
+                log_segment_size=self.log_segment_size,
+                cloud_storage_housekeeping_interval_ms=2000,
+                fast_uploads=True)
+            extra_rp_conf = dict(
+                log_compaction_interval_ms=2000,
+                compacted_log_segment_size=self.log_segment_size)
+            self.redpanda.set_extra_rp_conf(extra_rp_conf)
+            self.redpanda.set_si_settings(si_settings)
+
+        self.redpanda.start()
+        self._create_initial_topics()
+
+        if start_with_data is True:
+            produce_until_segments(
+                self.redpanda,
+                topic=self.topic,
+                partition_idx=0,
+                count=10,
+                acks=-1,
+            )
+
+        local_snapshot = self.redpanda.storage().segments_by_node(
+            "kafka", self.topic, 0)
+        assert len(local_snapshot) > 0, "empty snapshot"
+        self.redpanda.logger.info(f"Snapshot: {local_snapshot}")
+
+        if cloud_storage_enabled and apply_retention_settings:
+            self._apply_local_retention_settings()
+
+        return local_snapshot
+
+    def _apply_local_retention_settings(self):
+        # Will evict local segments every 2 segments, the rational here is to
+        # stress the TS path of delete-records where the data only exists in cloud
+        # and not locally
+        self.local_retention = self.log_segment_size * 2
+        self.redpanda.logger.info(
+            f"Turning on aggressive local retention, log_segment_size: {self.log_segment_size} retention.local.target.bytes: {self.local_retention}"
+        )
+        self.rpk.alter_topic_config(
+            self.topic, TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,
+            self.local_retention)
 
     def get_topic_info(self):
         topics_info = list(self.rpk.describe_topic(self.topic))
@@ -134,7 +200,9 @@ class DeleteRecordsTest(RedpandaTest):
             high_watermark), f"high watermark: {high_watermark} is consumable"
 
     @cluster(num_nodes=3)
-    def test_delete_records_topic_start_delta(self):
+    @parametrize(cloud_storage_enabled=True)
+    @parametrize(cloud_storage_enabled=False)
+    def test_delete_records_topic_start_delta(self, cloud_storage_enabled):
         """
         Test that delete-records moves forward the segment offset delta
 
@@ -144,6 +212,8 @@ class DeleteRecordsTest(RedpandaTest):
         num_records = 10240
         records_size = 512
         truncate_offset_start = 100
+
+        self._start(cloud_storage_enabled, start_with_data=False)
 
         # Produce some data, wait for it all to arrive
         kafka_tools = KafkaCliTools(self.redpanda)
@@ -172,11 +242,13 @@ class DeleteRecordsTest(RedpandaTest):
     # specific to delete-records but will happen in all cases where segment deletion
     # occurs at the moment a failure is injected.
     @cluster(num_nodes=3, check_for_storage_usage_inconsistencies=False)
-    @parametrize(truncate_point="at_segment_boundary")
-    @parametrize(truncate_point="random_offset")
-    @parametrize(truncate_point="one_below_high_watermark")
-    @parametrize(truncate_point="at_high_watermark")
-    def test_delete_records_segment_deletion(self, truncate_point: str):
+    @matrix(cloud_storage_enabled=[True, False],
+            truncate_point=[
+                "at_segment_boundary", "random_offset",
+                "one_below_high_watermark", "at_high_watermark"
+            ])
+    def test_delete_records_segment_deletion(self, cloud_storage_enabled: bool,
+                                             truncate_point: str):
         """
         Test that prefix truncation actually deletes data
 
@@ -184,27 +256,10 @@ class DeleteRecordsTest(RedpandaTest):
         can be asserted that all of those segments will be deleted once the
         log_eviction_stm processes the deletion event
         """
-        segments_to_write = 10
+        local_snapshot = self._start(cloud_storage_enabled,
+                                     apply_retention_settings=False)
 
-        # Produce 10 segments, then issue a truncation, assert corect number
-        # of segments are deleted
-        produce_until_segments(
-            self.redpanda,
-            topic=self.topic,
-            partition_idx=0,
-            count=segments_to_write,
-            acks=-1,
-        )
-
-        # Grab a snapshot of the segments to determine the final segment
-        # indicies of all segments. This is to test corner cases where the
-        # user happens to pass a segment index as a truncation index.
-        snapshot = self.redpanda.storage().segments_by_node(
-            "kafka", self.topic, 0)
-        assert len(snapshot) > 0, "empty snapshot"
-        self.redpanda.logger.info(f"Snapshot: {snapshot}")
-
-        def get_segment_boundaries(node):
+        def get_segment_boundaries_via_local_storage(node):
             def to_final_indicies(seg):
                 if seg.data_file is not None:
                     return int(seg.data_file.split('-')[0])
@@ -214,18 +269,25 @@ class DeleteRecordsTest(RedpandaTest):
                     # deletion is currently in flight.
                     return 0
 
-            return sorted([to_final_indicies(seg) for seg in node])
+            boundaries = sorted([to_final_indicies(seg) for seg in node])
+            self.redpanda.logger.debug(f"Local boundaries: {boundaries}")
+            return boundaries
+
+        def get_segment_boundaries_via_cloud_manifest(manifest):
+            boundaries = sorted([
+                int(idx.split('-')[0]) for idx in manifest['segments'].keys()
+            ])
+            self.redpanda.logger.debug(f"Cloud boundaries: {boundaries}")
+            return boundaries
 
         # Tests for 4 different types of scenarios
         # 1. User wants to truncate all data - high_watermark
         # 2. User wants to truncate 1 before  the high watermark
         # 3. User wants to truncate at a random point
         # 4. User wants to truncate at a random segment boundary
-        def obtain_test_parameters(snapshot):
-            node = snapshot[list(snapshot.keys())[-1]]
-            segment_boundaries = get_segment_boundaries(node)
-            self.redpanda.logger.info(
-                f"Segment boundaries: {segment_boundaries}")
+        def obtain_test_parameters(local_snapshot):
+            node = local_snapshot[list(local_snapshot.keys())[-1]]
+            segment_boundaries = get_segment_boundaries_via_local_storage(node)
             truncate_offset = None
             high_watermark = int(self.get_topic_info().high_watermark)
             if truncate_point == "one_below_high_watermark":
@@ -235,7 +297,7 @@ class DeleteRecordsTest(RedpandaTest):
             elif truncate_point == "random_offset":
                 truncate_offset = random.randint(1, high_watermark)
             elif truncate_point == "at_segment_boundary":
-                random_segment = random.randint(1, len(snapshot) - 1)
+                random_segment = random.randint(1, len(local_snapshot) - 1)
                 truncate_offset = segment_boundaries[random_segment]
             else:
                 assert False, "unknown test parameter encountered"
@@ -253,7 +315,11 @@ class DeleteRecordsTest(RedpandaTest):
             return (truncate_offset, rp_truncate_offset, high_watermark)
 
         (truncate_offset, rp_truncate_offset,
-         high_watermark) = obtain_test_parameters(snapshot)
+         high_watermark) = obtain_test_parameters(local_snapshot)
+
+        # Apply local retention settings after the truncation offset has been translated, otherwise
+        # the state within the offset translator may be truncated away
+        self._apply_local_retention_settings()
 
         # Make delete-records call, assert response looks ok
         try:
@@ -283,12 +349,13 @@ class DeleteRecordsTest(RedpandaTest):
             )
 
             def are_all_local_segments_removed():
-                snapshot = self.redpanda.storage(
+                local_snapshot = self.redpanda.storage(
                     all_nodes=True).segments_by_node("kafka", self.topic, 0)
                 return all([
-                    all_segments_removed(get_segment_boundaries(node),
-                                         rp_truncate_offset)
-                    for _, node in snapshot.items()
+                    all_segments_removed(
+                        get_segment_boundaries_via_local_storage(node),
+                        rp_truncate_offset)
+                    for _, node in local_snapshot.items()
                 ])
 
             wait_until(
@@ -306,24 +373,42 @@ class DeleteRecordsTest(RedpandaTest):
                 "kafka", self.topic, 0)
             for _, node in snapshot.items():
                 if node != stopped_node:
-                    assert all_segments_removed(get_segment_boundaries(node),
-                                                rp_truncate_offset)
+                    assert all_segments_removed(
+                        get_segment_boundaries_via_local_storage(node),
+                        rp_truncate_offset)
+
+        if cloud_storage_enabled:
+
+            def are_all_cloud_segments_removed():
+                bv = BucketView(self.redpanda)
+                cloud_manifest = bv.get_partition_manifest(
+                    NTP("kafka", self.topic, 0))
+                return all_segments_removed(
+                    get_segment_boundaries_via_cloud_manifest(cloud_manifest),
+                    rp_truncate_offset)
+
+            wait_until(
+                are_all_cloud_segments_removed,
+                timeout_sec=30,
+                backoff_sec=5,
+                err_msg=
+                f"Failed while waiting on all cloud segments below lwm: {low_watermark} to be removed"
+            )
 
     @cluster(num_nodes=3)
-    def test_delete_records_bounds_checking(self):
+    @parametrize(cloud_storage_enabled=True)
+    @parametrize(cloud_storage_enabled=False)
+    def test_delete_records_bounds_checking(self, cloud_storage_enabled):
         """
         Ensure that the delete-records handler returns the appropriate error
         code when a user attempts to truncate at an offset that is not within
         the boundaries of the partition.
         """
-        num_records = 10240
-        records_size = 512
         out_of_range_prefix = "OFFSET_OUT_OF_RANGE"
 
-        # Produce some data, wait for it all to arrive
-        kafka_tools = KafkaCliTools(self.redpanda)
-        kafka_tools.produce(self.topic, num_records, records_size)
-        self.wait_until_records(num_records, timeout_sec=10, backoff_sec=1)
+        self._start(cloud_storage_enabled)
+
+        num_records = self.get_topic_info().high_watermark
 
         def bad_truncation(truncate_offset):
             with expect_exception(RpkException,
@@ -355,10 +440,15 @@ class DeleteRecordsTest(RedpandaTest):
         bad_truncation(num_records + 1)
 
     @cluster(num_nodes=3)
-    def test_delete_records_empty_or_missing_topic_or_partition(self):
+    @parametrize(cloud_storage_enabled=True)
+    @parametrize(cloud_storage_enabled=False)
+    def test_delete_records_empty_or_missing_topic_or_partition(
+            self, cloud_storage_enabled):
         missing_topic = "foo_bar"
         out_of_range_prefix = "OFFSET_OUT_OF_RANGE"
         unknown_topic_or_partition = "UNKNOWN_TOPIC_OR_PARTITION"
+
+        self._start(cloud_storage_enabled, start_with_data=False)
 
         # Assert failure condition on unknown topic
         with expect_exception(RpkException,
@@ -377,8 +467,7 @@ class DeleteRecordsTest(RedpandaTest):
             self.rpk.trim_prefix(self.topic, 0, [0])
 
         # Assert correct behavior on a topic with 1 record
-        kafka_tools = KafkaCliTools(self.redpanda)
-        kafka_tools.produce(self.topic, 1, 512)
+        self.rpk.produce(self.topic, "k", "v", partition=0)
         self.wait_until_records(1, timeout_sec=5, backoff_sec=1)
         with expect_exception(RpkException,
                               lambda e: out_of_range_prefix in str(e)):
@@ -391,10 +480,14 @@ class DeleteRecordsTest(RedpandaTest):
         assert topic_info.high_watermark == 1
 
     @cluster(num_nodes=3)
-    def test_delete_records_with_transactions(self):
+    @parametrize(cloud_storage_enabled=True)
+    @parametrize(cloud_storage_enabled=False)
+    def test_delete_records_with_transactions(self, cloud_storage_enabled):
         """
         Tests that the log_eviction_stm is respecting the max_collectible_offset
         """
+        self._start(cloud_storage_enabled)
+
         payload = ''.join(
             random.choice(string.ascii_letters) for _ in range(512))
         producer = ck.Producer({
@@ -441,11 +534,15 @@ class DeleteRecordsTest(RedpandaTest):
             raise ThreadReporter.exc
 
     @cluster(num_nodes=5)
-    def test_delete_records_concurrent_truncations(self):
+    @parametrize(cloud_storage_enabled=True)
+    @parametrize(cloud_storage_enabled=False)
+    def test_delete_records_concurrent_truncations(self,
+                                                   cloud_storage_enabled):
         """
         This tests verifies that issuing DeleteRecords requests with concurrent
         producers and consumers has no effect on correctness
         """
+        self._start(cloud_storage_enabled)
 
         # Should complete producing within 20s
         producer = KgoVerifierProducer(self._ctx,


### PR DESCRIPTION
This change parameterizes the existing delete records tests in `tests/rptest/tests/delete_records_test.py` to work on local topics and topics enabled for cloud storage. When the cloud storage parameter is enabled, redpanda cfg options are configured so that local retention is aggressive enough to make all tests work with data that is not available locally but is available in tiered storage.

This change also includes another fix to the `at_segment_boundary` option in the `test_delete_records_segment_deletion` test. Previously this test compared the kafka low watermark against on disk segments base offsets to assert that data was actually deleted. This is incorrect because the low watermark is a kafka offset and the segment base offsets observed are redpanda offsets, one cannot make the assertions made in the test correctly comparing these two different offsets in this way.

To remedy this situation a new endpoint was introduced in admin_server to expose the local offset translator. The test can then translate the low watermark to a redpanda offset and use this translated offset to assert if all data on disk was correctly truncated or not.  

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
