### PR TITLE
Fix for incorrect handling of OffsetForLeaderEpoch request

### DIFF
--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -80,7 +80,7 @@ static ss::future<std::vector<epoch_end_offset>> fetch_offsets(
         ret.push_back(response_t::make_epoch_end_offset(
           r.ktp.get_partition(),
           co_await get_epoch_end_offset(r.requested_epoch, *p),
-          p->leader_epoch()));
+          r.requested_epoch));
     }
     co_return ret;
 }

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -339,6 +339,11 @@ replicated_partition::get_leader_epoch_last_offset_unbounded(
     const model::term_id term(epoch);
     const auto first_local_offset = _partition->raft_start_offset();
     const auto first_local_term = _partition->get_term(first_local_offset);
+    const auto last_local_term = _partition->term();
+    if (term > last_local_term) {
+        // Request for term that is in the future
+        co_return std::nullopt;
+    }
     // Look for the highest offset in the requested term, or the first offset
     // in the next term. This mirrors behavior in Kafka, see
     // https://github.com/apache/kafka/blob/97105a8e5812135515f5a0fa4d5ff554d80df2fe/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java#L255-L281


### PR DESCRIPTION
Correctly reported by @VladLazar and nicely explained in issue #11864 , the current issues with OffsetForLeaderEpochRequest handling are:

1. Requested epoch is in the future (i.e. larger than the current term). We should return `leader_epoch=-1 end_offset=-1`. Currently we return `leader_epoch=current_term end_offset=log_start_offset`.

2. Requested epoch is in the past, but still present in the log. We should return `leader_epoch=requested_epoch end_offset=last_offset of requested_epoch + 1` and we currently return `leader_epoch=current_term end_offset=last_offset of requested_epoch + 1`

This PR fixes both of these issues and modifies the ducktape tests to assert this new behavior holds true.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Bug Fixes

* Fix for OffsetForLeaderEpoch returning a value for when the requestedEpoch is larger then the highest known.
* Fix for OffsetForLeaderEpoch returning the current leaders epoch (term) instead of the requested.