### PR TITLE
storage: space management config and health integration

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -256,8 +256,10 @@ private:
     void set_block_puts(bool);
 
     std::filesystem::path _cache_dir;
-    config::binding<uint64_t> _max_bytes;
+    config::binding<uint64_t> _max_bytes_cfg;
+    uint64_t _max_bytes;
     config::binding<uint32_t> _max_objects;
+    void update_max_bytes();
 
     ss::abort_source _as;
     ss::gate _gate;

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -95,7 +95,10 @@ public:
     /// \param cache_dir is a directory where cached data is stored
     cache(
       std::filesystem::path cache_dir,
+      size_t,
+      config::binding<double>,
       config::binding<uint64_t>,
+      config::binding<std::optional<double>>,
       config::binding<uint32_t>) noexcept;
 
     cache(const cache&) = delete;
@@ -256,7 +259,10 @@ private:
     void set_block_puts(bool);
 
     std::filesystem::path _cache_dir;
+    size_t _disk_size;
+    config::binding<double> _disk_reservation;
     config::binding<uint64_t> _max_bytes_cfg;
+    config::binding<std::optional<double>> _max_percent;
     uint64_t _max_bytes;
     config::binding<uint32_t> _max_objects;
     void update_max_bytes();

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -55,7 +55,10 @@ public:
         sharded_cache
           .start(
             CACHE_DIR,
+            30_GiB, // disk size
+            config::mock_binding<double>(0.0),
             config::mock_binding<uint64_t>(1_MiB + 500_KiB),
+            config::mock_binding<std::optional<double>>(std::nullopt),
             config::mock_binding<uint32_t>(100000))
           .get();
         sharded_cache

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -114,7 +114,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
       false);
 
     config::shard_local_cfg().enable_metrics_reporter.set_value(false);
-    config::shard_local_cfg().retention_local_is_nonstrict.set_value(false);
+    config::shard_local_cfg().retention_local_strict.set_value(true);
 
     const model::topic topic_name("tapioca");
     model::ntp ntp(model::kafka_namespace, topic_name, 0);

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -114,6 +114,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
       false);
 
     config::shard_local_cfg().enable_metrics_reporter.set_value(false);
+    config::shard_local_cfg().retention_local_is_nonstrict.set_value(false);
 
     const model::topic topic_name("tapioca");
     model::ntp ntp(model::kafka_namespace, topic_name, 0);

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -38,7 +38,10 @@ struct cloud_storage_fixture : s3_imposter_fixture {
         cache
           .start(
             tmp_directory.get_path(),
+            30_GiB, // disk size
+            config::mock_binding<double>(0.0),
             config::mock_binding<uint64_t>(1024 * 1024 * 1024),
+            config::mock_binding<std::optional<double>>(std::nullopt),
             config::mock_binding<uint32_t>(100000))
           .get();
 

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -99,7 +99,7 @@ public:
         config::shard_local_cfg()
           .cloud_storage_spillover_manifest_size.set_value(
             std::optional<size_t>{});
-        config::shard_local_cfg().retention_local_is_nonstrict.set_value(false);
+        config::shard_local_cfg().retention_local_strict.set_value(true);
 
         topic_name = model::topic("tapioca");
         ntp = model::ntp(model::kafka_namespace, topic_name, 0);

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -99,6 +99,7 @@ public:
         config::shard_local_cfg()
           .cloud_storage_spillover_manifest_size.set_value(
             std::optional<size_t>{});
+        config::shard_local_cfg().retention_local_is_nonstrict.set_value(false);
 
         topic_name = model::topic("tapioca");
         ntp = model::ntp(model::kafka_namespace, topic_name, 0);

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -87,6 +87,13 @@ ss::future<> local_monitor::update_state() {
     update_alert_state(new_state);
 
     _state = new_state;
+
+    /*
+     * this is overriden by space management once it starts up. the default
+     * value is nullopt which indicates this early state.
+     */
+    _state.log_data_size = _log_data_state;
+
     co_return co_await update_disk_metrics();
 }
 

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -53,6 +53,14 @@ public:
     static constexpr std::string_view stable_alert_string
       = "storage space alert"; // for those who grep the logs..
 
+    /*
+     * used by the disk space manager to report the latest information about the
+     * data log configuration and usage so it can be added to health report.
+     */
+    void set_log_data_state(std::optional<local_state::log_data_state> state) {
+        _log_data_state = state;
+    }
+
 private:
     /// Periodically check node status until stopped by abort source
     ss::future<> _update_loop();
@@ -68,6 +76,9 @@ private:
 
     // state
     local_state _state;
+    // folded/merged into _state by the monitor.
+    std::optional<local_state::log_data_state> _log_data_state{std::nullopt};
+
     ss::logger::rate_limit _despam_interval = ss::logger::rate_limit(
       std::chrono::hours(1));
     config::binding<size_t> _free_bytes_alert_threshold;

--- a/src/v/cluster/node/types.cc
+++ b/src/v/cluster/node/types.cc
@@ -69,7 +69,7 @@ void local_state::serde_read(iobuf_parser& in, const serde::header& h) {
         }
     }
 
-    if (h._version >= 1) {
+    if (h._version >= 2) {
         log_data_size = serde::read_nested<std::optional<log_data_state>>(
           in, 0);
     }

--- a/src/v/cluster/node/types.cc
+++ b/src/v/cluster/node/types.cc
@@ -20,14 +20,27 @@
 
 namespace cluster::node {
 
+std::ostream&
+operator<<(std::ostream& o, const local_state::log_data_state& s) {
+    fmt::print(
+      o,
+      "{{target: {} current: {} reclaimable: {}}}",
+      human::bytes(s.data_target_size),
+      human::bytes(s.data_current_size),
+      human::bytes(s.data_reclaimable_size));
+    return o;
+}
+
 std::ostream& operator<<(std::ostream& o, const local_state& s) {
     fmt::print(
       o,
-      "{{redpanda_version: {}, uptime: {}, data_disk: {}, cache_disk: {}}}",
+      "{{redpanda_version: {}, uptime: {}, data_disk: {}, cache_disk: {} log "
+      "data {}}}",
       s.redpanda_version,
       s.uptime,
       s.data_disk,
-      s.cache_disk);
+      s.cache_disk,
+      s.log_data_size);
     return o;
 }
 
@@ -55,6 +68,11 @@ void local_state::serde_read(iobuf_parser& in, const serde::header& h) {
             d.alert = storage_space_alert;
         }
     }
+
+    if (h._version >= 1) {
+        log_data_size = serde::read_nested<std::optional<log_data_state>>(
+          in, 0);
+    }
 }
 
 void local_state::serde_write(iobuf& out) const {
@@ -63,6 +81,7 @@ void local_state::serde_write(iobuf& out) const {
     serde::write(out, uptime);
     serde::write(out, disks());
     serde::write(out, get_disk_alert());
+    serde::write(out, log_data_size);
 }
 
 storage::disk_space_alert local_state::get_disk_alert() const {

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -36,7 +36,7 @@ using application_version = named_type<ss::sstring, struct version_number_tag>;
  * A snapshot of node-local state: i.e. things that don't depend on consensus.
  */
 struct local_state
-  : serde::envelope<local_state, serde::version<1>, serde::compat_version<0>> {
+  : serde::envelope<local_state, serde::version<2>, serde::compat_version<0>> {
     application_version redpanda_version;
     cluster_version logical_version{invalid_version};
     std::chrono::milliseconds uptime;

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -56,6 +56,16 @@ struct local_state
         }
     }
 
+    // The non-const version above is used by some internal routines that
+    // manipulate state. This is just for reading.
+    const storage::disk& get_cache_disk() const {
+        if (cache_disk.has_value()) {
+            return cache_disk.value();
+        } else {
+            return data_disk;
+        }
+    }
+
     bool shared_disk() const { return !cache_disk.has_value(); }
 
     /// Report a generalized node-wide disk alert state: this is the worst of

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -62,6 +62,45 @@ struct local_state
     /// all drive's alert state.
     storage::disk_space_alert get_disk_alert() const;
 
+    /*
+     * the system may try to use less than the entire disk for log data. for
+     * example a configuration may be:
+     *
+     *    physical disk size: 1 TB
+     *
+     *    // configured reservations
+     *    target_size: 700 GB
+     *    cache size: 200 GB
+     *    overhead size: 100 GB
+     *
+     *    // current usage
+     *    current_size: 700 GB (at capacity)
+     *    reclaimable_size: 200 GB
+     *
+     * in this scenario scenario even though the target size has been reached,
+     * according to the retention policy on the node up to 200 GB is currently
+     * reclaimable if the target size is exceeded.
+     *
+     * data_target_size: the target capacity of log data
+     * data_current_size: current amount of log data
+     * data_reclaimable_size: amount of data reclaimable log data
+     *
+     * this information is optional because it is possible that early on in
+     * bootup that a health report might be generated before the system has had
+     * a chance to determine what values should be filled in here.
+     */
+    struct log_data_state
+      : serde::envelope<
+          log_data_state,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        uint64_t data_target_size{0};
+        uint64_t data_current_size{0};
+        uint64_t data_reclaimable_size{0};
+        friend std::ostream& operator<<(std::ostream&, const log_data_state&);
+    };
+    std::optional<log_data_state> log_data_size{std::nullopt};
+
     void serde_read(iobuf_parser&, const serde::header&);
     void serde_write(iobuf& out) const;
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1659,6 +1659,16 @@ configuration::configuration()
       true,
       property<bool>::noop_validator,
       legacy_default<bool>(false, legacy_version{9}))
+  , disk_reservation_percent(
+      *this,
+      "disk_reservation_percent",
+      "The percenage of the disk capacity reserved that Redpanda will not use.",
+      {.needs_restart = needs_restart::no,
+       .example = "20.0",
+       .visibility = visibility::tunable},
+      25.0,
+      property<double>::noop_validator,
+      legacy_default<double>(0.0, legacy_version{9}))
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1614,9 +1614,10 @@ configuration::configuration()
   , retention_local_strict(
       *this,
       "retention_local_strict",
-      "Allow log data to expand past local retention. When enabled, non-local "
-      "retention settings are used, and local retention settings are used to "
-      "inform data removal policies in low-disk space scenarios.",
+      "Trim log data when a cloud topic reaches its local retention limit. "
+      "When this option is disabled Redpanda will allow partitions to grow "
+      "past the local retention limit, and will be trimmed automatically as "
+      "storage reaches the configured target size.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false,
       property<bool>::noop_validator,
@@ -1636,10 +1637,10 @@ configuration::configuration()
   , retention_local_target_capacity_percent(
       *this,
       "retention_local_target_capacity_percent",
-      "The target capacity in percent of unreserved space that log storage "
-      "will try to use before additional retention rules will take over to "
-      "trim data in order to meet the target. When no target is specified "
-      "storage usage is unbounded.",
+      "The target capacity in percent of unreserved space (see "
+      "disk_reservation_percent) that log storage will try to use before "
+      "additional retention rules will take over to trim data in order to meet "
+      "the target. When no target is specified storage usage is unbounded.",
       {.needs_restart = needs_restart::no,
        .example = "80.0",
        .visibility = visibility::user},
@@ -1677,7 +1678,12 @@ configuration::configuration()
   , disk_reservation_percent(
       *this,
       "disk_reservation_percent",
-      "The percenage of the disk capacity reserved that Redpanda will not use.",
+      "The percenage of total disk capacity that Redpanda will avoid using. "
+      "This applies both when cloud cache and log data share a disk, as well "
+      "as when cloud cache uses a dedicated disk. It is recommended to not run "
+      "disks near capacity to avoid blocking I/O due to low disk space, as "
+      "well as avoiding performance issues associated with SSD garbage "
+      "collection.",
       {.needs_restart = needs_restart::no,
        .example = "25.0",
        .visibility = visibility::tunable},
@@ -1696,7 +1702,9 @@ configuration::configuration()
       *this,
       "cloud_storage_cache_size_percent",
       "The maximum size of the archival cache as a percentage of unreserved "
-      "disk space.",
+      "disk space (see disk_reservation_percent). The default value for this "
+      "option is tuned for a shared disk configuration. When using a dedicated "
+      "cache disk consider increasing the value.",
       {.needs_restart = needs_restart::no,
        .example = "20.0",
        .visibility = visibility::user},

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1649,6 +1649,12 @@ configuration::configuration()
        .example = "1.8",
        .visibility = visibility::tunable},
       2.0)
+  , space_management_enable(
+      *this,
+      "space_management_enable",
+      "Enable automatic space management.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      true)
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",
@@ -2003,13 +2009,6 @@ configuration::configuration()
       "the data directory. Redpanda will refuse to start if it is not found.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
-  , enable_storage_space_manager(
-      *this,
-      "enable_storage_space_manager",
-      "Enable the storage space manager that coordinates and control space "
-      "usage between log data and the cloud storage cache.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      true)
   , memory_abort_on_alloc_failure(
       *this,
       "memory_abort_on_alloc_failure",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1630,7 +1630,9 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "2147483648000",
        .visibility = visibility::user},
-      std::nullopt)
+      std::nullopt,
+      property<std::optional<size_t>>::noop_validator,
+      legacy_default<std::optional<size_t>>(std::nullopt, legacy_version{9}))
   , retention_local_target_capacity_percent(
       *this,
       "retention_local_target_capacity_percent",
@@ -1641,7 +1643,9 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "70.0",
        .visibility = visibility::user},
-      std::nullopt)
+      80.0,
+      property<std::optional<double>>::noop_validator,
+      legacy_default<std::optional<double>>(std::nullopt, legacy_version{9}))
   , retention_local_trim_interval(
       *this,
       "retention_local_trim_interval",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1618,7 +1618,9 @@ configuration::configuration()
       "retention settings are used, and local retention settings are used to "
       "inform data removal policies in low-disk space scenarios.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      false)
+      true,
+      property<bool>::noop_validator,
+      legacy_default<bool>(false, legacy_version{9}))
   , retention_local_target_capacity_bytes(
       *this,
       "retention_local_target_capacity_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1654,7 +1654,9 @@ configuration::configuration()
       "space_management_enable",
       "Enable automatic space management.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      true)
+      true,
+      property<bool>::noop_validator,
+      legacy_default<bool>(false, legacy_version{9}))
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1689,7 +1689,18 @@ configuration::configuration()
       "cloud_storage_cache_size",
       "Max size of archival cache",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      20_GiB)
+      0,
+      property<uint64_t>::noop_validator,
+      legacy_default<uint64_t>(20_GiB, legacy_version{9}))
+  , cloud_storage_cache_size_percent(
+      *this,
+      "cloud_storage_cache_size_percent",
+      "The maximum size of the archival cache as a percentage of unreserved "
+      "disk space.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      20.0,
+      property<std::optional<double>>::noop_validator,
+      legacy_default<std::optional<double>>(std::nullopt, legacy_version{9}))
   , cloud_storage_cache_max_objects(
       *this,
       "cloud_storage_cache_max_objects",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1631,6 +1631,17 @@ configuration::configuration()
        .example = "2147483648000",
        .visibility = visibility::user},
       std::nullopt)
+  , retention_local_target_capacity_percent(
+      *this,
+      "retention_local_target_capacity_percent",
+      "The target capacity in percent of unreserved space that log storage "
+      "will try to use before additional retention rules will take over to "
+      "trim data in order to meet the target. When no target is specified "
+      "storage usage is unbounded.",
+      {.needs_restart = needs_restart::no,
+       .example = "70.0",
+       .visibility = visibility::user},
+      std::nullopt)
   , retention_local_trim_interval(
       *this,
       "retention_local_trim_interval",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1641,10 +1641,10 @@ configuration::configuration()
       "trim data in order to meet the target. When no target is specified "
       "storage usage is unbounded.",
       {.needs_restart = needs_restart::no,
-       .example = "70.0",
+       .example = "80.0",
        .visibility = visibility::user},
       80.0,
-      property<std::optional<double>>::noop_validator,
+      {.min = 0.0, .max = 100.0},
       legacy_default<std::optional<double>>(std::nullopt, legacy_version{9}))
   , retention_local_trim_interval(
       *this,
@@ -1679,10 +1679,10 @@ configuration::configuration()
       "disk_reservation_percent",
       "The percenage of the disk capacity reserved that Redpanda will not use.",
       {.needs_restart = needs_restart::no,
-       .example = "20.0",
+       .example = "25.0",
        .visibility = visibility::tunable},
       25.0,
-      property<double>::noop_validator,
+      {.min = 0.0, .max = 100.0},
       legacy_default<double>(0.0, legacy_version{9}))
   , cloud_storage_cache_size(
       *this,
@@ -1697,9 +1697,11 @@ configuration::configuration()
       "cloud_storage_cache_size_percent",
       "The maximum size of the archival cache as a percentage of unreserved "
       "disk space.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      {.needs_restart = needs_restart::no,
+       .example = "20.0",
+       .visibility = visibility::user},
       20.0,
-      property<std::optional<double>>::noop_validator,
+      {.min = 0.0, .max = 100.0},
       legacy_default<std::optional<double>>(std::nullopt, legacy_version{9}))
   , cloud_storage_cache_max_objects(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1611,16 +1611,16 @@ configuration::configuration()
       "write enabled",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       24h)
-  , retention_local_is_nonstrict(
+  , retention_local_strict(
       *this,
-      "retention_local_is_nonstrict",
+      "retention_local_strict",
       "Allow log data to expand past local retention. When enabled, non-local "
       "retention settings are used, and local retention settings are used to "
       "inform data removal policies in low-disk space scenarios.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      true,
+      false,
       property<bool>::noop_validator,
-      legacy_default<bool>(false, legacy_version{9}))
+      legacy_default<bool>(true, legacy_version{9}))
   , retention_local_target_capacity_bytes(
       *this,
       "retention_local_target_capacity_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1611,9 +1611,9 @@ configuration::configuration()
       "write enabled",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       24h)
-  , retention_local_is_advisory(
+  , retention_local_is_nonstrict(
       *this,
-      "retention_local_is_advisory",
+      "retention_local_is_nonstrict",
       "Allow log data to expand past local retention. When enabled, non-local "
       "retention settings are used, and local retention settings are used to "
       "inform data removal policies in low-disk space scenarios.",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -320,7 +320,7 @@ struct configuration final : public config_store {
     // cloud storage read and write enabled
     property<std::optional<size_t>> retention_local_target_bytes_default;
     property<std::chrono::milliseconds> retention_local_target_ms_default;
-    property<bool> retention_local_is_nonstrict;
+    property<bool> retention_local_strict;
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
     property<std::optional<double>> retention_local_target_capacity_percent;
     property<std::chrono::milliseconds> retention_local_trim_interval;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -325,6 +325,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> retention_local_trim_interval;
     property<double> retention_local_trim_overage_coeff;
     property<bool> space_management_enable;
+    property<double> disk_reservation_percent;
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -324,6 +324,7 @@ struct configuration final : public config_store {
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
     property<std::chrono::milliseconds> retention_local_trim_interval;
     property<double> retention_local_trim_overage_coeff;
+    property<bool> space_management_enable;
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;
@@ -390,7 +391,6 @@ struct configuration final : public config_store {
     bounded_property<size_t> storage_space_alert_free_threshold_bytes;
     bounded_property<size_t> storage_min_free_bytes;
     property<bool> storage_strict_data_init;
-    property<bool> enable_storage_space_manager;
 
     // memory related settings
     property<bool> memory_abort_on_alloc_failure;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -320,7 +320,7 @@ struct configuration final : public config_store {
     // cloud storage read and write enabled
     property<std::optional<size_t>> retention_local_target_bytes_default;
     property<std::chrono::milliseconds> retention_local_target_ms_default;
-    property<bool> retention_local_is_advisory;
+    property<bool> retention_local_is_nonstrict;
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
     property<std::chrono::milliseconds> retention_local_trim_interval;
     property<double> retention_local_trim_overage_coeff;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -322,6 +322,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> retention_local_target_ms_default;
     property<bool> retention_local_is_nonstrict;
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
+    property<std::optional<double>> retention_local_target_capacity_percent;
     property<std::chrono::milliseconds> retention_local_trim_interval;
     property<double> retention_local_trim_overage_coeff;
     property<bool> space_management_enable;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -322,15 +322,17 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> retention_local_target_ms_default;
     property<bool> retention_local_strict;
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
-    property<std::optional<double>> retention_local_target_capacity_percent;
+    bounded_property<std::optional<double>, numeric_bounds>
+      retention_local_target_capacity_percent;
     property<std::chrono::milliseconds> retention_local_trim_interval;
     property<double> retention_local_trim_overage_coeff;
     property<bool> space_management_enable;
-    property<double> disk_reservation_percent;
+    bounded_property<double, numeric_bounds> disk_reservation_percent;
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;
-    property<std::optional<double>> cloud_storage_cache_size_percent;
+    bounded_property<std::optional<double>, numeric_bounds>
+      cloud_storage_cache_size_percent;
     property<uint32_t> cloud_storage_cache_max_objects;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
     property<std::optional<uint32_t>>

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -330,6 +330,7 @@ struct configuration final : public config_store {
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;
+    property<std::optional<double>> cloud_storage_cache_size_percent;
     property<uint32_t> cloud_storage_cache_max_objects;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
     property<std::optional<uint32_t>>

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -225,8 +225,10 @@ public:
             return;
         }
 
-        if (ov <= _legacy_default.value().max_original_version) {
+        if (
+          ov <= _legacy_default.value().max_original_version && is_default()) {
             _default = _legacy_default.value().value;
+            _value = _default;
             // In case someone already made a binding to us early in startup
             notify_watchers(_default);
         }

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -225,7 +225,7 @@ public:
             return;
         }
 
-        if (ov < _legacy_default.value().max_original_version) {
+        if (ov <= _legacy_default.value().max_original_version) {
             _default = _legacy_default.value().value;
             // In case someone already made a binding to us early in startup
             notify_watchers(_default);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1318,8 +1318,16 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
         construct_service(
           shadow_index_cache,
           config::node().cloud_storage_cache_path(),
+          local_monitor.local().get_state_cached().get_cache_disk().total,
+          ss::sharded_parameter([] {
+              return config::shard_local_cfg().disk_reservation_percent.bind();
+          }),
           ss::sharded_parameter([] {
               return config::shard_local_cfg().cloud_storage_cache_size.bind();
+          }),
+          ss::sharded_parameter([] {
+              return config::shard_local_cfg()
+                .cloud_storage_cache_size_percent.bind();
           }),
           ss::sharded_parameter([] {
               return config::shard_local_cfg()

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1379,7 +1379,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
 
     construct_single_service(
       space_manager,
-      config::shard_local_cfg().enable_storage_space_manager.bind(),
+      config::shard_local_cfg().space_management_enable.bind(),
       config::shard_local_cfg().retention_local_target_capacity_bytes.bind(),
       &local_monitor,
       &storage,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1381,6 +1381,8 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       space_manager,
       config::shard_local_cfg().space_management_enable.bind(),
       config::shard_local_cfg().retention_local_target_capacity_bytes.bind(),
+      config::shard_local_cfg().retention_local_target_capacity_percent.bind(),
+      config::shard_local_cfg().disk_reservation_percent.bind(),
       &local_monitor,
       &storage,
       &storage_node,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1381,6 +1381,7 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
       space_manager,
       config::shard_local_cfg().enable_storage_space_manager.bind(),
       config::shard_local_cfg().retention_local_target_capacity_bytes.bind(),
+      &local_monitor,
       &storage,
       &storage_node,
       &shadow_index_cache,

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -26,7 +26,9 @@ namespace storage {
 
 disk_space_manager::disk_space_manager(
   config::binding<bool> enabled,
-  config::binding<std::optional<uint64_t>> log_storage_target_size,
+  config::binding<std::optional<uint64_t>> retention_target_capacity_bytes,
+  config::binding<std::optional<double>> retention_target_capacity_pct,
+  config::binding<double> disk_reservation_percent,
   ss::sharded<cluster::node::local_monitor>* local_monitor,
   ss::sharded<storage::api>* storage,
   ss::sharded<storage::node>* storage_node,
@@ -38,8 +40,13 @@ disk_space_manager::disk_space_manager(
   , _storage_node(storage_node)
   , _cache(cache->local_is_initialized() ? cache : nullptr)
   , _pm(pm)
-  , _log_storage_target_size(std::move(log_storage_target_size))
+  , _retention_target_capacity_bytes(std::move(retention_target_capacity_bytes))
+  , _retention_target_capacity_percent(std::move(retention_target_capacity_pct))
+  , _disk_reservation_percent(std::move(disk_reservation_percent))
+  , _data_disk_size(_local_monitor->local().get_state_cached().data_disk.total)
+  , _target_size(0)
   , _policy(_pm, _storage) {
+    update_target_size(); // initialize
     _enabled.watch([this] {
         vlog(
           rlog.info,
@@ -47,6 +54,9 @@ disk_space_manager::disk_space_manager(
           _enabled() ? "Enabling" : "Disabling");
         _control_sem.signal();
     });
+    _retention_target_capacity_bytes.watch([this] { update_target_size(); });
+    _retention_target_capacity_percent.watch([this] { update_target_size(); });
+    _disk_reservation_percent.watch([this] { update_target_size(); });
 }
 
 ss::future<> disk_space_manager::start() {
@@ -95,13 +105,66 @@ ss::future<> disk_space_manager::run_loop() {
             continue;
         }
 
-        if (!_log_storage_target_size().has_value()) {
+        if (_target_size == 0) {
             _local_monitor->local().set_log_data_state(std::nullopt);
             continue;
         }
 
-        co_await manage_data_disk(_log_storage_target_size().value());
+        co_await manage_data_disk(_target_size);
     }
+}
+
+void disk_space_manager::update_target_size() {
+    // amount of data disk reserved for non-redpanda use
+    const uint64_t reservation_size = _data_disk_size
+                                      * (_disk_reservation_percent() / 100.0);
+
+    // unreserved data disk space
+    const auto usable_size = _data_disk_size - reservation_size;
+
+    // percent-based target size
+    const uint64_t target_size_pct
+      = usable_size
+        * (_retention_target_capacity_percent().value_or(0) / 100.0);
+
+    // bytes-based target size
+    uint64_t target_size_bytes = _retention_target_capacity_bytes().value_or(0);
+    if (target_size_bytes > usable_size) {
+        vlog(
+          rlog.info,
+          "Clamping requested target max bytes {} to usable size {}",
+          target_size_bytes,
+          usable_size);
+        target_size_bytes = usable_size;
+    }
+
+    if (target_size_pct > 0 && target_size_bytes == 0) {
+        // only percent target
+        _target_size = target_size_pct;
+    } else if (target_size_pct == 0 && target_size_bytes > 0) {
+        // only bytes target
+        _target_size = target_size_bytes;
+    } else if (target_size_pct > 0 && target_size_bytes > 0) {
+        // apply both targets
+        _target_size = std::min(target_size_pct, target_size_bytes);
+    } else {
+        // disabled
+        _target_size = 0;
+    }
+
+    if (_target_size > 0) {
+        _control_sem.signal();
+    }
+
+    vlog(
+      rlog.info,
+      "Setting new target log data size {}. Disk size {} reservation percent "
+      "{} target percent {} bytes {}",
+      human::bytes(_target_size),
+      human::bytes(_data_disk_size),
+      _disk_reservation_percent(),
+      _retention_target_capacity_percent(),
+      _retention_target_capacity_bytes());
 }
 
 void eviction_policy::schedule::seek(size_t cursor) {

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -218,7 +218,9 @@ class disk_space_manager {
 public:
     disk_space_manager(
       config::binding<bool> enabled,
-      config::binding<std::optional<uint64_t>> log_storage_target_size,
+      config::binding<std::optional<uint64_t>> retention_target_capacity_bytes,
+      config::binding<std::optional<double>> retention_target_capacity_percent,
+      config::binding<double> disk_reservation_percent,
       ss::sharded<cluster::node::local_monitor>* local_monitor,
       ss::sharded<storage::api>* storage,
       ss::sharded<storage::node>* storage_node,
@@ -249,7 +251,12 @@ private:
     node::disk_space_info _data_disk_info{};
 
     ss::future<> manage_data_disk(uint64_t target_size);
-    config::binding<std::optional<uint64_t>> _log_storage_target_size;
+    config::binding<std::optional<uint64_t>> _retention_target_capacity_bytes;
+    config::binding<std::optional<double>> _retention_target_capacity_percent;
+    config::binding<double> _disk_reservation_percent;
+    size_t _data_disk_size;
+    size_t _target_size;
+    void update_target_size();
 
     eviction_policy _policy;
 

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -27,7 +27,10 @@ class cache;
 
 namespace cluster {
 class partition_manager;
+namespace node {
+class local_monitor;
 }
+} // namespace cluster
 
 namespace storage {
 
@@ -216,6 +219,7 @@ public:
     disk_space_manager(
       config::binding<bool> enabled,
       config::binding<std::optional<uint64_t>> log_storage_target_size,
+      ss::sharded<cluster::node::local_monitor>* local_monitor,
       ss::sharded<storage::api>* storage,
       ss::sharded<storage::node>* storage_node,
       ss::sharded<cloud_storage::cache>* cache,
@@ -232,6 +236,7 @@ public:
 
 private:
     config::binding<bool> _enabled;
+    ss::sharded<cluster::node::local_monitor>* _local_monitor;
     ss::sharded<storage::api>* _storage;
     ss::sharded<storage::node>* _storage_node;
     ss::sharded<cloud_storage::cache>* _cache;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -686,7 +686,7 @@ gc_config disk_log_impl::maybe_override_retention_config(gc_config cfg) const {
      * don't override with local retention settings--let partition data expand
      * up to standard retention settings.
      */
-    if (config::shard_local_cfg().retention_local_is_nonstrict()) {
+    if (!config::shard_local_cfg().retention_local_strict()) {
         vlog(
           gclog.trace,
           "[{}] Skipped retention override for topic with remote write "

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -686,7 +686,7 @@ gc_config disk_log_impl::maybe_override_retention_config(gc_config cfg) const {
      * don't override with local retention settings--let partition data expand
      * up to standard retention settings.
      */
-    if (config::shard_local_cfg().retention_local_is_advisory()) {
+    if (config::shard_local_cfg().retention_local_is_nonstrict()) {
         vlog(
           gclog.trace,
           "[{}] Skipped retention override for topic with remote write "

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -313,6 +313,12 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
 
     config::shard_local_cfg().get("cloud_storage_enabled").set_value(true);
 
+    // this test assumes that retention overrides are applied, which they are
+    // not, if operating in nonstrict mode.
+    config::shard_local_cfg()
+      .get("retention_local_is_nonstrict")
+      .set_value(false);
+
     storage::ntp_config config{
       storage::log_builder_ntp(), builder.get_log_config().base_dir};
 

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -315,9 +315,7 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
 
     // this test assumes that retention overrides are applied, which they are
     // not, if operating in nonstrict mode.
-    config::shard_local_cfg()
-      .get("retention_local_is_nonstrict")
-      .set_value(false);
+    config::shard_local_cfg().get("retention_local_strict").set_value(true);
 
     storage::ntp_config config{
       storage::log_builder_ntp(), builder.get_log_config().base_dir};

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -452,15 +452,21 @@ struct compaction_result {
  *            retention policy was ignored. for example reclaiming
  *            past the retention limits if the data being reclaimed
  *            has been uploaded to cloud storage.
+ *
+ * local_retention: amount of data that can safely be reclaimed that is above
+ *                  the local retention policy. this will be affected by if
+ *                  local retention is advisory or not.
  */
 struct reclaim_size_limits {
     size_t retention{0};
     size_t available{0};
+    size_t local_retention{0};
 
     friend reclaim_size_limits
     operator+(reclaim_size_limits lhs, const reclaim_size_limits& rhs) {
         lhs.retention += rhs.retention;
         lhs.available += rhs.available;
+        lhs.local_retention += rhs.local_retention;
         return lhs;
     }
 };

--- a/tests/rptest/scale_tests/log_storage_target_size_test.py
+++ b/tests/rptest/scale_tests/log_storage_target_size_test.py
@@ -93,7 +93,7 @@ class LogStorageTargetSizeTest(RedpandaTest):
             'retention_local_trim_interval':
             self.retention_local_trim_interval,
             'retention_local_target_capacity_bytes': target_size,
-            'retention_local_is_advisory': advisory,
+            'retention_local_is_nonstrict': advisory,
         }
 
         # when local retention is advisory, data can expand past the local

--- a/tests/rptest/scale_tests/log_storage_target_size_test.py
+++ b/tests/rptest/scale_tests/log_storage_target_size_test.py
@@ -43,8 +43,8 @@ class LogStorageTargetSizeTest(RedpandaTest):
 
     @cluster(num_nodes=4)
     @matrix(log_segment_size=[1024 * 1024, 100 * 1024 * 1024],
-            advisory=[True, False])
-    def streaming_cache_test(self, log_segment_size, advisory):
+            strict=[True, False])
+    def streaming_cache_test(self, log_segment_size, strict):
         if self.redpanda.dedicated_nodes:
             partition_count = 64
             rate_limit_bps = int(120E6)
@@ -93,16 +93,16 @@ class LogStorageTargetSizeTest(RedpandaTest):
             'retention_local_trim_interval':
             self.retention_local_trim_interval,
             'retention_local_target_capacity_bytes': target_size,
-            'retention_local_is_nonstrict': advisory,
+            'retention_local_strict': strict,
             'disk_reservation_percent': 0,
             'retention_local_target_capacity_percent': 100,
         }
 
-        # when local retention is advisory, data can expand past the local
+        # when local retention is not strict, data can expand past the local
         # retention and this expanded data will be subject to reclaim first in
         # the eviction policy. reduce the expiration age from default 24 hours
         # to 30 seconds in order to make it more likely that we are testing this.
-        if advisory:
+        if not strict:
             extra_rp_conf.update({
                 'retention_local_target_ms_default':
                 30 * 1000,

--- a/tests/rptest/scale_tests/log_storage_target_size_test.py
+++ b/tests/rptest/scale_tests/log_storage_target_size_test.py
@@ -94,6 +94,8 @@ class LogStorageTargetSizeTest(RedpandaTest):
             self.retention_local_trim_interval,
             'retention_local_target_capacity_bytes': target_size,
             'retention_local_is_nonstrict': advisory,
+            'disk_reservation_percent': 0,
+            'retention_local_target_capacity_percent': 100,
         }
 
         # when local retention is advisory, data can expand past the local

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -378,7 +378,7 @@ class SISettings:
                  cloud_storage_spillover_manifest_max_segments: Optional[
                      int] = None,
                  fast_uploads=False,
-                 retention_local_is_nonstrict=False):
+                 retention_local_strict=True):
         """
         :param fast_uploads: if true, set low upload intervals to help tests run
                              quickly when they wait for uploads to complete.
@@ -427,7 +427,7 @@ class SISettings:
         self.bypass_bucket_creation = bypass_bucket_creation
         self.cloud_storage_housekeeping_interval_ms = cloud_storage_housekeeping_interval_ms
         self.cloud_storage_spillover_manifest_max_segments = cloud_storage_spillover_manifest_max_segments
-        self.retention_local_is_nonstrict = retention_local_is_nonstrict
+        self.retention_local_strict = retention_local_strict
 
         if fast_uploads:
             self.cloud_storage_segment_max_upload_interval_sec = 10
@@ -567,8 +567,7 @@ class SISettings:
             conf[
                 'cloud_storage_spillover_manifest_max_segments'] = self.cloud_storage_spillover_manifest_max_segments
 
-        conf[
-            'retention_local_is_nonstrict'] = self.retention_local_is_nonstrict
+        conf['retention_local_strict'] = self.retention_local_strict
 
         return conf
 
@@ -3189,7 +3188,7 @@ class RedpandaService(RedpandaServiceBase):
         if cur_ver != RedpandaInstaller.HEAD and cur_ver < (23, 2, 1):
             # this configuration property was introduced in 23.2, ensure
             # it doesn't appear in older configurations
-            conf.pop('retention_local_is_nonstrict', None)
+            conf.pop('retention_local_strict', None)
 
         if cur_ver != RedpandaInstaller.HEAD and cur_ver < (22, 2, 1):
             # this configuration property was introduced in 22.2.1, ensure

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -556,7 +556,10 @@ class LogStorageMaxSizeSI(RedpandaTest):
         # start redpanda with specific config like segment size
         si_settings = SISettings(test_context=self.test_context,
                                  log_segment_size=log_segment_size)
-        extra_rp_conf = {}
+        extra_rp_conf = {
+            'disk_reservation_percent': 0,
+            'retention_local_target_capacity_percent': 100,
+        }
         self.redpanda.set_extra_rp_conf(extra_rp_conf)
         self.redpanda.set_si_settings(si_settings)
         self.redpanda.start()


### PR DESCRIPTION
* First three commits are from PR https://github.com/redpanda-data/redpanda/pull/12132 under separate review which fix legacy_default config issue, but which this PR depends on.

* Then next four commits address integration with partition balancer by publishing size information into the cluster health report which the balancer will pick up. Used by @bharathv in separate PR.

* Final set of commits add / tweak configuration options to support (1) desired policies in upgrade scenarios and (2) percentage based expression of cache and log data disk size reservations.

Upgraded clusters
* The effect should be that new space management is not active
* In ordre to enable, turn the feature on and configure nonstrict-mode/disk sizes.

New clusters
* New space management is on by default.

Config option scenarios

|option|upgrade default|new-cluster default|
|----|---|---|
|local retention nonstrict|off|on|
|disk reservation|0|25%|
|log data capacity bytes|nullopt|nullopt|
|log data capacity pct|nullopt|80%|
|cache size bytes|10gb|0|
|cache size pct|nullopt|20%|
|feature toggle|off|on|


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

