### PR TITLE
rptest: enable `KgoVerifierProducer` to run against redpanda cloud

### DIFF
--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -40,7 +40,12 @@ class KafkaCliTools:
     # See tests/docker/Dockerfile to add new versions
     VERSIONS = ("3.0.0", "2.7.0", "2.5.0", "2.4.1", "2.3.1")
 
-    def __init__(self, redpanda, version=None, user=None, passwd=None):
+    def __init__(self,
+                 redpanda,
+                 version=None,
+                 user=None,
+                 passwd=None,
+                 protocol='SASL_PLAINTEXT'):
         self._redpanda = redpanda
         self._version = version
         assert self._version is None or \
@@ -50,7 +55,7 @@ class KafkaCliTools:
             self._command_config = tempfile.NamedTemporaryFile(mode="w")
             config = f"""
 sasl.mechanism=SCRAM-SHA-256
-security.protocol=SASL_PLAINTEXT
+security.protocol={protocol}
 sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{user}" password="{passwd}";
 """
             self._command_config.write(config)

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -93,11 +93,20 @@ class HighThroughputTest2(PreallocNodesTest):
             f"Producing {msg_count} messages of {msg_size} B, "
             f"{msg_count*msg_size} B total, target rate {ingress_rate} B/s")
 
+        # if this is a redpanda cloud cluster,
+        # use the default test superuser user/pass
+        security_config = self.redpanda.security_config()
+        username = security_config.get('sasl_plain_username', None)
+        password = security_config.get('sasl_plain_password', None)
+        enable_tls = security_config.get('enable_tls', False)
         producer0 = KgoVerifierProducer(self.test_context,
                                         self.redpanda,
                                         self.topic,
                                         msg_size=msg_size,
-                                        msg_count=msg_count)
+                                        msg_count=msg_count,
+                                        username=username,
+                                        password=password,
+                                        enable_tls=enable_tls)
         producer0.start()
         start = time.time()
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1789,6 +1789,13 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
         superuser = None
         if not self._skip_create_superuser:
             superuser = self._superuser
+
+        # set this for use in RedpandaTest
+        self._security_config = dict(security_protocol='SASL_SSL',
+                                     sasl_plain_username=superuser.username,
+                                     sasl_plain_password=superuser.password,
+                                     enable_tls=True)
+
         cluster_id = self._cloud_cluster.create(superuser=superuser)
         remote_uri = f'redpanda@{cluster_id}-agent'
         self._kubectl = KubectlTool(self,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1609,7 +1609,8 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
                  num_brokers,
                  *,
                  superuser: Optional[SaslCredentials] = None,
-                 tier_name: Optional[str] = None):
+                 tier_name: Optional[str] = None,
+                 **kwargs):
         """Initialize a RedpandaServiceCloud object.
 
         :param context: test context object

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -861,6 +861,7 @@ class RedpandaServiceBase(Service):
         self._trim_logs = self._context.globals.get(self.TRIM_LOGS_KEY, True)
 
         self._node_id_by_idx = {}
+        self._security_config = dict()
 
     def start_node(self, node, **kwargs):
         pass
@@ -1101,6 +1102,9 @@ class RedpandaServiceBase(Service):
 
     def validate_controller_log(self):
         pass
+
+    def security_config(self):
+        return self._security_config
 
 
 class RedpandaServiceK8s(RedpandaServiceBase):
@@ -1749,7 +1753,6 @@ class RedpandaService(RedpandaServiceBase):
             })
 
         self._started = []
-        self._security_config = dict()
 
         self._raise_on_errors = self._context.globals.get(
             self.RAISE_ON_ERRORS_KEY, True)
@@ -2157,9 +2160,6 @@ class RedpandaService(RedpandaServiceBase):
                 self._schema_registry_config.server_key = RedpandaService.TLS_SERVER_KEY_FILE
                 self._schema_registry_config.server_crt = RedpandaService.TLS_SERVER_CRT_FILE
                 self._schema_registry_config.truststore_file = RedpandaService.TLS_CA_CRT_FILE
-
-    def security_config(self):
-        return self._security_config
 
     def start_redpanda(self, node):
         preamble, res_args = self._resource_settings.to_cli(

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -11,3 +11,4 @@
 cloud:
   included:
     - tests/services_self_test.py::SimpleSelfTest
+    - scale_tests/high_throughput_test.py::HighThroughputTest2.test_throughput_simple

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -117,7 +117,11 @@ class RedpandaTest(Test):
         config = self.redpanda.security_config()
         user = config.get("sasl_plain_username")
         passwd = config.get("sasl_plain_password")
-        client = KafkaCliTools(self.redpanda, user=user, passwd=passwd)
+        protocol = config.get("security_protocol", "SASL_PLAINTEXT")
+        client = KafkaCliTools(self.redpanda,
+                               user=user,
+                               passwd=passwd,
+                               protocol=protocol)
         for spec in self.topics:
             self.logger.debug(f"Creating initial topic {spec}")
             client.create_topic(spec)


### PR DESCRIPTION
Updates to the ducktape tests so `KgoVerifierProducer` can work with redpanda cloud. Since redpanda cloud has TLS and SASL enabled by default, needed to configure the kgo-verifier and kafka cli tools to use these settings. The `HighThroughputTest2.test_throughput_simple` test was updated to use the redpanda cloud settings if they are detected and the test was added to the `test_suite_cloud.yml` so it can run on the scheduled buildkite job.

Fixes https://github.com/redpanda-data/cloudv2/issues/6663
Fixes https://github.com/redpanda-data/cloudv2/issues/6683

Output of run against redpanda cloud using an existing cluster in `preprod`:
```console
bash$ ducktape --globals=/home/ubuntu/redpanda/tests/globals.json --cluster=ducktape.cluster.json.JsonCluster  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json --test-runner-timeout=3600000 tests/rptest/scale_tests/high_throughput_test.py::HighThroughputTest2.test_throughput_simple
[INFO:2023-07-24 08:06:36,332]: starting test run with session id 2023-07-24--005...
[INFO:2023-07-24 08:06:36,332]: running 1 tests...
[INFO:2023-07-24 08:06:36,332]: Triggering test 1 of 1...
[INFO:2023-07-24 08:06:36,338]: RunnerClient: Loading test {'directory': '/home/ubuntu/redpanda/tests/rptest/scale_tests', 'file_name': 'high_throughput_test.py', 'cls_name': 'HighThroughputTest2', 'method_name': 'test_throughput_simple', 'injected_args': None}
[INFO:2023-07-24 08:06:36,342]: RunnerClient: rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple: Setting up...
[WARNING - 2023-07-24 08:06:36,342 - redpanda - create - lineno:1572]: will not create cluster; already have cluster_id ci0motok30vsi89l501g
WARN [TBOT]      CLI parameters are overriding onboarding config from  config/config.go:460
INFO [TBOT]      Anonymous telemetry is not enabled. Find out more about Machine ID's anonymous telemetry at https://goteleport.com/docs/machine-id/reference/telemetry/ tbot/anonymous_telemetry.go:83
INFO [TBOT]      Successfully loaded bot identity, valid: after=2023-07-24T07:57:09Z, before=2023-07-24T13:58:09Z, duration=6h1m0s | kind=tls, renewable=false, disallow-reissue=false, roles=[bot-buildkite-robot], principals=[-teleport-internal-join], generation=0 tbot/tbot.go:372
WARN [TBOT]      Note: onboarding config ignored as identity was loaded from persistent storage tbot/tbot.go:379
INFO [TBOT]      Beginning renewal loop: ttl=6h0m0s interval=6h0m0s tbot/renew.go:693
INFO [TBOT]      Started watching for CA rotations tbot/ca_rotation.go:173
INFO [TBOT]      Attempting to generate new identity from token tbot/renew.go:479
INFO [AUTH]      Attempting registration via proxy server. auth/register.go:277
INFO [AUTH]      Attempting to register Bot with IAM method using regional STS endpoint auth/register.go:623
INFO [AUTH]      Successfully registered Bot with IAM method using regional STS endpoint auth/register.go:656
INFO [AUTH]      Successfully registered via proxy server. auth/register.go:284
INFO [TBOT]      Successfully renewed bot certificates, valid: after=2023-07-24T08:05:38Z, before=2023-07-24T14:06:37Z, duration=6h0m59s | kind=tls, renewable=false, disallow-reissue=false, roles=[bot-buildkite-robot], principals=[-teleport-internal-join], generation=0 tbot/renew.go:601
INFO [TBOT]      Successfully renewed impersonated certificates for directory /tmp/machine-id, valid: after=2023-07-24T08:05:39Z, before=2023-07-24T14:06:37Z, duration=6h0m58s | kind=tls, renewable=false, disallow-reissue=true, roles=[teleport-admin], principals=[root redpanda {{internal.logins}} -teleport-internal-join], generation=0 tbot/renew.go:664
INFO [TBOT]      Started watching for CA rotations tbot/ca_rotation.go:173
INFO [TBOT]      Persisted certificates successfully. One-shot mode enabled so exiting. tbot/renew.go:747
[INFO:2023-07-24 08:06:41,534]: RunnerClient: rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple: Running...
[WARNING - 2023-07-24 08:06:41,534 - redpanda - create - lineno:1572]: will not create cluster; already have cluster_id ci0motok30vsi89l501g
WARN [TBOT]      CLI parameters are overriding onboarding config from  config/config.go:460
INFO [TBOT]      Anonymous telemetry is not enabled. Find out more about Machine ID's anonymous telemetry at https://goteleport.com/docs/machine-id/reference/telemetry/ tbot/anonymous_telemetry.go:83
INFO [TBOT]      Successfully loaded bot identity, valid: after=2023-07-24T08:05:38Z, before=2023-07-24T14:06:37Z, duration=6h0m59s | kind=tls, renewable=false, disallow-reissue=false, roles=[bot-buildkite-robot], principals=[-teleport-internal-join], generation=0 tbot/tbot.go:372
WARN [TBOT]      Note: onboarding config ignored as identity was loaded from persistent storage tbot/tbot.go:379
INFO [TBOT]      Beginning renewal loop: ttl=6h0m0s interval=6h0m0s tbot/renew.go:693
INFO [TBOT]      Started watching for CA rotations tbot/ca_rotation.go:173
INFO [TBOT]      Attempting to generate new identity from token tbot/renew.go:479
INFO [AUTH]      Attempting registration via proxy server. auth/register.go:277
INFO [AUTH]      Attempting to register Bot with IAM method using regional STS endpoint auth/register.go:623
INFO [AUTH]      Successfully registered Bot with IAM method using regional STS endpoint auth/register.go:656
INFO [AUTH]      Successfully registered via proxy server. auth/register.go:284
INFO [TBOT]      Successfully renewed bot certificates, valid: after=2023-07-24T08:05:43Z, before=2023-07-24T14:06:42Z, duration=6h0m59s | kind=tls, renewable=false, disallow-reissue=false, roles=[bot-buildkite-robot], principals=[-teleport-internal-join], generation=0 tbot/renew.go:601
INFO [TBOT]      Successfully renewed impersonated certificates for directory /tmp/machine-id, valid: after=2023-07-24T08:05:44Z, before=2023-07-24T14:06:42Z, duration=6h0m58s | kind=tls, renewable=false, disallow-reissue=true, roles=[teleport-admin], principals=[root redpanda {{internal.logins}} -teleport-internal-join], generation=0 tbot/renew.go:664
INFO [TBOT]      Started watching for CA rotations tbot/ca_rotation.go:173
INFO [TBOT]      Persisted certificates successfully. One-shot mode enabled so exiting. tbot/renew.go:747
[INFO:2023-07-24 08:06:57,753]: RunnerClient: rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple: PASS
[INFO:2023-07-24 08:06:57,753]: RunnerClient: rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple: Tearing down...
[WARNING - 2023-07-24 08:06:57,754 - runner_client - log - lineno:278]: RunnerClient: rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple: Test requested 3 nodes, used only 1
[WARNING:2023-07-24 08:06:57,755]: RunnerClient: rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple: Test requested 3 nodes, used only 1
[INFO:2023-07-24 08:06:57,755]: RunnerClient: rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple: Summary: 
[INFO:2023-07-24 08:06:57,755]: RunnerClient: rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple: Data: None
test_id:    rptest.scale_tests.high_throughput_test.HighThroughputTest2.test_throughput_simple
status:     PASS
run time:   21.413 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
============================================================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-07-24--005
run time:         21.427 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
============================================================================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
