### PR TITLE
acl: Avoid allocations when checking implied ops

### DIFF
--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -403,26 +403,6 @@ std::ostream& operator<<(std::ostream& o, const acl_binding_filter& f) {
     return o;
 }
 
-std::vector<acl_operation> acl_implied_ops(acl_operation operation) {
-    switch (operation) {
-    case acl_operation::describe:
-        return {
-          acl_operation::describe,
-          acl_operation::read,
-          acl_operation::write,
-          acl_operation::remove,
-          acl_operation::alter,
-        };
-    case acl_operation::describe_configs:
-        return {
-          acl_operation::describe_configs,
-          acl_operation::alter_configs,
-        };
-    default:
-        return {operation};
-    }
-}
-
 bool acl_entry_filter::matches(const acl_entry& other) const {
     if (_principal && _principal != other.principal()) {
         return false;

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -96,11 +96,6 @@ enum class acl_operation : int8_t {
     idempotent_write = 10,
 };
 
-/*
- * Compute the implied operations based on the specified operation.
- */
-std::vector<acl_operation> acl_implied_ops(acl_operation operation);
-
 std::ostream& operator<<(std::ostream&, acl_operation);
 
 /*

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -111,14 +111,7 @@ public:
         }
 
         // check for allow
-        auto ops = acl_implied_ops(operation);
-        return std::any_of(
-          ops.cbegin(),
-          ops.cend(),
-          [&acls, &principal, &host](acl_operation operation) {
-              return acls.contains(
-                operation, principal, host, acl_permission::allow);
-          });
+        return acl_any_implied_ops_allowed(acls, principal, host, operation);
     }
 
     ss::future<fragmented_vector<acl_binding>> all_bindings() const {
@@ -131,6 +124,42 @@ public:
     }
 
 private:
+    /*
+     * Compute whether the specified operation is allowed based on the implied
+     * operations.
+     */
+    bool acl_any_implied_ops_allowed(
+      const acl_matches& acls,
+      const acl_principal& principal,
+      const acl_host& host,
+      const acl_operation operation) const {
+        auto check_op = [&acls, &principal, &host](acl_operation operation) {
+            return acls.contains(
+              operation, principal, host, acl_permission::allow);
+        };
+
+        switch (operation) {
+        case acl_operation::describe: {
+            static constexpr std::array ops = {
+              acl_operation::describe,
+              acl_operation::read,
+              acl_operation::write,
+              acl_operation::remove,
+              acl_operation::alter,
+            };
+            return std::any_of(ops.begin(), ops.end(), check_op);
+        }
+        case acl_operation::describe_configs: {
+            static constexpr std::array ops = {
+              acl_operation::describe_configs,
+              acl_operation::alter_configs,
+            };
+            return std::any_of(ops.begin(), ops.end(), check_op);
+        }
+        default:
+            return check_op(operation);
+        }
+    }
     acl_store _store;
 
     // The list of superusers is stored twice: once as a vector in the


### PR DESCRIPTION
`acl_implied_ops` was quite visible (~3%) in the callchains leading to `operator new()` in the LRC profile.

It's called for every partition so this is not entirely surprising when using larger partition counts.

Avoid the allocations by "inlining" the check into the function so that no vector has to be allocated.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [x] v22.3.x
- [ ] v22.2.x

## Release Notes

* none


