### PR TITLE
admin/observability/debugging: add stm information to partition debug endpoint

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -385,6 +385,7 @@ get_allocation_domain(const model::ntp& ntp) {
 
 partition_state get_partition_state(ss::lw_shared_ptr<cluster::partition>);
 partition_raft_state get_partition_raft_state(consensus_ptr);
+std::vector<partition_stm_state> get_partition_stm_state(consensus_ptr);
 
 /**
  * Check that the configuration is valid, if not return a string with the

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -165,6 +165,10 @@ public:
     virtual ss::future<> remove_persistent_state();
     const ss::sstring& name() override { return _snapshot_backend.name(); }
 
+    model::offset last_applied() const override {
+        return raft::state_machine::last_applied_offset();
+    }
+
     ss::future<> make_snapshot();
     virtual uint64_t get_snapshot_size() const;
     /*

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -829,6 +829,24 @@
                 }
             }
         },
+        "stm_state": {
+            "id" : "stm_state",
+            "description": "Stm related state for a given replica.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "name of the stm"
+                },
+                "last_applied_offset": {
+                    "type": "long",
+                    "description": "Last applied offset"
+                },
+                "max_collectible_offset": {
+                    "type": "long",
+                    "description": "Max collectible offset"
+                }
+            }
+        },
         "raft_replica_state": {
             "id": "raft_replica_state",
             "description": "Raft level state for a single replica of a partition",
@@ -907,6 +925,13 @@
                         "type" : "raft_follower_state"
                     },
                     "description": "Follower metadata for this leader."
+                },
+                "stms": {
+                    "type": "array",
+                    "items": {
+                        "type": "stm_state"
+                    },
+                    "description": "All snapshottable stms attached to this replica"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4007,6 +4007,13 @@ void fill_raft_state(
             raft_state.followers.push(std::move(follower_state));
         }
     }
+    for (const auto& stm : state.raft_state.stms) {
+        ss::httpd::debug_json::stm_state state;
+        state.name = stm.name;
+        state.last_applied_offset = stm.last_applied_offset;
+        state.max_collectible_offset = stm.last_applied_offset;
+        raft_state.stms.push(std::move(state));
+    }
     replica.raft_state = std::move(raft_state);
 }
 } // namespace

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -178,6 +178,10 @@ public:
         return _tx_stm->parse_tx_control_batch(b);
     }
 
+    const std::vector<ss::shared_ptr<snapshotable_stm>>& stms() const {
+        return _stms;
+    }
+
     bool has_tx_stm() { return _tx_stm.get(); }
 
 private:

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -93,6 +93,8 @@ public:
     // log eviction attempts to offsets not greater than this.
     virtual model::offset max_collectible_offset() = 0;
 
+    virtual model::offset last_applied() const = 0;
+
     virtual const ss::sstring& name() = 0;
 
     // Only valid for state machines maintaining transactional state.

--- a/tests/rptest/tests/partition_state_api_test.py
+++ b/tests/rptest/tests/partition_state_api_test.py
@@ -26,6 +26,9 @@ class PartitionStateAPItest(RedpandaTest):
             leaders = list(
                 filter(lambda r: r["raft_state"]["is_elected_leader"],
                        s["replicas"]))
+            stms = list(
+                filter(lambda r: r["raft_state"]["stms"], s["replicas"]))
+            assert all(map(lambda stm: len(stm) > 0, stms)), stms
             assert (has_leader
                     and len(leaders) == 1) or (not has_leader
                                                and len(leaders) == 0), leaders


### PR DESCRIPTION
Most times we want to be able to answer the following questions about stms when debugging

* what is the last applied for the stm - to see if a specific stm is lagging
* what is the max_collectible_offset for an stm - to check if a partition stm is holding up house keeping

This PR adds this metadata to the partition state debug end point. For each replica of the partition something like following is included in the debug end point for that partition.

```
"stms": [
  {
    "name": "log_eviction_stm.snapshot",
    "last_applied_offset": 6,
    "max_collectible_offset": 6
  },
  {
    "name": "tx.snapshot",
    "last_applied_offset": 6,
    "max_collectible_offset": 6
   }
]
```


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
