### PR TITLE
archival: Adjust upload when end offset inside batch

### DIFF
--- a/src/v/storage/offset_to_filepos.h
+++ b/src/v/storage/offset_to_filepos.h
@@ -74,12 +74,22 @@ ss::future<result<offset_to_file_pos_result>> convert_begin_offset_to_file_pos(
   should_fail_on_missing_offset fail_on_missing_offset
   = should_fail_on_missing_offset::yes);
 
+using accept_batch_containing_offset
+  = ss::bool_class<struct accept_batch_containing_offset_t>;
+
+/// \brief given an offset, seeks through a segment until the batch containing
+/// that offset is found. Search stops when the last offset of a batch exceeds
+/// the searched-for offset. If the search mode is set to accept the batch
+/// containing the searched-for offset, then the last offset of the batch
+/// _containing_ the searched-for offset is returned.
 ss::future<result<offset_to_file_pos_result>> convert_end_offset_to_file_pos(
   model::offset end_inclusive,
   ss::lw_shared_ptr<storage::segment> segment,
   model::timestamp max_timestamp,
   ss::io_priority_class io_priority,
   should_fail_on_missing_offset fail_on_missing_offset
-  = should_fail_on_missing_offset::yes);
+  = should_fail_on_missing_offset::yes,
+  accept_batch_containing_offset search_mode
+  = accept_batch_containing_offset::no);
 
 } // namespace storage

--- a/src/v/storage/tests/offset_to_filepos_test.cc
+++ b/src/v/storage/tests/offset_to_filepos_test.cc
@@ -203,3 +203,81 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_allowed_to_be_missing) {
       model::timestamp{segment->index().max_timestamp().value()}};
     BOOST_REQUIRE(result.value() == expected);
 }
+
+inline ss::logger test_log("test");
+
+SEASTAR_THREAD_TEST_CASE(test_search_end_offset_inside_batch) {
+    temporary_dir tmp_dir("offset_to_fpos_translate");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+    b | add_segment(0);
+    auto ts = model::timestamp::now();
+    auto curr_offset = model::offset{0};
+    std::vector<size_t> batch_sizes{};
+    std::vector<model::timestamp> timestamps{};
+    for (auto i = 0; i < 2; ++i) {
+        model::test::record_batch_spec spec{
+          .offset = curr_offset,
+          .count = 100,
+          .records = 1,
+          .timestamp = ts,
+        };
+        b.add_random_batch(spec).get();
+        batch_sizes.push_back(b.bytes_written());
+        // add_random_batch uses the number of records in spec -1 to produce max
+        // ts per batch.
+        timestamps.emplace_back(ts.value() + 99);
+        curr_offset = model::next_offset(
+          b.get_log_segments().back()->offsets().committed_offset);
+        ts = model::timestamp{ts.value() + 1};
+    }
+
+    auto segment = b.get_log_segments().back();
+
+    // Search for offset 190 in batches [0-99] and [100-199]
+    const auto needle = curr_offset - model::offset{10};
+
+    // End the search before the batch containing offset.
+    {
+        auto result = convert_end_offset_to_file_pos(
+                        needle,
+                        segment,
+                        segment->index().max_timestamp(),
+                        ss::default_priority_class(),
+                        should_fail_on_missing_offset::yes,
+                        accept_batch_containing_offset::no)
+                        .get0();
+        // When the offset is not in batch, the timestamp of the next batch is
+        // used in the result as max ts.
+        const auto expected_ts = model::timestamp{timestamps[0].value() + 1};
+        storage::offset_to_file_pos_result expected{
+          model::offset{99}, batch_sizes[0], expected_ts};
+        BOOST_REQUIRE_EQUAL(result.value().offset, expected.offset);
+        BOOST_REQUIRE_EQUAL(result.value().bytes, expected.bytes);
+        BOOST_REQUIRE_EQUAL(result.value().ts, expected.ts);
+    }
+
+    // End the search at the batch containing offset.
+    {
+        auto result = convert_end_offset_to_file_pos(
+                        needle,
+                        segment,
+                        segment->index().max_timestamp(),
+                        ss::default_priority_class(),
+                        should_fail_on_missing_offset::yes,
+                        accept_batch_containing_offset::yes)
+                        .get0();
+        // When the offset is in batch, the max ts for the batch is returned
+        // with the result.
+        const auto expected_ts = timestamps[1];
+        storage::offset_to_file_pos_result expected{
+          model::offset{199}, batch_sizes[1], expected_ts};
+        BOOST_REQUIRE_EQUAL(result.value().offset, expected.offset);
+        BOOST_REQUIRE_EQUAL(result.value().bytes, expected.bytes);
+        BOOST_REQUIRE_EQUAL(result.value().ts, expected.ts);
+    }
+}


### PR DESCRIPTION
When creating an upload candidate, it is possible that the end offset lies inside a batch. Previously we stopped short of this batch when creating the upload candidate.

In this change we collect the batch containing the offset as part of the upload candidate, but we adjust the metadata to indicate that the segment ends at exactly the end offset. 

This will result in some extra records in the read path, which will be resolved as duplicate reads transparently by the remote segment reader.

FIXES: https://github.com/redpanda-data/redpanda/issues/12232

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

* none
