### PR TITLE
add slash command for triggering arm64 tests

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -5,6 +5,7 @@ on:
       - test-codecov-command
       - cdt-command
       - test-release-pipeline-command
+      - test-arm64-command
 
 jobs:
   run-build:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -18,6 +18,7 @@ jobs:
             test-codecov
             cdt
             test-release-pipeline
+            test-arm64
           static-args: |
             org=redpanda-data
             repo=redpanda


### PR DESCRIPTION
Add slash command to trigger `arm64` tests on PR builds. This will skip `amd64` (debug\+release) and will only trigger `arm64` build\+test

ref redpanda-data/devprod#432

## Depends on

This PR depends on merging the corresponding one in vtools: https://github.com/redpanda-data/vtools/pull/1963

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
