### PR TITLE
Fix incorrect node name comparison in `DeleteRecordsTest.test_delete_records_segment_deletion`

### DIFF
--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -372,10 +372,12 @@ class DeleteRecordsTest(RedpandaTest):
             )
             snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
                 "kafka", self.topic, 0)
-            for _, node in snapshot.items():
-                if node != stopped_node:
+            for node_name, segments in snapshot.items():
+                if node_name != stopped_node.name:
+                    self.redpanda.logger.debug(
+                        f"Verifying storage on node {node_name}...")
                     assert all_segments_removed(
-                        get_segment_boundaries_via_local_storage(node),
+                        get_segment_boundaries_via_local_storage(segments),
                         rp_truncate_offset)
 
         if cloud_storage_enabled:


### PR DESCRIPTION
- In situations where orphaned segments lead to test timeout the exception handler in the delete_records_test_segment_deletion test will ensure that other nodes that were not triggered by a crash still have all required segments to have been truncated.

- The test was however incorrectly comparing an array of segments to a node object, allows the assertion check to occur on the downed node which is expected to have orphaned segments. This incorrectly triggers a test failure.

- The fix is to correctly compare the node names when iterating through the storage snapshot.

- Fixes: #11932

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
