### PR TITLE
rptest: Unconditionally enable verbose logging for all rpk commands in ducktape

### DIFF
--- a/src/go/rpk/pkg/cli/group/offset_delete.go
+++ b/src/go/rpk/pkg/cli/group/offset_delete.go
@@ -12,6 +12,7 @@ package group
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
@@ -81,15 +82,20 @@ topic_b 0
 			out.MaybeDieErr(err)
 
 			tw := out.NewTabWriter()
-			defer tw.Flush()
+			ok := true
 			for topic, partitionErrors := range responses {
 				for partition, err := range partitionErrors {
 					msg := "OK"
 					if err != nil {
+						ok = false
 						msg = err.Error()
 					}
 					fmt.Fprintf(tw, "%s\t%d\t%s\n", topic, partition, msg)
 				}
+			}
+			tw.Flush()
+			if !ok { // At least one row contained an error.
+				os.Exit(1)
 			}
 		},
 	}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -36,10 +36,14 @@ class ClusterAuthorizationError(Exception):
 
 
 class RpkException(Exception):
-    def __init__(self, msg, stderr="", returncode=None):
+    def __init__(self, msg, stderr="", returncode=None, stdout=""):
         self.msg = msg
+        self.stdout = stdout
         self.stderr = stderr
         self.returncode = returncode
+        # Useful for when its desired to still propogate parsed stdout
+        # to caller when when rpk exits 1
+        self.parsed_output = None
 
     def __str__(self):
         if self.stderr:
@@ -50,7 +54,11 @@ class RpkException(Exception):
             retcode = f" returncode: {self.returncode}"
         else:
             retcode = ""
-        return f"RpkException<{self.msg}{err}{retcode}>"
+        if self.stdout:
+            stdout = f" stdout: {self.stdout}"
+        else:
+            stdout = ""
+        return f"RpkException<{self.msg}{err}{stdout}{retcode}>"
 
 
 class RpkPartition:
@@ -902,7 +910,7 @@ class RpkTool:
             raise RpkException(
                 'command %s returned %d, output: %s' %
                 (' '.join(cmd) if log_cmd else '[redacted]', p.returncode,
-                 output), stderror, p.returncode)
+                 output), stderror, p.returncode, output)
         else:
             # Send the verbose output of rpk to debug logger
             self._redpanda.logger.debug(f"\n{stderror}")
@@ -1121,8 +1129,8 @@ class RpkTool:
                 r"\s*(?P<topic>\S*)\s*(?P<partition>\d*)\s*(?P<status>\w+):?(?P<error>.*)"
             )
             matched = [regex.match(x) for x in output]
-            failed_matches = [x for x in matched if x is None]
-            if len(failed_matches) > 0:
+            failed_matches = any([x for x in matched if x is None])
+            if failed_matches:
                 raise RuntimeError("Failed to parse offset-delete output")
             return [
                 RpkOffsetDeleteResponsePartition(x['topic'],
@@ -1131,19 +1139,7 @@ class RpkTool:
                 for x in matched
             ]
 
-        def parse_offset_delete_output_err(output):
-            if len(output) == 0:
-                raise RuntimeError("Unexpected rpk output")
-            regex = re.compile(r"(\w*):(.*)")
-            matched = regex.match(output[0])
-            if matched is None:
-                raise RuntimeError("Failed to parse offset-delete output")
-            return RpkOffsetDeleteResponsePartition(None, None,
-                                                    matched.group(1),
-                                                    matched.group(2))
-
         def try_offset_delete(retries=5):
-            retriable_codes = set(['NOT_COORDINATOR'])
             while retries > 0:
                 try:
                     output = self._execute(cmd)
@@ -1151,9 +1147,10 @@ class RpkTool:
                 except RpkException as e:
                     if e.returncode != 1:
                         raise e
-                    err = parse_offset_delete_output_err(e.stderr.splitlines())
-                    if err.status not in retriable_codes:
-                        return err
+                    if not 'NOT_COORDINATOR' in str(e):
+                        e.parsed_output = parse_offset_delete_output(
+                            e.stdout.splitlines())
+                        raise e
                     retries -= 1
             raise RpkException("Max number of retries exceeded")
 
@@ -1184,7 +1181,7 @@ class RpkTool:
             group,
         ] + request_args_w_flags
 
-        # Retry if the command exits 1 (in case top level ec was returned)
+        # Retry if NOT_COORDINATOR is observed when command exits 1
         return try_offset_delete(retries=5)
 
     def generate_grafana(self, dashboard):


### PR DESCRIPTION
We want to always have all rpk commands logged at the verbose level so its easier to debug future problems. This specifically will be useful in tracking down the root cause of issue https://github.com/redpanda-data/redpanda/issues/11829

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
