### PR TITLE
rpk, github: use latest stable golang

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.3
+        go-version: stable
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: stable
 
       - name: Run tests
         working-directory: src/go/rpk/
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: stable
 
       - name: Create empty release notes
         run: |

--- a/src/go/rpk/.golangci.yml
+++ b/src/go/rpk/.golangci.yml
@@ -63,7 +63,7 @@ linters-settings:
   #
   # https://github.com/mvdan/gofumpt/issues/137
   gofumpt:
-    lang-version: "1.20.4"
+    lang-version: "1.20"
 
   # Revive is yet another metalinter with a lot of useful lints. 
   # The below opts in to all the ones we would like to use.


### PR DESCRIPTION
For gofumpt in golangci, the lang version can just be major releases -- this is for formatting changes, which only happens in major releases


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none