### PR TITLE
ducktape: allow ntr_no_topic_manifest in test_manifest_dump

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1631,6 +1631,7 @@ class RedpandaService(RedpandaServiceBase):
             })
 
         self._started = []
+        self._additional_permitted_anomalies = set()
         self._security_config = dict()
 
         self._raise_on_errors = self._context.globals.get(
@@ -1693,6 +1694,9 @@ class RedpandaService(RedpandaServiceBase):
                 del self._environment[k]
             except KeyError:
                 pass
+
+    def add_permitted_anomaly(self, anomaly: str):
+        self._additional_permitted_anomalies.add(anomaly)
 
     def set_extra_node_conf(self, node, conf):
         assert node in self.nodes, f"where node is {node.name}"
@@ -3893,6 +3897,7 @@ class RedpandaService(RedpandaServiceBase):
         # we externally validate
         # (https://github.com/redpanda-data/redpanda/issues/9072)
         permitted_anomalies = {"segments_outside_manifest"}
+        permitted_anomalies.update(self._additional_permitted_anomalies)
 
         # Whether any anomalies were found
         any_anomalies = any(len(v) for v in report['anomalies'].values())

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -201,6 +201,11 @@ class SIAdminApiTest(RedpandaTest):
         self.admin.await_stable_leader("test-topic", 0)
         response = self.admin.get_partition_manifest("test-topic", 0)
 
+        # We may end up with a no topic manifest if the restart below occurs
+        # before the topic manifest is written. Since we're disabling tiered
+        # storage, there is no further opportunity to write the topic manifest.
+        self.redpanda.add_permitted_anomaly("ntr_no_topic_manifest")
+
         assert "last_offset" in response
         assert response["last_offset"] == 0
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

The test explicitly disables tiered storage at runtime. It therefore
seems reasonable to be permissive of a missing topic manifest.

Fixes https://github.com/redpanda-data/redpanda/issues/10932
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
