### PR TITLE
tools/rp-storage-tool: Avoid overwriting manifest

### DIFF
--- a/tools/rp_storage_tool/src/bucket_reader.rs
+++ b/tools/rp_storage_tool/src/bucket_reader.rs
@@ -1514,7 +1514,12 @@ impl BucketReader {
             // Note: assuming memory is sufficient for manifests
             match self.partition_manifests.get_mut(&ntpr) {
                 Some(meta) => {
-                    meta.head_manifest = Some(manifest);
+                    // Avoid overwriting a binary manifest with a JSON manifest
+                    if meta.head_manifest.is_none()
+                        || meta.head_manifest.is_some() && key.ends_with(".bin")
+                    {
+                        meta.head_manifest = Some(manifest);
+                    }
                 }
                 None => {
                     self.partition_manifests.insert(


### PR DESCRIPTION
When scanning a bucket using rp-storage-tool, both the json and binary manifests may be present. In this case, avoid overwriting the binary manifest if it has already been ingested.

Fixes: #12093 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
