### PR TITLE
tests: query cloud api for region id, install pack ver, and product id

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1199,7 +1199,7 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
         CHECK_TIMEOUT_SEC = 3600
         CHECK_BACKOFF_SEC = 60.0
-        DEFAULT_PRODUCT_ID = 'cgrdrd9jiflmsknn2nl0'
+        DEFAULT_PRODUCT_ID = 'chqrd4q37efgkmohsbdg'  # preprod tier-1-aws
 
         def __init__(self,
                      logger,
@@ -1363,35 +1363,34 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
             name = f'rp-ducktape-cluster-{self._unique_id}'  # e.g. rp-ducktape-cluster-3b36f516
             self._logger.debug(f'creating cluster name {name}')
             body = {
-                "namespaceUuid": namespace_uuid,
-                "connectionType": "public",
-                "network": {
-                    "displayName": f"public-network-{name}",
-                    "spec": {
-                        "deploymentType": "FMC",
-                        "provider": "AWS",
-                        "regionId": "ccpfuvec6lhdao925q10",
-                        "zones": ["usw2-az1"],
-                        "installPackVersion": "23.1.20230502184729",
-                        "cidr": "10.0.0.0/16"
-                    }
-                },
                 "cluster": {
                     "name": name,
                     "productId": product_id,
                     "spec": {
                         "clusterType": "FMC",
-                        "provider": "AWS",
-                        "region": "us-west-2",
-                        "isMultiAz": False,
-                        "zones": ["usw2-az1"],
-                        "installPackVersion": "23.1.20230502184729",
                         "connectors": {
                             "enabled": True
                         },
-                        "networkId": ""
+                        "installPackVersion": "23.2.20230707135118",
+                        "isMultiAz": False,
+                        "networkId": "",
+                        "provider": "AWS",
+                        "region": "us-west-2",
+                        "zones": ["usw2-az1"],
                     }
-                }
+                },
+                "connectionType": "public",
+                "namespaceUuid": namespace_uuid,
+                "network": {
+                    "displayName": f"public-network-{name}",
+                    "spec": {
+                        "cidr": "10.1.0.0/16",
+                        "deploymentType": "FMC",
+                        "installPackVersion": "23.2.20230707135118",
+                        "provider": "AWS",
+                        "regionId": "cckac9vvbr5ofm048jjg",
+                    }
+                },
             }
 
             self._logger.debug(f'body: {json.dumps(body)}')

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1199,7 +1199,6 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
         CHECK_TIMEOUT_SEC = 3600
         CHECK_BACKOFF_SEC = 60.0
-        DEFAULT_PRODUCT_ID = 'chqrd4q37efgkmohsbdg'  # preprod tier-1-aws
 
         def __init__(self,
                      logger,
@@ -1342,15 +1341,74 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
                     return c['id']
             return None
 
-        def create(self, product_id=None):
-            """
-            Create a cloud cluster and a new namespace; block until cluster is finished creating.
+        def _get_install_pack_ver(self):
+            """Get the latest certified install pack version.
 
-            Returns the clusterId.
+            :return: version, e.g. '23.2.20230707135118'
             """
 
-            if product_id is None:
-                product_id = self.DEFAULT_PRODUCT_ID
+            versions = self._http_get(
+                '/api/v1/clusters-resources/install-pack-versions')
+            latest_version = ''
+            for v in versions:
+                if v['certified'] and v['version'] > latest_version:
+                    latest_version = v['version']
+            if latest_version == '':
+                return None
+            return latest_version
+
+        def _get_region_id(self, cluster_type, provider, region):
+            """Get the region id for a region.
+
+            :param cluster_type: cluster type, e.g. 'FMC'
+            :param provider: cloud provider, e.g. 'AWS'
+            :param region: region name, e.g. 'us-west-2'
+            :return: id, e.g. 'cckac9vvbr5ofm048jjg'
+            """
+
+            params = {'cluster_type': cluster_type}
+            regions = self._http_get('/api/v1/clusters-resources/regions',
+                                     params=params)
+            for r in regions[provider]:
+                if r['name'] == region:
+                    return r['id']
+            return None
+
+        def _get_product_id(self,
+                            config_profile_name,
+                            provider,
+                            cluster_type=None,
+                            region=None,
+                            install_pack_ver=None):
+            """Get the product id for the first matching config profile name using filter parameters.
+
+            :param config_profile_name: config profile name, e.g. 'tier-1-aws'
+            :param provider: cloud provider filter, e.g. 'AWS'
+            :param cluster_type: cluster type filter, e.g. 'FMC'
+            :param region: region name filter, e.g. 'us-west-2'
+            :param install_pack_ver: install pack version filter, e.g. '23.2.20230707135118'
+            :return: productId, e.g. 'chqrd4q37efgkmohsbdg'
+            """
+
+            params = {
+                'cloud_provider': provider,
+                'cluster_type': cluster_type,
+                'region': region,
+                'install_pack_version': install_pack_ver
+            }
+            products = self._http_get('/api/v1/clusters-resources/products',
+                                      params=params)
+            for p in products:
+                if p['redpandaConfigProfileName'] == config_profile_name:
+                    return p['id']
+            return None
+
+        def create(self, config_profile_name='tier-1-aws'):
+            """Create a cloud cluster and a new namespace; block until cluster is finished creating.
+
+            :param config_profile_name: config profile name, default 'tier-1-aws'
+            :return: clusterId, e.g. 'cimuhgmdcaa1uc1jtabc'
+            """
 
             if self.cluster_id != '':
                 self._logger.warn(
@@ -1359,24 +1417,33 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
                 return self.cluster_id
 
             namespace_uuid = self._create_namespace()
-
             name = f'rp-ducktape-cluster-{self._unique_id}'  # e.g. rp-ducktape-cluster-3b36f516
-            self._logger.debug(f'creating cluster name {name}')
+            install_pack_ver = self._get_install_pack_ver()
+            cluster_type = 'FMC'
+            provider = 'AWS'
+            region = 'us-west-2'
+            region_id = self._get_region_id(cluster_type, provider, region)
+            zones = ['usw2-az1']
+            product_id = self._get_product_id(config_profile_name, provider,
+                                              cluster_type, region,
+                                              install_pack_ver)
+
+            self._logger.info(f'creating cluster name {name}')
             body = {
                 "cluster": {
                     "name": name,
                     "productId": product_id,
                     "spec": {
-                        "clusterType": "FMC",
+                        "clusterType": cluster_type,
                         "connectors": {
                             "enabled": True
                         },
-                        "installPackVersion": "23.2.20230707135118",
+                        "installPackVersion": install_pack_ver,
                         "isMultiAz": False,
                         "networkId": "",
-                        "provider": "AWS",
-                        "region": "us-west-2",
-                        "zones": ["usw2-az1"],
+                        "provider": provider,
+                        "region": region,
+                        "zones": zones,
                     }
                 },
                 "connectionType": "public",
@@ -1385,10 +1452,10 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
                     "displayName": f"public-network-{name}",
                     "spec": {
                         "cidr": "10.1.0.0/16",
-                        "deploymentType": "FMC",
-                        "installPackVersion": "23.2.20230707135118",
-                        "provider": "AWS",
-                        "regionId": "cckac9vvbr5ofm048jjg",
+                        "deploymentType": cluster_type,
+                        "installPackVersion": install_pack_ver,
+                        "provider": provider,
+                        "regionId": region_id,
                     }
                 },
             }


### PR DESCRIPTION
Less hardcoding of values passed into cloud api when creating a redpanda cloud cluster. More web service calls to get the latest values for:
* `regionId`
* `installPackVersion`
* `productId`

Also allows ducktape to create clusters by config profile name instead of product id.

This PR supersedes PR #12048

This PR is needed for https://github.com/redpanda-data/cloudv2/issues/6662

Tested with this command using configuration against `preprod`:
```console
ducktape \
  --globals=/home/a/tmp/ducktape_globals.json \
  --cluster=ducktape.cluster.json.JsonCluster  \
  --cluster-file=/home/a/tmp/ducktape_cluster.json \
  --test-runner-timeout=3600000 \
  tests/rptest/tests/services_self_test.py::SimpleSelfTest
```

And the subsequent payload body generated with latest values:
```json
{
  "cluster": {
    "name": "rp-ducktape-cluster-a99cb098",
    "productId": "chqrd4q37efgkmohsbdg",
    "spec": {
      "clusterType": "FMC",
      "connectors": {
        "enabled": true
      },
      "installPackVersion": "23.2.20230712143249",
      "isMultiAz": false,
      "networkId": "",
      "provider": "AWS",
      "region": "us-west-2",
      "zones": [
        "usw2-az1"
      ]
    }
  },
  "connectionType": "public",
  "namespaceUuid": "d3efe9af-3796-4c53-bacb-0487c47defb4",
  "network": {
    "displayName": "public-network-rp-ducktape-cluster-a99cb098",
    "spec": {
      "cidr": "10.1.0.0/16",
      "deploymentType": "FMC",
      "installPackVersion": "23.2.20230712143249",
      "provider": "AWS",
      "regionId": "cckac9vvbr5ofm048jjg"
    }
  }
}
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none