### PR TITLE
Add area/wasm label to transform SDK

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,4 +15,4 @@ area/redpanda:
 - src/v/**/*
 
 area/wasm:
-- src/js/**/*
+- src/go/transform-sdk/**/*


### PR DESCRIPTION
The js directory has been deleted, and in #12322 we're introducing the
SDK for golang Wasm data transforms. More build/CI changes will come in
later PRs.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
