### PR TITLE
move RedpandaService::_ssh_output_stderr to standalone function in util.py

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3718,9 +3718,9 @@ class RedpandaService(RedpandaServiceBase):
             allow_fail=True,
             timeout_sec=60)
 
-        # if stderr contains a WARN logline:
+        # if stderr contains a WARN logline, log it as DEBUG, since this is mostly related to debugging rp-storage-tool itself
         if re.search(b'\[\S+ WARN', stderr) is not None:
-            self.logger.warning(f"rp-storage-tool stderr output: {stderr}")
+            self.logger.debug(f"rp-storage-tool stderr output: {stderr}")
 
         report = {}
         try:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3716,7 +3716,7 @@ class RedpandaService(RedpandaServiceBase):
             node,
             f"{environment} rp-storage-tool --backend {backend} scan-metadata --source {bucket}",
             allow_fail=True,
-            timeout_sec=30)
+            timeout_sec=60)
 
         # if stderr contains a WARN logline:
         if re.search(b'\[\S+ WARN', stderr) is not None:


### PR DESCRIPTION
followup on #12017 

util.py::ssh_output_stderr works like ducktape ssh_output, but returns byte strings for stdout and for stderr

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none