### PR TITLE
Aggregate `memory_units_t` in `fetch` to reduce cross-shard calls

### DIFF
--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -222,6 +222,19 @@ struct read_result {
         memory_units_t& operator=(memory_units_t&&) noexcept = default;
         memory_units_t(const memory_units_t&) = delete;
         memory_units_t& operator=(const memory_units_t&) = delete;
+        memory_units_t(
+          ssx::semaphore& memory_sem,
+          ssx::semaphore& memory_fetch_sem) noexcept;
+
+        /*
+         * Adopts another memory_units_t. This requires that both
+         * memory_units_t are from the same shard.
+         */
+        void adopt(memory_units_t&& o);
+
+        bool has_units() const {
+            return fetch.count() > 0 || kafka.count() > 0;
+        }
     };
 
     explicit read_result(error_code e)


### PR DESCRIPTION
By aggregating memory_units_t from the same shard together we reduce cross shard function calls from linear to the number of fetched partitions to 1.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
