### PR TITLE
[v23.2.x] storage: don't ostream all segments

### DIFF
--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -156,8 +156,20 @@ segment_set::upper_bound(model::term_id term) const {
 
 std::ostream& operator<<(std::ostream& o, const segment_set& s) {
     o << "{size: " << s.size() << ", [";
-    for (auto& p : s) {
-        o << p;
+    static constexpr size_t max_to_log = 8;
+    static constexpr size_t halved = max_to_log / 2;
+    if (s.size() <= max_to_log) {
+        for (auto& p : s) {
+            o << p;
+        }
+    } else {
+        for (size_t i = 0; i < halved; i++) {
+            o << s[i];
+        }
+        o << "...";
+        for (size_t i = s.size() - halved; i < s.size(); i++) {
+            o << s[i];
+        }
     }
     return o << "]}";
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12519
