### PR TITLE
Add "unhealthy reasons" to cluster_health_overview endpoint

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -871,8 +871,6 @@ health_monitor_backend::get_cluster_health_overview(
         ret.unhealthy_reasons.emplace_back("no_health_report");
     }
 
-    ret.is_healthy = ret.unhealthy_reasons.empty();
-
     ret.bytes_in_cloud_storage = _bytes_in_cloud_storage;
 
     co_return ret;

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -225,10 +225,18 @@ struct cluster_health_overview {
 
     // additional human readable information that will make debugging cluster
     // errors easier
-    // The ID of the controller node, or nullopt if no controller is currently elected.
+
+    // Zero or more "unhealthy" reasons, which are terse human-readable strings
+    // indicating one reason the cluster is unhealthy (there may be several).
+    // is_healthy is true iff this list is empty (effectively, is_healthy is
+    // redundnat but it's there for backwards compat and convenience).
+    std::vector<ss::sstring> unhealthy_reasons;
+
+    // The ID of the controller node, or nullopt if no controller is currently
+    // elected.
     std::optional<model::node_id> controller_id;
-    // All known nodes in the cluster, including nodes that have joined in the past
-    // but are not curently up.
+    // All known nodes in the cluster, including nodes that have joined in the
+    // past but are not curently up.
     std::vector<model::node_id> all_nodes;
     // A list of known nodes which are down from the point of view of the health
     // subsystem.

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -225,8 +225,13 @@ struct cluster_health_overview {
 
     // additional human readable information that will make debugging cluster
     // errors easier
+    // The ID of the controller node, or nullopt if no controller is currently elected.
     std::optional<model::node_id> controller_id;
+    // All known nodes in the cluster, including nodes that have joined in the past
+    // but are not curently up.
     std::vector<model::node_id> all_nodes;
+    // A list of known nodes which are down from the point of view of the health
+    // subsystem.
     std::vector<model::node_id> nodes_down;
     std::vector<model::ntp> leaderless_partitions;
     std::vector<model::ntp> under_replicated_partitions;

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -221,7 +221,7 @@ struct cluster_health_overview {
     // is healthy is a main cluster indicator, it is intended as an simple flag
     // that will allow all external cluster orchestrating processes to decide if
     // they can proceed with next steps
-    bool is_healthy;
+    bool is_healthy() { return unhealthy_reasons.empty(); }
 
     // additional human readable information that will make debugging cluster
     // errors easier

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -77,6 +77,13 @@
                     "type": "boolean",
                     "description": "basic cluster health indicator"
                 },
+                "unhealthy_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A list of reasons why the cluster is unhealthy (contains at least one cause when is_healthy is false)"
+                },
                 "controller_id": {
                     "type": "int",
                     "description": "node that is currently a leader or `-1` if leader is not elected"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4520,7 +4520,7 @@ void admin_server::register_cluster_routes() {
               model::time_from_now(std::chrono::seconds(5)))
             .then([](auto health_overview) {
                 ss::httpd::cluster_json::cluster_health_overview ret;
-                ret.is_healthy = health_overview.is_healthy;
+                ret.is_healthy = health_overview.is_healthy();
 
                 ret.unhealthy_reasons._set = true;
                 ret.all_nodes._set = true;

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4521,11 +4521,14 @@ void admin_server::register_cluster_routes() {
             .then([](auto health_overview) {
                 ss::httpd::cluster_json::cluster_health_overview ret;
                 ret.is_healthy = health_overview.is_healthy;
+
+                ret.unhealthy_reasons._set = true;
                 ret.all_nodes._set = true;
                 ret.nodes_down._set = true;
                 ret.leaderless_partitions._set = true;
                 ret.under_replicated_partitions._set = true;
 
+                ret.unhealthy_reasons = health_overview.unhealthy_reasons;
                 ret.all_nodes = health_overview.all_nodes;
                 ret.nodes_down = health_overview.nodes_down;
 


### PR DESCRIPTION
This series adds an "unhealthy reasons" field to the cluster health
admin endpoint.

Currently, the health monitor returns a boolean indicating if the
cluster is healthy, and some additional information about nodes which
are down and leaderless partitions.

However, it is possible for the "healthy" boolean to be false while
the remainder of the information does not indicate any problem,
leaving users of rpk cluster health with little to go on: "The cluster
is unhealthy, but you don't get to know why".

One way (only way?) this can happen is when the cluster health
report acquisition process fails.

This change adds an unhealthy reasons vector, which is set to non-empty
only if the cluster is unhealthy, and which contains one string for
each reason the cluster is unhealthy.

In another change this will be exposed in RPK.

No release note for this change as it's only affecting the mostly internal 
admin API, though I'll add one to the RPK change.

Issue #5263.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

