### PR TITLE
cloud_storage: fix a typo in a metric name

### DIFF
--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -200,7 +200,7 @@ void client_probe::setup_internal_metrics(
           sm::description("Lease duration histogram"),
           labels),
         sm::make_gauge(
-          "client_pool_utiliazation",
+          "client_pool_utilization",
           [this] { return _pool_utilization; },
           sm::description("Utilization of the cloud storage pool(0 - unused, "
                           "100 - fully utilized)"),
@@ -282,7 +282,7 @@ void client_probe::setup_public_metrics(
           sm::description("Lease duration histogram"),
           labels),
         sm::make_gauge(
-          "client_pool_utiliazation",
+          "client_pool_utilization",
           [this] { return _pool_utilization; },
           sm::description("Utilization of the cloud storage pool(0 - unused, "
                           "100 - fully utilized)"),


### PR DESCRIPTION
This metric was added in v23.2.1, very unlikely anyone is already using it, so let's quickly fix this before it becomes a backward compat issue.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none