### PR TITLE
k8s: Increase memory instead of decrease in e2e update test

### DIFF
--- a/src/go/k8s/tests/e2e/update/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/02-assert.yaml
@@ -8,7 +8,9 @@ spec:
       containers:
         - resources:
             requests:
-              memory: 990M
+              memory: 2Gi
+            limits:
+              memory: 2Gi
 ---
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster

--- a/src/go/k8s/tests/e2e/update/02-update-resources.yaml
+++ b/src/go/k8s/tests/e2e/update/02-update-resources.yaml
@@ -5,4 +5,6 @@ metadata:
 spec:
   resources:
     requests:
-      memory: 990M
+      memory: 2Gi
+    limits:
+      memory: 2Gi


### PR DESCRIPTION
The following CI runs failed due to :
* https://buildkite.com/redpanda/redpanda/builds/33919
* https://buildkite.com/redpanda/redpanda/builds/33913
* https://buildkite.com/redpanda/redpanda/builds/33916
* https://buildkite.com/redpanda/redpanda/builds/33899

Example
```
DEBUG 2023-07-25 01:10:44,080 [shard 0] seastar_memory - Failed to allocate 64 bytes at 0x6fcb423 0x6c4cb30 0x6c56fd9 0x6c9f6ac 0x6c92022 0x6c8e424 0x6cbf1c7 0x6cbd636 0x6cbcab4 0x6e842b4 0x6e368f0 0x6e44d27 0x6e4584c 0x6d1227f 0x6d15921 0x6d12ae6 0x6c175b0 0x6c159a8 0x213c945 0x700c27b /opt/redpanda/lib/libc.so.6+0x2d58f /opt/redpanda/lib/libc.so.6+0x2d648 0x21366a4
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::httpd::connection::do_response_loop()::$_0, seastar::future<void> seastar::future<std::__1::unique_ptr<seastar::http::reply, std::__1::default_delete<seastar::http::reply>>>::then_impl_nrvo<seastar::httpd::connection::do_response_loop()::$_0, seastar::future<void>>(seastar::httpd::connection::do_response_loop()::$_0&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::httpd::connection::do_response_loop()::$_0&, seastar::future_state<std::__1::unique_ptr<seastar::http::reply, std::__1::default_delete<seastar::http::reply>>>&&), std::__1::unique_ptr<seastar::http::reply, std::__1::default_delete<seastar::http::reply>>>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::httpd::connection::respond()::$_0, seastar::futurize<seastar::future<void>>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::httpd::connection::respond()::$_0>(seastar::httpd::connection::respond()::$_0&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::httpd::connection::respond()::$_0&, seastar::future_state<seastar::internal::monostate>&&), void>
   --------
   seastar::internal::when_all_state_component<seastar::future<void>>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::httpd::connection::process()::$_0, seastar::future<void> seastar::future<std::__1::tuple<seastar::future<void>, seastar::future<void>>>::then_impl_nrvo<seastar::httpd::connection::process()::$_0, seastar::future<void>>(seastar::httpd::connection::process()::$_0&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::httpd::connection::process()::$_0&, seastar::future_state<std::__1::tuple<seastar::future<void>, seastar::future<void>>>&&), std::__1::tuple<seastar::future<void>, seastar::future<void>>>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::future<void>::finally_body<seastar::httpd::connection::process()::$_1, true>, seastar::futurize<seastar::future<void>>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::future<void>::finally_body<seastar::httpd::connection::process()::$_1, true>>(seastar::future<void>::finally_body<seastar::httpd::connection::process()::$_1, true>&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::future<void>::finally_body<seastar::httpd::connection::process()::$_1, true>&, seastar::future_state<seastar::internal::monostate>&&), void>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::future<void> seastar::future<void>::handle_exception<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)>(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)&&)::'lambda'(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)&&), seastar::futurize<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::future<void> seastar::future<void>::handle_exception<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)>(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)&&)::'lambda'(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)&&)>(seastar::future<void> seastar::future<void>::handle_exception<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)>(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)&&)::'lambda'(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)&&)&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::future<void> seastar::future<void>::handle_exception<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)>(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)&&)::'lambda'(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()::operator()()::'lambda'(std::exception_ptr)&&)&, seastar::future_state<seastar::internal::monostate>&&), void>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::future<void>::finally_body<auto seastar::internal::invoke_func_with_gate<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()>(seastar::gate&, seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()&&)::'lambda'(), false>, seastar::futurize<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::future<void>::finally_body<auto seastar::internal::invoke_func_with_gate<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()>(seastar::gate&, seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()&&)::'lambda'(), false>>(seastar::future<void>::finally_body<auto seastar::internal::invoke_func_with_gate<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()>(seastar::gate&, seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()&&)::'lambda'(), false>&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::future<void>::finally_body<auto seastar::internal::invoke_func_with_gate<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()>(seastar::gate&, seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'()&&)::'lambda'(), false>&, seastar::future_state<seastar::internal::monostate>&&), void>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::future<void> seastar::future<void>::handle_exception_type<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)>(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)&&)::'lambda'(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)&&), seastar::futurize<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::future<void> seastar::future<void>::handle_exception_type<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)>(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)&&)::'lambda'(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)&&)>(seastar::future<void> seastar::future<void>::handle_exception_type<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)>(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)&&)::'lambda'(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)&&)&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::future<void> seastar::future<void>::handle_exception_type<seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)>(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)&&)::'lambda'(seastar::httpd::http_server::do_accept_one(int, bool)::$_0::operator()(seastar::accept_result)::'lambda'(seastar::gate_closed_exception const&)&&)&, seastar::future_state<seastar::internal::monostate>&&), void>

```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
