### PR TITLE
cloud_storage: Spillover race prevention

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2121,7 +2121,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
     while (cursor->get_status()
            == cloud_storage::async_manifest_view_cursor_status::
              materialized_spillover) {
-        auto stop = cursor->with_manifest(
+        auto stop = co_await cursor->with_manifest(
           [&](const cloud_storage::partition_manifest& manifest) {
               for (const auto& meta : manifest) {
                   if (meta.committed_offset < clean_offset) {

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2163,7 +2163,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
         if (stop) {
             break;
         }
-        auto path = cursor->manifest()->get().get_manifest_path();
+        auto path = cursor->manifest()->get_manifest_path();
         manifests_to_remove.push_back(path());
         auto res = co_await cursor->next();
         if (res.has_failure()) {

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -480,7 +480,7 @@ private:
             if (likely(new_stm_start_offset == stm_start_offset.value())) {
                 _view_cursor = std::move(cur.value());
                 if (
-                  _view_cursor->manifest()->get().get_start_offset().value()
+                  _view_cursor->manifest()->get_start_offset().value()
                   == new_stm_start_offset) {
                     _initial_stm_start_offset = new_stm_start_offset;
                 }
@@ -609,7 +609,7 @@ private:
                 // Our segment lookup may return incorrect results if the
                 // offset we're looking for has been moved out of this manifest
                 // (e.g. spillover of the STM manifest).
-                auto& manifest = maybe_manifest->get();
+                auto& manifest = *maybe_manifest;
                 if (
                   unlikely(
                     _initial_stm_start_offset.has_value()
@@ -859,7 +859,7 @@ remote_partition::aborted_transactions(offset_range offsets) {
             }
             auto cursor = std::move(cur_res.value());
             co_await ss::repeat([&meta_to_materialize, &cursor, offsets] {
-                const auto& manifest = cursor->manifest()->get();
+                const auto& manifest = *cursor->manifest();
                 for (auto it = manifest.segment_containing(offsets.begin);
                      it != manifest.end();
                      ++it) {

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -23,6 +23,7 @@
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/io_priority_class.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/testing/seastar_test.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -73,21 +74,7 @@ public:
 
     ~async_manifest_view_fixture() { view.stop().get(); }
 
-    // The current content of the manifest will be spilled over to the archive
-    // and new elements will be generated.
-    void generate_manifest_section(int num_segments, bool hydrate = true) {
-        if (stm_manifest.empty()) {
-            add_random_segments(stm_manifest, num_segments);
-        }
-        auto so = model::next_offset(stm_manifest.get_last_offset());
-        add_random_segments(stm_manifest, num_segments);
-        spillover_manifest spm(manifest_ntp, manifest_rev);
-        for (const auto& meta : stm_manifest) {
-            if (meta.committed_offset >= so) {
-                break;
-            }
-            spm.add(meta);
-        }
+    expectation spill_manifest(const spillover_manifest& spm, bool hydrate) {
         stm_manifest.spillover(spm.make_manifest_metadata());
         // update cache
         auto path = spm.get_manifest_path();
@@ -108,10 +95,28 @@ public:
         in_stream.close().get();
         out_stream.close().get();
         ss::sstring body = linearize_iobuf(std::move(tmp_buf));
-        expectation exp{
+        return expectation{
           .url = path().string(),
           .body = body,
         };
+    }
+
+    // The current content of the manifest will be spilled over to the archive
+    // and new elements will be generated.
+    void generate_manifest_section(int num_segments, bool hydrate = true) {
+        if (stm_manifest.empty()) {
+            add_random_segments(stm_manifest, num_segments);
+        }
+        auto so = model::next_offset(stm_manifest.get_last_offset());
+        add_random_segments(stm_manifest, num_segments);
+        spillover_manifest spm(manifest_ntp, manifest_rev);
+        for (const auto& meta : stm_manifest) {
+            if (meta.committed_offset >= so) {
+                break;
+            }
+            spm.add(meta);
+        }
+        auto exp = spill_manifest(spm, hydrate);
         _expectations.push_back(std::move(exp));
         spillover_start_offsets.push_back(so);
     }
@@ -868,4 +873,138 @@ FIXTURE_TEST(
     auto past_term_query = view.get_term_last_offset(model::term_id{100}).get();
     BOOST_REQUIRE(past_term_query.has_value());
     BOOST_REQUIRE(past_term_query.value() == std::nullopt);
+}
+
+FIXTURE_TEST(
+  test_async_manifest_view_spill_concurrently, async_manifest_view_fixture) {
+    // Enumerate all segments while spilling.
+    std::vector<segment_meta> expected;
+    collect_segments_to(expected);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_random_segments(stm_manifest, 10);
+    listen();
+
+    model::offset so = model::offset{0};
+    auto maybe_cursor = view.get_cursor(so).get();
+    BOOST_REQUIRE(!maybe_cursor.has_failure());
+
+    std::vector<segment_meta> actual;
+    auto cursor = std::move(maybe_cursor.value());
+    do {
+        vlog(
+          test_log.info,
+          "Manifest before sync [{}/{}], cursor status: {}",
+          cursor->manifest()->get_start_offset(),
+          cursor->manifest()->get_last_offset(),
+          cursor->get_status());
+
+        if (
+          cursor->get_status()
+          == cloud_storage::async_manifest_view_cursor_status::
+            materialized_stm) {
+            // Trigger fake spillover, spill manifest with one segment
+            spillover_manifest spm(manifest_ntp, manifest_rev);
+            for (const auto& meta : stm_manifest) {
+                spm.add(meta);
+                break;
+            }
+            spill_manifest(spm, true);
+            vlog(
+              test_log.info,
+              "Spilled new manifest with metadata: {}",
+              spm.make_manifest_metadata());
+        }
+
+        cursor->maybe_sync_manifest().get();
+
+        vlog(
+          test_log.info,
+          "Manifest after sync [{}/{}], cursor status: {}",
+          cursor->manifest()->get_start_offset(),
+          cursor->manifest()->get_last_offset(),
+          cursor->get_status());
+
+        for (auto meta : *cursor->manifest()) {
+            actual.push_back(meta);
+        }
+
+    } while (cursor->next().get().value() != eof::yes);
+
+    print_diff(actual, expected);
+    BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
+    BOOST_REQUIRE(expected == actual);
+}
+
+FIXTURE_TEST(test_async_manifest_view_test_iter, async_manifest_view_fixture) {
+    // Enumerate all segments while spilling.
+    std::vector<segment_meta> expected;
+    collect_segments_to(expected);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_random_segments(stm_manifest, 10);
+    listen();
+
+    model::offset so = model::offset{0};
+    auto maybe_cursor = view.get_cursor(so).get();
+    BOOST_REQUIRE(!maybe_cursor.has_failure());
+
+    std::vector<segment_meta> actual;
+    auto cursor = std::move(maybe_cursor.value());
+    cloud_storage::for_each_segment(
+      std::move(cursor),
+      [&actual](const cloud_storage::segment_meta& m) mutable {
+          actual.push_back(m);
+          return ss::stop_iteration::no;
+      })
+      .get();
+
+    print_diff(actual, expected);
+    BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
+    BOOST_REQUIRE(expected == actual);
+}
+
+FIXTURE_TEST(test_async_manifest_view_test_iter2, async_manifest_view_fixture) {
+    std::vector<segment_meta> expected;
+    collect_segments_to(expected);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_manifest_section(100);
+    generate_random_segments(stm_manifest, 10);
+    listen();
+
+    model::offset so = model::offset{0};
+    auto maybe_cursor = view.get_cursor(so).get();
+    BOOST_REQUIRE(!maybe_cursor.has_failure());
+
+    std::vector<segment_meta> actual;
+    auto cursor = std::move(maybe_cursor.value());
+    cloud_storage::for_each_manifest(
+      std::move(cursor),
+      [&actual](ssx::task_local_ptr<const cloud_storage::partition_manifest>
+                  p) mutable {
+          for (const auto& m : *p) {
+              actual.push_back(m);
+          }
+          return ss::stop_iteration::no;
+      })
+      .get();
+
+    print_diff(actual, expected);
+    BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
+    BOOST_REQUIRE(expected == actual);
 }

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -677,8 +677,8 @@ FIXTURE_TEST(test_async_manifest_view_retention, async_manifest_view_fixture) {
     auto cur = std::move(cur_res.value());
     // Set expected offset to the start of the second segment
     cur->next().get();
-    prefix_base_offset = cur->manifest()->get().begin()->base_offset;
-    prefix_delta = cur->manifest()->get().begin()->delta_offset;
+    prefix_base_offset = cur->manifest()->begin()->base_offset;
+    prefix_delta = cur->manifest()->begin()->delta_offset;
     stm_manifest.advance_start_kafka_offset(prefix_base_offset - prefix_delta);
     vlog(
       test_log.info,

--- a/src/v/ssx/task_local_ptr.h
+++ b/src/v/ssx/task_local_ptr.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "vassert.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/task.hh>
+#include <seastar/core/thread.hh>
+
+#include <stdexcept>
+
+namespace ssx {
+
+/// Exception that indicates that the accessed
+/// task_local_ptr object is invalidated.
+class task_local_ptr_invalidated : public std::runtime_error {
+public:
+    task_local_ptr_invalidated()
+      : std::runtime_error("task_local_ptr is invalidated") {}
+};
+
+/// The value that gets invalidated after first scheduling point.
+///
+/// Any attempt to access the value after invalidation
+/// will trigger 'task_local_invalidated' exception.
+template<class T>
+class task_local {
+    static const seastar::task* get_current_task() {
+        auto task = seastar::engine().current_task();
+        if (task == nullptr) {
+            task = seastar::thread_impl::get()->waiting_task();
+        }
+        vassert(task != nullptr, "No current task");
+        return task;
+    }
+
+public:
+    explicit task_local(const T& val)
+      : _val(val)
+      , _task(get_current_task()) {}
+
+    explicit task_local(T&& val)
+      : _val(val)
+      , _task(get_current_task()) {}
+
+    task_local() = delete;
+    ~task_local() = default;
+    task_local(const task_local& other) = default;
+    task_local(task_local&&) noexcept = default;
+    task_local& operator=(const task_local&) = default;
+    task_local& operator=(task_local&&) noexcept = default;
+
+    bool operator==(const task_local& other) const {
+        throw_on_bad_access();
+        return _val == other._val;
+    }
+
+    bool operator==(const T& other) const {
+        throw_on_bad_access();
+        return _val == other;
+    }
+
+    const T& value() const {
+        check_time_slice();
+        throw_on_bad_access();
+        return _val.value();
+    }
+
+    T& value() {
+        check_time_slice();
+        throw_on_bad_access();
+        return _val.value();
+    }
+
+    bool has_value() const {
+        check_time_slice();
+        return _val.has_value();
+    }
+
+private:
+    /// Check if the time slice is the same. Invalidate
+    /// the pointer if its not.
+    void check_time_slice() const {
+        if (get_current_task() != _task) {
+            // Opt-out from all checks if we don't have a valid pointer to
+            // the current task.
+            _val = std::nullopt;
+        }
+    }
+
+    void throw_on_bad_access() const {
+        if (!_val.has_value()) {
+            throw task_local_ptr_invalidated();
+        }
+    }
+
+    mutable std::optional<T> _val;
+    // Non-owning ptr
+    const seastar::task* _task;
+};
+
+template<class T, class... Args>
+auto make_task_local(Args&&... args) {
+    return task_local<T>(T((std::forward<Args>(args))...));
+}
+
+/// Non-owning smart pointer.
+/// Gets invalidated after first scheduling point.
+///
+/// Any attempt to access the object after invalidation
+/// will trigger 'task_local_invalidated' exception.
+template<class T>
+class task_local_ptr {
+public:
+    explicit task_local_ptr(T* val)
+      : _ref(val) {}
+
+    task_local_ptr()
+      : _ref(nullptr) {}
+
+    task_local_ptr(const task_local_ptr&) = default;
+    task_local_ptr(task_local_ptr&&) noexcept = default;
+    task_local_ptr& operator=(const task_local_ptr&) = default;
+    task_local_ptr& operator=(task_local_ptr&&) noexcept = default;
+    ~task_local_ptr() = default;
+
+    bool operator==(const task_local_ptr& other) const {
+        return _ref == other._ref;
+    }
+
+    bool operator==(const T* other) const { return _ref.value() == other; }
+
+    const T* operator->() const { return _ref.value(); }
+
+    T* operator->() { return _ref.value(); }
+
+    const T& operator*() const { return *_ref.value(); }
+
+    T& operator*() { return *_ref.value(); }
+
+    const T& value() const { return *_ref.value(); }
+
+    T& value() { return *_ref.value(); }
+
+    bool has_value() const { return _ref.has_value(); }
+
+private:
+    task_local<T*> _ref;
+};
+
+} // namespace ssx

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ rp_test(
     future_util.cc
     thread_worker.cc
     sleep_abortable_test.cc
+    task_local_ptr_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::ssx
   LABELS ssx

--- a/src/v/ssx/tests/task_local_ptr_test.cc
+++ b/src/v/ssx/tests/task_local_ptr_test.cc
@@ -1,0 +1,72 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/task_local_ptr.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/later.hh>
+
+#include <absl/algorithm/container.h>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test_log.hpp>
+
+using namespace ssx;
+
+SEASTAR_THREAD_TEST_CASE(task_local_throws_on_illegal_access) {
+    task_local<seastar::sstring> val("task-local-value");
+
+    BOOST_REQUIRE(val.has_value());
+
+    seastar::yield().get();
+
+    BOOST_REQUIRE(!val.has_value());
+    BOOST_REQUIRE_THROW(val.value(), task_local_ptr_invalidated);
+}
+
+SEASTAR_THREAD_TEST_CASE(task_local_make_val) {
+    seastar::sstring val = "task-local-value";
+    auto tl = make_task_local<seastar::sstring>(val.begin(), val.end());
+
+    BOOST_REQUIRE(tl.has_value());
+    BOOST_REQUIRE(tl.value() == val);
+
+    seastar::yield().get();
+
+    BOOST_REQUIRE(!tl.has_value());
+}
+
+SEASTAR_THREAD_TEST_CASE(task_local_ptr_not_available_after_scheduling_point) {
+    seastar::sstring val = "task_local_value";
+    task_local_ptr<seastar::sstring> ptr(&val);
+    task_local_ptr<seastar::sstring> nul;
+
+    BOOST_REQUIRE(ptr.has_value());
+    BOOST_REQUIRE(ptr != nul);
+    BOOST_REQUIRE(ptr != nullptr);
+    BOOST_REQUIRE(ptr == ptr);
+    BOOST_REQUIRE(ptr == &val);
+
+    seastar::yield().get();
+
+    BOOST_REQUIRE(!ptr.has_value());
+}
+
+SEASTAR_THREAD_TEST_CASE(task_local_ptr_throws_on_illegal_access) {
+    seastar::sstring val = "task_local_value";
+    task_local_ptr<seastar::sstring> ptr(&val);
+
+    BOOST_REQUIRE(ptr.has_value());
+    BOOST_REQUIRE(ptr->size());
+
+    seastar::yield().get();
+
+    BOOST_REQUIRE(!ptr.has_value());
+    BOOST_REQUIRE_THROW(ptr->size(), task_local_ptr_invalidated);
+}


### PR DESCRIPTION
The `async_manifest_view_cursor` is unsafe by default. When the code uses the cursor to iterate through all segments it is possible to hit a race condition. When the cursor selects STM manifest and then spillover happens the code will skip some segments.

This PR fixes these issues.
* The `task_local_ptr` smart pointer is used to return an object that should only be used in the same time-slice. It gets invalidated after the first scheduling point eliminating potential undefined behaviour when the object might be invalidated or not.
* The `task_local_ptr` is used to return a reference to the current manifest. The caller is supposed to use it in the same time slice (the code was already using it this way but it wasn't enforced).
* When the `async_manifest_view_cursor` is pointed to the STM manifest it caches its start offset (if the `seek` method was used) or expected start offset (if `next` method was used).
* The `sync_manifest` method was added to the `async_manifest_view_cursor`. This method checks if the current manifest is actually an STM manifest and if this is the case it validates it against the cached start offset. If the manifest was updated (spillover happened or it was truncated) it re-fetches the manifest.
* In case of truncation this shouldn't do anything and the user will see truncated manifest.
* In case of spillover this should fetch new spillover manifest with offsets that would otherwise be skipped.
* `for_each_segment` free function is added. This function can be used to iterate through the entire manifest + spills.
* TBD: update some use sites (GC, retention, read path)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none