### PR TITLE
rptest: setup access to kafka api for redpanda cloud 

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1020,7 +1020,7 @@ class RpkTool:
         if self._tls_enabled:
             flags += [
                 "-X",
-                "tls.enabled=" + self._tls_enabled,
+                "tls.enabled=" + str(self._tls_enabled),
             ]
         return flags
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1305,13 +1305,15 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
             resp.raise_for_status()
             return resp.json()
 
-        def _http_post(self, endpoint='', **kwargs):
+        def _http_post(self, base_url=None, endpoint='', **kwargs):
             token = self._get_token()
             headers = {
                 'Authorization': f'Bearer {token}',
                 'Accept': 'application/json'
             }
-            resp = requests.post(f'{self._api_url}{endpoint}',
+            if base_url is None:
+                base_url = self._api_url
+            resp = requests.post(f'{base_url}{endpoint}',
                                  headers=headers,
                                  **kwargs)
             resp.raise_for_status()


### PR DESCRIPTION
Creates a redpanda cloud user, grants acls, and exposes broker url so tests can use tools like `RpkTool` to send requests to the kafka api.

This PR is needed for https://github.com/redpanda-data/cloudv2/issues/6683

Updated `test_cloud` to use `rpk` with `tls_enabled` to verify user and acls work. Output of run against redpanda cloud:
```console
bash$ ducktape --globals=/home/a/tmp/ducktape_globals.json --cluster=ducktape.cluster.json.JsonCluster --cluster-file=/home/a/tmp/ducktape_cluster.json --test-runner-timeout=3600000 tests/rptest/tests/services_self_test.py::SimpleSelfTest
[INFO:2023-07-20 11:45:33,634]: starting test run with session id 2023-07-20--007...
[INFO:2023-07-20 11:45:33,634]: running 1 tests...
[INFO:2023-07-20 11:45:33,634]: Triggering test 1 of 1...
[INFO:2023-07-20 11:45:33,639]: RunnerClient: Loading test {'directory': '/home/a/src/redpanda/tests/rptest/tests', 'file_name': 'services_self_test.py', 'cls_name': 'SimpleSelfTest', 'method_name': 'test_cloud', 'injected_args': None}
[INFO:2023-07-20 11:45:33,643]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Setting up...
[INFO:2023-07-20 12:19:14,011]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Running...
[INFO:2023-07-20 12:19:44,706]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: PASS
[INFO:2023-07-20 12:19:44,707]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Tearing down...
[WARNING - 2023-07-20 12:19:44,710 - runner_client - log - lineno:278]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Test requested 3 nodes, used only 0
[WARNING:2023-07-20 12:19:44,711]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Test requested 3 nodes, used only 0
[INFO:2023-07-20 12:19:44,712]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Summary: 
[INFO:2023-07-20 12:19:44,713]: RunnerClient: rptest.tests.services_self_test.SimpleSelfTest.test_cloud: Data: None
test_id:    rptest.tests.services_self_test.SimpleSelfTest.test_cloud
status:     PASS
run time:   34 minutes 11.067 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
============================================================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-07-20--007
run time:         34 minutes 11.092 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
============================================================================================================================================================================================================================

```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none