### PR TITLE
rpk: make num flag required in add-partitions

### DIFF
--- a/src/go/rpk/pkg/cli/topic/add_partitions.go
+++ b/src/go/rpk/pkg/cli/topic/add_partitions.go
@@ -47,7 +47,7 @@ func newAddPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			defer adm.Close()
 
 			if num <= 0 {
-				out.Die("No additional partitions requested, exiting!")
+				out.Die("--num (-n) should be a positive value, exiting!")
 			}
 
 			resps, err := adm.CreatePartitions(context.Background(), num, topics...)
@@ -78,6 +78,7 @@ func newAddPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVarP(&num, "num", "n", 0, "Number of partitions to add to each topic")
+	cmd.MarkFlagRequired("num")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force change the partition count in internal topics, e.g. __consumer_offsets.")
 	return cmd
 }


### PR DESCRIPTION
This PR makes the `num` flag required in `rpk topic add-partitions`. 

Fixes https://github.com/redpanda-data/redpanda/issues/12004

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

### Improvements

* rpk: make num flag required in add-partitions
