### PR TITLE
rpk: Test `rpk plugin` and managed plugin flag handling.

### DIFF
--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -51,6 +51,9 @@ type DevOverrides struct {
 	// continue to use an admin command even if the command is technically
 	// not supported because the cluster is a cloud cluster.
 	AllowRpkCloudAdmin bool `env:"ALLOW_RPK_CLOUD_ADMIN"`
+	// CloudToken bypasses the oauth.LoadFlow, allowing you to pass a cloud
+	// token instead of logging in.
+	CloudToken string `env:"RPK_CLOUD_TOKEN"`
 }
 
 // Config encapsulates a redpanda.yaml and/or an rpk.yaml. This is the

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -181,6 +181,14 @@ RUN /k8s && \
 
 #################################
 
+FROM golang as byoc-mock
+
+COPY --chown=0:0 --chmod=0755 tests/go/byoc-mock /opt/redpanda-tests/byoc-mock
+COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/byoc-mock /
+RUN /byoc-mock && rm /byoc-mock
+
+#################################
+
 FROM librdkafka as final
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/teleport /
@@ -254,6 +262,7 @@ COPY --from=k8s /usr/local/bin/kubectl /usr/local/bin/helm /usr/local/bin/
 COPY --from=kaf /usr/local/bin/kaf /usr/local/bin/
 COPY --from=kcl /usr/local/bin/kcl /usr/local/bin/
 COPY --from=kgo-verifier /opt/kgo-verifier /opt/kgo-verifier
+COPY --from=byoc-mock /opt/redpanda-tests/byoc-mock/.rpk.managed-byoc /root/.local/bin/.rpk.managed-byoc
 
 RUN ldconfig
 

--- a/tests/docker/ducktape-deps/byoc-mock
+++ b/tests/docker/ducktape-deps/byoc-mock
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+cd /opt/redpanda-tests/byoc-mock
+go mod tidy
+go build -o .rpk.managed-byoc

--- a/tests/go/byoc-mock/go.mod
+++ b/tests/go/byoc-mock/go.mod
@@ -1,0 +1,10 @@
+module byoc-mock
+
+go 1.19
+
+require github.com/spf13/cobra v1.7.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/tests/go/byoc-mock/go.sum
+++ b/tests/go/byoc-mock/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/go/byoc-mock/main.go
+++ b/tests/go/byoc-mock/main.go
@@ -1,0 +1,133 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type pluginHelp struct {
+	Path    string   `json:"path,omitempty"`
+	Short   string   `json:"short,omitempty"`
+	Long    string   `json:"long,omitempty"`
+	Example string   `json:"example,omitempty"`
+	Args    []string `json:"args,omitempty"`
+}
+
+// In support of rpk.ac --help-autocomplete.
+func traverseHelp(cmd *cobra.Command, pieces []string) []pluginHelp {
+	pieces = append(pieces, strings.Split(cmd.Use, " ")[0])
+	help := []pluginHelp{{
+		Path:    strings.Join(pieces, "_"),
+		Short:   cmd.Short,
+		Long:    cmd.Long,
+		Example: cmd.Example,
+		Args:    cmd.ValidArgs,
+	}}
+	for _, cmd := range cmd.Commands() {
+		help = append(help, traverseHelp(cmd, pieces)...)
+	}
+	return help
+}
+
+func main() {
+	var helpAutocomplete bool
+	root := cobra.Command{
+		Use: "byoc",
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd: true,
+		},
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if helpAutocomplete {
+				json.NewEncoder(os.Stdout).Encode(traverseHelp(cmd, nil))
+				os.Exit(0)
+			}
+		},
+		Run: func(root *cobra.Command, _ []string) {
+			// The root command needs a "run", otherwise executing
+			// --help-autocomplete with no args will not actually
+			// do anything...
+			root.Help()
+		},
+	}
+	root.PersistentFlags().BoolVar(&helpAutocomplete, "help-autocomplete", false, "autocompletion help for rpk")
+	root.PersistentFlags().MarkHidden("help-autocomplete")
+
+	root.AddCommand(
+		newAWSCommand(),
+	)
+
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newAWSCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "aws",
+	}
+	cmd.AddCommand(
+		newAWSApplyCommand(),
+	)
+	return cmd
+}
+
+type flag struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+type output struct {
+	Args  []string `json:"args"`
+	Flags []flag   `json:"flags"` // We prefer a list, instead of a map to check for repeated values.
+}
+
+func newAWSApplyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "apply",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			// Allow unknown flags so that arbitrary flags can be passed
+			// through. In the actual byoc implementation we add these
+			// flags individually but here we just want to know what's being
+			// passed by rpk
+			UnknownFlags: true,
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			f := collectFlags(os.Args)
+			o := output{
+				Args:  args,
+				Flags: f,
+			}
+			b, err := json.Marshal(o)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(b))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func collectFlags(args []string) []flag {
+	var flags []flag
+	i := 0
+	for i < len(args)-1 {
+		if strings.HasPrefix(args[i], "-") {
+			flags = append(flags, flag{args[i], args[i+1]})
+		}
+		i++
+	}
+	return flags
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -13,6 +13,7 @@ import re
 import typing
 import time
 import itertools
+import os
 from collections import namedtuple
 from typing import Iterator, Optional
 from ducktape.cluster.cluster import ClusterNode
@@ -884,7 +885,7 @@ class RpkTool:
         ]
         return self._execute(cmd)
 
-    def _execute(self, cmd, stdin=None, timeout=None, log_cmd=True):
+    def _execute(self, cmd, stdin=None, timeout=None, log_cmd=True, env=None):
         if timeout is None:
             timeout = DEFAULT_TIMEOUT
 
@@ -894,10 +895,14 @@ class RpkTool:
         if log_cmd:
             self._redpanda.logger.debug("Executing command: %s", cmd)
 
+        if env is not None:
+            env.update(os.environ.copy())
+
         p = subprocess.Popen(cmd,
                              stdout=subprocess.PIPE,
                              stdin=subprocess.PIPE,
                              stderr=subprocess.PIPE,
+                             env=env,
                              text=True)
         try:
             output, stderror = p.communicate(input=stdin, timeout=timeout)

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1278,3 +1278,25 @@ class RpkTool:
 
         output = self._execute(cmd)
         return list(filter(None, map(parse, output.splitlines())))
+
+    def plugin_list(self):
+        cmd = [self._rpk_binary(), "plugin", "list", "--local"]
+
+        return self._execute(cmd)
+
+    def cloud_byoc_aws_apply(self, redpanda_id, token, extra_flags=[]):
+        envs = {
+            "RPK_CLOUD_SKIP_VERSION_CHECK": "true",
+            "RPK_CLOUD_TOKEN": token
+        }
+
+        cmd = [
+            self._rpk_binary(), "cloud", "byoc", "aws", "apply",
+            "--redpanda-id", redpanda_id
+        ]
+
+        if len(extra_flags) > 0:
+            cmd += extra_flags
+
+        out = self._execute(cmd, env=envs)
+        return json.loads(out)

--- a/tests/rptest/tests/rpk_plugin_test.py
+++ b/tests/rptest/tests/rpk_plugin_test.py
@@ -1,0 +1,81 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+
+
+class RpkPluginTest(RedpandaTest):
+    def __init__(self, ctx):
+        super(RpkPluginTest, self).__init__(test_context=ctx)
+        self._ctx = ctx
+        self._rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=1)
+    def test_managed_byoc(self):
+        """
+        Test that rpk is able to recognize the plugin when installed
+        in the default folder, and assert that we are passing the
+        required flags to the plugin itself.
+        """
+        assert ".rpk.managed-byoc" in self._rpk.plugin_list()
+
+        def find_flag(flags, name, value):
+            for flag in flags:
+                if flag["name"] == name and flag["value"] == value:
+                    return True
+            return False
+
+        test_id = "test_id"
+        test_token = "test_token"
+
+        # First we validate only passing the redpanda_id and token.
+        out = self._rpk.cloud_byoc_aws_apply(redpanda_id=test_id,
+                                             token=test_token)
+        assert len(out["args"]) == 0
+        assert find_flag(out["flags"], "--redpanda-id", test_id)
+        assert find_flag(out["flags"], "--cloud-api-token", test_token)
+
+        # Now we validate that we strip rpk flags (-X and --verbose).
+        out = self._rpk.cloud_byoc_aws_apply(
+            redpanda_id=test_id,
+            token=test_token,
+            extra_flags=["-X", "brokers=127.0.0.1:9092", "--verbose"])
+
+        assert len(out["args"]) == 0
+
+        # Included:
+        assert find_flag(out["flags"], "--redpanda-id", test_id)
+        assert find_flag(out["flags"], "--cloud-api-token", test_token)
+        # Stripped:
+        assert not find_flag(out["flags"], "-X", "brokers=127.0.0.1:9092")
+        assert not find_flag(out["flags"], "--verbose", "")
+
+        # Now we validate that we pass other byoc-only flags.
+        region = "us-east-2"
+        out = self._rpk.cloud_byoc_aws_apply(redpanda_id=test_id,
+                                             token=test_token,
+                                             extra_flags=[
+                                                 "-X",
+                                                 "brokers=127.0.0.1:9092",
+                                                 "--verbose", "--region",
+                                                 region
+                                             ])
+
+        assert len(out["args"]) == 0
+
+        # Included:
+        assert find_flag(out["flags"], "--redpanda-id", test_id)
+        assert find_flag(out["flags"], "--cloud-api-token", test_token)
+        assert find_flag(out["flags"], "--region", region)
+
+        # Stripped:
+        assert not find_flag(out["flags"], "-X", "brokers=127.0.0.1:9092")
+        assert not find_flag(out["flags"], "--verbose", "")


### PR DESCRIPTION
This PR Introduces:

* A new go binary into the ducktape docker image. This binary it's a mocked plugin which outputs the passed args.
* A test that uses this binary to assert that rpk is passing the required flags to the managed plugin (byoc). This is to test https://github.com/redpanda-data/redpanda/pull/12379
* A new dev override `RPK_CLOUD_TOKEN` that let the user bypass the login process and make rpk use the passed token.

## Backports Required
- [ ] none - issue does not exist in previous branches
- [x] v23.2.x

## Release Notes
* none
