### PR TITLE
transactions: fix ListTransactions to return open transactions

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -3221,6 +3221,10 @@ tx_gateway_frontend::get_all_transactions() {
           model::tx_manager_nt.ns, model::tx_manager_nt.tp, pa.id);
         auto ntp_res = co_await get_all_transactions_for_one_tx_partition(
           tx_manager_ntp);
+        if (
+          ntp_res.has_error() && ntp_res.error() == tx_errc::not_coordinator) {
+            continue;
+        }
         if (ntp_res.has_error()) {
             co_return std::move(ntp_res);
         }

--- a/tests/rptest/tests/transaction_kafka_api_test.py
+++ b/tests/rptest/tests/transaction_kafka_api_test.py
@@ -130,6 +130,7 @@ class TxKafkaApiTest(RedpandaTest):
         producer2.flush()
 
         txs_info = self.kafka_cli.list_transactions()
+        assert len(txs_info) > 0
         for tx in txs_info:
             tx_info = self.kafka_cli.describe_transaction(
                 tx["TransactionalId"])


### PR DESCRIPTION
Clients use scatter gather approach and asks all brokers to list transactions. A broker is expected to check hosted txn coordinators only if the broker is the current leader of the coordinators and let a client to merge the results. Fixing list transactions handler to ignore not leader errors.

Fixes https://github.com/redpanda-data/redpanda/issues/11948

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none