### PR TITLE
ducktape/cloud_storage: Ignore trim failure in test with small cache

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -325,7 +325,16 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
 
         self._trim_and_verify()
 
-    @cluster(num_nodes=4, log_allow_list=["Exceeded cache size limit"])
+    @cluster(
+        num_nodes=4,
+        log_allow_list=[
+            "Exceeded cache size limit",
+            # Ignore trim related errors for small cache, expected
+            # due to part files being present when exhaustive trim
+            # runs, and being converted to full chunk files by the
+            # time trim gets to deleting them.
+            "failed to free sufficient space in exhaustive trim"
+        ])
     def test_read_when_cache_smaller_than_segment_size(self):
         self.si_settings.cloud_storage_cache_size = 1048576 * 4
         self.redpanda.set_si_settings(self.si_settings)


### PR DESCRIPTION
In certain tests when the cache size is very small and trimming is done with a lot of downloads in progress, it is possible that cache trimming will not be able to free up enough space. This is usually a problem for systems with a well configured cache, but for tests with a small cache these errors should be ignored.

FIXES #12234 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
