### PR TITLE
c/rm_stm: fixed returning incorrect `max_collectible_offset`

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -221,13 +221,25 @@ public:
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
     ss::future<tx_errc> abort_tx(
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
-
+    /**
+     * Returns the next after the last one decided. If there are no ongoing
+     * transactions this will return next offset to be applied to the the stm.
+     */
     model::offset last_stable_offset();
     ss::future<fragmented_vector<rm_stm::tx_range>>
       aborted_transactions(model::offset, model::offset);
 
     model::offset max_collectible_offset() override {
-        return last_stable_offset();
+        const auto lso = last_stable_offset();
+        if (lso < model::offset{0}) {
+            return model::offset{};
+        }
+        /**
+         * Since the LSO may be equal to `_next` we must return offset which has
+         * already been decided and applied hence we subtract one from the last
+         * stable offset.
+         */
+        return model::prev_offset(lso);
     }
 
     storage::stm_type type() override {


### PR DESCRIPTION
An off by one error in `rm_stm::max_collectible_offset` may lead to situation in which an stm couldn't continue. If `max_collectible_offset` returned last offset in the segment it may lead to the situation in which the whole segment was evicted before its last entry was applied. As the `max_collectible_offset` was returning `last_stable_offset` which indicates the offset for which all _previous_ offsets are decided (has no pending transactions and have been committed). In rare cases it may lead to situation where a segment ending at offset `n` was removed even though only `n - 1` was decided.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes log segments being evicted too early