### PR TITLE
acl: Avoid allocations when checking implied ops

### DIFF
--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -97,29 +97,6 @@ enum class acl_operation : int8_t {
     idempotent_write = 10,
 };
 
-/*
- * Compute the implied operations based on the specified operation.
- */
-inline std::vector<acl_operation> acl_implied_ops(acl_operation operation) {
-    switch (operation) {
-    case acl_operation::describe:
-        return {
-          acl_operation::describe,
-          acl_operation::read,
-          acl_operation::write,
-          acl_operation::remove,
-          acl_operation::alter,
-        };
-    case acl_operation::describe_configs:
-        return {
-          acl_operation::describe_configs,
-          acl_operation::alter_configs,
-        };
-    default:
-        return {operation};
-    }
-}
-
 inline std::ostream& operator<<(std::ostream& os, acl_operation op) {
     switch (op) {
     case acl_operation::all:


### PR DESCRIPTION
`acl_implied_ops` was quite visible (~3%) in the callchains leading to `operator new()` in the LRC profile.

It's called for every partition so this is not entirely surprising when using larger partition counts.

Avoid the allocations by "inlining" the check into the function so that no vector has to be allocated.

(cherry picked from commit 74ea2372fd749c18ce7a63dc67790d20c8ad25df)

Fixes https://github.com/redpanda-data/redpanda/issues/12097


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes


* none

