### PR TITLE
archival: fix max collectible offset on read replicas

### DIFF
--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -19,6 +19,8 @@
 
 namespace tests {
 
+using needs_connect = ss::bool_class<struct needs_connect_tag>;
+
 class remote_segment_generator {
 public:
     remote_segment_generator(
@@ -58,8 +60,10 @@ public:
     //
     // The produced pattern "key<i>", "val<i>" for Kafka offset i.
     // Expects to be the only one mutating the underlying partition state.
-    ss::future<int> produce() {
-        co_await _producer.start();
+    ss::future<int> produce(needs_connect conn = needs_connect::yes) {
+        if (conn == needs_connect::yes) {
+            co_await _producer.start();
+        }
         auto* log = dynamic_cast<storage::disk_log_impl*>(
           _partition.log().get_impl());
         auto& archiver = _partition.archiver().value().get();

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -226,6 +226,8 @@ public:
 
     model::offset get_last_clean_at() const { return _last_clean_at; };
 
+    model::offset max_collectible_offset() override;
+
 private:
     ss::future<std::error_code> do_add_segments(
       std::vector<cloud_storage::segment_meta>,
@@ -241,7 +243,6 @@ private:
 
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
-    model::offset max_collectible_offset() override;
 
     struct segment;
     struct start_offset;
@@ -293,10 +294,13 @@ private:
 
     // The offset of the last mark_clean_cmd applied: if the manifest is
     // clean, this will equal _insync_offset.
-    model::offset _last_clean_at;
+    model::offset _last_clean_at{};
 
     // The offset of the last record that modified this stm
-    model::offset _last_dirty_at;
+    model::offset _last_dirty_at{};
+
+    // Offset of the last applied replace_manifest command.
+    std::optional<model::offset> _last_applied_replace_cmd{std::nullopt};
 
     cloud_storage::remote& _cloud_storage_api;
     features::feature_table& _feature_table;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -730,7 +730,7 @@ gc_config disk_log_impl::override_retention_config(gc_config cfg) const {
 
 bool disk_log_impl::is_cloud_retention_active() const {
     return config::shard_local_cfg().cloud_storage_enabled()
-           && (config().is_archival_enabled());
+           && (config().is_archival_enabled() || config().is_read_replica_mode_enabled());
 }
 
 /*
@@ -2329,22 +2329,6 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
         vlog(
           stlog.debug,
           "Reporting no reclaimable offsets for non-cloud partition {}",
-          config().ntp());
-        co_return res;
-    }
-
-    /*
-     * there is currently a bug with read replicas that makes the max
-     * collectible offset unreliable. the read replica topics still have a
-     * retention setting, but we are going to exempt them from forced reclaim
-     * until this bug is fixed to avoid any complications.
-     *
-     * https://github.com/redpanda-data/redpanda/issues/11936
-     */
-    if (config().is_read_replica_mode_enabled()) {
-        vlog(
-          stlog.debug,
-          "Reporting no reclaimable offsets for read replica partition {}",
           config().ntp());
         co_return res;
     }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -651,16 +651,6 @@ bool disk_log_impl::has_local_retention_override() const {
 }
 
 gc_config disk_log_impl::maybe_override_retention_config(gc_config cfg) const {
-    // Read replica topics have a different default retention
-    if (config().is_read_replica_mode_enabled()) {
-        cfg.eviction_time = std::max(
-          model::timestamp(
-            model::timestamp::now().value()
-            - ntp_config::read_replica_retention.count()),
-          cfg.eviction_time);
-        return cfg;
-    }
-
     // cloud_retention is disabled, do not override
     if (!is_cloud_retention_active()) {
         return cfg;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -33,8 +33,6 @@ public:
     static constexpr bool default_remote_delete{true};
     static constexpr bool legacy_remote_delete{false};
 
-    static constexpr std::chrono::milliseconds read_replica_retention{3600000};
-
     struct default_overrides {
         // if not set use the log_manager's configuration
         std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -186,12 +184,6 @@ public:
             // If no value set, fall through and use the cluster-wide default.
         }
 
-        if (is_read_replica_mode_enabled()) {
-            // Read replicas have a special hardcoded default, because they do
-            // not retain user data in local raft log, just configuration.
-            return read_replica_retention;
-        }
-
         return config::shard_local_cfg().delete_retention_ms();
     }
 
@@ -240,12 +232,6 @@ public:
                 return _overrides->segment_ms.value();
             }
             // fall through to server config
-        }
-
-        if (is_read_replica_mode_enabled()) {
-            // Read replicas have a special hardcoded default, because they do
-            // not retain user data in local raft log, just configuration.
-            return read_replica_retention;
         }
 
         return config::shard_local_cfg().log_segment_ms;

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -195,7 +195,7 @@ class TestRunner():
         # If in CI, run with trace because we need the evidence if something
         # fails.  Locally, use INFO to improve runtime: the developer can
         # selectively re-run failing tests with more logging if needed.
-        log_level = 'trace' if self.ci else 'info'
+        log_level = 'trace' if self.ci else 'debug'
 
         def has_flag(flag, *synonyms):
             """Check if the args list already contains a particularly CLI flag,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
We're currently using 1hr as the time to wait before truncating read
replicas' local logs. While probably safe, this isn't based in anything
material on the archival_metadata_stm.

This commit tweaks the max collectible offset to be the offset of the
last applied replace_manifest command.

Fixes #11936
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
