### PR TITLE
Revert "r/state_machine: share linearizable barrier result"

### DIFF
--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -15,8 +15,6 @@
 #include "storage/log.h"
 #include "storage/record_batch_builder.h"
 
-#include <seastar/util/later.hh>
-
 namespace raft {
 
 state_machine::state_machine(
@@ -181,38 +179,23 @@ ss::future<result<model::offset>> state_machine::insert_linearizable_barrier(
     /**
      * Inject leader barrier and wait until returned offset is applied
      */
-    if (_barrier_promise) {
-        return _barrier_promise->get_shared_future();
-    }
-    _barrier_promise = barrier_promise_t{};
-    auto f = _barrier_promise->get_shared_future();
-
     return ss::with_timeout(
              timeout,
              _raft->linearizable_barrier().then(
                [this, timeout](result<model::offset> r) {
                    if (!r) {
-                       _barrier_promise->set_value(r);
-                       _barrier_promise.reset();
-                       return ss::now();
+                       return ss::make_ready_future<result<model::offset>>(
+                         r.error());
                    }
 
                    // wait for the returned offset to be applied
-                   return wait(r.value(), timeout).then([this, r] {
-                       _barrier_promise->set_value(r);
-                       _barrier_promise.reset();
+                   return wait(r.value(), timeout).then([r] {
+                       return result<model::offset>(r.value());
                    });
                }))
-      .handle_exception_type([this](const ss::timed_out_error&) {
-          _barrier_promise->set_value(errc::timeout);
-          _barrier_promise.reset();
-      })
-      .handle_exception([this](const std::exception_ptr& e) {
-          vlog(_log.warn, "Linearizable barrier failed - {}", e);
-          _barrier_promise->set_value(errc::append_entries_dispatch_error);
-          _barrier_promise.reset();
-      })
-      .then([f = std::move(f)]() mutable { return std::move(f); });
+      .handle_exception_type([](const ss::timed_out_error&) {
+          return result<model::offset>(errc::timeout);
+      });
 }
 
 ss::future<model::offset> state_machine::bootstrap_committed_offset() {

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -21,7 +21,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/shared_future.hh>
 #include <seastar/util/log.hh>
 
 namespace raft {
@@ -144,13 +143,6 @@ private:
     model::offset _next;
     ss::abort_source _as;
     model::offset _bootstrap_last_applied;
-    /**
-     * Shared promise used to propagate barrier result to all the waiters. The
-     * shared promise allow us to share the result of ongoing linearizable
-     * barrier request with multiple callers.
-     */
-    using barrier_promise_t = ss::shared_promise<result<model::offset>>;
-    std::optional<barrier_promise_t> _barrier_promise;
 };
 
 } // namespace raft


### PR DESCRIPTION
 7cb919c0dda574ddab1595bd5b5423fcb2c65283 introduced an optimisation which
 uses `shared_future` for concurrent calls to trigger a linearisable barrier. Looks like
 the related code caused an asan violation in https://github.com/redpanda-data/redpanda/issues/12143.
 
 The code in the reverted commit looks fine, but I have some doubts about the `shared_future`
 implementation. Note there should be no semantic change here as 7cb919c0dda574ddab1595bd5b5423fcb2c65283
 is just an optimisation.
 
 Fixes https://github.com/redpanda-data/redpanda/issues/12143 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
