### PR TITLE
storage: Do not hardcode set of batch types in storage

### DIFF
--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -33,9 +33,9 @@ ss::future<stream_stats> offset_translator::copy_stream(
 
     auto pred =
       [this, &min_offset, &max_offset](model::record_batch_header& hdr) {
-          if (
-            hdr.type == model::record_batch_type::raft_configuration
-            || hdr.type == model::record_batch_type::archival_metadata) {
+          static const auto types = model::offset_translator_batch_types();
+          auto n = std::count(types.begin(), types.end(), hdr.type);
+          if (n > 0) {
               _ot_state->add_gap(hdr.base_offset, hdr.last_offset());
           }
           min_offset = std::min(min_offset, hdr.base_offset);

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -48,4 +48,12 @@ enum class record_batch_type : int8_t {
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);
 
+inline std::vector<model::record_batch_type> offset_translator_batch_types() {
+    return {
+      model::record_batch_type::raft_configuration,
+      model::record_batch_type::archival_metadata,
+      model::record_batch_type::version_fence,
+      model::record_batch_type::prefix_truncate};
+}
+
 } // namespace model

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -16,6 +16,7 @@
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
 #include "model/timeout_clock.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "raft/consensus_client_protocol.h"
@@ -78,11 +79,7 @@ namespace raft {
 std::vector<model::record_batch_type>
 offset_translator_batch_types(const model::ntp& ntp) {
     if (ntp.ns == model::kafka_namespace) {
-        return {
-          model::record_batch_type::raft_configuration,
-          model::record_batch_type::archival_metadata,
-          model::record_batch_type::version_fence,
-          model::record_batch_type::prefix_truncate};
+        return model::offset_translator_batch_types();
     } else {
         return {};
     }

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_reader.h"
 #include "storage/compacted_index_writer.h"
@@ -197,10 +198,10 @@ struct clean_segment_value
 };
 
 inline bool is_compactible(const model::record_batch& b) {
-    return !(
-      b.header().type == model::record_batch_type::raft_configuration
-      || b.header().type == model::record_batch_type::archival_metadata
-      || b.header().type == model::record_batch_type::version_fence);
+    static const auto filtered_types = model::offset_translator_batch_types();
+    auto n = std::count(
+      filtered_types.begin(), filtered_types.end(), b.header().type);
+    return n == 0;
 }
 
 offset_delta_time should_apply_delta_time_offset(


### PR DESCRIPTION
Currently, Raft and Tiered-storage are using the same set of batch types for offset translation. It's encoded in the
raft::offset_translator_batch_types function. But the comapction uses its own function called 'is_compactible' which uses hardcoded set of types. This commit fixes this by using the same set of types everywhere.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none