### PR TITLE
[v22.3.x] Fixed marking node as alive in health monitor backend

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -518,11 +518,7 @@ map_reply_result(result<get_node_health_reply> reply) {
 
 result<node_health_report> health_monitor_backend::process_node_reply(
   model::node_id id, result<get_node_health_reply> reply) {
-    auto it = _last_replies.find(id);
-    if (it == _last_replies.end()) {
-        auto [inserted, _] = _last_replies.emplace(id, reply_status{});
-        it = inserted;
-    }
+    auto [it, _] = _last_replies.try_emplace(id);
 
     auto res = map_reply_result(reply);
     if (!res) {

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -551,8 +551,8 @@ result<node_health_report> health_monitor_backend::process_node_reply(
           clusterlog.info,
           "received node {} health report, marking node as up",
           id);
-        it->second.is_alive = alive::yes;
     }
+    it->second.is_alive = alive::yes;
 
     return res;
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12313
