### PR TITLE
[v23.2.x] ducktape: set small upload interval in retention_policy_test

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -511,7 +511,8 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                 "cloud_storage_enable_remote_write": True,
                 "cloud_storage_enable_remote_read": True,
                 "cloud_storage_housekeeping_interval_ms":
-                cs_housekeeping_interval
+                cs_housekeeping_interval,
+                "cloud_storage_segment_max_upload_interval_sec": 1,
             },
             expect_restart=True)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12129
Fixes: https://github.com/redpanda-data/redpanda/issues/12158,