### PR TITLE
Update seastar to 8c70099

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 6f442562679c4a9307c3f4c7daf0a3ab976e0eaf
+  GIT_TAG 8c70099aee8c97790f75abe831ca2f56a1725dd1
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   LIST_SEPARATOR |


### PR DESCRIPTION
Update to 8c70099aee8c97790f75abe831ca2f56a1725dd1.

This brings in the following 5 changes:

8c70099a Match type for pure_check_for_work
df2811ce Do not use std::function for check_for_work() 59b3ded1 Add a basic sized deletion test
c2beb5e1 Optimize the allocator free path
9cc2e030 Optimize allocate path

These are 2 optimizations for the seastar allocator, one test change to support that, and 2 minor optimizations in the reactor loop.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

<!--
Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
