### PR TITLE
Force refresh health report if partition size is missing 

### DIFF
--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -137,6 +137,7 @@ private:
           last_tick_decommission_realloc_failures;
 
         bool _ondemand_rebalance_requested = false;
+        bool _force_health_report_refresh = false;
     };
     std::optional<per_term_state> _cur_term;
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -407,7 +407,7 @@ public:
     result<reallocation_step> move_replica(
       model::node_id replica,
       double max_disk_usage_ratio,
-      std::string_view reason);
+      partition_balancer_planner::change_reason reason);
 
     void revert(const reallocation_step&);
 
@@ -454,7 +454,7 @@ public:
 
     bool cancel_requested() const { return _cancel_requested; }
 
-    void request_cancel(std::string_view reason) {
+    void request_cancel(partition_balancer_planner::change_reason reason) {
         if (!_cancel_requested) {
             vlog(
               clusterlog.info,
@@ -488,8 +488,9 @@ public:
         }
     }
 
-    void
-    report_failure(std::string_view reason, std::string_view change_reason) {
+    void report_failure(
+      std::string_view reason,
+      partition_balancer_planner::change_reason change_reason) {
         if (_ctx.increment_failure_count()) {
             vlog(
               clusterlog.info,
@@ -545,7 +546,8 @@ public:
 
     immutability_reason reason() const { return _reason; }
 
-    void report_failure(std::string_view change_reason) {
+    void
+    report_failure(partition_balancer_planner::change_reason change_reason) {
         bool can_log = _ctx.increment_failure_count();
         if (!can_log) {
             return;
@@ -842,7 +844,7 @@ result<reallocation_step>
 partition_balancer_planner::reassignable_partition::move_replica(
   model::node_id replica,
   double max_disk_usage_ratio,
-  std::string_view reason) {
+  partition_balancer_planner::change_reason reason) {
     if (!_reallocated) {
         _reallocated
           = _ctx._parent._partition_allocator.make_allocated_partition(
@@ -947,7 +949,7 @@ void partition_balancer_planner::reassignable_partition::revert(
 ss::future<> partition_balancer_planner::get_node_drain_actions(
   request_context& ctx,
   const absl::flat_hash_set<model::node_id>& nodes,
-  std::string_view reason) {
+  partition_balancer_planner::change_reason reason) {
     if (nodes.empty()) {
         co_return;
     }
@@ -1076,12 +1078,12 @@ ss::future<> partition_balancer_planner::get_rack_constraint_repair_actions(
                           (void)part.move_replica(
                             replica,
                             ctx.config().hard_max_disk_usage_ratio,
-                            "rack constraint repair");
+                            change_reason::rack_constraint_repair);
                       }
                   }
               },
               [](immutable_partition& part) {
-                  part.report_failure("rack constraint repair");
+                  part.report_failure(change_reason::rack_constraint_repair);
               },
               [](moving_partition&) {});
         });
@@ -1299,7 +1301,7 @@ partition_balancer_planner::get_full_node_actions(request_context& ctx) {
                           (void)part.move_replica(
                             replica.node_id,
                             ctx.config().soft_max_disk_usage_ratio,
-                            "full_nodes");
+                            change_reason::disk_full);
                       }
                   },
                   [](auto&) {});
@@ -1382,7 +1384,7 @@ ss::future<> partition_balancer_planner::get_counts_rebalancing_actions(
                   auto res = part.move_replica(
                     bs.node_id,
                     ctx.config().soft_max_disk_usage_ratio,
-                    "counts rebalancing");
+                    change_reason::partition_count_rebalancing);
                   if (!res) {
                       continue;
                   }
@@ -1490,12 +1492,14 @@ partition_balancer_planner::plan_actions(
     co_await init_ntp_sizes_from_health_report(health_report, ctx);
 
     co_await get_node_drain_actions(
-      ctx, ctx.decommissioning_nodes, "decommission");
+      ctx, ctx.decommissioning_nodes, change_reason::node_decommissioning);
 
     if (ctx.config().mode == model::partition_autobalancing_mode::continuous) {
         if (ctx.num_nodes_in_maintenance == 0) {
             co_await get_node_drain_actions(
-              ctx, ctx.timed_out_unavailable_nodes, "unavailable nodes");
+              ctx,
+              ctx.timed_out_unavailable_nodes,
+              change_reason::node_unavailable);
             co_await get_rack_constraint_repair_actions(ctx);
             co_await get_full_node_actions(ctx);
         } else if (!result.violations.is_empty()) {
@@ -1507,6 +1511,28 @@ partition_balancer_planner::plan_actions(
 
     ctx.collect_actions(result);
     co_return result;
+}
+
+std::ostream&
+operator<<(std::ostream& o, partition_balancer_planner::change_reason r) {
+    switch (r) {
+    case partition_balancer_planner::change_reason::rack_constraint_repair:
+        fmt::print(o, "rack_constraint_repair");
+        break;
+    case partition_balancer_planner::change_reason::partition_count_rebalancing:
+        fmt::print(o, "partition_count_rebalancing");
+        break;
+    case partition_balancer_planner::change_reason::node_unavailable:
+        fmt::print(o, "node_unavailable");
+        break;
+    case partition_balancer_planner::change_reason::node_decommissioning:
+        fmt::print(o, "node_decommissioning");
+        break;
+    case partition_balancer_planner::change_reason::disk_full:
+        fmt::print(o, "disk_full");
+        break;
+    }
+    return o;
 }
 
 } // namespace cluster

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -68,6 +68,16 @@ public:
         waiting_for_maintenance_end,
         waiting_for_reports,
     };
+    /**
+     * class describing a reason underlying partition replica set change
+     */
+    enum class change_reason {
+        rack_constraint_repair,
+        partition_count_rebalancing,
+        node_decommissioning,
+        node_unavailable,
+        disk_full,
+    };
 
     struct plan_data {
         partition_balancer_violations violations;
@@ -99,7 +109,8 @@ private:
     static ss::future<> get_node_drain_actions(
       request_context&,
       const absl::flat_hash_set<model::node_id>&,
-      std::string_view reason);
+      change_reason reason);
+
     static ss::future<> get_rack_constraint_repair_actions(request_context&);
     static ss::future<> get_full_node_actions(request_context&);
     static ss::future<> get_counts_rebalancing_actions(request_context&);
@@ -110,6 +121,8 @@ private:
     planner_config _config;
     partition_balancer_state& _state;
     partition_allocator& _partition_allocator;
+
+    friend std::ostream& operator<<(std::ostream&, change_reason);
 };
 
 } // namespace cluster

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -67,6 +67,7 @@ public:
         actions_planned,
         waiting_for_maintenance_end,
         waiting_for_reports,
+        missing_sizes,
     };
     /**
      * class describing a reason underlying partition replica set change


### PR DESCRIPTION
In the case when partition is created right before the node is being
decommissioned it may be the case that its size is not present in the
health report. In this case a balancer would have to wait for at most
two metadata refresh periods to get the partition size information.
During that period the balancer backend may enter stalled mode.

Added a mechanism allowing partition balancer backend to detect
situation in which partition size is missing and force refresh the
health report. In this case a balancer tick is scheduled immediately.

Fixes: #11999


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
