### PR TITLE
txns: fix list txns failure when it's used before find_coordinator

### DIFF
--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -35,6 +35,8 @@ public:
       ss::sharded<cluster::tx_coordinator_mapper>&,
       ss::sharded<features::feature_table>&);
 
+    ss::future<bool> ensure_tx_topic_exists();
+
     ss::future<find_coordinator_reply>
       find_coordinator(kafka::transactional_id, model::timeout_clock::duration);
 

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/id_allocator_frontend.h"
 #include "cluster/topics_frontend.h"
+#include "cluster/tx_registry_frontend.h"
 #include "config/broker_authn_endpoint.h"
 #include "config/configuration.h"
 #include "config/node_config.h"
@@ -1565,6 +1566,16 @@ list_transactions_handler::handle(request_context ctx, ss::smp_service_group) {
         }
         return true;
     };
+
+    auto& tx_registry = ctx.tx_registry_frontend();
+    if (!co_await tx_registry.ensure_tx_topic_exists()) {
+        vlog(
+          klog.error,
+          "Can not return list of transactions. Failed to create {}",
+          model::tx_manager_nt);
+        response.data.error_code = kafka::error_code::unknown_server_error;
+        co_return co_await ctx.respond(std::move(response));
+    }
 
     auto& tx_frontend = ctx.tx_gateway_frontend();
     auto txs = co_await tx_frontend.get_all_transactions();

--- a/tests/rptest/tests/transaction_kafka_api_test.py
+++ b/tests/rptest/tests/transaction_kafka_api_test.py
@@ -28,7 +28,8 @@ class TxKafkaApiTest(RedpandaTest):
                                  "tx_timeout_delay_ms": 10000000,
                                  "abort_timed_out_transactions_interval_ms":
                                  10000000,
-                                 'enable_leader_balancer': False
+                                 "enable_leader_balancer": False,
+                                 "transaction_coordinator_partitions": 4
                              })
 
         self.kafka_cli = KafkaCliTools(self.redpanda, "3.0.0")
@@ -105,6 +106,11 @@ class TxKafkaApiTest(RedpandaTest):
             for partition in range(topic.partition_count):
                 tpoic_partition = f"{topic}-{partition}"
                 assert tpoic_partition in expected_partitions
+
+    @cluster(num_nodes=3)
+    def test_empty_list_transactions(self):
+        txs_info = self.kafka_cli.list_transactions()
+        assert len(txs_info) == 0
 
     @cluster(num_nodes=3)
     def test_list_transactions(self):


### PR DESCRIPTION
`find_coordinator` creates txn coordinator's topic when it's used for the first time. `list_transactions` api expects the topic to be already created so it used to fail when the api was invoked before `find_coordinator`. Fixed the problem by creating the topic on the first list txns call too.

Fixes https://github.com/redpanda-data/redpanda/issues/11947

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none