### PR TITLE
r/append_entries_buffer: use chunked fifo to store requests

### DIFF
--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -91,7 +91,7 @@ ss::future<> append_entries_buffer::flush() {
 ss::future<> append_entries_buffer::do_flush(
   request_t requests, response_t response_promises, ssx::semaphore_units u) {
     bool needs_flush = false;
-    std::vector<reply_t> replies;
+    reply_list_t replies;
     auto f = ss::now();
     {
         ssx::semaphore_units op_lock_units = std::move(u);
@@ -123,7 +123,7 @@ ss::future<> append_entries_buffer::do_flush(
 }
 
 void append_entries_buffer::propagate_results(
-  std::vector<reply_t> replies, response_t response_promises) {
+  reply_list_t replies, response_t response_promises) {
     vassert(
       replies.size() == response_promises.size(),
       "Number of requests and response promiseshave to be equal. Have {} "


### PR DESCRIPTION
Append entries buffer is used to coalesce multiple append entry requests into single batch and reduce number of flushes. Usually the size of the batch is small. In some case when it grows larger it may end up in causing large contiguous allocation.

Replaced vector used to buffer pending requests with a `chunked_fifo`. The chunk size was set to 32 as usually the size of the queue is small.

Fixes: #12072

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none