### PR TITLE
schema_registry: Improve the ordering of protobuf files

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -15,14 +15,17 @@
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
+#include "ssx/sformat.h"
 #include "utils/base64.h"
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
 
 #include <absl/container/flat_hash_set.h>
+#include <boost/algorithm/string/trim.hpp>
 #include <confluent/meta.pb.h>
 #include <confluent/types/decimal.pb.h>
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <google/protobuf/any.pb.h>
 #include <google/protobuf/api.pb.h>
@@ -58,6 +61,7 @@
 #include <google/type/quaternion.pb.h>
 #include <google/type/timeofday.pb.h>
 
+#include <string_view>
 #include <unordered_set>
 
 namespace pandaproxy::schema_registry {
@@ -303,11 +307,60 @@ ss::future<const pb::FileDescriptor*> import_schema(
 struct protobuf_schema_definition::impl {
     pb::DescriptorPool _dp;
     const pb::FileDescriptor* fd{};
+
+    /**
+     * debug_string swaps the order of the import and package lines that
+     * DebugString produces, so that it conforms to
+     * https://protobuf.dev/programming-guides/style/#file-structure
+     *
+     * from:
+     * syntax
+     * imports
+     * package
+     * messages
+     *
+     * to:
+     * syntax
+     * package
+     * imports
+     * messages
+     */
+    ss::sstring debug_string() const {
+        auto s = fd->DebugString();
+
+        // reordering not required if no package or no dependencies
+        if (fd->package().empty() || fd->dependency_count() == 0) {
+            return s;
+        }
+
+        std::string_view sv{s};
+
+        constexpr size_t expected_syntax_len = 18;
+        auto syntax_pos = sv.find("syntax = \"proto");
+        auto syntax_end = syntax_pos + expected_syntax_len;
+
+        auto package = fmt::format("package {};", fd->package());
+        auto package_pos = sv.find(package);
+
+        auto imports_pos = syntax_end;
+        auto imports_len = package_pos - syntax_end;
+
+        auto trim = [](std::string_view sv) {
+            return boost::algorithm::trim_copy_if(
+              sv, [](char c) { return c == '\n'; });
+        };
+        auto header = trim(sv.substr(0, syntax_end));
+        auto imports = trim(sv.substr(imports_pos, imports_len));
+        auto footer = trim(sv.substr(package_pos + package.length()));
+
+        return ssx::sformat(
+          "{}\n{}\n\n{}\n\n{}\n", header, package, imports, footer);
+    }
 };
 
 canonical_schema_definition::raw_string
 protobuf_schema_definition::raw() const {
-    return canonical_schema_definition::raw_string{_impl->fd->DebugString()};
+    return canonical_schema_definition::raw_string{_impl->debug_string()};
 }
 
 ::result<ss::sstring, kafka::error_code>

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -424,3 +424,198 @@ SEASTAR_THREAD_TEST_CASE(
     BOOST_REQUIRE(check_compatible(
       pps::compatibility_level::full_transitive, recursive, recursive));
 }
+
+auto sanitize(std::string_view raw_proto) {
+    simple_sharded_store s;
+    return pps::make_canonical_protobuf_schema(
+             s.store,
+             pps::unparsed_schema{
+               pps::subject{"foo"},
+               pps::unparsed_schema_definition{
+                 raw_proto, pps::schema_type::protobuf}})
+      .get()
+      .def()
+      .raw()();
+}
+
+constexpr auto foobar_proto = R"(syntax = "proto3";
+package foo;
+
+import "google/protobuf/timestamp.proto";
+
+message Bar {
+  .google.protobuf.Timestamp timestamp = 1;
+}
+)";
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_strip_comments_and_newlines) {
+    BOOST_REQUIRE_EQUAL(
+      sanitize(R"(
+
+/* comment */
+
+syntax = "proto3";
+
+/* comment */
+
+package foo;
+
+/* comment */
+
+import "google/protobuf/timestamp.proto";
+
+/* comment */
+
+message Bar {
+  google.protobuf.Timestamp timestamp = 1; //comment
+}
+
+/* comment */
+
+)"),
+      foobar_proto);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_ordering_no_newlines) {
+    BOOST_REQUIRE_EQUAL(
+      sanitize(R"(syntax = "proto3";
+import "google/protobuf/timestamp.proto";
+package foo;
+message Bar {
+  google.protobuf.Timestamp timestamp = 1; //comment
+}
+)"),
+      foobar_proto);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_ordering_more_newlines) {
+    BOOST_REQUIRE_EQUAL(
+      sanitize(R"(
+
+syntax = "proto3";
+
+
+import "google/protobuf/timestamp.proto";
+
+
+package foo;
+
+
+message Bar {
+  google.protobuf.Timestamp timestamp = 1; //comment
+}
+
+)"),
+      foobar_proto);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_syntax) {
+    BOOST_REQUIRE_EQUAL(
+      sanitize(R"(
+package foo;
+
+import "google/protobuf/timestamp.proto";
+
+message Bar {
+  optional google.protobuf.Timestamp timestamp = 1; //comment
+}
+)"),
+      R"(syntax = "proto2";
+package foo;
+
+import "google/protobuf/timestamp.proto";
+
+message Bar {
+  optional .google.protobuf.Timestamp timestamp = 1;
+}
+)");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_package) {
+    BOOST_REQUIRE_EQUAL(
+      sanitize(R"(syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+message Bar {
+  google.protobuf.Timestamp timestamp = 1; //comment
+}
+)"),
+      R"(syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+message Bar {
+  .google.protobuf.Timestamp timestamp = 1;
+}
+
+)");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_syntax_package) {
+    BOOST_REQUIRE_EQUAL(
+      sanitize(R"(
+
+import "google/protobuf/timestamp.proto";
+
+message Bar {
+  optional google.protobuf.Timestamp timestamp = 1; //comment
+}
+)"),
+      R"(syntax = "proto2";
+
+import "google/protobuf/timestamp.proto";
+message Bar {
+  optional .google.protobuf.Timestamp timestamp = 1;
+}
+
+)");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_imports) {
+    BOOST_REQUIRE_EQUAL(
+      sanitize(R"(syntax = "proto3";
+package foo;
+
+message Bar {
+  int64 val = 1;
+}
+)"),
+      R"(syntax = "proto3";
+
+package foo;
+
+message Bar {
+  int64 val = 1;
+}
+
+)");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_multiple_imports) {
+    BOOST_REQUIRE_EQUAL(
+      sanitize(R"(syntax = "proto3";
+
+package foo;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+
+
+message Bar {
+  .google.protobuf.Timestamp timestamp = 1;
+  .google.protobuf.Any any = 2;
+}
+
+)"),
+      R"(syntax = "proto3";
+package foo;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+
+message Bar {
+  .google.protobuf.Timestamp timestamp = 1;
+  .google.protobuf.Any any = 2;
+}
+)");
+}


### PR DESCRIPTION
`FileDescriptorProto::DebugString` puts import lines before the package line, swap them to adhere to https://protobuf.dev/programming-guides/style/#file-structure

Fixes #12335

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x
- [x] v22.2.x

## Release Notes

### Improvements

* schema_registry: Improve the ordering of protobuf files