### PR TITLE
config: fix legacy_default feature and add tests

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -225,8 +225,10 @@ public:
             return;
         }
 
-        if (ov <= _legacy_default.value().max_original_version) {
+        if (
+          ov <= _legacy_default.value().max_original_version && is_default()) {
             _default = _legacy_default.value().value;
+            _value = _default;
             // In case someone already made a binding to us early in startup
             notify_watchers(_default);
         }

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -225,7 +225,7 @@ public:
             return;
         }
 
-        if (ov < _legacy_default.value().max_original_version) {
+        if (ov <= _legacy_default.value().max_original_version) {
             _default = _legacy_default.value().value;
             // In case someone already made a binding to us early in startup
             notify_watchers(_default);


### PR DESCRIPTION
Fix the legacy_default feature. First two commits fix what appear to be bugs in the feature, and the last commit introduces a test that exercises the functionality.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
