### PR TITLE
[v23.2.x] retest: fix default cloud storage cache size test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -526,7 +526,7 @@ class SISettings:
             # larger, so that a test doing any significant amount of throughput will exercise trimming.
             conf[
                 "cloud_storage_cache_size"] = SISettings.cache_size_for_throughput(
-                    1024 * 1024 * 100),
+                    1024 * 1024 * 100)
         else:
             conf["cloud_storage_cache_size"] = self.cloud_storage_cache_size
 

--- a/tests/rptest/tests/adjacent_segment_merging_test.py
+++ b/tests/rptest/tests/adjacent_segment_merging_test.py
@@ -39,7 +39,7 @@ class AdjacentSegmentMergingTest(RedpandaTest):
         si_settings = SISettings(
             test_context,
             cloud_storage_max_connections=10,
-            log_segment_size=0x10000,
+            log_segment_size=1024 * 1024,
             cloud_storage_segment_max_upload_interval_sec=1,
             cloud_storage_enable_remote_write=True)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12445
