### PR TITLE
archival: promote log for noop GC to error

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2179,11 +2179,10 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
     }
 
     // Drop out if we have no work to do, avoid doing things like the following
-    // manifest flushing unnecessarily. This is potentially problematic since,
-    // we've already checked that the clean offset is greater than the start
-    // offset.
+    // manifest flushing unnecessarily. This is problematic since, we've already
+    // checked that the clean offset is greater than the start offset.
     if (objects_to_remove.empty() && manifests_to_remove.empty()) {
-        vlog(_rtclog.warn, "Nothing to remove in archive GC");
+        vlog(_rtclog.error, "Nothing to remove in archive GC");
         co_return;
     }
 


### PR DESCRIPTION
Follow up from https://github.com/redpanda-data/redpanda/pull/12177#discussion_r1267999549

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

