### PR TITLE
cloud_storage/segment_meta_cstore: empty() shortcircuit

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -673,7 +673,7 @@ public:
         return it != _base_offset.end();
     }
 
-    bool empty() const { return size() == 0; }
+    bool empty() const { return _base_offset.empty(); }
 
     void serde_write(iobuf& out) {
         // hint_map_t (absl::btree_map) is not serde-enabled, it's serialized

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -645,6 +645,12 @@ public:
         return total;
     }
 
+    bool empty() const {
+        // short circuit at the first non empty frame
+        return std::ranges::all_of(
+          _frames, [](auto& f) { return f.size() == 0; });
+    }
+
     size_t mem_use() const {
         size_t total = 0;
         for (const auto& p : _frames) {


### PR DESCRIPTION
short circuit segment_meta_cstore.empty() check
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none