### PR TITLE
cloud_storage: Debug topic recovery test failures

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -339,6 +339,8 @@ request_creator::make_delete_objects_request(
         return ec;
     }
 
+    vlog(s3_log.trace, "delete request body: \n{}", body);
+
     return {
       std::move(header),
       ss::input_stream<char>{ss::data_source{

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -600,8 +600,10 @@ ss::future<> topic_recovery_service::do_check_for_downloads() {
 
         vlog(
           cst_log.debug,
-          "processing result for {}: [{}]. current status: {}",
+          "processing UUID {} result for {}/{}: [{}]. current status: {}",
+          result.uuid,
           result.tp_ns,
+          result.partition,
           result.result,
           status);
     }

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3761,7 +3761,7 @@ class RedpandaService(RedpandaServiceBase):
          "segments_outside_manifest":[],
          "unknown_keys":[]}
         """
-        vars = {"RUST_LOG": "warn"}
+        vars = {"RUST_LOG": "info"}
         backend = ""
         if self.si_settings.cloud_storage_type == CloudStorageType.S3:
             backend = "aws"

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -464,8 +464,13 @@ def ssh_output_stderr(source_service,
     stdin, stdout, stderr = client.exec_command(cmd, timeout=timeout_sec)
 
     try:
+        stderrdata = []
+        for log_entry in iter(lambda: stderr.readline().strip(), ''):
+            source_service.logger.debug(f'rp-storage-tool output: {log_entry}')
+            stderrdata.append(log_entry)
+
+        stderrdata = '\n'.join(stderrdata)
         stdoutdata = stdout.read()
-        stderrdata = stderr.read()
 
         exit_status = stdin.channel.recv_exit_status()
         if exit_status != 0:
@@ -482,4 +487,4 @@ def ssh_output_stderr(source_service,
         stderr.close()
     source_service.logger.debug(
         f"Returning ssh command output:\n{stdoutdata}\n")
-    return stdoutdata, stderrdata
+    return stdoutdata, stderrdata.encode()


### PR DESCRIPTION
Adds debugging to topic recovery delete operations. Some of these logs will be part of a final PR but the current state is for debugging.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
