### PR TITLE
dockerize lint clang-format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,11 +76,16 @@ jobs:
 
     - name: Run clang-format
       run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 16
-        sudo apt-get install -y clang-format-16
-        find . -type f -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format-16 -i -style=file -fallback-style=none
+        docker run \
+        -v $PWD:/redpanda ubuntu \
+        bash -c "cd /redpanda && \
+          apt update && \
+          apt install -y wget git lsb-release wget software-properties-common gnupg && \
+          wget https://apt.llvm.org/llvm.sh && \
+          chmod +x llvm.sh && \
+          ./llvm.sh 16 && \
+          apt-get install -y clang-format-16 && \
+          find . -type f -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format-16 -i -style=file -fallback-style=none"
         git diff --exit-code
 
   sh:


### PR DESCRIPTION
fixes redpanda-data/devprod#800

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
