### PR TITLE
cloud_storage: remove remote object tagging

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -170,12 +170,6 @@ ntp_archiver::ntp_archiver(
       config::shard_local_cfg().cloud_storage_housekeeping_interval_ms.bind())
   , _housekeeping_jitter(_housekeeping_interval(), housekeeping_jit)
   , _next_housekeeping(_housekeeping_jitter())
-  , _segment_tags(cloud_storage::remote::make_segment_tags(_ntp, _rev))
-  , _manifest_tags(
-      cloud_storage::remote::make_partition_manifest_tags(_ntp, _rev))
-  , _tx_tags(cloud_storage::remote::make_tx_manifest_tags(_ntp, _rev))
-  , _segment_index_tags(
-      cloud_storage::remote::make_segment_index_tags(_ntp, _rev))
   , _local_segment_merger(maybe_make_adjacent_segment_merger(
       *this, _rtclog, parent.log().config(), parent.is_leader()))
   , _manifest_upload_interval(
@@ -937,7 +931,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
       manifest().get_manifest_path());
 
     auto result = co_await _remote.upload_manifest(
-      get_bucket_name(), manifest(), fib, _manifest_tags);
+      get_bucket_name(), manifest(), fib);
 
     if (result == cloud_storage::upload_result::success) {
         _last_manifest_upload_time = ss::lowres_clock::now();
@@ -1070,8 +1064,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::do_upload_segment(
           candidate.content_length,
           std::move(reset_func),
           fib,
-          lazy_abort_source,
-          _segment_tags);
+          lazy_abort_source);
     } catch (const ss::gate_closed_exception&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const ss::abort_requested_exception&) {
@@ -1134,7 +1127,6 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
           cloud_storage_clients::object_key{index_path},
           idx_res->index.to_iobuf(),
           fib,
-          _segment_index_tags,
           "segment-index");
 
         co_return ntp_archiver_upload_result(idx_res->stats);
@@ -1239,7 +1231,7 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_tx(
     cloud_storage::tx_range_manifest manifest(path, std::move(tx_range));
 
     co_return co_await _remote.upload_manifest(
-      get_bucket_name(), manifest, fib, _tx_tags);
+      get_bucket_name(), manifest, fib);
 }
 
 ss::future<std::optional<ntp_archiver::make_segment_index_result>>

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -636,11 +636,6 @@ private:
 
     std::optional<ntp_level_probe> _probe{std::nullopt};
 
-    const cloud_storage_clients::object_tag_formatter _segment_tags;
-    const cloud_storage_clients::object_tag_formatter _manifest_tags;
-    const cloud_storage_clients::object_tag_formatter _tx_tags;
-    const cloud_storage_clients::object_tag_formatter _segment_index_tags;
-
     // NTP level adjacent segment merging job
     std::unique_ptr<housekeeping_job> _local_segment_merger;
 

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -548,8 +548,6 @@ scrubber::write_remote_lifecycle_marker(
       marker_key,
       serde::to_iobuf(std::move(remote_marker)),
       marker_rtc,
-      _api.make_lifecycle_marker_tags(
-        nt_revision.nt.ns, nt_revision.nt.tp, nt_revision.initial_revision_id),
       "remote_lifecycle_marker");
 }
 

--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -155,7 +155,7 @@ private:
     // version that we've tested with is used in field.
     //
     // Update this version to use a different storage API version.
-    static constexpr auto azure_storage_api_version = "2021-08-06";
+    static constexpr auto azure_storage_api_version = "2023-01-03";
 
     result<ss::sstring>
     get_string_to_sign(http::client::request_header& header) const;

--- a/src/v/cloud_roles/tests/signature_test.cc
+++ b/src/v/cloud_roles/tests/signature_test.cc
@@ -188,7 +188,7 @@ SEASTAR_THREAD_TEST_CASE(test_abs_signature_computation) {
 
     std::string expected
       = "SharedKey "
-        "vladstorageaccount123:rDsCDHPhdsr7SMkt81ofyrnNNxL3VKFW7ydsDQeVPIM=";
+        "vladstorageaccount123:W5Xz1fJNgftpQm0ppLUcOJRzXStXct7OEe8pgj7Og5A=";
 
     BOOST_REQUIRE_EQUAL(
       header.at(boost::beast::http::field::authorization), expected);
@@ -216,7 +216,7 @@ SEASTAR_THREAD_TEST_CASE(test_abs_signature_computation_many_query_params) {
 
     std::string expected
       = "SharedKey "
-        "vladstorageaccount123:hWp74AgakkrSYVzYBKSabfLP4NWVa410CNRm/dMxX2M=";
+        "vladstorageaccount123:2P67qqyi833QDaUq+ghFvwewOJkJFjA8PY3hnssTy0M=";
 
     BOOST_REQUIRE_EQUAL(
       header.at(boost::beast::http::field::authorization), expected);

--- a/src/v/cloud_storage/recovery_utils.cc
+++ b/src/v/cloud_storage/recovery_utils.cc
@@ -68,14 +68,11 @@ ss::future<> place_download_result(
   retry_chain_node& parent) {
     retry_chain_node fib{&parent};
     auto result_path = generate_result_path(ntp_cfg, result_completed);
-    cloud_storage_clients::object_tag_formatter tags{
-      {"rp-type", "download-result"}};
     auto result = co_await remote.upload_object(
       bucket,
       cloud_storage_clients::object_key{result_path},
       iobuf{},
       fib,
-      tags,
       "download result file");
     if (result != upload_result::success) {
         vlog(

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1068,7 +1068,6 @@ struct finalize_data {
     model::initial_revision_id revision;
     cloud_storage_clients::bucket_name bucket;
     cloud_storage_clients::object_key key;
-    cloud_storage_clients::object_tag_formatter tags;
     iobuf serialized_manifest;
     model::offset insync_offset;
 };
@@ -1123,7 +1122,6 @@ ss::future<> finalize_background(remote& api, finalize_data data) {
           data.key,
           std::move(data.serialized_manifest),
           local_rtc,
-          data.tags,
           "manifest");
 
         if (manifest_put_result != upload_result::success) {
@@ -1167,8 +1165,6 @@ void remote_partition::finalize() {
       .bucket = _bucket,
       .key
       = cloud_storage_clients::object_key{stm_manifest.get_manifest_path()()},
-      .tags = cloud_storage::remote::make_partition_manifest_tags(
-        stm_manifest.get_ntp(), stm_manifest.get_revision_id()),
       .serialized_manifest = std::move(serialized_manifest),
       .insync_offset = stm_manifest.get_insync_offset()};
 

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -193,8 +193,7 @@ void upload_index(
                           cloud_storage_clients::object_key{
                             path().native() + ".index"},
                           std::move(ixbuf),
-                          fib,
-                          remote::default_index_tags)
+                          fib)
                         .get();
     BOOST_REQUIRE(upload_res == upload_result::success);
 }

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -99,8 +99,6 @@ static iobuf make_iobuf_from_string(std::string_view s) {
     return b;
 }
 
-static const cloud_storage_clients::object_tag_formatter upload_tags{{}};
-
 struct noop_mixin_t {};
 
 template<model::cloud_storage_backend backend>
@@ -605,8 +603,7 @@ FIXTURE_TEST(test_list_bucket, remote_fixture) {
                 cloud_storage_clients::object_key path{
                   fmt::format("{}/{}/{}", i, j, k)};
                 auto result = remote.local()
-                                .upload_object(
-                                  bucket, path, iobuf{}, fib, upload_tags)
+                                .upload_object(bucket, path, iobuf{}, fib)
                                 .get();
                 BOOST_REQUIRE_EQUAL(
                   cloud_storage::upload_result::success, result);
@@ -652,10 +649,8 @@ FIXTURE_TEST(test_list_bucket_with_prefix, remote_fixture) {
         for (const char second : {'a', 'b'}) {
             cloud_storage_clients::object_key path{
               fmt::format("{}/{}", first, second)};
-            auto result = remote.local()
-                            .upload_object(
-                              bucket, path, iobuf{}, fib, upload_tags)
-                            .get();
+            auto result
+              = remote.local().upload_object(bucket, path, iobuf{}, fib).get();
             BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
         }
     }
@@ -681,9 +676,8 @@ FIXTURE_TEST(test_list_bucket_with_filter, remote_fixture) {
     retry_chain_node fib(never_abort, 100ms, 20ms);
     cloud_storage_clients::bucket_name bucket{"test"};
     cloud_storage_clients::object_key path{"b"};
-    auto upl_result = remote.local()
-                        .upload_object(bucket, path, iobuf{}, fib, upload_tags)
-                        .get();
+    auto upl_result
+      = remote.local().upload_object(bucket, path, iobuf{}, fib).get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, upl_result);
 
     auto result = remote.local()
@@ -708,11 +702,10 @@ FIXTURE_TEST(test_put_string, remote_fixture) {
     retry_chain_node fib(never_abort, 100ms, 20ms);
 
     cloud_storage_clients::object_key path{"p"};
-    auto result
-      = remote.local()
-          .upload_object(
-            bucket, path, make_iobuf_from_string("p"), fib, upload_tags)
-          .get();
+    auto result = remote.local()
+                    .upload_object(
+                      bucket, path, make_iobuf_from_string("p"), fib)
+                    .get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
 
     auto request = get_requests()[0];
@@ -771,8 +764,7 @@ FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
           bucket,
           cloud_storage_clients::object_key{"p"},
           make_iobuf_from_string("p"),
-          fib,
-          upload_tags)
+          fib)
         .get());
     BOOST_REQUIRE_EQUAL(
       cloud_storage::upload_result::success,
@@ -781,8 +773,7 @@ FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
           bucket,
           cloud_storage_clients::object_key{"q"},
           make_iobuf_from_string("q"),
-          fib,
-          upload_tags)
+          fib)
         .get());
 
     std::vector<cloud_storage_clients::object_key> to_delete{
@@ -818,8 +809,7 @@ FIXTURE_TEST(
           bucket,
           cloud_storage_clients::object_key{"p"},
           make_iobuf_from_string("p"),
-          fib,
-          upload_tags)
+          fib)
         .get());
 
     std::vector<cloud_storage_clients::object_key> to_delete{

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -33,13 +33,11 @@ public:
     /// \param key is the blob identifier
     /// \param payload_size_bytes is a size of the object in bytes
     /// \param payload_size_bytes is a size of the object in bytes
-    /// \param tags are formatted tags for 'x-ms-tags'
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_put_blob_request(
       bucket_name const& name,
       object_key const& key,
-      size_t payload_size_bytes,
-      const object_tag_formatter& tags);
+      size_t payload_size_bytes);
 
     /// \brief Create a 'Get Blob' request header
     ///
@@ -147,7 +145,6 @@ public:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout) override;
 
     /// Send List Blobs request
@@ -208,7 +205,6 @@ private:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout);
 
     ss::future<head_object_result> do_head_object(

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -23,41 +23,6 @@
 
 namespace cloud_storage_clients {
 
-/// Object tag formatter that can be used
-/// to format tags for x_amz_tagging or x-ms-tag fields
-/// The value is supposed to be cached and
-/// not re-created on every request.
-class object_tag_formatter {
-public:
-    object_tag_formatter() = default;
-
-    object_tag_formatter(
-      std::initializer_list<std::pair<std::string_view, std::string_view>>&&
-        il) {
-        for (auto [key, value] : il) {
-            add(key, value);
-        }
-    }
-
-    template<class ValueT>
-    void add(std::string_view tag, const ValueT& value) {
-        if (empty()) {
-            _tags += ssx::sformat("{}={}", tag, value);
-        } else {
-            _tags += ssx::sformat("&{}={}", tag, value);
-        }
-    }
-
-    bool empty() const { return _tags.empty(); }
-
-    boost::beast::string_view str() const {
-        return {_tags.data(), _tags.size()};
-    }
-
-private:
-    ss::sstring _tags;
-};
-
 using http_byte_range = std::pair<uint64_t, uint64_t>;
 
 class client {
@@ -111,7 +76,6 @@ public:
     /// \param key is an id of the object
     /// \param payload_size is a size of the object in bytes
     /// \param body is an input_stream that can be used to read body
-    /// \param tags is a a tag formatter using query string format
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the upload is completed
     virtual ss::future<result<no_response, error_outcome>> put_object(
@@ -119,7 +83,6 @@ public:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout)
       = 0;
 

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -128,10 +128,7 @@ result<http::client::request_header> request_creator::make_head_object_request(
 
 result<http::client::request_header>
 request_creator::make_unsigned_put_object_request(
-  bucket_name const& name,
-  object_key const& key,
-  size_t payload_size_bytes,
-  const object_tag_formatter& tags) {
+  bucket_name const& name, object_key const& key, size_t payload_size_bytes) {
     // PUT /my-image.jpg HTTP/1.1
     // Host: myBucket.s3.<Region>.amazonaws.com
     // Date: Wed, 12 Oct 2009 17:50:00 GMT
@@ -154,10 +151,6 @@ request_creator::make_unsigned_put_object_request(
     header.insert(
       boost::beast::http::field::content_length,
       std::to_string(payload_size_bytes));
-
-    if (!tags.empty()) {
-        header.insert(aws_header_names::x_amz_tagging, tags.str());
-    }
 
     auto ec = _apply_credentials->add_auth(header);
     if (ec) {
@@ -624,10 +617,9 @@ ss::future<result<s3_client::no_response, error_outcome>> s3_client::put_object(
   object_key const& key,
   size_t payload_size,
   ss::input_stream<char> body,
-  const object_tag_formatter& tags,
   ss::lowres_clock::duration timeout) {
     return send_request(
-      do_put_object(name, key, payload_size, std::move(body), tags, timeout)
+      do_put_object(name, key, payload_size, std::move(body), timeout)
         .then(
           []() { return ss::make_ready_future<no_response>(no_response{}); }),
       name,
@@ -639,10 +631,9 @@ ss::future<> s3_client::do_put_object(
   object_key const& id,
   size_t payload_size,
   ss::input_stream<char> body,
-  const object_tag_formatter& tags,
   ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_unsigned_put_object_request(
-      name, id, payload_size, tags);
+      name, id, payload_size);
     if (!header) {
         return body.close().then([header] {
             return ss::make_exception_future<>(

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -50,8 +50,7 @@ public:
     result<http::client::request_header> make_unsigned_put_object_request(
       bucket_name const& name,
       object_key const& key,
-      size_t payload_size_bytes,
-      const object_tag_formatter& tags);
+      size_t payload_size_bytes);
 
     /// \brief Create a 'GetObject' request header
     ///
@@ -167,7 +166,6 @@ public:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout) override;
 
     ss::future<result<list_bucket_result, error_outcome>> list_objects(
@@ -208,7 +206,6 @@ private:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout);
 
     ss::future<list_bucket_result> do_list_objects_v2(

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -281,7 +281,6 @@ int main(int args, char** argv, char** env) {
                                                 lcfg.blobs.front(),
                                                 payload_size,
                                                 std::move(payload),
-                                                {},
                                                 http::default_connect_timeout)
                                               .get0();
                         if (!result) {

--- a/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
@@ -283,7 +283,6 @@ int main(int args, char** argv, char** env) {
                                                 lcfg.objects.front(),
                                                 payload_size,
                                                 std::move(payload),
-                                                {},
                                                 http::default_connect_timeout)
                                               .get0();
 

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -354,7 +354,6 @@ SEASTAR_TEST_CASE(test_put_object_success) {
             cloud_storage_clients::object_key("test"),
             expected_payload_size,
             std::move(payload_stream),
-            {},
             100ms)
           .get();
         // shouldn't throw
@@ -378,7 +377,6 @@ SEASTAR_TEST_CASE(test_put_object_failure) {
                                 cloud_storage_clients::object_key("test-error"),
                                 expected_payload_size,
                                 std::move(payload_stream),
-                                {},
                                 100ms)
                               .get();
         BOOST_REQUIRE(!result);

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     restart: always
     ports:
     - 10000:10000
-    image: mcr.microsoft.com/azure-storage/azurite:3.21.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.25.0
     networks:
     - redpanda-test
   rp:


### PR DESCRIPTION
Previously, Redpanda would apply tags to objects uploaded to S3 and ABS. These tags were not used anywhere and caused compatibility issues when Redpanda was used with a storage account where "Hierachical Namespaces" were enabled.

This commit removes the tagging.

Related #11578

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
* Remove unused object tagging within cloud storage

