### PR TITLE
archival: promote some guardrail warnings to error

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -1002,7 +1002,7 @@ void archival_metadata_stm::apply_add_segment(const segment& segment) {
     if (!disable_safe_add && !_manifest->safe_segment_meta_to_add(meta)) {
         auto last = _manifest->last_segment();
         vlog(
-          _logger.warn,
+          _logger.error,
           "Can't add segment: {}, previous segment: {}",
           meta,
           last);
@@ -1029,7 +1029,7 @@ void archival_metadata_stm::apply_add_segment(const segment& segment) {
             // the hole.
 
             vlog(
-              _logger.warn,
+              _logger.error,
               "hole in the remote offset range detected! previous last "
               "offset: "
               "{}, new segment base offset: {}",
@@ -1135,7 +1135,7 @@ void archival_metadata_stm::apply_spillover(const spillover_cmd& so) {
           get_start_offset(),
           get_last_offset());
     } else {
-        vlog(_logger.warn, "Can't apply spillover_cmd: {}", so.manifest_meta);
+        vlog(_logger.error, "Can't apply spillover_cmd: {}", so.manifest_meta);
     }
 }
 
@@ -1175,7 +1175,7 @@ archival_metadata_stm::get_segments_to_cleanup() const {
             // manifest in S3 so if we will delete it the data will be lost.
             if (m_name == s_name) {
                 vlog(
-                  _logger.warn,
+                  _logger.error,
                   "The replaced segment name {} collides with the segment {} "
                   "in the manifest. It will be removed to prevent the data "
                   "loss.",


### PR DESCRIPTION
They're scary when they happen because they indicate a bug in our logic. Let's promote to error to make sure we see them when they happen.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
