### PR TITLE
[v23.2.x] c/rm_stm: fixed returning incorrect `max_collectible_offset`

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -221,13 +221,25 @@ public:
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
     ss::future<tx_errc> abort_tx(
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
-
+    /**
+     * Returns the next after the last one decided. If there are no ongoing
+     * transactions this will return next offset to be applied to the the stm.
+     */
     model::offset last_stable_offset();
     ss::future<fragmented_vector<rm_stm::tx_range>>
       aborted_transactions(model::offset, model::offset);
 
     model::offset max_collectible_offset() override {
-        return last_stable_offset();
+        const auto lso = last_stable_offset();
+        if (lso < model::offset{0}) {
+            return model::offset{};
+        }
+        /**
+         * Since the LSO may be equal to `_next` we must return offset which has
+         * already been decided and applied hence we subtract one from the last
+         * stable offset.
+         */
+        return model::prev_offset(lso);
     }
 
     storage::stm_type type() override {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12176
