### PR TITLE
Add thrashing of old txn sessions to prevent OOM

### DIFF
--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -1074,6 +1074,12 @@ ss::future<tm_stm::get_txs_result> tm_stm::get_all_transactions() {
     co_return _cache->get_all_transactions();
 }
 
+size_t tm_stm::tx_cache_size() const { return _cache->tx_cache_size(); }
+
+std::optional<tm_transaction> tm_stm::oldest_tx() const {
+    return _cache->oldest_tx();
+}
+
 ss::future<checked<tm_transaction, tm_stm::op_status>>
 tm_stm::delete_partition_from_tx(
   model::term_id term,

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -9,7 +9,6 @@
 
 #include "cluster/tm_stm.h"
 
-#include "cluster/logger.h"
 #include "cluster/tm_tx_hash_ranges.h"
 #include "cluster/types.h"
 #include "model/record.h"
@@ -1021,6 +1020,37 @@ ss::future<> tm_stm::apply(model::record_batch b) {
 bool tm_stm::is_expired(const tm_transaction& tx) {
     auto now_ts = clock_type::now();
     return _transactional_id_expiration < now_ts - tx.last_update_ts;
+}
+
+ss::lw_shared_ptr<mutex> tm_stm::get_tx_lock(kafka::transactional_id tid) {
+    auto [lock_it, inserted] = _tx_locks.try_emplace(tid, nullptr);
+    if (inserted) {
+        lock_it->second = ss::make_lw_shared<mutex>();
+    }
+    return lock_it->second;
+}
+
+ss::future<txlock_unit>
+tm_stm::lock_tx(kafka::transactional_id tx_id, std::string_view lock_name) {
+    auto [lock_it, inserted] = _tx_locks.try_emplace(tx_id, nullptr);
+    if (inserted) {
+        lock_it->second = ss::make_lw_shared<mutex>();
+    }
+    auto units = co_await lock_it->second->get_units();
+    co_return txlock_unit(this, std::move(units), tx_id, lock_name);
+}
+
+std::optional<txlock_unit>
+tm_stm::try_lock_tx(kafka::transactional_id tx_id, std::string_view lock_name) {
+    auto [lock_it, inserted] = _tx_locks.try_emplace(tx_id, nullptr);
+    if (inserted) {
+        lock_it->second = ss::make_lw_shared<mutex>();
+    }
+    auto units = lock_it->second->try_get_units();
+    if (units) {
+        return txlock_unit(this, std::move(units.value()), tx_id, lock_name);
+    }
+    return std::nullopt;
 }
 
 absl::btree_set<kafka::transactional_id> tm_stm::get_expired_txs() {

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -266,6 +266,12 @@ public:
         return _raft->ntp().tp.partition;
     }
 
+    mutex& get_tx_thrashing_lock() { return _tx_thrashing_lock; }
+
+    size_t tx_cache_size() const;
+
+    std::optional<tm_transaction> oldest_tx() const;
+
 protected:
     ss::future<> handle_raft_snapshot() override;
 
@@ -283,6 +289,7 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     ss::lw_shared_ptr<cluster::tm_stm_cache> _cache;
     tm_tx_hosted_transactions _hosted_txes;
+    mutex _tx_thrashing_lock;
 
     ss::future<> apply(model::record_batch b) override;
     ss::future<> apply_hosted_transactions(model::record_batch b);

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/logger.h"
 #include "cluster/persisted_stm.h"
 #include "cluster/tm_stm_cache.h"
 #include "cluster/tm_tx_hash_ranges.h"
@@ -41,6 +42,70 @@ namespace cluster {
 
 using use_tx_version_with_last_pid_bool
   = ss::bool_class<struct use_tx_version_with_last_pid_tag>;
+
+class tm_stm;
+
+class txlock_unit {
+    tm_stm* _stm;
+    kafka::transactional_id _id;
+    std::string_view _name;
+    bool _is_locked;
+    ssx::semaphore_units _units;
+
+    txlock_unit(
+      tm_stm* stm,
+      ssx::semaphore_units&& units,
+      kafka::transactional_id id,
+      std::string_view name) noexcept
+      : _stm(stm)
+      , _id(id)
+      , _name(name) {
+        _is_locked = (bool)units;
+        _units = std::move(units);
+        vassert(_is_locked, "units must be initialized");
+        vlog(txlog.trace, "got_lock name:{}, tx_id:{}", _name, _id);
+    }
+
+    friend class tm_stm;
+
+public:
+    txlock_unit(txlock_unit&& token) noexcept
+      : _stm(token._stm)
+      , _id(token._id)
+      , _name(token._name)
+      , _is_locked(token._is_locked)
+      , _units(std::move(token._units)) {
+        token._stm = nullptr;
+        token._is_locked = false;
+    }
+    txlock_unit(const txlock_unit&) = delete;
+    txlock_unit(const txlock_unit&&) = delete;
+    txlock_unit() = delete;
+
+    bool return_all() {
+        if (_is_locked) {
+            _units.return_all();
+            _is_locked = false;
+            vlog(txlog.trace, "released_lock name:{}, tx_id:{}", _name, _id);
+            return true;
+        }
+        return false;
+    }
+
+    txlock_unit& operator=(txlock_unit&& other) noexcept {
+        if (this != &other) {
+            _stm = other._stm;
+            _units = std::move(other._units);
+            _id = other._id;
+            _name = other._name;
+            other._stm = nullptr;
+            other._is_locked = false;
+        }
+        return *this;
+    }
+
+    ~txlock_unit() noexcept;
+};
 
 /**
  * TM stands for transaction manager (2PC slang for a transaction
@@ -83,7 +148,7 @@ public:
       ss::sharded<features::feature_table>&,
       ss::lw_shared_ptr<cluster::tm_stm_cache>);
 
-    void try_rm_lock(kafka::transactional_id tid) {
+    void try_rm_lock(const kafka::transactional_id& tid) {
         auto tx_opt = _cache->find_mem(tid);
         if (tx_opt) {
             return;
@@ -175,13 +240,12 @@ public:
 
     // before calling a tm_stm modifying operation a caller should
     // take get_tx_lock mutex
-    ss::lw_shared_ptr<mutex> get_tx_lock(kafka::transactional_id tid) {
-        auto [lock_it, inserted] = _tx_locks.try_emplace(tid, nullptr);
-        if (inserted) {
-            lock_it->second = ss::make_lw_shared<mutex>();
-        }
-        return lock_it->second;
-    }
+    ss::lw_shared_ptr<mutex> get_tx_lock(kafka::transactional_id);
+
+    ss::future<txlock_unit> lock_tx(kafka::transactional_id, std::string_view);
+
+    std::optional<txlock_unit>
+      try_lock_tx(kafka::transactional_id, std::string_view);
 
     absl::btree_set<kafka::transactional_id> get_expired_txs();
 
@@ -263,5 +327,13 @@ private:
     model::record_batch
     serialize_hosted_transactions(tm_tx_hosted_transactions hr);
 };
+
+inline txlock_unit::~txlock_unit() noexcept {
+    return_all();
+    if (_stm) {
+        _stm->try_rm_lock(_id);
+        _stm = nullptr;
+    }
+}
 
 } // namespace cluster

--- a/src/v/cluster/tm_stm_cache.cc
+++ b/src/v/cluster/tm_stm_cache.cc
@@ -274,4 +274,14 @@ std::deque<tm_transaction> tm_stm_cache::checkpoint() {
     return txes_to_checkpoint;
 }
 
+std::optional<tm_transaction> tm_stm_cache::oldest_tx() const {
+    if (lru_txes.empty()) {
+        return std::nullopt;
+    }
+
+    return lru_txes.front().tx;
+}
+
+size_t tm_stm_cache::tx_cache_size() const { return lru_txes.size(); }
+
 } // namespace cluster

--- a/src/v/cluster/tm_stm_cache.cc
+++ b/src/v/cluster/tm_stm_cache.cc
@@ -68,8 +68,8 @@ tm_stm_cache::find(model::term_id term, kafka::transactional_id tx_id) {
         return tx_it->second;
     }
 
-    tx_it = _log_txes.find(tx_id);
-    if (tx_it == _log_txes.end()) {
+    auto log_it = _log_txes.find(tx_id);
+    if (log_it == _log_txes.end()) {
         vlog(
           txlog.trace,
           "looking for tx:{} etag:{}: can't find tx:{} in log",
@@ -79,20 +79,20 @@ tm_stm_cache::find(model::term_id term, kafka::transactional_id tx_id) {
         return std::nullopt;
     }
 
-    if (tx_it->second.etag != term) {
+    if (log_it->second.tx.etag != term) {
         vlog(
           txlog.trace,
           "looking for tx:{} etag:{}: found a tx with etag:{} pid:{} tx_seq:{} "
           "(wrong etag)",
           tx_id,
           term,
-          tx_it->second.etag,
-          tx_it->second.pid,
-          tx_it->second.tx_seq);
+          log_it->second.tx.etag,
+          log_it->second.tx.pid,
+          log_it->second.tx.tx_seq);
         return std::nullopt;
     }
 
-    return tx_it->second;
+    return log_it->second.tx;
 }
 
 std::optional<tm_transaction>
@@ -119,7 +119,7 @@ tm_stm_cache::find_log(kafka::transactional_id tx_id) {
     if (tx_it == _log_txes.end()) {
         return std::nullopt;
     }
-    return tx_it->second;
+    return tx_it->second.tx;
 }
 
 void tm_stm_cache::set_log(tm_transaction tx) {
@@ -130,7 +130,17 @@ void tm_stm_cache::set_log(tm_transaction tx) {
       tx.etag,
       tx.pid,
       tx.tx_seq);
-    _log_txes[tx.id] = tx;
+
+    auto [tx_it, inserted] = _log_txes.try_emplace(tx.id, tx);
+    if (!inserted) {
+        tx_it->second.tx = tx;
+    }
+
+    if (tx_it->second._hook.is_linked()) {
+        tx_it->second._hook.unlink();
+    }
+    lru_txes.push_back(tx_it->second);
+
     for (auto& [term, entry] : _state) {
         if (term < tx.etag) {
             entry.txes.erase(tx.id);
@@ -143,7 +153,7 @@ void tm_stm_cache::erase_log(kafka::transactional_id tx_id) {
     if (tx_it == _log_txes.end()) {
         return;
     }
-    auto tx = tx_it->second;
+    auto& tx = tx_it->second.tx;
     vlog(
       txlog.trace,
       "erasing tx:{} etag:{} pid:{} tx_seq:{} from log",
@@ -151,13 +161,13 @@ void tm_stm_cache::erase_log(kafka::transactional_id tx_id) {
       tx.etag,
       tx.pid,
       tx.tx_seq);
-    _log_txes.erase(tx_id);
+    _log_txes.erase(tx_it);
 }
 
 fragmented_vector<tm_transaction> tm_stm_cache::get_log_transactions() {
     fragmented_vector<tm_transaction> txes;
     for (auto& entry : _log_txes) {
-        txes.push_back(entry.second);
+        txes.push_back(entry.second.tx);
     }
     return txes;
 }
@@ -226,7 +236,7 @@ fragmented_vector<tm_transaction> tm_stm_cache::get_all_transactions() {
             for (const auto& [id, tx] : _log_txes) {
                 auto tx_it = entry_it->second.txes.find(id);
                 if (tx_it == entry_it->second.txes.end()) {
-                    ans.push_back(tx);
+                    ans.push_back(tx.tx);
                 }
             }
             return ans;

--- a/src/v/cluster/tm_stm_cache.h
+++ b/src/v/cluster/tm_stm_cache.h
@@ -239,6 +239,10 @@ public:
 
     std::deque<tm_transaction> checkpoint();
 
+    std::optional<tm_transaction> oldest_tx() const;
+
+    size_t tx_cache_size() const;
+
 private:
     struct tx_wrapper {
         tx_wrapper() = default;

--- a/src/v/cluster/tm_stm_cache.h
+++ b/src/v/cluster/tm_stm_cache.h
@@ -188,71 +188,22 @@ public:
         return _state_lock.hold_write_lock();
     }
 
-    void clear_mem() {
-        if (_mem_term) {
-            _sealed_term = _mem_term.value();
-        }
-        _mem_term = std::nullopt;
-    }
+    void clear_mem();
 
     void clear_log();
 
     std::optional<tm_transaction> find(model::term_id, kafka::transactional_id);
 
-    std::optional<tm_transaction> find_mem(kafka::transactional_id tx_id) {
-        if (_mem_term == std::nullopt) {
-            return std::nullopt;
-        }
-        auto term = _mem_term.value();
-        auto entry_it = _state.find(term);
-        if (entry_it == _state.end()) {
-            return std::nullopt;
-        }
-        auto& entry = entry_it->second;
-        auto tx_it = entry.txes.find(tx_id);
-        if (tx_it == entry.txes.end()) {
-            return std::nullopt;
-        }
-        return tx_it->second;
-    }
+    std::optional<tm_transaction> find_mem(kafka::transactional_id tx_id);
 
-    std::optional<tm_transaction> find_log(kafka::transactional_id tx_id) {
-        auto tx_it = _log_txes.find(tx_id);
-        if (tx_it == _log_txes.end()) {
-            return std::nullopt;
-        }
-        return tx_it->second;
-    }
+    std::optional<tm_transaction> find_log(kafka::transactional_id tx_id);
 
     void set_log(tm_transaction);
-
     void erase_log(kafka::transactional_id);
 
-    fragmented_vector<tm_transaction> get_log_transactions() {
-        fragmented_vector<tm_transaction> txes;
-        for (auto& entry : _log_txes) {
-            txes.push_back(entry.second);
-        }
-        return txes;
-    }
+    fragmented_vector<tm_transaction> get_log_transactions();
 
-    void set_mem(
-      model::term_id term, kafka::transactional_id tx_id, tm_transaction tx) {
-        auto entry_it = _state.find(term);
-        if (entry_it == _state.end()) {
-            _state[term] = tm_stm_cache_entry{.term = term};
-            entry_it = _state.find(term);
-        }
-        entry_it->second.txes[tx_id] = tx;
-
-        if (!_mem_term) {
-            if (!_sealed_term || _sealed_term.value() < term) {
-                _mem_term = term;
-            }
-        } else if (_mem_term.value() < term) {
-            _mem_term = term;
-        }
-    }
+    void set_mem(model::term_id, kafka::transactional_id, tm_transaction);
 
     void erase_mem(kafka::transactional_id);
 
@@ -280,54 +231,9 @@ public:
         return ids;
     }
 
-    fragmented_vector<tm_transaction> get_all_transactions() {
-        fragmented_vector<tm_transaction> ans;
-        if (_mem_term) {
-            auto entry_it = _state.find(_mem_term.value());
-            if (entry_it != _state.end()) {
-                for (const auto& [_, tx] : entry_it->second.txes) {
-                    ans.push_back(tx);
-                }
-                for (const auto& [id, tx] : _log_txes) {
-                    auto tx_it = entry_it->second.txes.find(id);
-                    if (tx_it == entry_it->second.txes.end()) {
-                        ans.push_back(tx);
-                    }
-                }
-                return ans;
-            }
-        }
-        return get_log_transactions();
-    }
+    fragmented_vector<tm_transaction> get_all_transactions();
 
-    std::deque<tm_transaction> checkpoint() {
-        std::deque<tm_transaction> txes_to_checkpoint;
-
-        if (_mem_term == std::nullopt) {
-            return txes_to_checkpoint;
-        }
-        auto term = _mem_term.value();
-
-        auto entry_it = _state.find(term);
-        if (entry_it == _state.end()) {
-            return txes_to_checkpoint;
-        }
-        auto& entry = entry_it->second;
-
-        auto can_transfer = [](const tm_transaction& tx) {
-            return !tx.transferring
-                   && (tx.status == tm_transaction::ready || tx.status == tm_transaction::ongoing);
-        };
-        // Loop through all ongoing/pending txns in memory and checkpoint.
-
-        for (auto& [_, tx] : entry.txes) {
-            if (can_transfer(tx)) {
-                txes_to_checkpoint.push_back(tx);
-            }
-        }
-
-        return txes_to_checkpoint;
-    }
+    std::deque<tm_transaction> checkpoint();
 
 private:
     ss::basic_rwlock<> _state_lock;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -183,7 +183,8 @@ tx_gateway_frontend::tx_gateway_frontend(
   rm_group_proxy* group_proxy,
   ss::sharded<cluster::rm_partition_frontend>& rm_partition_frontend,
   ss::sharded<features::feature_table>& feature_table,
-  ss::sharded<cluster::tm_stm_cache_manager>& tm_stm_cache_manager)
+  ss::sharded<cluster::tm_stm_cache_manager>& tm_stm_cache_manager,
+  config::binding<uint64_t> max_transactions_per_coordinator)
   : _ssg(ssg)
   , _partition_manager(partition_manager)
   , _shard_table(shard_table)
@@ -202,8 +203,8 @@ tx_gateway_frontend::tx_gateway_frontend(
       config::shard_local_cfg().metadata_dissemination_retry_delay_ms.value())
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.value())
-  , _transactions_enabled(
-      config::shard_local_cfg().enable_transactions.value()) {
+  , _transactions_enabled(config::shard_local_cfg().enable_transactions.value())
+  , _max_transactions_per_coordinator(max_transactions_per_coordinator) {
     /**
      * do not start expriry timer when transactions are disabled
      */

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1211,7 +1211,56 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::limit_init_tm_tx(
     }
     auto term = term_opt.value();
 
+    if (stm->tx_cache_size() > _max_transactions_per_coordinator()) {
+        // lock is sloppy and doesn't guarantee that tx_cache_size
+        // never exceeds _max_transactions_per_coordinator. init_tm_tx
+        // request may pass limit_init_tm_tx but not yet increase
+        // tx_cache_size so there is a small window of time when the
+        // next init tx request may pass too even if the first request
+        // eventually tip tx cache over max transactions per coordinator.
+        // it isn't the problem, the next request will correct it
+        auto init_units = co_await stm->get_tx_thrashing_lock().get_units();
+
+        // similar to double-checked locking pattern
+        // it protects concurrent access to oldest_tx
+        if (stm->tx_cache_size() > _max_transactions_per_coordinator()) {
+            auto tx_opt = stm->oldest_tx();
+            if (!tx_opt) {
+                vlog(
+                  txlog.warn,
+                  "oldest_tx shouldn't return empty when tx cache is at "
+                  "capacity");
+                co_return init_tm_tx_reply{tx_errc::not_coordinator};
+            }
+
+            auto tx = tx_opt.value();
+            vlog(
+              txlog.info,
+              "tx cache is at capacity; expiring oldest tx with id:{}",
+              tx.id);
+            auto tx_units = co_await stm->lock_tx(tx_id, "init_tm_tx");
+            auto ec = co_await do_expire_old_tx(
+              stm,
+              term,
+              tx.id,
+              config::shard_local_cfg().create_topic_timeout_ms(),
+              true);
+            if (ec != tx_errc::none) {
+                vlog(
+                  txlog.trace,
+                  "do_expire_old_tx with tx_id={} returned ec={}",
+                  tx.id,
+                  ec);
+                co_return init_tm_tx_reply{tx_errc::not_coordinator};
+            }
+            tx_units.return_all();
+        }
+
+        init_units.return_all();
+    }
+
     auto units = co_await stm->lock_tx(tx_id, "init_tm_tx");
+
     co_return co_await do_init_tm_tx(
       stm, term, tx_id, transaction_timeout_ms, timeout, expected_pid);
 }

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -3034,21 +3034,23 @@ ss::future<> tx_gateway_frontend::expire_old_tx(
       stm,
       term,
       tx_id,
-      config::shard_local_cfg().create_topic_timeout_ms());
+      config::shard_local_cfg().create_topic_timeout_ms(),
+      false);
 }
 
 ss::future<tx_errc> tx_gateway_frontend::do_expire_old_tx(
   ss::shared_ptr<tm_stm> stm,
   model::term_id term,
   kafka::transactional_id tx_id,
-  model::timeout_clock::duration timeout) {
+  model::timeout_clock::duration timeout,
+  bool ignore_update_ts) {
     auto r0 = co_await get_tx(term, stm, tx_id, timeout);
     if (!r0.has_value()) {
         // either timeout or already expired
         co_return tx_errc::tx_not_found;
     }
     auto tx = r0.value();
-    if (!stm->is_expired(tx)) {
+    if (!ignore_update_ts && !stm->is_expired(tx)) {
         co_return tx_errc::none;
     }
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -50,16 +50,11 @@ static auto with(
   kafka::transactional_id tx_id,
   const std::string_view name,
   Func&& func) noexcept {
-    return stm->get_tx_lock(tx_id)
-      ->with([name, tx_id, func = std::forward<Func>(func)]() mutable {
-          vlog(txlog.trace, "got_lock name:{}, tx_id:{}", name, tx_id);
+    return stm->lock_tx(tx_id, name)
+      .then([stm, tx_id, func = std::forward<Func>(func)](auto units) mutable {
           return ss::futurize_invoke(std::forward<Func>(func))
-            .finally([name, tx_id]() {
-                vlog(
-                  txlog.trace, "released_lock name:{}, tx_id:{}", name, tx_id);
-            });
-      })
-      .finally([tx_id, stm]() { stm->try_rm_lock(tx_id); });
+            .finally([units = std::move(units)] {});
+      });
 }
 
 template<typename Func>
@@ -68,26 +63,17 @@ static auto with_free(
   kafka::transactional_id tx_id,
   const std::string_view name,
   Func&& func) noexcept {
+    auto units = stm->try_lock_tx(tx_id, name);
     auto f = ss::now();
-    auto lock = stm->get_tx_lock(tx_id);
-    if (!lock->ready()) {
+
+    if (!units) {
         f = ss::make_exception_future(ss::semaphore_timed_out());
     }
+
     return f.then(
-      [lock, stm, name, tx_id, func = std::forward<Func>(func)]() mutable {
-          return lock
-            ->with([name, tx_id, func = std::forward<Func>(func)]() mutable {
-                vlog(txlog.trace, "got_lock name:{}, tx_id:{}", name, tx_id);
-                return ss::futurize_invoke(std::forward<Func>(func))
-                  .finally([name, tx_id]() {
-                      vlog(
-                        txlog.trace,
-                        "released_lock name:{}, tx_id:{}",
-                        name,
-                        tx_id);
-                  });
-            })
-            .finally([tx_id, stm]() { stm->try_rm_lock(tx_id); });
+      [units = std::move(units), func = std::forward<Func>(func)]() mutable {
+          return ss::futurize_invoke(std::forward<Func>(func))
+            .finally([units = std::move(units)] {});
       });
 }
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -3010,29 +3010,46 @@ ss::future<> tx_gateway_frontend::expire_old_txs(ss::shared_ptr<tm_stm> stm) {
 
 ss::future<> tx_gateway_frontend::expire_old_tx(
   ss::shared_ptr<tm_stm> stm, kafka::transactional_id tx_id) {
-    return with(stm, tx_id, "expire_old_tx", [this, stm, tx_id]() {
-        return do_expire_old_tx(
-          stm, tx_id, config::shard_local_cfg().create_topic_timeout_ms());
-    });
-}
+    auto units = co_await stm->lock_tx(tx_id, "expire_old_tx");
 
-ss::future<> tx_gateway_frontend::do_expire_old_tx(
-  ss::shared_ptr<tm_stm> stm,
-  kafka::transactional_id tx_id,
-  model::timeout_clock::duration timeout) {
     auto term_opt = co_await stm->sync();
     if (!term_opt.has_value()) {
+        if (term_opt.error() == tm_stm::op_status::not_leader) {
+            vlog(
+              txlog.trace,
+              "this node isn't a leader for tx.id={} coordinator",
+              tx_id);
+        }
+        vlog(
+          txlog.warn,
+          "got error {} on syncing state machine (loading tx.id={})",
+          term_opt.error(),
+          tx_id);
         co_return;
     }
+
     auto term = term_opt.value();
+
+    co_await do_expire_old_tx(
+      stm,
+      term,
+      tx_id,
+      config::shard_local_cfg().create_topic_timeout_ms());
+}
+
+ss::future<tx_errc> tx_gateway_frontend::do_expire_old_tx(
+  ss::shared_ptr<tm_stm> stm,
+  model::term_id term,
+  kafka::transactional_id tx_id,
+  model::timeout_clock::duration timeout) {
     auto r0 = co_await get_tx(term, stm, tx_id, timeout);
     if (!r0.has_value()) {
         // either timeout or already expired
-        co_return;
+        co_return tx_errc::tx_not_found;
     }
     auto tx = r0.value();
     if (!stm->is_expired(tx)) {
-        co_return;
+        co_return tx_errc::none;
     }
 
     checked<tm_transaction, tx_errc> r(tx);
@@ -3051,12 +3068,20 @@ ss::future<> tx_gateway_frontend::do_expire_old_tx(
         r = co_await do_abort_tm_tx(term, stm, tx, timeout);
     }
     if (!r.has_value()) {
-        co_return;
+        vlog(txlog.warn, "got error {} on aborting tx.id={}", r.error(), tx_id);
+
+        co_return r.error();
     }
 
     // it's ok not to check ec because if the expiration isn't passed
     // it will be retried and it's an idempotent operation
-    co_await stm->expire_tx(term, tx_id).discard_result();
+    auto ec = co_await stm->expire_tx(term, tx_id);
+    if (ec != tm_stm::op_status::success) {
+        vlog(txlog.warn, "got error {} on expiring tx.id={}", ec, tx.id);
+        co_return tx_errc::not_coordinator;
+    }
+
+    co_return tx_errc::none;
 }
 
 ss::future<tx_gateway_frontend::return_all_txs_res>

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -204,8 +204,15 @@ private:
       model::timeout_clock::duration,
       model::producer_identity,
       model::partition_id);
+    ss::future<cluster::init_tm_tx_reply> limit_init_tm_tx(
+      ss::shared_ptr<tm_stm>,
+      kafka::transactional_id,
+      std::chrono::milliseconds,
+      model::timeout_clock::duration,
+      model::producer_identity);
     ss::future<cluster::init_tm_tx_reply> do_init_tm_tx(
       ss::shared_ptr<tm_stm>,
+      model::term_id,
       kafka::transactional_id,
       std::chrono::milliseconds,
       model::timeout_clock::duration,

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -40,7 +40,8 @@ public:
       rm_group_proxy*,
       ss::sharded<cluster::rm_partition_frontend>&,
       ss::sharded<features::feature_table>&,
-      ss::sharded<cluster::tm_stm_cache_manager>&);
+      ss::sharded<cluster::tm_stm_cache_manager>&,
+      config::binding<uint64_t> max_transactions_per_coordinator);
 
     ss::future<std::optional<model::ntp>> get_ntp(kafka::transactional_id);
     ss::future<bool> hosts(model::partition_id, kafka::transactional_id);
@@ -101,6 +102,7 @@ private:
     ss::timer<model::timeout_clock> _expire_timer;
     std::chrono::milliseconds _transactional_id_expiration;
     bool _transactions_enabled;
+    config::binding<uint64_t> _max_transactions_per_coordinator;
 
     // Transaction GA includes: KIP_447, KIP-360, fix for compaction tx_group*
     // records, perf fix#1(Do not writing preparing state on disk in tm_stn),

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -269,8 +269,9 @@ private:
     ss::future<> expire_old_txs(model::ntp);
     ss::future<> expire_old_txs(ss::shared_ptr<tm_stm>);
     ss::future<> expire_old_tx(ss::shared_ptr<tm_stm>, kafka::transactional_id);
-    ss::future<> do_expire_old_tx(
+    ss::future<tx_errc> do_expire_old_tx(
       ss::shared_ptr<tm_stm>,
+      model::term_id term,
       kafka::transactional_id,
       model::timeout_clock::duration);
 

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -273,7 +273,8 @@ private:
       ss::shared_ptr<tm_stm>,
       model::term_id term,
       kafka::transactional_id,
-      model::timeout_clock::duration);
+      model::timeout_clock::duration,
+      bool ignore_update_ts);
 
     friend tx_gateway;
 };

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -597,6 +597,17 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::numeric_limits<uint64_t>::max(),
       {.min = 1})
+  , max_transactions_per_coordinator(
+      *this,
+      "max_transactions_per_coordinator",
+      "Max number of the active txn sessions (producers). When the threshold "
+      "is passed Redpanda terminates old sessions. When an idle producer "
+      "corresponding to the terminated session wakes up and produces - it "
+      "leads to its batches being rejected with invalid producer epoch or "
+      "invalid_producer_id_mapping (it depends on the txn execution phase).",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::numeric_limits<uint64_t>::max(),
+      {.min = 1})
   , enable_idempotence(
       *this,
       "enable_idempotence",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -590,8 +590,10 @@ configuration::configuration()
   , max_concurrent_producer_ids(
       *this,
       "max_concurrent_producer_ids",
-      "Max cache size for pids which rm_stm stores inside internal state. In "
-      "overflow rm_stm will delete old pids and clear their status",
+      "Max number of the active sessions (producers). When the threshold "
+      "is passed Redpanda terminates old sessions. When an idle producer "
+      "corresponding to the terminated session wakes up and produces - it "
+      "leads to its batches being rejected with out of order sequence error.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::numeric_limits<uint64_t>::max(),
       {.min = 1})

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -139,6 +139,7 @@ struct configuration final : public config_store {
     // same as transactional.id.expiration.ms in kafka
     property<std::chrono::milliseconds> transactional_id_expiration_ms;
     bounded_property<uint64_t> max_concurrent_producer_ids;
+    bounded_property<uint64_t> max_transactions_per_coordinator;
     property<bool> enable_idempotence;
     property<bool> enable_transactions;
     property<uint32_t> abort_index_segment_size;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1531,7 +1531,11 @@ void application::wire_up_redpanda_services(
       _rm_group_proxy.get(),
       std::ref(rm_partition_frontend),
       std::ref(feature_table),
-      std::ref(tm_stm_cache_manager))
+      std::ref(tm_stm_cache_manager),
+      ss::sharded_parameter([] {
+          return config::shard_local_cfg()
+            .max_transactions_per_coordinator.bind();
+      }))
       .get();
     _kafka_conn_quotas
       .start([]() {

--- a/src/v/utils/rwlock.h
+++ b/src/v/utils/rwlock.h
@@ -38,6 +38,7 @@ public:
 
     rwlock_unit& operator=(rwlock_unit&& other) noexcept {
         if (this != &other) {
+            this->_lock = other._lock;
             other._lock = nullptr;
         }
         return *this;

--- a/src/v/utils/rwlock.h
+++ b/src/v/utils/rwlock.h
@@ -23,10 +23,13 @@ class rwlock_unit {
     rwlock* _lock;
     bool _is_write_lock{false};
 
-public:
     rwlock_unit(rwlock* lock, bool is_write_lock) noexcept
       : _lock(lock)
       , _is_write_lock(is_write_lock) {}
+
+    friend class rwlock;
+
+public:
     rwlock_unit(rwlock_unit&& token) noexcept
       : _lock(token._lock)
       , _is_write_lock(token._is_write_lock) {
@@ -35,6 +38,8 @@ public:
     rwlock_unit(const rwlock_unit&) = delete;
     rwlock_unit(const rwlock_unit&&) = delete;
     rwlock_unit() = delete;
+
+    explicit operator bool() const noexcept { return _lock != nullptr; }
 
     rwlock_unit& operator=(rwlock_unit&& other) noexcept {
         if (this != &other) {

--- a/src/v/utils/tests/rwlock_test.cc
+++ b/src/v/utils/tests/rwlock_test.cc
@@ -51,3 +51,15 @@ SEASTAR_THREAD_TEST_CASE(test_rwlock_unit_move) {
     auto unit2 = rwlock.attempt_write_lock();
     BOOST_REQUIRE(unit2);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_rwlock_assign) {
+    ssx::rwlock rwlock;
+    auto unit1 = rwlock.attempt_write_lock();
+    BOOST_REQUIRE(unit1);
+    BOOST_REQUIRE(unit1.value());
+
+    ssx::rwlock_unit unit2 = std::move(unit1.value());
+
+    BOOST_REQUIRE(!unit1.value());
+    BOOST_REQUIRE(unit2);
+}

--- a/tests/rptest/tests/tx_overflow_test.py
+++ b/tests/rptest/tests/tx_overflow_test.py
@@ -1,0 +1,74 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+
+from rptest.tests.redpanda_test import RedpandaTest
+from confluent_kafka.cimpl import KafkaException, KafkaError
+from confluent_kafka import Producer
+from rptest.clients.rpk import RpkTool
+
+
+class TxOverflowTest(RedpandaTest):
+    topics = [TopicSpec(partition_count=1, replication_factor=3)]
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_leader_balancer": False,
+            "partition_autobalancing_mode": "off",
+            "transaction_coordinator_partitions": 1
+        }
+
+        super(TxOverflowTest, self).__init__(test_context=test_context,
+                                             extra_rp_conf=extra_rp_conf,
+                                             log_level="trace")
+
+    def set_max_transactions_per_coordinator(self, n):
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_config_set("max_transactions_per_coordinator", str(n))
+
+    @cluster(num_nodes=3)
+    def underflow_test(self):
+        producers = []
+        for i in range(20):
+            p = Producer({
+                'bootstrap.servers': self.redpanda.brokers(),
+                'transactional.id': f"tx_{i}",
+            })
+            p.init_transactions()
+            producers.append(p)
+
+        for p in producers:
+            p.begin_transaction()
+            p.produce(self.topic, "key", "value", partition=0)
+            p.commit_transaction()
+
+    @cluster(num_nodes=3)
+    def overflow_test(self):
+        self.set_max_transactions_per_coordinator(10)
+
+        producers = []
+        for i in range(20):
+            p = Producer({
+                'bootstrap.servers': self.redpanda.brokers(),
+                'transactional.id': f"tx_{i}",
+            })
+            p.init_transactions()
+            producers.append(p)
+
+        oldest_producer = producers[0]
+        oldest_producer.begin_transaction()
+        oldest_producer.produce(self.topic, "key", "value", partition=0)
+        try:
+            oldest_producer.commit_transaction()
+            assert False, ""
+        except KafkaException as e:
+            assert e.args[0].code(
+            ) == KafkaError.INVALID_PRODUCER_ID_MAPPING, f"observed code={e.args[0].code()}"


### PR DESCRIPTION
PR adds tx thrashing to abort & evict old txn sessions once the number of known txn session passes a threshold (new `max_transactions_per_coordinator` property).

Fixes #12424

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none