### PR TITLE
rpk: add new linker flags for the enhanced rpk version

### DIFF
--- a/src/go/rpk/.goreleaser.yaml
+++ b/src/go/rpk/.goreleaser.yaml
@@ -6,6 +6,9 @@ builds:
     ldflags:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0
@@ -22,6 +25,9 @@ builds:
     ldflags:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0

--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -24,7 +24,7 @@ import (
 var (
 	version   string // Semver of rpk.
 	rev       string // Short git SHA.
-	buildTime string // Timestamp of build time, ISO 8601.
+	buildTime string // Timestamp of build time, RFC3339.
 	hostOs    string // OS that was used to built rpk (go env GOHOSTOS).
 	hostArch  string // Arch that was used to built rpk (go env GOHOSTARCH).
 )


### PR DESCRIPTION
PR #12321 introduced an enhanced `rpk version` command that will use some values injected at build time.

Tested in Linux:

```
$ goreleaser release --snapshot --clean
  • starting release...
  • loading config file                              file=.goreleaser.yaml
...
  • building binaries
    • building                                       binary=dist/windows-and-linux_linux_arm64/rpk
    • building                                       binary=dist/windows-and-linux_windows_amd64_v1/rpk.exe
    • building                                       binary=dist/windows-and-linux_windows_arm64/rpk.exe
    • building                                       binary=dist/windows-and-linux_linux_amd64_v1/rpk
...

$ ./dist/windows-and-linux_linux_amd64_v1/rpk version
Version:     v23.2.1-rc7
Git ref:     114da28be
Build date:  2023-07-27T16:06:32Z
OS/Arch:     linux/amd64
Go version:  go1.20.6

Redpanda Cluster
  node-1  v23.2.2 - 3aae933c6ff7a6beeaeb4d81a06ccce0d76ec967
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

