### PR TITLE
[v23.2.x] Revert "r/state_machine: share linearizable barrier result"

### DIFF
--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -15,8 +15,6 @@
 #include "storage/log.h"
 #include "storage/record_batch_builder.h"
 
-#include <seastar/util/later.hh>
-
 namespace raft {
 
 state_machine::state_machine(
@@ -181,38 +179,23 @@ ss::future<result<model::offset>> state_machine::insert_linearizable_barrier(
     /**
      * Inject leader barrier and wait until returned offset is applied
      */
-    if (_barrier_promise) {
-        return _barrier_promise->get_shared_future();
-    }
-    _barrier_promise = barrier_promise_t{};
-    auto f = _barrier_promise->get_shared_future();
-
     return ss::with_timeout(
              timeout,
              _raft->linearizable_barrier().then(
                [this, timeout](result<model::offset> r) {
                    if (!r) {
-                       _barrier_promise->set_value(r);
-                       _barrier_promise.reset();
-                       return ss::now();
+                       return ss::make_ready_future<result<model::offset>>(
+                         r.error());
                    }
 
                    // wait for the returned offset to be applied
-                   return wait(r.value(), timeout).then([this, r] {
-                       _barrier_promise->set_value(r);
-                       _barrier_promise.reset();
+                   return wait(r.value(), timeout).then([r] {
+                       return result<model::offset>(r.value());
                    });
                }))
-      .handle_exception_type([this](const ss::timed_out_error&) {
-          _barrier_promise->set_value(errc::timeout);
-          _barrier_promise.reset();
-      })
-      .handle_exception([this](const std::exception_ptr& e) {
-          vlog(_log.warn, "Linearizable barrier failed - {}", e);
-          _barrier_promise->set_value(errc::append_entries_dispatch_error);
-          _barrier_promise.reset();
-      })
-      .then([f = std::move(f)]() mutable { return std::move(f); });
+      .handle_exception_type([](const ss::timed_out_error&) {
+          return result<model::offset>(errc::timeout);
+      });
 }
 
 ss::future<model::offset> state_machine::bootstrap_committed_offset() {

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -21,7 +21,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/shared_future.hh>
 #include <seastar/util/log.hh>
 
 namespace raft {
@@ -144,13 +143,6 @@ private:
     model::offset _next;
     ss::abort_source _as;
     model::offset _bootstrap_last_applied;
-    /**
-     * Shared promise used to propagate barrier result to all the waiters. The
-     * shared promise allow us to share the result of ongoing linearizable
-     * barrier request with multiple callers.
-     */
-    using barrier_promise_t = ss::shared_promise<result<model::offset>>;
-    std::optional<barrier_promise_t> _barrier_promise;
 };
 
 } // namespace raft


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12157
Fixes: https://github.com/redpanda-data/redpanda/issues/12173,