### PR TITLE
cloud_storage: Partition manifest fixes

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -539,12 +539,13 @@ void partition_manifest::flush_write_buffer() {
 }
 
 uint64_t partition_manifest::compute_cloud_log_size() const {
-    return std::transform_reduce(
-      find(_start_offset),
-      end(),
-      uint64_t{0},
-      std::plus{},
-      [](const auto& seg) { return seg.size_bytes; });
+    const auto& bo_col = _segments.get_base_offset_column();
+    const auto& sz_col = _segments.get_size_bytes_column();
+    auto it = bo_col.find(_start_offset);
+    if (it.is_end()) {
+        return 0;
+    }
+    return std::accumulate(sz_col.at_index(it.index()), sz_col.end(), 0);
 }
 
 uint64_t partition_manifest::cloud_log_size() const {

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -276,10 +276,10 @@ public:
                 co_return storage_t{};
             }
             if (_reader->config().over_budget) {
-                vlog(_ctxlog.debug, "We're overbudget, stopping");
+                vlog(_ctxlog.debug, "We're over-budget, stopping");
                 // We need to stop in such way that will keep the
                 // reader in the reusable state, so we could reuse
-                // it on next itertaion
+                // it on next iteration
 
                 // The existing state have to be rebuilt
                 dispose_current_reader();
@@ -295,8 +295,8 @@ public:
                   !_ot_state->empty()
                   && _ot_state->last_delta() > reader_delta) {
                     // It's not safe to call 'read_sone' with the current
-                    // offset translator state becuase delta offset of the
-                    // current reader is below last delta registred by the
+                    // offset translator state because delta offset of the
+                    // current reader is below last delta registered by the
                     // offset translator. The offset translator contains data
                     // from the previous segment and there is an inconsistency
                     // between them.

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -853,6 +853,11 @@ class segment_meta_cstore::impl
 public:
     void append(const segment_meta& meta) { _col.append(meta); }
 
+    const auto& get_size_bytes_column() const {
+        flush_write_buffer();
+        return _col.get_column_cref<segment_meta_ix::size_bytes>();
+    }
+
     const auto& get_base_offset_column() const {
         flush_write_buffer();
         return _col.get_column_cref<segment_meta_ix::base_offset>();
@@ -1177,6 +1182,10 @@ segment_meta_cstore::append(const segment_meta& meta) {
 }
 
 void segment_meta_cstore::flush_write_buffer() { _impl->flush_write_buffer(); }
+
+const gauge_col_t& segment_meta_cstore::get_size_bytes_column() const {
+    return _impl->get_size_bytes_column();
+}
 
 const counter_col_t& segment_meta_cstore::get_base_offset_column() const {
     return _impl->get_base_offset_column();

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -977,6 +977,7 @@ public:
     void flush_write_buffer();
 
     // Access individual columns
+    const gauge_col_t& get_size_bytes_column() const;
     const counter_col_t& get_base_offset_column() const;
     const gauge_col_t& get_committed_offset_column() const;
     const gauge_col_t& get_delta_offset_end_column() const;


### PR DESCRIPTION
Make `size_bytes` column available directly and use it to compute the size of the log instead of materialising every `segment_meta` struct.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none