### PR TITLE
[v23.2.x] Print output from Rpk commands that timeout in ducktape

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -901,7 +901,10 @@ class RpkTool:
             output, stderror = p.communicate(input=stdin, timeout=timeout)
         except subprocess.TimeoutExpired:
             p.kill()
-            raise RpkException(f"command {' '.join(cmd)} timed out")
+            output, stderr = p.communicate()
+            raise RpkException(
+                f"command {' '.join(cmd)} timed out, output: {output} \n error: {stderr}",
+                stderr, None, output)
 
         self._redpanda.logger.debug(f'\n{output}')
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12121
