### PR TITLE
Replace `hdr_hist` with `log_hist`  

### DIFF
--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -12,6 +12,7 @@
 
 #include "cloud_storage/fwd.h"
 #include "cloud_storage/materialized_manifest_cache.h"
+#include "cloud_storage/partition_probe.h"
 #include "cloud_storage/probe.h"
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/types.h"
@@ -217,7 +218,7 @@ private:
     struct materialization_request_t {
         segment_meta search_vec;
         ss::promise<result<manifest_section_t, error_outcome>> promise;
-        std::unique_ptr<hdr_hist::measurement> _measurement;
+        std::unique_ptr<partition_probe::hist_t::measurement> _measurement;
     };
     std::deque<materialization_request_t> _requests;
     ss::condition_variable _cvar;

--- a/src/v/cloud_storage/partition_probe.cc
+++ b/src/v/cloud_storage/partition_probe.cc
@@ -91,10 +91,7 @@ partition_probe::partition_probe(const model::ntp& ntp) {
 
         sm::make_histogram(
           "spillover_manifest_latency",
-          [this] {
-              return ssx::metrics::report_default_histogram(
-                _spillover_mat_latency);
-          },
+          [this] { return _spillover_mat_latency.public_histogram_logform(); },
           sm::description(
             "Spillover manifest materialization latency histogram"),
           labels),
@@ -102,8 +99,7 @@ partition_probe::partition_probe(const model::ntp& ntp) {
         sm::make_histogram(
           "chunk_hydration_latency",
           [this] {
-              return ssx::metrics::report_default_histogram(
-                _chunk_hydration_latency);
+              return _chunk_hydration_latency.public_histogram_logform();
           },
           sm::description("Chunk hydration latency histogram"),
           labels),

--- a/src/v/cloud_storage/partition_probe.h
+++ b/src/v/cloud_storage/partition_probe.h
@@ -12,7 +12,7 @@
 
 #include "model/fundamental.h"
 #include "ssx/metrics.h"
-#include "utils/hdr_hist.h"
+#include "utils/log_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -20,6 +20,8 @@ namespace cloud_storage {
 
 class partition_probe {
 public:
+    using hist_t = log_hist_internal;
+
     explicit partition_probe(const model::ntp& ntp);
 
     void add_bytes_read(uint64_t read) { _bytes_read += read; }
@@ -71,9 +73,9 @@ private:
     int64_t _spillover_manifest_materialized = 0;
     int64_t _spillover_manifest_hydrated = 0;
     /// Spillover manifest materialization latency
-    hdr_hist _spillover_mat_latency;
+    hist_t _spillover_mat_latency;
 
-    hdr_hist _chunk_hydration_latency;
+    hist_t _chunk_hydration_latency;
 
     uint64_t _chunk_size = 0;
 

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -132,15 +132,13 @@ remote_probe::remote_probe(
             sm::make_histogram(
               "client_acquisition_latency",
               [this] {
-                  return ssx::metrics::report_default_histogram(
-                    _client_acquisition_latency);
+                  return _client_acquisition_latency.public_histogram_logform();
               },
               sm::description("Client acquisition latency histogram")),
             sm::make_histogram(
               "segment_download_latency",
               [this] {
-                  return ssx::metrics::report_default_histogram(
-                    _segment_download_latency);
+                  return _segment_download_latency.public_histogram_logform();
               },
               sm::description("Segment download latency histogram")),
           });

--- a/src/v/cloud_storage/probe.h
+++ b/src/v/cloud_storage/probe.h
@@ -14,6 +14,7 @@
 #include "model/fundamental.h"
 #include "seastarx.h"
 #include "ssx/metrics.h"
+#include "utils/log_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
 
@@ -26,6 +27,8 @@ class materialized_resources;
 /// Cloud storage endpoint level probe
 class remote_probe {
 public:
+    using hist_t = log_hist_internal;
+
     explicit remote_probe(
       remote_metrics_disabled disabled,
       remote_metrics_disabled public_disabled,
@@ -268,8 +271,8 @@ private:
     /// Number of spillover manifest downloads
     uint64_t _cnt_spillover_manifest_downloads{0};
 
-    hdr_hist _client_acquisition_latency;
-    hdr_hist _segment_download_latency;
+    hist_t _client_acquisition_latency;
+    hist_t _segment_download_latency;
 
     ssx::metrics::metric_groups _metrics
       = ssx::metrics::metric_groups::make_internal();

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -977,7 +977,7 @@ ss::future<> remote_segment::hydrate_chunk(segment_chunk_range range) {
     auto res = co_await _api.download_segment(
       _bucket, _path, std::move(consumer), rtc, std::make_pair(start, end));
     if (res != download_result::success) {
-        measurement->set_trace(false);
+        measurement->cancel();
         throw download_exception{res, _path};
     }
 }

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -188,7 +188,7 @@ client_pool::acquire(ss::abort_source& as) {
       normalized_num_clients_in_use(),
       source_sid.has_value());
 
-    std::unique_ptr<hdr_hist::measurement> measurement;
+    std::unique_ptr<client_probe::hist_t::measurement> measurement;
     if (_probe) {
         measurement = _probe->register_lease_duration();
     }

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -12,8 +12,8 @@
 
 #include "cloud_roles/apply_credentials.h"
 #include "cloud_storage_clients/client.h"
+#include "cloud_storage_clients/client_probe.h"
 #include "utils/gate_guard.h"
-#include "utils/hdr_hist.h"
 #include "utils/intrusive_list_helpers.h"
 
 #include <seastar/core/condition-variable.hh>
@@ -44,13 +44,13 @@ public:
         ss::deleter deleter;
         ss::abort_source::subscription as_sub;
         intrusive_list_hook _hook;
-        std::unique_ptr<hdr_hist::measurement> _track_duration;
+        std::unique_ptr<client_probe::hist_t::measurement> _track_duration;
 
         client_lease(
           http_client_ptr p,
           ss::abort_source& as,
           ss::deleter deleter,
-          std::unique_ptr<hdr_hist::measurement> m)
+          std::unique_ptr<client_probe::hist_t::measurement> m)
           : client(std::move(p))
           , deleter(std::move(deleter))
           , _track_duration(std::move(m)) {

--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -12,7 +12,6 @@
 
 #include "prometheus/prometheus_sanitize.h"
 #include "ssx/metrics.h"
-#include "utils/hdr_hist.h"
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/metrics_types.hh>
@@ -94,7 +93,8 @@ void client_probe::register_retryable_failure(
 
 void client_probe::register_borrow() { _total_borrows += 1; }
 
-std::unique_ptr<hdr_hist::measurement> client_probe::register_lease_duration() {
+std::unique_ptr<client_probe::hist_t::measurement>
+client_probe::register_lease_duration() {
     return _lease_duration.auto_measure();
 }
 
@@ -194,9 +194,7 @@ void client_probe::setup_internal_metrics(
           labels),
         sm::make_histogram(
           "lease_duration",
-          [this] {
-              return ssx::metrics::report_default_histogram(_lease_duration);
-          },
+          [this] { return _lease_duration.public_histogram_logform(); },
           sm::description("Lease duration histogram"),
           labels),
         sm::make_gauge(
@@ -276,9 +274,7 @@ void client_probe::setup_public_metrics(
           labels),
         sm::make_histogram(
           "lease_duration",
-          [this] {
-              return ssx::metrics::report_default_histogram(_lease_duration);
-          },
+          [this] { return _lease_duration.public_histogram_logform(); },
           sm::description("Lease duration histogram"),
           labels),
         sm::make_gauge(

--- a/src/v/cloud_storage_clients/client_probe.h
+++ b/src/v/cloud_storage_clients/client_probe.h
@@ -18,7 +18,7 @@
 #include "model/fundamental.h"
 #include "net/types.h"
 #include "ssx/metrics.h"
-#include "utils/hdr_hist.h"
+#include "utils/log_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/metrics_types.hh>
@@ -47,6 +47,8 @@ enum class op_type_tag { upload, download };
 ///       time-series.
 class client_probe : public http::client_probe {
 public:
+    using hist_t = log_hist_internal;
+
     /// \brief Probe c-tor for S3 client
     ///
     /// \param disable is used to switch the internal monitoring off
@@ -81,7 +83,7 @@ public:
     /// Call on a shard which needs to borrow a client
     void register_borrow();
     /// Register total lease duration
-    std::unique_ptr<hdr_hist::measurement> register_lease_duration();
+    std::unique_ptr<hist_t::measurement> register_lease_duration();
     /// Utilization metric which is used to decide if borrowing is possible
     void register_utilization(unsigned clients_in_use);
 
@@ -109,7 +111,7 @@ private:
     /// Number of times this shard borrowed resources from other shards
     uint64_t _total_borrows{0};
     /// Total time the lease is held by the ntp_archiver (or another user)
-    hdr_hist _lease_duration;
+    hist_t _lease_duration;
     /// Current utilization of the client pool
     uint64_t _pool_utilization;
     ssx::metrics::metric_groups _metrics

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -14,7 +14,6 @@
 #include "http/client.h"
 #include "seastarx.h"
 #include "syschecks/syschecks.h"
-#include "utils/hdr_hist.h"
 #include "vlog.h"
 
 #include <seastar/core/app-template.hh>

--- a/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
@@ -15,7 +15,6 @@
 #include "http/client.h"
 #include "seastarx.h"
 #include "syschecks/syschecks.h"
-#include "utils/hdr_hist.h"
 #include "vlog.h"
 
 #include <seastar/core/app-template.hh>

--- a/src/v/http/demo/client.cc
+++ b/src/v/http/demo/client.cc
@@ -13,7 +13,6 @@
 #include "rpc/types.h"
 #include "seastarx.h"
 #include "syschecks/syschecks.h"
-#include "utils/hdr_hist.h"
 #include "vlog.h"
 
 #include <seastar/core/app-template.hh>

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -21,7 +21,6 @@
 #include "security/mtls.h"
 #include "security/sasl_authentication.h"
 #include "ssx/semaphore.h"
-#include "utils/hdr_hist.h"
 #include "utils/log_hist.h"
 #include "utils/named_type.h"
 
@@ -102,7 +101,7 @@ struct session_resources {
     ss::lowres_clock::duration backpressure_delay;
     ssx::semaphore_units memlocks;
     ssx::semaphore_units queue_units;
-    std::unique_ptr<hdr_hist::measurement> method_latency;
+    std::unique_ptr<server::hist_t::measurement> method_latency;
     std::unique_ptr<handler_probe::hist_t::measurement> handler_latency;
     std::unique_ptr<request_tracker> tracker;
     request_data request_data;

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -17,8 +17,8 @@
 #include "model/fundamental.h"
 #include "model/ktp.h"
 #include "model/metadata.h"
-#include "utils/hdr_hist.h"
 #include "utils/intrusive_list_helpers.h"
+#include "utils/log_hist.h"
 
 #include <seastar/core/smp.hh>
 
@@ -32,7 +32,7 @@ using fetch_handler = single_stage_handler<fetch_api, 4, 11>;
  * Fetch operation context
  */
 struct op_context {
-    using latency_clock = hdr_hist::clock_type;
+    using latency_clock = log_hist_internal::clock_type;
     using latency_point = latency_clock::time_point;
 
     class response_placeholder {

--- a/src/v/kafka/server/handlers/handler_probe.cc
+++ b/src/v/kafka/server/handlers/handler_probe.cc
@@ -106,7 +106,7 @@ void handler_probe::setup_metrics(
           "latency_microseconds",
           sm::description("Latency histogram of kafka requests"),
           labels,
-          [this] { return _latency.seastar_histogram_logform(1); })
+          [this] { return _latency.internal_histogram_logform(); })
           .aggregate(aggregate_labels),
       });
 }

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -404,7 +404,7 @@ static partition_produce_stages produce_topic_partition(
                   auto dur = std::chrono::steady_clock::now() - start;
                   octx.rctx.connection()->server().update_produce_latency(dur);
               } else {
-                  m->set_trace(false);
+                  m->cancel();
               }
               return p;
           });

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -334,7 +334,7 @@ void server::setup_metrics() {
            "{}: Memory consumed by request processing", cfg.name))),
        sm::make_histogram(
          "dispatch_handler_latency",
-         [this] { return _hist.seastar_histogram_logform(); },
+         [this] { return _hist.internal_histogram_logform(); },
          sm::description(ssx::sformat("{}: Latency ", cfg.name)))});
 }
 
@@ -355,7 +355,7 @@ void server::setup_public_metrics() {
          "latency_seconds",
          sm::description("RPC latency"),
          {server_label(server_name)},
-         [this] { return ssx::metrics::report_default_histogram(_hist); })
+         [this] { return _hist.public_histogram_logform(); })
          .aggregate({sm::shard_label})});
 }
 

--- a/src/v/pandaproxy/probe.cc
+++ b/src/v/pandaproxy/probe.cc
@@ -54,7 +54,9 @@ void probe::setup_metrics() {
          "request_latency",
          sm::description("Request latency"),
          labels,
-         [this] { return _request_metrics.hist().seastar_histogram_logform(); })
+         [this] {
+             return _request_metrics.hist().internal_histogram_logform();
+         })
          .aggregate(internal_aggregate_labels)});
 }
 
@@ -81,10 +83,7 @@ void probe::setup_public_metrics() {
          sm::description(
            ssx::sformat("Internal latency of request for {}", _group_name)),
          labels,
-         [this] {
-             return ssx::metrics::report_default_histogram(
-               _request_metrics.hist());
-         })
+         [this] { return _request_metrics.hist().public_histogram_logform(); })
          .aggregate(aggregate_labels),
 
        sm::make_counter(

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "ssx/metrics.h"
-#include "utils/hdr_hist.h"
+#include "utils/log_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/http/json_path.hh>
@@ -23,10 +23,11 @@ namespace pandaproxy {
 /// If the request is good, measure latency, otherwise record the error.
 class http_status_metric {
 public:
+    using hist_t = log_hist_internal;
     class measurement {
     public:
         measurement(
-          http_status_metric* p, std::unique_ptr<hdr_hist::measurement> m)
+          http_status_metric* p, std::unique_ptr<hist_t::measurement> m)
           : _p(p)
           , _m(std::move(m)) {}
 
@@ -42,17 +43,17 @@ public:
             } else {
                 ++_p->_5xx_count;
             }
-            _m->set_trace(false);
+            _m->cancel();
         }
 
     private:
         http_status_metric* _p;
-        std::unique_ptr<hdr_hist::measurement> _m;
+        std::unique_ptr<hist_t::measurement> _m;
     };
-    hdr_hist& hist() { return _hist; }
+    hist_t& hist() { return _hist; }
     auto auto_measure() { return measurement{this, _hist.auto_measure()}; }
 
-    hdr_hist _hist;
+    hist_t _hist;
     int64_t _5xx_count{0};
     int64_t _4xx_count{0};
     int64_t _3xx_count{0};

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -97,7 +97,7 @@ public:
               prometheus_sanitize::metrics_name("internal_rpc"),
               {sm::make_histogram(
                 "latency",
-                [this] { return _methods[{{loop.index-1}}].probes.latency_hist().seastar_histogram_logform(); },
+                [this] { return _methods[{{loop.index-1}}].probes.latency_hist().internal_histogram_logform(); },
                 sm::description("Internal RPC service latency"),
                 labels)
                 .aggregate(aggregate_labels)});

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -262,7 +262,8 @@ ss::future<> rpc_server::dispatch_method_once(
                     }
                     return send_reply(ctx, std::move(reply_buf))
                       .finally([m, l = std::move(l)]() mutable {
-                          m->probes.latency_hist().record(std::move(l));
+                          m->probes.latency_hist().record(
+                            l->compute_total_latency().count());
                       });
                 });
           })

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -18,7 +18,7 @@
 #include "outcome.h"
 #include "seastarx.h"
 #include "ssx/semaphore.h"
-#include "utils/hdr_hist.h"
+#include "utils/log_hist.h"
 #include "vassert.h"
 
 #include <seastar/core/future.hh>
@@ -416,12 +416,14 @@ inline void netbuf::set_min_compression_bytes(size_t min) {
 
 class method_probes {
 public:
-    hdr_hist& latency_hist() { return _latency_hist; }
-    const hdr_hist& latency_hist() const { return _latency_hist; }
+    using hist_t = log_hist_internal;
+
+    hist_t& latency_hist() { return _latency_hist; }
+    const hist_t& latency_hist() const { return _latency_hist; }
 
 private:
-    // roughly 2024 bytes
-    hdr_hist _latency_hist{120s, 1ms};
+    // roughly 208 bytes
+    hist_t _latency_hist;
 };
 
 /// \brief most method implementations will be codegenerated

--- a/src/v/utils/CMakeLists.txt
+++ b/src/v/utils/CMakeLists.txt
@@ -15,6 +15,7 @@ v_cc_library(
     request_auth.cc
     bottomless_token_bucket.cc
     utf8.cc
+    log_hist.cc
   DEPS
     Seastar::seastar
     Hdrhistogram::hdr_histogram

--- a/src/v/utils/log_hist.cc
+++ b/src/v/utils/log_hist.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/log_hist.h"
+
+template<
+  typename duration_t,
+  int number_of_buckets,
+  uint64_t first_bucket_upper_bound>
+template<typename cfg>
+seastar::metrics::histogram
+log_hist<duration_t, number_of_buckets, first_bucket_upper_bound>::
+  seastar_histogram_logform() const {
+    seastar::metrics::histogram hist;
+    hist.buckets.resize(cfg::bucket_count);
+    hist.sample_sum = static_cast<double>(_sample_sum)
+                      / static_cast<double>(cfg::scale);
+
+    const unsigned first_bucket_exp
+      = 64 - std::countl_zero(first_bucket_upper_bound - 1);
+    const unsigned cfg_first_bucket_exp
+      = 64 - std::countl_zero(cfg::first_bucket_bound - 1);
+
+    // Write bounds to seastar histogram
+    for (int i = 0; i < cfg::bucket_count; i++) {
+        auto& bucket = hist.buckets[i];
+        bucket.count = 0;
+
+        uint64_t unscaled_upper_bound = ((uint64_t)1
+                                         << (cfg_first_bucket_exp + i))
+                                        - 1;
+        bucket.upper_bound = static_cast<double>(unscaled_upper_bound)
+                             / static_cast<double>(cfg::scale);
+    }
+
+    uint64_t cumulative_count = 0;
+    size_t current_hist_idx = 0;
+    double current_hist_upper_bound = hist.buckets[0].upper_bound;
+
+    // Write _counts to seastar histogram
+    for (size_t i = 0; i < _counts.size(); i++) {
+        uint64_t unscaled_upper_bound = ((uint64_t)1 << (first_bucket_exp + i))
+                                        - 1;
+        double scaled_upper_bound = static_cast<double>(unscaled_upper_bound)
+                                    / static_cast<double>(cfg::scale);
+
+        cumulative_count += _counts[i];
+
+        while (scaled_upper_bound > current_hist_upper_bound
+               && current_hist_idx != (hist.buckets.size() - 1)) {
+            current_hist_idx++;
+            current_hist_upper_bound
+              = hist.buckets[current_hist_idx].upper_bound;
+        }
+
+        hist.buckets[current_hist_idx].count = cumulative_count;
+    }
+
+    hist.sample_count = cumulative_count;
+    return hist;
+}
+
+template<
+  typename duration_t,
+  int number_of_buckets,
+  uint64_t first_bucket_upper_bound>
+seastar::metrics::histogram
+log_hist<duration_t, number_of_buckets, first_bucket_upper_bound>::
+  public_histogram_logform() const {
+    using public_hist_config = logform_config<1'000'000l, 256ul, 18>;
+
+    return seastar_histogram_logform<public_hist_config>();
+}
+
+template<
+  typename duration_t,
+  int number_of_buckets,
+  uint64_t first_bucket_upper_bound>
+seastar::metrics::histogram
+log_hist<duration_t, number_of_buckets, first_bucket_upper_bound>::
+  internal_histogram_logform() const {
+    using internal_hist_config = logform_config<1l, 8ul, 26>;
+
+    return seastar_histogram_logform<internal_hist_config>();
+}
+
+// Explicit instantiation for log_hist_public
+template class log_hist<std::chrono::microseconds, 18, 256ul>;
+// Explicit instantiation for log_hist_internal
+template class log_hist<std::chrono::microseconds, 26, 8ul>;

--- a/src/v/utils/log_hist.h
+++ b/src/v/utils/log_hist.h
@@ -128,7 +128,7 @@ public:
      */
     void record(uint64_t val) {
         _sample_sum += val;
-        const int i = std::clamp(
+        const unsigned i = std::clamp(
           first_bucket_clz - std::countl_zero(val),
           0,
           static_cast<int>(_counts.size() - 1));

--- a/src/v/utils/log_hist.h
+++ b/src/v/utils/log_hist.h
@@ -14,12 +14,10 @@
 #include <seastar/core/metrics_types.hh>
 #include <seastar/core/shared_ptr.hh>
 
-#include <boost/intrusive/list.hpp>
-
+#include <array>
 #include <bit>
 #include <chrono>
 #include <cstdint>
-#include <vector>
 
 /*
  * A histogram implementation
@@ -112,7 +110,7 @@ public:
 
     log_hist()
       : _canary(seastar::make_lw_shared(true))
-      , _counts(number_of_buckets) {}
+      , _counts() {}
     log_hist(const log_hist& o) = delete;
     log_hist& operator=(const log_hist&) = delete;
     log_hist(log_hist&& o) = delete;
@@ -135,32 +133,38 @@ public:
         _counts[i]++;
     }
 
-    void record(std::unique_ptr<measurement> m) {
-        record(m->compute_duration());
-    }
+    template<int64_t _scale, uint64_t _first_bucket_bound, int _bucket_count>
+    struct logform_config {
+        static constexpr auto bound_is_pow_2 = _first_bucket_bound >= 1
+                                               && (_first_bucket_bound
+                                                   & (_first_bucket_bound - 1))
+                                                    == 0;
+        static_assert(
+          bound_is_pow_2, "_first_bucket_bound must be a power of 2");
 
-    seastar::metrics::histogram seastar_histogram_logform(int64_t scale) const {
-        seastar::metrics::histogram hist;
-        hist.buckets.resize(_counts.size());
-        hist.sample_sum = static_cast<double>(_sample_sum)
-                          / static_cast<double>(scale);
+        static constexpr auto scale = _scale;
+        static constexpr auto first_bucket_bound = _first_bucket_bound;
+        static constexpr auto bucket_count = _bucket_count;
+    };
 
-        uint64_t cumulative_count = 0;
-        for (uint64_t i = 0; i < _counts.size(); i++) {
-            auto& bucket = hist.buckets[i];
-
-            cumulative_count += _counts[i];
-            bucket.count = cumulative_count;
-            uint64_t unscaled_upper_bound = ((uint64_t)1
-                                             << (first_bucket_exp + i))
-                                            - 1;
-            bucket.upper_bound = static_cast<double>(unscaled_upper_bound)
-                                 / static_cast<double>(scale);
-        }
-
-        hist.sample_count = cumulative_count;
-        return hist;
-    }
+    template<typename cfg>
+    seastar::metrics::histogram seastar_histogram_logform() const;
+    /*
+     * Generates a Prometheus histogram with 18 buckets. The first bucket has an
+     * upper bound of 256 - 1 and subsequent buckets have an upper bound of 2
+     * times the upper bound of the previous bucket.
+     *
+     * This is the histogram type used in the `/public_metrics` endpoint
+     */
+    seastar::metrics::histogram public_histogram_logform() const;
+    /*
+     * Generates a Prometheus histogram with 26 buckets. The first bucket has an
+     * upper bound of 8 - 1 and subsequent buckets have an upper bound of 2
+     * times the upper bound of the previous bucket.
+     *
+     * This is the histogram type used in the `/metrics` endpoint
+     */
+    seastar::metrics::histogram internal_histogram_logform() const;
 
 private:
     friend measurement;
@@ -168,7 +172,7 @@ private:
     // Used to inform measurements whether `log_hist` has been destroyed
     measurement_canary_t _canary;
 
-    std::vector<uint64_t> _counts;
+    std::array<uint64_t, number_of_buckets> _counts;
     uint64_t _sample_sum{0};
 };
 
@@ -179,8 +183,7 @@ private:
  * will produce the same seastar histogram as
  * `ssx::metrics::report_default_histogram(hdr_hist)`.
  */
-using log_hist_public = log_hist<std::chrono::microseconds, 18, 256>;
-static constexpr int64_t log_hist_public_scale = 1'000'000;
+using log_hist_public = log_hist<std::chrono::microseconds, 18, 256ul>;
 
 /*
  * This histogram produces results that are similar, but not indentical to the
@@ -188,4 +191,4 @@ static constexpr int64_t log_hist_public_scale = 1'000'000;
  * following bounds; [log_hist_internal upper bounds, internal hdr_hist upper
  * bounds] [8, 10], [16, 20], [32, 41], [64, 83], [128, 167], [256, 335]
  */
-using log_hist_internal = log_hist<std::chrono::microseconds, 26, 8>;
+using log_hist_internal = log_hist<std::chrono::microseconds, 26, 8ul>;

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -55,3 +55,11 @@ rp_test(
   LIBRARIES Boost::unit_test_framework v::utils absl::flat_hash_map
   LABELS utils
 )
+
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME seastar_histogram
+  SOURCES seastar_histogram_bench.cc
+  LIBRARIES Seastar::seastar_perf_testing v::utils
+  LABELS utils
+)

--- a/src/v/utils/tests/seastar_histogram_bench.cc
+++ b/src/v/utils/tests/seastar_histogram_bench.cc
@@ -1,0 +1,39 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "utils/hdr_hist.h"
+#include "utils/log_hist.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/testing/perf_tests.hh>
+
+static constexpr int number_of_values_to_record = 100'000'000;
+
+PERF_TEST(hdr_hist, record) {
+    hdr_hist h;
+    perf_tests::start_measuring_time();
+#pragma nounroll
+    for (int i = 0; i < number_of_values_to_record; i++) {
+        [[clang::noinline]] h.record(i);
+    }
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(h.seastar_histogram_logform());
+}
+
+PERF_TEST(log_hist, record) {
+    log_hist_internal h;
+    perf_tests::start_measuring_time();
+#pragma nounroll
+    for (int i = 0; i < number_of_values_to_record; i++) {
+        [[clang::noinline]] h.record(i);
+    }
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(h.internal_histogram_logform());
+}

--- a/src/v/utils/tests/seastar_histogram_test.cc
+++ b/src/v/utils/tests/seastar_histogram_test.cc
@@ -1,3 +1,4 @@
+#include "ssx/metrics.h"
 #include "utils/hdr_hist.h"
 #include "utils/log_hist.h"
 
@@ -34,42 +35,21 @@ bool approximately_equal(double a, double b) {
     return std::abs(a - b) <= precision_error;
 }
 
-struct hist_config {
-    int64_t scale;
-    bool use_approximately_equal;
-};
-
-constexpr std::array hist_configs = {
-  hist_config{log_hist_public_scale, true}, hist_config{1, false}};
-
 template<typename l_hist>
-void validate_histograms_equal(const hdr_hist& a, const l_hist& b) {
-    for (auto cfg : hist_configs) {
-        const auto logform_a = a.seastar_histogram_logform(
-          18, 250, 2.0, cfg.scale);
-        const auto logform_b = b.seastar_histogram_logform(cfg.scale);
+void validate_public_histograms_equal(const hdr_hist& a, const l_hist& b) {
+    const auto logform_a = ssx::metrics::report_default_histogram(a);
+    const auto logform_b = b.public_histogram_logform();
 
-        BOOST_CHECK_EQUAL(logform_a.sample_count, logform_b.sample_count);
-        if (cfg.use_approximately_equal) {
-            BOOST_CHECK(
-              approximately_equal(logform_a.sample_sum, logform_b.sample_sum));
-        } else {
-            BOOST_CHECK_EQUAL(logform_a.sample_sum, logform_b.sample_sum);
-        }
+    BOOST_CHECK_EQUAL(logform_a.sample_count, logform_b.sample_count);
+    BOOST_CHECK(
+      approximately_equal(logform_a.sample_sum, logform_b.sample_sum));
 
-        for (size_t idx = 0; idx < logform_a.buckets.size(); ++idx) {
-            if (cfg.use_approximately_equal) {
-                BOOST_CHECK(approximately_equal(
-                  logform_a.buckets[idx].upper_bound,
-                  logform_b.buckets[idx].upper_bound));
-            } else {
-                BOOST_CHECK_EQUAL(
-                  logform_a.buckets[idx].upper_bound,
-                  logform_b.buckets[idx].upper_bound);
-            }
-            BOOST_CHECK_EQUAL(
-              logform_a.buckets[idx].count, logform_b.buckets[idx].count);
-        }
+    for (size_t idx = 0; idx < logform_a.buckets.size(); ++idx) {
+        BOOST_CHECK(approximately_equal(
+          logform_a.buckets[idx].upper_bound,
+          logform_b.buckets[idx].upper_bound));
+        BOOST_CHECK_EQUAL(
+          logform_a.buckets[idx].count, logform_b.buckets[idx].count);
     }
 }
 } // namespace
@@ -77,8 +57,6 @@ void validate_histograms_equal(const hdr_hist& a, const l_hist& b) {
 // ensures both the log_hist_public and the public hdr_hist return identical
 // seastar histograms for values recorded around bucket bounds.
 SEASTAR_THREAD_TEST_CASE(test_public_log_hist_and_hdr_hist_equal_bounds) {
-    using namespace std::chrono_literals;
-
     hdr_hist a;
     log_hist_public b;
 
@@ -94,14 +72,12 @@ SEASTAR_THREAD_TEST_CASE(test_public_log_hist_and_hdr_hist_equal_bounds) {
         b.record(upper_bound + 1);
     }
 
-    validate_histograms_equal(a, b);
+    validate_public_histograms_equal(a, b);
 }
 
 // ensures both the log_hist_public and the public hdr_hist return identical
 // seastar histograms for randomly selected values.
 SEASTAR_THREAD_TEST_CASE(test_public_log_hist_and_hdr_hist_equal_rand) {
-    using namespace std::chrono_literals;
-
     hdr_hist a;
     log_hist_public b;
 
@@ -115,5 +91,58 @@ SEASTAR_THREAD_TEST_CASE(test_public_log_hist_and_hdr_hist_equal_rand) {
         b.record(sample);
     }
 
-    validate_histograms_equal(a, b);
+    validate_public_histograms_equal(a, b);
+}
+
+// Ensures that an internal histogram is properly converted to a public metrics
+// histogram.
+SEASTAR_THREAD_TEST_CASE(test_internal_hist_to_public_hist_bounds) {
+    hdr_hist a;
+    log_hist_internal b;
+
+    a.record(1);
+    b.record(1);
+
+    for (unsigned i = 0; i < 17; i++) {
+        auto upper_bound
+          = (((unsigned)1 << (log_hist_internal::first_bucket_exp + i)) - 1);
+        a.record(upper_bound);
+        a.record(upper_bound + 1);
+        b.record(upper_bound);
+        b.record(upper_bound + 1);
+    }
+
+    validate_public_histograms_equal(a, b);
+}
+
+// Ensures that generating a internal seastar histogram from log_hist_public
+// results in the additional buckets for the extended lower bounds having counts
+// of zero.
+SEASTAR_THREAD_TEST_CASE(test_public_hist_to_internal_hist) {
+    log_hist_public a;
+    log_hist_internal b;
+
+    a.record(1);
+    b.record(1);
+
+    for (unsigned i = 0; i < 17; i++) {
+        auto upper_bound
+          = (((unsigned)1 << (log_hist_internal::first_bucket_exp + i)) - 1);
+        a.record(upper_bound);
+        a.record(upper_bound + 1);
+        b.record(upper_bound);
+        b.record(upper_bound + 1);
+    }
+
+    auto pub_to_int_hist = a.internal_histogram_logform();
+    auto int_to_int_hist = b.internal_histogram_logform();
+
+    const auto public_ub_exp = 8;
+    const auto internal_ub_exp = 3;
+
+    // The buckets in the extended lower bounds should be empty
+    for (int i = 0; i < public_ub_exp - internal_ub_exp; i++) {
+        BOOST_CHECK_EQUAL(pub_to_int_hist.buckets[i].count, 0);
+        BOOST_CHECK_NE(int_to_int_hist.buckets[i].count, 0);
+    }
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR replaces all but one use-case of `hdr_hist` with `log_hist`. `src/v/cluster/self_test` can't be converted to `log_hist` yet as `log_hist` doesn't support generating quantiles.

This replacement reduces per-histogram memory usage from potentially hundreds kilobytes to 208 bytes. It also reduces the time to record a value to the histogram by about half.

Public metric histograms generated with;
```cpp
ssx::metrics::report_default_histogram(hdr_hist);
```
are now replaced with;
```cpp
log_hist.public_histogram_logform();
```
which both produce the same Prometheus histogram given that the same values were recorded to each. Hence it is a drop in replacement with no noticeable effects in the metrics.

The replacement for internal histograms, however, does not produce identical Prometheus histograms as what it replaces. In this case this;
```cpp
hdr_hist.seastar_histogram_logform();
```
is now replaced with;
```cpp
log_hist.internal_histogram_logform();
```
There are a couple differences between the two Prometheus histograms. The first is that the upper bound for the first bucket will be 8 instead of 10 now. The second is that buckets will now have upper bounds of `2^n -1` , hence comparing `[replacement, current]` the buckets are now `[8, 10], [16, 20], [32, 41], [64, 83], [128, 167], [256, 335]...`.

This shouldn't be a huge problem as Prometheus supports in-frequent bucket bound changes. And since a upgrade necessitates a restart histogram values will be unstable anyway.  

Beyond this the PR also refactors `log_hist` to add a couple of things;
- Outputting a seastar metrics public histogram from `log_hist_internal` this allows us to share a single internal histogram for both public and internal metrics
- Pausing auto latency measures. This allows us to avoid including purposefully added latencies (like the debounce in the fetch handler) in the overall latency.
- A benchmark comparing `hdr_hist::record` to `log_hist:record`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
