### PR TITLE
[v23.2.x] cloud_storage: fix a typo in a metric name

### DIFF
--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -200,7 +200,7 @@ void client_probe::setup_internal_metrics(
           sm::description("Lease duration histogram"),
           labels),
         sm::make_gauge(
-          "client_pool_utiliazation",
+          "client_pool_utilization",
           [this] { return _pool_utilization; },
           sm::description("Utilization of the cloud storage pool(0 - unused, "
                           "100 - fully utilized)"),
@@ -282,7 +282,7 @@ void client_probe::setup_public_metrics(
           sm::description("Lease duration histogram"),
           labels),
         sm::make_gauge(
-          "client_pool_utiliazation",
+          "client_pool_utilization",
           [this] { return _pool_utilization; },
           sm::description("Utilization of the cloud storage pool(0 - unused, "
                           "100 - fully utilized)"),


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12342
