### PR TITLE
[v23.2.x] k8s: Increase memory instead of decrease in e2e update test

### DIFF
--- a/src/go/k8s/tests/e2e/update/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/02-assert.yaml
@@ -8,7 +8,9 @@ spec:
       containers:
         - resources:
             requests:
-              memory: 990M
+              memory: 2Gi
+            limits:
+              memory: 2Gi
 ---
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster

--- a/src/go/k8s/tests/e2e/update/02-update-resources.yaml
+++ b/src/go/k8s/tests/e2e/update/02-update-resources.yaml
@@ -5,4 +5,6 @@ metadata:
 spec:
   resources:
     requests:
-      memory: 990M
+      memory: 2Gi
+    limits:
+      memory: 2Gi


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12458
