### PR TITLE
[v23.1.x] kafka: Disable use of separate fetch scheduling group

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -521,7 +521,7 @@ configuration::configuration()
       "use_fetch_scheduler_group",
       "Use a separate scheduler group for fetch processing",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      true)
+      false)
   , metadata_status_wait_timeout_ms(
       *this,
       "metadata_status_wait_timeout_ms",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/11919
Fixes: https://github.com/redpanda-data/redpanda/issues/12034,