### PR TITLE
storage: Use async_stream_zstd compression

### DIFF
--- a/src/v/compression/compression.h
+++ b/src/v/compression/compression.h
@@ -23,4 +23,12 @@ struct compressor {
     static iobuf uncompress(const iobuf&, type);
 };
 
+// A simple opinionated stream compressor.
+//
+// Will use stream compression when available, to defer to compressor.
+struct stream_compressor {
+    static ss::future<iobuf> compress(iobuf, type);
+    static ss::future<iobuf> uncompress(iobuf, type);
+};
+
 } // namespace compression

--- a/src/v/storage/parser_utils.h
+++ b/src/v/storage/parser_utils.h
@@ -52,10 +52,7 @@ model::record_batch maybe_decompress_batch_sync(const model::record_batch&);
 
 /// \brief batch compression
 ss::future<model::record_batch>
-compress_batch(model::compression, model::record_batch&&);
-/// \brief batch compression
-ss::future<model::record_batch>
-compress_batch(model::compression, const model::record_batch&);
+  compress_batch(model::compression, model::record_batch);
 
 /// \brief resets the size, header crc and payload crc
 void reset_size_checksum_metadata(model::record_batch_header&, const iobuf&);


### PR DESCRIPTION
To avoid large allocations and stalls, introduce a `compression::stream_compressor`, and use it in parse_utils for asynchronous compression.

This is a base that can be built on for decompression and other codecs.

Fixes #11934

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* Avoid large allocations with zstd compacted topics.
