### PR TITLE
[v23.1.x] acl: Avoid allocations when checking implied ops

### DIFF
--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -376,26 +376,6 @@ std::ostream& operator<<(std::ostream& o, const acl_binding_filter& f) {
     return o;
 }
 
-std::vector<acl_operation> acl_implied_ops(acl_operation operation) {
-    switch (operation) {
-    case acl_operation::describe:
-        return {
-          acl_operation::describe,
-          acl_operation::read,
-          acl_operation::write,
-          acl_operation::remove,
-          acl_operation::alter,
-        };
-    case acl_operation::describe_configs:
-        return {
-          acl_operation::describe_configs,
-          acl_operation::alter_configs,
-        };
-    default:
-        return {operation};
-    }
-}
-
 bool acl_entry_filter::matches(const acl_entry& other) const {
     if (_principal && _principal != other.principal()) {
         return false;

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -96,11 +96,6 @@ enum class acl_operation : int8_t {
     idempotent_write = 10,
 };
 
-/*
- * Compute the implied operations based on the specified operation.
- */
-std::vector<acl_operation> acl_implied_ops(acl_operation operation);
-
 std::ostream& operator<<(std::ostream&, acl_operation);
 
 /*


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12079
