### PR TITLE
storage: don't ostream all segments

### DIFF
--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -156,8 +156,20 @@ segment_set::upper_bound(model::term_id term) const {
 
 std::ostream& operator<<(std::ostream& o, const segment_set& s) {
     o << "{size: " << s.size() << ", [";
-    for (auto& p : s) {
-        o << p;
+    static constexpr size_t max_to_log = 8;
+    static constexpr size_t halved = max_to_log / 2;
+    if (s.size() <= max_to_log) {
+        for (auto& p : s) {
+            o << p;
+        }
+    } else {
+        for (size_t i = 0; i < halved; i++) {
+            o << s[i];
+        }
+        o << "...";
+        for (size_t i = s.size() - halved; i < s.size(); i++) {
+            o << s[i];
+        }
     }
     return o << "]}";
 }


### PR DESCRIPTION
When we log a disk_log_impl, it logs every segment. This can be stressful for logs that have thousands of local segments, since each segment may stream several hundreds of bytes of text[1], and in some cases cause Redpanda to OOM while logging[2].

This commit mitigates this by reducing the number of segments logged when logging a segment_set.

[1]
```
{offset_tracker:{term:20, base_offset:96, committed_offset:104, dirty_offset:104}, compacted_segment=0, finished_self_compaction=0, generation={18}, reader={/var/lib/redpanda/data/kafka/events/22_378813/96-20-v1.log, (8349 bytes)}, writer={no_of_chunks:64, closed:0, fallocation_offset:33554432, committed_offset:8349, bytes_flush_pending:0}, cache={cache_size=5}, compaction_index:nullopt, closed=0, tombstone=0, index={file:/var/lib/redpanda/data/kafka/events/22_378813/96-20-v1.base_index, offsets:{96}, index:{header_bitflags:0, base_offset:{96}, max_offset:{104}, base_timestamp:{timestamp: 1689708130873}, max_timestamp:{timestamp: 1689708130873}, batch_timestamps_are_monotonic:1, index(1,1,1)}, step:32768, needs_persistence:1}}
```

[2]
```
[Backtrace #0]
lib/libc.so.6: ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=6e7b96dfb83f0bdcb6a410469b82f86415e5ada3, for GNU/Linux 3.2.0, not stripped

__GI___clone3 at ??:0
start_thread at ??:0
std::__1::__function::__value_func<void ()>::operator()() const at /vectorized/llvm/bin/../include/c++/v1/__functional/function.h:507
 (inlined by) std::__1::function<void ()>::operator()() const at /vectorized/llvm/bin/../include/c++/v1/__functional/function.h:1184
 (inlined by) seastar::posix_thread::start_routine(void*) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/posix.cc:73
seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95::operator()() const at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:4140
 (inlined by) decltype(static_cast<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95&>(fp)()) std::__1::__invoke<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95&>(seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95&) at /vectorized/llvm/bin/../include/c++/v1/type_traits:3640
 (inlined by) void std::__1::__invoke_void_return_wrapper<void, true>::__call<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95&>(seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95&) at /vectorized/llvm/bin/../include/c++/v1/__functional/invoke.h:61
 (inlined by) std::__1::__function::__alloc_func<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95, std::__1::allocator<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95>, void ()>::operator()() at /vectorized/llvm/bin/../include/c++/v1/__functional/function.h:180
 (inlined by) std::__1::__function::__func<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95, std::__1::allocator<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_95>, void ()>::operator()() at /vectorized/llvm/bin/../include/c++/v1/__functional/function.h:354
seastar::reactor::do_run() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2906
seastar::reactor::run_tasks(seastar::reactor::task_queue&) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2330
 (inlined by) seastar::reactor::run_some_tasks() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2737
cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6::operator()() const at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/cluster/partition_manager.cc:339
 (inlined by) decltype(static_cast<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&>(fp)()) std::__1::__invoke<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&>(cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&) at /vectorized/llvm/bin/../include/c++/v1/type_traits:3640
 (inlined by) std::__1::invoke_result<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&>::type std::__1::invoke<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&>(cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&) at /vectorized/llvm/bin/../include/c++/v1/__functional/invoke.h:93
 (inlined by) auto seastar::internal::future_invoke<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::internal::monostate>(cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::internal::monostate&&) at /vectorized/include/seastar/core/future.hh:1223
 (inlined by) seastar::future<void> seastar::future<void>::then_impl_nrvo<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6, seastar::future<void>>(cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::future_state<seastar::internal::monostate>&&)::operator()(seastar::internal::promise_base_with_type<void>&&, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::future_state<seastar::internal::monostate>&&) const::'lambda'()::operator()() const at /vectorized/include/seastar/core/future.hh:1596
 (inlined by) void seastar::futurize<seastar::future<void>>::satisfy_with_result_of<seastar::future<void> seastar::future<void>::then_impl_nrvo<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6, seastar::future<void>>(cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::future_state<seastar::internal::monostate>&&)::operator()(seastar::internal::promise_base_with_type<void>&&, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::future_state<seastar::internal::monostate>&&) const::'lambda'()>(seastar::internal::promise_base_with_type<void>&&, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&&) at /vectorized/include/seastar/core/future.hh:2134
 (inlined by) seastar::future<void> seastar::future<void>::then_impl_nrvo<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6, seastar::future<void>>(cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::future_state<seastar::internal::monostate>&&)::operator()(seastar::internal::promise_base_with_type<void>&&, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::future_state<seastar::internal::monostate>&&) const at /vectorized/include/seastar/core/future.hh:1589
 (inlined by) seastar::continuation<seastar::internal::promise_base_with_type<void>, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6, seastar::future<void> seastar::future<void>::then_impl_nrvo<cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6, seastar::future<void>>(cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, cluster::partition_manager::remove(model::ntp const&, cluster::partition_removal_mode)::$_6&, seastar::future_state<seastar::internal::monostate>&&), void>::run_and_dispose() at /vectorized/include/seastar/core/future.hh:781
void seastar::logger::log<char const*, int, storage::log&>(seastar::log_level, seastar::logger::format_info, char const*&&, int&&, storage::log&) at /vectorized/include/seastar/util/log.hh:227
 (inlined by) void seastar::logger::info<char const*, int, storage::log&>(seastar::logger::format_info, char const*&&, int&&, storage::log&) at /vectorized/include/seastar/util/log.hh:346
 (inlined by) storage::log_manager::remove(model::ntp) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/storage/log_manager.cc:405
seastar::logger::do_log(seastar::log_level, seastar::logger::log_writer&) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/util/log.cc:335
seastar::logger::do_log(seastar::log_level, seastar::logger::log_writer&)::$_0::operator()(seastar::internal::log_buf::inserter_iterator) const at /v/build/v_deps_build/seastar-prefix/src/seastar/src/util/log.cc:323
void fmt::v8::detail::parse_format_string<false, char, void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler>(fmt::v8::basic_string_view<char>, void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler&&) at /vectorized/include/fmt/core.h:2626
 (inlined by) void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref) at /vectorized/include/fmt/format.h:2988
 (inlined by) seastar::internal::log_buf::inserter_iterator fmt::v8::vformat_to<seastar::internal::log_buf::inserter_iterator, 0>(seastar::internal::log_buf::inserter_iterator, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<fmt::v8::appender, char>>) at /vectorized/include/fmt/core.h:3128
 (inlined by) seastar::internal::log_buf::inserter_iterator fmt::v8::format_to<seastar::internal::log_buf::inserter_iterator, char const*, int, storage::log&, 0>(seastar::internal::log_buf::inserter_iterator, fmt::v8::basic_format_string<char, fmt::v8::type_identity<char const*>::type, fmt::v8::type_identity<int>::type, fmt::v8::type_identity<storage::log&>::type>, char const*&&, int&&, storage::log&) at /vectorized/include/fmt/core.h:3148
 (inlined by) void seastar::logger::log<char const*, int, storage::log&>(seastar::log_level, seastar::logger::format_info, char const*&&, int&&, storage::log&)::'lambda'(seastar::internal::log_buf::inserter_iterator)::operator()(seastar::internal::log_buf::inserter_iterator) const at /vectorized/include/seastar/util/log.hh:222
 (inlined by) seastar::logger::lambda_log_writer<void seastar::logger::log<char const*, int, storage::log&>(seastar::log_level, seastar::logger::format_info, char const*&&, int&&, storage::log&)::'lambda'(seastar::internal::log_buf::inserter_iterator)>::operator()(seastar::internal::log_buf::inserter_iterator) at /vectorized/include/seastar/util/log.hh:108
fmt::v8::basic_format_arg<fmt::v8::basic_format_context<fmt::v8::appender, char>>::handle::format(fmt::v8::basic_format_parse_context<char, fmt::v8::detail::error_handler>&, fmt::v8::basic_format_context<fmt::v8::appender, char>&) const at /vectorized/include/fmt/core.h:1558
 (inlined by) fmt::v8::detail::default_arg_formatter<char>::operator()(fmt::v8::basic_format_arg<fmt::v8::basic_format_context<fmt::v8::appender, char>>::handle) at /vectorized/include/fmt/format.h:2202
 (inlined by) decltype(fp(0)) fmt::v8::visit_format_arg<fmt::v8::detail::default_arg_formatter<char>, fmt::v8::basic_format_context<fmt::v8::appender, char>>(fmt::v8::detail::default_arg_formatter<char>&&, fmt::v8::basic_format_arg<fmt::v8::basic_format_context<fmt::v8::appender, char>> const&) at /vectorized/include/fmt/core.h:1622
 (inlined by) void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler::on_replacement_field(int, char const*) at /vectorized/include/fmt/format.h:2962
 (inlined by) char const* fmt::v8::detail::parse_replacement_field<char, void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler&>(char const*, char const*, void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler&) at /vectorized/include/fmt/core.h:2591
void fmt::v8::detail::value<fmt::v8::basic_format_context<fmt::v8::appender, char>>::format_custom_arg<storage::log, fmt::v8::detail::fallback_formatter<storage::log, char, void>>(void*, fmt::v8::basic_format_parse_context<char, fmt::v8::detail::error_handler>&, fmt::v8::basic_format_context<fmt::v8::appender, char>&) at /vectorized/include/fmt/core.h:1282
storage::log::print(std::__1::basic_ostream<char, std::__1::char_traits<char>>&) const at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/storage/log.h:208
 (inlined by) storage::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, storage::log const&) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/storage/log.h:218
 (inlined by) void fmt::v8::detail::format_value<char, storage::log>(fmt::v8::detail::buffer<char>&, storage::log const&, fmt::v8::detail::locale_ref) at /vectorized/include/fmt/ostream.h:77
 (inlined by) fmt::v8::appender fmt::v8::detail::fallback_formatter<storage::log, char, void>::format<fmt::v8::appender>(storage::log const&, fmt::v8::basic_format_context<fmt::v8::appender, char>&) at /vectorized/include/fmt/ostream.h:92
void fmt::v8::detail::parse_format_string<false, char, void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler>(fmt::v8::basic_string_view<char>, void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler&&) at /vectorized/include/fmt/core.h:2660
 (inlined by) void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref) at /vectorized/include/fmt/format.h:2988
 (inlined by) void fmt::v8::vprint<char>(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>) at /vectorized/include/fmt/ostream.h:113
 (inlined by) void fmt::v8::print<char [59], storage::offset_stats, bool const&, storage::segment_set const&, storage::ntp_config const&, char>(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, char const (&) [59], storage::offset_stats&&, bool const&, storage::segment_set const&, storage::ntp_config const&) at /vectorized/include/fmt/ostream.h:130
 (inlined by) storage::disk_log_impl::print(std::__1::basic_ostream<char, std::__1::char_traits<char>>&) const at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/storage/disk_log_impl.cc:1771
fmt::v8::basic_format_arg<fmt::v8::basic_format_context<fmt::v8::appender, char>>::handle::format(fmt::v8::basic_format_parse_context<char, fmt::v8::detail::error_handler>&, fmt::v8::basic_format_context<fmt::v8::appender, char>&) const at /vectorized/include/fmt/core.h:1558
 (inlined by) fmt::v8::detail::default_arg_formatter<char>::operator()(fmt::v8::basic_format_arg<fmt::v8::basic_format_context<fmt::v8::appender, char>>::handle) at /vectorized/include/fmt/format.h:2202
 (inlined by) decltype(fp(0)) fmt::v8::visit_format_arg<fmt::v8::detail::default_arg_formatter<char>, fmt::v8::basic_format_context<fmt::v8::appender, char>>(fmt::v8::detail::default_arg_formatter<char>&&, fmt::v8::basic_format_arg<fmt::v8::basic_format_context<fmt::v8::appender, char>> const&) at /vectorized/include/fmt/core.h:1622
 (inlined by) void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler::on_replacement_field(int, char const*) at /vectorized/include/fmt/format.h:2962
 (inlined by) char const* fmt::v8::detail::parse_replacement_field<char, void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler&>(char const*, char const*, void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::__1::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appender, std::__1::back_insert_iterator<fmt::v8::detail::buffer<fmt::v8::type_identity<char>::type>>>::type, fmt::v8::type_identity<char>::type>>, fmt::v8::detail::locale_ref)::format_handler&) at /vectorized/include/fmt/core.h:2591
void fmt::v8::detail::value<fmt::v8::basic_format_context<fmt::v8::appender, char>>::format_custom_arg<storage::segment_set, fmt::v8::detail::fallback_formatter<storage::segment_set, char, void>>(void*, fmt::v8::basic_format_parse_context<char, fmt::v8::detail::error_handler>&, fmt::v8::basic_format_context<fmt::v8::appender, char>&) at /vectorized/include/fmt/core.h:1282
void fmt::v8::detail::format_value<char, storage::segment_set>(fmt::v8::detail::buffer<char>&, storage::segment_set const&, fmt::v8::detail::locale_ref) at /vectorized/include/fmt/ostream.h:77
 (inlined by) fmt::v8::appender fmt::v8::detail::fallback_formatter<storage::segment_set, char, void>::format<fmt::v8::appender>(storage::segment_set const&, fmt::v8::basic_format_context<fmt::v8::appender, char>&) at /vectorized/include/fmt/ostream.h:92
std::__1::basic_ostream<char, std::__1::char_traits<char>>& seastar::operator<<<storage::segment>(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, seastar::lw_shared_ptr<storage::segment> const&) at /vectorized/include/seastar/core/shared_ptr.hh:453
 (inlined by) storage::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, storage::segment_set const&) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/storage/segment_set.cc:160
storage::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, storage::segment const&) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/storage/segment.cc:601
storage::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, storage::segment_index const&) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/storage/segment_index.cc:263
std::__1::basic_ostream<char, std::__1::char_traits<char>>& seastar::operator<<<char, unsigned int, 15u, true, std::__1::char_traits<char>>(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, seastar::basic_sstring<char, unsigned int, 15u, true> const&) at /vectorized/include/seastar/core/sstring.hh:641
 (inlined by) storage::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, storage::segment_full_path const&) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-056640813104f5ee7-1/redpanda/redpanda/src/v/storage/fs_utils.cc:136
lib/libc++.so.1: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, not stripped

std::__1::basic_ostream<char, std::__1::char_traits<char>>::write(char const*, long) at ??:0
fmt::v8::detail::buffer<char>::try_reserve(unsigned long) at /vectorized/include/fmt/core.h:846
 (inlined by) void fmt::v8::detail::buffer<char>::append<char>(char const*, char const*) at /vectorized/include/fmt/format.h:633
 (inlined by) fmt::v8::detail::formatbuf<std::__1::basic_streambuf<char, std::__1::char_traits<char>>>::xsputn(char const*, long) at /vectorized/include/fmt/format.h:281
void* std::__1::__libcpp_operator_new<unsigned long>(unsigned long) at /vectorized/llvm/bin/../include/c++/v1/new:245
 (inlined by) std::__1::__libcpp_allocate(unsigned long, unsigned long) at /vectorized/llvm/bin/../include/c++/v1/new:271
 (inlined by) std::__1::allocator<char>::allocate(unsigned long) at /vectorized/llvm/bin/../include/c++/v1/__memory/allocator.h:105
 (inlined by) std::__1::allocator_traits<std::__1::allocator<char>>::allocate(std::__1::allocator<char>&, unsigned long) at /vectorized/llvm/bin/../include/c++/v1/__memory/allocator_traits.h:262
 (inlined by) fmt::v8::basic_memory_buffer<char, 500ul, std::__1::allocator<char>>::grow(unsigned long) at /vectorized/include/fmt/format.h:791
operator new(unsigned long) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:2079
seastar::memory::on_allocation_failure(unsigned long) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:1821
 (inlined by) seastar::memory::allocate(unsigned long) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:1410
abort at ??:0
?? at ??:0
seastar::print_with_backtrace(char const*, bool) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:796
 (inlined by) seastar::sigsegv_action() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:3658
 (inlined by) void seastar::install_oneshot_signal_handler<11, (void (*)())(&seastar::sigsegv_action())>()::'lambda'(int, siginfo_t*, void*)::operator()(int, siginfo_t*, void*) const at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:3639
 (inlined by) void seastar::install_oneshot_signal_handler<11, (void (*)())(&seastar::sigsegv_action())>()::'lambda'(int, siginfo_t*, void*)::__invoke(int, siginfo_t*, void*) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:3635
void seastar::backtrace<seastar::backtrace_buffer::append_backtrace()::'lambda'(seastar::frame)>(seastar::backtrace_buffer::append_backtrace()::'lambda'(seastar::frame)&&) at /v/build/v_deps_build/seastar-prefix/src/seastar/include/seastar/util/backtrace.hh:59
 (inlined by) seastar::backtrace_buffer::append_backtrace() at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:754
 (inlined by) seastar::print_with_backtrace(seastar::backtrace_buffer&, bool) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:784
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

-->

### Improvements

* Redpanda will now be less verbose when logging certain operations in partitions with many local segments.
