### PR TITLE
Print output from Rpk commands that timeout in ducktape

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -901,7 +901,10 @@ class RpkTool:
             output, stderror = p.communicate(input=stdin, timeout=timeout)
         except subprocess.TimeoutExpired:
             p.kill()
-            raise RpkException(f"command {' '.join(cmd)} timed out")
+            output, stderr = p.communicate()
+            raise RpkException(
+                f"command {' '.join(cmd)} timed out, output: {output} \n error: {stderr}",
+                stderr, None, output)
 
         self._redpanda.logger.debug(f'\n{output}')
 


### PR DESCRIPTION
When an Rpk command times out in ducktape no output is printed except for a vague exception messaging stating that the command has timed out.  This change grabs the output from the process, prints it and forwards it to the RpkException constructor before throwing so the reason for the timeout can be more easy to debug.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none

