### PR TITLE
Support watching all topics within partition manager

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -69,8 +69,8 @@ ss::future<> group_manager::start() {
       });
 
     _unmanage_notify_handle = _pm.local().register_unmanage_notification(
-      _tp_ns.ns, _tp_ns.tp, [this](model::partition_id p_id) {
-          detach_partition(model::ntp(_tp_ns.ns, _tp_ns.tp, p_id));
+      _tp_ns.ns, _tp_ns.tp, [this](model::topic_partition_view tp_p) {
+          detach_partition(model::ntp(_tp_ns.ns, _tp_ns.tp, tp_p.partition));
       });
 
     /*


### PR DESCRIPTION
Within WASM transforms we're going to need the ability to intersect all of the topic partitions within a node/shard with the transforms that exist. This patch adds the appropriate callbacks to partition manager to support this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x
- [ ] v22.2.x

## Release Notes

* none
