### PR TITLE
rpk: strip quotes from additional start args

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/redpanda/start.go
@@ -729,7 +729,7 @@ func parseFlags(flags []string) map[string]string {
 		parts := strings.SplitN(trimmed, "=", 2)
 		if len(parts) >= 2 {
 			name := strings.Trim(parts[0], " ")
-			value := strings.Trim(parts[1], " ")
+			value := strings.Trim(parts[1], ` "`)
 			parsed[name] = value
 			continue
 		}

--- a/src/go/rpk/pkg/cli/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/redpanda/start_test.go
@@ -1854,6 +1854,37 @@ func Test_buildRedpandaFlags(t *testing.T) {
 	}
 }
 
+func Test_ParseFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   []string
+		exp  map[string]string
+	}{
+		{
+			name: "empty flags",
+			in:   []string{"", "-", "--"},
+			exp:  map[string]string{},
+		}, {
+			name: "bool flags - no value",
+			in:   []string{"--overprovisioned", "-true"},
+			exp:  map[string]string{"overprovisioned": "", "true": ""},
+		}, {
+			name: "flags with value",
+			in:   []string{"--smp=2", "--memory=4G", "--default-log-level=info"},
+			exp:  map[string]string{"smp": "2", "memory": "4G", "default-log-level": "info"},
+		}, {
+			name: "flags with value and quotes",
+			in:   []string{`--logger-log-level="rpc=debug"`},
+			exp:  map[string]string{"logger-log-level": "rpc=debug"},
+		},
+	} {
+		t.Run(tt.name, func(st *testing.T) {
+			got := parseFlags(tt.in)
+			require.Equal(st, tt.exp, got)
+		})
+	}
+}
+
 func intPtr(i int) *int {
 	return &i
 }


### PR DESCRIPTION
These are meant to be passed to the shell as we were typing them into the terminal. Normally, shells strip quotes from the string.

See https://github.com/redpanda-data/redpanda/issues/7878#issuecomment-1638524400 for extra logs on why stripping the quotes.

Fixes #7878

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Bug Fixes

* rpk: fixes a bug where using quotes in flags values inside redpanda.yaml's `rpk.additional_start_flags` would make redpanda to fail on start.
