### PR TITLE
cloud_storage: add metrics for spilled manifest cache

### DIFF
--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -208,6 +208,22 @@ remote_probe::remote_probe(
               sm::description("Successful spillover manifest uploads"),
               {})
               .aggregate({sm::shard_label}),
+            sm::make_gauge(
+              "spillover_manifests_materialized_count",
+              [&ms] { return ms.get_materialized_manifest_cache().size(); },
+              sm::description(
+                "How many spilled manifests are currently cached in memory"),
+              {})
+              .aggregate({sm::shard_label}),
+            sm::make_gauge(
+              "spillover_manifests_materialized_bytes",
+              [&ms] {
+                  return ms.get_materialized_manifest_cache().size_bytes();
+              },
+              sm::description("Bytes of memory used for spilled manifests "
+                              "currently cached in memory"),
+              {})
+              .aggregate({sm::shard_label}),
           });
     }
 }


### PR DESCRIPTION
This is a resource which is subject to a limit, so it is appropriate to have a metric that lets you track how the cache utilization is behaving relative to
the limit.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
