### PR TITLE
rptest: increase failure injection test timeout

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3171,7 +3171,7 @@ class RedpandaService(RedpandaServiceBase):
     def remove_local_data(self, node):
         node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/data/*")
 
-    def redpanda_pid(self, node, timeout=None):
+    def redpanda_pid(self, node, timeout=None, silent=True):
         try:
             cmd = "pgrep --list-full --exact redpanda"
             for line in node.account.ssh_capture(cmd,
@@ -3181,6 +3181,10 @@ class RedpandaService(RedpandaServiceBase):
                 # by running `redpanda --version` like in `self.get_version(node)`
                 if "--version" in line:
                     continue
+
+                if silent == False:
+                    self.logger.debug(f"pgrep output: {line}")
+
                 # The pid is listed first, that's all we need
                 return int(line.split()[0])
             return None

--- a/tests/rptest/services/redpanda_monitor.py
+++ b/tests/rptest/services/redpanda_monitor.py
@@ -32,7 +32,11 @@ class RedpandaMonitor(BackgroundThreadService):
             started_dead_nodes = []
             for n in self.redpanda.started_nodes():
                 try:
-                    pid = self.redpanda.redpanda_pid(n, timeout=3)
+                    self.redpanda.logger.info(
+                        f"RedpandaMonitor checking {n.account.hostname}")
+                    pid = self.redpanda.redpanda_pid(n,
+                                                     timeout=3,
+                                                     silent=False)
                     if pid is None:
                         started_dead_nodes.append(n)
 


### PR DESCRIPTION
`StorageFailureInjectionTest.test_storage_failure_injection` failed reliably on CDT nodes while waiting for the node to be restarted after a storage failure injection event. Upon further investigation it turned out that a large amount of time could be spent in the kernel in order to clean up resources associate with the Redpanda process. During this time, the process would be in the "uninterruptible sleep" state.

This patch makes the timeout more generous.

Fixes #12396

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

