### PR TITLE
tests: update ducktape use of cloud product id

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1199,7 +1199,7 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
         CHECK_TIMEOUT_SEC = 3600
         CHECK_BACKOFF_SEC = 60.0
-        DEFAULT_PRODUCT_ID = 'cgrdrd9jiflmsknn2nl0'
+        DEFAULT_PRODUCT_ID = 'chqrd4q37efgkmohsbdg'  # preprod tier-1-aws
 
         def __init__(self,
                      logger,
@@ -1363,35 +1363,34 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
             name = f'rp-ducktape-cluster-{self._unique_id}'  # e.g. rp-ducktape-cluster-3b36f516
             self._logger.debug(f'creating cluster name {name}')
             body = {
-                "namespaceUuid": namespace_uuid,
-                "connectionType": "public",
-                "network": {
-                    "displayName": f"public-network-{name}",
-                    "spec": {
-                        "deploymentType": "FMC",
-                        "provider": "AWS",
-                        "regionId": "ccpfuvec6lhdao925q10",
-                        "zones": ["usw2-az1"],
-                        "installPackVersion": "23.1.20230502184729",
-                        "cidr": "10.0.0.0/16"
-                    }
-                },
                 "cluster": {
                     "name": name,
                     "productId": product_id,
                     "spec": {
                         "clusterType": "FMC",
-                        "provider": "AWS",
-                        "region": "us-west-2",
-                        "isMultiAz": False,
-                        "zones": ["usw2-az1"],
-                        "installPackVersion": "23.1.20230502184729",
                         "connectors": {
                             "enabled": True
                         },
-                        "networkId": ""
+                        "installPackVersion": "23.2.20230707135118",
+                        "isMultiAz": False,
+                        "networkId": "",
+                        "provider": "AWS",
+                        "region": "us-west-2",
+                        "zones": ["usw2-az1"],
                     }
-                }
+                },
+                "connectionType": "public",
+                "namespaceUuid": namespace_uuid,
+                "network": {
+                    "displayName": f"public-network-{name}",
+                    "spec": {
+                        "cidr": "10.1.0.0/16",
+                        "deploymentType": "FMC",
+                        "installPackVersion": "23.2.20230707135118",
+                        "provider": "AWS",
+                        "regionId": "cckac9vvbr5ofm048jjg",
+                    }
+                },
             }
 
             self._logger.debug(f'body: {json.dumps(body)}')


### PR DESCRIPTION
Fix ducktape creation of redpanda cloud clusters on preprod. Changes only ducktape tests running on redpanda cloud.

Works, but need to bump ducktape test runner timeout to at least 1 hr because cluster creation will take over 50 minutes.
```console
ducktape \
  --globals=/home/a/tmp/ducktape_globals.json \
  --cluster=ducktape.cluster.json.JsonCluster  \
  --cluster-file=/home/a/tmp/ducktape_cluster.json \
  --test-runner-timeout=3600000 \
  tests/rptest/tests/services_self_test.py::SimpleSelfTest
```

This fix is needed for https://github.com/redpanda-data/cloudv2/issues/6662

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none