### PR TITLE
rpk group: total describe lag

### DIFF
--- a/src/go/rpk/pkg/cli/group/describe.go
+++ b/src/go/rpk/pkg/cli/group/describe.go
@@ -136,6 +136,7 @@ func printDescribedGroupSummary(group kadm.DescribedGroupLag) {
 	fmt.Fprintf(tw, "STATE\t%s\n", group.State)
 	fmt.Fprintf(tw, "BALANCER\t%s\n", group.Protocol)
 	fmt.Fprintf(tw, "MEMBERS\t%d\n", len(group.Members))
+	fmt.Fprintf(tw, "TOTAL-LAG\t%d\n", group.Lag.Total())
 	if group.Error() != nil {
 		fmt.Fprintf(tw, "ERROR\t%s\n", group.Error())
 	}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -106,6 +106,7 @@ class RpkGroup(typing.NamedTuple):
     state: str
     balancer: str
     members: int
+    total_lag: int
     partitions: list[RpkGroupPartition]
 
 
@@ -666,8 +667,9 @@ class RpkTool:
             state = parse_field("STATE", lines[2])
             balancer = parse_field("BALANCER", lines[3])
             members = parse_field("MEMBERS", lines[4])
+            total_lag = parse_field("TOTAL-LAG", lines[5])
             partitions = []
-            for l in lines[5:]:
+            for l in lines[6:]:
                 #skip header line
                 if l.startswith("TOPIC") or len(l) < 2:
                     continue
@@ -683,7 +685,8 @@ class RpkTool:
                             state=state,
                             balancer=balancer,
                             members=int(members),
-                            partitions=partitions)
+                            partitions=partitions,
+                            total_lag=int(total_lag))
 
         attempts = 10
         rpk_group = None


### PR DESCRIPTION
This PR adds a `TOTAL-LAG` field in the summary of `rpk group describe` and a new flag `--print-lag-per-topic` to print the total lag per topic:

```
$ rpk group describe g1 --print-lag-per-topic 
GROUP        g1
COORDINATOR  1
STATE        Empty
BALANCER     
MEMBERS      0
TOTAL-LAG    11

TOPIC      LAG
oct-10     2
test-seek  9
```

**Before and After:**
![image](https://github.com/redpanda-data/redpanda/assets/59714880/114f9450-0c74-4f6c-ae19-e8b56b462b40)

Fixes #5214
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
* rpk now prints the total lag of a group in `rpk group describe` and a new `--print-lag-per-topic` to aggregate the lag per topic.

