### PR TITLE
[ducktape] Add debug message when failing to decode partition manifests

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2879,7 +2879,7 @@ class RedpandaService(RedpandaServiceBase):
                             self.logger).decode_partition_manifest(
                                 body, self.logger)
                     except Exception as e:
-                        self.logger.warn(f"Failed to decode {m}")
+                        self.logger.warn(f"Failed to decode {m}: {e}")
                     else:
                         json_filename = f"{filename}_decoded.json"
                         json_bytes = json.dumps(decoded, indent=2)


### PR DESCRIPTION
This was seen in a couple of tests and gives some insight into why the
command fails

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
