### PR TITLE
storage: fix race between segment.ms application and the disk append path

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -516,7 +516,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
 
     auto rdr_holder = co_await readers_cache.evict_segment_readers(s);
 
-    auto write_lock_holder = co_await s->write_lock();
+    auto destructibe_op_lock_holder = co_await s->destructive_op_lock();
     if (segment_generation != s->get_generation_id()) {
         vlog(
           stlog.debug,
@@ -920,8 +920,8 @@ ss::future<std::vector<ss::rwlock::holder>> write_lock_segments(
             std::vector<ss::future<ss::rwlock::holder>> held_f;
             held_f.reserve(segments.size());
             for (auto& segment : segments) {
-                held_f.push_back(
-                  segment->write_lock(ss::semaphore::clock::now() + timeout));
+                held_f.push_back(segment->destructive_op_lock(
+                  ss::semaphore::clock::now() + timeout));
             }
             held = co_await ss::when_all_succeed(held_f.begin(), held_f.end());
             break;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1746,7 +1746,7 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
     }
 
     {
-        auto lock = segments[2]->write_lock().get0();
+        auto lock = segments[2]->destructive_op_lock().get0();
         BOOST_REQUIRE_THROW(
           storage::internal::write_lock_segments(
             segments, std::chrono::seconds(1), 1)


### PR DESCRIPTION
We have seen a couple of races between the application of `segment.ms`
and the normal append path. They had the following pattern in common:
1. application of `segment.ms` begins
2. a call to `segment::append` is interleaved
3. the append finishes first and and advances the dirty offsets, which
the rolling logic in `segment.ms` does not expect
-- or --
4. `segment.ms` releases the current appender while the append is
ongoing, which the append logic does not expect

The issue is solved by introducing a mutex and grabbing it on the append
path. The same mutex is held during the application of `segment.ms` in
order to block writes.

The overhead of this solution should be minimal for two reasons:
* One (previously undocumented) invariant of the storage layer is that
there may be only one append in flight to a partition (flushes may be
concurrent however). This invariant is also respected by Raft; see
`append_entries_buffer::do_flush` where the call to
`consensus::do_append_entries` is done under the Raft op lock.
* Contention is still possible if we decide to apply `segment.ms` and
receive and wish to append while holding the lock. However, `segment.ms`
should almost never be applied in high throughput scenarios as the
segments will roll naturally in that case.

@dotnwat did a superb job reproducing these issues by enforcing the ordering
of futures with condition variables [here](https://github.com/dotnwat/redpanda/tree/seg-append-assert-repro).
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [X] v23.1.x
- [ ] v22.3.x

## Release Notes


### Bug Fixes

* fix race between segment.ms application and the disk append path
