### PR TITLE
[storage]: remove storage::log pimpl wrapper

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -36,7 +36,7 @@ std::optional<storage::disk_log_impl*> get_concrete_log_impl(ss::shared_ptr<stor
     // NOTE: we need to break encapsulation here to access underlying
     // implementation because upload policy and archival subsystem needs to
     // access individual log segments (disk backed).
-    auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+    auto plog = dynamic_cast<storage::disk_log_impl*>(log.get());
     if (plog == nullptr || plog->segment_count() == 0) {
         return std::nullopt;
     }

--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -32,11 +32,11 @@
 
 namespace {
 
-std::optional<storage::disk_log_impl*> get_concrete_log_impl(storage::log log) {
+std::optional<storage::disk_log_impl*> get_concrete_log_impl(ss::shared_ptr<storage::log> log) {
     // NOTE: we need to break encapsulation here to access underlying
     // implementation because upload policy and archival subsystem needs to
     // access individual log segments (disk backed).
-    auto plog = dynamic_cast<storage::disk_log_impl*>(log.get_impl());
+    auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
     if (plog == nullptr || plog->segment_count() == 0) {
         return std::nullopt;
     }
@@ -120,7 +120,7 @@ bool archival_policy::upload_deadline_reached() {
 archival_policy::lookup_result archival_policy::find_segment(
   model::offset start_offset,
   model::offset adjusted_lso,
-  storage::log log,
+  ss::shared_ptr<storage::log> log,
   const storage::offset_translator_state& ot_state) {
     vlog(
       archival_log.debug,
@@ -389,7 +389,7 @@ static ss::future<upload_candidate_with_locks> create_upload_candidate(
 ss::future<upload_candidate_with_locks> archival_policy::get_next_candidate(
   model::offset begin_inclusive,
   model::offset end_exclusive,
-  storage::log log,
+  ss::shared_ptr<storage::log> log,
   const storage::offset_translator_state& ot_state,
   ss::lowres_clock::duration segment_lock_duration) {
     // NOTE: end_exclusive (which is initialized with LSO) points to the first
@@ -427,7 +427,7 @@ ss::future<upload_candidate_with_locks> archival_policy::get_next_candidate(
 ss::future<upload_candidate_with_locks>
 archival_policy::get_next_compacted_segment(
   model::offset begin_inclusive,
-  storage::log log,
+  ss::shared_ptr<storage::log> log,
   const cloud_storage::partition_manifest& manifest,
   ss::lowres_clock::duration segment_lock_duration) {
     auto plog = get_concrete_log_impl(std::move(log));

--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -32,7 +32,8 @@
 
 namespace {
 
-std::optional<storage::disk_log_impl*> get_concrete_log_impl(ss::shared_ptr<storage::log> log) {
+std::optional<storage::disk_log_impl*>
+get_concrete_log_impl(ss::shared_ptr<storage::log> log) {
     // NOTE: we need to break encapsulation here to access underlying
     // implementation because upload policy and archival subsystem needs to
     // access individual log segments (disk backed).

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -66,13 +66,13 @@ public:
     ss::future<upload_candidate_with_locks> get_next_candidate(
       model::offset begin_inclusive,
       model::offset end_exclusive,
-      storage::log,
+      ss::shared_ptr<storage::log>,
       const storage::offset_translator_state&,
       ss::lowres_clock::duration segment_lock_duration);
 
     ss::future<upload_candidate_with_locks> get_next_compacted_segment(
       model::offset begin_inclusive,
-      storage::log log,
+      ss::shared_ptr<storage::log> log,
       const cloud_storage::partition_manifest& manifest,
       ss::lowres_clock::duration segment_lock_duration);
 
@@ -93,7 +93,7 @@ private:
     lookup_result find_segment(
       model::offset last_offset,
       model::offset adjusted_lso,
-      storage::log,
+      ss::shared_ptr<storage::log>,
       const storage::offset_translator_state&);
 
     model::ntp _ntp;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -177,7 +177,7 @@ ntp_archiver::ntp_archiver(
   , _segment_index_tags(
       cloud_storage::remote::make_segment_index_tags(_ntp, _rev))
   , _local_segment_merger(maybe_make_adjacent_segment_merger(
-      *this, _rtclog, parent.log().config(), parent.is_leader()))
+      *this, _rtclog, parent.log()->config(), parent.is_leader()))
   , _manifest_upload_interval(
       config::shard_local_cfg()
         .cloud_storage_manifest_max_upload_interval_sec.bind())
@@ -1905,7 +1905,7 @@ uint64_t ntp_archiver::estimate_backlog_size() {
     auto last_offset = manifest().size() ? manifest().get_last_offset()
                                          : model::offset(0);
     auto log_generic = _parent.log();
-    auto log = dynamic_cast<storage::disk_log_impl*>(log_generic.get_impl());
+    auto log = dynamic_cast<storage::disk_log_impl*>(log_generic->get_impl());
     uint64_t total_size = std::accumulate(
       std::begin(log->segments()),
       std::end(log->segments()),
@@ -2718,7 +2718,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
     if (run->meta.base_offset >= _parent.raft_start_offset()) {
         auto log_generic = _parent.log();
         auto& log = dynamic_cast<storage::disk_log_impl&>(
-          *log_generic.get_impl());
+          *log_generic->get_impl());
         segment_collector collector(
           run->meta.base_offset,
           manifest(),

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2717,8 +2717,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
     auto units = co_await ss::get_units(_mutex, 1, _as);
     if (run->meta.base_offset >= _parent.raft_start_offset()) {
         auto log_generic = _parent.log();
-        auto& log = dynamic_cast<storage::disk_log_impl&>(
-          *log_generic);
+        auto& log = dynamic_cast<storage::disk_log_impl&>(*log_generic);
         segment_collector collector(
           run->meta.base_offset,
           manifest(),

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1905,7 +1905,7 @@ uint64_t ntp_archiver::estimate_backlog_size() {
     auto last_offset = manifest().size() ? manifest().get_last_offset()
                                          : model::offset(0);
     auto log_generic = _parent.log();
-    auto log = dynamic_cast<storage::disk_log_impl*>(log_generic->get_impl());
+    auto log = dynamic_cast<storage::disk_log_impl*>(log_generic.get());
     uint64_t total_size = std::accumulate(
       std::begin(log->segments()),
       std::end(log->segments()),
@@ -2718,7 +2718,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
     if (run->meta.base_offset >= _parent.raft_start_offset()) {
         auto log_generic = _parent.log();
         auto& log = dynamic_cast<storage::disk_log_impl&>(
-          *log_generic->get_impl());
+          *log_generic);
         segment_collector collector(
           run->meta.base_offset,
           manifest(),

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -318,7 +318,7 @@ public:
     void complete_transfer_leadership();
 
     const storage::ntp_config& ntp_config() const {
-        return _parent.log().config();
+        return _parent.log()->config();
     }
 
     /// If we have a projected manifest clean offset, then flush it to

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -177,7 +177,7 @@ struct reupload_fixture : public archiver_fixture {
 
     storage::disk_log_impl* disk_log_impl() {
         return dynamic_cast<storage::disk_log_impl*>(
-          get_local_storage_api().log_mgr().get(manifest_ntp).value().get());
+          get_local_storage_api().log_mgr().get(manifest_ntp).get());
     }
 
     cloud_storage::partition_manifest

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -177,7 +177,7 @@ struct reupload_fixture : public archiver_fixture {
 
     storage::disk_log_impl* disk_log_impl() {
         return dynamic_cast<storage::disk_log_impl*>(
-          get_local_storage_api().log_mgr().get(manifest_ntp).value()->get_impl());
+          get_local_storage_api().log_mgr().get(manifest_ntp).value().get());
     }
 
     cloud_storage::partition_manifest

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -177,7 +177,7 @@ struct reupload_fixture : public archiver_fixture {
 
     storage::disk_log_impl* disk_log_impl() {
         return dynamic_cast<storage::disk_log_impl*>(
-          get_local_storage_api().log_mgr().get(manifest_ntp)->get_impl());
+          get_local_storage_api().log_mgr().get(manifest_ntp).value()->get_impl());
     }
 
     cloud_storage::partition_manifest

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -80,7 +80,7 @@ static void log_segment(const storage::segment& s) {
 
 static void log_segment_set(storage::log_manager& lm) {
     auto log = lm.get(manifest_ntp);
-    auto plog = dynamic_cast<const storage::disk_log_impl*>(log.value()->get_impl());
+    auto plog = dynamic_cast<const storage::disk_log_impl*>(log.value().get());
     BOOST_REQUIRE(plog != nullptr);
     const auto& sset = plog->segments();
     for (const auto& s : sset) {
@@ -923,7 +923,7 @@ FIXTURE_TEST(
         as))
       .get0();
 
-    auto plog = dynamic_cast<storage::disk_log_impl*>(log.value()->get_impl());
+    auto plog = dynamic_cast<storage::disk_log_impl*>(log.value().get());
 
     auto seg = plog->segments().begin();
 

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -972,7 +972,8 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
     auto start_offset = model::offset{0};
 
     auto get_next_upload = [&]() {
-        auto last_stable_offset = log->offsets().dirty_offset + model::offset{1};
+        auto last_stable_offset = log->offsets().dirty_offset
+                                  + model::offset{1};
         auto ret = policy
                      .get_next_candidate(
                        start_offset,

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -80,7 +80,7 @@ static void log_segment(const storage::segment& s) {
 
 static void log_segment_set(storage::log_manager& lm) {
     auto log = lm.get(manifest_ntp);
-    auto plog = dynamic_cast<const storage::disk_log_impl*>(log.value().get());
+    auto plog = dynamic_cast<const storage::disk_log_impl*>(log.get());
     BOOST_REQUIRE(plog != nullptr);
     const auto& sset = plog->segments();
     for (const auto& s : sset) {
@@ -838,7 +838,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     auto upload1
       = policy
           .get_next_candidate(
-            model::offset(0), lso, *log, tr, segment_read_lock_timeout)
+            model::offset(0), lso, log, tr, segment_read_lock_timeout)
           .get()
           .candidate;
     log_upload_candidate(upload1);
@@ -851,7 +851,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
                    + model::offset(1);
     auto upload2 = policy
                      .get_next_candidate(
-                       start_offset, lso, *log, tr, segment_read_lock_timeout)
+                       start_offset, lso, log, tr, segment_read_lock_timeout)
                      .get()
                      .candidate;
     log_upload_candidate(upload2);
@@ -865,7 +865,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
                    + model::offset(1);
     auto upload3 = policy
                      .get_next_candidate(
-                       start_offset, lso, *log, tr, segment_read_lock_timeout)
+                       start_offset, lso, log, tr, segment_read_lock_timeout)
                      .get()
                      .candidate;
     log_upload_candidate(upload3);
@@ -879,7 +879,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
                    + model::offset(1);
     auto upload4 = policy
                      .get_next_candidate(
-                       start_offset, lso, *log, tr, segment_read_lock_timeout)
+                       start_offset, lso, log, tr, segment_read_lock_timeout)
                      .get()
                      .candidate;
     BOOST_REQUIRE(upload4.sources.empty());
@@ -887,7 +887,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     start_offset = lso + model::offset(1);
     auto upload5 = policy
                      .get_next_candidate(
-                       start_offset, lso, *log, tr, segment_read_lock_timeout)
+                       start_offset, lso, log, tr, segment_read_lock_timeout)
                      .get()
                      .candidate;
     BOOST_REQUIRE(upload5.sources.empty());
@@ -914,7 +914,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE(log);
 
     ss::abort_source as{};
-    log.value()
+    log
       ->housekeeping(storage::housekeeping_config(
         model::timestamp::now(),
         std::nullopt,
@@ -923,7 +923,7 @@ FIXTURE_TEST(
         as))
       .get0();
 
-    auto plog = dynamic_cast<storage::disk_log_impl*>(log.value().get());
+    auto plog = dynamic_cast<storage::disk_log_impl*>(log.get());
 
     auto seg = plog->segments().begin();
 
@@ -936,7 +936,7 @@ FIXTURE_TEST(
                        .get_next_candidate(
                          model::offset(0),
                          lso,
-                         *log,
+                         log,
                          *partition->get_offset_translator_state(),
                          segment_read_lock_timeout)
                        .get()
@@ -1552,7 +1552,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     // Starting offset is lower than offset1
     auto upload1 = policy
                      .get_next_candidate(
-                       start_offset, lso, *log, tr, segment_read_lock_timeout)
+                       start_offset, lso, log, tr, segment_read_lock_timeout)
                      .get()
                      .candidate;
     log_upload_candidate(upload1);
@@ -1563,7 +1563,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
                    + model::offset(1);
     auto upload2 = policy
                      .get_next_candidate(
-                       start_offset, lso, *log, tr, segment_read_lock_timeout)
+                       start_offset, lso, log, tr, segment_read_lock_timeout)
                      .get()
                      .candidate;
     log_upload_candidate(upload2);
@@ -1577,7 +1577,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
                    + model::offset(1);
     auto upload3 = policy
                      .get_next_candidate(
-                       start_offset, lso, *log, tr, segment_read_lock_timeout)
+                       start_offset, lso, log, tr, segment_read_lock_timeout)
                      .get()
                      .candidate;
     log_upload_candidate(upload3);
@@ -1591,7 +1591,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
                    + model::offset(1);
     auto upload4 = policy
                      .get_next_candidate(
-                       start_offset, lso, *log, tr, segment_read_lock_timeout)
+                       start_offset, lso, log, tr, segment_read_lock_timeout)
                      .get()
                      .candidate;
     BOOST_REQUIRE(upload4.sources.empty());

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -321,8 +321,7 @@ segment_matcher<Fixture>::list_segments(const model::ntp& ntp) {
     std::vector<ss::lw_shared_ptr<storage::segment>> result;
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.get());
-        dlog) {
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.get()); dlog) {
         std::copy_if(
           dlog->segments().begin(),
           dlog->segments().end(),
@@ -339,8 +338,7 @@ ss::lw_shared_ptr<storage::segment> segment_matcher<Fixture>::get_segment(
   const model::ntp& ntp, const archival::segment_name& name) {
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.get());
-        dlog) {
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.get()); dlog) {
         for (const auto& s : dlog->segments()) {
             if (
               !s->has_appender()

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -306,7 +306,7 @@ void archiver_fixture::initialize_shard(
             {nm->broker})
           .get();
         BOOST_CHECK_EQUAL(
-          api.log_mgr().get(ntp.first).value()->segment_count(), ntp.second);
+          api.log_mgr().get(ntp.first)->segment_count(), ntp.second);
 
         vlog(fixt_log.trace, "storage log {}", *api.log_mgr().get(ntp.first));
     }
@@ -321,7 +321,7 @@ segment_matcher<Fixture>::list_segments(const model::ntp& ntp) {
     std::vector<ss::lw_shared_ptr<storage::segment>> result;
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.value().get());
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.get());
         dlog) {
         std::copy_if(
           dlog->segments().begin(),
@@ -339,7 +339,7 @@ ss::lw_shared_ptr<storage::segment> segment_matcher<Fixture>::get_segment(
   const model::ntp& ntp, const archival::segment_name& name) {
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.value().get());
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.get());
         dlog) {
         for (const auto& s : dlog->segments()) {
             if (

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -306,7 +306,7 @@ void archiver_fixture::initialize_shard(
             {nm->broker})
           .get();
         BOOST_CHECK_EQUAL(
-          api.log_mgr().get(ntp.first)->segment_count(), ntp.second);
+          api.log_mgr().get(ntp.first).value()->segment_count(), ntp.second);
 
         vlog(fixt_log.trace, "storage log {}", *api.log_mgr().get(ntp.first));
     }
@@ -321,7 +321,7 @@ segment_matcher<Fixture>::list_segments(const model::ntp& ntp) {
     std::vector<ss::lw_shared_ptr<storage::segment>> result;
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.value()->get_impl());
         dlog) {
         std::copy_if(
           dlog->segments().begin(),
@@ -339,7 +339,7 @@ ss::lw_shared_ptr<storage::segment> segment_matcher<Fixture>::get_segment(
   const model::ntp& ntp, const archival::segment_name& name) {
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.value()->get_impl());
         dlog) {
         for (const auto& s : dlog->segments()) {
             if (

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -321,7 +321,7 @@ segment_matcher<Fixture>::list_segments(const model::ntp& ntp) {
     std::vector<ss::lw_shared_ptr<storage::segment>> result;
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.value()->get_impl());
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.value().get());
         dlog) {
         std::copy_if(
           dlog->segments().begin(),
@@ -339,7 +339,7 @@ ss::lw_shared_ptr<storage::segment> segment_matcher<Fixture>::get_segment(
   const model::ntp& ntp, const archival::segment_name& name) {
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.value()->get_impl());
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.value().get());
         dlog) {
         for (const auto& s : dlog->segments()) {
             if (

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -60,8 +60,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
     // Do some sanity checks that our partition looks the way we expect (has a
     // log, archiver, etc).
     auto partition = app.partition_manager.local().get(ntp);
-    auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log().get());
+    auto* log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
     auto& archiver = partition->archiver().value().get();
     BOOST_REQUIRE(archiver.sync_for_tests().get());
 
@@ -128,8 +127,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
     // Do some sanity checks that our partition looks the way we expect (has a
     // log, archiver, etc).
     auto partition = app.partition_manager.local().get(ntp);
-    auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log().get());
+    auto* log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
     auto archiver_ref = partition->archiver();
     BOOST_REQUIRE(archiver_ref.has_value());
     auto& archiver = archiver_ref.value().get();
@@ -379,8 +377,7 @@ public:
         add_topic({model::kafka_namespace, topic_name}, 1, props).get();
         wait_for_leader(ntp).get();
         partition = app.partition_manager.local().get(ntp).get();
-        log = dynamic_cast<storage::disk_log_impl*>(
-          partition->log().get());
+        log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
         archiver = &partition->archiver()->get();
     }
 

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -61,7 +61,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
     // log, archiver, etc).
     auto partition = app.partition_manager.local().get(ntp);
     auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log()->get_impl());
+      partition->log().get());
     auto& archiver = partition->archiver().value().get();
     BOOST_REQUIRE(archiver.sync_for_tests().get());
 
@@ -129,7 +129,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
     // log, archiver, etc).
     auto partition = app.partition_manager.local().get(ntp);
     auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log()->get_impl());
+      partition->log().get());
     auto archiver_ref = partition->archiver();
     BOOST_REQUIRE(archiver_ref.has_value());
     auto& archiver = archiver_ref.value().get();
@@ -380,7 +380,7 @@ public:
         wait_for_leader(ntp).get();
         partition = app.partition_manager.local().get(ntp).get();
         log = dynamic_cast<storage::disk_log_impl*>(
-          partition->log()->get_impl());
+          partition->log().get());
         archiver = &partition->archiver()->get();
     }
 

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -61,7 +61,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
     // log, archiver, etc).
     auto partition = app.partition_manager.local().get(ntp);
     auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log().get_impl());
+      partition->log()->get_impl());
     auto& archiver = partition->archiver().value().get();
     BOOST_REQUIRE(archiver.sync_for_tests().get());
 
@@ -78,7 +78,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
       log->stm_manager()->max_collectible_offset(),
       ss::default_priority_class(),
       as);
-    partition->log().housekeeping(housekeeping_conf).get();
+    partition->log()->housekeeping(housekeeping_conf).get();
     // NOTE: the storage layer only initially requests eviction; it relies on
     // Raft to write a snapshot and subsequently truncate.
     tests::cooperative_spin_wait_with_timeout(3s, [log] {
@@ -129,7 +129,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
     // log, archiver, etc).
     auto partition = app.partition_manager.local().get(ntp);
     auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log().get_impl());
+      partition->log()->get_impl());
     auto archiver_ref = partition->archiver();
     BOOST_REQUIRE(archiver_ref.has_value());
     auto& archiver = archiver_ref.value().get();
@@ -380,7 +380,7 @@ public:
         wait_for_leader(ntp).get();
         partition = app.partition_manager.local().get(ntp).get();
         log = dynamic_cast<storage::disk_log_impl*>(
-          partition->log().get_impl());
+          partition->log()->get_impl());
         archiver = &partition->archiver()->get();
     }
 

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -114,7 +114,7 @@ public:
         wait_for_leader(ntp).get();
         partition = app.partition_manager.local().get(ntp).get();
         log = dynamic_cast<storage::disk_log_impl*>(
-          partition->log().get_impl());
+          partition->log()->get_impl());
         auto archiver_ref = partition->archiver();
         BOOST_REQUIRE(archiver_ref.has_value());
         archiver = &archiver_ref.value().get();

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -114,7 +114,7 @@ public:
         wait_for_leader(ntp).get();
         partition = app.partition_manager.local().get(ntp).get();
         log = dynamic_cast<storage::disk_log_impl*>(
-          partition->log()->get_impl());
+          partition->log().get());
         auto archiver_ref = partition->archiver();
         BOOST_REQUIRE(archiver_ref.has_value());
         archiver = &archiver_ref.value().get();

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -113,8 +113,7 @@ public:
         add_topic({model::kafka_namespace, topic_name}, 1, props).get();
         wait_for_leader(ntp).get();
         partition = app.partition_manager.local().get(ntp).get();
-        log = dynamic_cast<storage::disk_log_impl*>(
-          partition->log().get());
+        log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
         auto archiver_ref = partition->archiver();
         BOOST_REQUIRE(archiver_ref.has_value());
         archiver = &archiver_ref.value().get();

--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -61,7 +61,7 @@ public:
     ss::future<int> produce() {
         co_await _producer.start();
         auto* log = dynamic_cast<storage::disk_log_impl*>(
-          _partition.log()->get_impl());
+          _partition.log().get());
         auto& archiver = _partition.archiver().value().get();
 
         size_t total_records = 0;

--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -61,7 +61,7 @@ public:
     ss::future<int> produce() {
         co_await _producer.start();
         auto* log = dynamic_cast<storage::disk_log_impl*>(
-          _partition.log().get_impl());
+          _partition.log()->get_impl());
         auto& archiver = _partition.archiver().value().get();
 
         size_t total_records = 0;

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -479,10 +479,10 @@ partition_raft_state get_partition_raft_state(consensus_ptr ptr) {
 
 std::vector<partition_stm_state> get_partition_stm_state(consensus_ptr ptr) {
     std::vector<partition_stm_state> result;
-    if (unlikely(!ptr) || unlikely(!ptr->log().stm_manager())) {
+    if (unlikely(!ptr) || unlikely(!ptr->log()->stm_manager())) {
         return result;
     }
-    const auto& stms = ptr->log().stm_manager()->stms();
+    const auto& stms = ptr->log()->stm_manager()->stms();
     result.reserve(stms.size());
     for (const auto& stm : stms) {
         partition_stm_state state;

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -323,7 +323,7 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
           return _stm.invoke_on(controller_stm_shard, &controller_stm::start);
       })
       .then([this, &as = shard0_as] {
-          auto disk_dirty_offset = _raft0->log().offsets().dirty_offset;
+          auto disk_dirty_offset = _raft0->log()->offsets().dirty_offset;
 
           return _stm
             .invoke_on(

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -93,7 +93,7 @@ ss::future<> log_eviction_stm::handle_log_eviction_events() {
             previous_iter_truncated_everything = true;
             continue;
         }
-        auto truncation_point = _raft->log().index_lower_bound(evict_until);
+        auto truncation_point = _raft->log()->index_lower_bound(evict_until);
         if (!truncation_point) {
             vlog(
               _log.warn,
@@ -172,10 +172,10 @@ log_eviction_stm::do_write_raft_snapshot(model::offset truncation_point) {
     co_await _raft->visible_offset_monitor().wait(
       truncation_point, model::no_timeout, _as);
     co_await _raft->refresh_commit_index();
-    co_await _raft->log().stm_manager()->ensure_snapshot_exists(
+    co_await _raft->log()->stm_manager()->ensure_snapshot_exists(
       truncation_point);
     const auto max_collectible_offset
-      = _raft->log().stm_manager()->max_collectible_offset();
+      = _raft->log()->stm_manager()->max_collectible_offset();
     if (truncation_point > max_collectible_offset) {
         truncation_point = max_collectible_offset;
         if (truncation_point <= _raft->last_snapshot_index()) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -182,7 +182,7 @@ public:
     model::term_id term() { return _raft->term(); }
 
     model::offset dirty_offset() const {
-        return _raft->log().offsets().dirty_offset;
+        return _raft->log()->offsets().dirty_offset;
     }
 
     /// Return the offset up to which the storage layer would like to
@@ -199,7 +199,7 @@ public:
 
     const model::ntp& ntp() const { return _raft->ntp(); }
 
-    storage::log log() const { return _raft->log(); }
+    ss::shared_ptr<storage::log> log() const { return _raft->log(); }
 
     ss::shared_ptr<const cloud_storage::remote_partition>
     remote_partition() const {
@@ -273,14 +273,14 @@ public:
 
     ss::shared_ptr<cluster::rm_stm> rm_stm();
 
-    size_t size_bytes() const { return _raft->log().size_bytes(); }
+    size_t size_bytes() const { return _raft->log()->size_bytes(); }
 
     uint64_t non_log_disk_size_bytes() const;
 
     ss::future<> update_configuration(topic_properties);
 
     const storage::ntp_config& get_ntp_config() const {
-        return _raft->log().config();
+        return _raft->log()->config();
     }
 
     ss::shared_ptr<cluster::tm_stm> tm_stm() { return _tm_stm; }

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -208,15 +208,15 @@ ss::future<consensus_ptr> partition_manager::manage(
               ntp_cfg, manifest, max_offset);
         }
     }
-    storage::log log = co_await _storage.log_mgr().manage(std::move(ntp_cfg));
+    auto log = co_await _storage.log_mgr().manage(std::move(ntp_cfg));
     vlog(
       clusterlog.debug,
       "Log created manage completed, ntp: {}, rev: {}, {} "
       "segments, {} bytes",
-      log.config().ntp(),
-      log.config().get_revision(),
-      log.segment_count(),
-      log.size_bytes());
+      log->config().ntp(),
+      log->config().get_revision(),
+      log->segment_count(),
+      log->size_bytes());
 
     ss::lw_shared_ptr<raft::consensus> c
       = co_await _raft_manager.local().create_group(
@@ -239,7 +239,7 @@ ss::future<consensus_ptr> partition_manager::manage(
       _max_concurrent_producer_ids,
       read_replica_bucket);
 
-    _ntp_table.emplace(log.config().ntp(), p);
+    _ntp_table.emplace(log->config().ntp(), p);
     _raft_table.emplace(group, p);
 
     /*

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -460,9 +460,9 @@ persisted_stm<T>::sync(model::timeout_clock::duration timeout) {
     // committed index, so we won't need any additional flushes even if the
     // client produces with acks=1.
     model::offset sync_offset;
-    auto log_offsets = _c->log().offsets();
+    auto log_offsets = _c->log()->offsets();
     if (log_offsets.dirty_offset_term == term) {
-        auto last_term_start_offset = _c->log().find_last_term_start_offset();
+        auto last_term_start_offset = _c->log()->find_last_term_start_offset();
         if (last_term_start_offset > model::offset{0}) {
             sync_offset = last_term_start_offset - model::offset{1};
         } else {

--- a/src/v/cluster/tests/eviction_stm_test.cc
+++ b/src/v/cluster/tests/eviction_stm_test.cc
@@ -67,7 +67,7 @@ FIXTURE_TEST(test_eviction_stm_deadlock, raft_test_fixture) {
 
     /// Publish records and open new segments
     auto* impl = dynamic_cast<storage::disk_log_impl*>(
-      leader_raft->log()->get_impl());
+      leader_raft->log().get());
     std::vector<storage::offset_stats> offsets;
     for (auto i = 0; i < 5; ++i) {
         replicate_random_batches(gr, 20).get0();

--- a/src/v/cluster/tests/eviction_stm_test.cc
+++ b/src/v/cluster/tests/eviction_stm_test.cc
@@ -67,7 +67,7 @@ FIXTURE_TEST(test_eviction_stm_deadlock, raft_test_fixture) {
 
     /// Publish records and open new segments
     auto* impl = dynamic_cast<storage::disk_log_impl*>(
-      leader_raft->log().get_impl());
+      leader_raft->log()->get_impl());
     std::vector<storage::offset_stats> offsets;
     for (auto i = 0; i < 5; ++i) {
         replicate_random_batches(gr, 20).get0();

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -611,8 +611,7 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
 
     auto log = _storage.local().log_mgr().get(_raft->ntp());
     BOOST_REQUIRE(log);
-    auto* disk_log = dynamic_cast<storage::disk_log_impl*>(
-      log.get());
+    auto* disk_log = dynamic_cast<storage::disk_log_impl*>(log.get());
 
     static int64_t pid_counter = 0;
     const auto tx_seq = model::tx_seq(0);

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -612,7 +612,7 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
     auto log = _storage.local().log_mgr().get(_raft->ntp());
     BOOST_REQUIRE(log);
     auto* disk_log = dynamic_cast<storage::disk_log_impl*>(
-      log.value().get());
+      log.get());
 
     static int64_t pid_counter = 0;
     const auto tx_seq = model::tx_seq(0);

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -612,7 +612,7 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
     auto log = _storage.local().log_mgr().get(_raft->ntp());
     BOOST_REQUIRE(log);
     auto* disk_log = dynamic_cast<storage::disk_log_impl*>(
-      log.value()->get_impl());
+      log.value().get());
 
     static int64_t pid_counter = 0;
     const auto tx_seq = model::tx_seq(0);

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -612,7 +612,7 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
     auto log = _storage.local().log_mgr().get(_raft->ntp());
     BOOST_REQUIRE(log);
     auto* disk_log = dynamic_cast<storage::disk_log_impl*>(
-      log.value().get_impl());
+      log.value()->get_impl());
 
     static int64_t pid_counter = 0;
     const auto tx_seq = model::tx_seq(0);

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -44,7 +44,7 @@ using cluster::random_tx_generator;
     wait_for_confirmed_leader();                                               \
     wait_for_meta_initialized();                                               \
     auto log = _storage.local().log_mgr().get(_raft->ntp());                   \
-    log.value()->stm_manager()->add_stm(stm);                                          \
+    log->stm_manager()->add_stm(stm);                                          \
     BOOST_REQUIRE(log);
 
 storage::disk_log_impl* get_disk_log(ss::shared_ptr<storage::log> log) {
@@ -74,7 +74,7 @@ FIXTURE_TEST(test_tx_compaction_combinations, mux_state_machine_fixture) {
                         STM_BOOTSTRAP();
                         vlog(test_logger.info, "Running spec: {}", spec);
                         random_tx_generator{}.run_workload(
-                          spec, _raft->term(), stm, get_disk_log(log.value()));
+                          spec, _raft->term(), stm, get_disk_log(log));
                         vlog(test_logger.info, "Finished spec: {}", spec);
                     }
                 }

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -44,11 +44,11 @@ using cluster::random_tx_generator;
     wait_for_confirmed_leader();                                               \
     wait_for_meta_initialized();                                               \
     auto log = _storage.local().log_mgr().get(_raft->ntp());                   \
-    log->stm_manager()->add_stm(stm);                                          \
+    log.value()->stm_manager()->add_stm(stm);                                          \
     BOOST_REQUIRE(log);
 
-storage::disk_log_impl* get_disk_log(storage::log& log) {
-    return dynamic_cast<storage::disk_log_impl*>(log.get_impl());
+storage::disk_log_impl* get_disk_log(ss::shared_ptr<storage::log> log) {
+    return dynamic_cast<storage::disk_log_impl*>(log->get_impl());
 }
 
 FIXTURE_TEST(test_tx_compaction_combinations, mux_state_machine_fixture) {

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -48,7 +48,7 @@ using cluster::random_tx_generator;
     BOOST_REQUIRE(log);
 
 storage::disk_log_impl* get_disk_log(ss::shared_ptr<storage::log> log) {
-    return dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+    return dynamic_cast<storage::disk_log_impl*>(log.get());
 }
 
 FIXTURE_TEST(test_tx_compaction_combinations, mux_state_machine_fixture) {

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -607,7 +607,7 @@ FIXTURE_TEST(test_offset_for_leader_epoch, prod_consume_fixture) {
             auto partition = mgr.get(ntp);
             storage::truncate_prefix_config cfg(
               model::offset(1), ss::default_priority_class());
-            partition->log().truncate_prefix(cfg).get();
+            partition->log()->truncate_prefix(cfg).get();
         })
       .get();
 
@@ -648,7 +648,7 @@ FIXTURE_TEST(test_offset_for_leader_epoch, prod_consume_fixture) {
             *shard,
             [ntp](cluster::partition_manager& mgr) {
                 auto partition = mgr.get(ntp);
-                auto start_offset = partition->log().offsets().start_offset;
+                auto start_offset = partition->log()->offsets().start_offset;
                 return partition->get_offset_translator_state()
                   ->from_log_offset(start_offset);
             })
@@ -664,7 +664,7 @@ FIXTURE_TEST(test_basic_delete_around_batch, prod_consume_fixture) {
     const model::ntp ntp(tp_ns.ns, tp_ns.tp, pid);
     auto partition = app.partition_manager.local().get(ntp);
     auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log().get_impl());
+      partition->log()->get_impl());
 
     tests::kafka_produce_transport producer(make_kafka_client().get());
     producer.start().get();

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -663,8 +663,7 @@ FIXTURE_TEST(test_basic_delete_around_batch, prod_consume_fixture) {
     const model::partition_id pid(0);
     const model::ntp ntp(tp_ns.ns, tp_ns.tp, pid);
     auto partition = app.partition_manager.local().get(ntp);
-    auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log().get());
+    auto* log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
 
     tests::kafka_produce_transport producer(make_kafka_client().get());
     producer.start().get();

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -664,7 +664,7 @@ FIXTURE_TEST(test_basic_delete_around_batch, prod_consume_fixture) {
     const model::ntp ntp(tp_ns.ns, tp_ns.tp, pid);
     auto partition = app.partition_manager.local().get(ntp);
     auto* log = dynamic_cast<storage::disk_log_impl*>(
-      partition->log()->get_impl());
+      partition->log().get());
 
     tests::kafka_produce_transport producer(make_kafka_client().get());
     producer.start().get();

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -143,7 +143,9 @@ share_n(model::record_batch_reader&& r, std::size_t ncopies) {
 }
 
 ss::future<configuration_bootstrap_state> read_bootstrap_state(
-  ss::shared_ptr<storage::log> log, model::offset start_offset, ss::abort_source& as) {
+  ss::shared_ptr<storage::log> log,
+  model::offset start_offset,
+  ss::abort_source& as) {
     // TODO(agallego, michal) - iterate the log in reverse
     // as an optimization
     auto lstats = log->offsets();

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -143,14 +143,14 @@ share_n(model::record_batch_reader&& r, std::size_t ncopies) {
 }
 
 ss::future<configuration_bootstrap_state> read_bootstrap_state(
-  storage::log log, model::offset start_offset, ss::abort_source& as) {
+  ss::shared_ptr<storage::log> log, model::offset start_offset, ss::abort_source& as) {
     // TODO(agallego, michal) - iterate the log in reverse
     // as an optimization
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     auto rcfg = storage::log_reader_config(
       start_offset, lstats.dirty_offset, raft_priority(), as);
     auto cfg_state = std::make_unique<configuration_bootstrap_state>();
-    return log.make_reader(rcfg).then(
+    return log->make_reader(rcfg).then(
       [state = std::move(cfg_state)](
         model::record_batch_reader reader) mutable {
           auto raw = state.get();

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -44,8 +44,8 @@ model::record_batch_reader serialize_configuration(group_configuration cfg);
 
 /// returns a fully parsed config state from a given storage log, starting at
 /// given offset
-ss::future<raft::configuration_bootstrap_state>
-read_bootstrap_state(ss::shared_ptr<storage::log>, model::offset, ss::abort_source&);
+ss::future<raft::configuration_bootstrap_state> read_bootstrap_state(
+  ss::shared_ptr<storage::log>, model::offset, ss::abort_source&);
 
 ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
   model::offset, ss::circular_buffer<model::record_batch>&&);

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -45,7 +45,7 @@ model::record_batch_reader serialize_configuration(group_configuration cfg);
 /// returns a fully parsed config state from a given storage log, starting at
 /// given offset
 ss::future<raft::configuration_bootstrap_state>
-read_bootstrap_state(storage::log, model::offset, ss::abort_source&);
+read_bootstrap_state(ss::shared_ptr<storage::log>, model::offset, ss::abort_source&);
 
 ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
   model::offset, ss::circular_buffer<model::record_batch>&&);

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -80,10 +80,10 @@ ss::future<> group_manager::stop_heartbeats() { return _heartbeats.stop(); }
 ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
   raft::group_id id,
   std::vector<model::broker> nodes,
-  storage::log log,
+  ss::shared_ptr<storage::log> log,
   with_learner_recovery_throttle enable_learner_recovery_throttle,
   keep_snapshotted_log keep_snapshotted_log) {
-    auto revision = log.config().get_revision();
+    auto revision = log->config().get_revision();
     auto raft_cfg = create_initial_configuration(std::move(nodes), revision);
 
     auto raft = ss::make_lw_shared<raft::consensus>(

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -63,7 +63,7 @@ public:
     ss::future<ss::lw_shared_ptr<raft::consensus>> create_group(
       raft::group_id id,
       std::vector<model::broker> nodes,
-      storage::log log,
+      ss::shared_ptr<storage::log> log,
       with_learner_recovery_throttle enable_learner_recovery_throttle,
       keep_snapshotted_log = keep_snapshotted_log::no);
 

--- a/src/v/raft/offset_translator.h
+++ b/src/v/raft/offset_translator.h
@@ -71,7 +71,7 @@ public:
 
     /// Searches for non-data batches up to the tip of the log. After this
     /// method succeeds, offset translator is usable.
-    ss::future<> sync_with_log(storage::log, storage::opt_abort_source_t);
+    ss::future<> sync_with_log(ss::shared_ptr<storage::log>, storage::opt_abort_source_t);
 
     /// Process the batch and add it to offset translation state if it is not
     /// a data batch.

--- a/src/v/raft/offset_translator.h
+++ b/src/v/raft/offset_translator.h
@@ -71,7 +71,8 @@ public:
 
     /// Searches for non-data batches up to the tip of the log. After this
     /// method succeeds, offset translator is usable.
-    ss::future<> sync_with_log(ss::shared_ptr<storage::log>, storage::opt_abort_source_t);
+    ss::future<>
+      sync_with_log(ss::shared_ptr<storage::log>, storage::opt_abort_source_t);
 
     /// Process the batch and add it to offset translation state if it is not
     /// a data batch.

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -155,7 +155,7 @@ ss::future<bool> prevote_stm::prevote(bool leadership_transfer) {
           _config->for_each_voter(
             [this](vnode id) { _replies.emplace(id, vmeta{}); });
 
-          auto lstats = _ptr->_log.offsets();
+          auto lstats = _ptr->_log->offsets();
           auto last_entry_term = _ptr->get_last_entry_term(lstats);
 
           _req = vote_request{

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -348,7 +348,7 @@ replicate_entries_stm::wait_for_majority() {
         const auto truncated = _ptr->term() > appended_term
                                && current_committed_offset
                                     > _initial_committed_offset
-                               && _ptr->_log.get_term(appended_offset)
+                               && _ptr->_log->get_term(appended_offset)
                                     != appended_term;
 
         return committed || truncated;
@@ -384,7 +384,7 @@ result<replicate_result> replicate_entries_stm::process_result(
     // if term has changed we have to check if entry was
     // replicated
     if (unlikely(appended_term != _ptr->term())) {
-        const auto current_term = _ptr->_log.get_term(appended_offset);
+        const auto current_term = _ptr->_log->get_term(appended_offset);
         if (current_term != appended_term) {
             vlog(
               _ctxlog.debug,

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -455,7 +455,7 @@ FIXTURE_TEST(test_compacted_log_recovery, raft_test_fixture) {
     batch = model::test::make_random_batch(model::offset(68), 11, false);
     batch.set_term(model::term_id(2));
     builder.add_batch(std::move(batch)).get0();
-    builder.get_log().flush().get0();
+    builder.get_log()->flush().get0();
     builder.stop().get0();
 
     gr.enable_all();

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -69,15 +69,15 @@ struct bootstrap_fixture : raft::simple_record_fixture {
           model::no_timeout};
         std::vector<storage::append_result> res;
         res.push_back(datas(n)
-                        .for_each_ref(get_log().make_appender(cfg), cfg.timeout)
+                        .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
                         .get0());
         res.push_back(configs(n)
-                        .for_each_ref(get_log().make_appender(cfg), cfg.timeout)
+                        .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
                         .get0());
-        get_log().flush().get();
+        get_log()->flush().get();
         return res;
     }
-    storage::log get_log() { return _storage.log_mgr().get(_ntp).value(); }
+    ss::shared_ptr<storage::log> get_log() { return _storage.log_mgr().get(_ntp).value(); }
 
     ~bootstrap_fixture() {
         _storage.stop().get();

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -77,7 +77,7 @@ struct bootstrap_fixture : raft::simple_record_fixture {
         get_log()->flush().get();
         return res;
     }
-    ss::shared_ptr<storage::log> get_log() { return _storage.log_mgr().get(_ntp).value(); }
+    ss::shared_ptr<storage::log> get_log() { return _storage.log_mgr().get(_ntp); }
 
     ~bootstrap_fixture() {
         _storage.stop().get();

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -68,16 +68,20 @@ struct bootstrap_fixture : raft::simple_record_fixture {
           ss::default_priority_class(),
           model::no_timeout};
         std::vector<storage::append_result> res;
-        res.push_back(datas(n)
-                        .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
-                        .get0());
-        res.push_back(configs(n)
-                        .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
-                        .get0());
+        res.push_back(
+          datas(n)
+            .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
+            .get0());
+        res.push_back(
+          configs(n)
+            .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
+            .get0());
         get_log()->flush().get();
         return res;
     }
-    ss::shared_ptr<storage::log> get_log() { return _storage.log_mgr().get(_ntp); }
+    ss::shared_ptr<storage::log> get_log() {
+        return _storage.log_mgr().get(_ntp);
+    }
 
     ~bootstrap_fixture() {
         _storage.stop().get();

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -142,7 +142,7 @@ struct foreign_entry_fixture {
     ss::logger _test_logger{"foreign-test-logger"};
     ss::sharded<features::feature_table> _feature_table;
     storage::api _storage;
-    ss::shared_ptr<storage::log> get_log() { return _storage.log_mgr().get(_ntp).value(); }
+    ss::shared_ptr<storage::log> get_log() { return _storage.log_mgr().get(_ntp); }
     model::ntp _ntp{
       model::ns("test.bootstrap." + random_generators::gen_alphanum_string(8)),
       model::topic(random_generators::gen_alphanum_string(6)),

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -80,12 +80,12 @@ struct foreign_entry_fixture {
           model::no_timeout};
         std::vector<storage::append_result> res;
         res.push_back(gen_data_record_batch_reader(n)
-                        .for_each_ref(get_log().make_appender(cfg), cfg.timeout)
+                        .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
                         .get0());
         res.push_back(gen_config_record_batch_reader(n)
-                        .for_each_ref(get_log().make_appender(cfg), cfg.timeout)
+                        .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
                         .get0());
-        get_log().flush().get();
+        get_log()->flush().get();
         return res;
     }
     template<typename Func>
@@ -142,7 +142,7 @@ struct foreign_entry_fixture {
     ss::logger _test_logger{"foreign-test-logger"};
     ss::sharded<features::feature_table> _feature_table;
     storage::api _storage;
-    storage::log get_log() { return _storage.log_mgr().get(_ntp).value(); }
+    ss::shared_ptr<storage::log> get_log() { return _storage.log_mgr().get(_ntp).value(); }
     model::ntp _ntp{
       model::ns("test.bootstrap." + random_generators::gen_alphanum_string(8)),
       model::topic(random_generators::gen_alphanum_string(6)),

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -79,12 +79,14 @@ struct foreign_entry_fixture {
           ss::default_priority_class(),
           model::no_timeout};
         std::vector<storage::append_result> res;
-        res.push_back(gen_data_record_batch_reader(n)
-                        .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
-                        .get0());
-        res.push_back(gen_config_record_batch_reader(n)
-                        .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
-                        .get0());
+        res.push_back(
+          gen_data_record_batch_reader(n)
+            .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
+            .get0());
+        res.push_back(
+          gen_config_record_batch_reader(n)
+            .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
+            .get0());
         get_log()->flush().get();
         return res;
     }
@@ -142,7 +144,9 @@ struct foreign_entry_fixture {
     ss::logger _test_logger{"foreign-test-logger"};
     ss::sharded<features::feature_table> _feature_table;
     storage::api _storage;
-    ss::shared_ptr<storage::log> get_log() { return _storage.log_mgr().get(_ntp); }
+    ss::shared_ptr<storage::log> get_log() {
+        return _storage.log_mgr().get(_ntp);
+    }
     model::ntp _ntp{
       model::ns("test.bootstrap." + random_generators::gen_alphanum_string(8)),
       model::topic(random_generators::gen_alphanum_string(6)),

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -110,7 +110,7 @@ struct mux_state_machine_fixture {
                     _data_dir,
                     std::make_unique<storage::ntp_config::default_overrides>(
                       overrides)))
-                  .then([this](storage::log&& log) mutable {
+                  .then([this](ss::shared_ptr<storage::log> log) mutable {
                       auto group = raft::group_id(0);
                       return _group_mgr.local()
                         .create_group(

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -144,8 +144,8 @@ struct raft_node {
           std::make_unique<storage::ntp_config::default_overrides>(
             std::move(overrides)));
 
-        log = std::make_unique<storage::log>(
-          storage.local().log_mgr().manage(std::move(ntp_cfg)).get0());
+        log =
+          storage.local().log_mgr().manage(std::move(ntp_cfg)).get0();
 
         recovery_throttle
           .start(
@@ -166,7 +166,7 @@ struct raft_node {
           gr_id,
           std::move(cfg),
           std::move(jit),
-          *log,
+          log,
           raft::scheduling_config(
             seastar::default_scheduling_group(),
             seastar::default_priority_class()),
@@ -279,7 +279,7 @@ struct raft_node {
           })
           .then([this] {
               tstlog.info("Stopping storage at node {}", broker.id());
-              log.reset();
+              log = nullptr;
               return storage.stop();
           })
           .then([this] { return feature_table.stop(); })
@@ -343,7 +343,7 @@ struct raft_node {
     model::broker broker;
     ss::sharded<storage::api> storage;
     ss::sharded<raft::coordinated_recovery_throttle> recovery_throttle;
-    std::unique_ptr<storage::log> log;
+    ss::shared_ptr<storage::log> log;
     ss::sharded<ss::abort_source> as_service;
     ss::sharded<rpc::connection_cache> cache;
     ss::sharded<rpc::rpc_server> server;

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -144,8 +144,7 @@ struct raft_node {
           std::make_unique<storage::ntp_config::default_overrides>(
             std::move(overrides)));
 
-        log =
-          storage.local().log_mgr().manage(std::move(ntp_cfg)).get0();
+        log = storage.local().log_mgr().manage(std::move(ntp_cfg)).get0();
 
         recovery_throttle
           .start(

--- a/src/v/raft/tests/state_removal_test.cc
+++ b/src/v/raft/tests/state_removal_test.cc
@@ -69,7 +69,7 @@ void stop_node(raft_node& node) {
     node.hbeats->stop().get0();
     node.hbeats.reset();
     node.cache.stop().get0();
-    node.log.reset();
+    node.log = nullptr;
     node.storage.stop().get0();
     node.feature_table.stop().get0();
     node.as_service.stop().get();

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -119,7 +119,7 @@ ss::future<> vote_stm::vote(bool leadership_transfer) {
           // vote is the only method under _op_sem
           _config->for_each_voter(
             [this](vnode id) { _replies.emplace(id, vmeta{}); });
-          auto lstats = _ptr->_log.offsets();
+          auto lstats = _ptr->_log->offsets();
           auto last_entry_term = _ptr->get_last_entry_term(lstats);
 
           _req = vote_request{

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -272,7 +272,7 @@ eviction_policy::collect_reclaimable_offsets() {
     fragmented_vector<partition> res;
     co_await ss::max_concurrent_for_each(
       partitions.begin(), partitions.end(), 20, [&res, cfg](const auto& p) {
-          auto log = dynamic_cast<storage::disk_log_impl*>(p->log()->get_impl());
+          auto log = dynamic_cast<storage::disk_log_impl*>(p->log().get());
           return log->get_reclaimable_offsets(cfg)
             .then([&res, group = p->group()](auto offsets) {
                 res.push_back({
@@ -331,7 +331,7 @@ ss::future<size_t> eviction_policy::install_schedule(shard_partitions shard) {
             }
 
             auto log = dynamic_cast<storage::disk_log_impl*>(
-              p->log()->get_impl());
+              p->log().get());
             log->set_cloud_gc_offset(partition.decision.value());
             ++decisions;
 

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -330,8 +330,7 @@ ss::future<size_t> eviction_policy::install_schedule(shard_partitions shard) {
                 continue;
             }
 
-            auto log = dynamic_cast<storage::disk_log_impl*>(
-              p->log().get());
+            auto log = dynamic_cast<storage::disk_log_impl*>(p->log().get());
             log->set_cloud_gc_offset(partition.decision.value());
             ++decisions;
 

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -272,7 +272,7 @@ eviction_policy::collect_reclaimable_offsets() {
     fragmented_vector<partition> res;
     co_await ss::max_concurrent_for_each(
       partitions.begin(), partitions.end(), 20, [&res, cfg](const auto& p) {
-          auto log = dynamic_cast<storage::disk_log_impl*>(p->log().get_impl());
+          auto log = dynamic_cast<storage::disk_log_impl*>(p->log()->get_impl());
           return log->get_reclaimable_offsets(cfg)
             .then([&res, group = p->group()](auto offsets) {
                 res.push_back({
@@ -331,7 +331,7 @@ ss::future<size_t> eviction_policy::install_schedule(shard_partitions shard) {
             }
 
             auto log = dynamic_cast<storage::disk_log_impl*>(
-              p->log().get_impl());
+              p->log()->get_impl());
             log->set_cloud_gc_offset(partition.decision.value());
             ++decisions;
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1970,7 +1970,7 @@ std::ostream& operator<<(std::ostream& o, const disk_log_impl& d) {
     return d.print(o);
 }
 
-log make_disk_backed_log(
+ss::shared_ptr<log> make_disk_backed_log(
   ntp_config cfg,
   log_manager& manager,
   segment_set segs,
@@ -1978,7 +1978,7 @@ log make_disk_backed_log(
   ss::sharded<features::feature_table>& feature_table) {
     auto ptr = ss::make_shared<disk_log_impl>(
       std::move(cfg), manager, std::move(segs), kvstore, feature_table);
-    return log(ptr);
+    return ss::make_shared<log>(ptr);
 }
 
 /*

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -92,7 +92,7 @@ disk_log_impl::disk_log_impl(
   segment_set segs,
   kvstore& kvstore,
   ss::sharded<features::feature_table>& feature_table)
-  : log::impl(std::move(cfg))
+  : log(std::move(cfg))
   , _manager(manager)
   , _segment_size_jitter(
       internal::random_jitter(_manager.config().segment_size_jitter))
@@ -1976,9 +1976,8 @@ ss::shared_ptr<log> make_disk_backed_log(
   segment_set segs,
   kvstore& kvstore,
   ss::sharded<features::feature_table>& feature_table) {
-    auto ptr = ss::make_shared<disk_log_impl>(
+    return ss::make_shared<disk_log_impl>(
       std::move(cfg), manager, std::move(segs), kvstore, feature_table);
-    return ss::make_shared<log>(ptr);
 }
 
 /*

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -34,7 +34,7 @@
 
 namespace storage {
 
-class disk_log_impl final : public log::impl {
+class disk_log_impl final : public log {
 public:
     using failure_probes = storage::log_failure_probes;
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -61,7 +61,7 @@ public:
       kvstore&,
       ss::sharded<features::feature_table>& feature_table);
     ~disk_log_impl() override;
-    disk_log_impl(disk_log_impl&&) noexcept = default;
+    disk_log_impl(disk_log_impl&&) noexcept = delete;
     disk_log_impl& operator=(disk_log_impl&&) noexcept = delete;
     disk_log_impl(const disk_log_impl&) = delete;
     disk_log_impl& operator=(const disk_log_impl&) = delete;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -33,8 +33,8 @@ public:
         explicit log(ntp_config cfg) noexcept
           : _config(std::move(cfg))
           , _stm_manager(ss::make_lw_shared<storage::stm_manager>()) {}
-        log(log&&) noexcept = default;
-        log& operator=(log&&) noexcept = default;
+        log(log&&) noexcept = delete;
+        log& operator=(log&&) noexcept = delete;
         log(const log&) = delete;
         log& operator=(const log&) = delete;
         virtual ~log() noexcept = default;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -128,8 +128,6 @@ public:
 
         virtual int64_t compaction_backlog() const = 0;
 
-        log* get_impl() { return this; }
-
     private:
         ntp_config _config;
 

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -235,7 +235,7 @@ private:
 class log_manager;
 class segment_set;
 class kvstore;
-log make_disk_backed_log(
+ss::shared_ptr<log> make_disk_backed_log(
   ntp_config,
   log_manager&,
   segment_set,

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -30,115 +30,114 @@ namespace storage {
 
 class log {
 public:
-        explicit log(ntp_config cfg) noexcept
-          : _config(std::move(cfg))
-          , _stm_manager(ss::make_lw_shared<storage::stm_manager>()) {}
-        log(log&&) noexcept = delete;
-        log& operator=(log&&) noexcept = delete;
-        log(const log&) = delete;
-        log& operator=(const log&) = delete;
-        virtual ~log() noexcept = default;
+    explicit log(ntp_config cfg) noexcept
+      : _config(std::move(cfg))
+      , _stm_manager(ss::make_lw_shared<storage::stm_manager>()) {}
+    log(log&&) noexcept = delete;
+    log& operator=(log&&) noexcept = delete;
+    log(const log&) = delete;
+    log& operator=(const log&) = delete;
+    virtual ~log() noexcept = default;
 
-        // it shouldn't block for a long time as it will block other logs
-        // eviction
-        virtual ss::future<> housekeeping(housekeeping_config) = 0;
+    // it shouldn't block for a long time as it will block other logs
+    // eviction
+    virtual ss::future<> housekeeping(housekeeping_config) = 0;
 
-        /**
-         * \brief Truncate the suffix of log at a base offset
-         *
-         * Having a segment:
-         * segment: {[10,10][11,30][31,100][101,103]}
-         * Truncate at offset (31) will result in
-         * segment: {[10,10][11,30]}
-         * Truncating mid-batch is forbidden:
-         * Truncate at offset 35 will result in an exception.
-         */
-        virtual ss::future<> truncate(truncate_config) = 0;
+    /**
+     * \brief Truncate the suffix of log at a base offset
+     *
+     * Having a segment:
+     * segment: {[10,10][11,30][31,100][101,103]}
+     * Truncate at offset (31) will result in
+     * segment: {[10,10][11,30]}
+     * Truncating mid-batch is forbidden:
+     * Truncate at offset 35 will result in an exception.
+     */
+    virtual ss::future<> truncate(truncate_config) = 0;
 
-        /**
-         * \brief Truncate the prefix of a log at a base offset
-         *
-         * Having a segment:
-         * segment: {[10,10][11,30][31,100][101,103]}
-         * Truncate prefix at offset (31) will result in
-         * segment: {[31,100][101,103]}
-         * Truncate prefix mid-batch (at offset 35) will result in
-         * segment {[31, 100][101,103]}, but reported start_offset will be 35.
-         *
-         * The typical use case is installing a snapshot. In this case the snapshot
-         * covers a section of the log up to and including a position X (generally
-         * would be a batch's last offset). To prepare a log for a snapshot it would
-         * be prefix truncated at offset X+1, so that the next element in the log to
-         * be replayed against the snapshot is X+1.
-         */
-        virtual ss::future<> truncate_prefix(truncate_prefix_config) = 0;
-        virtual ss::future<> gc(gc_config) = 0;
+    /**
+     * \brief Truncate the prefix of a log at a base offset
+     *
+     * Having a segment:
+     * segment: {[10,10][11,30][31,100][101,103]}
+     * Truncate prefix at offset (31) will result in
+     * segment: {[31,100][101,103]}
+     * Truncate prefix mid-batch (at offset 35) will result in
+     * segment {[31, 100][101,103]}, but reported start_offset will be 35.
+     *
+     * The typical use case is installing a snapshot. In this case the snapshot
+     * covers a section of the log up to and including a position X (generally
+     * would be a batch's last offset). To prepare a log for a snapshot it would
+     * be prefix truncated at offset X+1, so that the next element in the log to
+     * be replayed against the snapshot is X+1.
+     */
+    virtual ss::future<> truncate_prefix(truncate_prefix_config) = 0;
+    virtual ss::future<> gc(gc_config) = 0;
 
-        // TODO should compact be merged in this?
-        // run housekeeping task, like rolling segments
-        virtual ss::future<> apply_segment_ms() = 0;
+    // TODO should compact be merged in this?
+    // run housekeeping task, like rolling segments
+    virtual ss::future<> apply_segment_ms() = 0;
 
-        virtual ss::future<model::record_batch_reader>
-          make_reader(log_reader_config) = 0;
-        virtual log_appender make_appender(log_append_config) = 0;
+    virtual ss::future<model::record_batch_reader>
+      make_reader(log_reader_config) = 0;
+    virtual log_appender make_appender(log_append_config) = 0;
 
-        // final operation. Invalid filesystem state after
-        virtual ss::future<std::optional<ss::sstring>> close() = 0;
-        // final operation. Invalid state after
-        virtual ss::future<> remove() = 0;
+    // final operation. Invalid filesystem state after
+    virtual ss::future<std::optional<ss::sstring>> close() = 0;
+    // final operation. Invalid state after
+    virtual ss::future<> remove() = 0;
 
-        virtual ss::future<> flush() = 0;
+    virtual ss::future<> flush() = 0;
 
-        virtual ss::future<std::optional<timequery_result>>
-          timequery(timequery_config) = 0;
+    virtual ss::future<std::optional<timequery_result>>
+      timequery(timequery_config) = 0;
 
-        const ntp_config& config() const { return _config; }
+    const ntp_config& config() const { return _config; }
 
-        virtual size_t segment_count() const = 0;
-        virtual storage::offset_stats offsets() const = 0;
-        // Base offset of the first batch in the most recent term stored in log
-        virtual model::offset find_last_term_start_offset() const = 0;
-        virtual model::timestamp start_timestamp() const = 0;
-        virtual std::ostream& print(std::ostream& o) const = 0;
-        virtual std::optional<model::term_id> get_term(model::offset) const = 0;
-        virtual std::optional<model::offset>
-          get_term_last_offset(model::term_id) const = 0;
-        virtual std::optional<model::offset>
-        index_lower_bound(model::offset o) const = 0;
+    virtual size_t segment_count() const = 0;
+    virtual storage::offset_stats offsets() const = 0;
+    // Base offset of the first batch in the most recent term stored in log
+    virtual model::offset find_last_term_start_offset() const = 0;
+    virtual model::timestamp start_timestamp() const = 0;
+    virtual std::ostream& print(std::ostream& o) const = 0;
+    virtual std::optional<model::term_id> get_term(model::offset) const = 0;
+    virtual std::optional<model::offset>
+      get_term_last_offset(model::term_id) const = 0;
+    virtual std::optional<model::offset>
+    index_lower_bound(model::offset o) const = 0;
 
-        /**
-         * \brief Returns a future that resolves when log eviction is scheduled
-         *
-         * Important note: The api may throw ss::abort_requested_exception when
-         * passed in abort source was triggered or storage::segment_closed_exception
-         * when log was closed while waiting for eviction to happen.
-         *
-         */
-        virtual ss::future<model::offset>
-        monitor_eviction(ss::abort_source&) = 0;
-        ss::lw_shared_ptr<storage::stm_manager> stm_manager() {
-            return _stm_manager;
-        }
+    /**
+     * \brief Returns a future that resolves when log eviction is scheduled
+     *
+     * Important note: The api may throw ss::abort_requested_exception when
+     * passed in abort source was triggered or storage::segment_closed_exception
+     * when log was closed while waiting for eviction to happen.
+     *
+     */
+    virtual ss::future<model::offset> monitor_eviction(ss::abort_source&) = 0;
+    ss::lw_shared_ptr<storage::stm_manager> stm_manager() {
+        return _stm_manager;
+    }
 
-        virtual size_t size_bytes() const = 0;
-        // Byte size of the log for all segments after offset 'o'
-        virtual uint64_t size_bytes_after_offset(model::offset o) const = 0;
-        virtual ss::future<>
-          update_configuration(ntp_config::default_overrides) = 0;
+    virtual size_t size_bytes() const = 0;
+    // Byte size of the log for all segments after offset 'o'
+    virtual uint64_t size_bytes_after_offset(model::offset o) const = 0;
+    virtual ss::future<>
+      update_configuration(ntp_config::default_overrides) = 0;
 
-        virtual int64_t compaction_backlog() const = 0;
+    virtual int64_t compaction_backlog() const = 0;
 
-    private:
-        ntp_config _config;
+private:
+    ntp_config _config;
 
-        friend std::ostream& operator<<(std::ostream& o, const log& lg) {
-            return lg.print(o);
-        }
+    friend std::ostream& operator<<(std::ostream& o, const log& lg) {
+        return lg.print(o);
+    }
 
-    protected:
-        ntp_config& mutable_config() { return _config; }
-        ss::lw_shared_ptr<storage::stm_manager> _stm_manager;
-    };
+protected:
+    ntp_config& mutable_config() { return _config; }
+    ss::lw_shared_ptr<storage::stm_manager> _stm_manager;
+};
 
 class log_manager;
 class segment_set;

--- a/src/v/storage/log_housekeeping_meta.h
+++ b/src/v/storage/log_housekeeping_meta.h
@@ -20,10 +20,10 @@ struct log_housekeeping_meta {
         none = 0,
         compacted = 1U,
     };
-    explicit log_housekeeping_meta(log l) noexcept
+    explicit log_housekeeping_meta(ss::shared_ptr<log> l) noexcept
       : handle(std::move(l)) {}
 
-    log handle;
+    ss::shared_ptr<log> handle;
     bitflags flags{bitflags::none};
     ss::lowres_clock::time_point last_compaction;
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -342,7 +342,7 @@ ss::future<> log_manager::housekeeping_loop() {
 
                 auto ntp = log_meta.handle->config().ntp();
                 auto log = dynamic_cast<disk_log_impl*>(
-                  log_meta.handle->get_impl());
+                  log_meta.handle.get());
                 auto usage = co_await log->disk_usage(
                   gc_config(collection_threshold(), _config.retention_bytes()));
 
@@ -765,7 +765,7 @@ ss::future<usage_report> log_manager::disk_usage() {
       logs.begin(),
       logs.end(),
       [this, collection_threshold](ss::shared_ptr<log> l) {
-          auto log = dynamic_cast<disk_log_impl*>(l->get_impl());
+          auto log = dynamic_cast<disk_log_impl*>(l.get());
           return log->disk_usage(
             gc_config(collection_threshold, _config.retention_bytes()));
       },

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -362,10 +362,10 @@ ss::future<> log_manager::housekeeping_loop() {
              */
             for (const auto& candidate : ntp_by_gc_size) {
                 auto log = get(candidate.second);
-                if (!log.has_value()) {
+                if (!log) {
                     continue;
                 }
-                co_await log.value()->gc(
+                co_await log->gc(
                   gc_config(collection_threshold(), _config.retention_bytes()));
             }
         }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -341,8 +341,7 @@ ss::future<> log_manager::housekeeping_loop() {
                 }
 
                 auto ntp = log_meta.handle->config().ntp();
-                auto log = dynamic_cast<disk_log_impl*>(
-                  log_meta.handle.get());
+                auto log = dynamic_cast<disk_log_impl*>(log_meta.handle.get());
                 auto usage = co_await log->disk_usage(
                   gc_config(collection_threshold(), _config.retention_bytes()));
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -147,18 +147,18 @@ log_manager::log_manager(
     });
 }
 
-ss::future<> log_manager::clean_close(storage::log& log) {
-    auto clean_segment = co_await log.close();
+ss::future<> log_manager::clean_close(ss::shared_ptr<storage::log> log) {
+    auto clean_segment = co_await log->close();
 
     if (clean_segment) {
         vlog(
           stlog.debug,
           "writing clean record for: {} {}",
-          log.config().ntp(),
+          log->config().ntp(),
           clean_segment.value());
         co_await _kvstore.put(
           kvstore::key_space::storage,
-          internal::clean_segment_key(log.config().ntp()),
+          internal::clean_segment_key(log->config().ntp()),
           serde::to_iobuf(internal::clean_segment_value{
             .segment_name = std::filesystem::path(clean_segment.value())
                               .filename()
@@ -207,7 +207,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
      *   compaction, the whole task could be made concurrent
      */
     for (auto& log_meta : _logs_list) {
-        co_await log_meta.handle.apply_segment_ms();
+        co_await log_meta.handle->apply_segment_ms();
     }
 
     for (auto& log_meta : _logs_list) {
@@ -228,11 +228,11 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         current_log.last_compaction = ss::lowres_clock::now();
 
         auto ntp_sanitizer_cfg = _config.maybe_get_ntp_sanitizer_config(
-          current_log.handle.config().ntp());
-        co_await current_log.handle.housekeeping(housekeeping_config(
+          current_log.handle->config().ntp());
+        co_await current_log.handle->housekeeping(housekeeping_config(
           collection_threshold,
           _config.retention_bytes(),
-          current_log.handle.stm_manager()->max_collectible_offset(),
+          current_log.handle->stm_manager()->max_collectible_offset(),
           _config.compaction_priority,
           _abort_source,
           std::move(ntp_sanitizer_cfg)));
@@ -335,14 +335,14 @@ ss::future<> log_manager::housekeeping_loop() {
                  * applying segment.ms will make reclaimable data from the
                  * active segment visible.
                  */
-                co_await log_meta.handle.apply_segment_ms();
+                co_await log_meta.handle->apply_segment_ms();
                 if (!log_meta.link.is_linked()) {
                     continue;
                 }
 
-                auto ntp = log_meta.handle.config().ntp();
+                auto ntp = log_meta.handle->config().ntp();
                 auto log = dynamic_cast<disk_log_impl*>(
-                  log_meta.handle.get_impl());
+                  log_meta.handle->get_impl());
                 auto usage = co_await log->disk_usage(
                   gc_config(collection_threshold(), _config.retention_bytes()));
 
@@ -365,7 +365,7 @@ ss::future<> log_manager::housekeeping_loop() {
                 if (!log.has_value()) {
                     continue;
                 }
-                co_await log->gc(
+                co_await log.value()->gc(
                   gc_config(collection_threshold(), _config.retention_bytes()));
             }
         }
@@ -443,7 +443,7 @@ log_manager::create_cache(with_cache ntp_cache_enabled) {
     return batch_cache_index(_batch_cache);
 }
 
-ss::future<log> log_manager::manage(ntp_config cfg) {
+ss::future<ss::shared_ptr<log>> log_manager::manage(ntp_config cfg) {
     auto gate = _open_gate.hold();
 
     auto units = co_await _resources.get_recovery_units();
@@ -469,7 +469,7 @@ ss::future<> log_manager::recover_log_state(const ntp_config& cfg) {
       });
 }
 
-ss::future<log> log_manager::do_manage(ntp_config cfg) {
+ss::future<ss::shared_ptr<log>> log_manager::do_manage(ntp_config cfg) {
     if (_config.base_dir.empty()) {
         throw std::runtime_error(
           "log_manager:: cannot have empty config.base_dir");
@@ -507,7 +507,7 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
     auto l = storage::make_disk_backed_log(
       std::move(cfg), *this, std::move(segments), _kvstore, _feature_table);
     auto [it, success] = _logs.emplace(
-      l.config().ntp(), std::make_unique<log_housekeeping_meta>(l));
+      l->config().ntp(), std::make_unique<log_housekeeping_meta>(l));
     _logs_list.push_back(*it->second);
     _resources.update_partition_count(_logs.size());
     vassert(success, "Could not keep track of:{} - concurrency issue", l);
@@ -534,16 +534,16 @@ ss::future<> log_manager::remove(model::ntp ntp) {
         co_return;
     }
     // 'ss::shared_ptr<>' make a copy
-    storage::log lg = handle.mapped()->handle;
+    auto lg = handle.mapped()->handle;
     vlog(stlog.info, "Removing: {}", lg);
     // NOTE: it is ok to *not* externally synchronize the log here
     // because remove, takes a write lock on each individual segments
     // waiting for all of them to be closed before actually removing the
     // underlying log. If there is a background operation like
     // compaction or so, it will block correctly.
-    auto ntp_dir = lg.config().work_directory();
-    ss::sstring topic_dir = lg.config().topic_directory().string();
-    co_await lg.remove();
+    auto ntp_dir = lg->config().work_directory();
+    ss::sstring topic_dir = lg->config().topic_directory().string();
+    co_await lg->remove();
     directory_walker walker;
     co_await walker.walk(
       ntp_dir, [&ntp_dir](const ss::directory_entry& de) -> ss::future<> {
@@ -714,7 +714,7 @@ int64_t log_manager::compaction_backlog() const {
       _logs.end(),
       int64_t(0),
       [](int64_t acc, const logs_type::value_type& p) {
-          return acc + p.second->handle.compaction_backlog();
+          return acc + p.second->handle->compaction_backlog();
       });
 }
 
@@ -756,7 +756,7 @@ ss::future<usage_report> log_manager::disk_usage() {
           - _config.delete_retention()->count());
     }
 
-    fragmented_vector<log> logs;
+    fragmented_vector<ss::shared_ptr<log>> logs;
     for (auto& it : _logs) {
         logs.push_back(it.second->handle);
     }
@@ -764,8 +764,8 @@ ss::future<usage_report> log_manager::disk_usage() {
     co_return co_await ss::map_reduce(
       logs.begin(),
       logs.end(),
-      [this, collection_threshold](log l) {
-          auto log = dynamic_cast<disk_log_impl*>(l.get_impl());
+      [this, collection_threshold](ss::shared_ptr<log> l) {
+          auto log = dynamic_cast<disk_log_impl*>(l->get_impl());
           return log->disk_usage(
             gc_config(collection_threshold, _config.retention_bytes()));
       },

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -211,11 +211,11 @@ public:
     size_t size() const { return _logs.size(); }
 
     /// Returns the log for the specified ntp.
-    std::optional<ss::shared_ptr<log>> get(const model::ntp& ntp) {
+    ss::shared_ptr<log> get(const model::ntp& ntp) {
         if (auto it = _logs.find(ntp); it != _logs.end()) {
             return it->second->handle;
         }
-        return std::nullopt;
+        return nullptr;
     }
 
     /// Returns all ntp's managed by this instance

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -168,7 +168,7 @@ public:
       storage_resources&,
       ss::sharded<features::feature_table>&) noexcept;
 
-    ss::future<log> manage(ntp_config);
+    ss::future<ss::shared_ptr<log>> manage(ntp_config);
 
     ss::future<> shutdown(model::ntp);
 
@@ -211,7 +211,7 @@ public:
     size_t size() const { return _logs.size(); }
 
     /// Returns the log for the specified ntp.
-    std::optional<log> get(const model::ntp& ntp) {
+    std::optional<ss::shared_ptr<log>> get(const model::ntp& ntp) {
         if (auto it = _logs.find(ntp); it != _logs.end()) {
             return it->second->handle;
         }
@@ -243,8 +243,8 @@ private:
     using compaction_list_type
       = intrusive_list<log_housekeeping_meta, &log_housekeeping_meta::link>;
 
-    ss::future<log> do_manage(ntp_config);
-    ss::future<> clean_close(storage::log&);
+    ss::future<ss::shared_ptr<log>> do_manage(ntp_config);
+    ss::future<> clean_close(ss::shared_ptr<storage::log>);
 
     /**
      * \brief delete old segments and trigger compacted segments

--- a/src/v/storage/opfuzz/opfuzz.h
+++ b/src/v/storage/opfuzz/opfuzz.h
@@ -27,7 +27,7 @@ class opfuzz {
 public:
     struct op_context {
         model::term_id* term;
-        storage::log* log;
+        ss::shared_ptr<storage::log> log;
         ss::abort_source* _as;
     };
     struct op {
@@ -61,7 +61,7 @@ public:
         max = term_roll,
     };
 
-    opfuzz(storage::log l, size_t ops_count)
+    opfuzz(ss::shared_ptr<storage::log> l, size_t ops_count)
       : _log(std::move(l)) {
         generate_workload(ops_count);
     }
@@ -72,7 +72,7 @@ public:
     opfuzz& operator=(opfuzz&&) noexcept = default;
 
     ss::future<> execute();
-    const storage::log& log() const { return _log; }
+    const ss::shared_ptr<storage::log> log() const { return _log; }
 
 private:
     std::unique_ptr<op> random_operation();
@@ -80,7 +80,7 @@ private:
 
     model::term_id _term = model::term_id(0);
     std::vector<std::unique_ptr<op>> _workload;
-    storage::log _log;
+    ss::shared_ptr<storage::log> _log;
     ss::abort_source _as;
 };
 } // namespace storage

--- a/src/v/storage/opfuzz/opfuzz_test.cc
+++ b/src/v/storage/opfuzz/opfuzz_test.cc
@@ -131,7 +131,7 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
         const model::ntp& ntp = ntps_to_fuzz[i];
         info("test... removing: {}", ntp);
         mngr.remove(ntp).get();
-        BOOST_REQUIRE(mngr.get(ntp) == std::nullopt);
+        BOOST_REQUIRE(!mngr.get(ntp));
     }
     std::sort(
       random_ntp_removal_sequence.begin(), random_ntp_removal_sequence.end());

--- a/src/v/storage/tests/disk_log_builder_fixture.h
+++ b/src/v/storage/tests/disk_log_builder_fixture.h
@@ -24,7 +24,7 @@ public:
 
     ss::future<log_stats> get_stats() {
         return b.consume<stat_consumer>().then([this](log_stats stats) {
-            stats.seg_count = b.get_log().segment_count();
+            stats.seg_count = b.get_log()->segment_count();
             return ss::make_ready_future<log_stats>(stats);
         });
     }

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -131,10 +131,10 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
     m.manage(config_from_ntp(ntps[2].ntp())).get();
     m.manage(config_from_ntp(ntps[3].ntp())).get();
     BOOST_CHECK_EQUAL(4, m.size());
-    BOOST_CHECK_EQUAL(m.get(ntps[0].ntp())->segment_count(), 0);
-    BOOST_CHECK_EQUAL(m.get(ntps[1].ntp())->segment_count(), 0);
-    BOOST_CHECK_EQUAL(m.get(ntps[2].ntp())->segment_count(), 1);
-    BOOST_CHECK_EQUAL(m.get(ntps[3].ntp())->segment_count(), 0);
+    BOOST_CHECK_EQUAL(m.get(ntps[0].ntp()).value()->segment_count(), 0);
+    BOOST_CHECK_EQUAL(m.get(ntps[1].ntp()).value()->segment_count(), 0);
+    BOOST_CHECK_EQUAL(m.get(ntps[2].ntp()).value()->segment_count(), 1);
+    BOOST_CHECK_EQUAL(m.get(ntps[3].ntp()).value()->segment_count(), 0);
     BOOST_CHECK(!file_exists(seg->reader().filename()).get0());
     BOOST_CHECK(file_exists(seg3->reader().filename()).get0());
     BOOST_CHECK(!file_exists(seg4->reader().filename()).get0());

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -131,10 +131,10 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
     m.manage(config_from_ntp(ntps[2].ntp())).get();
     m.manage(config_from_ntp(ntps[3].ntp())).get();
     BOOST_CHECK_EQUAL(4, m.size());
-    BOOST_CHECK_EQUAL(m.get(ntps[0].ntp()).value()->segment_count(), 0);
-    BOOST_CHECK_EQUAL(m.get(ntps[1].ntp()).value()->segment_count(), 0);
-    BOOST_CHECK_EQUAL(m.get(ntps[2].ntp()).value()->segment_count(), 1);
-    BOOST_CHECK_EQUAL(m.get(ntps[3].ntp()).value()->segment_count(), 0);
+    BOOST_CHECK_EQUAL(m.get(ntps[0].ntp())->segment_count(), 0);
+    BOOST_CHECK_EQUAL(m.get(ntps[1].ntp())->segment_count(), 0);
+    BOOST_CHECK_EQUAL(m.get(ntps[2].ntp())->segment_count(), 1);
+    BOOST_CHECK_EQUAL(m.get(ntps[3].ntp())->segment_count(), 0);
     BOOST_CHECK(!file_exists(seg->reader().filename()).get0());
     BOOST_CHECK(file_exists(seg3->reader().filename()).get0());
     BOOST_CHECK(!file_exists(seg4->reader().filename()).get0());

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -36,16 +36,16 @@ FIXTURE_TEST(retention_test_time, gc_fixture) {
       | storage::add_segment(104) | storage::add_random_batches(104, 3);
     BOOST_TEST_MESSAGE(
       "Should not collect segments with timestamp older than 1");
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 3);
     builder | storage::garbage_collect(model::timestamp(1), std::nullopt);
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 3);
 
     BOOST_TEST_MESSAGE("Should not collect segments because size is infinity");
     builder
       | storage::garbage_collect(
         model::timestamp(1),
         std::make_optional<size_t>(std::numeric_limits<size_t>::max()));
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 3);
 
     BOOST_TEST_MESSAGE("Should leave one active segment");
     builder
@@ -53,7 +53,7 @@ FIXTURE_TEST(retention_test_time, gc_fixture) {
         model::timestamp{base_ts() + 1000}, std::nullopt)
       | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 1);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 1);
 }
 
 FIXTURE_TEST(retention_test_size, gc_fixture) {
@@ -70,14 +70,14 @@ FIXTURE_TEST(retention_test_size, gc_fixture) {
         model::timestamp(1),
         std::make_optional(
           builder.get_disk_log_impl().get_probe().partition_size()));
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 3);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 3);
 
     BOOST_TEST_MESSAGE("Should collect all segments");
     builder
       | storage::garbage_collect(model::timestamp(1), std::optional<size_t>(0))
       | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
 }
 
 /*
@@ -223,7 +223,7 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
 
     builder | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
 }
 FIXTURE_TEST(retention_test_after_truncation, gc_fixture) {
     BOOST_TEST_MESSAGE("Should be safe to garbage collect after truncation");
@@ -232,7 +232,7 @@ FIXTURE_TEST(retention_test_after_truncation, gc_fixture) {
       | storage::truncate_log(model::offset(0))
       | storage::garbage_collect(model::timestamp::now(), std::nullopt)
       | storage::stop();
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
     BOOST_CHECK_EQUAL(
       builder.get_disk_log_impl().get_probe().partition_size(), 0);
 }
@@ -280,13 +280,13 @@ FIXTURE_TEST(retention_by_size_with_remote_write, gc_fixture) {
         partition_size
           = builder.get_disk_log_impl().get_probe().partition_size();
 
-        auto segment_count_before_gc = builder.get_log().segment_count();
+        auto segment_count_before_gc = builder.get_log()->segment_count();
         builder
           .gc(
             model::timestamp(1),
             std::make_optional<size_t>(std::numeric_limits<size_t>::max()))
           .get();
-        auto segment_count_after_gc = builder.get_log().segment_count();
+        auto segment_count_after_gc = builder.get_log()->segment_count();
 
         if (partition_size > size_limit) {
             BOOST_CHECK_GE(segment_count_before_gc, segment_count_after_gc);
@@ -350,7 +350,7 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
     // Try to garbage collet the segments. None should get collected
     // because we are currently using the default local target retention.
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt);
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 2);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 2);
 
     // Override the local target retention.
     storage::ntp_config::default_overrides time_override;
@@ -362,7 +362,7 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
     // Collect again. All segments should be removed this time.
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt)
       | storage::stop();
-    BOOST_CHECK_EQUAL(builder.get_log().segment_count(), 0);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
 }
 
 FIXTURE_TEST(non_collectible_disk_usage_test, gc_fixture) {

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -549,8 +549,7 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     f1.get0();
     f2.get0();
 
-    auto& impl = dynamic_cast<storage::disk_log_impl&>(
-      *log);
+    auto& impl = dynamic_cast<storage::disk_log_impl&>(*log);
 
     BOOST_REQUIRE_EQUAL(
       (*impl.segments().begin())->offsets().base_offset,
@@ -680,8 +679,7 @@ FIXTURE_TEST(test_index_max_timestamp_update, storage_test_fixture) {
         model::offset{20}, ss::default_priority_class()))
       .get();
 
-    auto& impl = dynamic_cast<storage::disk_log_impl&>(
-      *log);
+    auto& impl = dynamic_cast<storage::disk_log_impl&>(*log);
 
     // The maximum timestamp in the index should be the maximum
     // timestamp of the batch preceeding the batch where the truncation

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -474,7 +474,7 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
       [&rec_mgr]() mutable { rec_mgr.stop().get0(); });
     auto rec_log
       = rec_mgr.manage(storage::ntp_config(ntp, cfg.base_dir)).get0();
-    auto& impl = dynamic_cast<disk_log_impl&>(*rec_log->get_impl());
+    auto& impl = dynamic_cast<disk_log_impl&>(*rec_log);
 
     BOOST_REQUIRE_EQUAL(impl.segment_count(), 3);
 
@@ -549,8 +549,8 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     f1.get0();
     f2.get0();
 
-    storage::disk_log_impl& impl = *reinterpret_cast<storage::disk_log_impl*>(
-      log->get_impl());
+    auto& impl = dynamic_cast<storage::disk_log_impl&>(
+      *log);
 
     BOOST_REQUIRE_EQUAL(
       (*impl.segments().begin())->offsets().base_offset,
@@ -680,8 +680,8 @@ FIXTURE_TEST(test_index_max_timestamp_update, storage_test_fixture) {
         model::offset{20}, ss::default_priority_class()))
       .get();
 
-    storage::disk_log_impl& impl = *reinterpret_cast<storage::disk_log_impl*>(
-      log->get_impl());
+    auto& impl = dynamic_cast<storage::disk_log_impl&>(
+      *log);
 
     // The maximum timestamp in the index should be the maximum
     // timestamp of the batch preceeding the batch where the truncation

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -48,16 +48,16 @@ FIXTURE_TEST(test_truncate_whole, storage_test_fixture) {
     std::vector<model::record_batch_header> headers;
     for (auto i = 0; i < 10; i++) {
         append_random_batches(log, 1, model::term_id(i));
-        log.flush().get();
+        log->flush().get();
     }
     model::offset truncate_offset{0};
     log
-      .truncate(
+      ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
       .get0();
 
     auto read_batches = read_and_validate_all_batches(log);
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(read_batches.size(), 0);
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, model::offset{});
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, model::offset{});
@@ -72,7 +72,7 @@ FIXTURE_TEST(test_truncate_in_the_middle_of_segment, storage_test_fixture) {
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
     append_random_batches(log, 6, model::term_id(0));
-    log.flush().get0();
+    log->flush().get0();
 
     auto all_batches = read_and_validate_all_batches(log);
     auto truncate_offset = all_batches[4].base_offset();
@@ -80,7 +80,7 @@ FIXTURE_TEST(test_truncate_in_the_middle_of_segment, storage_test_fixture) {
     // truncate in the middle
     info("Truncating at offset:{}", truncate_offset);
     log
-      .truncate(
+      ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
       .get0();
     info("reading all batches");
@@ -89,7 +89,7 @@ FIXTURE_TEST(test_truncate_in_the_middle_of_segment, storage_test_fixture) {
     // one less
     auto expected = all_batches[3].last_offset();
 
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, expected);
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, expected);
     if (truncate_offset != model::offset(0)) {
@@ -113,7 +113,7 @@ FIXTURE_TEST(test_truncate_in_the_middle_of_batch, storage_test_fixture) {
       log, model::test::make_random_batch(model::offset{0}, 5, true));
 
     auto truncate_at = [log](model::offset o) mutable {
-        log.truncate(storage::truncate_config(o, ss::default_priority_class()))
+        log->truncate(storage::truncate_config(o, ss::default_priority_class()))
           .get();
     };
 
@@ -121,7 +121,7 @@ FIXTURE_TEST(test_truncate_in_the_middle_of_batch, storage_test_fixture) {
     BOOST_CHECK_THROW(truncate_at(model::offset{12}), std::exception);
 
     truncate_at(model::offset{20});
-    BOOST_CHECK_EQUAL(log.offsets().dirty_offset, model::offset{14});
+    BOOST_CHECK_EQUAL(log->offsets().dirty_offset, model::offset{14});
     auto read_batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read_batches.size(), 2);
     BOOST_CHECK_EQUAL(read_batches[1].last_offset(), model::offset{14});
@@ -135,10 +135,10 @@ FIXTURE_TEST(test_truncate_empty_log, storage_test_fixture) {
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
     append_random_batches(log, 1, model::term_id(1));
-    log.flush().get0();
+    log->flush().get0();
 
     auto all_batches = read_and_validate_all_batches(log);
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(
       lstats.committed_offset, all_batches.back().last_offset());
 }
@@ -155,7 +155,7 @@ FIXTURE_TEST(test_truncate_middle_of_old_segment, storage_test_fixture) {
     // Generate from 10 up to 100 batches
     for (auto i = 0; i < 10; i++) {
         auto part = append_random_batches(log, 1, model::term_id(i));
-        log.flush().get();
+        log->flush().get();
     }
     auto all_batches = read_and_validate_all_batches(log);
 
@@ -164,13 +164,13 @@ FIXTURE_TEST(test_truncate_middle_of_old_segment, storage_test_fixture) {
     }
     // truncate @ offset that belongs to an old segment
     log
-      .truncate(storage::truncate_config(
+      ->truncate(storage::truncate_config(
         all_batches.back().base_offset(), ss::default_priority_class()))
       .get0();
     all_batches.pop_back(); // we just removed the last one!
     auto final_batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(all_batches.size(), final_batches.size());
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(
       lstats.committed_offset, all_batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, all_batches.back().last_offset());
@@ -191,22 +191,22 @@ FIXTURE_TEST(truncate_whole_log_and_then_again, storage_test_fixture) {
     std::vector<model::record_batch_header> headers;
     for (auto i = 0; i < 10; i++) {
         append_random_batches(log, 1, model::term_id(i));
-        log.flush().get();
+        log->flush().get();
     }
 
     const auto truncate_offset = model::offset{0};
     log
-      .truncate(
+      ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
       .get0();
     log
-      .truncate(
+      ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
       .get0();
 
     auto read_batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read_batches.size(), 0);
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, model::offset{});
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, model::offset{});
 }
@@ -221,7 +221,7 @@ FIXTURE_TEST(truncate_before_read, storage_test_fixture) {
     std::vector<model::record_batch_header> headers;
     for (auto i = 0; i < 10; i++) {
         append_random_batches(log, 1, model::term_id(i));
-        log.flush().get();
+        log->flush().get();
     }
     storage::log_reader_config cfg(
       model::offset(0),
@@ -230,9 +230,9 @@ FIXTURE_TEST(truncate_before_read, storage_test_fixture) {
 
     // first create the reader
     auto reader_ptr = std::make_unique<model::record_batch_reader>(
-      log.make_reader(std::move(cfg)).get0());
+      log->make_reader(std::move(cfg)).get0());
     // truncate
-    auto f = log.truncate(
+    auto f = log->truncate(
       storage::truncate_config(model::offset(0), ss::default_priority_class()));
     // Memory log works fine
     reader_ptr->consume(batch_validating_consumer{}, model::no_timeout).get0();
@@ -240,7 +240,7 @@ FIXTURE_TEST(truncate_before_read, storage_test_fixture) {
     f.get();
     auto read_batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read_batches.size(), 0);
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, model::offset{});
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, model::offset{});
 }
@@ -254,7 +254,7 @@ FIXTURE_TEST(
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
     append_random_batches(log, 6, model::term_id(0));
-    log.flush().get0();
+    log->flush().get0();
 
     auto all_batches = read_and_validate_all_batches(log);
     auto truncate_offset = all_batches[4].base_offset();
@@ -262,7 +262,7 @@ FIXTURE_TEST(
     // truncate in the middle
     info("Truncating at offset:{}", truncate_offset);
     log
-      .truncate(
+      ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
       .get0();
     info("reading all batches");
@@ -270,7 +270,7 @@ FIXTURE_TEST(
 
     // one less
     auto expected = all_batches[3].last_offset();
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, expected);
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, expected);
     if (truncate_offset != model::offset(0)) {
@@ -280,7 +280,7 @@ FIXTURE_TEST(
     }
     // Append new batches
     auto headers = append_random_batches(log, 6, model::term_id(0));
-    log.flush().get0();
+    log->flush().get0();
     auto read_after_append = read_and_validate_all_batches(log);
     // 4 batches were not truncated
     BOOST_REQUIRE_EQUAL(read_after_append.size(), headers.size() + 4);
@@ -308,13 +308,13 @@ FIXTURE_TEST(test_truncate_last_single_record_batch, storage_test_fixture) {
             ts));
           return ret;
       });
-    log.flush().get0();
+    log->flush().get0();
 
-    for (auto lstats = log.offsets(); lstats.dirty_offset > model::offset{};
-         lstats = log.offsets()) {
+    for (auto lstats = log->offsets(); lstats.dirty_offset > model::offset{};
+         lstats = log->offsets()) {
         auto truncate_offset = lstats.dirty_offset;
         log
-          .truncate(storage::truncate_config(
+          ->truncate(storage::truncate_config(
             truncate_offset, ss::default_priority_class()))
           .get0();
         auto all_batches = read_and_validate_all_batches(log);
@@ -349,14 +349,14 @@ FIXTURE_TEST(
                  .get0();
     append_random_batches(log, 10, model::term_id(0));
     append_random_batches(log, 10, model::term_id(0));
-    log.flush().get0();
+    log->flush().get0();
     auto ts = now();
     append_random_batches(log, 10, model::term_id(0));
-    log.flush().get0();
+    log->flush().get0();
     // garbadge collect first append series
     ss::abort_source as;
     log
-      .housekeeping(housekeeping_config(
+      ->housekeeping(housekeeping_config(
         ts,
         std::nullopt,
         model::offset::max(),
@@ -365,11 +365,11 @@ FIXTURE_TEST(
       .get0();
     // truncate at 0, offset earlier then the one present in log
     log
-      .truncate(storage::truncate_config(
+      ->truncate(storage::truncate_config(
         model::offset(0), ss::default_priority_class()))
       .get0();
 
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, model::offset{});
 }
 
@@ -419,7 +419,7 @@ FIXTURE_TEST(test_truncate, storage_test_fixture) {
       | storage::truncate_log(220);
 
     BOOST_REQUIRE_EQUAL(
-      builder.get_log().offsets().dirty_offset, model::offset(219));
+      builder.get_log()->offsets().dirty_offset, model::offset(219));
     builder | storage::stop();
 }
 
@@ -436,7 +436,7 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
         auto log = mgr.manage(storage::ntp_config(ntp, cfg.base_dir)).get0();
 
         append_random_batches(log, 10, model::term_id(0));
-        log.flush().get0();
+        log->flush().get0();
 
         // truncate in the middle
         auto all_batches = read_and_validate_all_batches(log);
@@ -444,7 +444,7 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
 
         info("Truncating at offset:{}", truncate_offsets.back());
         log
-          .truncate(storage::truncate_config(
+          ->truncate(storage::truncate_config(
             truncate_offsets.back(), ss::default_priority_class()))
           .get();
 
@@ -457,14 +457,14 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
 
         info("Truncating at offset:{}", truncate_offsets.back());
         log
-          .truncate(storage::truncate_config(
+          ->truncate(storage::truncate_config(
             truncate_offsets.back(), ss::default_priority_class()))
           .get();
 
         // force segment roll
         append_random_batches(log, 3, model::term_id(2));
 
-        log.flush().get();
+        log->flush().get();
     }
 
     // recover log
@@ -474,7 +474,7 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
       [&rec_mgr]() mutable { rec_mgr.stop().get0(); });
     auto rec_log
       = rec_mgr.manage(storage::ntp_config(ntp, cfg.base_dir)).get0();
-    auto& impl = dynamic_cast<disk_log_impl&>(*rec_log.get_impl());
+    auto& impl = dynamic_cast<disk_log_impl&>(*rec_log->get_impl());
 
     BOOST_REQUIRE_EQUAL(impl.segment_count(), 3);
 
@@ -521,40 +521,40 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
                  .get0();
 
     append_random_batches(log, 10, model::term_id(0));
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
 
     append_random_batches(log, 10, model::term_id(1));
-    log.flush().get0();
+    log->flush().get0();
 
     auto ts = now();
 
     append_random_batches(log, 10, model::term_id(2));
-    log.flush().get0();
+    log->flush().get0();
     ss::abort_source as;
 
     // The call to 'compact' simply triggers a notification
     // for the log eviction stm with an offset until which
     // to evict. The test does not listen for the notification,
     // so this call is basically a no-op.
-    auto f1 = log.housekeeping(housekeeping_config(
+    auto f1 = log->housekeeping(housekeeping_config(
       ts,
       std::nullopt,
       model::offset::max(),
       ss::default_priority_class(),
       as));
 
-    auto f2 = log.truncate_prefix(storage::truncate_prefix_config(
+    auto f2 = log->truncate_prefix(storage::truncate_prefix_config(
       model::next_offset(lstats.dirty_offset), ss::default_priority_class()));
 
     f1.get0();
     f2.get0();
 
     storage::disk_log_impl& impl = *reinterpret_cast<storage::disk_log_impl*>(
-      log.get_impl());
+      log->get_impl());
 
     BOOST_REQUIRE_EQUAL(
       (*impl.segments().begin())->offsets().base_offset,
-      log.offsets().start_offset);
+      log->offsets().start_offset);
 }
 
 FIXTURE_TEST(
@@ -573,30 +573,30 @@ FIXTURE_TEST(
 
     auto truncate_at = [log](model::offset o) mutable {
         log
-          .truncate_prefix(
+          ->truncate_prefix(
             storage::truncate_prefix_config(o, ss::default_priority_class()))
           .get();
     };
 
     truncate_at(model::offset{7});
-    BOOST_CHECK_EQUAL(log.offsets().start_offset, model::offset{7});
+    BOOST_CHECK_EQUAL(log->offsets().start_offset, model::offset{7});
     auto batches1 = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(batches1.size(), 2);
     BOOST_CHECK_EQUAL(batches1[0].base_offset(), model::offset{0});
 
     truncate_at(model::offset{12});
-    BOOST_CHECK_EQUAL(log.offsets().start_offset, model::offset{12});
+    BOOST_CHECK_EQUAL(log->offsets().start_offset, model::offset{12});
     auto batches2 = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(batches2.size(), 1);
     BOOST_CHECK_EQUAL(batches2[0].base_offset(), model::offset{10});
 
     truncate_at(model::offset{20});
-    BOOST_CHECK_EQUAL(log.offsets().start_offset, model::offset{20});
+    BOOST_CHECK_EQUAL(log->offsets().start_offset, model::offset{20});
     auto batches3 = read_and_validate_all_batches(log);
     BOOST_CHECK_EQUAL(batches3.size(), 0);
 
     truncate_at(model::offset{3});
-    BOOST_CHECK_EQUAL(log.offsets().start_offset, model::offset{20});
+    BOOST_CHECK_EQUAL(log->offsets().start_offset, model::offset{20});
     auto batches4 = read_and_validate_all_batches(log);
     BOOST_CHECK_EQUAL(batches4.size(), 0);
 }
@@ -615,22 +615,22 @@ FIXTURE_TEST(test_prefix_truncate_then_truncate_all, storage_test_fixture) {
       log, model::test::make_random_batch(model::offset{0}, 5, true));
 
     log
-      .truncate_prefix(storage::truncate_prefix_config(
+      ->truncate_prefix(storage::truncate_prefix_config(
         model::offset{10}, ss::default_priority_class()))
       .get();
     log
-      .truncate(storage::truncate_config(
+      ->truncate(storage::truncate_config(
         model::offset{10}, ss::default_priority_class()))
       .get();
 
     // Check that even though the log is empty, start offset is saved.
 
-    BOOST_CHECK_EQUAL(log.offsets().start_offset, model::offset{10});
+    BOOST_CHECK_EQUAL(log->offsets().start_offset, model::offset{10});
     BOOST_CHECK_EQUAL(read_and_validate_all_batches(log).size(), 0);
 
     append_batch(
       log, model::test::make_random_batch(model::offset{0}, 3, true));
-    BOOST_CHECK_EQUAL(log.offsets().start_offset, model::offset{10});
+    BOOST_CHECK_EQUAL(log->offsets().start_offset, model::offset{10});
     auto read_batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read_batches.size(), 1);
     BOOST_CHECK_EQUAL(read_batches[0].base_offset(), model::offset{10});
@@ -676,12 +676,12 @@ FIXTURE_TEST(test_index_max_timestamp_update, storage_test_fixture) {
         model::timestamp(30000)));
 
     log
-      .truncate(storage::truncate_config(
+      ->truncate(storage::truncate_config(
         model::offset{20}, ss::default_priority_class()))
       .get();
 
     storage::disk_log_impl& impl = *reinterpret_cast<storage::disk_log_impl*>(
-      log.get_impl());
+      log->get_impl());
 
     // The maximum timestamp in the index should be the maximum
     // timestamp of the batch preceeding the batch where the truncation

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2804,7 +2804,7 @@ FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
     }
 }
 
-static storage::log_gap_analysis analyze(storage::log::impl& log) {
+static storage::log_gap_analysis analyze(storage::log& log) {
     // TODO factor out common constant
     storage::log_reader_config reader_cfg(
       model::offset(0),

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -51,7 +51,7 @@
 #include <vector>
 
 storage::disk_log_impl* get_disk_log(ss::shared_ptr<storage::log> log) {
-    return dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+    return dynamic_cast<storage::disk_log_impl*>(log.get());
 }
 
 void validate_offsets(

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -50,8 +50,8 @@
 #include <optional>
 #include <vector>
 
-storage::disk_log_impl* get_disk_log(storage::log log) {
-    return dynamic_cast<storage::disk_log_impl*>(log.get_impl());
+storage::disk_log_impl* get_disk_log(ss::shared_ptr<storage::log> log) {
+    return dynamic_cast<storage::disk_log_impl*>(log->get_impl());
 }
 
 void validate_offsets(
@@ -98,12 +98,12 @@ FIXTURE_TEST(
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
     auto headers = append_random_batches(log, 10);
-    log.flush().get0();
+    log->flush().get0();
     auto batches = read_and_validate_all_batches(log);
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
-    auto lstats = log.offsets();
-    auto last_term_start_offset = log.find_last_term_start_offset();
+    auto lstats = log->offsets();
+    auto last_term_start_offset = log->find_last_term_start_offset();
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
@@ -118,16 +118,16 @@ FIXTURE_TEST(append_twice_to_same_segment, storage_test_fixture) {
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
     auto headers = append_random_batches(log, 10);
-    log.flush().get0();
+    log->flush().get0();
     auto headers_2 = append_random_batches(log, 10);
-    log.flush().get0();
+    log->flush().get0();
     std::move(
       std::begin(headers_2), std::end(headers_2), std::back_inserter(headers));
     auto batches = read_and_validate_all_batches(log);
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
-    auto lstats = log.offsets();
-    auto last_term_start_offset = log.find_last_term_start_offset();
+    auto lstats = log->offsets();
+    auto last_term_start_offset = log->find_last_term_start_offset();
     BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
@@ -143,12 +143,12 @@ FIXTURE_TEST(test_assigning_offsets_in_multiple_segment, storage_test_fixture) {
     auto log
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
     auto headers = append_random_batches(log, 10);
-    log.flush().get0();
+    log->flush().get0();
     auto batches = read_and_validate_all_batches(log);
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
-    auto lstats = log.offsets();
-    auto last_term_start_offset = log.find_last_term_start_offset();
+    auto lstats = log->offsets();
+    auto last_term_start_offset = log->find_last_term_start_offset();
     BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
@@ -179,12 +179,12 @@ FIXTURE_TEST(test_single_record_per_segment, storage_test_fixture) {
             ts));
           return batches;
       });
-    log.flush().get0();
+    log->flush().get0();
     auto batches = read_and_validate_all_batches(log);
     info("Flushed log: {}", log);
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
-    auto lstats = log.offsets();
-    auto last_term_start_offset = log.find_last_term_start_offset();
+    auto lstats = log->offsets();
+    auto last_term_start_offset = log->find_last_term_start_offset();
     BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
@@ -218,12 +218,12 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
       },
       storage::log_append_config::fsync::no,
       false);
-    log.flush().get0();
+    log->flush().get0();
     auto batches = read_and_validate_all_batches(log);
     info("Flushed log: {}", log);
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
-    auto lstats = log.offsets();
-    auto last_term_start_offset = log.find_last_term_start_offset();
+    auto lstats = log->offsets();
+    auto last_term_start_offset = log->find_last_term_start_offset();
     BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(lstats.committed_offset, batches.back().last_offset());
@@ -246,7 +246,7 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
       },
       storage::log_append_config::fsync::no,
       false);
-    auto new_lstats = log.offsets();
+    auto new_lstats = log->offsets();
     BOOST_REQUIRE_GE(new_lstats.committed_offset, lstats.committed_offset);
     auto new_batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(last_term_start_offset, batches.front().base_offset());
@@ -262,7 +262,7 @@ FIXTURE_TEST(test_reading_range_from_a_log, storage_test_fixture) {
       = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
     auto headers = append_random_batches(log, 10);
-    log.flush().get0();
+    log->flush().get0();
     auto batches = read_and_validate_all_batches(log);
 
     // range from base of beging to last of end
@@ -309,17 +309,17 @@ FIXTURE_TEST(test_rolling_term, storage_test_fixture) {
         for (auto h : part) {
             current_offset += h.last_offset_delta + 1;
         }
-        log.flush().get();
+        log->flush().get();
         BOOST_REQUIRE_EQUAL(
           model::term_id(i),
-          log.get_term(current_offset - model::offset(1)).value());
-        auto last_term_start_offset = log.find_last_term_start_offset();
+          log->get_term(current_offset - model::offset(1)).value());
+        auto last_term_start_offset = log->find_last_term_start_offset();
         BOOST_REQUIRE_EQUAL(last_term_start_offset, term_start_offset);
         std::move(part.begin(), part.end(), std::back_inserter(headers));
     }
 
     auto read_batches = read_and_validate_all_batches(log);
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, read_batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(
       lstats.committed_offset, read_batches.back().last_offset());
@@ -353,12 +353,12 @@ FIXTURE_TEST(test_append_batches_from_multiple_terms, storage_test_fixture) {
       model::no_timeout};
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
     std::move(reader)
-      .for_each_ref(log.make_appender(append_cfg), append_cfg.timeout)
+      .for_each_ref(log->make_appender(append_cfg), append_cfg.timeout)
       .get0();
-    log.flush().get();
+    log->flush().get();
 
     auto read_batches = read_and_validate_all_batches(log);
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, read_batches.back().last_offset());
     BOOST_REQUIRE_EQUAL(
       lstats.committed_offset, read_batches.back().last_offset());
@@ -395,7 +395,7 @@ struct custom_ts_batch_generator {
 };
 
 void append_custom_timestamp_batches(
-  storage::log log,
+  ss::shared_ptr<storage::log> log,
   int batch_count,
   model::term_id term,
   model::timestamp base_ts) {
@@ -423,7 +423,7 @@ void append_custom_timestamp_batches(
         };
 
         std::move(reader)
-          .for_each_ref(log.make_appender(cfg), cfg.timeout)
+          .for_each_ref(log->make_appender(cfg), cfg.timeout)
           .get();
         current_ts = model::timestamp(current_ts() + 1);
     }
@@ -432,7 +432,7 @@ void append_custom_timestamp_batches(
 FIXTURE_TEST(
   test_timestamp_updates_when_max_timestamp_is_not_set, storage_test_fixture) {
     auto append_batch_with_no_max_ts =
-      [](storage::log log, model::term_id term, model::timestamp base_ts) {
+      [](ss::shared_ptr<storage::log> log, model::term_id term, model::timestamp base_ts) {
           auto current_ts = base_ts;
 
           iobuf key = bytes_to_iobuf(bytes("key"));
@@ -458,7 +458,7 @@ FIXTURE_TEST(
           };
 
           std::move(reader)
-            .for_each_ref(log.make_appender(cfg), cfg.timeout)
+            .for_each_ref(log->make_appender(cfg), cfg.timeout)
             .get();
           current_ts = model::timestamp(current_ts() + 1);
       };
@@ -533,9 +533,9 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
       model::offset::min(), // should prevent compaction
       ss::default_priority_class(),
       as);
-    auto before = log.offsets();
-    log.housekeeping(ccfg_no_compact).get0();
-    auto after = log.offsets();
+    auto before = log->offsets();
+    log->housekeeping(ccfg_no_compact).get0();
+    auto after = log->offsets();
     BOOST_REQUIRE_EQUAL(after.start_offset, before.start_offset);
 
     auto make_compaction_cfg = [&as](int timestamp) {
@@ -591,7 +591,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
     auto disk_log = get_disk_log(log);
     auto headers = append_random_batches(log, 10);
-    log.flush().get0();
+    log->flush().get0();
     auto all_batches = read_and_validate_all_batches(log);
     size_t first_size = std::accumulate(
       all_batches.begin(),
@@ -599,7 +599,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       size_t(0),
       [](size_t acc, model::record_batch& b) { return acc + b.size_bytes(); });
 
-    auto lstats = log.offsets();
+    auto lstats = log->offsets();
     info("Offsets to be evicted {}", lstats);
     headers = append_random_batches(log, 10);
     auto new_batches = read_and_validate_all_batches(log);
@@ -619,7 +619,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       as);
     compact_and_prefix_truncate(*disk_log, ccfg_no_compact);
 
-    auto new_lstats = log.offsets();
+    auto new_lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(new_lstats.start_offset, lstats.start_offset);
 
     // max log size
@@ -648,7 +648,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       as);
     compact_and_prefix_truncate(*disk_log, ccfg);
 
-    new_lstats = log.offsets();
+    new_lstats = log->offsets();
     info("Final offsets {}", new_lstats);
     BOOST_REQUIRE_EQUAL(
       new_lstats.start_offset, last_offset + model::offset(1));
@@ -688,7 +688,7 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    (void)log.monitor_eviction(as).then(
+    (void)log->monitor_eviction(as).then(
       [&last_evicted_offset](model::offset o) mutable {
           last_evicted_offset.set_value(o);
       });
@@ -698,9 +698,9 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       10,
       model::term_id(0),
       custom_ts_batch_generator(model::timestamp::now()));
-    log.flush().get0();
+    log->flush().get0();
     model::timestamp gc_ts = headers.back().max_timestamp;
-    auto lstats_before = log.offsets();
+    auto lstats_before = log->offsets();
     info("Offsets to be evicted {}", lstats_before);
     headers = append_random_batches(
       log,
@@ -714,20 +714,20 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       ss::default_priority_class(),
       as);
 
-    log.housekeeping(ccfg).get0();
+    log->housekeeping(ccfg).get0();
 
     auto offset = last_evicted_offset.get_future().get0();
-    log.housekeeping(ccfg).get0();
-    auto lstats_after = log.offsets();
+    log->housekeeping(ccfg).get0();
+    auto lstats_after = log->offsets();
 
     BOOST_REQUIRE_EQUAL(lstats_before.start_offset, lstats_after.start_offset);
     // wait for compaction
-    log.housekeeping(ccfg).get0();
+    log->housekeeping(ccfg).get0();
     log
-      .truncate_prefix(storage::truncate_prefix_config{
+      ->truncate_prefix(storage::truncate_prefix_config{
         model::next_offset(offset), ss::default_priority_class()})
       .get();
-    auto compacted_lstats = log.offsets();
+    auto compacted_lstats = log->offsets();
     info("Compacted offsets {}", compacted_lstats);
     // check if compaction happend
     BOOST_REQUIRE_EQUAL(
@@ -735,7 +735,7 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       lstats_before.dirty_offset + model::offset(1));
 };
 ss::future<storage::append_result> append_exactly(
-  storage::log log,
+  ss::shared_ptr<storage::log> log,
   size_t batch_count,
   size_t batch_sz,
   std::optional<bytes> key = std::nullopt) {
@@ -786,7 +786,7 @@ ss::future<storage::append_result> append_exactly(
 
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
     return std::move(rdr).for_each_ref(
-      log.make_appender(append_cfg), model::no_timeout);
+      log->make_appender(append_cfg), model::no_timeout);
 }
 
 FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
@@ -808,7 +808,7 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
 
     append_exactly(log, 10, 100).get0();
-    BOOST_REQUIRE_EQUAL(log.offsets().dirty_offset, model::offset(9));
+    BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, model::offset(9));
 
     std::vector<ss::future<>> futures;
 
@@ -822,7 +822,7 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
           model::offset::max(),
           ss::default_priority_class(),
           as);
-        return log.housekeeping(ccfg);
+        return log->housekeeping(ccfg);
     };
 
     auto append =
@@ -852,7 +852,7 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
 
     as.request_abort();
     loop.get0();
-    auto lstats_after = log.offsets();
+    auto lstats_after = log->offsets();
     BOOST_REQUIRE_EQUAL(
       lstats_after.dirty_offset,
       model::offset(9 + appends * batches_per_append));
@@ -903,7 +903,7 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
         should_flush_t::no);
 
     builder.get_log()
-      .truncate(storage::truncate_config(
+      ->truncate(storage::truncate_config(
         model::offset(6), ss::default_priority_class()))
       .get0();
 
@@ -933,10 +933,10 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
 
-    auto offsets_after_recovery = log.offsets();
+    auto offsets_after_recovery = log->offsets();
 
     // Append single batch
-    storage::log_appender appender = log.make_appender(
+    storage::log_appender appender = log->make_appender(
       storage::log_append_config{
         .should_fsync = storage::log_append_config::fsync::no,
         .io_priority = ss::default_priority_class(),
@@ -953,7 +953,7 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
 
     // after append we expect offset to be equal to {6} as one record was
     // appended
-    BOOST_REQUIRE_EQUAL(log.offsets().dirty_offset, model::offset(6));
+    BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, model::offset(6));
 }
 
 FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
@@ -1005,15 +1005,15 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
       as);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
-    auto offsets_after_recovery = log.offsets();
+    auto offsets_after_recovery = log->offsets();
     info("After recovery: {}", log);
     // trigger compaction
-    log.housekeeping(compaction_cfg).get0();
-    auto offsets_after_compact = log.offsets();
+    log->housekeeping(compaction_cfg).get0();
+    auto offsets_after_compact = log->offsets();
     info("After compaction, offsets: {}, {}", offsets_after_compact, log);
 
     // Append single batch
-    storage::log_appender appender = log.make_appender(
+    storage::log_appender appender = log->make_appender(
       storage::log_append_config{
         .should_fsync = storage::log_append_config::fsync::no,
         .io_priority = ss::default_priority_class(),
@@ -1031,11 +1031,11 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
     BOOST_REQUIRE_EQUAL(offsets_after_compact.dirty_offset, model::offset(1));
 
     // after append we expect offset to be equal to {2}
-    BOOST_REQUIRE_EQUAL(log.offsets().dirty_offset, model::offset(2));
+    BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, model::offset(2));
 }
 
 void append_single_record_batch(
-  storage::log log,
+  ss::shared_ptr<storage::log> log,
   int cnt,
   model::term_id term,
   size_t val_size = 0,
@@ -1071,7 +1071,7 @@ void append_single_record_batch(
         };
 
         std::move(reader)
-          .for_each_ref(log.make_appender(cfg), cfg.timeout)
+          .for_each_ref(log->make_appender(cfg), cfg.timeout)
           .get0();
     }
 }
@@ -1104,20 +1104,20 @@ FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
           = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
         // 1) append few single record batches in term 1
         append_single_record_batch(log, 14, model::term_id(1));
-        log.flush().get0();
+        log->flush().get0();
         // 2) truncate in the middle of segment
         model::offset truncate_at(7);
         info("Truncating at offset:{}", truncate_at);
         log
-          .truncate(
+          ->truncate(
             storage::truncate_config(truncate_at, ss::default_priority_class()))
           .get0();
         // 3) append some more batches to the same segment
         append_single_record_batch(log, 10, model::term_id(1));
-        log.flush().get0();
+        log->flush().get0();
         //  4) roll term by appending to new segment
         append_single_record_batch(log, 1, model::term_id(8));
-        log.flush().get0();
+        log->flush().get0();
     }
     // 5) restart log manager
     {
@@ -1129,8 +1129,8 @@ FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
           = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
         auto read = read_and_validate_all_batches(log);
 
-        for (model::offset o(0); o < log.offsets().committed_offset; ++o) {
-            BOOST_REQUIRE(log.get_term(o).has_value());
+        for (model::offset o(0); o < log->offsets().committed_offset; ++o) {
+            BOOST_REQUIRE(log->get_term(o).has_value());
         }
     }
 }
@@ -1164,21 +1164,21 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
           model::offset::max(),
           ss::default_priority_class(),
           as);
-        log.flush().get0();
+        log->flush().get0();
         model::offset truncate_at(7);
         info("Truncating at offset:{}", truncate_at);
         log
-          .truncate(
+          ->truncate(
             storage::truncate_config(truncate_at, ss::default_priority_class()))
           .get0();
         // roll segment
         append_single_record_batch(log, 10, model::term_id(2));
-        log.flush().get0();
+        log->flush().get0();
 
         // roll segment
         append_single_record_batch(log, 1, model::term_id(8));
         // compact log
-        log.housekeeping(c_cfg).get0();
+        log->housekeeping(c_cfg).get0();
     }
 
     // force recovery
@@ -1191,10 +1191,10 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
           = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
 
         auto read = read_and_validate_all_batches(log);
-        auto lstats = log.offsets();
+        auto lstats = log->offsets();
         for (model::offset o = lstats.start_offset; o < lstats.committed_offset;
              ++o) {
-            BOOST_REQUIRE(log.get_term(o).has_value());
+            BOOST_REQUIRE(log->get_term(o).has_value());
         }
     }
 }
@@ -1229,20 +1229,20 @@ FIXTURE_TEST(
       model::offset::max(),
       ss::default_priority_class(),
       as);
-    log.flush().get0();
+    log->flush().get0();
     model::offset truncate_at(7);
     info("Truncating at offset:{}", truncate_at);
-    BOOST_REQUIRE_EQUAL(log.segment_count(), 1);
+    BOOST_REQUIRE_EQUAL(log->segment_count(), 1);
     log
-      .truncate(
+      ->truncate(
         storage::truncate_config(truncate_at, ss::default_priority_class()))
       .get0();
     append_single_record_batch(log, 10, model::term_id(1));
-    log.flush().get0();
+    log->flush().get0();
 
     // segment should be rolled after truncation
-    BOOST_REQUIRE_EQUAL(log.segment_count(), 2);
-    log.housekeeping(c_cfg).get0();
+    BOOST_REQUIRE_EQUAL(log->segment_count(), 2);
+    log->housekeeping(c_cfg).get0();
 
     auto read = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read.begin()->base_offset(), model::offset(6));
@@ -1397,7 +1397,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
 
     // Test becomes non-deterministic if we allow flush in background: flush
     // explicitly instead.
-    log.flush().get();
+    log->flush().get();
 
     // Read back and validate content of log pre-compaction.
     BOOST_REQUIRE_EQUAL(
@@ -1405,7 +1405,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
       input_batch_count * batch_size);
     BOOST_REQUIRE_EQUAL(
       read_and_validate_all_batches(log).size(), input_batch_count);
-    auto lstats_before = log.offsets();
+    auto lstats_before = log->offsets();
     BOOST_REQUIRE_EQUAL(
       lstats_before.committed_offset, model::offset{input_batch_count - 1});
     BOOST_REQUIRE_EQUAL(lstats_before.start_offset, model::offset{0});
@@ -1425,7 +1425,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     get_disk_log(log)->get_probe().partition_size();
 
     as.request_abort();
-    auto lstats_after = log.offsets();
+    auto lstats_after = log->offsets();
     BOOST_REQUIRE_EQUAL(
       lstats_after.committed_offset, lstats_before.committed_offset);
     BOOST_REQUIRE_EQUAL(lstats_after.start_offset, model::offset{50});
@@ -1464,7 +1464,7 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager(cfg);
 
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
-    std::vector<storage::log> logs;
+    std::vector<ss::shared_ptr<storage::log>> logs;
     for (int i = 0; i < 5; ++i) {
         auto ntp = model::ntp("default", ssx::sformat("test-{}", i), 0);
         storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
@@ -1515,7 +1515,7 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     append_single_record_batch(log, 40, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     append_single_record_batch(log, 50, model::term_id(1));
-    log.flush().get0();
+    log->flush().get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
@@ -1526,9 +1526,9 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
       ss::default_priority_class(),
       as);
 
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     // Self compactions complete.
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
@@ -1536,20 +1536,20 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     // offset of first segment. Nothing should be compacted.
     const auto first_segment_offsets = disk_log->segments().front()->offsets();
     c_cfg.compact.max_collectible_offset = first_segment_offsets.base_offset;
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
     // reset
     c_cfg.compact.max_collectible_offset = model::offset::max();
 
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 
     // no change since we can't combine with appender segment
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 }
 
@@ -1583,7 +1583,7 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
     append_single_record_batch(log, 40, model::term_id(3));
     append_single_record_batch(log, 50, model::term_id(4));
     append_single_record_batch(log, 50, model::term_id(5));
-    log.flush().get0();
+    log->flush().get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
@@ -1594,23 +1594,23 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
       ss::default_priority_class(),
       as);
 
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
     // the two segments with term 2 can be combined
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     // no more pairs with the same term
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     for (int i = 0; i < 5; i++) {
@@ -1660,7 +1660,7 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
     add_segment(16_KiB, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     add_segment(16_KiB, model::term_id(1));
-    log.flush().get0();
+    log->flush().get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
@@ -1672,28 +1672,28 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
       as);
 
     // self compaction steps
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
     // the first two segments are combined 2+2=4 < 6 MB
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     // the new first and second are too big 4+5 > 6 MB but the second and third
     // can be combined 5 + 15KB < 6 MB
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
     // then the next 16 KB can be folded in
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 
     // that's all that can be done. the next seg is an appender
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 }
 
@@ -1726,7 +1726,7 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
     append_single_record_batch(log, 40, model::term_id(3));
     disk_log->force_roll(ss::default_priority_class()).get();
     append_single_record_batch(log, 50, model::term_id(4));
-    log.flush().get0();
+    log->flush().get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
@@ -1801,7 +1801,7 @@ FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
 
     model::offset next_to_read;
     {
-        auto reader = log.make_reader(reader_cfg).get();
+        auto reader = log->make_reader(reader_cfg).get();
 
         auto rec = model::consume_reader_to_memory(
                      std::move(reader), model::no_timeout)
@@ -1812,7 +1812,7 @@ FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
     {
         reader_cfg.start_offset = next_to_read;
         reader_cfg.max_bytes = 150_KiB;
-        auto reader = log.make_reader(reader_cfg).get();
+        auto reader = log->make_reader(reader_cfg).get();
 
         auto rec = model::consume_reader_to_memory(
                      std::move(reader), model::no_timeout)
@@ -1860,7 +1860,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
     add_segment(16_KiB, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     add_segment(16_KiB, model::term_id(1));
-    log.flush().get0();
+    log->flush().get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
@@ -1875,7 +1875,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
      * calculate backlog size.
      */
     auto& segments = disk_log->segments();
-    auto backlog_size = log.compaction_backlog();
+    auto backlog_size = log->compaction_backlog();
     size_t self_seg_compaction_sz = 0;
     for (auto& s : segments) {
         self_seg_compaction_sz += s->size_bytes();
@@ -1886,13 +1886,13 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
         + 2 * segments[2]->size_bytes() + segments[3]->size_bytes()
         + self_seg_compaction_sz);
     // self compaction steps
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
-    auto new_backlog_size = log.compaction_backlog();
+    auto new_backlog_size = log->compaction_backlog();
     /**
      * after all self segments are compacted they shouldn't be included into the
      * backlog (only last segment is since it has appender and isn't self
@@ -1941,11 +1941,11 @@ FIXTURE_TEST(not_compacted_log_backlog, storage_test_fixture) {
     add_segment(16_KiB, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     add_segment(16_KiB, model::term_id(1));
-    log.flush().get0();
+    log->flush().get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
-    BOOST_REQUIRE_EQUAL(log.compaction_backlog(), 0);
+    BOOST_REQUIRE_EQUAL(log->compaction_backlog(), 0);
 }
 
 ss::future<model::record_batch_reader::data_t> copy_reader_to_memory(
@@ -1987,7 +1987,7 @@ FIXTURE_TEST(disposing_in_use_reader, storage_test_fixture) {
     for (auto i = 1; i < 100; ++i) {
         append_single_record_batch(log, 1, model::term_id(1), 128, true);
     }
-    log.flush().get();
+    log->flush().get();
     // read only up to 4096 bytes, this way a reader will still be in a cache
     storage::log_reader_config reader_cfg(
       model::offset(0),
@@ -2001,12 +2001,12 @@ FIXTURE_TEST(disposing_in_use_reader, storage_test_fixture) {
 
     auto truncate_f = ss::now();
     {
-        auto reader = log.make_reader(reader_cfg).get();
+        auto reader = log->make_reader(reader_cfg).get();
 
         auto rec = copy_reader_to_memory(reader, model::no_timeout).get();
 
         BOOST_REQUIRE_EQUAL(rec.back().last_offset(), model::offset(17));
-        truncate_f = log.truncate(storage::truncate_config(
+        truncate_f = log->truncate(storage::truncate_config(
           model::offset(5), ss::default_priority_class()));
         // yield to allow truncate fiber to reach waiting for a lock
         ss::sleep(200ms).get();
@@ -2054,7 +2054,7 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
 
     auto append = [&] {
         // Append single batch
-        storage::log_appender appender = log.make_appender(
+        storage::log_appender appender = log->make_appender(
           storage::log_append_config{
             .should_fsync = storage::log_append_config::fsync::no,
             .io_priority = ss::default_priority_class(),
@@ -2084,10 +2084,10 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
         return write_mutex.get_units().then([&](ssx::semaphore_units u) {
             return append().then(
               [&, u = std::move(u)](storage::append_result res) mutable {
-                  auto f = log.flush();
+                  auto f = log->flush();
                   u.return_all();
                   return f.then([&, dirty = res.last_offset] {
-                      auto lstats = log.offsets();
+                      auto lstats = log->offsets();
                       BOOST_REQUIRE_GE(lstats.committed_offset, dirty);
                   });
               });
@@ -2159,7 +2159,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
                 };
 
                 std::move(reader)
-                  .for_each_ref(log.make_appender(cfg), cfg.timeout)
+                  .for_each_ref(log->make_appender(cfg), cfg.timeout)
                   .get0();
             }
         } while (disk_log->segments().back()->size_bytes() < size);
@@ -2170,7 +2170,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
     add_segment(1_MiB, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     add_segment(1_MiB, model::term_id(1));
-    log.flush().get0();
+    log->flush().get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 
@@ -2182,8 +2182,8 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
       as);
 
     // self compaction steps
-    log.housekeeping(c_cfg).get0();
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
 
     // read all batches
     auto first_read = read_and_validate_all_batches(log);
@@ -2191,7 +2191,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
     overrides.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::deletion;
     // update cleanup policy to deletion
-    log.update_configuration(overrides).get();
+    log->update_configuration(overrides).get();
 
     // read all batches again
     auto second_read = read_and_validate_all_batches(log);
@@ -2250,7 +2250,7 @@ FIXTURE_TEST(reader_prevents_log_shutdown, storage_test_fixture) {
       std::nullopt);
     auto f = ss::now();
     {
-        auto reader = log.make_reader(reader_cfg).get();
+        auto reader = log->make_reader(reader_cfg).get();
         auto batches = copy_to_mem(reader).get();
 
         f = mgr.shutdown(ntp);
@@ -2275,7 +2275,7 @@ FIXTURE_TEST(test_querying_term_last_offset, storage_test_fixture) {
                  .get0();
     // append some baches in term 0
     append_random_batches(log, 10, model::term_id(0));
-    auto lstats_term_0 = log.offsets();
+    auto lstats_term_0 = log->offsets();
     // append some batches in term 1
     append_random_batches(log, 10, model::term_id(1));
     {
@@ -2285,34 +2285,34 @@ FIXTURE_TEST(test_querying_term_last_offset, storage_test_fixture) {
     }
     // append more batches in the same term
     append_random_batches(log, 10, model::term_id(1));
-    auto lstats_term_1 = log.offsets();
+    auto lstats_term_1 = log->offsets();
     // append some batche sin term 2
     append_random_batches(log, 10, model::term_id(2));
 
     BOOST_REQUIRE_EQUAL(
       lstats_term_0.dirty_offset,
-      log.get_term_last_offset(model::term_id(0)).value());
+      log->get_term_last_offset(model::term_id(0)).value());
     BOOST_REQUIRE_EQUAL(
       lstats_term_1.dirty_offset,
-      log.get_term_last_offset(model::term_id(1)).value());
+      log->get_term_last_offset(model::term_id(1)).value());
     BOOST_REQUIRE_EQUAL(
-      log.offsets().dirty_offset,
-      log.get_term_last_offset(model::term_id(2)).value());
+      log->offsets().dirty_offset,
+      log->get_term_last_offset(model::term_id(2)).value());
 
-    BOOST_REQUIRE(!log.get_term_last_offset(model::term_id(3)).has_value());
+    BOOST_REQUIRE(!log->get_term_last_offset(model::term_id(3)).has_value());
     // prefix truncate log at end offset fo term 0
 
     log
-      .truncate_prefix(storage::truncate_prefix_config(
+      ->truncate_prefix(storage::truncate_prefix_config(
         lstats_term_0.dirty_offset + model::offset(1),
         ss::default_priority_class()))
       .get();
 
-    BOOST_REQUIRE(!log.get_term_last_offset(model::term_id(0)).has_value());
+    BOOST_REQUIRE(!log->get_term_last_offset(model::term_id(0)).has_value());
 }
 
 void write_batch(
-  storage::log log,
+  ss::shared_ptr<storage::log> log,
   ss::sstring key,
   int value,
   model::record_batch_type batch_type) {
@@ -2329,13 +2329,13 @@ void write_batch(
       .timeout = model::no_timeout,
     };
 
-    std::move(reader).for_each_ref(log.make_appender(cfg), cfg.timeout).get0();
+    std::move(reader).for_each_ref(log->make_appender(cfg), cfg.timeout).get0();
 }
 
 absl::flat_hash_map<std::pair<model::record_batch_type, ss::sstring>, int>
-compact_in_memory(storage::log log) {
+compact_in_memory(ss::shared_ptr<storage::log> log) {
     auto rdr = log
-                 .make_reader(storage::log_reader_config(
+                 ->make_reader(storage::log_reader_config(
                    model::offset(0),
                    model::offset::max(),
                    ss::default_priority_class()))
@@ -2399,7 +2399,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
 
     disk_log->force_roll(ss::default_priority_class()).get();
 
-    log.flush().get0();
+    log->flush().get0();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 
@@ -2413,7 +2413,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(before_compaction.size(), 3);
     // compact
-    log.housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get0();
     auto after_compaction = compact_in_memory(log);
 
     BOOST_REQUIRE(before_compaction == after_compaction);
@@ -2464,26 +2464,26 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
             .with([reader = std::move(reader), cfg, &log]() mutable {
                 info("append_lock");
                 return std::move(reader).for_each_ref(
-                  log.make_appender(cfg), cfg.timeout);
+                  log->make_appender(cfg), cfg.timeout);
             })
             .then([](storage::append_result res) {
                 info("append_result: {}", res.last_offset);
             })
-            .then([&log] { return log.flush(); })
+            .then([&log] { return log->flush(); })
             .finally([&cnt] { cnt++; });
       });
 
     auto read = ss::do_until(
       [&] { return cnt > max; },
       [&log, &cnt] {
-          auto offset = log.offsets();
+          auto offset = log->offsets();
           storage::log_reader_config cfg(
             std::max(model::offset(0), offset.dirty_offset - model::offset(10)),
             cnt % 2 == 0 ? offset.dirty_offset - model::offset(2)
                          : offset.dirty_offset,
             ss::default_priority_class());
           auto start = ss::steady_clock_type::now();
-          return log.make_reader(cfg)
+          return log->make_reader(cfg)
             .then([start](model::record_batch_reader rdr) {
                 // assert that creating a reader took less than 5 seconds
                 BOOST_REQUIRE_LT(
@@ -2506,16 +2506,16 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
     auto truncate = ss::do_until(
       [&] { return cnt > max; },
       [&log, &log_mutex] {
-          auto offset = log.offsets();
+          auto offset = log->offsets();
           if (offset.dirty_offset <= model::offset(0)) {
               return ss::now();
           }
           return log_mutex.with([&log] {
-              auto offset = log.offsets();
+              auto offset = log->offsets();
               info("truncate offsets: {}", offset);
               auto start = ss::steady_clock_type::now();
               return log
-                .truncate(storage::truncate_config(
+                ->truncate(storage::truncate_config(
                   offset.dirty_offset, ss::default_priority_class()))
                 .finally([start] {
                     // assert that truncation took less than 5 seconds
@@ -2584,12 +2584,12 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
               return log_mutex
                 .with([reader = std::move(reader), cfg, &log]() mutable {
                     return std::move(reader).for_each_ref(
-                      log.make_appender(cfg), cfg.timeout);
+                      log->make_appender(cfg), cfg.timeout);
                 })
                 .then([](storage::append_result res) {
                     info("append_result: {}", res.last_offset);
                 })
-                .then([&log] { return log.flush(); })
+                .then([&log] { return log->flush(); })
                 .finally([&cnt] { cnt++; });
           })
           .finally([&] { done = true; });
@@ -2598,12 +2598,12 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
       = ss::do_until(
           [&] { return done; },
           [&log, &log_mutex] {
-              auto offset = log.offsets();
+              auto offset = log->offsets();
               if (offset.dirty_offset <= model::offset(0)) {
                   return ss::now();
               }
               return log_mutex.with([&log] {
-                  auto offset = log.offsets();
+                  auto offset = log->offsets();
                   auto truncate_at = model::offset{
                     random_generators::get_int<int64_t>(
                       offset.dirty_offset() / 2, offset.dirty_offset)};
@@ -2613,7 +2613,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                     truncate_at);
 
                   return log
-                    .truncate(storage::truncate_config(
+                    ->truncate(storage::truncate_config(
                       truncate_at, ss::default_priority_class()))
                     .then_wrapped([log, o = truncate_at](ss::future<> f) {
                         vassert(
@@ -2621,7 +2621,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                           "truncation failed with {}",
                           f.get_exception());
                         BOOST_REQUIRE_LE(
-                          log.offsets().dirty_offset, model::prev_offset(o));
+                          log->offsets().dirty_offset, model::prev_offset(o));
                     });
               });
           })
@@ -2631,7 +2631,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                      [&] { return done; },
                      [&log, &as] {
                          return log
-                           .housekeeping(storage::housekeeping_config(
+                           ->housekeeping(storage::housekeeping_config(
                              model::timestamp::min(),
                              std::nullopt,
                              model::offset::max(),
@@ -2656,7 +2656,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
 
     // Ensure we've cleaned up all our staging segments such that a removal of
     // the log results in nothing leftover.
-    auto dir_path = log.config().work_directory();
+    auto dir_path = log->config().work_directory();
     try {
         mgr.remove(ntp).get();
     } catch (...) {
@@ -2719,13 +2719,13 @@ FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
           };
 
           std::move(reader)
-            .for_each_ref(log.make_appender(appender_cfg), model::no_timeout)
+            .for_each_ref(log->make_appender(appender_cfg), model::no_timeout)
             .discard_result()
-            .then([&log] { return log.flush(); })
+            .then([&log] { return log->flush(); })
             .get();
 
           log
-            .housekeeping(storage::housekeeping_config(
+            ->housekeeping(storage::housekeeping_config(
               model::timestamp::min(),
               std::nullopt,
               model::offset::max(),
@@ -2758,11 +2758,11 @@ FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
         model::offset truncate_offset(10);
 
         log
-          .truncate(storage::truncate_config(
+          ->truncate(storage::truncate_config(
             truncate_offset, ss::default_priority_class()))
           .get();
-        info("truncated at: {}, offsets: {}", truncate_offset, log.offsets());
-        BOOST_REQUIRE_EQUAL(log.offsets().dirty_offset, model::offset(0));
+        info("truncated at: {}, offsets: {}", truncate_offset, log->offsets());
+        BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, model::offset(0));
     }
 
     {
@@ -2790,17 +2790,17 @@ FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
 
         model::offset truncate_offset(11);
         log
-          .truncate_prefix(storage::truncate_prefix_config(
+          ->truncate_prefix(storage::truncate_prefix_config(
             truncate_offset, ss::default_priority_class()))
           .get();
 
         log
-          .truncate(storage::truncate_config(
+          ->truncate(storage::truncate_config(
             truncate_offset, ss::default_priority_class()))
           .get();
-        info("truncated at: {}, offsets: {}", truncate_offset, log.offsets());
+        info("truncated at: {}, offsets: {}", truncate_offset, log->offsets());
         // empty log have a dirty offset equal to (start_offset - 1)
-        BOOST_REQUIRE_EQUAL(log.offsets().dirty_offset, model::offset(10));
+        BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, model::offset(10));
     }
 }
 
@@ -2844,8 +2844,8 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
       log, 20);
 
     // (2) remember log offset, roll log, and produce more messages
-    log.flush().get0();
-    auto first_stats = log.offsets();
+    log->flush().get0();
+    auto first_stats = log->offsets();
     info("Offsets to be compacted {}", first_stats);
     disk_log->force_roll(ss::default_priority_class()).get();
     headers = append_random_batches<key_limited_random_batch_generator>(
@@ -2853,8 +2853,8 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
 
     // (3) roll log and trigger compaction, analyzing offset gaps before and
     // after, to observe compaction behavior.
-    log.flush().get0();
-    auto second_stats = log.offsets();
+    log->flush().get0();
+    auto second_stats = log->offsets();
     auto pre_compact_gaps = analyze(*disk_log);
     disk_log->force_roll(ss::default_priority_class()).get();
     auto max_compact_offset = first_stats.committed_offset;
@@ -2864,8 +2864,8 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
       max_compact_offset,
       ss::default_priority_class(),
       as);
-    log.housekeeping(ccfg).get0();
-    auto final_stats = log.offsets();
+    log->housekeeping(ccfg).get0();
+    auto final_stats = log->offsets();
     auto post_compact_gaps = analyze(*disk_log);
 
     // (4) check correctness.
@@ -2911,7 +2911,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
       log, 20);
 
     // (2) remember log offset, roll log, and produce more messages
-    log.flush().get0();
+    log->flush().get0();
 
     disk_log->force_roll(ss::default_priority_class()).get();
     headers = append_random_batches<key_limited_random_batch_generator>(
@@ -2919,7 +2919,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
 
     // (3) roll log and trigger compaction, analyzing offset gaps before and
     // after, to observe compaction behavior.
-    log.flush().get0();
+    log->flush().get0();
 
     disk_log->force_roll(ss::default_priority_class()).get();
     storage::housekeeping_config ccfg(
@@ -2933,7 +2933,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
                     ->offset_data_stream(
                       model::offset(0), ss::default_priority_class())
                     .get();
-    log.housekeeping(std::move(ccfg)).get();
+    log->housekeeping(std::move(ccfg)).get();
     stream.close().get();
 };
 
@@ -2959,7 +2959,7 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
     // Append some linear kv ints
     int num_appends = 5;
     append_random_batches<linear_int_kv_batch_generator>(log, num_appends);
-    log.flush().get0();
+    log->flush().get0();
     disk_log->force_roll(ss::default_priority_class()).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 
@@ -2983,7 +2983,7 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
       ss::default_priority_class(),
       as);
 
-    log.housekeeping(ccfg).get();
+    log->housekeeping(ccfg).get();
 
     batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(
@@ -3019,7 +3019,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
     auto disk_log = get_disk_log(log);
 
-    auto append_batch = [](storage::log log, model::term_id term) {
+    auto append_batch = [](ss::shared_ptr<storage::log> log, model::term_id term) {
         iobuf key = bytes_to_iobuf(bytes("key"));
         iobuf value = random_generators::make_iobuf(100);
 
@@ -3041,7 +3041,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
         };
 
         std::move(reader)
-          .for_each_ref(log.make_appender(cfg), cfg.timeout)
+          .for_each_ref(log->make_appender(cfg), cfg.timeout)
           .get();
     };
 
@@ -3054,9 +3054,9 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     append_batch(log, model::term_id(0)); // write single message for final
                                           // segment after last roll
 
-    log.flush().get();
+    log->flush().get();
     auto pre_gaps = analyze(*disk_log);
-    auto pre_stats = log.offsets();
+    auto pre_stats = log->offsets();
     BOOST_REQUIRE_EQUAL(
       pre_stats.committed_offset, args.segments * args.msg_per_segment);
     BOOST_REQUIRE_EQUAL(pre_gaps.num_gaps, 0);
@@ -3068,8 +3068,8 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
       model::offset(args.max_compact_offs),
       ss::default_priority_class(),
       as);
-    log.housekeeping(ccfg).get0();
-    auto final_stats = log.offsets();
+    log->housekeeping(ccfg).get0();
+    auto final_stats = log->offsets();
     auto final_gaps = analyze(*disk_log);
     tlog.info("post-compact stats: {}, analysis: {}", final_stats, final_gaps);
     BOOST_REQUIRE_EQUAL(
@@ -3379,11 +3379,11 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
             .with([reader = std::move(reader), cfg, &log]() mutable {
                 info("append_lock");
                 return std::move(reader)
-                  .for_each_ref(log.make_appender(cfg), cfg.timeout)
+                  .for_each_ref(log->make_appender(cfg), cfg.timeout)
                   .then([](storage::append_result res) {
                       info("append_result: {}", res.last_offset);
                   })
-                  .then([&log] { return log.flush(); });
+                  .then([&log] { return log->flush(); });
             })
             .finally([&cnt] { cnt++; });
       });
@@ -3391,7 +3391,7 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
     auto read = ss::do_until(
       [&] { return cnt > max; },
       [&log, &last_truncate] {
-          auto offset = log.offsets();
+          auto offset = log->offsets();
           storage::log_reader_config cfg(
             last_truncate - model::offset(1),
             offset.dirty_offset,
@@ -3399,7 +3399,7 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
           cfg.type_filter = model::record_batch_type::raft_data;
 
           auto start = ss::steady_clock_type::now();
-          return log.make_reader(cfg)
+          return log->make_reader(cfg)
             .then([start](model::record_batch_reader rdr) {
                 // assert that creating a reader took less than 5 seconds
                 BOOST_REQUIRE_LT(
@@ -3422,18 +3422,18 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
     auto truncate = ss::do_until(
       [&] { return cnt > max; },
       [&log, &log_mutex, &last_truncate] {
-          auto offset = log.offsets();
+          auto offset = log->offsets();
           if (offset.dirty_offset <= model::offset(0)) {
               return ss::now();
           }
           return log_mutex
             .with([&log, &last_truncate] {
-                auto offset = log.offsets();
+                auto offset = log->offsets();
                 info("truncate offsets: {}", offset);
                 auto start = ss::steady_clock_type::now();
                 last_truncate = offset.dirty_offset;
                 return log
-                  .truncate(storage::truncate_config(
+                  ->truncate(storage::truncate_config(
                     offset.dirty_offset, ss::default_priority_class()))
                   .finally([start] {
                       // assert that truncation took less than 5 seconds

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -348,7 +348,8 @@ public:
         return headers;
     }
 
-    void append_batch(ss::shared_ptr<storage::log> log, model::record_batch batch) {
+    void
+    append_batch(ss::shared_ptr<storage::log> log, model::record_batch batch) {
         model::record_batch_reader::data_t buffer;
         const auto last_offset_delta = model::offset(
           batch.header().last_offset_delta);
@@ -383,7 +384,9 @@ public:
     // model::offset max_offset = model::model_limits<model::offset>::max(); //
     // inclusive
     ss::circular_buffer<model::record_batch> read_range_to_vector(
-      ss::shared_ptr<storage::log> log, model::offset start, model::offset end) {
+      ss::shared_ptr<storage::log> log,
+      model::offset start,
+      model::offset end) {
         storage::log_reader_config cfg(
           start, end, ss::default_priority_class());
         tlog.info("read_range_to_vector: {}", cfg);

--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -73,11 +73,11 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
 
         storage::timequery_config config(
           model::timestamp(ts),
-          log.offsets().dirty_offset,
+          log->offsets().dirty_offset,
           ss::default_priority_class(),
           std::nullopt);
 
-        auto res = log.timequery(config).get0();
+        auto res = log->timequery(config).get0();
         BOOST_TEST(res);
         BOOST_TEST(res->time == model::timestamp(ts));
         BOOST_TEST(res->offset == model::offset(ts));
@@ -95,13 +95,13 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
 
         storage::timequery_config config(
           model::timestamp(ts),
-          log.offsets().dirty_offset,
+          log->offsets().dirty_offset,
           ss::default_priority_class(),
           std::nullopt);
 
         auto offset = (ts - 100) * 5 + 100;
 
-        auto res = log.timequery(config).get0();
+        auto res = log->timequery(config).get0();
         BOOST_TEST(res);
         BOOST_TEST(res->time == model::timestamp(ts));
         BOOST_TEST(res->offset == model::offset(offset));
@@ -128,17 +128,17 @@ FIXTURE_TEST(timequery_single_value, log_builder_fixture) {
     auto log = b.get_log();
     storage::timequery_config config(
       model::timestamp(1200),
-      log.offsets().dirty_offset,
+      log->offsets().dirty_offset,
       ss::default_priority_class(),
       std::nullopt);
 
-    auto empty_res = log.timequery(config).get0();
+    auto empty_res = log->timequery(config).get0();
     BOOST_TEST(!empty_res);
 
     // ask for 999 it should return first segment
     config.time = model::timestamp(999);
 
-    auto res = log.timequery(config).get0();
+    auto res = log->timequery(config).get0();
     BOOST_TEST(res);
     BOOST_TEST(res->time == model::timestamp(1000));
     BOOST_TEST(res->offset == model::offset(0));
@@ -174,11 +174,11 @@ FIXTURE_TEST(timequery_sparse_index, log_builder_fixture) {
     auto log = b.get_log();
     storage::timequery_config config(
       model::timestamp(1600),
-      log.offsets().dirty_offset,
+      log->offsets().dirty_offset,
       ss::default_priority_class(),
       std::nullopt);
 
-    auto res = log.timequery(config).get0();
+    auto res = log->timequery(config).get0();
     BOOST_TEST(res);
     BOOST_TEST(res->time == model::timestamp(1600));
     BOOST_TEST(res->offset == model::offset(1));
@@ -207,11 +207,11 @@ FIXTURE_TEST(timequery_one_element_index, log_builder_fixture) {
     auto log = b.get_log();
     storage::timequery_config config(
       model::timestamp(1000),
-      log.offsets().dirty_offset,
+      log->offsets().dirty_offset,
       ss::default_priority_class(),
       std::nullopt);
 
-    auto res = log.timequery(config).get0();
+    auto res = log->timequery(config).get0();
     BOOST_TEST(res);
     BOOST_TEST(res->time == model::timestamp(1000));
     BOOST_TEST(res->offset == model::offset(0));
@@ -256,11 +256,11 @@ FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
     for (const auto& [offset, ts] : batch_spec) {
         storage::timequery_config config(
           model::timestamp(ts),
-          log.offsets().dirty_offset,
+          log->offsets().dirty_offset,
           ss::default_priority_class(),
           std::nullopt);
 
-        auto res = log.timequery(config).get0();
+        auto res = log->timequery(config).get0();
 
         if (offset == model::offset(4)) {
             // A timequery will always return from within the
@@ -281,11 +281,11 @@ FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
     // We should return the first element in the log
     storage::timequery_config config(
       model::timestamp(-5000),
-      log.offsets().dirty_offset,
+      log->offsets().dirty_offset,
       ss::default_priority_class(),
       std::nullopt);
 
-    auto res = log.timequery(config).get0();
+    auto res = log->timequery(config).get0();
 
     BOOST_TEST(res);
     BOOST_TEST(res->offset == model::offset(0));
@@ -323,12 +323,12 @@ FIXTURE_TEST(timequery_clamp, log_builder_fixture) {
     auto log = b.get_log();
     storage::timequery_config config(
       model::timestamp(storage::offset_time_index::delta_time_max * 2 + 1),
-      log.offsets().dirty_offset,
+      log->offsets().dirty_offset,
       ss::default_priority_class(),
       std::nullopt);
 
     const auto& [expected_offset, expected_ts] = batch_spec.back();
-    auto res = log.timequery(config).get0();
+    auto res = log->timequery(config).get0();
     BOOST_TEST(res);
     BOOST_TEST(res->time == expected_ts);
     BOOST_TEST(res->offset == expected_offset);

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -166,12 +166,12 @@ ss::future<> disk_log_builder::stop() {
 // Low lever interface access
 // Access log impl
 ss::shared_ptr<log> disk_log_builder::get_log() {
-    vassert(_log.has_value(), "Log is unintialized. Please use start() first");
-    return *_log;
+    vassert(_log, "Log is unintialized. Please use start() first");
+    return _log;
 }
 
 disk_log_impl& disk_log_builder::get_disk_log_impl() {
-    return dynamic_cast<disk_log_impl&>(*_log.value());
+    return dynamic_cast<disk_log_impl&>(*_log);
 }
 
 segment_set& disk_log_builder::get_log_segments() {
@@ -221,7 +221,7 @@ ss::future<> disk_log_builder::write(
       .then([this, flush](storage::append_result ar) {
           _bytes_written += ar.byte_size;
           if (flush) {
-              return _log.value()->flush();
+              return _log->flush();
           }
           return ss::now();
       });

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -171,7 +171,7 @@ ss::shared_ptr<log> disk_log_builder::get_log() {
 }
 
 disk_log_impl& disk_log_builder::get_disk_log_impl() {
-    return *reinterpret_cast<disk_log_impl*>(_log.value()->get_impl());
+    return dynamic_cast<disk_log_impl&>(*_log.value());
 }
 
 segment_set& disk_log_builder::get_log_segments() {

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -101,12 +101,12 @@ ss::future<> disk_log_builder::start(storage::ntp_config cfg) {
       [this, cfg = std::move(cfg)]() mutable {
           return _storage.log_mgr()
             .manage(std::move(cfg))
-            .then([this](storage::log log) { _log = log; });
+            .then([this](ss::shared_ptr<storage::log> log) { _log = log; });
       });
 }
 
 ss::future<> disk_log_builder::truncate(model::offset o) {
-    return get_log().truncate(
+    return get_log()->truncate(
       storage::truncate_config(o, ss::default_priority_class()));
 }
 
@@ -114,10 +114,10 @@ ss::future<> disk_log_builder::gc(
   model::timestamp collection_upper_bound,
   std::optional<size_t> max_partition_retention_size) {
     ss::abort_source as;
-    auto eviction_future = get_log().monitor_eviction(as);
+    auto eviction_future = get_log()->monitor_eviction(as);
 
     get_log()
-      .housekeeping(housekeeping_config(
+      ->housekeeping(housekeeping_config(
         collection_upper_bound,
         max_partition_retention_size,
         model::offset::max(),
@@ -127,7 +127,7 @@ ss::future<> disk_log_builder::gc(
 
     if (eviction_future.available()) {
         auto evict_until = eviction_future.get();
-        return get_log().truncate_prefix(storage::truncate_prefix_config{
+        return get_log()->truncate_prefix(storage::truncate_prefix_config{
           model::next_offset(evict_until), ss::default_priority_class()});
     } else {
         as.request_abort();
@@ -165,13 +165,13 @@ ss::future<> disk_log_builder::stop() {
 
 // Low lever interface access
 // Access log impl
-log& disk_log_builder::get_log() {
+ss::shared_ptr<log> disk_log_builder::get_log() {
     vassert(_log.has_value(), "Log is unintialized. Please use start() first");
     return *_log;
 }
 
 disk_log_impl& disk_log_builder::get_disk_log_impl() {
-    return *reinterpret_cast<disk_log_impl*>(_log->get_impl());
+    return *reinterpret_cast<disk_log_impl*>(_log.value()->get_impl());
 }
 
 segment_set& disk_log_builder::get_log_segments() {
@@ -221,7 +221,7 @@ ss::future<> disk_log_builder::write(
       .then([this, flush](storage::append_result ar) {
           _bytes_written += ar.byte_size;
           if (flush) {
-              return _log->flush();
+              return _log.value()->flush();
           }
           return ss::now();
       });

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -338,7 +338,7 @@ public:
     // Read interface
     // Default consume
     auto consume(log_reader_config config = reader_config()) {
-        return _log.value()->make_reader(config).then(
+        return _log->make_reader(config).then(
           [](model::record_batch_reader reader) {
               return model::consume_reader_to_memory(
                 std::move(reader), model::no_timeout);
@@ -361,7 +361,7 @@ public:
 
     ss::future<> update_configuration(ntp_config::default_overrides o) {
         if (_log) {
-            return _log.value()->update_configuration(o);
+            return _log->update_configuration(o);
         }
 
         return ss::make_ready_future<>();
@@ -379,7 +379,7 @@ public:
 private:
     template<typename Consumer>
     auto consume_impl(Consumer c, log_reader_config config) {
-        return _log.value()->make_reader(config).then(
+        return _log->make_reader(config).then(
           [c = std::move(c)](model::record_batch_reader reader) mutable {
               return std::move(reader).consume(std::move(c), model::no_timeout);
           });
@@ -408,7 +408,7 @@ private:
     ss::sharded<features::feature_table> _feature_table;
     storage::log_config _log_config;
     storage::api _storage;
-    std::optional<ss::shared_ptr<log>> _log;
+    ss::shared_ptr<log> _log;
     size_t _bytes_written{0};
     std::vector<std::vector<model::record_batch>> _batches;
     ss::abort_source _abort_source;

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -322,7 +322,7 @@ public:
 
     // Low lever interface access
     // Access log impl
-    log& get_log();
+    ss::shared_ptr<log> get_log();
     disk_log_impl& get_disk_log_impl();
     segment_set& get_log_segments();
     // Index range is [0....total_segments)
@@ -338,7 +338,7 @@ public:
     // Read interface
     // Default consume
     auto consume(log_reader_config config = reader_config()) {
-        return _log->make_reader(config).then(
+        return _log.value()->make_reader(config).then(
           [](model::record_batch_reader reader) {
               return model::consume_reader_to_memory(
                 std::move(reader), model::no_timeout);
@@ -361,7 +361,7 @@ public:
 
     ss::future<> update_configuration(ntp_config::default_overrides o) {
         if (_log) {
-            return _log->update_configuration(o);
+            return _log.value()->update_configuration(o);
         }
 
         return ss::make_ready_future<>();
@@ -379,7 +379,7 @@ public:
 private:
     template<typename Consumer>
     auto consume_impl(Consumer c, log_reader_config config) {
-        return _log->make_reader(config).then(
+        return _log.value()->make_reader(config).then(
           [c = std::move(c)](model::record_batch_reader reader) mutable {
               return std::move(reader).consume(std::move(c), model::no_timeout);
           });
@@ -408,7 +408,7 @@ private:
     ss::sharded<features::feature_table> _feature_table;
     storage::log_config _log_config;
     storage::api _storage;
-    std::optional<log> _log;
+    std::optional<ss::shared_ptr<log>> _log;
     size_t _bytes_written{0};
     std::vector<std::vector<model::record_batch>> _batches;
     ss::abort_source _abort_source;

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -63,7 +63,8 @@ static inline ss::future<> persist_log_file(
         auto& mgr = storage.local().log_mgr();
         try {
             mgr.manage(storage::ntp_config(file_ntp, mgr.config().base_dir))
-              .then([b = std::move(batches)](ss::shared_ptr<storage::log> log) mutable {
+              .then([b = std::move(batches)](
+                      ss::shared_ptr<storage::log> log) mutable {
                   storage::log_append_config cfg{
                     storage::log_append_config::fsync::yes,
                     ss::default_priority_class(),

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -63,7 +63,7 @@ static inline ss::future<> persist_log_file(
         auto& mgr = storage.local().log_mgr();
         try {
             mgr.manage(storage::ntp_config(file_ntp, mgr.config().base_dir))
-              .then([b = std::move(batches)](storage::log log) mutable {
+              .then([b = std::move(batches)](ss::shared_ptr<storage::log> log) mutable {
                   storage::log_append_config cfg{
                     storage::log_append_config::fsync::yes,
                     ss::default_priority_class(),
@@ -71,9 +71,9 @@ static inline ss::future<> persist_log_file(
                   auto reader = model::make_memory_record_batch_reader(
                     std::move(b));
                   return std::move(reader)
-                    .for_each_ref(log.make_appender(cfg), cfg.timeout)
+                    .for_each_ref(log->make_appender(cfg), cfg.timeout)
                     .then([log](storage::append_result) mutable {
-                        return log.flush();
+                        return log->flush();
                     })
                     .finally([log] {});
               })
@@ -140,9 +140,9 @@ read_log_file(ss::sstring base_dir, model::ntp file_ntp) {
         try {
             auto batches
               = mgr.manage(storage::ntp_config(file_ntp, mgr.config().base_dir))
-                  .then([](storage::log log) mutable {
+                  .then([](ss::shared_ptr<storage::log> log) mutable {
                       return log
-                        .make_reader(storage::log_reader_config(
+                        ->make_reader(storage::log_reader_config(
                           model::offset(0),
                           model::model_limits<model::offset>::max(),
                           ss::default_priority_class()))


### PR DESCRIPTION
Last quarter we remove the in-memory implementation, but then we were left with the pimpl wrapper and only one implementation. This PR removes the pimpl wrapper.

* pimpl is fun, and very cool, but clangd can't see through it which is a bummer.
* we only have disk implementation, but kept the abstraction layer because it is nice to not export the entire implementation out of storage layer.
* updating multiple interfaces and punching through with pimpl was pure overhead with no gain.
* `ss::shared_ptr<log>` vs `using log_ptr = ss::shared_ptr<log>` - used the former because (1) explicit is nice and (2) outside of tests (ie core redpanda) there are only a handful of places where it is spelled out explicitly such as method parameters.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
