### PR TITLE
cloud_storage: Remove stuck reader exception

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -339,66 +339,25 @@ public:
                   "{}",
                   _reader->config());
 
-                try {
-                    auto result = co_await _reader->read_some(
-                      deadline, *_ot_state);
-                    if (!result) {
-                        vlog(
-                          _ctxlog.debug,
-                          "Error while reading from stream '{}'",
-                          result.error());
-                        co_await set_end_of_stream();
-                        throw std::system_error(result.error());
-                    }
-                    data_t d = std::move(result.value());
-                    for (const auto& batch : d) {
-                        _partition->_probe.add_bytes_read(
-                          batch.header().size_bytes);
-                        _partition->_probe.add_records_read(
-                          batch.record_count());
-                    }
-                    if (
-                      _first_produced_offset == model::offset{} && !d.empty()) {
-                        _first_produced_offset = d.front().base_offset();
-                    }
-                    co_return storage_t{std::move(d)};
-                } catch (const stuck_reader_exception& ex) {
+                auto result = co_await _reader->read_some(deadline, *_ot_state);
+                if (!result) {
                     vlog(
-                      _ctxlog.warn,
-                      "stuck reader: current rp offset: {}, max rp offset: {}",
-                      ex.rp_offset,
-                      _reader->max_rp_offset());
-
-                    // If the reader is stuck because of a mismatch between
-                    // segment data and manifest entry, set reader to EOF and
-                    // try to reset reader on the next loop iteration. We only
-                    // do this when the reader has not reached eof. For example,
-                    // the segment ends at offset 10 but the manifest has max
-                    // offset at 11 for the segment, with offset 11 actually
-                    // present in the next segment. When the reader is stuck,
-                    // the current offset will be 10 which we will not be able
-                    // to read from. Switching to the next segment should enable
-                    // reads to proceed.
-                    if (
-                      model::next_offset(ex.rp_offset)
-                        >= _next_segment_base_offset
-                      && !_reader->is_eof()) {
-                        vlog(
-                          _ctxlog.info,
-                          "mismatch between current segment end and manifest "
-                          "data: current rp offset {}, manifest max rp offset "
-                          "{}, next segment base offset {}, reader is EOF: {}. "
-                          "set EOF on reader and try to "
-                          "reset",
-                          ex.rp_offset,
-                          _reader->max_rp_offset(),
-                          _next_segment_base_offset,
-                          _reader->is_eof());
-                        _reader->set_eof();
-                        continue;
-                    }
-                    throw;
+                      _ctxlog.debug,
+                      "Error while reading from stream '{}'",
+                      result.error());
+                    co_await set_end_of_stream();
+                    throw std::system_error(result.error());
                 }
+                data_t d = std::move(result.value());
+                for (const auto& batch : d) {
+                    _partition->_probe.add_bytes_read(
+                      batch.header().size_bytes);
+                    _partition->_probe.add_records_read(batch.record_count());
+                }
+                if (_first_produced_offset == model::offset{} && !d.empty()) {
+                    _first_produced_offset = d.front().base_offset();
+                }
+                co_return storage_t{std::move(d)};
             }
         } catch (const ss::gate_closed_exception&) {
             vlog(
@@ -467,8 +426,10 @@ private:
             co_return;
         }
         _view_cursor = std::move(cur.value());
-        co_await _view_cursor->maybe_sync_manifest();
-        initialize_reader_state(_view_cursor->manifest().value(), config);
+        co_await _view_cursor->with_manifest(
+          [this, &config](const partition_manifest& m) {
+              initialize_reader_state(m, config);
+          });
         co_return;
     }
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -36,19 +36,6 @@
 
 namespace cloud_storage {
 
-class stuck_reader_exception final : public std::runtime_error {
-public:
-    stuck_reader_exception(
-      model::offset cur_rp_offset,
-      size_t cur_bytes_consumed,
-      ss::sstring context)
-      : std::runtime_error{context}
-      , rp_offset(cur_rp_offset)
-      , bytes_consumed(cur_bytes_consumed) {}
-    const model::offset rp_offset;
-    const size_t bytes_consumed;
-};
-
 std::filesystem::path
 generate_index_path(const cloud_storage::remote_segment_path& p);
 

--- a/src/v/ssx/task_local_ptr.h
+++ b/src/v/ssx/task_local_ptr.h
@@ -18,6 +18,7 @@
 #include <seastar/core/thread.hh>
 
 #include <stdexcept>
+#include <utility>
 
 namespace ssx {
 
@@ -50,7 +51,12 @@ public:
       , _task(get_current_task()) {}
 
     explicit task_local(T&& val)
-      : _val(val)
+      : _val(std::move(val))
+      , _task(get_current_task()) {}
+
+    template<class... Args>
+    explicit task_local(std::in_place_t, Args&&... args)
+      : _val(std::in_place, std::forward<Args>(args)...)
       , _task(get_current_task()) {}
 
     task_local() = delete;
@@ -111,7 +117,7 @@ private:
 
 template<class T, class... Args>
 auto make_task_local(Args&&... args) {
-    return task_local<T>(T((std::forward<Args>(args))...));
+    return task_local<T>(std::in_place, (std::forward<Args>(args))...);
 }
 
 /// Non-owning smart pointer.


### PR DESCRIPTION
Remove unused exception and the code that handles it. This PR also includes some followup changes from previous PR:
* in the `remote_partition` use `with_manifest` to call `initialize_reader_state` to avoid potential race condition.
* in the `task_local` add new c-tor that accepts `std::in_place_t` + list of parameters to construct underlying value.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none