### PR TITLE
cloud_storage: handle cases where reads race with spillover

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -456,19 +456,50 @@ private:
             // stored using model::offset type.
             query = model::offset_cast(config.start_offset);
         }
-        // Find manifest that contains requested timestamp
-        auto cur = co_await _partition->_manifest_view->get_cursor(query);
-        if (cur.has_failure()) {
+        // Find manifest that contains requested offset or timestamp
+        int retry_quota = 4;
+        while (retry_quota-- > 0) {
+            auto stm_start_offset
+              = _partition->_manifest_view->stm_manifest().get_start_offset();
+            if (!stm_start_offset.has_value()) {
+                vlog(
+                  _ctxlog.error, "STM manifest has no start offset; no data");
+                co_return;
+            }
+            auto cur = co_await _partition->_manifest_view->get_cursor(query);
+            if (cur.has_failure()) {
+                vlog(
+                  _ctxlog.error,
+                  "Failed to query spillover manifests: {}, query: {}",
+                  cur.error(),
+                  query);
+                co_return;
+            }
+            auto new_stm_start_offset
+              = _partition->_manifest_view->stm_manifest().get_start_offset();
+            if (likely(new_stm_start_offset == stm_start_offset.value())) {
+                _view_cursor = std::move(cur.value());
+                if (
+                  _view_cursor->manifest()->get().get_start_offset().value()
+                  == new_stm_start_offset) {
+                    _initial_stm_start_offset = new_stm_start_offset;
+                }
+                initialize_reader_state(
+                  _view_cursor->manifest().value(), config);
+                co_return;
+            }
             vlog(
-              _ctxlog.error,
-              "Failed to query spillover manifests: {}, query: {}",
-              cur.error(),
+              _ctxlog.info,
+              "STM manifest start offset moved from {} to {} due to spillover "
+              "or truncation; retrying lookup {}",
+              stm_start_offset,
+              new_stm_start_offset,
               query);
-            co_return;
         }
-        _view_cursor = std::move(cur.value());
-        initialize_reader_state(_view_cursor->manifest().value(), config);
-        co_return;
+        vlog(
+          _ctxlog.warn,
+          "Couldn't initialize cursor for {} after retrying",
+          query);
     }
 
     // Initialize object using remote_partition as a source
@@ -573,8 +604,25 @@ private:
               _view_cursor->get_status());
             auto maybe_manifest = _view_cursor->manifest();
             if (
-              !maybe_manifest.has_value()
-              || _next_segment_base_offset != model::offset{}) {
+              maybe_manifest.has_value()
+              && _next_segment_base_offset != model::offset{}) {
+                // Our segment lookup may return incorrect results if the
+                // offset we're looking for has been moved out of this manifest
+                // (e.g. spillover of the STM manifest).
+                auto& manifest = maybe_manifest->get();
+                if (
+                  unlikely(
+                    _initial_stm_start_offset.has_value()
+                    && _initial_stm_start_offset != manifest.get_start_offset()
+                    && (!manifest.get_start_offset().has_value() || manifest.get_start_offset() > _next_segment_base_offset))) {
+                    vlog(
+                      _ctxlog.debug,
+                      "maybe_reset_reader, STM manifest start offset moved to "
+                      "{} while iterating to {}. Stopping iteration",
+                      manifest.get_start_offset(),
+                      _next_segment_base_offset);
+                    co_return false;
+                }
                 auto [new_reader, new_next_offset]
                   = _partition->borrow_next_segment_reader(
                     maybe_manifest.value(), config, _next_segment_base_offset);
@@ -613,6 +661,24 @@ private:
     ss::shared_ptr<remote_partition> _partition;
     /// Manifest view cursor
     std::unique_ptr<async_manifest_view_cursor> _view_cursor;
+
+    // Start of the STM manifest at the time the cursor was constructed, if
+    // constructed pointing at the STM manifest.
+    //
+    // It's critical for correctness that as readers look for segments in the
+    // STM manifest, that they check whether the STM has changed (e.g. because
+    // of spillover). If so, segment lookups within the manifest may
+    // incorrectly consider a reduced set of segments and subsequently skip
+    // segments.
+    //
+    // Set to nullopt if view_cursor doesn't point at the STM manifest, or if
+    // the STM manifest has no start offset (it's empty), in which case such a
+    // check needn't be done.
+    //
+    // NOTE: the reader iterates through at most one manifest
+    // TODO: make this less fragile.
+    std::optional<model::offset> _initial_stm_start_offset{std::nullopt};
+
     ss::lw_shared_ptr<storage::offset_translator_state> _ot_state;
     /// Reader state that was borrowed from the materialized_segment_state
     std::unique_ptr<remote_segment_batch_reader> _reader;

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -278,11 +278,9 @@ FIXTURE_TEST(test_delete_from_stm_consume, delete_records_e2e_fixture) {
                                 model::partition_id(0),
                                 model::offset(1))
                               .get();
-    BOOST_CHECK_GE(consumed_records.size(), 2);
+    BOOST_CHECK_GE(consumed_records.size(), 1);
     BOOST_CHECK_EQUAL("key1", consumed_records[0].key);
     BOOST_CHECK_EQUAL("val1", consumed_records[0].val);
-    BOOST_CHECK_EQUAL("key2", consumed_records[1].key);
-    BOOST_CHECK_EQUAL("val2", consumed_records[1].val);
     check_consume_out_of_range(
       consumer, topic_name, model::partition_id(0), model::offset(0));
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

There is a general problem with APIs that read from tiered storage, that they typically don't account for when spillover happens during the call. This PR addresses this by installing a check for when spillover happens, and retrying lookups or returning early to clients if it is detected.

I'm not in love with the approach, as it's very bolted on, but it's nice in that it doesn't incur an additional roundtrip to the client in most cases. Other approaches I considered:
- Put the detection closer to the Kafka layer, and return an error code to clients to retry (probably some timeout error; given these are rare, it's acceptable)
- Add a lock to the manifest on the read path that prevents spillover during iteration.
- Harden cursor iteration and usage of segment_containing() to be able to tolerate such a race. This seems non-trivial.

Along the way I added a TODO comment advocating for the latter, and fixed an unsafe iteration of segments.

Fixes https://github.com/redpanda-data/redpanda/issues/11866

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
