### PR TITLE
tests/cg-recovery: disable the leader balancer

### DIFF
--- a/tests/rptest/tests/consumer_group_recovery_tool_test.py
+++ b/tests/rptest/tests/consumer_group_recovery_tool_test.py
@@ -31,8 +31,9 @@ class ConsumerOffsetsRecoveryToolTest(PreallocNodesTest):
             test_ctx,
             num_brokers=3,
             *args,
-            # disable leader balancer to make sure that group will not be realoaded because of leadership changes
+            # disable leader balancer to make sure that group will not be reloaded or removed because of leadership changes
             extra_rp_conf={
+                "enable_leader_balancer": False,
                 # clear topics from the the kafka_nodelete_topics to allow for
                 # __consumer_offsets to be configured in this test.
                 "kafka_nodelete_topics": [],


### PR DESCRIPTION
It is possible for the leader balancer to initiate a leadership transfer for a `__consumer_offsets` NTP. This could lead to a consumer group being removed too early as a consequence of leadership change. For details, see comment https://github.com/redpanda-data/redpanda/issues/10363#issuecomment-1642598711

Fixes: #10363

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

* none
