### PR TITLE
Make compute_storage.py robust to directories being deleted

### DIFF
--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -7,23 +7,34 @@ Useful in tests if you want to know what files exist on a node or if they are a 
 from pathlib import Path
 import sys
 import json
+from collections.abc import Iterable
+
+
+def safe_listdir(p: Path) -> Iterable[Path]:
+    """
+    It's valid for directories to be deleted at any time, 
+    in that case that the directory is missing, just return
+    that there are no files.
+    """
+    try:
+        return p.iterdir()
+    except FileNotFoundError:
+        return []
 
 
 def compute_size(data_dir: Path, sizes: bool):
     output = {}
-    for ns in data_dir.iterdir():
+    for ns in safe_listdir(data_dir):
         if not ns.is_dir():
-            continue
-        if ns.name == ".coprocessor_offset_checkpoints":
             continue
         if ns.name == "cloud_storage_cache":
             continue
         ns_output = {}
-        for topic in ns.iterdir():
+        for topic in safe_listdir(ns):
             topic_output = {}
-            for partition in topic.iterdir():
+            for partition in safe_listdir(topic):
                 part_output = {}
-                for segment in partition.iterdir():
+                for segment in safe_listdir(partition):
                     seg_output = {}
                     if sizes:
                         try:

--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -10,6 +10,18 @@ import json
 from collections.abc import Iterable
 
 
+def safe_isdir(p: Path) -> bool:
+    """
+    It's valid for files to be deleted at any time, 
+    in that case that the file is missing, just return
+    that it's not a directory
+    """
+    try:
+        return p.is_dir()
+    except FileNotFoundError:
+        return False
+
+
 def safe_listdir(p: Path) -> Iterable[Path]:
     """
     It's valid for directories to be deleted at any time, 
@@ -25,7 +37,7 @@ def safe_listdir(p: Path) -> Iterable[Path]:
 def compute_size(data_dir: Path, sizes: bool):
     output = {}
     for ns in safe_listdir(data_dir):
-        if not ns.is_dir():
+        if not safe_isdir(ns):
             continue
         if ns.name == "cloud_storage_cache":
             continue


### PR DESCRIPTION
In
https://buildkite.com/redpanda/redpanda/builds/33545#01896f0b-4206-4688-b578-4321e0069ea1
there was a failure due to a directory being deleted so the `listdir`
method threw. This fixes that by returning an empty list for those
case where the directory has been deleted by the time we got to listing
it.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
