### PR TITLE
[v23.1.x] schema_registry: Improve sanitization of Avro namespaces

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -173,12 +173,16 @@ struct member_sorter {
     }
 };
 
-result<void> sanitize(json::Value& v, json::MemoryPoolAllocator& alloc);
-result<void> sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc);
-result<void> sanitize(json::Value::Array& a, json::MemoryPoolAllocator& alloc);
+struct sanitize_context {
+    json::MemoryPoolAllocator& alloc;
+};
 
-result<void> sanitize_union_symbol_name(
-  json::Value& name, json::MemoryPoolAllocator& alloc) {
+result<void> sanitize(json::Value& v, sanitize_context& ctx);
+result<void> sanitize(json::Value::Object& o, sanitize_context& ctx);
+result<void> sanitize(json::Value::Array& a, sanitize_context& ctx);
+
+result<void>
+sanitize_union_symbol_name(json::Value& name, sanitize_context& ctx) {
     // A name should have the leading dot stripped iff it's the only one
 
     if (!name.IsString() || name.GetStringLength() == 0) {
@@ -193,13 +197,12 @@ result<void> sanitize_union_symbol_name(
         fullname_sv.remove_prefix(1);
         // SetString uses memcpy, take a copy so the range doesn't overlap.
         auto new_name = ss::sstring{fullname_sv};
-        name.SetString(new_name.data(), new_name.length(), alloc);
+        name.SetString(new_name.data(), new_name.length(), ctx.alloc);
     }
     return outcome::success();
 }
 
-result<void>
-sanitize_record(json::Value::Object& v, json::MemoryPoolAllocator& alloc) {
+result<void> sanitize_record(json::Value::Object& v, sanitize_context& ctx) {
     auto f_it = v.FindMember("fields");
     if (f_it == v.MemberEnd()) {
         return error_info{
@@ -209,13 +212,11 @@ sanitize_record(json::Value::Object& v, json::MemoryPoolAllocator& alloc) {
         return error_info{
           error_code::schema_invalid, "JSON field \"fields\" is not an array"};
     }
-    return sanitize(f_it->value, alloc);
+    return sanitize(f_it->value, ctx);
 }
 
 result<void> sanitize_avro_type(
-  json::Value::Object& o,
-  std::string_view type_sv,
-  json::MemoryPoolAllocator& alloc) {
+  json::Value::Object& o, std::string_view type_sv, sanitize_context& ctx) {
     auto type = string_switch<std::optional<avro::Type>>(type_sv)
                   .match("record", avro::Type::AVRO_RECORD)
                   .match("array", avro::Type::AVRO_ARRAY)
@@ -236,7 +237,7 @@ result<void> sanitize_avro_type(
         std::sort(o.begin(), o.end(), member_sorter<object_type::complex>{});
         break;
     case avro::AVRO_RECORD: {
-        auto res = sanitize_record(o, alloc);
+        auto res = sanitize_record(o, ctx);
         std::sort(o.begin(), o.end(), member_sorter<object_type::complex>{});
         return res;
     }
@@ -246,15 +247,15 @@ result<void> sanitize_avro_type(
     return outcome::success();
 }
 
-result<void> sanitize(json::Value& v, json::MemoryPoolAllocator& alloc) {
+result<void> sanitize(json::Value& v, sanitize_context& ctx) {
     switch (v.GetType()) {
     case json::Type::kObjectType: {
         auto o = v.GetObject();
-        return sanitize(o, alloc);
+        return sanitize(o, ctx);
     }
     case json::Type::kArrayType: {
         auto a = v.GetArray();
-        return sanitize(a, alloc);
+        return sanitize(a, ctx);
     }
     case json::Type::kFalseType:
     case json::Type::kTrueType:
@@ -266,8 +267,7 @@ result<void> sanitize(json::Value& v, json::MemoryPoolAllocator& alloc) {
     __builtin_unreachable();
 }
 
-result<void>
-sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
+result<void> sanitize(json::Value::Object& o, sanitize_context& ctx) {
     if (auto it = o.FindMember("name"); it != o.MemberEnd()) {
         // A name should have the leading dot stripped iff it's the only one
         // Otherwise split on the last dot into a name and a namespace
@@ -290,7 +290,7 @@ sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
             fullname_sv = fullname;
 
             auto new_name{fullname_sv.substr(last_dot + 1)};
-            name.SetString(new_name.data(), new_name.length(), alloc);
+            name.SetString(new_name.data(), new_name.length(), ctx.alloc);
 
             fullname.resize(last_dot);
             new_namespace = std::move(fullname);
@@ -314,20 +314,20 @@ sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
                 o.AddMember(
                   json::Value("namespace"),
                   json::Value(
-                    new_namespace.data(), new_namespace.length(), alloc),
-                  alloc);
+                    new_namespace.data(), new_namespace.length(), ctx.alloc),
+                  ctx.alloc);
             }
         }
     }
 
     if (auto t_it = o.FindMember("type"); t_it != o.MemberEnd()) {
-        auto res = sanitize(t_it->value, alloc);
+        auto res = sanitize(t_it->value, ctx);
         if (res.has_error()) {
             return res.assume_error();
         } else if (t_it->value.GetType() == json::Type::kStringType) {
             std::string_view type_sv = {
               t_it->value.GetString(), t_it->value.GetStringLength()};
-            auto res = sanitize_avro_type(o, type_sv, alloc);
+            auto res = sanitize_avro_type(o, type_sv, ctx);
             if (res.has_error()) {
                 return res.assume_error();
             }
@@ -335,18 +335,18 @@ sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
             auto a = t_it->value.GetArray();
             for (auto& m : a) {
                 if (m.IsString()) {
-                    auto res = sanitize_union_symbol_name(m, alloc);
+                    auto res = sanitize_union_symbol_name(m, ctx);
                     if (res.has_error()) {
                         return res.assume_error();
                     }
                 }
             }
-            auto res = sanitize_avro_type(o, "field", alloc);
+            auto res = sanitize_avro_type(o, "field", ctx);
             if (res.has_error()) {
                 return res.assume_error();
             }
         } else if (t_it->value.GetType() == json::Type::kObjectType) {
-            auto res = sanitize_avro_type(o, "field", alloc);
+            auto res = sanitize_avro_type(o, "field", ctx);
             if (res.has_error()) {
                 return res.assume_error();
             }
@@ -355,9 +355,9 @@ sanitize(json::Value::Object& o, json::MemoryPoolAllocator& alloc) {
     return outcome::success();
 }
 
-result<void> sanitize(json::Value::Array& a, json::MemoryPoolAllocator& alloc) {
+result<void> sanitize(json::Value::Array& a, sanitize_context& ctx) {
     for (auto& m : a) {
-        auto s = sanitize(m, alloc);
+        auto s = sanitize(m, ctx);
         if (s.has_error()) {
             return s.assume_error();
         }
@@ -476,8 +476,8 @@ sanitize_avro_schema_definition(unparsed_schema_definition def) {
             rapidjson::GetParseError_En(doc.GetParseError()),
             doc.GetErrorOffset())};
     }
-
-    auto res = sanitize(doc, doc.GetAllocator());
+    sanitize_context ctx{.alloc = doc.GetAllocator()};
+    auto res = sanitize(doc, ctx);
     if (res.has_error()) {
         return error_info{
           res.assume_error().code(),

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -306,9 +306,10 @@ result<void> sanitize(json::Value::Object& o, sanitize_context& ctx) {
                 std::string_view existing_namespace{
                   it->value.GetString(), it->value.GetStringLength()};
                 if (existing_namespace != new_namespace) {
-                    return error_info{
-                      error_code::schema_invalid,
-                      "name doesn't match namespace"};
+                    it->value.SetString(
+                      new_namespace.data(),
+                      new_namespace.length(),
+                      ctx.alloc);
                 }
             } else {
                 o.AddMember(

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -24,6 +24,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/exception.hh>
+#include <seastar/util/defer.hh>
 
 #include <absl/container/flat_hash_set.h>
 #include <avro/Compiler.hh>
@@ -39,6 +40,7 @@
 #include <rapidjson/error/en.h>
 
 #include <exception>
+#include <stack>
 #include <string_view>
 
 namespace pandaproxy::schema_registry {
@@ -175,6 +177,8 @@ struct member_sorter {
 
 struct sanitize_context {
     json::MemoryPoolAllocator& alloc;
+    // The stack of namespaces, starting with implictly null
+    std::stack<ss::sstring> ns{{""}};
 };
 
 result<void> sanitize(json::Value& v, sanitize_context& ctx);
@@ -268,6 +272,9 @@ result<void> sanitize(json::Value& v, sanitize_context& ctx) {
 }
 
 result<void> sanitize(json::Value::Object& o, sanitize_context& ctx) {
+    auto pop_ns_impl = [&ctx]() { ctx.ns.pop(); };
+    std::optional<ss::deferred_action<decltype(pop_ns_impl)>> pop_ns;
+
     if (auto it = o.FindMember("name"); it != o.MemberEnd()) {
         // A name should have the leading dot stripped iff it's the only one
         // Otherwise split on the last dot into a name and a namespace
@@ -282,7 +289,7 @@ result<void> sanitize(json::Value::Object& o, sanitize_context& ctx) {
         std::string_view fullname_sv{name.GetString(), name.GetStringLength()};
         auto last_dot = fullname_sv.find_last_of('.');
 
-        ss::sstring new_namespace;
+        std::optional<ss::sstring> new_namespace;
         if (last_dot != std::string::npos) {
             // Take a copy, fullname_sv will be invalidated when new_name is
             // set, and SetString uses memcpy, the range musn't overlap.
@@ -296,7 +303,21 @@ result<void> sanitize(json::Value::Object& o, sanitize_context& ctx) {
             new_namespace = std::move(fullname);
         }
 
-        if (!new_namespace.empty()) {
+        if (!new_namespace.has_value()) {
+            if (auto it = o.FindMember("namespace"); it != o.MemberEnd()) {
+                if (!it->value.IsString()) {
+                    return error_info{
+                      error_code::schema_invalid,
+                      "Invalid JSON Field \"namespace\""};
+                }
+                new_namespace.emplace(
+                  it->value.GetString(), it->value.GetStringLength());
+            }
+        }
+
+        if (new_namespace.has_value() && ctx.ns.top() != new_namespace) {
+            ctx.ns.emplace(*new_namespace);
+            pop_ns.emplace(std::move(pop_ns_impl));
             if (auto it = o.FindMember("namespace"); it != o.MemberEnd()) {
                 if (!it->value.IsString()) {
                     return error_info{
@@ -307,17 +328,19 @@ result<void> sanitize(json::Value::Object& o, sanitize_context& ctx) {
                   it->value.GetString(), it->value.GetStringLength()};
                 if (existing_namespace != new_namespace) {
                     it->value.SetString(
-                      new_namespace.data(),
-                      new_namespace.length(),
+                      new_namespace->data(),
+                      new_namespace->length(),
                       ctx.alloc);
                 }
             } else {
                 o.AddMember(
                   json::Value("namespace"),
                   json::Value(
-                    new_namespace.data(), new_namespace.length(), ctx.alloc),
+                    new_namespace->data(), new_namespace->length(), ctx.alloc),
                   ctx.alloc);
             }
+        } else {
+            o.RemoveMember("namespace");
         }
     }
 

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -276,8 +276,14 @@ result<void> sanitize(json::Value::Object& o, sanitize_context& ctx) {
     std::optional<ss::deferred_action<decltype(pop_ns_impl)>> pop_ns;
 
     if (auto it = o.FindMember("name"); it != o.MemberEnd()) {
-        // A name should have the leading dot stripped iff it's the only one
-        // Otherwise split on the last dot into a name and a namespace
+        // Sanitize names and namespaces according to
+        // https://avro.apache.org/docs/1.11.1/specification/#names
+        //
+        // This sanitization:
+        // * Is not Parsing Canonical Form
+        // * Splits fullnames into a simple name and a namespace
+        //   * A namespace attribute is ignored if the name is a fullname
+        // * Removes namespaces that are redundant (same as parent scope)
 
         auto& name = it->value;
 

--- a/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
@@ -99,6 +99,18 @@ pps::unparsed_schema_definition namespace_nested_same_unsanitized{
   "doc": "A simple name (attribute) and no namespace attribute: use the null namespace; the fullname is 'Example'.",
   "fields": [
     {
+      "name": "inheritNull",
+      "type": {
+        "type": "enum",
+        "name": "Simple",
+        "doc": "A simple name (attribute) and no namespace attribute: inherit the null namespace of the enclosing type 'Example'. The fullname is 'Simple'.",
+        "symbols": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    {
       "name": "fullName",
       "type": {
         "type": "fixed",
@@ -106,6 +118,29 @@ pps::unparsed_schema_definition namespace_nested_same_unsanitized{
         "namespace": "explicit",
         "doc": "A name (attribute) and a namespace (attribute). The fullname is 'a.full.Name', and the namespace is 'a.full'.",
         "size": 12
+      }
+    },
+    {
+      "name": "explicitNamespace",
+      "type": {
+        "type": "record",
+        "name": "Simple",
+        "namespace": "explicit",
+        "doc": "A simple name (attribute) and a namespace (attribute); the fullname is 'explicit.Simple' (this is a different type than of the 'inheritNull' field).",
+        "fields": [
+          {
+            "name": "inheritNamespace",
+            "type": {
+              "type": "enum",
+              "name": "Understanding",
+              "doc": "A simple name (attribute) and no namespace attribute: inherit the namespace of the enclosing type 'explicit.Simple'. The fullname is 'explicit.Understanding'.",
+              "symbols": [
+                "d",
+                "e"
+              ]
+            }
+          }
+        ]
       }
     }
   ]
@@ -120,6 +155,18 @@ pps::canonical_schema_definition namespace_nested_same_sanitized{
   "doc": "A simple name (attribute) and no namespace attribute: use the null namespace; the fullname is 'Example'.",
   "fields": [
     {
+      "name": "inheritNull",
+      "type": {
+        "type": "enum",
+        "name": "Simple",
+        "doc": "A simple name (attribute) and no namespace attribute: inherit the null namespace of the enclosing type 'Example'. The fullname is 'Simple'.",
+        "symbols": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    {
       "name": "fullName",
       "type": {
         "type": "fixed",
@@ -127,6 +174,29 @@ pps::canonical_schema_definition namespace_nested_same_sanitized{
         "namespace": "a.full",
         "doc": "A name (attribute) and a namespace (attribute). The fullname is 'a.full.Name', and the namespace is 'a.full'.",
         "size": 12
+      }
+    },
+    {
+      "name": "explicitNamespace",
+      "type": {
+        "type": "record",
+        "name": "Simple",
+        "namespace": "explicit",
+        "doc": "A simple name (attribute) and a namespace (attribute); the fullname is 'explicit.Simple' (this is a different type than of the 'inheritNull' field).",
+        "fields": [
+          {
+            "name": "inheritNamespace",
+            "type": {
+              "type": "enum",
+              "name": "Understanding",
+              "doc": "A simple name (attribute) and no namespace attribute: inherit the namespace of the enclosing type 'explicit.Simple'. The fullname is 'explicit.Understanding'.",
+              "symbols": [
+                "d",
+                "e"
+              ]
+            }
+          }
+        ]
       }
     }
   ]

--- a/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
@@ -139,6 +139,44 @@ pps::unparsed_schema_definition namespace_nested_same_unsanitized{
                 "e"
               ]
             }
+          },
+          {
+            "name": "duplicateNamespace",
+            "type": {
+              "type": "enum",
+              "name": "Reduction",
+              "namespace": "explicit",
+              "doc": "A simple name (attribute) and namespace attribute: same namespace of the enclosing type 'explicit'. The fullname is 'explicit.Reduction'.",
+              "symbols": [
+                "d",
+                "e"
+              ]
+            }
+          },
+          {
+            "name": "emptyNamespace",
+            "type": {
+              "type": "enum",
+              "name": "NullNamespace",
+              "namespace": "",
+              "doc": "A simple name (attribute) and namespace attribute: namespace is explicitly null. The fullname is 'NullNamespace'.",
+              "symbols": [
+                "d",
+                "e"
+              ]
+            }
+          },
+          {
+            "name": "emptyFullname",
+            "type": {
+              "type": "enum",
+              "name": ".NullFullname",
+              "doc": "A name (attribute) and no namespace attribute: namespace is null. The fullname is 'NullFullname'.",
+              "symbols": [
+                "d",
+                "e"
+              ]
+            }
           }
         ]
       }
@@ -190,6 +228,44 @@ pps::canonical_schema_definition namespace_nested_same_sanitized{
               "type": "enum",
               "name": "Understanding",
               "doc": "A simple name (attribute) and no namespace attribute: inherit the namespace of the enclosing type 'explicit.Simple'. The fullname is 'explicit.Understanding'.",
+              "symbols": [
+                "d",
+                "e"
+              ]
+            }
+          },
+          {
+            "name": "duplicateNamespace",
+            "type": {
+              "type": "enum",
+              "name": "Reduction",
+              "doc": "A simple name (attribute) and namespace attribute: same namespace of the enclosing type 'explicit'. The fullname is 'explicit.Reduction'.",
+              "symbols": [
+                "d",
+                "e"
+              ]
+            }
+          },
+          {
+            "name": "emptyNamespace",
+            "type": {
+              "type": "enum",
+              "name": "NullNamespace",
+              "namespace": "",
+              "doc": "A simple name (attribute) and namespace attribute: namespace is explicitly null. The fullname is 'NullNamespace'.",
+              "symbols": [
+                "d",
+                "e"
+              ]
+            }
+          },
+          {
+            "name": "emptyFullname",
+            "type": {
+              "type": "enum",
+              "name": "NullFullname",
+              "namespace": "",
+              "doc": "A name (attribute) and no namespace attribute: namespace is null. The fullname is 'NullFullname'.",
               "symbols": [
                 "d",
                 "e"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12334
Fixes: https://github.com/redpanda-data/redpanda/issues/12415,

Manual backport because `<stack>` wasn't included

Closes #12417