### PR TITLE
Optimize send path error handling

### DIFF
--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -268,12 +268,14 @@ inline constexpr detail::background_t background;
 /// \brief Create a new future, handling common shutdown exception types.
 inline seastar::future<>
 ignore_shutdown_exceptions(seastar::future<> fut) noexcept {
-    return std::move(fut)
-      .handle_exception_type([](const seastar::abort_requested_exception&) {})
-      .handle_exception_type([](const seastar::gate_closed_exception&) {})
-      .handle_exception_type([](const seastar::broken_semaphore&) {})
-      .handle_exception_type([](const seastar::broken_promise&) {})
-      .handle_exception_type([](const seastar::broken_condition_variable&) {});
+    try {
+        co_await std::move(fut);
+    } catch (const seastar::abort_requested_exception&) {
+    } catch (const seastar::gate_closed_exception&) {
+    } catch (const seastar::broken_semaphore&) {
+    } catch (const seastar::broken_promise&) {
+    } catch (const seastar::broken_condition_variable&) {
+    }
 }
 
 /// \brief Check if the exception is a commonly ignored shutdown exception.


### PR DESCRIPTION
Travis mentioned in slack that `ssx::handle_shutdown_errors` was showing up in profiles.

This attempts to address that problem by creating less continuations when dispatching sends in the rpc transport layer. Additionally, switch `ssx::handle_shutdown_errors` to be a corountine.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

* none
