### PR TITLE
cloud_storage: avoid attempting to GET and cache empty transaction manifests

### DIFF
--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -58,16 +58,6 @@ using manifest_section_t = std::variant<
   ss::shared_ptr<materialized_manifest>,
   std::reference_wrapper<const partition_manifest>>;
 
-/// Result of the ListObjectsV2 scan
-struct spillover_manifest_list {
-    /// List of manifest paths
-    std::deque<remote_manifest_path> manifests;
-    /// List of decoded path components (offsets and timestamps)
-    std::deque<spillover_manifest_path_components> components;
-    /// List of manifest sizes (in binary format)
-    std::deque<size_t> sizes;
-};
-
 class async_manifest_view_cursor;
 
 /// Service that maintains a view of the entire

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -741,33 +741,6 @@ ss::future<bool> remote_segment::maybe_materialize_index() {
     }
 }
 
-// NOTE: Aborted transactions handled using tx_range manifests.
-// The manifests are uploaded alongside the segments with (.tx)
-// suffix added to the name. The hydration of tx_range manifest
-// is not optional. We can't use the segment without it. The following
-// cases are possible:
-// - Both segment and tx-range are not hydrated;
-// - The segment is hydrated but tx-range isn't
-// - The segment is not hydrated but tx-range is
-// - Both segment and tx-range are hydrated
-// This doesn't include various 'in_progress' combinations which are
-// disallowed.
-//
-// Also, both segment and tx-range can be materialized or not. In case
-// of the segment this means that we're holding an opened file handler.
-// In case of tx-range this means that we parsed the json and populated
-// _tx_range collection.
-//
-// In order to be able to deal with the complexity this code combines
-// the flags and tries to handle all combinations that makes sense.
-enum class segment_txrange_status {
-    in_progress,
-    available,
-    not_available,
-    available_not_available,
-    not_available_available,
-};
-
 void remote_segment::set_waiter_errors(const std::exception_ptr& err) {
     while (!_wait_list.empty()) {
         auto& p = _wait_list.front();

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -293,6 +293,7 @@ private:
     bool _hydration_loop_running{false};
 
     segment_name_format _sname_format;
+    uint64_t _metadata_size_hint{0};
 
     using fallback_mode = ss::bool_class<struct fallback_mode_tag>;
     fallback_mode _fallback_mode{fallback_mode::no};


### PR DESCRIPTION
    cloud_storage: avoid writing empty tx ranges to cache
    
    Previously the check for metadata_size_hint==0 was
    initializing `_tx_range`, but that didn't stop `do_hydrate_txrange`
    from running, attempting to download the transaction manifest,
    and usually generating a 404 response and putting an empty
    manifest into the cache.
    
    After this change, segments with no tx manifest entries simply
    issue no request for the tx manifest, and write nothing to
    the cache for tx manifest.

Plus a test for this, and a couple of cleanup commits -- noticed this stuff while updating internals docs.

While this isn't strictly a functional bug fix, it is worth backporting because:
- with this change, SREs can start monitoring for 404s without having to deal with a load of false positives from `.tx` GETs.
- it is a significant eater of the cache object count limit on systems with small segments

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Tiered storage cache skips writing empty `.tx` files to cache, improving efficiency.
