### PR TITLE
Initial Wasm Golang Transform SDK

### DIFF
--- a/src/go/transform-sdk/LICENSE
+++ b/src/go/transform-sdk/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Redpanda Data
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/src/go/transform-sdk/abi.go
+++ b/src/go/transform-sdk/abi.go
@@ -1,0 +1,66 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build wasm
+
+package redpanda
+
+import (
+	"unsafe"
+)
+
+// These are the host functions that go allows for wasm functions that are imported.
+// See: https://github.com/golang/go/issues/59149
+
+// readRecordHeader reads all the data from the batch header into memory.
+//
+// Returns 0 upon success.
+//
+//go:wasmimport redpanda_transform read_batch_header
+func readRecordHeader(
+	h inputBatchHandle,
+	baseOffset unsafe.Pointer,
+	recordCount unsafe.Pointer,
+	partitionLeaderEpoch unsafe.Pointer,
+	attributes unsafe.Pointer,
+	lastOffsetDelta unsafe.Pointer,
+	baseTimestamp unsafe.Pointer,
+	maxTimestamp unsafe.Pointer,
+	producerId unsafe.Pointer,
+	producerEpoch unsafe.Pointer,
+	baseSequence unsafe.Pointer,
+) int32
+
+// readRecord reads the record specified using the handle. The format of the data
+// written into `buf` is a single record as specified by kafka protocol's serialized
+// wire format.
+//
+// See: https://kafka.apache.org/documentation/#record for more information.
+//
+// Returns the amount that was written into `buf` on success, otherwise
+// returns a negative number to indicate an error.
+//
+//go:wasmimport redpanda_transform read_record
+func readRecord(h inputRecordHandle, buf unsafe.Pointer, len int32) int32
+
+// writeRecord writes a new record by copying the data pointed to. The expected
+// format of `buf` is to be a record serialized according to the kafka protocol's
+// wire format.
+//
+// See: https://kafka.apache.org/documentation/#record for more information.
+//
+// Returns a negative number to indicate an error.
+//
+//go:wasmimport redpanda_transform write_record
+func writeRecord(buf unsafe.Pointer, len int32) int32

--- a/src/go/transform-sdk/doc.go
+++ b/src/go/transform-sdk/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package redpanda is the SDK for Redpanda's inline Data Transforms, based on WebAssembly.
+
+This library provides a framework for transforming records written within Redpanda from
+an input to an output topic.
+*/
+package redpanda

--- a/src/go/transform-sdk/example_mirror_test.go
+++ b/src/go/transform-sdk/example_mirror_test.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda_test
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+)
+
+// This example shows the basic usage of the package:
+// This is a "transform" that does nothing but copies the same data to an new
+// topic.
+func Example_identityTransform() {
+	// Other setup can happen here, such as setting up lookup tables,
+	// initializing reusable buffers, reading environment variables, etc.
+
+	// Make sure to register your callback so Redpanda knows which
+	// function to invoke when records are written
+	redpanda.OnRecordWritten(mirrorTransform)
+}
+
+// This will be called for each record in the source topic.
+//
+// The output records returned will be written to the destination topic.
+func mirrorTransform(e redpanda.WriteEvent) ([]redpanda.Record, error) {
+	return []redpanda.Record{e.Record()}, nil
+}

--- a/src/go/transform-sdk/example_regexp_filter_test.go
+++ b/src/go/transform-sdk/example_regexp_filter_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda_test
+
+import (
+	"os"
+	"regexp"
+
+	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+)
+
+var (
+	re         *regexp.Regexp = nil
+	checkValue bool           = false
+)
+
+// This example shows a filter that uses a regexp to filter records from
+// one topic into another. The filter can be determined when the transform
+// is deployed by using environment variables to specify the pattern.
+func Example_regularExpressionFilter() {
+	// setup the regexp
+	pattern, ok := os.LookupEnv("PATTERN")
+	if !ok {
+		panic("Missing PATTERN variable")
+	}
+	re = regexp.MustCompile(pattern)
+	mk, ok := os.LookupEnv("MATCH_VALUE")
+	checkValue = ok && mk == "1"
+
+	redpanda.OnRecordWritten(doRegexFilter)
+}
+
+func doRegexFilter(e redpanda.WriteEvent) ([]redpanda.Record, error) {
+	var b []byte
+	if checkValue {
+		b = e.Record().Value
+	} else {
+		b = e.Record().Key
+	}
+	if b == nil {
+		return nil, nil
+	}
+	pass := re.Match(b)
+	if pass {
+		return []redpanda.Record{e.Record()}, nil
+	} else {
+		return nil, nil
+	}
+}

--- a/src/go/transform-sdk/example_transcoding_test.go
+++ b/src/go/transform-sdk/example_transcoding_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda_test
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+
+	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+)
+
+// This example shows a transform that converts CSV into JSON.
+func Example_transcoding() {
+	redpanda.OnRecordWritten(csvToJsonTransform)
+}
+
+type Foo struct {
+	A string `json:"a"`
+	B int    `json:"b"`
+}
+
+func csvToJsonTransform(e redpanda.WriteEvent) ([]redpanda.Record, error) {
+	// The input data is a CSV (without a header row) that is the structure of:
+	// key, a, b
+	// This transform emits each row in that CSV as JSON.
+	reader := csv.NewReader(bytes.NewReader(e.Record().Value))
+	// Improve performance by reusing the result slice.
+	reader.ReuseRecord = true
+	output := []redpanda.Record{}
+	for {
+		row, err := reader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		if len(row) != 3 {
+			return nil, errors.New("unexpected number of rows")
+		}
+		// Convert the last column into an int
+		b, err := strconv.Atoi(row[2])
+		if err != nil {
+			return nil, err
+		}
+		// Marshal our JSON value
+		f := Foo{
+			A: row[1],
+			B: b,
+		}
+		v, err := json.Marshal(&f)
+		if err != nil {
+			return nil, err
+		}
+		// Add our output record using the first column as the key.
+		output = append(output, redpanda.Record{
+			Key:   []byte(row[0]),
+			Value: v,
+		})
+
+	}
+	return output, nil
+}

--- a/src/go/transform-sdk/go.mod
+++ b/src/go/transform-sdk/go.mod
@@ -1,0 +1,3 @@
+module github.com/redpanda-data/redpanda/src/go/transform-sdk
+
+go 1.20

--- a/src/go/transform-sdk/guest_callbacks.go
+++ b/src/go/transform-sdk/guest_callbacks.go
@@ -1,0 +1,145 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda
+
+import (
+	"time"
+	"unsafe"
+
+	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+)
+
+type (
+	eventErrorCode    int32
+	inputBatchHandle  int32
+	inputRecordHandle int32
+)
+
+const (
+	evtSuccess       = eventErrorCode(0)
+	evtConfigError   = eventErrorCode(1)
+	evtUserError     = eventErrorCode(2)
+	evtInternalError = eventErrorCode(3)
+)
+
+type batchHeader struct {
+	handle               inputBatchHandle
+	baseOffset           int64
+	recordCount          int
+	partitionLeaderEpoch int
+	attributes           int16
+	lastOffsetDelta      int
+	baseTimestamp        int64
+	maxTimestamp         int64
+	producerId           int64
+	producerEpoch        int16
+	baseSequence         int
+}
+
+// Cache a bunch of objects to not GC
+var (
+	currentHeader batchHeader  = batchHeader{handle: -1}
+	inbuf         *rwbuf.RWBuf = rwbuf.New(128)
+	outbuf        *rwbuf.RWBuf = rwbuf.New(128)
+	e             writeEvent
+)
+
+// The ABI that our SDK provides. Redpanda executes this function to determine the protocol contract to execute.
+//
+//lint:ignore U1000 this is not unused, but exposed for our Wasm host environment
+//export redpanda_transform_abi_version
+func redpandaAbiVersion() int32 {
+	return 1
+}
+
+// The Redpanda broker will invoke this method for each record that needs to be transformed.
+//
+//lint:ignore U1000 this is not unused, but exposed for our Wasm host environment
+//export redpanda_transform_on_record_written
+func redpandaOnRecord(bh inputBatchHandle, rh inputRecordHandle, recordSize int, currentRelativeOutputOffset int) eventErrorCode {
+	if userTransformFunction == nil {
+		println("Invalid configuration, there is no registered user transform function")
+		return evtConfigError
+	}
+	if currentHeader.handle != bh {
+		currentHeader.handle = bh
+		errno := readRecordHeader(
+			bh,
+			unsafe.Pointer(&currentHeader.baseOffset),
+			unsafe.Pointer(&currentHeader.recordCount),
+			unsafe.Pointer(&currentHeader.partitionLeaderEpoch),
+			unsafe.Pointer(&currentHeader.attributes),
+			unsafe.Pointer(&currentHeader.lastOffsetDelta),
+			unsafe.Pointer(&currentHeader.baseTimestamp),
+			unsafe.Pointer(&currentHeader.maxTimestamp),
+			unsafe.Pointer(&currentHeader.producerId),
+			unsafe.Pointer(&currentHeader.producerEpoch),
+			unsafe.Pointer(&currentHeader.baseSequence),
+		)
+		if errno != 0 {
+			println("Failed to read batch header")
+			return evtInternalError
+		}
+	}
+	// TODO: Also release memory if a single large record comes in that is bigger than "normal" records.
+	inbuf.Reset()
+	inbuf.EnsureSize(recordSize)
+	amt := int(readRecord(rh, unsafe.Pointer(inbuf.WriterBufPtr()), int32(recordSize)))
+	inbuf.AdvanceWriter(amt)
+	if amt != recordSize {
+		println("reading record failed with errno:", amt)
+		return evtInternalError
+	}
+	err := e.record.deserialize(inbuf)
+	if err != nil {
+		println("deserializing record failed:", err.Error())
+		return evtInternalError
+	}
+	// Save the original timestamp for output records
+	ot := e.Record().Timestamp
+	// Fix up the offsets to be absolute values
+	e.record.Offset += currentHeader.baseOffset
+	if e.record.Attrs.TimestampType() == 0 {
+		e.record.Timestamp = time.UnixMilli(e.record.Timestamp.UnixMilli() + currentHeader.baseTimestamp)
+	} else {
+		e.record.Timestamp = time.UnixMilli(currentHeader.maxTimestamp)
+	}
+	rs, err := userTransformFunction(&e)
+	if err != nil {
+		println("transforming record failed:", err.Error())
+		return evtUserError
+	}
+	if rs == nil {
+		return evtSuccess
+	}
+	for i, r := range rs {
+		// Because the previous record in the batch could have
+		// output multiple records, we need to account for this,
+		// by adjusting the offset accordingly.
+		r.Offset = int64(currentRelativeOutputOffset + i)
+		// Keep the same timestamp as the input record.
+		r.Timestamp = ot
+
+		outbuf.Reset()
+		r.serialize(outbuf)
+		b := outbuf.ReadAll()
+		amt := int(writeRecord(unsafe.Pointer(&b[0]), int32(len(b))))
+		if amt != len(b) {
+			println("writing record failed with errno:", amt)
+			return evtInternalError
+		}
+	}
+	return evtSuccess
+}

--- a/src/go/transform-sdk/internal/rwbuf/rwbuf.go
+++ b/src/go/transform-sdk/internal/rwbuf/rwbuf.go
@@ -1,0 +1,180 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A buffer with a reader and writer index that gives access to the underlying array.
+package rwbuf
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type RWBuf struct {
+	// Underlying resizeable buffer
+	buf []byte
+	// Reader index. r <= w
+	r int
+	// Writer index
+	w int
+}
+
+func New(size int) *RWBuf {
+	return &RWBuf{
+		buf: make([]byte, size),
+		r:   0,
+		w:   0,
+	}
+}
+
+func (r *RWBuf) EnsureSize(n int) {
+	if len(r.buf) >= n {
+		return
+	}
+	r.buf = append(r.buf, make([]byte, n-len(r.buf))...)
+}
+
+func (r *RWBuf) Reset() {
+	r.r = 0
+	r.w = 0
+}
+
+func (r *RWBuf) WriterBuf() []byte {
+	return r.buf[r.w:]
+}
+
+func (r *RWBuf) WriterBufPtr() *byte {
+	return &r.buf[r.w]
+}
+
+func (r *RWBuf) WriterLen() int {
+	return len(r.buf) - r.w
+}
+
+func (r *RWBuf) EnsureWriterSpace(n int) {
+	r.EnsureSize(r.w + n)
+}
+
+func (r *RWBuf) AdvanceWriter(n int) {
+	r.w += n
+}
+
+func (r *RWBuf) WriteVarint(v int64) {
+	r.EnsureWriterSpace(binary.MaxVarintLen64)
+	r.w += binary.PutVarint(r.WriterBuf(), v)
+}
+
+func (r *RWBuf) Write(b []byte) (int, error) {
+	r.EnsureWriterSpace(len(b))
+	copy(r.WriterBuf(), b)
+	r.w += len(b)
+	return len(b), nil
+}
+
+func (r *RWBuf) WriteString(s string) (int, error) {
+	// This is "safe" because we only copy out of this slice, never write to it.
+	return r.Write(unsafeStringToBytes(s))
+}
+
+func (r *RWBuf) WriteByte(b byte) error {
+	r.EnsureWriterSpace(1)
+	r.buf[r.w] = b
+	r.w++
+	return nil
+}
+
+func (r *RWBuf) WriteBytesWithSize(b []byte) {
+	if b == nil {
+		r.WriteVarint(-1)
+		return
+	}
+	r.WriteVarint(int64(len(b)))
+	// This cannot fail
+	_, _ = r.Write(b)
+}
+
+func (r *RWBuf) WriteStringWithSize(s string) {
+	r.WriteVarint(int64(len(s)))
+	// This cannot fail
+	_, _ = r.WriteString(s)
+}
+
+// Delay a write of size n, that will be issued using the supplied function,
+// it can be invoked at any time at a later time, even if buffers have
+// been resized.
+func (r *RWBuf) DelayWrite(n int, fn func(b []byte)) func() {
+	r.EnsureWriterSpace(n)
+	m := r.w
+	r.w += n
+	return func() {
+		fn(r.buf[m:n])
+	}
+}
+
+func (r *RWBuf) AdvanceReader(n int) {
+	r.r += n
+	if r.r > r.w {
+		r.r = r.w
+	}
+}
+
+func (r *RWBuf) ReaderLen() int {
+	return r.w - r.r
+}
+
+func (r *RWBuf) ReadByte() (byte, error) {
+	if r.ReaderLen() == 0 {
+		return 0, io.EOF
+	}
+	c := r.buf[r.r]
+	r.r++
+	return c, nil
+}
+
+func (r *RWBuf) ReadSlice(n int) ([]byte, error) {
+	if n > r.ReaderLen() {
+		return nil, io.ErrShortBuffer
+	}
+	i := r.r
+	r.r += n
+	return r.buf[i:r.r], nil
+}
+
+func (r *RWBuf) ReadSizedSlice() ([]byte, error) {
+	l, err := binary.ReadVarint(r)
+	if err != nil {
+		return nil, err
+	}
+	var v []byte = nil
+	if l >= 0 {
+		v, err = r.ReadSlice(int(l))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return v, nil
+}
+
+func (r *RWBuf) ReadSizedStringCopy() (string, error) {
+	b, err := r.ReadSizedSlice()
+	if err != nil {
+		return "", err
+	}
+	return string(b), err
+}
+
+func (r *RWBuf) ReadAll() []byte {
+	// Errors are impossible here
+	b, _ := r.ReadSlice(r.ReaderLen())
+	return b
+}

--- a/src/go/transform-sdk/internal/rwbuf/rwbuf_test.go
+++ b/src/go/transform-sdk/internal/rwbuf/rwbuf_test.go
@@ -1,0 +1,113 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rwbuf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestWriteThenRead(t *testing.T) {
+	b := New(2048)
+	if b.ReaderLen() != 0 {
+		t.Error("invalid initial reader len:", b.ReaderLen())
+	}
+	if b.WriterLen() != 2048 {
+		t.Error("invalid initial writer len:", b.WriterLen())
+	}
+	n, err := b.Write([]byte{1, 2, 3, 4})
+	if n != 4 || err != nil {
+		t.Error("invalid write response:", n, "err:", err)
+	}
+	if b.ReaderLen() != 4 {
+		t.Error("invalid reader len after write:", b.ReaderLen())
+	}
+	s, err := b.ReadSlice(1)
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(s, []byte{1}) {
+		t.Error("invalid read of first byte", hex.EncodeToString(s))
+	}
+	b.Reset()
+	if b.ReaderLen() != 0 {
+		t.Error("invalid reader len after reset:", b.WriterLen())
+	}
+	if b.WriterLen() != 2048 {
+		t.Error("invalid writer len after reset:", b.WriterLen())
+	}
+}
+
+type example struct {
+	A int
+	B string
+	C float32
+}
+
+func TestDelayWrite(t *testing.T) {
+	b := New(2048)
+	s := 0
+	fn := b.DelayWrite(4, func(buf []byte) {
+		binary.LittleEndian.PutUint32(buf, uint32(s))
+	})
+	d := example{
+		A: 42,
+		B: "foo",
+		C: 3.14,
+	}
+	c, err := json.Marshal(&d)
+	if err != nil {
+		t.Error(err)
+	}
+	s, err = b.Write(c)
+	if err != nil {
+		t.Error(err)
+	}
+	if s != len(c) {
+		t.Error("didn't write all the bytes", s, "!=", len(c))
+	}
+	fn()
+	l := b.ReaderLen()
+	if l != 4+len(c) {
+		t.Error("didn't update the reader len correctly", s, "!=", len(c))
+	}
+	c, err = b.ReadSlice(4)
+	if err != nil {
+		t.Error(err)
+	}
+	a := binary.LittleEndian.Uint32(c)
+	if int(a) != s {
+		t.Error("size mismatch", a, "!=", s)
+	}
+	c, err = b.ReadSlice(int(a))
+	if err != nil {
+		t.Error(err)
+	}
+	var e example
+	err = json.Unmarshal(c, &e)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(d, e) {
+		t.Error(d, "!=", e)
+	}
+	if b.ReaderLen() != 0 {
+		t.Error("Reader still had bytes left:", b.ReaderLen())
+	}
+}

--- a/src/go/transform-sdk/internal/rwbuf/unsafe.go
+++ b/src/go/transform-sdk/internal/rwbuf/unsafe.go
@@ -1,0 +1,24 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rwbuf
+
+import "unsafe"
+
+// An helper method to get a string's underlying data as a byte slice.
+//
+// It's important the the resulting slice is never modified.
+func unsafeStringToBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/src/go/transform-sdk/sdk.go
+++ b/src/go/transform-sdk/sdk.go
@@ -1,0 +1,91 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda
+
+import (
+	"time"
+)
+
+// OnRecordWritten registers a callback to be fired when a record is written to the input topic.
+//
+// OnRecordWritten should be called in a package's `main` function to register the transform function that will be applied.
+func OnRecordWritten(fn OnRecordWrittenCallback) {
+	userTransformFunction = fn
+}
+
+// OnRecordWrittenCallback is a callback to transform records after a write event happens in the input topic.
+type OnRecordWrittenCallback func(e WriteEvent) ([]Record, error)
+
+var userTransformFunction OnRecordWrittenCallback = nil
+
+// WriteEvent contains information about the write that took place,
+// namely it contains the record that was written.
+type WriteEvent interface {
+	// Access the record associated with this event
+	Record() Record
+}
+
+// Look at options/builder pattern for making TransformEvent, and make it a "private" interface
+
+type writeEvent struct {
+	record Record
+}
+
+func (e *writeEvent) Record() Record {
+	return e.record
+}
+
+// Headers are optional key/value pairs that are passed along with
+// records.
+type RecordHeader struct {
+	Key   []byte
+	Value []byte
+}
+
+// Record is a record that has been written to Redpanda.
+type Record struct {
+	// Key is an optional field.
+	Key []byte
+	// Value is the blob of data that is written to Redpanda.
+	Value []byte
+	// Headers are client specified key/value pairs that are
+	// attached to a record.
+	Headers []RecordHeader
+	// Attrs is the attributes of a record.
+	//
+	// Output records should leave these unset.
+	Attrs RecordAttrs
+	// The timestamp associated with this record.
+	//
+	// For output records this can be left unset as it will
+	// always be the same value as the input record.
+	Timestamp time.Time
+	// The offset of this record in the partition.
+	//
+	// For output records this field is left unset,
+	// as it will be set by Redpanda.
+	Offset int64
+}
+
+type RecordAttrs struct {
+	attr uint8
+}
+
+func (a RecordAttrs) TimestampType() int8 {
+	if a.attr&0b1000_0000 != 0 {
+		return -1
+	}
+	return int8(a.attr&0b0000_1000) >> 3
+}

--- a/src/go/transform-sdk/serialize.go
+++ b/src/go/transform-sdk/serialize.go
@@ -1,0 +1,118 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda
+
+import (
+	"encoding/binary"
+	"errors"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+)
+
+// Reusable slice of record headers
+var incomingRecordHeaders []RecordHeader = nil
+
+func (r *Record) deserialize(b *rwbuf.RWBuf) error {
+	rs, err := binary.ReadVarint(b)
+	if err != nil {
+		return err
+	}
+	if rs != int64(b.ReaderLen()) {
+		return errors.New("record size mismatch")
+	}
+	attr, err := b.ReadByte()
+	if err != nil {
+		return err
+	}
+	td, err := binary.ReadVarint(b)
+	if err != nil {
+		return err
+	}
+	od, err := binary.ReadVarint(b)
+	if err != nil {
+		return err
+	}
+
+	k, err := b.ReadSizedSlice()
+	if err != nil {
+		return err
+	}
+	v, err := b.ReadSizedSlice()
+	if err != nil {
+		return err
+	}
+	hc, err := binary.ReadVarint(b)
+	if err != nil {
+		return err
+	}
+	if incomingRecordHeaders == nil || len(incomingRecordHeaders) < int(hc) {
+		incomingRecordHeaders = make([]RecordHeader, hc)
+	}
+	for i := 0; i < int(hc); i++ {
+		k, err := b.ReadSizedSlice()
+		if err != nil {
+			return err
+		}
+		v, err := b.ReadSizedSlice()
+		if err != nil {
+			return err
+		}
+		incomingRecordHeaders[i] = RecordHeader{
+			Key:   k,
+			Value: v,
+		}
+	}
+	r.Key = k
+	r.Value = v
+	r.Attrs.attr = attr
+	r.Headers = incomingRecordHeaders
+	r.Timestamp = time.UnixMilli(td)
+	r.Offset = od
+	return nil
+}
+
+// Serialize this output record into the buffer
+func (r Record) serialize(b *rwbuf.RWBuf) {
+	// The first thing we write is the size of the record,
+	// which we need to go over the data to see how big that is.
+	// Instead of going over the data twice, we reserve some space
+	// then write the varint at the end in the space we reserved.
+	f := b.DelayWrite(binary.MaxVarintLen32, func(buf []byte) {
+		rs := int64(b.ReaderLen() - binary.MaxVarintLen32)
+		o := binary.PutVarint(buf, rs)
+		// Shift the varint to the start of the record
+		copy(buf[len(buf)-o:], buf[:o])
+		// Skip over the bytes we didn't use
+		b.AdvanceReader(len(buf) - o)
+	})
+	// this can never fail
+	_ = b.WriteByte(r.Attrs.attr)
+	b.WriteVarint(r.Timestamp.UnixMilli())
+	b.WriteVarint(r.Offset)
+	b.WriteBytesWithSize(r.Key)
+	b.WriteBytesWithSize(r.Value)
+	if r.Headers != nil {
+		b.WriteVarint(int64(len(r.Headers)))
+		for _, h := range r.Headers {
+			b.WriteBytesWithSize(h.Key)
+			b.WriteBytesWithSize(h.Value)
+		}
+	} else {
+		b.WriteVarint(0)
+	}
+	// Now write the header
+	f()
+}

--- a/src/go/transform-sdk/serialize_test.go
+++ b/src/go/transform-sdk/serialize_test.go
@@ -1,0 +1,84 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda
+
+import (
+	cryptorand "crypto/rand"
+	mathrand "math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+)
+
+var (
+	baseTimestamp = int64(9)
+	baseOffset    = int64(42)
+)
+
+func makeRandomHeaders(n int) []RecordHeader {
+	h := make([]RecordHeader, n)
+	for i := 0; i < n; i++ {
+		k := make([]byte, mathrand.Intn(32))
+		_, err := cryptorand.Read(k)
+		if err != nil {
+			panic(err)
+		}
+		v := make([]byte, mathrand.Intn(32))
+		_, err = cryptorand.Read(v)
+		if err != nil {
+			panic(err)
+		}
+		h[i] = RecordHeader{Key: k, Value: v}
+	}
+	return h
+}
+
+func makeRandomRecord() Record {
+	k := make([]byte, mathrand.Intn(32))
+	_, err := cryptorand.Read(k)
+	if err != nil {
+		panic(err)
+	}
+	v := make([]byte, mathrand.Intn(32))
+	_, err = cryptorand.Read(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return Record{
+		Key:       k,
+		Value:     v,
+		Attrs:     RecordAttrs{0},
+		Headers:   makeRandomHeaders(2),
+		Timestamp: time.UnixMilli(baseTimestamp + 9),
+		Offset:    baseOffset + 6,
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	r := makeRandomRecord()
+	b := rwbuf.New(0)
+	r.serialize(b)
+	output := Record{}
+	err := output.deserialize(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(r, output) {
+		t.Fatalf("%#v != %#v", r, output)
+	}
+}

--- a/src/go/transform-sdk/stub_abi.go
+++ b/src/go/transform-sdk/stub_abi.go
@@ -1,0 +1,49 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !wasm
+
+package redpanda
+
+import (
+	"unsafe"
+)
+
+// These functions are stubs of the functions documented in `abi.go`, these functions
+// exist here so that the code can be compiled in a non-wasm environment, even if they
+// will always fail at runtime.
+
+func readRecordHeader(
+	h inputBatchHandle,
+	baseOffset unsafe.Pointer,
+	recordCount unsafe.Pointer,
+	partitionLeaderEpoch unsafe.Pointer,
+	attributes unsafe.Pointer,
+	lastOffsetDelta unsafe.Pointer,
+	baseTimestamp unsafe.Pointer,
+	maxTimestamp unsafe.Pointer,
+	producerId unsafe.Pointer,
+	producerEpoch unsafe.Pointer,
+	baseSequence unsafe.Pointer,
+) int32 {
+	panic("stub")
+}
+
+func readRecord(h inputRecordHandle, buf unsafe.Pointer, len int32) int32 {
+	panic("stub")
+}
+
+func writeRecord(buf unsafe.Pointer, len int32) int32 {
+	panic("stub")
+}


### PR DESCRIPTION
This patch set implements the initial ABI + SDK for Redpanda's data transforms.

There are 3 major pieces to Wasm Data Transforms:
- rpk: the `rpk transform` commands that allow you to write, manage and deploy transforms
- sdk: this golang module, which is the set of helper libraries to give users a idiomatic and user friendly interface to write these transforms and adhere to the ABI contract that the broker expects.
- core: there will be two new subsystems, transform and wasm. The wasm subsystem will abstract the actual wasm engine and contain the actual ABI contract that the SDK will provide. The second subsystem transform, will be manage the lifecycle of a transform and leverage the engine exposed in the wasm subsystem to actually perform the transforms.

See the individual commits for more information on the actual SDK pieces.

I'll open another PR after this one for Github Actions to run on these. In the meantime, I've run these manually.

Here is a [companion video to aid reviews](https://drive.google.com/file/d/1H81RLlwWuyQ1CgYg-JxQ5peHLX8hXQyS/view?usp=sharing) if that's helpful. I recommend watching on 2x 😄 

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* Added a Golang SDK for Redpanda's Data Transforms.

