### PR TITLE
Introduce ssx::metrics::metric_groups

### DIFF
--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -77,9 +77,10 @@ private:
     /// Number of segments awaiting deletion
     int64_t _segments_to_delete = 0;
 
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 /// Metrics probe for upload housekeeping service
@@ -155,10 +156,10 @@ private:
     uint64_t _segment_deletions{0};
     uint64_t _metadata_syncs{0};
 
-    ss::metrics::metric_groups _service_metrics{
-      ssx::metrics::public_metrics_handle};
-    ss::metrics::metric_groups _jobs_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _service_metrics
+      = ssx::metrics::metric_groups::make_public();
+    ssx::metrics::metric_groups _jobs_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace archival

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -175,11 +175,11 @@ archiver_fixture::get_configurations() {
     s3conf.access_key = cloud_roles::public_key_str("acess-key");
     s3conf.secret_key = cloud_roles::private_key_str("secret-key");
     s3conf.region = cloud_roles::aws_region_name("us-east-1");
-    s3conf._probe = ss::make_shared(cloud_storage_clients::client_probe(
+    s3conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,
       net::public_metrics_disabled::yes,
       cloud_roles::aws_region_name{},
-      cloud_storage_clients::endpoint_url{}));
+      cloud_storage_clients::endpoint_url{});
     s3conf.server_addr = server_addr;
 
     archival::configuration aconf;

--- a/src/v/cloud_roles/probe.h
+++ b/src/v/cloud_roles/probe.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "seastarx.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -34,7 +35,8 @@ public:
 private:
     uint64_t _successful_fetches{0};
     uint64_t _fetch_errors{0};
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 
 } // namespace cloud_roles

--- a/src/v/cloud_storage/cache_probe.h
+++ b/src/v/cloud_storage/cache_probe.h
@@ -57,9 +57,10 @@ private:
     int64_t _exhaustive_trims{0};
     int64_t _failed_trims{0};
 
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_probe.h
+++ b/src/v/cloud_storage/partition_probe.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "model/fundamental.h"
+#include "ssx/metrics.h"
 #include "utils/hdr_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -76,7 +77,8 @@ private:
 
     uint64_t _chunk_size = 0;
 
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -22,8 +22,7 @@ namespace cloud_storage {
 remote_probe::remote_probe(
   remote_metrics_disabled disabled,
   remote_metrics_disabled public_disabled,
-  materialized_resources& ms)
-  : _public_metrics(ssx::metrics::public_metrics_handle) {
+  materialized_resources& ms) {
     namespace sm = ss::metrics;
 
     if (!disabled) {

--- a/src/v/cloud_storage/probe.h
+++ b/src/v/cloud_storage/probe.h
@@ -13,6 +13,7 @@
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -270,8 +271,10 @@ private:
     hdr_hist _client_acquisition_latency;
     hdr_hist _segment_download_latency;
 
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage_clients/client_probe.h
+++ b/src/v/cloud_storage_clients/client_probe.h
@@ -112,9 +112,10 @@ private:
     hdr_hist _lease_duration;
     /// Current utilization of the client pool
     uint64_t _pool_utilization;
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace cloud_storage_clients

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -436,7 +436,8 @@ private:
      * first created on current node before cross core move series
      */
     absl::node_hash_map<model::ntp, model::revision_id> _bootstrap_revisions;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 
 controller_backend::deltas_t calculate_bootstrap_deltas(

--- a/src/v/cluster/controller_log_limiter.h
+++ b/src/v/cluster/controller_log_limiter.h
@@ -60,8 +60,8 @@ private:
     config::binding<std::optional<size_t>> _capacity_binding;
     token_bucket<> _throttler;
     int64_t _dropped_requests_amount{};
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 class controller_log_limiter {

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -61,7 +61,7 @@ void controller_probe::setup_metrics() {
         return;
     }
 
-    _public_metrics = std::make_unique<ss::metrics::metric_groups>(
+    _public_metrics = std::make_unique<ssx::metrics::metric_groups>(
       ssx::metrics::public_metrics_handle);
     _public_metrics->add_group(
       prometheus_sanitize::metrics_name("cluster"),

--- a/src/v/cluster/controller_probe.h
+++ b/src/v/cluster/controller_probe.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/types.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -30,7 +31,7 @@ public:
 
 private:
     cluster::controller& _controller;
-    std::unique_ptr<ss::metrics::metric_groups> _public_metrics;
+    std::unique_ptr<ssx::metrics::metric_groups> _public_metrics;
     cluster::notification_id_type _leadership_notification_handle;
 };
 

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -160,7 +160,8 @@ private:
     ss::circular_buffer<members_manager::node_update> _raft0_updates;
     std::chrono::milliseconds _retry_timeout;
     ss::condition_variable _new_updates;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_public();
     config::binding<size_t> _max_concurrent_reallocations;
 };
 std::ostream&

--- a/src/v/cluster/node_status_backend.cc
+++ b/src/v/cluster/node_status_backend.cc
@@ -298,7 +298,7 @@ node_status_backend::process_request(node_status_request request) {
 }
 
 void node_status_backend::setup_metrics(
-  ss::metrics::metric_groups& metric_groups) {
+  ssx::metrics::metric_groups& metric_groups) {
     namespace sm = ss::metrics;
 
     metric_groups.add_group(

--- a/src/v/cluster/node_status_backend.h
+++ b/src/v/cluster/node_status_backend.h
@@ -80,7 +80,7 @@ private:
     ss::future<ss::shard_id>
       maybe_create_client(model::node_id, net::unresolved_address);
 
-    void setup_metrics(ss::metrics::metric_groups&);
+    void setup_metrics(ssx::metrics::metric_groups&);
 
     struct statistics {
         int64_t rpcs_sent;
@@ -115,9 +115,10 @@ private:
     notification_id_type _members_table_notification_handle;
 
     statistics _stats{};
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 
     ss::sharded<ss::abort_source>& _as;
     struct member_notification {

--- a/src/v/cluster/partition_balancer_state.cc
+++ b/src/v/cluster/partition_balancer_state.cc
@@ -149,7 +149,7 @@ partition_balancer_state::probe::probe(const partition_balancer_state& parent)
 }
 
 void partition_balancer_state::probe::setup_metrics(
-  ss::metrics::metric_groups& metrics) {
+  ssx::metrics::metric_groups& metrics) {
     namespace sm = ss::metrics;
     metrics.add_group(
       prometheus_sanitize::metrics_name("cluster:partition"),

--- a/src/v/cluster/partition_balancer_state.h
+++ b/src/v/cluster/partition_balancer_state.h
@@ -13,6 +13,7 @@
 #include "cluster/fwd.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "ssx/metrics.h"
 #include "utils/stable_iterator_adaptor.h"
 
 #include <seastar/core/sharded.hh>
@@ -85,11 +86,11 @@ private:
     struct probe {
         explicit probe(const partition_balancer_state&);
 
-        void setup_metrics(ss::metrics::metric_groups&);
+        void setup_metrics(ssx::metrics::metric_groups&);
 
         const partition_balancer_state& _parent;
-        ss::metrics::metric_groups _metrics;
-        ss::metrics::metric_groups _public_metrics;
+        ssx::metrics::metric_groups _metrics;
+        ssx::metrics::metric_groups _public_metrics;
     };
 
 private:

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -22,8 +22,7 @@ namespace cluster {
 
 replicated_partition_probe::replicated_partition_probe(
   const partition& p) noexcept
-  : _partition(p)
-  , _public_metrics(ssx::metrics::public_metrics_handle) {
+  : _partition(p) {
     config::shard_local_cfg().enable_schema_id_validation.bind().watch(
       [this]() { reconfigure_metrics(); });
 }

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "model/fundamental.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -88,8 +89,10 @@ private:
     uint64_t _bytes_produced{0};
     uint64_t _bytes_fetched{0};
     uint64_t _schema_id_validation_records_failed{0};
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace cluster

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -23,6 +23,7 @@
 #include "raft/logger.h"
 #include "raft/state_machine.h"
 #include "raft/types.h"
+#include "ssx/metrics.h"
 #include "storage/offset_translator_state.h"
 #include "storage/snapshot.h"
 #include "utils/available_promise.h"
@@ -965,7 +966,8 @@ private:
     prefix_logger _ctx_log;
     config::binding<uint64_t> _max_concurrent_producer_ids;
     mutex _clean_old_pids_mtx;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 
 struct fence_batch_data {

--- a/src/v/cluster/scheduling/leader_balancer_probe.h
+++ b/src/v/cluster/scheduling/leader_balancer_probe.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -33,7 +34,8 @@ private:
     uint64_t _leader_transfer_timeout = 0;
     uint64_t _leader_transfer_no_improvement = 0;
 
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 
 } // namespace cluster

--- a/src/v/cluster/topic_table_probe.h
+++ b/src/v/cluster/topic_table_probe.h
@@ -51,9 +51,10 @@ private:
     model::node_id _node_id;
     absl::flat_hash_map<model::topic_namespace, ss::metrics::metric_groups>
       _topics_metrics;
-    ss::metrics::metric_groups _internal_metrics;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _internal_metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
     int32_t _moving_to_partitions = 0;
     int32_t _moving_from_partitions = 0;
     int32_t _cancelling_movements = 0;

--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -27,8 +27,7 @@ namespace kafka {
 class group_offset_probe {
 public:
     explicit group_offset_probe(model::offset& offset) noexcept
-      : _offset(offset)
-      , _public_metrics(ssx::metrics::public_metrics_handle) {}
+      : _offset(offset) {}
     group_offset_probe(const group_offset_probe&) = delete;
     group_offset_probe& operator=(const group_offset_probe&) = delete;
     group_offset_probe(group_offset_probe&&) = delete;
@@ -87,8 +86,10 @@ public:
 
 private:
     model::offset& _offset;
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 template<typename KeyType, typename ValType>
@@ -105,8 +106,7 @@ public:
       offsets_map& offsets) noexcept
       : _members(members)
       , _static_members(static_members)
-      , _offsets(offsets)
-      , _public_metrics(ssx::metrics::public_metrics_handle) {}
+      , _offsets(offsets) {}
 
     group_probe(const group_probe&) = delete;
     group_probe& operator=(const group_probe&) = delete;
@@ -146,7 +146,8 @@ private:
     member_map& _members;
     static_member_map& _static_members;
     offsets_map& _offsets;
-    ss::metrics::metric_groups _public_metrics;
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace kafka

--- a/src/v/kafka/latency_probe.h
+++ b/src/v/kafka/latency_probe.h
@@ -95,9 +95,10 @@ public:
 private:
     hdr_hist _produce_latency;
     hdr_hist _fetch_latency;
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/fetch_session_cache.h
+++ b/src/v/kafka/server/fetch_session_cache.h
@@ -12,6 +12,7 @@
 
 #include "kafka/server/fetch_session.h"
 #include "kafka/types.h"
+#include "ssx/metrics.h"
 #include "units.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -76,7 +77,8 @@ private:
 
     size_t _sessions_mem_usage = 0;
 
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/handler_probe.cc
+++ b/src/v/kafka/server/handlers/handler_probe.cc
@@ -50,7 +50,7 @@ handler_probe::handler_probe()
   : _last_recorded_in_progress(ss::lowres_clock::now()) {}
 
 void handler_probe::setup_metrics(
-  ss::metrics::metric_groups& metrics, api_key key) {
+  ssx::metrics::metric_groups& metrics, api_key key) {
     namespace sm = ss::metrics;
 
     if (config::shard_local_cfg().disable_metrics()) {

--- a/src/v/kafka/server/handlers/handler_probe.h
+++ b/src/v/kafka/server/handlers/handler_probe.h
@@ -28,7 +28,7 @@ public:
     handler_probe(handler_probe&&) = delete;
     handler_probe& operator=(handler_probe&&) = delete;
     ~handler_probe() = default;
-    void setup_metrics(ss::metrics::metric_groups&, api_key);
+    void setup_metrics(ssx::metrics::metric_groups&, api_key);
 
     void sample_in_progress();
     void request_completed() {
@@ -76,7 +76,8 @@ public:
     handler_probe& get_probe(api_key key);
 
 private:
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
     std::vector<handler_probe> _probes;
 };
 

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -29,6 +29,7 @@
 #include "security/krb5_configurator.h"
 #include "security/mtls.h"
 #include "ssx/fwd.h"
+#include "ssx/metrics.h"
 #include "utils/ema.h"
 
 #include <seastar/core/future.hh>
@@ -218,7 +219,8 @@ private:
     ssx::semaphore _memory_fetch_sem;
 
     handler_probe_manager _handler_probes;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
     std::unique_ptr<class latency_probe> _probe;
     ssx::thread_worker& _thread_worker;
     std::unique_ptr<replica_selector> _replica_selector;

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -13,6 +13,7 @@
 #include "config/property.h"
 #include "config/throughput_control_group.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 #include "utils/bottomless_token_bucket.h"
 #include "utils/mutex.h"
 
@@ -55,7 +56,8 @@ public:
 
 private:
     class snc_quota_manager& _qm;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
     uint64_t _balancer_runs = 0;
     size_t _traffic_in = 0;
 };

--- a/src/v/net/client_probe.h
+++ b/src/v/net/client_probe.h
@@ -14,6 +14,7 @@
 #include "net/unresolved_address.h"
 #include "rpc/logger.h"
 #include "rpc/types.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -76,7 +77,7 @@ public:
     void waiting_for_available_memory() { ++_requests_blocked_memory; }
 
     void setup_metrics(
-      ss::metrics::metric_groups& mgs,
+      ssx::metrics::metric_groups& mgs,
       const std::optional<rpc::connection_cache_label>& label,
       const std::optional<model::node_id>& node_id,
       const net::unresolved_address& target_addr);
@@ -97,7 +98,8 @@ private:
     uint32_t _server_correlation_errors = 0;
     uint32_t _client_correlation_errors = 0;
     uint32_t _requests_blocked_memory = 0;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 
     friend std::ostream& operator<<(std::ostream& o, const client_probe& p);
 };

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -21,7 +21,7 @@
 
 namespace net {
 void server_probe::setup_metrics(
-  ss::metrics::metric_groups& mgs, std::string_view proto) {
+  ssx::metrics::metric_groups& mgs, std::string_view proto) {
     namespace sm = ss::metrics;
     auto aggregate_labels = config::shard_local_cfg().aggregate_metrics()
                               ? std::vector<sm::label>{sm::shard_label}
@@ -112,7 +112,7 @@ void server_probe::setup_metrics(
 }
 
 void server_probe::setup_public_metrics(
-  ss::metrics::metric_groups& mgs, std::string_view proto) {
+  ssx::metrics::metric_groups& mgs, std::string_view proto) {
     namespace sm = ss::metrics;
 
     if (proto.ends_with("_rpc")) {
@@ -154,7 +154,7 @@ std::ostream& operator<<(std::ostream& o, const server_probe& p) {
 }
 
 void client_probe::setup_metrics(
-  ss::metrics::metric_groups& mgs,
+  ssx::metrics::metric_groups& mgs,
   const std::optional<rpc::connection_cache_label>& label,
   const std::optional<model::node_id>& node_id,
   const net::unresolved_address& target_addr) {

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -33,8 +33,7 @@ server::server(server_configuration c, ss::logger& log)
   : cfg(std::move(c))
   , _log(log)
   , _memory{size_t{static_cast<size_t>(cfg.max_service_memory_per_core)}, "net/server-mem"}
-  , _probe(std::make_unique<server_probe>())
-  , _public_metrics(ssx::metrics::public_metrics_handle) {
+  , _probe(std::make_unique<server_probe>()) {
     vlog(
       _log.info, "Creating net::server for {} with config {}", cfg.name, cfg);
 }

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -16,6 +16,7 @@
 #include "net/connection.h"
 #include "net/connection_rate.h"
 #include "net/types.h"
+#include "ssx/metrics.h"
 #include "ssx/semaphore.h"
 #include "utils/hdr_hist.h"
 
@@ -106,8 +107,8 @@ class server {
 public:
     explicit server(server_configuration, ss::logger&);
     explicit server(ss::sharded<server_configuration>* s, ss::logger&);
-    server(server&&) noexcept = default;
-    server& operator=(server&&) noexcept = delete;
+    server(server&&) = delete;
+    server& operator=(server&&) = delete;
     server(const server&) = delete;
     server& operator=(const server&) = delete;
     virtual ~server();
@@ -171,8 +172,10 @@ private:
     ss::gate _conn_gate;
     hdr_hist _hist;
     std::unique_ptr<server_probe> _probe;
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 
     std::optional<config_connection_rate_bindings> connection_rate_bindings;
     std::optional<connection_rate<>> _connection_rates;

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "seastarx.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -59,10 +60,11 @@ public:
 
     void waiting_for_conection_rate() { ++_connections_wait_rate; }
 
-    void setup_metrics(ss::metrics::metric_groups& mgs, std::string_view proto);
+    void
+    setup_metrics(ssx::metrics::metric_groups& mgs, std::string_view proto);
 
     void setup_public_metrics(
-      ss::metrics::metric_groups& mgs, std::string_view proto);
+      ssx::metrics::metric_groups& mgs, std::string_view proto);
 
 private:
     uint64_t _requests_completed = 0;

--- a/src/v/pandaproxy/probe.cc
+++ b/src/v/pandaproxy/probe.cc
@@ -24,8 +24,7 @@ probe::probe(
   : _request_metrics()
   , _path(path_desc)
   , _group_name(group_name)
-  , _metrics()
-  , _public_metrics(ssx::metrics::public_metrics_handle) {
+  , _metrics() {
     setup_metrics();
     setup_public_metrics();
 }

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "ssx/metrics.h"
 #include "utils/hdr_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -76,8 +77,10 @@ private:
     http_status_metric _request_metrics;
     const ss::httpd::path_description& _path;
     const ss::sstring& _group_name;
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace pandaproxy

--- a/src/v/pandaproxy/schema_registry/validation_metrics.h
+++ b/src/v/pandaproxy/schema_registry/validation_metrics.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "config/configuration.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -62,7 +63,8 @@ public:
     void decompressed() { ++_batches_decompressed; }
 
 private:
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
     int64_t _hits;
     int64_t _misses;
     int64_t _batches_decompressed;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -34,6 +34,7 @@
 #include "raft/timeout_jitter.h"
 #include "raft/types.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 #include "ssx/semaphore.h"
 #include "storage/fwd.h"
 #include "storage/log.h"
@@ -754,7 +755,8 @@ private:
     std::chrono::milliseconds _replicate_append_timeout;
     std::chrono::milliseconds _recovery_append_timeout;
     size_t _heartbeat_disconnect_failures;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
     ss::abort_source _as;
     storage::api& _storage;
     std::optional<std::reference_wrapper<coordinated_recovery_throttle>>

--- a/src/v/raft/coordinated_recovery_throttle.h
+++ b/src/v/raft/coordinated_recovery_throttle.h
@@ -132,9 +132,10 @@ private:
     ss::gate _gate;
     ss::timer<clock_t> _coordinator;
 
-    ss::metrics::metric_groups _internal_metrics;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _internal_metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace raft

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -17,6 +17,7 @@
 #include "raft/recovery_memory_quota.h"
 #include "raft/types.h"
 #include "rpc/fwd.h"
+#include "ssx/metrics.h"
 #include "storage/fwd.h"
 #include "utils/notification_list.h"
 
@@ -99,7 +100,8 @@ private:
     std::vector<ss::lw_shared_ptr<raft::consensus>> _groups;
     notification_list<leader_cb_t, cluster::notification_id_type>
       _notifications;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
     storage::api& _storage;
     coordinated_recovery_throttle& _recovery_throttle;
     recovery_memory_quota _recovery_mem_quota;

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -74,8 +74,9 @@ private:
     uint64_t _replicate_request_error = 0;
     uint64_t _recovery_request_error = 0;
 
-    ss::metrics::metric_groups _metrics;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 } // namespace raft

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -266,7 +266,8 @@ private:
     std::unique_ptr<monitor_unsafe_log_flag> _monitor_unsafe_log_flag;
     ss::sharded<archival::scrubber> _archival_scrubber;
 
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
     ss::sharded<ssx::metrics::public_metrics_group> _public_metrics;
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
 

--- a/src/v/resource_mgmt/scheduling_groups_probe.h
+++ b/src/v/resource_mgmt/scheduling_groups_probe.h
@@ -48,6 +48,6 @@ public:
     void clear() { _public_metrics.clear(); }
 
 private:
-    seastar::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -36,6 +36,7 @@ RPC_TEMPLATE = """
 #include "outcome.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 
 // extra includes
 {%- for include in includes %}
@@ -147,7 +148,7 @@ private:
       }){{ "," if not loop.last }}
       {%- endfor %}
     {% raw %}}}{% endraw %};
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics;
 };
 
 using {{service_name}}_service = {{service_name}}_service_base<rpc::default_message_codec>;

--- a/src/v/rpc/rpc_server.h
+++ b/src/v/rpc/rpc_server.h
@@ -28,9 +28,9 @@ public:
     explicit rpc_server(ss::sharded<net::server_configuration>* s)
       : net::server(s, rpclog) {}
 
-    rpc_server(rpc_server&&) noexcept = default;
-    ~rpc_server() = default;
+    ~rpc_server() override = default;
 
+    rpc_server(rpc_server&&) noexcept = delete;
     rpc_server& operator=(rpc_server&&) noexcept = delete;
     rpc_server(const rpc_server&) = delete;
     rpc_server& operator=(const rpc_server&) = delete;

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -20,6 +20,7 @@
 #include "rpc/response_handler.h"
 #include "rpc/types.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/gate.hh>
@@ -119,9 +120,9 @@ public:
       std::optional<connection_cache_label> label = std::nullopt,
       std::optional<model::node_id> node_id = std::nullopt);
     ~transport() override;
-    transport(transport&&) noexcept = default;
     // semaphore is not move assignable
-    transport& operator=(transport&&) noexcept = delete;
+    transport(transport&&) = delete;
+    transport& operator=(transport&&) = delete;
     transport(const transport&) = delete;
     transport& operator=(const transport&) = delete;
 
@@ -201,7 +202,8 @@ private:
     absl::flat_hash_map<uint32_t, std::unique_ptr<response_entry>>
       _correlations;
     uint32_t _correlation_idx{0};
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
     /**
      * Ordered map containing requests to be sent over the wire. The map
      * preserves order of calling send_typed function. It is fine to use

--- a/src/v/ssx/metrics.h
+++ b/src/v/ssx/metrics.h
@@ -22,7 +22,78 @@ namespace ssx::metrics {
 
 // The seastar metrics handle to be used for the '/public_metrics' prometheus
 // endpoint.
-const auto public_metrics_handle = seastar::metrics::default_handle() + 1;
+const auto public_metrics_handle = ss::metrics::default_handle() + 1;
+
+// A thin wrapper around ss::metrics::metric_groups that isn't moveable.
+//
+// The standard usage pattern for metric_groups is as a member of a class, then
+// various additional members on that class are the metrics. As part of
+// registration, a lambda captures [this], which means that the holder class of
+// the metric_groups should not be moved without updating the metrics.
+//
+// Instead of explicitly supporting moves (they're easy to forget when the
+// compiler generates them for you) we mark this class as not moveable.
+class metric_groups {
+public:
+    metric_groups() = default;
+    explicit metric_groups(int handle)
+      : _underlying(handle) {}
+    metric_groups(const metric_groups&) = delete;
+    metric_groups& operator=(const metric_groups&) = delete;
+    metric_groups(metric_groups&&) = delete;
+    metric_groups& operator=(metric_groups&&) = delete;
+    ~metric_groups() = default;
+
+    static metric_groups make_internal() { return {}; }
+    static metric_groups make_public() {
+        return metric_groups(public_metrics_handle);
+    }
+
+    // Add metrics belonging to the same group.
+    //
+    // Use the metrics creation functions to add metrics.
+    //
+    // For example:
+    //  _metrics.add_group("my_group", {
+    //   make_counter(
+    //     "my_counter_name1",
+    //     counter,
+    //     description("my counter description")
+    //   ),
+    //   make_counter(
+    //     "my_counter_name2",
+    //     counter,
+    //     description("my other counter description")
+    //   ),
+    //   make_gauge(
+    //     "my_gauge_name1",
+    //     gauge,
+    //     description("my gauge description")
+    //   ),
+    //  });
+    metric_groups& add_group(
+      const ss::metrics::group_name_type& name,
+      const std::initializer_list<ss::metrics::metric_definition>& l) {
+        _underlying.add_group(name, l);
+        return *this;
+    }
+
+    // Add metrics belonging to the same group.
+    //
+    // This is the same method as above but using an explicit vector.
+    metric_groups& add_group(
+      const ss::metrics::group_name_type& name,
+      const std::vector<ss::metrics::metric_definition>& l) {
+        _underlying.add_group(name, l);
+        return *this;
+    }
+
+    // Clear all metric registrations.
+    void clear() { _underlying.clear(); }
+
+private:
+    ss::metrics::metric_groups _underlying;
+};
 
 // Convert an HDR histogram to a seastar histogram for reporting.
 // Entries with values ranging form 250 microseconds to 1 minute are
@@ -44,7 +115,7 @@ inline ss::metrics::label make_namespaced_label(const seastar::sstring& name) {
 }
 
 struct public_metrics_group {
-    ss::metrics::metric_groups groups{public_metrics_handle};
+    metric_groups groups = metric_groups::make_public();
     ss::future<> stop() {
         groups.clear();
         return ss::make_ready_future<>();
@@ -59,7 +130,8 @@ struct public_metrics_group {
  * and /public_metrics (aka "public") metrics endpoint.
  */
 class all_metrics_groups {
-    ss::metrics::metric_groups _public{public_metrics_handle}, _internal;
+    metric_groups _public = metric_groups::make_public();
+    metric_groups _internal = metric_groups::make_internal();
 
 public:
     /**

--- a/src/v/storage/backlog_controller.h
+++ b/src/v/storage/backlog_controller.h
@@ -9,6 +9,7 @@
 
 #pragma once
 #include "seastarx.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/io_priority_class.hh>
@@ -125,6 +126,7 @@ private:
     int _min_shares;
     int _max_shares;
     ss::gate _gate;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 } // namespace storage

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "bytes/iobuf.h"
 #include "seastarx.h"
+#include "ssx/metrics.h"
 #include "storage/ntp_config.h"
 #include "storage/parser.h"
 #include "storage/segment_set.h"
@@ -227,7 +228,8 @@ private:
         uint64_t entries_removed{0};
         size_t cached_bytes{0};
 
-        ss::metrics::metric_groups metrics;
+        ssx::metrics::metric_groups metrics
+          = ssx::metrics::metric_groups::make_internal();
     };
 
     probe _probe;

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -46,8 +46,8 @@ public:
 
 private:
     disk_metrics _disk;
-    ss::metrics::metric_groups _public_metrics{
-      ssx::metrics::public_metrics_handle};
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 // Per-NTP probe.
@@ -131,6 +131,7 @@ private:
     uint32_t _batch_parse_errors = 0;
     uint32_t _batch_write_errors = 0;
     double _compaction_ratio = 1.0;
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 } // namespace storage

--- a/src/v/storage/readers_cache_probe.h
+++ b/src/v/storage/readers_cache_probe.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "model/fundamental.h"
+#include "ssx/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -24,6 +25,7 @@ private:
     uint64_t _cache_misses{0};
     uint64_t _cache_hits{0};
 
-    ss::metrics::metric_groups _metrics;
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
 };
 } // namespace storage


### PR DESCRIPTION
A wrapper around ss::metrics::metric_groups that is not moveable. This
prevents from the metrics_groups capturing a reference to the parent
object and the parent object being implicitly moveable because all it's
members are moveable.

Fixes: #11402

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
