### PR TITLE
archival: Reject segment reupload if candidate lies inside compacted batch

### DIFF
--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -498,6 +498,35 @@ segment_collector::make_upload_candidate(
     auto head_seek = head_seek_result.value();
     auto tail_seek = tail_seek_result.value();
 
+    if (head_seek.offset_inside_batch || tail_seek.offset_inside_batch) {
+        vlog(
+          archival_log.warn,
+          "The upload candidate boundaries lie inside batch, skipping upload. "
+          "begin inclusive: {}, is inside batch: {}, seek result: {}, end "
+          "inclusive: {}, is "
+          "inside batch: {}, seek result: {}",
+          _begin_inclusive,
+          head_seek.offset_inside_batch,
+          head_seek.offset,
+          _end_inclusive,
+          tail_seek.offset_inside_batch,
+          tail_seek.offset);
+        co_return upload_candidate_with_locks{
+          upload_candidate{
+            .exposed_name = {},
+            .starting_offset = _begin_inclusive,
+            .file_offset = 0,
+            .content_length = 0,
+            .final_offset = _end_inclusive,
+            .final_file_offset = 0,
+            .base_timestamp = {},
+            .max_timestamp = {},
+            .term = {},
+            .sources = {},
+          },
+          {}};
+    }
+
     vlog(
       archival_log.debug,
       "collected size: {}, last segment {}-{}/{}, head seek bytes: {}, tail "

--- a/src/v/storage/offset_to_filepos.h
+++ b/src/v/storage/offset_to_filepos.h
@@ -59,6 +59,7 @@ struct offset_to_file_pos_result {
     model::offset offset;
     size_t bytes;
     model::timestamp ts;
+    bool offset_inside_batch{false};
 
     auto operator<=>(const offset_to_file_pos_result&) const = default;
 };


### PR DESCRIPTION
When an upload candidate is created with the start or end offsets (which are read from the manifest) and also inside the batch boundaries of local disk segment, this change rejects the upload and skips ahead of the upload candidate.

FIXES: https://github.com/redpanda-data/redpanda/issues/12232

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

* none
