### PR TITLE
Add unhealthy reasons to RPK

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_cluster.go
+++ b/src/go/rpk/pkg/adminapi/api_cluster.go
@@ -17,6 +17,7 @@ import (
 // Health overview data structure.
 type ClusterHealthOverview struct {
 	IsHealthy                 bool     `json:"is_healthy"`
+	UnhealthyReasons          []string `json:"unhealthy_reasons"`
 	ControllerID              int      `json:"controller_id"`
 	AllNodes                  []int    `json:"all_nodes"`
 	NodesDown                 []int    `json:"nodes_down"`

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -72,12 +72,13 @@ following conditions are met:
 func printHealthOverview(hov *adminapi.ClusterHealthOverview) {
 	types.Sort(hov)
 	out.Section("CLUSTER HEALTH OVERVIEW")
-	overviewFormat := `Healthy:               %v
+	overviewFormat := `Healthy:                     %v
+Unhealthy reasons:           %v
 Controller ID:               %v
 All nodes:                   %v
 Nodes down:                  %v
 Leaderless partitions:       %v
 Under-replicated partitions: %v
 `
-	fmt.Printf(overviewFormat, hov.IsHealthy, hov.ControllerID, hov.AllNodes, hov.NodesDown, hov.LeaderlessPartitions, hov.UnderReplicatedPartitions)
+	fmt.Printf(overviewFormat, hov.IsHealthy, hov.UnhealthyReasons, hov.ControllerID, hov.AllNodes, hov.NodesDown, hov.LeaderlessPartitions, hov.UnderReplicatedPartitions)
 }


### PR DESCRIPTION
See PR https://github.com/redpanda-data/redpanda/pull/12039 for more context.

This is that change + the RPK side changes to expose this value in `rpk cluster health`, so for the purposes of this review look only at the last commit (split the reviews since the audience is different and we want the redpanda side change even if RPK doens't expose it).

This basically adds one more line called `Unhealthy reasons:` to the `cluster health` output like so:

```
CLUSTER HEALTH OVERVIEW
=======================
Healthy:                     false
Unhealthy reasons:           [nodes_down under_replicated_partitions]
Controller ID:               0
All nodes:                   [0 1 2]
Nodes down:                  [1]
Leaderless partitions:       []
Under-replicated partitions: [redpanda/controller/0]
```

To make it clear what are the list of reasons for an unhealthy partition.

Not sure how good this DX is: I've just use a _-separated identifiers for the various reasons which should be fairly self-explanatory to most users who are otherwise familiar with the stuff show in the health report.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* An additional "unhealthy reasons" field is shown in rpk's cluster health command which indicates the full list of reasons a cluster is unhealthy.
