### PR TITLE
rpk: enhanced version command

### DIFF
--- a/src/go/rpk/build.sh
+++ b/src/go/rpk/build.sh
@@ -10,6 +10,9 @@
 
 version=$1
 rev=${2:-$(git rev-parse --short HEAD)}
+buildTime="$(date -Iseconds)"
+hostOs="$(go env GOHOSTOS)"
+hostArch="$(go env GOHOSTARCH)"
 # auth0 clientId for the vectorized cloud, optional
 clientId=$3
 img_tag=${version:-latest}
@@ -22,5 +25,5 @@ ver_pkg='github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version'
 cont_pkg='github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common'
 
 go build \
-  -ldflags "-X ${ver_pkg}.version=${version} -X ${ver_pkg}.rev=${rev} -X ${cont_pkg}.tag=${img_tag}" \
+  -ldflags "-X ${ver_pkg}.version=${version} -X ${ver_pkg}.rev=${rev} -X ${cont_pkg}.tag=${img_tag} -X ${ver_pkg}.buildTime=${buildTime} -X ${ver_pkg}.hostOs=${hostOs} -X ${ver_pkg}.hostArch=${hostArch}" \
   -o "${out_dir}" ./...

--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -199,7 +199,7 @@ func newAdminAPI(urls []string, auth Auth, tlsConfig *tls.Config, forCloud bool)
 	client.LogHook = func(e pester.ErrEntry) {
 		// Only log from here when retrying: a final error propagates to caller
 		if e.Err != nil && e.Retry <= client.MaxRetries {
-			fmt.Printf("Retrying %s for error: %s\n", e.Verb, e.Err.Error())
+			zap.L().Sugar().Debugf("Retrying %s for error: %s\n", e.Verb, e.Err.Error())
 		}
 	}
 

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -105,7 +105,7 @@ func Execute() {
 		group.NewCommand(fs, p),
 		plugincmd.NewCommand(fs),
 		topic.NewCommand(fs, p),
-		version.NewCommand(),
+		version.NewCommand(fs, p),
 
 		newStatusCommand(), // deprecated
 	)

--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -11,27 +11,109 @@ package version
 
 import (
 	"fmt"
+	"runtime"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
+// Default build-time variables, passed via ldflags.
 var (
-	version string
-	rev     string
+	version   string // Semver of rpk.
+	rev       string // Short git SHA.
+	buildTime string // Timestamp of build time, ISO 8601.
+	hostOs    string // OS that was used to built rpk (go env GOHOSTOS).
+	hostArch  string // Arch that was used to built rpk (go env GOHOSTARCH).
 )
+
+type rpkVersion struct {
+	Version   string `json:"version,omitempty" yaml:"version,omitempty"`
+	GitRef    string `json:"git_ref,omitempty" yaml:"git_ref,omitempty"`
+	BuildTime string `json:"build_time,omitempty" yaml:"build_time,omitempty"`
+	GoVersion string `json:"go_version,omitempty" yaml:"go_version,omitempty"`
+	OsArch    string `json:"os_arch,omitempty" yaml:"os_arch,omitempty"`
+}
+
+type redpandaVersion struct {
+	NodeID  int
+	Version string
+}
+type redpandaVersions []redpandaVersion
 
 func Pretty() string {
 	return fmt.Sprintf("%s (rev %s)", version, rev)
 }
 
-func NewCommand() *cobra.Command {
-	command := &cobra.Command{
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Check the current version",
-		Long:  "",
-		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println(Pretty())
+		Short: "Prints the current rpk and Redpanda version",
+		Long: `Prints the current rpk and Redpanda version.
+
+This command prints the current rpk version and allows you to list the Redpanda 
+version running on each node in your cluster.
+
+To list the Redpanda version of each node in your cluster you may pass the
+Admin API hosts via flags, profile, or environment variables.`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			rv := rpkVersion{
+				Version:   version,
+				GitRef:    rev,
+				BuildTime: buildTime,
+				GoVersion: runtime.Version(),
+				OsArch:    fmt.Sprintf("%s/%s", hostOs, hostArch),
+			}
+			printRpkVersion(rv)
+			var rows redpandaVersions
+			defer printClusterVersions(&rows)
+
+			p, err := p.LoadVirtualProfile(fs)
+			if err != nil {
+				zap.L().Sugar().Errorf("unable to load the profile: %v", err)
+				return
+			}
+			cl, err := adminapi.NewClient(fs, p)
+			if err != nil {
+				zap.L().Sugar().Errorf("unable to create the admin client: %v", err)
+				return
+			}
+			bs, err := cl.Brokers(cmd.Context())
+			if err != nil {
+				zap.L().Sugar().Errorf("unable to request broker info: %v", err)
+				return
+			}
+			for _, b := range bs {
+				if b.IsAlive != nil {
+					rows = append(rows, redpandaVersion{b.NodeID, b.Version})
+				}
+			}
 		},
 	}
-	return command
+	return cmd
+}
+
+func printRpkVersion(rv rpkVersion) {
+	fmt.Printf(`Version:     %s
+Git ref:     %s
+Build date:  %s
+OS/Arch:     %s
+Go version:  %s
+`, rv.Version, rv.GitRef, rv.BuildTime, rv.OsArch, rv.GoVersion)
+}
+
+func printClusterVersions(rpv *redpandaVersions) {
+	fmt.Println()
+	fmt.Println("Redpanda Cluster")
+	if len(*rpv) == 0 {
+		fmt.Println(`  Unreachable, to debug, use the '-v' flag. To get the broker versions, pass the
+  hosts via flags, profile, or environment variables:
+    rpk version -X admin.hosts=<host address>`)
+		return
+	}
+	for _, v := range *rpv {
+		fmt.Printf("  node-%v  %s\n", v.NodeID, v.Version)
+	}
 }


### PR DESCRIPTION
This PR introduces an enhanced version command for rpk that prints more useful information about the build of rpk and, if possible, prints the Redpanda version running in each node in your cluster.

```
$ rpk version
Version:     v23.1.1
Git ref:     135af8f57
Build date:  2023-07-21T07:54:18-05:00
OS/Arch:     linux/amd64
Go version:  go1.20.4

Redpanda Cluster
  node-0  v23.1.13 - 6b1c6f55d2a46871fafc7d003383b59215f12351
  node-1  v23.1.13 - 6b1c6f55d2a46871fafc7d003383b59215f12351
  node-2  v23.1.13 - 6b1c6f55d2a46871fafc7d003383b59215f12351
```

**Error handling:**
```
$ rpk version 
Version:     v23.1.1
Git ref:     e8c0ac04e
Build date:  2023-07-19T16:14:12-05:00
OS/Arch:     linux/amd64
Go version:  go1.20.4

Redpanda Cluster
  Unreachable, to debug, use the '-v' flag. To get the broker versions, pass the hosts via flags, profile, or environment variables:
    rpk version -X admin.hosts=<host address>
```

Fixes #4609

Once approved and before merging, we should create a PR in vtools to handle the new ldflags. 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements

* rpk version now prints build information and the Redpanda version of each node in your cluster. 