### PR TITLE
Explicitly set seed_servers property in misconfigured bootstrap test

### DIFF
--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -46,6 +46,12 @@ class ClusterBootstrapNew(RedpandaTest):
         for node in self.redpanda.nodes:
             self.redpanda.set_extra_node_conf(
                 node, {"empty_seed_starts_cluster": False})
+
+        # setup seed servers on the other two nodes to prevent them from joining
+        # cluster point the nodes to node 0
+        for node in self.redpanda.nodes[1:]:
+            self.redpanda.set_seed_servers([self.redpanda.nodes[0]])
+
         try:
             self.redpanda.start(omit_seeds_on_idx_one=True)
             assert False, "Should have been unable to start"


### PR DESCRIPTION
The test validating misconfigured cluster behavior is based on assumption that the nodes other than node[0] will not be able to exchange information with each other. Setting `seed_servers_explicitly` makes the previous semantics of a test.

Fixes: #12026

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none