### PR TITLE
rpk: fix flag name in help text of `rpk generate app`

### DIFF
--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -455,7 +455,7 @@ func (a *AdminAPI) sendOne(
 }
 
 // sendAll sends a request to all URLs in the admin client. The first successful
-// response will be unmarshaled into `into` if it is non-nil.
+// response will be unmarshalled into `into` if it is non-nil.
 //
 // As of v21.11.1, the Redpanda admin API redirects requests to the leader based
 // on certain assumptions about all nodes listening on the same admin port, and
@@ -536,7 +536,7 @@ func (a *AdminAPI) eachBroker(fn func(aa *AdminAPI) error) error {
 //
 // * If into is a *[]byte, the raw response put directly into `into`.
 // * If into is a *string, the raw response put directly into `into` as a string.
-// * Otherwise, the response is json unmarshaled into `into`.
+// * Otherwise, the response is json unmarshalled into `into`.
 func maybeUnmarshalRespInto(method, url string, resp *http.Response, into interface{}) error {
 	defer resp.Body.Close()
 	if into == nil {

--- a/src/go/rpk/pkg/adminapi/api_config.go
+++ b/src/go/rpk/pkg/adminapi/api_config.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Config represents a Redpanda configuration. There are many keys returned, so
-// the raw response is just unmarshaled into an interface.
+// the raw response is just unmarshalled into an interface.
 type Config map[string]interface{}
 
 // Config returns a single admin endpoint's configuration. This errors if

--- a/src/go/rpk/pkg/cli/generate/app.go
+++ b/src/go/rpk/pkg/cli/generate/app.go
@@ -354,9 +354,10 @@ specify how you would like your application to be created using flags.
 
 The --language option allows you to specify the language. There is no default.
 
-The --new-sasl--user <user>:<password> allows you to generate a new SASL user
-with admin ACLs. If you don't want to use your current profile user nor create a
-new one, you may use --no-user flag to generate the starter app without the user.
+The --new-sasl-credentials <user>:<password> allows you to generate a new SASL
+user with admin ACLs. If you don't want to use your current profile user nor
+create a new one, you may use --no-user flag to generate the starter app without
+the user.
 
 If you are having trouble connecting to your cluster, you can use -X
 admin.hosts=comma,delimited,host:ports to pass a specific admin api address.
@@ -370,7 +371,7 @@ Generate an app in a specified language with the existing SASL user:
   rpk generate app --language <lang>
 
 Generate an app in the specified language with a new SASL user:
-  rpk generate app -l <lang> --new-sasl-user <user>:<password>
+  rpk generate app -l <lang> --new-sasl-credentials <user>:<password>
 
 Generate an app in the 'tmp' dir, but take no action on the user:
   rpk generate app -l <lang> --no-user --output /tmp

--- a/src/go/rpk/pkg/cli/group/offset_delete.go
+++ b/src/go/rpk/pkg/cli/group/offset_delete.go
@@ -37,7 +37,7 @@ The broker will only allow the request to succeed if the group is in a dead
 state (no subscriptions) or there are no subscriptions for offsets for
 topic/partitions requested to be deleted.
 
-Use either the --from-file or the --topic option. They are mututally exclusive.
+Use either the --from-file or the --topic option. They are mutually exclusive.
 To indicate which topics or topic partitions you'd like to remove offsets from use
 the --topic (-t) flag, followed by a comma separated list of partition ids. Supplying
 no list will delete all offsets for all partitions for a given topic.

--- a/src/go/rpk/pkg/cloudapi/api_installpack.go
+++ b/src/go/rpk/pkg/cloudapi/api_installpack.go
@@ -27,7 +27,7 @@ type InstallPackArtifact struct {
 
 type InstallPackArtifacts []InstallPackArtifact
 
-// Find returns the arftifact if it exists.
+// Find returns the artifact if it exists.
 func (as InstallPackArtifacts) Find(name string) (InstallPackArtifact, bool) {
 	for _, a := range as {
 		if a.Name == name {

--- a/src/go/rpk/pkg/httpapi/httpapi.go
+++ b/src/go/rpk/pkg/httpapi/httpapi.go
@@ -18,7 +18,7 @@
 //     bytes.Reader
 //   - If into is an io.Writer, the response is copied directly to the writer.
 //   - Otherwise, this attempts to json decode the response into 'into' and
-//     returns any json unmarshaling error.
+//     returns any json unmarshalling error.
 package httpapi
 
 import (

--- a/src/go/rpk/pkg/net/hostport.go
+++ b/src/go/rpk/pkg/net/hostport.go
@@ -91,7 +91,7 @@ func splitSchemeHostPort(h string) (scheme, host, port string, err error) {
 //   - We optionally allow a port :\d+.
 //   - We optionally allow the single path, "/".
 //
-// This regexp is compilicated, but what FindStringSubmatch will return if it
+// This regexp is complicated, but what FindStringSubmatch will return if it
 // matches at all:
 //   - index 0: the full match
 //   - index 1: the scheme, if present

--- a/src/go/rpk/pkg/system/grub_test.go
+++ b/src/go/rpk/pkg/system/grub_test.go
@@ -169,7 +169,7 @@ func TestOptionsNeedChange(t *testing.T) {
 			want:      true,
 		},
 		{
-			name:      "shall return true as key/value option differes",
+			name:      "shall return true as key/value option differs",
 			current:   []string{"opt1=val1", "noht", "opt_2=val_2"},
 			requested: []string{"opt1=val1", "noht", "opt_2=val_3"},
 			want:      true,

--- a/src/go/rpk/pkg/tuners/aggregated_tunable_test.go
+++ b/src/go/rpk/pkg/tuners/aggregated_tunable_test.go
@@ -40,7 +40,7 @@ func Test_aggregatedTunable_Tune(t *testing.T) {
 		want   TuneResult
 	}{
 		{
-			name: "shall return success when all tune opertions are suceessful",
+			name: "shall return success when all tune operations are successful",
 			fields: fields{
 				tunables: []Tunable{
 					&mockedTunable{
@@ -148,7 +148,7 @@ func Test_aggregatedTunable_CheckIfSupported(t *testing.T) {
 			wantReason:    "",
 		},
 		{
-			name: "shall forward reson when one of tunables is not supported",
+			name: "shall forward reason when one of tunables is not supported",
 			tunables: []Tunable{
 				&mockedTunable{
 					checkIfSupported: func() (bool, string) {

--- a/src/go/rpk/pkg/tuners/disk_tuner.go
+++ b/src/go/rpk/pkg/tuners/disk_tuner.go
@@ -51,7 +51,7 @@ func (tuner *diskTuner) Tune() TuneResult {
 func (tuner *diskTuner) CheckIfSupported() (supported bool, reason string) {
 	if len(tuner.directories) == 0 && len(tuner.devices) == 0 {
 		return false,
-			"Either direcories or devices must be provided for disk tuner"
+			"Either directories or devices must be provided for disk tuner"
 	}
 	tunables, err := tuner.createDeviceTuners()
 	if err != nil {

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
@@ -26,11 +26,11 @@ type writeSizedFileCommand struct {
 	sizeBytes int64
 }
 
-// Creates a file of size sizeBytes at the given path.
+// NewWriteSizedFileCmd creates a file of size sizeBytes at the given path.
 // When executed through DirectExecutor, it uses fallocate to create
 // the file. If the file already existed, then it uses ftruncate to shrink it
 // down if needed.
-// The script rendered throug a ScriptRenderingExecutor calls `truncate`,
+// The script rendered through a ScriptRenderingExecutor calls `truncate`,
 // which has the same behavior.
 func NewWriteSizedFileCmd(path string, sizeBytes int64) Command {
 	return &writeSizedFileCommand{path, sizeBytes}

--- a/src/go/rpk/pkg/tuners/float_checker_test.go
+++ b/src/go/rpk/pkg/tuners/float_checker_test.go
@@ -58,7 +58,7 @@ func Test_floatChecker_Check(t *testing.T) {
 			},
 		},
 		{
-			name:           "Shall return result with an error when getCurretn returns an error",
+			name:           "Shall return result with an error when getCurrent returns an error",
 			check:          func(c float64) bool { return c < 10.0 },
 			renderRequired: func() string { return "< 10" },
 			getCurrent:     func() (float64, error) { return 0.0, errors.New("err") },

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -231,7 +231,7 @@ func Test_nic_GetRxQueueCount(t *testing.T) {
 		want          int
 	}{
 		{
-			name: "Shall return len(IRQ) when RPS is disabled and driver is not limiting queus number",
+			name: "Shall return len(IRQ) when RPS is disabled and driver is not limiting queues number",
 			irqProcFile: &procFileMock{
 				getIRQProcFileLinesMap: func() (map[int]string, error) {
 					return map[int]string{
@@ -317,7 +317,7 @@ func Test_nic_GetNTupleStatus(t *testing.T) {
 		want          NTupleStatus
 	}{
 		{
-			name: "Shall return not suported when iface does not support NTuples",
+			name: "Shall return not supported when iface does not support NTuples",
 			ethtool: &ethtoolMock{
 				features: func(string) (map[string]bool, error) {
 					return map[string]bool{


### PR DESCRIPTION
I went ahead and fixed a couple of typos apart from the help text.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

