### PR TITLE
retest: fix default cloud storage cache size test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -535,7 +535,7 @@ class SISettings:
             # larger, so that a test doing any significant amount of throughput will exercise trimming.
             conf[
                 "cloud_storage_cache_size"] = SISettings.cache_size_for_throughput(
-                    1024 * 1024 * 100),
+                    1024 * 1024 * 100)
         else:
             conf["cloud_storage_cache_size"] = self.cloud_storage_cache_size
 

--- a/tests/rptest/tests/adjacent_segment_merging_test.py
+++ b/tests/rptest/tests/adjacent_segment_merging_test.py
@@ -39,7 +39,7 @@ class AdjacentSegmentMergingTest(RedpandaTest):
         si_settings = SISettings(
             test_context,
             cloud_storage_max_connections=10,
-            log_segment_size=0x10000,
+            log_segment_size=1024 * 1024,
             cloud_storage_segment_max_upload_interval_sec=1,
             cloud_storage_enable_remote_write=True)
 


### PR DESCRIPTION
This PR includes a fix for the default cloud storage cache size used in duck-tape tests
and also tweaks the adjacent segment merging test to use a smaller segment size.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
