### PR TITLE
rpk: fix ldflags for version in goreleaser

### DIFF
--- a/src/go/rpk/.goreleaser.yaml
+++ b/src/go/rpk/.goreleaser.yaml
@@ -4,9 +4,9 @@ builds:
     main: ./cmd/rpk
     binary: rpk
     ldflags:
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version.version={{.Tag}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version.rev={{.ShortCommit}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/container/common.tag={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -20,9 +20,9 @@ builds:
     main: ./cmd/rpk
     binary: rpk
     ldflags:
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version.version={{.Tag}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version.rev={{.ShortCommit}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/container/common.tag={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/devprod/issues/791

Following on from changes in PR #9981 that removed `github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none