### PR TITLE
Add the ability to recieve notifications for partition writes

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -402,6 +402,7 @@ ss::future<result<kafka_result>> partition::replicate(
     if (!res) {
         co_return ret_t(res.error());
     }
+    notify_write_completion();
     co_return ret_t(
       kafka_result{kafka::offset(get_offset_translator_state()->from_log_offset(
         res.value().last_offset)())});
@@ -470,7 +471,8 @@ kafka_stages partition::replicate_in_stages(
     }
 
     if (_rm_stm) {
-        return _rm_stm->replicate_in_stages(bid, std::move(r), opts);
+        return wrap_in_write_notification_on_completion(
+          _rm_stm->replicate_in_stages(bid, std::move(r), opts));
     }
 
     auto res = _raft->replicate_in_stages(std::move(r), opts);
@@ -484,8 +486,8 @@ kafka_stages partition::replicate_in_stages(
             get_offset_translator_state()->from_log_offset(old_offset)());
           return ret_t(kafka_result{new_offset});
       });
-    return kafka_stages(
-      std::move(res.request_enqueued), std::move(replicate_finished));
+    return wrap_in_write_notification_on_completion(kafka_stages(
+      std::move(res.request_enqueued), std::move(replicate_finished)));
 }
 
 ss::future<> partition::start() {
@@ -1156,6 +1158,32 @@ ss::future<> partition::unsafe_reset_remote_partition_manifest(iobuf buf) {
       clusterlog.info,
       "[{}] Unsafe reset replicated STM commands successfully",
       ntp());
+}
+
+kafka_stages
+partition::wrap_in_write_notification_on_completion(kafka_stages stages) {
+    return {
+      std::move(stages.request_enqueued),
+      std::move(stages.replicate_finished).then([this](auto result) {
+          notify_write_completion();
+          return result;
+      })};
+}
+
+void partition::notify_write_completion() const {
+    for (const auto& [id, cb] : _write_notifications) {
+        cb();
+    }
+}
+cluster::notification_id_type
+partition::register_on_write_notification(ss::noncopyable_function<void()> cb) {
+    _write_notifications.emplace(++_latest_id, std::move(cb));
+    return _latest_id;
+}
+
+void partition::unregister_on_write_notification(
+  cluster::notification_id_type id) {
+    _write_notifications.erase(id);
 }
 
 std::ostream& operator<<(std::ostream& o, const partition& x) {

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -61,6 +61,12 @@ public:
         virtual ss::future<error_code> validate_fetch_offset(
           model::offset, bool, model::timeout_clock::time_point)
           = 0;
+        virtual cluster::notification_id_type
+        register_on_write_notification(ss::noncopyable_function<void()> cb)
+          = 0;
+        virtual void
+          unregister_on_write_notification(cluster::notification_id_type)
+          = 0;
 
         virtual result<partition_info> get_partition_info() const = 0;
         virtual cluster::partition_probe& probe() = 0;
@@ -134,6 +140,14 @@ public:
 
     result<partition_info> get_partition_info() const {
         return _impl->get_partition_info();
+    }
+
+    cluster::notification_id_type
+    register_on_write_notification(ss::noncopyable_function<void()> cb) {
+        return _impl->register_on_write_notification(std::move(cb));
+    }
+    void unregister_on_write_notification(cluster::notification_id_type id) {
+        _impl->unregister_on_write_notification(id);
     }
 
 private:

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -510,4 +510,15 @@ result<partition_info> replicated_partition::get_partition_info() const {
     return {std::move(ret)};
 }
 
+cluster::notification_id_type
+replicated_partition::register_on_write_notification(
+  ss::noncopyable_function<void()> cb) {
+    return _partition->register_on_write_notification(std::move(cb));
+}
+
+void replicated_partition::unregister_on_write_notification(
+  cluster::notification_id_type id) {
+    _partition->unregister_on_write_notification(id);
+}
+
 } // namespace kafka

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -187,6 +187,11 @@ public:
 
     result<partition_info> get_partition_info() const final;
 
+    cluster::notification_id_type
+    register_on_write_notification(ss::noncopyable_function<void()> cb) final;
+
+    void unregister_on_write_notification(cluster::notification_id_type) final;
+
 private:
     // Returns the Kafka offset corresponding to the lowest offset in the
     // log, including local and cloud storage. Doesn't take into account any


### PR DESCRIPTION
In WASM transforms, we're going to want to be able to know when a write
has been completed and we can go read it and perform the transform. This
patch adds the ability to do this without polling.

However, this notification is best effort only, there is no garentee
that this is going to successfully fire for every write. In transform
land we'll solve this by having the transform periodically poll the
partition on a very slow interval (10 seconds or something?) to catch
any missing notifications. However on partitions with non-trivial
traffic this notification will fire on writes that take place later.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
