### PR TITLE
[v23.2.x] rpk: fix ldflags for version in goreleaser

### DIFF
--- a/src/go/rpk/.goreleaser.yaml
+++ b/src/go/rpk/.goreleaser.yaml
@@ -4,9 +4,9 @@ builds:
     main: ./cmd/rpk
     binary: rpk
     ldflags:
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version.version={{.Tag}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version.rev={{.ShortCommit}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/container/common.tag={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -20,9 +20,9 @@ builds:
     main: ./cmd/rpk
     binary: rpk
     ldflags:
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version.version={{.Tag}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/version.rev={{.ShortCommit}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/container/common.tag={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12386
