### PR TITLE
rpk: profile globals rename

### DIFF
--- a/src/go/rpk/pkg/cli/profile/edit_gobals.go
+++ b/src/go/rpk/pkg/cli/profile/edit_gobals.go
@@ -19,14 +19,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newEditDefaultsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newEditGlobalsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "edit-defaults",
-		Short: "Edit rpk defaults",
-		Long: `Edit rpk defaults.
+		Use:   "edit-globals",
+		Short: "Edit rpk globals",
+		Long: `Edit rpk globals.
 
-This command opens your default editor to edit the specified profile, or
-the current profile if no profile is specified.
+This command opens your default editor to edit the rpk global configurations.
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(*cobra.Command, []string) {
@@ -35,12 +34,12 @@ the current profile if no profile is specified.
 			y, err := cfg.ActualRpkYamlOrEmpty()
 			out.MaybeDie(err, "unable to load config: %v", err)
 
-			y.Defaults, err = rpkos.EditTmpYAMLFile(fs, y.Defaults)
+			y.Globals, err = rpkos.EditTmpYAMLFile(fs, y.Globals)
 			out.MaybeDieErr(err)
 
 			err = y.Write(fs)
 			out.MaybeDie(err, "unable to write rpk.yaml: %v", err)
-			fmt.Println("Defaults updated successfully.")
+			fmt.Println("Global configurations updated successfully.")
 		},
 	}
 	return cmd

--- a/src/go/rpk/pkg/cli/profile/print_globals.go
+++ b/src/go/rpk/pkg/cli/profile/print_globals.go
@@ -19,18 +19,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func newPrintDefaultsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newPrintGlobalsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	return &cobra.Command{
-		Use:   "print-defaults",
-		Short: "Print rpk default",
-		Long:  `Print rpk defaults.`,
+		Use:   "print-globals",
+		Short: "Print rpk global configuration",
 		Args:  cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, args []string) {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 
 			y := cfg.VirtualRpkYaml()
-			m, err := yaml.Marshal(y.Defaults)
+			m, err := yaml.Marshal(y.Globals)
 			out.MaybeDie(err, "unable to encode profile: %v", err)
 			fmt.Println(string(m))
 		},

--- a/src/go/rpk/pkg/cli/profile/profile.go
+++ b/src/go/rpk/pkg/cli/profile/profile.go
@@ -37,14 +37,14 @@ your configuration in one place.
 		newCurrentCommand(fs, p),
 		newDeleteCommand(fs, p),
 		newEditCommand(fs, p),
-		newEditDefaultsCommand(fs, p),
+		newEditGlobalsCommand(fs, p),
 		newListCommand(fs, p),
 		newPrintCommand(fs, p),
-		newPrintDefaultsCommand(fs, p),
+		newPrintGlobalsCommand(fs, p),
 		newPromptCommand(fs, p),
 		newRenameToCommand(fs, p),
 		newSetCommand(fs, p),
-		newSetDefaultsCommand(fs, p),
+		newSetGlobalsCommand(fs, p),
 		newUseCommand(fs, p),
 	)
 

--- a/src/go/rpk/pkg/cli/profile/prompt.go
+++ b/src/go/rpk/pkg/cli/profile/prompt.go
@@ -93,7 +93,7 @@ Four modifiers are supported, "bold", "faint", "underline", and "invert".
 				return
 			}
 
-			prompt := cfg.VirtualRpkYaml().Defaults.Prompt
+			prompt := cfg.VirtualRpkYaml().Globals.Prompt
 			if p.Prompt != "" {
 				prompt = p.Prompt
 			}

--- a/src/go/rpk/pkg/cli/profile/prompt.go
+++ b/src/go/rpk/pkg/cli/profile/prompt.go
@@ -209,6 +209,9 @@ func parsePrompt(s string, name string) (string, []color.Attribute, error) {
 			output = append(output, c)
 		}
 	}
+	if len(s) != 0 && len(text) == 0 {
+		output = append(output, name...)
+	}
 	return string(output), attrs, nil
 }
 

--- a/src/go/rpk/pkg/cli/profile/prompt_test.go
+++ b/src/go/rpk/pkg/cli/profile/prompt_test.go
@@ -60,7 +60,7 @@ func TestParsePrompt(t *testing.T) {
 		{`\"blue\"`, "", nil, true},          // backslash only allowed in quoted str
 		{` "prompt" `, "prompt", nil, false}, // simple
 		{`unknown-thing `, "", nil, true},    // unknown keyword stripped
-		{`blue	green red, bg-hi-blue`, "", []color.Attribute{color.FgBlue, color.FgGreen, color.FgRed, color.BgHiBlue}, false}, // attr at end is kept
+		{`blue	green red, bg-hi-blue`, "foo", []color.Attribute{color.FgBlue, color.FgGreen, color.FgRed, color.BgHiBlue}, false}, // attr at end is kept, name is added by default
 		{` " %n " `, " foo ", nil, false},   // name swapped in
 		{`"\\\%%%%n"`, "\\%%n", nil, false}, // escaping works, and %% works
 		{`"text1" "text2"`, "", nil, true},  // one quoted string

--- a/src/go/rpk/pkg/cli/profile/set.go
+++ b/src/go/rpk/pkg/cli/profile/set.go
@@ -98,7 +98,7 @@ func validSetArgs(_ *cobra.Command, _ []string, toComplete string) (ps []string,
 	}()
 
 	xf, ypaths := config.XProfileFlags()
-	ypaths = append(ypaths, "description") // we have no xflag for the description field since this is purely informational
+	ypaths = append(ypaths, "description", "prompt") // we have no xflag for the description nor prompt field, the latter is a global that can also be edited per profile
 	if len(toComplete) == 0 {
 		return ypaths, cobra.ShellCompDirectiveNoSpace
 	}

--- a/src/go/rpk/pkg/cli/profile/set_globals.go
+++ b/src/go/rpk/pkg/cli/profile/set_globals.go
@@ -19,24 +19,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSetDefaultsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newSetGlobalsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	return &cobra.Command{
-		Use:   "set-defaults [KEY=VALUE]+",
-		Short: "Set rpk default fields",
-		Long: `Set rpk default fields.
+		Use:   "set-globals [KEY=VALUE]+",
+		Short: "Set rpk globals fields",
+		Long: `Set rpk globals fields.
 
-This command takes a list of key=value pairs to write to the defaults section
-of rpk.yaml. The defaults section contains a set of settings that apply to all
-profiles and changes the way that rpk acts. For a list of default flags and
-what they mean, check 'rpk -X help' and look for any key that begins with
-"defaults".
+This command takes a list of key=value pairs to write to the global config 
+section of rpk.yaml. The globals section contains a set of settings that apply
+to all profiles and changes the way that rpk acts. For a list of global flags
+and what they mean, check 'rpk -X help' and look for any key that begins with
+"globals".
 
 This command supports autocompletion of valid keys. You can also use the
 format 'set key value' if you intend to only set one key.
 `,
 
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: validSetDefaultsArgs,
+		ValidArgsFunction: validSetGlobalArgs,
 		Run: func(_ *cobra.Command, args []string) {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
@@ -51,7 +51,7 @@ format 'set key value' if you intend to only set one key.
 			y, err := cfg.ActualRpkYamlOrEmpty()
 			out.MaybeDie(err, "unable to load rpk.yaml: %v", err)
 
-			err = doSetDefaults(y, args)
+			err = doSetGlobals(y, args)
 			out.MaybeDieErr(err)
 			err = y.Write(fs)
 			out.MaybeDieErr(err)
@@ -60,7 +60,7 @@ format 'set key value' if you intend to only set one key.
 	}
 }
 
-func doSetDefaults(y *config.RpkYaml, set []string) error {
+func doSetGlobals(y *config.RpkYaml, set []string) error {
 	for _, kv := range set {
 		split := strings.SplitN(kv, "=", 2)
 		if len(split) != 2 {
@@ -78,9 +78,9 @@ func doSetDefaults(y *config.RpkYaml, set []string) error {
 	return nil
 }
 
-func validSetDefaultsArgs(_ *cobra.Command, _ []string, toComplete string) (ps []string, d cobra.ShellCompDirective) {
+func validSetGlobalArgs(_ *cobra.Command, _ []string, toComplete string) (ps []string, d cobra.ShellCompDirective) {
 	var possibilities []string
-	_, ypaths := config.XRpkDefaultsFlags()
+	_, ypaths := config.XRpkGlobalFlags()
 	for _, p := range ypaths {
 		if strings.HasPrefix(p, toComplete) {
 			possibilities = append(possibilities, p+"=")

--- a/src/go/rpk/pkg/cli/topic/trim.go
+++ b/src/go/rpk/pkg/cli/topic/trim.go
@@ -102,7 +102,7 @@ Trim records from a JSON file
 				err := printDeleteRecordRequest(cmd.Context(), adm, o)
 				out.MaybeDie(err, "unable to print trimming request: %v", err)
 				fmt.Println()
-				confirmed, err := out.Confirm("Confirm trimming of the above offsets?")
+				confirmed, err := out.Confirm("Confirm deletion of all data before the new start offsets?")
 				out.MaybeDie(err, "unable to confirm: %v", err)
 				if !confirmed {
 					out.Exit("Trimming canceled.")

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -325,12 +325,12 @@ var xflags = map[string]xflag{
 		},
 	},
 
-	"globals.redpanda_client_id": {
-		"globals.redpanda_client_id",
+	"globals.kafka_protocol_request_client_id": {
+		"globals.kafka_protocol_request_client_id",
 		"rpk",
 		xkindGlobal,
 		func(v string, y *RpkYaml) error {
-			y.Globals.RedpandaClientID = v
+			y.Globals.KafkaProtocolReqClientID = v
 			return nil
 		},
 	},
@@ -532,7 +532,7 @@ globals.fetch_max_wait=5s
   This timeout specifies the maximum time that brokers will wait before
   replying to a fetch request with whatever data is available.
 
-globals.redpanda_client_id=rpk
+globals.kafka_protocol_request_client_id=rpk
   This string value is the client ID that rpk uses when issuing Kafka protocol
   requests to Redpanda. This client ID shows up in Redpanda logs and metrics,
   changing it can be useful if you want to have your own rpk client stand out
@@ -563,7 +563,7 @@ globals.dial_timeout=duration(3s,1m,2h)
 globals.request_timeout_overhead=duration(10s,1m,2h)
 globals.retry_timeout=duration(30s,1m,2h)
 globals.fetch_max_wait=duration(5s,1m,2h)
-globals.redpanda_client_id=rpk
+globals.kafka_protocol_request_client_id=rpk
 `
 }
 

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -71,7 +71,7 @@ const (
 const (
 	xkindProfile   = iota // configuration for the current profile
 	xkindCloudAuth        // configuration for the current cloud_auth
-	xkindDefault          // configuration for rpk.yaml defaults
+	xkindGlobal           // configuration for rpk.yaml globals
 )
 
 type xflag struct {
@@ -268,69 +268,69 @@ var xflags = map[string]xflag{
 		},
 	},
 
-	"defaults.prompt": {
-		"defaults.prompt",
+	"globals.prompt": {
+		"globals.prompt",
 		"bg-red \"%n\"",
-		xkindDefault,
+		xkindGlobal,
 		func(v string, y *RpkYaml) error {
-			y.Defaults.Prompt = v
+			y.Globals.Prompt = v
 			return nil
 		},
 	},
 
-	"defaults.no_default_cluster": {
-		"defaults.no_default_cluster",
+	"globals.no_default_cluster": {
+		"globals.no_default_cluster",
 		"false",
-		xkindDefault,
+		xkindGlobal,
 		func(v string, y *RpkYaml) error {
 			b, err := strconv.ParseBool(v)
-			y.Defaults.NoDefaultCluster = b
+			y.Globals.NoDefaultCluster = b
 			return err
 		},
 	},
 
-	"defaults.dial_timeout": {
-		"defaults.dial_timeout",
+	"globals.dial_timeout": {
+		"globals.dial_timeout",
 		"3s",
-		xkindDefault,
+		xkindGlobal,
 		func(v string, y *RpkYaml) error {
-			return y.Defaults.DialTimeout.UnmarshalText([]byte(v))
+			return y.Globals.DialTimeout.UnmarshalText([]byte(v))
 		},
 	},
 
-	"defaults.request_timeout_overhead": {
-		"defaults.request_timeout_overhead",
+	"globals.request_timeout_overhead": {
+		"globals.request_timeout_overhead",
 		"10s",
-		xkindDefault,
+		xkindGlobal,
 		func(v string, y *RpkYaml) error {
-			return y.Defaults.RequestTimeoutOverhead.UnmarshalText([]byte(v))
+			return y.Globals.RequestTimeoutOverhead.UnmarshalText([]byte(v))
 		},
 	},
 
-	"defaults.retry_timeout": {
-		"defaults.retry_timeout",
+	"globals.retry_timeout": {
+		"globals.retry_timeout",
 		"30s",
-		xkindDefault,
+		xkindGlobal,
 		func(v string, y *RpkYaml) error {
-			return y.Defaults.RetryTimeout.UnmarshalText([]byte(v))
+			return y.Globals.RetryTimeout.UnmarshalText([]byte(v))
 		},
 	},
 
-	"defaults.fetch_max_wait": {
-		"defaults.fetch_max_wait",
+	"globals.fetch_max_wait": {
+		"globals.fetch_max_wait",
 		"5s",
-		xkindDefault,
+		xkindGlobal,
 		func(v string, y *RpkYaml) error {
-			return y.Defaults.FetchMaxWait.UnmarshalText([]byte(v))
+			return y.Globals.FetchMaxWait.UnmarshalText([]byte(v))
 		},
 	},
 
-	"defaults.redpanda_client_id": {
-		"defaults.redpanda_client_id",
+	"globals.redpanda_client_id": {
+		"globals.redpanda_client_id",
 		"rpk",
-		xkindDefault,
+		xkindGlobal,
 		func(v string, y *RpkYaml) error {
-			y.Defaults.RedpandaClientID = v
+			y.Globals.RedpandaClientID = v
 			return nil
 		},
 	},
@@ -367,12 +367,12 @@ func XCloudAuthFlags() (xs, yamlPaths []string) {
 	return
 }
 
-// XRpkDefaultsFlags returns all X flags that modify rpk defaults, and their
-// corresponding yaml paths. Note that for rpk defaults, the X flags always
-// have the same name as the yaml path and always begin with "defaults.".
-func XRpkDefaultsFlags() (xs, yamlPaths []string) {
+// XRpkGlobalFlags returns all X flags that modify rpk globals, and their
+// corresponding yaml paths. Note that for rpk globals, the X flags always
+// have the same name as the yaml path and always begin with "globals.".
+func XRpkGlobalFlags() (xs, yamlPaths []string) {
 	for k, v := range xflags {
-		if v.kind == xkindDefault {
+		if v.kind == xkindGlobal {
 			xs = append(xs, k)
 			yamlPaths = append(yamlPaths, v.path)
 		}
@@ -503,36 +503,36 @@ cloud.client_id=somestring
 cloud.client_secret=somelongerstring
   An oauth client secret to use for authenticating with the Redpanda Cloud API.
 
-defaults.prompt="%n"
+globals.prompt="%n"
   A format string to use for the default prompt; see 'rpk profile prompt' for
   more information.
 
-defaults.no_default_cluster=false
+globals.no_default_cluster=false
   A boolean that disables rpk from talking to localhost:9092 if no other
   cluster is specified.
 
-defaults.dial_timeout=3s
+globals.dial_timeout=3s
   A duration that rpk will wait for a connection to be established before
   timing out.
 
-defaults.request_timeout_overhead=10s
+globals.request_timeout_overhead=10s
   A duration that limits how long rpk waits for responses, *on top* of any
   request-internal timeout. For example, ListOffsets has no Timeout field so
   if request_timeout_overhead is 10s, rpk will wait for 10s for a response.
   However, JoinGroup has a RebalanceTimeoutMillis field, so the 10s is applied
   on top of the rebalance timeout.
 
-defaults.retry_timeout=30s
+globals.retry_timeout=30s
   This timeout specifies how long rpk will retry Kafka API requests. This
   timeout is evaluated before any backoff -- if a request fails, we first check
   if the retry timeout has elapsed and if so, we stop retrying. If not, we wait
   for the backoff and then retry.
 
-defaults.fetch_max_wait=5s
+globals.fetch_max_wait=5s
   This timeout specifies the maximum time that brokers will wait before
   replying to a fetch request with whatever data is available.
 
-defaults.redpanda_client_id=rpk
+globals.redpanda_client_id=rpk
   This string value is the client ID that rpk uses when issuing Kafka protocol
   requests to Redpanda. This client ID shows up in Redpanda logs and metrics,
   changing it can be useful if you want to have your own rpk client stand out
@@ -557,13 +557,13 @@ admin.tls.cert=/path/to/cert.pem
 admin.tls.key=/path/to/key.pem
 cloud.client_id=somestring
 cloud.client_secret=somelongerstring
-defaults.prompt="%n"
-defaults.no_default_cluster=boolean
-defaults.dial_timeout=duration(3s,1m,2h)
-defaults.request_timeout_overhead=duration(10s,1m,2h)
-defaults.retry_timeout=duration(30s,1m,2h)
-defaults.fetch_max_wait=duration(5s,1m,2h)
-defaults.redpanda_client_id=rpk
+globals.prompt="%n"
+globals.no_default_cluster=boolean
+globals.dial_timeout=duration(3s,1m,2h)
+globals.request_timeout_overhead=duration(10s,1m,2h)
+globals.retry_timeout=duration(30s,1m,2h)
+globals.fetch_max_wait=duration(5s,1m,2h)
+globals.redpanda_client_id=rpk
 `
 }
 
@@ -769,7 +769,7 @@ func (p *Params) Load(fs afero.Fs) (*Config, error) {
 	c.addConfigToProfiles()
 	c.parseDevOverrides()
 
-	if !c.rpkYaml.Defaults.NoDefaultCluster {
+	if !c.rpkYaml.Globals.NoDefaultCluster {
 		c.ensureBrokerAddrs()
 	}
 

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -1041,7 +1041,7 @@ func TestXSetExamples(t *testing.T) {
 	for _, fn := range []func() (xs, yamlPaths []string){
 		XProfileFlags,
 		XCloudAuthFlags,
-		XRpkDefaultsFlags,
+		XRpkGlobalFlags,
 	} {
 		xs, yamlPaths := fn()
 		for i, x := range xs {
@@ -1059,7 +1059,7 @@ func TestXSetExamples(t *testing.T) {
 				err = Set(new(RpkProfile), yamlPath, xf.testExample)
 			case xkindCloudAuth:
 				err = Set(new(RpkCloudAuth), yamlPath, xf.testExample)
-			case xkindDefault:
+			case xkindGlobal:
 				err = Set(new(RpkYaml), yamlPath, xf.testExample)
 			default:
 				t.Errorf("unrecognized xflag kind %v", xf.kind)
@@ -1077,13 +1077,13 @@ func TestXSetExamples(t *testing.T) {
 }
 
 func TestXSetDefaultsPaths(t *testing.T) {
-	xs, paths := XRpkDefaultsFlags()
+	xs, paths := XRpkGlobalFlags()
 	for i, x := range xs {
 		if paths[i] != x {
-			t.Errorf("XRpkDefaultsFlags() returned different xflag %s and path %s", x, paths[i])
+			t.Errorf("XRpkGlobalFlags() returned different xflag %s and path %s", x, paths[i])
 		}
-		if !strings.HasPrefix(x, "defaults.") {
-			t.Errorf("XRpkDefaultsFlags() returned xflag %s that doesn't start with defaults.", x)
+		if !strings.HasPrefix(x, "globals.") {
+			t.Errorf("XRpkGlobalFlags() returned xflag %s that doesn't start with globals.", x)
 		}
 	}
 }

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -121,8 +121,8 @@ type (
 		// fetch requests.
 		FetchMaxWait Duration `yaml:"fetch_max_wait"`
 
-		// RedpandaClientID is the client ID to use for the Kafka API.
-		RedpandaClientID string `yaml:"redpanda_client_id"`
+		// KafkaProtocolReqClientID is the client ID to use for the Kafka API.
+		KafkaProtocolReqClientID string `yaml:"kafka_protocol_request_client_id"`
 	}
 
 	RpkProfile struct {

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -86,7 +86,7 @@ type (
 		// upgrade rpk".
 		Version int `yaml:"version"`
 
-		Defaults RpkDefaults `yaml:"defaults,omitempty"`
+		Globals RpkGlobals `yaml:"globals,omitempty"`
 
 		CurrentProfile   string         `yaml:"current_profile"`
 		CurrentCloudAuth string         `yaml:"current_cloud_auth"`
@@ -94,7 +94,7 @@ type (
 		CloudAuths       []RpkCloudAuth `yaml:"cloud_auth,omitempty"`
 	}
 
-	RpkDefaults struct {
+	RpkGlobals struct {
 		// Prompt is the prompt to use for all profiles, unless the
 		// profile itself overrides it.
 		Prompt string `yaml:"prompt"`
@@ -249,8 +249,8 @@ func (p *RpkProfile) SugarLogger() *zap.SugaredLogger {
 }
 
 // Defaults returns the virtual defaults for the rpk.yaml.
-func (p *RpkProfile) Defaults() *RpkDefaults {
-	return &p.c.rpkYaml.Defaults
+func (p *RpkProfile) Defaults() *RpkGlobals {
+	return &p.c.rpkYaml.Globals
 }
 
 // CurrentAuth returns the current cloud Auth.

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -119,7 +119,7 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		v1sha = "0f2ca9327b6ea07b93e37909c7c2c4eb1497d953038386443d6bac553f36b4fa" // 23-07-13
+		v1sha = "80da2a033d75b87212732138f5a4f9acbecee31a8d8c8be96afb2625f2b4f202" // 23-07-13
 	)
 
 	if shastr != v1sha {

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -119,7 +119,7 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		v1sha = "2ad0d7eee688f2a38a0ca126c919bbc5af2c42b6c848fa40947dfc6dd5a2fce3" // 23-06-08
+		v1sha = "0f2ca9327b6ea07b93e37909c7c2c4eb1497d953038386443d6bac553f36b4fa" // 23-07-13
 	)
 
 	if shastr != v1sha {

--- a/src/go/rpk/pkg/kafka/client_franz.go
+++ b/src/go/rpk/pkg/kafka/client_franz.go
@@ -92,7 +92,7 @@ func NewFranzClient(fs afero.Fs, p *config.RpkProfile, extraOpts ...kgo.Opt) (*k
 	if d := d.FetchMaxWait; d.Duration != 0 {
 		opts = append(opts, kgo.FetchMaxWait(d.Duration))
 	}
-	if id := d.RedpandaClientID; id != "" {
+	if id := d.KafkaProtocolReqClientID; id != "" {
 		opts = append(opts, kgo.ClientID(id))
 	}
 


### PR DESCRIPTION
Addressing a few feedbacks:

- Renaming profile defaults -> globals.
- Defaulting to printing the name of the profile in `rpk profile prompt` if the prompt string is not empty.
- Renaming `redpanda_client_id` to `kafka_protocol_request_client_id`
- Reword of confirmation prompt text in `rpk topic trim`

## Backports Required
- [ ] none - issue does not exist in previous branches


These features have not been released yet:

## Release Notes
* none
