### PR TITLE
Align usage metrics to the configured interval

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -563,26 +563,6 @@ result<node_health_report> health_monitor_backend::process_node_reply(
     return res;
 }
 
-ss::future<> health_monitor_backend::maybe_refresh_cloud_health_stats() {
-    auto holder = _gate.hold();
-    auto units = co_await _refresh_mutex.get_units();
-    auto leader_id = _raft0->get_leader_id();
-    if (!leader_id || leader_id != _raft0->self().id()) {
-        co_return;
-    }
-    vlog(clusterlog.debug, "collecting cloud health statistics");
-
-    cluster::cloud_storage_size_reducer reducer(
-      _topic_table,
-      _members,
-      _partition_leaders_table,
-      _connections,
-      topic_table_partition_generator::default_batch_size,
-      cloud_storage_size_reducer::default_retries_allowed);
-
-    _bytes_in_cloud_storage = co_await reducer.reduce();
-}
-
 ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
     /**
      * We are collecting cluster health on raft 0 leader only
@@ -635,6 +615,29 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
         }
     }
     _reports_disk_health = cluster_disk_health;
+
+    if (config::shard_local_cfg().enable_usage()) {
+        vlog(clusterlog.info, "collecting cloud health statistics");
+
+        cluster::cloud_storage_size_reducer reducer(
+          _topic_table,
+          _members,
+          _partition_leaders_table,
+          _connections,
+          topic_table_partition_generator::default_batch_size,
+          cloud_storage_size_reducer::default_retries_allowed);
+
+        try {
+            /// TODO: https://github.com/redpanda-data/redpanda/issues/12515
+            /// Eventually move the cloud storage size metrics into the node
+            /// health report which will reduce the number of redundent RPCs
+            /// needed to be made
+            _bytes_in_cloud_storage = co_await reducer.reduce();
+        } catch (const std::exception& ex) {
+            // All exceptions are already logged by this class, in this case
+        }
+    }
+
     _last_refresh = ss::lowres_clock::now();
     co_return errc::success;
 }

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -82,8 +82,6 @@ public:
 
     bool does_raft0_have_leader();
 
-    ss::future<> maybe_refresh_cloud_health_stats();
-
 private:
     /**
      * Struct used to track pending refresh request, it gives ability

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -50,12 +50,6 @@ health_monitor_frontend::get_cluster_health(
       });
 }
 
-ss::future<> health_monitor_frontend::maybe_refresh_cloud_health_stats() {
-    return dispatch_to_backend([](health_monitor_backend& be) {
-        return be.maybe_refresh_cloud_health_stats();
-    });
-}
-
 storage::disk_space_alert health_monitor_frontend::get_cluster_disk_health() {
     return _cluster_disk_health;
 }

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -85,13 +85,6 @@ public:
 
     ss::future<bool> does_raft0_have_leader();
 
-    /**
-     * All health metadata is refreshed automatically via the
-     * health_monitor_backend on a timer. The cloud storage stats are an
-     * exception, this method is for external events to trigger this refresh.
-     */
-    ss::future<> maybe_refresh_cloud_health_stats();
-
 private:
     template<typename Func>
     auto dispatch_to_backend(Func&& f) {

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -38,6 +38,7 @@ v_cc_library(
     server/group.cc
     server/group_router.cc
     server/group_manager.cc
+    server/usage_aggregator.cc
     server/usage_manager.cc
     server/rm_group_frontend.cc
     server/connection_context.cc

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ set(srcs
   delete_topics_test.cc
   offset_fetch_test.cc
   api_versions_test.cc
+  usage_manager_test.cc
   create_topics_test.cc
   find_coordinator_test.cc
   list_offsets_test.cc

--- a/src/v/kafka/server/tests/usage_manager_test.cc
+++ b/src/v/kafka/server/tests/usage_manager_test.cc
@@ -1,0 +1,173 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/usage_aggregator.h"
+#include "storage/tests/kvstore_fixture.h"
+#include "vlog.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/log.hh>
+
+static ss::logger af_logger{"test-accounting-fiber"};
+
+class test_accounting_fiber final
+  : public kafka::usage_aggregator<ss::manual_clock> {
+public:
+    test_accounting_fiber(
+      storage::kvstore& kvstore,
+      size_t usage_num_windows,
+      std::chrono::seconds usage_window_width_interval,
+      std::chrono::seconds usage_disk_persistance_interval)
+      : kafka::usage_aggregator<ss::manual_clock>(
+        kvstore,
+        usage_num_windows,
+        usage_window_width_interval,
+        usage_disk_persistance_interval) {}
+
+    void add_bytes(size_t sent, size_t recv) {
+        vlog(af_logger.info, "Adding bytes sent: {} recv: {}", sent, recv);
+        _bytes_sent += sent;
+        _bytes_recv += recv;
+    }
+
+    template<typename Duration>
+    ss::future<> advance_clock(Duration d) {
+        if (_window_closed_promise) {
+            return ss::make_exception_future<>(
+              std::logic_error("Already a waiter on data fetching"));
+        }
+        _window_closed_promise = ss::promise<>();
+        auto f = _window_closed_promise->get_future();
+        ss::manual_clock::advance(d);
+        return ss::with_timeout(ss::lowres_clock::now() + d, std::move(f))
+          .handle_exception_type([this, d](const ss::timed_out_error&) {
+              vlog(
+                af_logger.info,
+                "Clock advanced {}s but window didn't close",
+                d.count());
+              _window_closed_promise = std::nullopt;
+          });
+    }
+
+protected:
+    ss::future<kafka::usage> close_current_window() final {
+        vlog(af_logger.info, "Data taken...");
+        auto u = kafka::usage{
+          .bytes_sent = _bytes_sent, .bytes_received = _bytes_recv};
+        _bytes_sent = 0;
+        _bytes_recv = 0;
+        co_return u;
+    }
+
+    void window_closed() final {
+        vlog(af_logger.info, "Window closed...");
+        if (_window_closed_promise) {
+            _window_closed_promise->set_value();
+            _window_closed_promise = std::nullopt;
+        }
+    }
+
+private:
+    std::optional<ss::promise<>> _window_closed_promise;
+    size_t _bytes_sent{0};
+    size_t _bytes_recv{0};
+};
+
+namespace {
+std::vector<kafka::usage>
+strip_window_data(const std::vector<kafka::usage_window>& v) {
+    std::vector<kafka::usage> vv;
+    std::transform(
+      v.begin(),
+      v.end(),
+      std::back_inserter(vv),
+      [](const kafka::usage_window& uw) { return uw.u; });
+    return vv;
+}
+
+ss::sstring print_window_data(const std::vector<kafka::usage_window>& v) {
+    std::stringstream ss;
+    ss << "\n[\n";
+    for (const auto& vs : v) {
+        ss << "\t" << vs.u << ",\n";
+    }
+    ss << "]";
+    return ss.str();
+}
+} // namespace
+
+FIXTURE_TEST(test_usage, kvstore_test_fixture) {
+    using namespace std::chrono_literals;
+    auto kvstore = make_kvstore();
+    kvstore->start().get();
+
+    const auto num_windows = 10;
+    const auto window_width = 10s;
+    const auto disk_write_interval = 1s;
+
+    auto usage_fiber = std::make_unique<test_accounting_fiber>(
+      *kvstore, num_windows, window_width, disk_write_interval);
+    usage_fiber->start().get();
+
+    /// Create expected data set
+    std::vector<kafka::usage> data;
+    for (auto i = 0; i < num_windows; ++i) {
+        const uint64_t sent = i * 100;
+        const uint64_t recv = i * 200;
+        data.emplace_back(
+          kafka::usage{.bytes_sent = sent, .bytes_received = recv});
+    }
+
+    /// Publish some data as the windows move across in time, assert observed is
+    /// as expected
+    for (const auto& e : data) {
+        usage_fiber->add_bytes(e.bytes_sent, e.bytes_received);
+        usage_fiber->advance_clock(window_width).get();
+        vlog(
+          af_logger.info,
+          "Clock advanced: by {}s, data: {}",
+          window_width.count(),
+          print_window_data(usage_fiber->get_usage_stats().get()));
+    }
+    auto result = strip_window_data(usage_fiber->get_usage_stats().get());
+    BOOST_CHECK_EQUAL(result, data);
+
+    /// Add to open window
+    usage_fiber->add_bytes(10, 10);
+    usage_fiber->advance_clock(2s).get();
+    usage_fiber->add_bytes(10, 10);
+    usage_fiber->advance_clock(2s).get();
+    const auto open_windows = usage_fiber->get_usage_stats().get();
+    vlog(
+      af_logger.info,
+      "Clock advanced 4s, data: {}",
+      print_window_data(open_windows));
+    const auto open_window = open_windows[0];
+    BOOST_CHECK_EQUAL(open_window.u.bytes_sent, 20);
+    BOOST_CHECK_EQUAL(open_window.u.bytes_received, 20);
+
+    /// Shut it down, note clean shutdowns persist data to kvstore
+    usage_fiber->stop().get();
+    usage_fiber = nullptr;
+
+    /// Restart the instance, and verify expected behavior
+    usage_fiber = std::make_unique<test_accounting_fiber>(
+      *kvstore, num_windows, window_width, disk_write_interval);
+    usage_fiber->start().get();
+
+    // Ensure open window is consistent
+    result = strip_window_data(usage_fiber->get_usage_stats().get());
+    const auto& new_open_window = result[0];
+    BOOST_CHECK_EQUAL(new_open_window.bytes_sent, 20);
+    BOOST_CHECK_EQUAL(new_open_window.bytes_received, 20);
+    BOOST_CHECK_EQUAL(result, data);
+
+    usage_fiber->stop().get();
+    kvstore->stop().get();
+}

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/usage_aggregator.h"
+
+#include "kafka/server/logger.h"
+#include "vlog.h"
+
+using namespace std::chrono_literals;
+
+namespace kafka {
+static constexpr std::string_view period_key{"period"};
+static constexpr std::string_view max_duration_key{"max_duration"};
+static constexpr std::string_view buckets_key{"buckets"};
+
+static bytes key_to_bytes(std::string_view sv) {
+    bytes k;
+    k.append(reinterpret_cast<const uint8_t*>(sv.begin()), sv.size());
+    return k;
+}
+
+struct persisted_state {
+    std::chrono::seconds configured_period;
+    size_t configured_windows;
+    fragmented_vector<usage_window> current_state;
+};
+
+static ss::future<>
+persist_to_disk(storage::kvstore& kvstore, persisted_state s) {
+    using kv_ks = storage::kvstore::key_space;
+
+    co_await kvstore.put(
+      kv_ks::usage,
+      key_to_bytes(period_key),
+      serde::to_iobuf(s.configured_period));
+    co_await kvstore.put(
+      kv_ks::usage,
+      key_to_bytes(max_duration_key),
+      serde::to_iobuf(s.configured_windows));
+    co_await kvstore.put(
+      kv_ks::usage,
+      key_to_bytes(buckets_key),
+      serde::to_iobuf(std::move(s.current_state)));
+}
+
+static std::optional<persisted_state>
+restore_from_disk(storage::kvstore& kvstore) {
+    using kv_ks = storage::kvstore::key_space;
+    std::optional<iobuf> period, windows, data;
+    try {
+        period = kvstore.get(kv_ks::usage, key_to_bytes(period_key));
+        windows = kvstore.get(kv_ks::usage, key_to_bytes(max_duration_key));
+        data = kvstore.get(kv_ks::usage, key_to_bytes(buckets_key));
+    } catch (const std::exception& ex) {
+        vlog(
+          klog.debug,
+          "Encountered exception when retriving usage data from disk: {}",
+          ex);
+        return std::nullopt;
+    }
+    if (!period && !windows && !data) {
+        /// Data didn't exist
+        return std::nullopt;
+    } else if (!period || !windows || !data) {
+        vlog(
+          klog.error,
+          "Inconsistent usage_manager on disk state detected, failed to "
+          "recover state");
+        return std::nullopt;
+    }
+    return persisted_state{
+      .configured_period = serde::from_iobuf<std::chrono::seconds>(
+        std::move(*period)),
+      .configured_windows = serde::from_iobuf<size_t>(std::move(*windows)),
+      .current_state = serde::from_iobuf<fragmented_vector<usage_window>>(
+        std::move(*data))};
+}
+
+static ss::future<> clear_persisted_state(storage::kvstore& kvstore) {
+    using kv_ks = storage::kvstore::key_space;
+    try {
+        co_await kvstore.remove(kv_ks::usage, key_to_bytes(period_key));
+        co_await kvstore.remove(kv_ks::usage, key_to_bytes(max_duration_key));
+        co_await kvstore.remove(kv_ks::usage, key_to_bytes(buckets_key));
+    } catch (const std::exception& ex) {
+        vlog(klog.debug, "Ignoring exception from storage layer: {}", ex);
+    }
+}
+
+usage usage::operator+(const usage& other) const {
+    return usage{
+      .bytes_sent = bytes_sent + other.bytes_sent,
+      .bytes_received = bytes_received + other.bytes_received};
+}
+
+template<typename time_point>
+auto epoch_time_secs(time_point now) {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+             now.time_since_epoch())
+      .count();
+}
+
+void usage_window::reset(ss::lowres_system_clock::time_point now) {
+    begin = epoch_time_secs(now);
+    end = 0;
+    u.bytes_sent = 0;
+    u.bytes_received = 0;
+    u.bytes_cloud_storage = std::nullopt;
+}
+
+template<typename clock_type>
+usage_aggregator<clock_type>::usage_aggregator(
+  storage::kvstore& kvstore,
+  size_t usage_num_windows,
+  std::chrono::seconds usage_window_width_interval,
+  std::chrono::seconds usage_disk_persistance_interval)
+  : _usage_num_windows(usage_num_windows)
+  , _usage_window_width_interval(usage_window_width_interval)
+  , _usage_disk_persistance_interval(usage_disk_persistance_interval)
+  , _kvstore(kvstore) {
+    vlog(
+      klog.info,
+      "Starting accounting fiber with settings, {{usage_num_windows: {} "
+      "usage_window_width_interval: {} "
+      "usage_disk_persistance_interval:{}}}",
+      usage_num_windows,
+      usage_window_width_interval,
+      usage_disk_persistance_interval);
+    _persist_disk_timer.set_callback([this] {
+        ssx::background
+          = ssx::spawn_with_gate_then(
+              _bg_write_gate,
+              [this] {
+                  return persist_to_disk(
+                    _kvstore,
+                    persisted_state{
+                      .configured_period = _usage_window_width_interval,
+                      .configured_windows = _usage_num_windows,
+                      .current_state = _buckets.copy()});
+              })
+              .then([this] {
+                  if (!_gate.is_closed()) {
+                      _persist_disk_timer.arm(_usage_disk_persistance_interval);
+                  }
+              })
+              .handle_exception([this](std::exception_ptr eptr) {
+                  vlog(
+                    klog.debug,
+                    "Encountered exception when persisting usage data to disk: "
+                    "{} , retrying",
+                    eptr);
+                  if (!_gate.is_closed()) {
+                      const auto retry = std::min(
+                        _usage_disk_persistance_interval, 5s);
+                      _persist_disk_timer.arm(clock_type::now() + retry);
+                  }
+              });
+    });
+    _timer.set_callback([this] {
+        ssx::background = ssx::spawn_with_gate_then(_gate, [this]() {
+                              return close_window();
+                          }).finally([this] {
+            if (!_gate.is_closed()) {
+                _timer.arm(_usage_window_width_interval);
+            }
+        });
+    });
+    /// TODO: This should be refactored when fragmented_vector::resize is
+    /// implemented
+    for (size_t i = 0; i < _usage_num_windows; ++i) {
+        _buckets.push_back(usage_window{});
+    }
+    _buckets[_current_window].reset(ss::lowres_system_clock::now());
+}
+
+template<typename clock_type>
+ss::future<> usage_aggregator<clock_type>::start() {
+    /// In the event of a quick restart, reset_state() will set the
+    /// _current_index to where it was before restart, however the total time
+    /// until the next window must be accounted for. This is the duration for
+    /// which redpanda was down.
+    auto h = _gate.hold();
+    auto last_window_delta = std::chrono::seconds(0);
+    auto state = restore_from_disk(_kvstore);
+    if (state) {
+        if (
+          state->configured_period != _usage_window_width_interval
+          || state->configured_windows != _usage_num_windows) {
+            vlog(
+              klog.info,
+              "Persisted usage state had been configured with different "
+              "options, clearing state and restarting with current "
+              "configuration options");
+            co_await clear_persisted_state(_kvstore);
+        } else {
+            last_window_delta = reset_state(std::move(state->current_state));
+        }
+    }
+
+    vassert(
+      last_window_delta <= _usage_window_width_interval,
+      "Error correctly detecting last window delta");
+    _timer.arm(_usage_window_width_interval - last_window_delta);
+    _persist_disk_timer.arm(_usage_disk_persistance_interval);
+}
+
+template<typename clock_type>
+std::vector<usage_window> usage_aggregator<clock_type>::get_usage_stats() {
+    std::vector<usage_window> stats;
+    for (size_t i = 1; i < _buckets.size(); ++i) {
+        const auto idx = (_current_window + i) % _usage_num_windows;
+        if (!_buckets[idx].is_uninitialized()) {
+            stats.push_back(_buckets[idx]);
+        }
+    }
+    /// Open bucket last ensures ordering from oldest to newest
+    stats.push_back(_buckets[_current_window]);
+    /// std::reverse returns results in ordering from newest to oldest
+    std::reverse(stats.begin(), stats.end());
+    return stats;
+}
+
+template<typename clock_type>
+ss::future<> usage_aggregator<clock_type>::stop() {
+    _timer.cancel();
+    _persist_disk_timer.cancel();
+    co_await _bg_write_gate.close();
+    try {
+        co_await persist_to_disk(
+          _kvstore,
+          persisted_state{
+            .configured_period = _usage_window_width_interval,
+            .configured_windows = _usage_num_windows,
+            .current_state = _buckets.copy()});
+    } catch (const std::exception& ex) {
+        vlog(
+          klog.debug,
+          "Encountered exception when persisting usage data to disk: {}",
+          ex);
+    }
+    co_await _gate.close();
+}
+
+/// Method to write response to correct bucket, the index to write should be
+/// \ref index, however if enough time has passed that window has been
+/// overwritten, therefore the data can be omitted
+template<typename clock_type>
+bool usage_aggregator<clock_type>::is_bucket_stale(
+  size_t idx, uint64_t close_ts) const {
+    /// Check is simple, close_ts should be what it was when the window
+    /// closed, if it isn't, then the window is stale and was re-used,
+    /// data was overwritten.
+    return _buckets[idx].end != close_ts;
+}
+
+template<typename clock_type>
+void usage_aggregator<clock_type>::close_window() {
+    const auto now = ss::lowres_system_clock::now();
+    const auto now_ts = epoch_time_secs(now);
+    const auto before_close_idx = _current_window;
+    _buckets[before_close_idx].end = now_ts;
+    _current_window = (_current_window + 1) % _buckets.size();
+    _buckets[_current_window].reset(now);
+    /// The timer must progress so subsequent windows may be closed, async work
+    /// may hold that up for a significant amount of time, therefore async work
+    /// will be dispatched in the background and the result set written to the
+    /// correct bucket when it is eventually computed
+    ssx::spawn_with_gate(_gate, [this, before_close_idx, close_ts = now_ts] {
+        return close_current_window()
+          .then([this, before_close_idx, close_ts](usage next) {
+              if (!is_bucket_stale(before_close_idx, close_ts)) {
+                  _buckets[before_close_idx].u = next;
+              }
+          })
+          .handle_exception([](std::exception_ptr eptr) {
+              vlog(
+                klog.debug,
+                "usage_manager async job exception encountered: {}",
+                eptr);
+          });
+    });
+}
+
+template<typename clock_type>
+std::chrono::seconds usage_aggregator<clock_type>::reset_state(
+  fragmented_vector<usage_window> buckets) {
+    /// called after restart to determine which bucket is the 'current' bucket
+    auto last_window_delta = std::chrono::seconds(0);
+    _current_window = 0;
+    if (!buckets.empty()) {
+        std::optional<size_t> open_index;
+        for (size_t i = 0; i < buckets.size(); ++i) {
+            /// There will always be exactly 1 open_window in the result set
+            if (buckets[i].is_open()) {
+                vassert(!open_index, "Data serialization was incorrect");
+                open_index = i;
+                break;
+            }
+        }
+        vassert(open_index, "Data serialization was incorrect");
+        _current_window = *open_index;
+        /// Optimization to begin picking up if wall time is within
+        /// window interval
+        const auto begin = std::chrono::seconds(buckets[*open_index].begin);
+        const auto now_ts = ss::lowres_system_clock::now();
+        const auto now = std::chrono::seconds(epoch_time_secs(now_ts));
+        const auto delta = now - begin;
+        if (delta >= _usage_window_width_interval) {
+            /// Close window and open a new one
+            buckets[*open_index].end = epoch_time_secs(now_ts);
+            _current_window = (*open_index + 1) % buckets.size();
+            buckets[_current_window].reset(now_ts);
+        } else if (delta >= std::chrono::seconds(0)) {
+            /// Keep last window open and adjust delta so next window closes
+            /// that much sooner
+            last_window_delta = delta;
+        }
+    }
+    _buckets = std::move(buckets);
+    return last_window_delta;
+}
+
+template class usage_aggregator<ss::lowres_clock>;
+template class usage_aggregator<ss::manual_clock>;
+
+} // namespace kafka

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -44,6 +44,9 @@ struct usage_window
     bool is_open() const { return begin != 0 && end == 0; }
 
     void reset(ss::lowres_system_clock::time_point now);
+    void reset_to_nearest_interval(
+      std::chrono::seconds usage_window_width_interval,
+      ss::lowres_system_clock::time_point tp);
 
     auto serde_fields() { return std::tie(begin, end, u); }
 };
@@ -74,7 +77,7 @@ protected:
     virtual ss::future<usage> close_current_window() = 0;
 
 private:
-    std::chrono::seconds reset_state(fragmented_vector<usage_window> buckets);
+    void reset_state(fragmented_vector<usage_window> buckets);
     void close_window();
     void rearm_window_timer();
     bool is_bucket_stale(size_t idx, uint64_t close_ts) const;

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "storage/kvstore.h"
+#include "utils/fragmented_vector.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/timer.hh>
+
+namespace kafka {
+
+/// Main structure of statistics that are being accounted for. These are
+/// periodically serialized to disk, hence why the struct inherits from the
+/// serde::envelope
+struct usage
+  : serde::envelope<usage, serde::version<0>, serde::compat_version<0>> {
+    uint64_t bytes_sent{0};
+    uint64_t bytes_received{0};
+    std::optional<uint64_t> bytes_cloud_storage;
+    usage operator+(const usage&) const;
+    auto serde_fields() {
+        return std::tie(bytes_sent, bytes_received, bytes_cloud_storage);
+    }
+};
+
+struct usage_window
+  : serde::envelope<usage_window, serde::version<0>, serde::compat_version<0>> {
+    uint64_t begin{0};
+    uint64_t end{0};
+    usage u;
+
+    /// Only valid to assert these conditions internal to usage manager. When it
+    /// returns windows as results these conditions may not hold.
+    bool is_uninitialized() const { return begin == 0 && end == 0; }
+    bool is_open() const { return begin != 0 && end == 0; }
+
+    void reset(ss::lowres_system_clock::time_point now);
+
+    auto serde_fields() { return std::tie(begin, end, u); }
+};
+
+template<typename clock_type = ss::lowres_clock>
+class usage_aggregator {
+public:
+    usage_aggregator(
+      storage::kvstore& kvstore,
+      size_t usage_num_windows,
+      std::chrono::seconds usage_window_width_interval,
+      std::chrono::seconds usage_disk_persistance_interval);
+    virtual ~usage_aggregator() = default;
+
+    virtual ss::future<> start();
+    virtual ss::future<> stop();
+
+    std::vector<usage_window> get_usage_stats();
+
+    std::chrono::seconds max_history() const {
+        return _usage_window_width_interval * _usage_num_windows;
+    }
+
+protected:
+    /// Portions of the implementation that rely on higher level constructs
+    /// to obtain the data are not relevent to unit testing this class and
+    /// can be broken out so this class can be made more testable
+    virtual ss::future<usage> close_current_window() = 0;
+
+private:
+    std::chrono::seconds reset_state(fragmented_vector<usage_window> buckets);
+    void close_window();
+    bool is_bucket_stale(size_t idx, uint64_t close_ts) const;
+
+private:
+    size_t _usage_num_windows;
+    std::chrono::seconds _usage_window_width_interval;
+    std::chrono::seconds _usage_disk_persistance_interval;
+
+    /// Timers for controlling window closure and disk persistance
+    ss::timer<clock_type> _timer;
+    ss::timer<clock_type> _persist_disk_timer;
+
+    ss::gate _bg_write_gate;
+    ss::gate _gate;
+    size_t _current_window{0};
+    fragmented_vector<usage_window> _buckets;
+    storage::kvstore& _kvstore;
+};
+} // namespace kafka

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -76,6 +76,7 @@ protected:
 private:
     std::chrono::seconds reset_state(fragmented_vector<usage_window> buckets);
     void close_window();
+    void rearm_window_timer();
     bool is_bucket_stale(size_t idx, uint64_t close_ts) const;
 
 private:

--- a/src/v/kafka/server/usage_manager.cc
+++ b/src/v/kafka/server/usage_manager.cc
@@ -61,7 +61,6 @@ usage_manager::usage_accounting_fiber::get_cloud_usage_data() {
     }
     const auto expiry = std::min<std::chrono::seconds>(
       max_history(), std::chrono::seconds(10));
-    co_await _health_monitor.maybe_refresh_cloud_health_stats();
     auto health_overview = co_await _health_monitor.get_cluster_health_overview(
       ss::lowres_clock::now() + expiry);
     co_return health_overview.bytes_in_cloud_storage;

--- a/src/v/kafka/server/usage_manager.cc
+++ b/src/v/kafka/server/usage_manager.cc
@@ -20,335 +20,40 @@
 
 namespace kafka {
 
-static constexpr std::string_view period_key{"period"};
-static constexpr std::string_view max_duration_key{"max_duration"};
-static constexpr std::string_view buckets_key{"buckets"};
-
-static bytes key_to_bytes(std::string_view sv) {
-    bytes k;
-    k.append(reinterpret_cast<const uint8_t*>(sv.begin()), sv.size());
-    return k;
-}
-
-struct persisted_state {
-    std::chrono::seconds configured_period;
-    size_t configured_windows;
-    fragmented_vector<usage_window> current_state;
-};
-
-static ss::future<>
-persist_to_disk(storage::kvstore& kvstore, persisted_state s) {
-    using kv_ks = storage::kvstore::key_space;
-
-    co_await kvstore.put(
-      kv_ks::usage,
-      key_to_bytes(period_key),
-      serde::to_iobuf(s.configured_period));
-    co_await kvstore.put(
-      kv_ks::usage,
-      key_to_bytes(max_duration_key),
-      serde::to_iobuf(s.configured_windows));
-    co_await kvstore.put(
-      kv_ks::usage,
-      key_to_bytes(buckets_key),
-      serde::to_iobuf(std::move(s.current_state)));
-}
-
-static std::optional<persisted_state>
-restore_from_disk(storage::kvstore& kvstore) {
-    using kv_ks = storage::kvstore::key_space;
-    std::optional<iobuf> period, windows, data;
-    try {
-        period = kvstore.get(kv_ks::usage, key_to_bytes(period_key));
-        windows = kvstore.get(kv_ks::usage, key_to_bytes(max_duration_key));
-        data = kvstore.get(kv_ks::usage, key_to_bytes(buckets_key));
-    } catch (const std::exception& ex) {
-        vlog(
-          klog.debug,
-          "Encountered exception when retriving usage data from disk: {}",
-          ex);
-        return std::nullopt;
-    }
-    if (!period && !windows && !data) {
-        /// Data didn't exist
-        return std::nullopt;
-    } else if (!period || !windows || !data) {
-        vlog(
-          klog.error,
-          "Inconsistent usage_manager on disk state detected, failed to "
-          "recover state");
-        return std::nullopt;
-    }
-    return persisted_state{
-      .configured_period = serde::from_iobuf<std::chrono::seconds>(
-        std::move(*period)),
-      .configured_windows = serde::from_iobuf<size_t>(std::move(*windows)),
-      .current_state = serde::from_iobuf<fragmented_vector<usage_window>>(
-        std::move(*data))};
-}
-
-static ss::future<> clear_persisted_state(storage::kvstore& kvstore) {
-    using kv_ks = storage::kvstore::key_space;
-    try {
-        co_await kvstore.remove(kv_ks::usage, key_to_bytes(period_key));
-        co_await kvstore.remove(kv_ks::usage, key_to_bytes(max_duration_key));
-        co_await kvstore.remove(kv_ks::usage, key_to_bytes(buckets_key));
-    } catch (const std::exception& ex) {
-        vlog(klog.debug, "Ignoring exception from storage layer: {}", ex);
-    }
-}
-
-static auto epoch_time_secs(
-  ss::lowres_system_clock::time_point now = ss::lowres_system_clock::now()) {
-    return std::chrono::duration_cast<std::chrono::seconds>(
-             now.time_since_epoch())
-      .count();
-}
-
-void usage_window::reset(ss::lowres_system_clock::time_point now) {
-    begin = epoch_time_secs(now);
-    end = 0;
-    u.bytes_sent = 0;
-    u.bytes_received = 0;
-    u.bytes_cloud_storage = 0;
-}
-
-usage usage::operator+(const usage& other) const {
-    return usage{
-      .bytes_sent = bytes_sent + other.bytes_sent,
-      .bytes_received = bytes_received + other.bytes_received};
-}
-
-usage_manager::accounting_fiber::accounting_fiber(
+usage_manager::usage_accounting_fiber::usage_accounting_fiber(
   ss::sharded<usage_manager>& um,
   ss::sharded<cluster::health_monitor_frontend>& health_monitor,
   ss::sharded<storage::api>& storage,
   size_t usage_num_windows,
   std::chrono::seconds usage_window_width_interval,
   std::chrono::seconds usage_disk_persistance_interval)
-  : _usage_num_windows(usage_num_windows)
-  , _usage_window_width_interval(usage_window_width_interval)
-  , _usage_disk_persistance_interval(usage_disk_persistance_interval)
+  : usage_aggregator<>(
+    storage.local().kvs(),
+    usage_num_windows,
+    usage_window_width_interval,
+    usage_disk_persistance_interval)
   , _health_monitor(health_monitor.local())
-  , _kvstore(storage.local().kvs())
-  , _um(um) {
-    vlog(
-      klog.info,
-      "Starting accounting fiber with settings, {{usage_num_windows: {} "
-      "usage_window_width_interval: {} "
-      "usage_disk_persistance_interval:{}}}",
-      usage_num_windows,
-      usage_window_width_interval,
-      usage_disk_persistance_interval);
-    /// TODO: This should be refactored when fragmented_vector::resize is
-    /// implemented
-    for (size_t i = 0; i < _usage_num_windows; ++i) {
-        _buckets.push_back(usage_window{});
-    }
-    _buckets[_current_window].reset(ss::lowres_system_clock::now());
+  , _um(um) {}
+
+/// The fiber running on the timer has a mutable effect when sample() is
+/// called, to prevent issues when open bucket is querying all shards for
+/// current stats, guard this area of code with a mutex.
+ss::future<usage>
+usage_manager::usage_accounting_fiber::close_current_window() {
+    auto u = co_await _um.map_reduce0(
+      [](usage_manager& um) { return um.sample(); }, usage{}, std::plus<>());
+    u.bytes_cloud_storage = co_await get_cloud_usage_data();
+    co_return u;
 }
 
-ss::future<> usage_manager::accounting_fiber::start() {
-    /// In the event of a quick restart, reset_state() will set the
-    /// _current_index to where it was before restart, however the total time
-    /// until the next window must be accounted for. This is the duration for
-    /// which redpanda was down.
-    auto h = _gate.hold();
-    auto last_window_delta = std::chrono::seconds(0);
-    auto state = restore_from_disk(_kvstore);
-    if (state) {
-        if (
-          state->configured_period != _usage_window_width_interval
-          || state->configured_windows != _usage_num_windows) {
-            vlog(
-              klog.info,
-              "Persisted usage state had been configured with different "
-              "options, clearing state and restarting with current "
-              "configuration options");
-            co_await clear_persisted_state(_kvstore);
-        } else {
-            last_window_delta = reset_state(std::move(state->current_state));
-        }
-    }
-    _persist_disk_timer.set_callback([this] {
-        ssx::background
-          = ssx::spawn_with_gate_then(
-              _bg_write_gate,
-              [this] {
-                  return persist_to_disk(
-                    _kvstore,
-                    persisted_state{
-                      .configured_period = _usage_window_width_interval,
-                      .configured_windows = _usage_num_windows,
-                      .current_state = _buckets.copy()});
-              })
-              .then([this] {
-                  if (!_gate.is_closed()) {
-                      _persist_disk_timer.arm(
-                        ss::lowres_clock::now()
-                        + _usage_disk_persistance_interval);
-                  }
-              })
-              .handle_exception([this](std::exception_ptr eptr) {
-                  using namespace std::chrono_literals;
-                  vlog(
-                    klog.debug,
-                    "Encountered exception when persisting usage data to disk: "
-                    "{} , retrying",
-                    eptr);
-                  if (!_gate.is_closed()) {
-                      const auto retry = std::min(
-                        _usage_disk_persistance_interval, 5s);
-                      _persist_disk_timer.arm(ss::lowres_clock::now() + retry);
-                  }
-              });
-    });
-    _timer.set_callback([this] {
-        ssx::background = ssx::spawn_with_gate_then(_gate, [this]() {
-                              return close_window();
-                          }).finally([this] {
-            if (!_gate.is_closed()) {
-                _timer.arm(
-                  ss::lowres_clock::now() + _usage_window_width_interval);
-            }
-        });
-    });
-    const auto now = ss::lowres_clock::now();
-    vassert(
-      last_window_delta <= _usage_window_width_interval,
-      "Error correctly detecting last window delta");
-    _timer.arm((now + _usage_window_width_interval) - last_window_delta);
-    _persist_disk_timer.arm(now + _usage_disk_persistance_interval);
-}
-
-std::vector<usage_window>
-usage_manager::accounting_fiber::get_usage_stats() const {
-    std::vector<usage_window> stats;
-    for (size_t i = 1; i < _buckets.size(); ++i) {
-        const auto idx = (_current_window + i) % _usage_num_windows;
-        if (!_buckets[idx].is_uninitialized()) {
-            stats.push_back(_buckets[idx]);
-        }
-    }
-    /// Open bucket last ensures ordering from oldest to newest
-    stats.push_back(_buckets[_current_window]);
-    /// std::reverse returns results in ordering from newest to oldest
-    std::reverse(stats.begin(), stats.end());
-    return stats;
-}
-
-ss::future<> usage_manager::accounting_fiber::stop() {
-    _timer.cancel();
-    _persist_disk_timer.cancel();
-    co_await _bg_write_gate.close();
-    try {
-        co_await persist_to_disk(
-          _kvstore,
-          persisted_state{
-            .configured_period = _usage_window_width_interval,
-            .configured_windows = _usage_num_windows,
-            .current_state = _buckets.copy()});
-    } catch (const std::exception& ex) {
-        vlog(
-          klog.debug,
-          "Encountered exception when persisting usage data to disk: {}",
-          ex);
-    }
-    co_await _gate.close();
-}
-
-void usage_manager::accounting_fiber::close_window() {
-    const auto now = ss::lowres_system_clock::now();
-    const auto now_ts = epoch_time_secs(now);
-    const auto before_close_idx = _current_window;
-    _buckets[before_close_idx].end = now_ts;
-    _current_window = (_current_window + 1) % _buckets.size();
-    _buckets[_current_window].reset(now);
-    /// The timer must progress so subsequent windows may be closed, async work
-    /// may hold that up for a significant amount of time, therefore async work
-    /// will be dispatched in the background and the result set written to the
-    /// correct bucket when it is eventually computed
-    ssx::spawn_with_gate(_gate, [this, before_close_idx, now_ts] {
-        return async_data_fetch(before_close_idx, now_ts)
-          .handle_exception([](std::exception_ptr eptr) {
-              vlog(
-                klog.debug,
-                "usage_manager async job exception encountered: {}",
-                eptr);
-          });
-    });
-}
-
-ss::future<> usage_manager::accounting_fiber::async_data_fetch(
-  size_t index, uint64_t close_ts) {
-    /// Method to write response to correct bucket, the index to write should be
-    /// \ref index, however if enough time has passed that window has been
-    /// overwritten, therefore the data can be omitted
-    const auto is_bucket_stale = [this, index, close_ts]() {
-        /// Check is simple, close_ts should be what it was when the window
-        /// closed, if it isn't, then the window is stale and was re-used, data
-        /// was overwritten.
-        return _buckets[index].end != close_ts;
-    };
-
-    /// Collect all kafka ingress/egress stats across all cores
-    usage kafka_stats = co_await _um.map_reduce0(
-      [](usage_manager& um) { return um.sample(); },
-      usage{},
-      [](const usage& acc, const usage& x) { return acc + x; });
-    if (!is_bucket_stale()) {
-        _buckets[index].u = kafka_stats;
-    }
-
-    /// Grab cloud storage stats via health monitor
+ss::future<std::optional<uint64_t>>
+usage_manager::usage_accounting_fiber::get_cloud_usage_data() {
     const auto expiry = std::min<std::chrono::seconds>(
-      (_usage_window_width_interval * _usage_num_windows),
-      std::chrono::seconds(10));
+      max_history(), std::chrono::seconds(10));
     co_await _health_monitor.maybe_refresh_cloud_health_stats();
     auto health_overview = co_await _health_monitor.get_cluster_health_overview(
       ss::lowres_clock::now() + expiry);
-    if (!is_bucket_stale()) {
-        _buckets[index].u.bytes_cloud_storage
-          = health_overview.bytes_in_cloud_storage;
-    }
-}
-
-std::chrono::seconds usage_manager::accounting_fiber::reset_state(
-  fragmented_vector<usage_window> buckets) {
-    /// called after restart to determine which bucket is the 'current' bucket
-    auto last_window_delta = std::chrono::seconds(0);
-    _current_window = 0;
-    if (!buckets.empty()) {
-        std::optional<size_t> open_index;
-        for (size_t i = 0; i < buckets.size(); ++i) {
-            /// There will always be exactly 1 open_window in the result set
-            if (buckets[i].is_open()) {
-                vassert(!open_index, "Data serialization was incorrect");
-                open_index = i;
-                break;
-            }
-        }
-        vassert(open_index, "Data serialization was incorrect");
-        _current_window = *open_index;
-        /// Optimization to begin picking up if wall time is within
-        /// window interval
-        const auto begin = std::chrono::seconds(buckets[*open_index].begin);
-        const auto now_ts = ss::lowres_system_clock::now();
-        const auto now = std::chrono::seconds(epoch_time_secs(now_ts));
-        const auto delta = now - begin;
-        if (delta >= _usage_window_width_interval) {
-            /// Close window and open a new one
-            buckets[*open_index].end = epoch_time_secs(now_ts);
-            _current_window = (*open_index + 1) % buckets.size();
-            buckets[_current_window].reset(now_ts);
-        } else if (delta >= std::chrono::seconds(0)) {
-            /// Keep last window open and adjust delta so next window closes
-            /// that much sooner
-            last_window_delta = delta;
-        }
-    }
-    _buckets = std::move(buckets);
-    return last_window_delta;
+    co_return health_overview.bytes_in_cloud_storage;
 }
 
 usage_manager::usage_manager(
@@ -388,7 +93,7 @@ ss::future<> usage_manager::start_accounting_fiber() {
     if (_accounting_fiber) {
         co_return; /// Double start called, do-nothing
     }
-    _accounting_fiber = std::make_unique<accounting_fiber>(
+    _accounting_fiber = std::make_unique<usage_accounting_fiber>(
       this->container(),
       _health_monitor,
       _storage,

--- a/src/v/kafka/server/usage_manager.cc
+++ b/src/v/kafka/server/usage_manager.cc
@@ -130,16 +130,16 @@ ss::future<> usage_manager::stop() {
     co_await _accounting_fiber->stop();
 }
 
-std::vector<usage_window> usage_manager::get_usage_stats() const {
+ss::future<std::vector<usage_window>> usage_manager::get_usage_stats() const {
     if (ss::this_shard_id() != usage_manager_main_shard) {
         throw std::runtime_error(
           "Attempt to query results of "
           "kafka::usage_manager off the main accounting shard");
     }
     if (!_accounting_fiber) {
-        return {}; // no stats
+        co_return std::vector<usage_window>{}; // no stats
     }
-    return _accounting_fiber->get_usage_stats();
+    co_return co_await _accounting_fiber->get_usage_stats();
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -36,6 +36,7 @@ public:
     class usage_accounting_fiber final : public usage_aggregator<> {
     public:
         usage_accounting_fiber(
+          cluster::controller* controller,
           ss::sharded<usage_manager>& um,
           ss::sharded<cluster::health_monitor_frontend>& health_monitor,
           ss::sharded<storage::api>& storage,
@@ -50,6 +51,7 @@ public:
         ss::future<std::optional<uint64_t>> get_cloud_usage_data();
 
     private:
+        cluster::controller* _controller;
         cluster::health_monitor_frontend& _health_monitor;
         ss::sharded<usage_manager>& _um;
     };
@@ -59,6 +61,7 @@ public:
     /// Context is to be in a sharded service, will grab \ref usage_num_windows
     /// and \ref usage_window_sec configuration parameters from cluster config
     explicit usage_manager(
+      cluster::controller* controller,
       ss::sharded<cluster::health_monitor_frontend>& health_monitor,
       ss::sharded<storage::api>& storage);
 
@@ -107,6 +110,7 @@ private:
     config::binding<std::chrono::seconds> _usage_window_width_interval;
     config::binding<std::chrono::seconds> _usage_disk_persistance_interval;
 
+    cluster::controller* _controller;
     ss::sharded<cluster::health_monitor_frontend>& _health_monitor;
     ss::sharded<storage::api>& _storage;
 

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -11,41 +11,15 @@
 
 #pragma once
 #include "config/property.h"
+#include "kafka/server/usage_aggregator.h"
 #include "oncore.h"
 #include "storage/kvstore.h"
 #include "utils/fragmented_vector.h"
-#include "utils/mutex.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/timer.hh>
 
 namespace kafka {
-
-/// Main structure of statistics that are being accounted for. These are
-/// periodically serialized to disk, hence why the struct inherits from the
-/// serde::envelope
-struct usage
-  : serde::envelope<usage, serde::version<0>, serde::compat_version<0>> {
-    uint64_t bytes_sent{0};
-    uint64_t bytes_received{0};
-    std::optional<uint64_t> bytes_cloud_storage;
-    usage operator+(const usage&) const;
-    auto serde_fields() {
-        return std::tie(bytes_sent, bytes_received, bytes_cloud_storage);
-    }
-};
-
-struct usage_window
-  : serde::envelope<usage_window, serde::version<0>, serde::compat_version<0>> {
-    uint64_t begin{0};
-    uint64_t end{0};
-    usage u;
-
-    bool is_uninitialized() const { return begin == 0 && end == 0; }
-    bool is_open() const { return begin != 0 && end == 0; }
-    void reset(ss::lowres_system_clock::time_point now);
-    auto serde_fields() { return std::tie(begin, end, u); }
-};
 
 /// Class that manages all usage statistics. Usage stats are more accurate
 /// representation of node usage. This class maintains these stats windowed,
@@ -59,9 +33,9 @@ class usage_manager : public ss::peering_sharded_service<usage_manager> {
 public:
     static constexpr ss::shard_id usage_manager_main_shard{0};
 
-    class accounting_fiber {
+    class usage_accounting_fiber final : public usage_aggregator<> {
     public:
-        accounting_fiber(
+        usage_accounting_fiber(
           ss::sharded<usage_manager>& um,
           ss::sharded<cluster::health_monitor_frontend>& health_monitor,
           ss::sharded<storage::api>& storage,
@@ -69,37 +43,14 @@ public:
           std::chrono::seconds usage_window_width_interval,
           std::chrono::seconds usage_disk_persistance_interval);
 
-        /// Starts a fiber that manage window interval evolution and disk
-        /// persistance
-        ss::future<> start();
-
-        /// Stops the fiber and flushes current in memory results to disk
-        ss::future<> stop();
-
-        /// Returns aggregate of all \ref usage stats across cores
-        std::vector<usage_window> get_usage_stats() const;
+    protected:
+        virtual ss::future<usage> close_current_window() final;
 
     private:
-        std::chrono::seconds
-        reset_state(fragmented_vector<usage_window> buckets);
-        void close_window();
-        ss::future<> async_data_fetch(size_t index, uint64_t close_ts);
+        ss::future<std::optional<uint64_t>> get_cloud_usage_data();
 
     private:
-        size_t _usage_num_windows;
-        std::chrono::seconds _usage_window_width_interval;
-        std::chrono::seconds _usage_disk_persistance_interval;
-
-        /// Timers for controlling window closure and disk persistance
-        ss::timer<ss::lowres_clock> _timer;
-        ss::timer<ss::lowres_clock> _persist_disk_timer;
-
-        ss::gate _bg_write_gate;
-        ss::gate _gate;
-        size_t _current_window{0};
-        fragmented_vector<usage_window> _buckets;
         cluster::health_monitor_frontend& _health_monitor;
-        storage::kvstore& _kvstore;
         ss::sharded<usage_manager>& _um;
     };
 
@@ -165,7 +116,7 @@ private:
     ss::gate _background_gate;
 
     /// Valid on core-0 when usage_enabled() == true
-    std::unique_ptr<accounting_fiber> _accounting_fiber;
+    std::unique_ptr<usage_aggregator<>> _accounting_fiber;
 };
 
 /// Bytes accounted for by the kafka::usage_manager will not take into

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -82,7 +82,7 @@ public:
 
     /// Obtain all current stats - for all shards
     ///
-    std::vector<usage_window> get_usage_stats() const;
+    ss::future<std::vector<usage_window>> get_usage_stats() const;
 
     /// Obtain all current stats - for 'this' shard, resets window
     ///

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1476,6 +1476,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
     syschecks::systemd_message("Creating kafka usage manager frontend").get();
     construct_service(
       usage_manager,
+      controller.get(),
       std::ref(controller->get_health_monitor()),
       std::ref(storage))
       .get();

--- a/tests/rptest/tests/usage_test.py
+++ b/tests/rptest/tests/usage_test.py
@@ -9,6 +9,7 @@
 
 import time
 import random
+import operator
 from rptest.clients.rpk import RpkTool
 from requests.exceptions import HTTPError
 from rptest.services.cluster import cluster
@@ -28,6 +29,76 @@ from rptest.clients.types import TopicSpec
 from rptest.utils.functional import flat_map
 
 
+class UsageWindow:
+    def __init__(self, begin, end, is_open, bytes_sent, bytes_received,
+                 bytes_in_cloud_storage):
+        self.begin = begin
+        self.end = end
+        self.is_open = is_open
+        self.bytes_sent = bytes_sent
+        self.bytes_received = bytes_received
+        self.bytes_in_cloud_storage = bytes_in_cloud_storage
+
+    @property
+    def is_closed(self):
+        return not self.is_open
+
+    def __repr__(self):
+        r = {
+            'begin': self.begin,
+            'end': self.end,
+            'is_open': self.is_open,
+            'bytes_sent': self.bytes_sent,
+            'bytes_received': self.bytes_received,
+            'bytes_in_cloud_storage': self.bytes_in_cloud_storage
+        }
+        return str(r)
+
+
+def parse_usage_response(usage_response):
+    def parse_usage_window(e):
+        return UsageWindow(e['begin_timestamp'], e['end_timestamp'], e['open'],
+                           e['kafka_bytes_sent_count'],
+                           e['kafka_bytes_received_count'],
+                           e['cloud_storage_bytes_gauge'])
+
+    return [parse_usage_window(e) for e in usage_response]
+
+
+def assert_usage_consistency(node, a, b):
+    """
+    This method returns true if windows with matching timestamps contain the same values
+
+    node: String (For debugging if assertions fires)
+    a: List[UsageWindow]
+    b: List[UsageWindow]
+
+    Windows from list b are assumed to be from a newer response, so this method will verify
+    that all items from b, if they exist in a, are equivalent.
+
+    One excepton if the window is considered an 'open' window, there would be at max 1
+    per request, if there is a matching open window in both inputs, their values
+    are checked so that the value of b's open window would be >= the value in a's.
+    """
+    def group_windows(ws):
+        return {(x.begin, x.end): x for x in ws}
+
+    def compare(x, y, fn):
+        return fn(x.bytes_sent, y.bytes_sent) and fn(
+            x.bytes_received, y.bytes_received) and fn(
+                x.bytes_in_cloud_storage, y.bytes_in_cloud_storage)
+
+    # Windows from group 'a' are expected to be from a previous request
+    grp_a = group_windows(a)
+    for x in b:
+        key = (x.begin, x.end)
+        a_value = grp_a.get(key, None)
+        if a_value is not None:
+            fn = operator.le if a_value.is_open else operator.eq
+            assert compare(a_value, x,
+                           fn), f"node: {node} a: {str(a_value)} b:{str(x)}"
+
+
 class UsageTest(RedpandaTest):
     """
     Tests that the usage endpoint is tracking kafka metrics
@@ -35,49 +106,152 @@ class UsageTest(RedpandaTest):
     topics = (TopicSpec(), )
 
     def __init__(self, test_context):
-        extra_conf = {
-            'enable_usage': True,
-            'usage_num_windows': 30,
-            'usage_window_width_interval_sec': 1,
-            'usage_disk_persistance_interval_sec': 5
-        }
+        self._settings = self._usage_conf(enable_usage=True,
+                                          num_windows=30,
+                                          window_interval=3,
+                                          disk_write_interval=5)
         super(UsageTest, self).__init__(test_context=test_context,
-                                        extra_rp_conf=extra_conf)
+                                        extra_rp_conf=self._settings)
         self._ctx = test_context
         self._admin = Admin(self.redpanda)
+        # Dict[NodeName, v1/usage_response] cached history of responses
+        # used to validate future usage requests against historical ones to
+        # detect for any inconsistencies
+        self._previous_response = {}
 
-    def _get_all_usage(self, include_open=True):
+    @property
+    def usage_enabled(self):
+        return self._settings.get('enable_usage', False)
+
+    @property
+    def num_windows(self):
+        return self._settings.get('usage_num_windows', 0)
+
+    @property
+    def window_interval(self):
+        return self._settings.get('usage_window_width_interval_sec', 0)
+
+    @property
+    def disk_write_interval(self):
+        return self._settings.get('usage_disk_persistance_interval_sec', 0)
+
+    def _usage_conf(self,
+                    enable_usage=None,
+                    num_windows=None,
+                    window_interval=None,
+                    disk_write_interval=None):
+        changes = {}
+        if enable_usage is not None:
+            changes['enable_usage'] = enable_usage
+        if num_windows is not None:
+            changes['usage_num_windows'] = num_windows
+        if window_interval is not None:
+            changes['usage_window_width_interval_sec'] = window_interval
+        if disk_write_interval is not None:
+            changes[
+                'usage_disk_persistance_interval_sec'] = disk_write_interval
+
+        return changes
+
+    def _modify_settings(self,
+                         enable_usage=None,
+                         num_windows=None,
+                         window_interval=None,
+                         disk_write_interval=None):
+        conf = self._usage_conf(enable_usage=enable_usage,
+                                num_windows=num_windows,
+                                window_interval=window_interval,
+                                disk_write_interval=disk_write_interval)
+        self._admin.patch_cluster_config(upsert=conf)
+        self._settings = self._settings | conf
+        return conf
+
+    def _get_usage(self, node, include_open, retries=3):
+        exc = None
+        while retries > 0:
+            try:
+                response = self._admin.get_usage(node, include_open)
+                if response == []:
+                    raise RuntimeError("Empty response received")
+                return response
+            except Exception as e:
+                self.redpanda.logger.error(
+                    f"Error making v1/usage request: {e}")
+                retries -= 1
+                time.sleep(1)
+                exc = e
+        raise exc
+
+    def _get_all_usage(self,
+                       include_open=True,
+                       allow_gaps=False,
+                       only_nodes=None):
         """
         Performs an additional check that results are correctly ordered
-        """
-        def validate(node_response):
-            prev_begin = datetime.now()
-            prev_end = datetime.now()
-            for e in node_response:
-                begin = datetime.fromtimestamp(e['begin_timestamp'])
-                if e['open'] is True:
-                    # Open windows have a value of 0 for end timestamp
-                    prev_begin = begin
-                    continue
-                end = datetime.fromtimestamp(e['end_timestamp'])
-                assert begin < end, f"Begin: {begin}, End: {end}"
-                assert begin < prev_begin, f"Begin: {begin}, PrevBegin: {prev_begin}"
-                assert end < prev_end, f"End: {end}, PrevEnd: {prev_end}"
-                prev_begin = begin
-                prev_end = end
 
+        include_open: Make usage requests with the include_open_window option
+        allow_gaps: Assert all closed windows end timestamps match with proceeding begin
+        only_nodes: Make request to a subset of rp nodes
+        """
+        def assert_history(node, node_response):
+            # Ensure no historical results were lost or modified
+            prev = self._previous_response.get(node, None)
+            if prev is not None:
+                assert_usage_consistency(node, prev, node_response)
+            self._previous_response[node] = node_response
+
+        def validate_ts(ts):
+            # All timestamps must be a multiple of the interval in seconds
+            return ts % self.window_interval == 0
+
+        def validate_no_duplicates(response):
+            # Ensure no two entires contain matching begin & end timestamps
+            to_tss = [(x.begin, x.end) for x in response]
+            return len(to_tss) == len(set(to_tss))
+
+        def validate(node, node_response):
+            # Ensure all windows in in chronological order with end timestamp
+            # matching next beginning
+            node_response = parse_usage_response(node_response)
+            assert validate_no_duplicates(node_response), f"{node_response}"
+            prev_begin = float('inf')
+            prev_end = float('inf')
+            for e in node_response:
+                assert validate_ts(e.begin), e.begin
+                if e.is_open is True:
+                    # Open windows have a value of time::now() for end
+                    prev_begin = e.begin
+                    continue
+                assert validate_ts(e.end), e.end
+                # A window may be dropped which would mean this difference
+                # being a multiple of the interval but not less than it
+                assert e.end - e.begin >= self.window_interval, f"Expected interval: {self.window_interval} observed {e.end - e.begin}"
+                assert e.begin < e.end, f"Begin: {e.begin}, End: {e.end}"
+                assert e.begin < prev_begin, f"Begin: {e.begin}, PrevBegin: {prev_begin}"
+                assert e.end < prev_end, f"End: {e.end}, PrevEnd: {prev_end}"
+                if prev_begin != float('inf'):
+                    if not allow_gaps:
+                        assert e.end == prev_begin, f"End: {e.end} PrevEnd: {prev_begin}"
+                    else:
+                        assert e.end <= prev_begin, f"End: {e.end}, PrevBegin: {prev_begin}"
+                prev_begin = e.begin
+                prev_end = e.end
+
+            assert_history(node, node_response)
             return node_response
 
-        # validate() checks results are ordered newest to oldest
+        # validate() checks results are ordered newest to oldest and the timestamps
+        # are multiples of the window interval
+        nodes = self.redpanda.nodes if only_nodes is None else only_nodes
         return flat_map(
-            lambda x: validate(self._admin.get_usage(x, include_open)),
-            self.redpanda.nodes)
+            lambda x: validate(x.name, self._get_usage(x, include_open)),
+            nodes)
 
     def _calculate_total_usage(self, results=None):
         # Total number of ingress/egress bytes across entire cluster
         def all_bytes(x):
-            kafka_ingress = x['kafka_bytes_sent_count']
-            kafka_egress = x['kafka_bytes_received_count']
+            kafka_ingress = x.bytes_sent
+            kafka_egress = x.bytes_received
             return kafka_ingress + kafka_egress
 
         if results is None:
@@ -122,7 +296,7 @@ class UsageTest(RedpandaTest):
         iterations = 1
         prev_usage = self._get_all_usage()
         producer = KafkaCliTools(self.redpanda)
-        while iterations < 37:
+        while iterations < (self.num_windows + 7):
             producer.produce(self.topic, (512 * iterations), 512, acks=1)
             time.sleep(1)
 
@@ -138,43 +312,44 @@ class UsageTest(RedpandaTest):
                 # and the initial non 0 recorded data are also included in the total recorded amt
                 total_data = self._calculate_total_usage(usage)
                 total_prev = self._calculate_total_usage(prev_usage)
-                assert total_data > total_prev, f"Expected {total_data} > {total_prev} itr: {iterations}"
+                assert total_data > 0, "no data observed"
+                assert total_data >= total_prev, f"Expected {total_data} >= {total_prev} itr: {iterations}"
 
             prev_usage = usage
             iterations += 1
 
     @cluster(num_nodes=4)
     def test_usage_collection_restart(self):
-        self._admin.patch_cluster_config(
-            upsert={'usage_disk_persistance_interval_sec': 1})
-        # Ensure the restarted accounting fiber is up before data begins to be produced
-        time.sleep(2)
-
         # Produce / consume test data, should observe usage numbers increase
         _ = self._produce_and_consume_data()
         time.sleep(3)
 
         # Query usage of node to restart before restart
         usage_pre_restart = self._calculate_total_usage(
-            self._admin.get_usage(node=self.redpanda.nodes[0]))
+            self._get_all_usage(include_open=True,
+                                allow_gaps=True,
+                                only_nodes=[self.redpanda.nodes[0]]))
 
         self.redpanda.restart_nodes([self.redpanda.nodes[0]])
 
         # Compare values pre/post restart to ensure data was persisted to disk
         usage_post_restart = self._calculate_total_usage(
-            self._admin.get_usage(node=self.redpanda.nodes[0]))
+            self._get_all_usage(include_open=True,
+                                allow_gaps=True,
+                                only_nodes=[self.redpanda.nodes[0]]))
         assert usage_post_restart >= usage_pre_restart, f"Usage post restart: {usage_post_restart} Usage pre restart: {usage_pre_restart}"
 
     @cluster(num_nodes=3)
     def test_usage_settings_changed(self):
-        # Should expect maximum of 2 windows per broker
-        self._admin.patch_cluster_config(upsert={'usage_num_windows': 2})
-        time.sleep(2)
+        # Should expect maximum of 2 windows per broker (including open)
+        self._modify_settings(num_windows=2)
+        # Wait 3 intervals
+        time.sleep(self.window_interval * 3)
         response = self._get_all_usage()
-        assert len(response) == 6
+        assert len(response) == 6, f"{len(response)}"
 
         # Should expect a 500 from the cluster
-        self._admin.patch_cluster_config(upsert={'enable_usage': False})
+        self._modify_settings(enable_usage=False)
         try:
             _ = self._get_all_usage()
             assert False, "Expecting v1/usage to return 400"
@@ -182,19 +357,15 @@ class UsageTest(RedpandaTest):
             assert e.response.status_code == 400
 
         # Should expect windows to have been resized correctly
-        self._admin.patch_cluster_config(
-            upsert={
-                'enable_usage': True,
-                'usage_num_windows': 3,
-                'usage_window_width_interval_sec': 2
-            })
-        time.sleep(3)
-        response = self._get_all_usage(False)
+        self._modify_settings(enable_usage=True,
+                              num_windows=3,
+                              window_interval=2,
+                              disk_write_interval=5)
+        time.sleep(self.window_interval * 5)
+        response = self._get_all_usage(include_open=False, allow_gaps=True)
         for r in response:
-            begin = datetime.fromtimestamp(r['begin_timestamp'])
-            end = datetime.fromtimestamp(r['end_timestamp'])
-            total = end - begin
-            assert total.seconds == 2 or total.seconds == 3, total.seconds
+            if r.is_closed:
+                assert (r.end - r.begin) == self.window_interval
 
 
 class UsageTestCloudStorageMetrics(RedpandaTest):
@@ -284,10 +455,11 @@ class UsageTestCloudStorageMetrics(RedpandaTest):
             # Check that the usage reporting system has reported correct values
             manifest_usage = bucket_view.cloud_log_sizes_sum().total(
                 no_archive=True)
-            reported_usage = self.admin.get_usage(
-                random.choice(self.redpanda.nodes))
+            # Only active leader will have latest value of cs_bytes
+            reported_usages = flat_map(lambda node: self.admin.get_usage(node),
+                                       self.redpanda.nodes)
             reported_usages = [
-                x['cloud_storage_bytes_gauge'] for x in reported_usage
+                x['cloud_storage_bytes_gauge'] for x in reported_usages
             ]
 
             self.logger.info(


### PR DESCRIPTION
This change modifies how all nodes aggregate their usage metrics. Usage metrics are currently a feature needed to implement cloud billing. Previously all nodes independently opened their initial bucket on startup. This means that there would be a cluster-wide skew on the open/close interval of all aggregated usage data.

To prevent this skew this PR modifies the behavior to roll back the open time of the first usage bucket to the nearest hour. That way all nodes will have their buckets aligned to an hour and consumers of this data can properly aggregate it by time.

Fixes:  #11451

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Modifies usage metrics to be aligned by the configured interval
