### PR TITLE
cloud_storage: skip below clean offset in archive sized retention and other fixes

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2093,6 +2093,23 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
       clean_offset,
       start_offset);
 
+    if (clean_offset == start_offset) {
+        vlog(
+          _rtclog.debug,
+          "Garbage collection in the archive not required as clean offset "
+          "equals the start offset ({})",
+          clean_offset);
+        co_return;
+    } else if (clean_offset > start_offset) {
+        vlog(
+          _rtclog.error,
+          "Garbage collection requested until offset {}, but start offset is "
+          "at {}. Skipping garbage collection.",
+          clean_offset,
+          start_offset);
+        co_return;
+    }
+
     model::offset new_clean_offset;
     // Value includes segments but doesn't include manifests
     size_t bytes_to_remove = 0;
@@ -2162,9 +2179,11 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
     }
 
     // Drop out if we have no work to do, avoid doing things like the following
-    // manifest flushing unnecessarily.
+    // manifest flushing unnecessarily. This is potentially problematic since,
+    // we've already checked that the clean offset is greater than the start
+    // offset.
     if (objects_to_remove.empty() && manifests_to_remove.empty()) {
-        vlog(_rtclog.debug, "Nothing to remove in archive GC");
+        vlog(_rtclog.warn, "Nothing to remove in archive GC");
         co_return;
     }
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2041,7 +2041,7 @@ ss::future<> ntp_archiver::apply_archive_retention() {
     if (
       res.value().offset == model::offset{}
       || res.value().offset
-           == _manifest_view->stm_manifest().get_archive_start_offset()) {
+           <= _manifest_view->stm_manifest().get_archive_start_offset()) {
         co_return;
     }
 

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -512,7 +512,7 @@ async_manifest_view::get_cursor(
         if (_stm_manifest.get_archive_start_offset() == model::offset{}) {
             begin = _stm_manifest.get_start_offset().value_or(begin);
         } else {
-            begin = _stm_manifest.get_archive_start_offset();
+            begin = _stm_manifest.get_archive_clean_offset();
         }
 
         if (end < begin) {
@@ -719,7 +719,7 @@ bool async_manifest_view::in_archive(async_view_search_query_t o) {
     return ss::visit(
       o,
       [this](model::offset ro) {
-          return ro >= _stm_manifest.get_archive_start_offset()
+          return ro >= _stm_manifest.get_archive_clean_offset()
                  && ro < _stm_manifest.get_start_offset().value_or(
                       model::offset::min());
       },
@@ -1005,7 +1005,7 @@ async_manifest_view::size_based_retention(size_t size_limit) noexcept {
             }
 
             auto res = co_await get_cursor(
-              _stm_manifest.get_archive_start_offset(),
+              _stm_manifest.get_archive_clean_offset(),
               model::prev_offset(_stm_manifest.get_start_offset().value()));
             if (res.has_failure()) {
                 vlog(

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -980,7 +980,8 @@ ss::future<
 async_manifest_view::size_based_retention(size_t size_limit) noexcept {
     archive_start_offset_advance result;
     try {
-        auto cloud_log_size = _stm_manifest.cloud_log_size();
+        const auto cloud_log_size = _stm_manifest.cloud_log_size();
+        const auto clean_offset = _stm_manifest.get_archive_clean_offset();
         if (cloud_log_size > size_limit) {
             auto to_remove = cloud_log_size - size_limit;
             vlog(
@@ -1025,8 +1026,25 @@ async_manifest_view::size_based_retention(size_t size_limit) noexcept {
                 // The end condition is the lambda returned true, otherwise
                 // we should keep scanning.
                 auto eof = cursor->with_manifest(
-                  [this, &to_remove, &result](const auto& manifest) mutable {
+                  [this, &to_remove, &result, clean_offset](
+                    const auto& manifest) mutable {
                       for (const auto& meta : manifest) {
+                          // Skip segments below the clean offset as they're
+                          // already eligible for GC. The reason why we are
+                          // using the clean offset and not the start offset
+                          // here is that the archive size (used above in
+                          // `partition_manifest::cloud_log_size` is updated
+                          // with the clean offset.
+                          if (meta.base_offset < clean_offset) {
+                              vlog(
+                                _ctxlog.debug,
+                                "Retention skip {}, as it's below the clean "
+                                "offset {}",
+                                meta,
+                                clean_offset);
+                              continue;
+                          }
+
                           result.offset = meta.base_offset;
                           result.delta = meta.delta_offset;
 

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -347,7 +347,7 @@ FIXTURE_TEST(test_async_manifest_view_iter, async_manifest_view_fixture) {
 }
 
 FIXTURE_TEST(test_async_manifest_view_truncate, async_manifest_view_fixture) {
-    // Check that segments in the truncated part are not accessible
+    // Check archive truncation
     std::vector<segment_meta> expected;
     collect_segments_to(expected);
     generate_manifest_section(100);
@@ -370,8 +370,9 @@ FIXTURE_TEST(test_async_manifest_view_truncate, async_manifest_view_fixture) {
 
     model::offset so = model::offset{0};
     auto maybe_cursor = view.get_cursor(so).get();
-    BOOST_REQUIRE(maybe_cursor.has_failure());
-    BOOST_REQUIRE(maybe_cursor.error() == error_outcome::out_of_range);
+    // The clean offset should still be accesible such that retention
+    // can operate above it.
+    BOOST_REQUIRE(!maybe_cursor.has_failure());
 
     maybe_cursor = view.get_cursor(new_so).get();
     BOOST_REQUIRE(!maybe_cursor.has_failure());
@@ -703,60 +704,69 @@ FIXTURE_TEST(test_async_manifest_view_after_gc, async_manifest_view_fixture) {
      */
     std::vector<segment_meta> expected;
     collect_segments_to(expected);
-    for (int i = 0; i < 2; i++) {
-        generate_manifest_section(100);
+    for (int i = 0; i < 3; i++) {
+        generate_manifest_section(5);
     }
 
     listen();
 
-    size_t total_size = 0;
-    for (const auto& meta : expected) {
-        total_size += meta.size_bytes;
-    }
+    // This test expects all generated segments to have the same size.
+    const auto segments_to_keep = 6;
+    const size_t size_limit = segments_to_keep * expected[0].size_bytes;
+    const auto truncation_point = expected[expected.size() - segments_to_keep];
 
-    const auto& first_seg = expected[0];
-    const auto& second_seg = expected[1];
-    const auto& third_seg = expected[2];
-
-    BOOST_REQUIRE(first_seg.size_bytes == second_seg.size_bytes);
+    // The test created 3 spillover manifest with 5 segments each.
+    // The STM manifest also has 5 segments. Advance the start offset
+    // to the second segment in the second spillover manifest.
+    BOOST_REQUIRE(spillover_start_offsets.size() == 3);
+    const auto second_spill_start = spillover_start_offsets[0];
+    auto iter = std::next(std::find_if(
+      expected.begin(), expected.end(), [second_spill_start](const auto& meta) {
+          return meta.base_offset == second_spill_start;
+      }));
+    const auto second_seg_second_spill = *iter;
 
     stm_manifest.set_archive_start_offset(
-      second_seg.base_offset, second_seg.delta_offset);
+      second_seg_second_spill.base_offset,
+      second_seg_second_spill.delta_offset);
 
-    size_t size_limit = total_size - 2 * first_seg.size_bytes;
+    // Advance the clean archive offset through each possible position given
+    // the current start offset and verify that the truncation point is correct
+    // (it should be the same every time).
+    size_t prev_segment_size = 0;
+    for (const auto& pre_start_seg : expected) {
+        if (
+          pre_start_seg.base_offset > stm_manifest.get_archive_start_offset()) {
+            break;
+        }
 
-    // The first attempt to compute retention is before the clean offset was
-    // advanced. At this point the manifest has not updated it's archive size
-    // (it's total_size).
-    vlog(
-      test_log.info,
-      "Triggering size based retention, current archive start offset: "
-      "{}, current archive clean offset: {}, expected offset: {}",
-      stm_manifest.get_archive_start_offset(),
-      stm_manifest.get_archive_clean_offset(),
-      second_seg.base_offset);
-    auto res = view.compute_retention(size_limit, std::nullopt).get();
+        stm_manifest.set_archive_clean_offset(
+          pre_start_seg.base_offset, prev_segment_size);
+        vlog(
+          test_log.info,
+          "Triggering size based retention, current archive start offset: "
+          "{}, current archive clean offset: {}, expected offset: {}",
+          stm_manifest.get_archive_start_offset(),
+          stm_manifest.get_archive_clean_offset(),
+          truncation_point.base_offset);
 
-    BOOST_REQUIRE(res.has_value());
-    BOOST_REQUIRE_EQUAL(res.value().offset, third_seg.base_offset);
-    BOOST_REQUIRE_EQUAL(res.value().delta, third_seg.delta_offset);
+        auto res = view.compute_retention(size_limit, std::nullopt).get();
+        BOOST_REQUIRE(res.has_value());
 
-    // Compute retention again after updating the clean offset and the archive
-    // size. In order to get the correct result, `first_seg` must be skipped.
-    stm_manifest.set_archive_clean_offset(
-      second_seg.base_offset, first_seg.size_bytes);
-    vlog(
-      test_log.info,
-      "Triggering size based retention, current archive start offset: "
-      "{}, current archive clean offset: {}, expected offset: {}",
-      stm_manifest.get_archive_start_offset(),
-      stm_manifest.get_archive_clean_offset(),
-      second_seg.base_offset);
-    auto res2 = view.compute_retention(size_limit, std::nullopt).get();
+        if (res.value().offset > truncation_point.base_offset) {
+            vlog(
+              test_log.error,
+              "Retention collected too much data:"
+              "truncation offset: {}, expected : {}",
+              res.value().offset,
+              truncation_point.base_offset);
+        }
 
-    BOOST_REQUIRE(res2.has_value());
-    BOOST_REQUIRE_EQUAL(res2.value().offset, third_seg.base_offset);
-    BOOST_REQUIRE_EQUAL(res2.value().delta, third_seg.delta_offset);
+        BOOST_CHECK_EQUAL(res.value().offset, truncation_point.base_offset);
+        BOOST_CHECK_EQUAL(res.value().delta, truncation_point.delta_offset);
+
+        prev_segment_size = pre_start_seg.size_bytes;
+    }
 }
 
 FIXTURE_TEST(


### PR DESCRIPTION
The main change in this PR is to teach size based retention in the archive
to start from the clean offset. Previously, size based retention in the archive
would always start collecting from the first segment in the same spillover
manifest as the archive start offset. Since spillover manifests are not reuploaded,
said segment could have been below the archive clean offset. In this case,
retention wouldn't collect enough data to correctly satisfy the
retention policy as it's selecting the same segments as in previous
iterations.

This patch updates size based retention to skip segments below the clean
offsets when looking for the truncation point. It might look strange
that we're using the clean offset here. Intuitively, retention should
operate from the archive start offset. The intuition is correct, but the
archive size stored in the manifest is updated when the clean offset is
updated (not the archive start offset).

Early exit code paths are also added to archive retention and GC for
the cases when there's no work to be done. This avoids replicating
commands/hydrating spillover manifests when there's no need.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

