### PR TITLE
rpk cloud byoc: pass --redpanda-id to the plugin

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
+++ b/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
@@ -50,7 +50,7 @@ func init() {
 			out.MaybeDie(err, "unable to ensure byoc plugin version: %v", err)
 
 			// Finally, exec.
-			run(cmd, append(pluginArgs, "--"+flagCloudAPIToken, token))
+			run(cmd, append(pluginArgs, "--"+flagCloudAPIToken, token, "--"+flagRedpandaID, redpandaID))
 		}
 		return cmd
 	})
@@ -145,7 +145,7 @@ and then come back to this command to complete the process.
 			path, token, _, err := loginAndEnsurePluginVersion(cmd.Context(), fs, cfg, redpandaID)
 			out.MaybeDie(err, "unable to ensure byoc plugin version: %v", err)
 
-			err = execFn(path, append(pluginArgs, "--"+flagCloudAPIToken, token))
+			err = execFn(path, append(pluginArgs, "--"+flagCloudAPIToken, token, "--"+flagRedpandaID, redpandaID))
 			out.MaybeDie(err, "unable to execute plugin: %v", err)
 		},
 	}


### PR DESCRIPTION
This previously was implicitly always passed because rpk did not strip rpk specific flags.

A PR in April changed the behavior to strip all rpk specific flags -- this was done for safety so that people could pass -X, -v, etc. to rpk while also execing the plugin, and rpk would strip all rpk flags and only give the plugin the plugin specific flags.

Since --redpanda-id was a defined rpk flag, it wasn't obvious that this flag was a part of the contract handoff to byoc, and we did not include it in the PR.

As it turns out, the flag is required.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* `rpk cloud byoc` now properly adds the `--redpanda-id` flag when handing off to the cloud plugin.
