### PR TITLE
rptest: ducktape failure injection infra

### DIFF
--- a/src/v/storage/file_sanitizer_types.cc
+++ b/src/v/storage/file_sanitizer_types.cc
@@ -96,20 +96,24 @@ from_json(const json::Value& key, const json::Value& value) {
     if (auto it = value.FindMember("delay_probability");
         it != value.MemberEnd()) {
         op_config.delay_probability = it->value.GetDouble();
-    }
 
-    if (auto it = value.FindMember("min_delay_ms"); it != value.MemberEnd()) {
-        op_config.min_delay_ms = it->value.GetInt();
-    } else {
-        throw std::runtime_error("JSON failure injection config specifies "
-                                 "'delay_probability', but no 'min_delay_ms'");
-    }
+        if (auto it = value.FindMember("min_delay_ms");
+            it != value.MemberEnd()) {
+            op_config.min_delay_ms = it->value.GetInt();
+        } else {
+            throw std::runtime_error(
+              "JSON failure injection config specifies "
+              "'delay_probability', but no 'min_delay_ms'");
+        }
 
-    if (auto it = value.FindMember("max_delay_ms"); it != value.MemberEnd()) {
-        op_config.max_delay_ms = it->value.GetInt();
-    } else {
-        throw std::runtime_error("JSON failure injection config specifies "
-                                 "'delay_probability', but no 'max_delay_ms'");
+        if (auto it = value.FindMember("max_delay_ms");
+            it != value.MemberEnd()) {
+            op_config.max_delay_ms = it->value.GetInt();
+        } else {
+            throw std::runtime_error(
+              "JSON failure injection config specifies "
+              "'delay_probability', but no 'max_delay_ms'");
+        }
     }
 
     return op_config;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1045,3 +1045,10 @@ class Admin:
             f"debug/storage/offset_translator/kafka/{topic}/{partition}?translate_to={translate_to}",
             node=node,
             json=offsets).json()
+
+    def set_storage_failure_injection(self, node, value: bool):
+        str_value = "true" if value else "false"
+        return self._request(
+            "PUT",
+            f"debug/set_storage_failure_injection_enabled?value={str_value}",
+            node=node)

--- a/tests/rptest/services/redpanda_monitor.py
+++ b/tests/rptest/services/redpanda_monitor.py
@@ -1,0 +1,69 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import threading
+
+from rptest.services.redpanda import RedpandaService
+
+from ducktape.services.background_thread import BackgroundThreadService
+
+
+class RedpandaMonitor(BackgroundThreadService):
+    def __init__(self, context, redpanda: RedpandaService):
+        super(RedpandaMonitor, self).__init__(context, num_nodes=1)
+        self.redpanda = redpanda
+        self.stopping = threading.Event()
+        self.interval = 2  # seconds
+
+    def _worker(self, idx, node):
+        self.stopping.clear()
+
+        self.redpanda.logger.info(
+            f"Started RedpandaMonitor on {node.account.hostname}")
+
+        while not self.stopping.is_set():
+            started_dead_nodes = []
+            for n in self.redpanda.started_nodes():
+                try:
+                    pid = self.redpanda.redpanda_pid(n, timeout=3)
+                    if pid is None:
+                        started_dead_nodes.append(n)
+
+                except Exception as e:
+                    self.redpanda.logger.warn(
+                        f"Failed to fetch PID for node {n.account.hostname}")
+
+            for n in started_dead_nodes:
+                self.redpanda.remove_from_started_nodes(n)
+
+            for n in started_dead_nodes:
+                try:
+                    self.redpanda.logger.info(
+                        f"RedpandaMonitor restarting {n.account.hostname}")
+                    self.redpanda.start_node(node=n,
+                                             write_config=False,
+                                             timeout=60)
+                except Exception as e:
+                    self.redpanda.logger.error(
+                        f"RedpandaMonitor failed to restart {n.account.hostname}: {e}"
+                    )
+
+            time.sleep(self.interval)
+
+        self.redpanda.logger.info(
+            f"Stopped RedpandaMonitor on {node.account.hostname}")
+
+    def stop_node(self, node):
+        self.redpanda.logger.info(
+            f"Stopping RedpandaMonitor on {node.account.hostname}")
+        self.stopping.set()
+
+    def clean_node(self, nodes):
+        pass

--- a/tests/rptest/services/storage_failure_injection.py
+++ b/tests/rptest/services/storage_failure_injection.py
@@ -1,0 +1,122 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+
+from collections import ChainMap
+from enum import Enum
+from dataclasses import dataclass
+from typing import Optional
+from functools import reduce
+
+
+class BatchType(str, Enum):
+    raft_data = "batch_type::raft_data"
+    raft_configuration = "batch_type::raft_configuration"
+    controller = "batch_type::controller"
+    kvstore = "batch_type::kvstore"
+    checkpoint = "batch_type::checkpoint"
+    topic_management_cmd = "batch_type::topic_management_cmd"
+    ghost_batch = "batch_type::ghost_batch"
+    id_allocator = "batch_type::id_allocator"
+    tx_prepare = "batch_type::tx_prepare"
+    tx_fence = "batch_type::tx_fence"
+    tm_update = "batch_type::tm_update"
+    user_management_cmd = "batch_type::user_management_cmd"
+    acl_management_cmd = "batch_type::acl_management_cmd"
+    group_prepare_tx = "batch_type::group_prepare_tx"
+    group_commit_tx = "batch_type::group_commit_tx"
+    group_abort_tx = "batch_type::group_abort_tx"
+    node_management_cmd = "batch_type::node_management_cmd"
+    data_policy_management_cmd = "batch_type::data_policy_management_cmd"
+    archival_metadata = "batch_type::archival_metadata"
+    cluster_config_cmd = "batch_type::cluster_config_cmd"
+    feature_update = "batch_type::feature_update"
+    cluster_bootstrap_cmd = "batch_type::cluster_boostrap_cmd"
+    version_fence = "batch_type::version_fence"
+    tx_tm_hosted_trasactions = "batch_type::tx_tm_hosted_trasactions"
+    prefix_truncate = "batch_type::prefix_truncate"
+
+
+class Operation(str, Enum):
+    write = "write"
+    falloc = "falloc"
+    flush = "flush"
+    truncate = "truncate"
+    close = "close"
+
+
+@dataclass
+class NTP:
+    topic: str
+    partition: int
+    namespace: str = "kafka"
+
+
+@dataclass
+class FailureConfig:
+    operation: Operation
+    batch_type: Optional[BatchType] = None
+    failure_probability: Optional[float] = None
+    delay_probability: Optional[float] = None
+    min_delay_ms: Optional[int] = None
+    max_delay_ms: Optional[int] = None
+
+    def to_dict(self):
+        op_config = dict()
+        if self.batch_type:
+            op_config["batch_type"] = self.batch_type.value
+        if self.failure_probability:
+            op_config["failure_probability"] = self.failure_probability
+        if self.delay_probability:
+            op_config["delay_probability"] = self.delay_probability
+        if self.min_delay_ms:
+            op_config["min_delay_ms"] = self.min_delay_ms
+        if self.max_delay_ms:
+            op_config["max_delay_ms"] = self.max_delay_ms
+
+        return {self.operation.value: op_config}
+
+
+@dataclass
+class NTPFailureInjectionConfig:
+    ntp: NTP
+    failure_configs: list[FailureConfig]
+
+    def to_dict(self):
+        return {
+            "namespace":
+            self.ntp.namespace,
+            "topic":
+            self.ntp.topic,
+            "partition":
+            self.ntp.partition,
+            "failure_configs":
+            reduce(lambda a, b: {
+                **a,
+                **b
+            }, [cfg.to_dict() for cfg in self.failure_configs])
+        }
+
+
+@dataclass
+class FailureInjectionConfig:
+    seed: int
+    ntp_failure_configs: list[NTPFailureInjectionConfig]
+
+    def to_dict(self):
+        return {
+            "seed": self.seed,
+            "ntps":
+            [ntp_cfg.to_dict() for ntp_cfg in self.ntp_failure_configs]
+        }
+
+    def write_to_file(self, path):
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f)

--- a/tests/rptest/tests/storage_failure_injection_test.py
+++ b/tests/rptest/tests/storage_failure_injection_test.py
@@ -1,0 +1,94 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+from rptest.services.redpanda import RedpandaService, FAILURE_INJECTION_LOG_ALLOW_LIST
+from rptest.services.redpanda_monitor import RedpandaMonitor
+from rptest.services.storage_failure_injection import FailureInjectionConfig, NTPFailureInjectionConfig, FailureConfig, NTP, Operation, BatchType
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.util import expect_exception
+from ducktape.utils.util import wait_until
+
+
+class StorageFailureInjectionTest(RedpandaTest):
+    ntp: NTP = NTP(topic="ftest", partition=0)
+
+    def __init__(self, test_context):
+        super(StorageFailureInjectionTest, self).__init__(test_context,
+                                                          num_brokers=1)
+
+    def setUp(self):
+        pass
+
+    def generate_failure_injection_config(self) -> FailureInjectionConfig:
+        fcfg = FailureConfig(operation=Operation.write,
+                             batch_type=BatchType.raft_data,
+                             failure_probability=100)
+        ntp_fcfg = NTPFailureInjectionConfig(ntp=self.ntp,
+                                             failure_configs=[fcfg])
+
+        return FailureInjectionConfig(seed=0, ntp_failure_configs=[ntp_fcfg])
+
+    @cluster(num_nodes=2, log_allow_list=FAILURE_INJECTION_LOG_ALLOW_LIST)
+    def test_storage_failure_injection(self):
+        """
+        Simple test that enables storage failure injection for a redpanda node.
+        It can be used as a template for more complex failure injection tests.
+        Roughly it performs the following:
+        1. Set up a failure injection configuration
+            * generate config
+            * write config to file
+            * prepare node level finject config
+        2. Start the RedpandaMonitor service to bring the node back after the crash
+        3. Enable failure injection via the admin API and watch the node crash and come back
+        """
+        lonely_node = self.redpanda.nodes[0]
+
+        fail_cfg = self.generate_failure_injection_config()
+        self.redpanda.set_up_failure_injection(finject_cfg=fail_cfg,
+                                               enabled=False,
+                                               nodes=[lonely_node],
+                                               tolerate_crashes=True)
+
+        self.redpanda.start()
+        RedpandaMonitor(self.test_context, self.redpanda).start()
+
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(self.ntp.topic, partitions=1, replicas=1)
+
+        rpk.produce(self.ntp.topic, key="don't", msg="crash")
+
+        Admin(self.redpanda).set_storage_failure_injection(lonely_node,
+                                                           value=True)
+
+        with expect_exception(RpkException, lambda _: True):
+            rpk.produce(self.ntp.topic,
+                        key="poisoned",
+                        msg="chalice",
+                        timeout=1)
+
+        wait_until(
+            lambda: next(rpk.describe_topic(self.ntp.topic)
+                         ).high_watermark == 1,
+            timeout_sec=30,
+            backoff_sec=5,
+            err_msg="Node did not come back after crash or HWM is wrong",
+            retry_on_exc=True)
+
+        rpk.produce(self.ntp.topic, key="don't", msg="crash")
+        wait_until(lambda: next(rpk.describe_topic(self.ntp.topic)).
+                   high_watermark == 2,
+                   timeout_sec=3,
+                   backoff_sec=1,
+                   err_msg="HWM did not advance after crash")
+
+        # Assert that the node was restarted by RedpandaMonitor
+        assert self.redpanda.count_log_node(lonely_node, "Welcome") == 2

--- a/tools/offline_log_viewer/storage.py
+++ b/tools/offline_log_viewer/storage.py
@@ -136,6 +136,9 @@ class BatchType(Enum):
     cluster_config_cmd = 20
     feature_update = 21
     cluster_bootstrap_cmd = 22
+    version_fence = 23
+    tx_tm_hosted_trasactions = 24
+    prefix_truncate = 25
     unknown = -1
 
     @classmethod


### PR DESCRIPTION
This PR introduces the ducktape infra required to run tests with failure injection
enabled. A ducktape test that exercises the failure injection facilities is also added.
It can be used as a template for more complex failure injection tests.

## Backports Required


- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
