### PR TITLE
kafka: turn connection_context::dispatch_method_once into coroutine

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -432,7 +432,6 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
               "Discarding second stage failure {}",
               std::current_exception());
         }
-        sres->tracker->mark_errored();
         vlog(
           klog.info,
           "Detected error dispatching request: {}",

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -444,10 +444,16 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
     /**
      * second stage processed in background.
      */
-    ssx::background = ssx::spawn_with_gate_then(_server.conn_gate(), [&] {
-        return handle_response(
-          self, std::move(res.response), sres, seq, correlation);
-    });
+    ssx::spawn_with_gate(
+      _server.conn_gate(),
+      [this,
+       self,
+       f = std::move(res.response),
+       sres,
+       seq,
+       correlation]() mutable {
+          return handle_response(self, std::move(f), sres, seq, correlation);
+      });
 }
 
 ss::future<> connection_context::handle_response(

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -425,10 +425,7 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
     /*
      * if the dispatch/first stage failed, then we need to
      * need to consume the second stage since it might be
-     * an exceptional future. if we captured `f` in the
-     * lambda but didn't use `then_wrapped` then the
-     * lambda would be destroyed and an ignored
-     * exceptional future would be caught by seastar.
+     * an exceptional future.
      */
     if (dispatch_eptr) {
         try {

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -424,6 +424,10 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
     auto dispatch = co_await ss::coroutine::as_future(
       std::move(res.dispatched));
     if (dispatch.failed()) {
+        vlog(
+          klog.info,
+          "Detected error dispatching request: {}",
+          dispatch.get_exception());
         try {
             co_await std::move(res.response);
         } catch (...) {
@@ -432,10 +436,6 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
               "Discarding second stage failure {}",
               std::current_exception());
         }
-        vlog(
-          klog.info,
-          "Detected error dispatching request: {}",
-          dispatch.get_exception());
         self->conn->shutdown_input();
         sres->tracker->mark_errored();
         co_return;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -288,7 +288,12 @@ private:
      * stage of processing and allows for some request handling overlap.
      */
     ss::future<> dispatch_method_once(request_header, size_t sz);
-    ss::future<> handle_response(ss::lw_shared_ptr<connection_context>, ss::future<response_ptr>, ss::lw_shared_ptr<session_resources>, sequence_id, correlation_id);
+    ss::future<> handle_response(
+      ss::lw_shared_ptr<connection_context>,
+      ss::future<response_ptr>,
+      ss::lw_shared_ptr<session_resources>,
+      sequence_id,
+      correlation_id);
 
     class ctx_log {
     public:

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -283,6 +283,8 @@ private:
     using sequence_id = named_type<uint64_t, struct kafka_protocol_sequence>;
     using map_t = absl::flat_hash_map<sequence_id, response_and_resources>;
 
+    ss::future<> handle_response(ss::lw_shared_ptr<connection_context>, ss::future<response_ptr>, ss::lw_shared_ptr<session_resources>, sequence_id, correlation_id);
+
     class ctx_log {
     public:
         ctx_log(const ss::net::inet_address& addr, uint16_t port)

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -252,8 +252,6 @@ private:
     ss::future<session_resources>
     throttle_request(const request_header&, size_t sz);
 
-    ss::future<> dispatch_method_once(request_header, size_t sz);
-
     /**
      * Process zero or more ready responses in request order.
      *
@@ -283,6 +281,13 @@ private:
     using sequence_id = named_type<uint64_t, struct kafka_protocol_sequence>;
     using map_t = absl::flat_hash_map<sequence_id, response_and_resources>;
 
+    /*
+     * dispatch_method_once is the first stage processing of a request and
+     * handles work synchronously such as sequencing data off the connection.
+     * handle_response waits for the response in the background as a second
+     * stage of processing and allows for some request handling overlap.
+     */
+    ss::future<> dispatch_method_once(request_header, size_t sz);
     ss::future<> handle_response(ss::lw_shared_ptr<connection_context>, ss::future<response_ptr>, ss::lw_shared_ptr<session_resources>, sequence_id, correlation_id);
 
     class ctx_log {

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -276,6 +276,25 @@ ignore_shutdown_exceptions(seastar::future<> fut) noexcept {
       .handle_exception_type([](const seastar::broken_condition_variable&) {});
 }
 
+/// \brief Check if the exception is a commonly ignored shutdown exception.
+inline bool is_shutdown_exception(const std::exception_ptr& e) {
+    try {
+        std::rethrow_exception(e);
+    } catch (const seastar::abort_requested_exception&) {
+        return true;
+    } catch (const seastar::gate_closed_exception&) {
+        return true;
+    } catch (const seastar::broken_semaphore&) {
+        return true;
+    } catch (const seastar::broken_promise&) {
+        return true;
+    } catch (const seastar::broken_condition_variable&) {
+        return true;
+    } catch (...) {
+    }
+    return false;
+}
+
 /// \brief Create a future holding a gate, handling common shutdown exception
 /// types.  Returns the resulting future, onto which further exception handling
 /// may be chained.


### PR DESCRIPTION
Turns the long and hideous dispatch_method_once function into a coroutine in an on-going effort to clean-up and simplify the Kafka server.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

