### PR TITLE
[v23.1.x] r/append_entries_buffer: use chunked fifo to store requests

### DIFF
--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -91,7 +91,7 @@ ss::future<> append_entries_buffer::flush() {
 ss::future<> append_entries_buffer::do_flush(
   request_t requests, response_t response_promises, ssx::semaphore_units u) {
     bool needs_flush = false;
-    std::vector<reply_t> replies;
+    reply_list_t replies;
     auto f = ss::now();
     {
         ssx::semaphore_units op_lock_units = std::move(u);
@@ -123,7 +123,7 @@ ss::future<> append_entries_buffer::do_flush(
 }
 
 void append_entries_buffer::propagate_results(
-  std::vector<reply_t> replies, response_t response_promises) {
+  reply_list_t replies, response_t response_promises) {
     vassert(
       replies.size() == response_promises.size(),
       "Number of requests and response promiseshave to be equal. Have {} "


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12074
Fixes: https://github.com/redpanda-data/redpanda/issues/12077,