### PR TITLE
test utilities for artificially injecting CPU stress

### DIFF
--- a/src/v/finjector/CMakeLists.txt
+++ b/src/v/finjector/CMakeLists.txt
@@ -1,6 +1,8 @@
 v_cc_library(
   NAME finjector
-  SRCS hbadger.cc
+  SRCS
+    hbadger.cc
+    stress_fiber.cc
   DEPS
     Seastar::seastar
     absl::flat_hash_map

--- a/src/v/finjector/stress_fiber.cc
+++ b/src/v/finjector/stress_fiber.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "finjector/stress_fiber.h"
+
+#include "random/generators.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/timer.hh>
+
+class stress_payload {
+public:
+    // Starts the stress payload with the given configuration.
+    static std::unique_ptr<stress_payload> start(stress_config cfg) {
+        return std::unique_ptr<stress_payload>(new stress_payload(cfg));
+    }
+
+    // Stops any existing stress fibers.
+    ss::future<> stop();
+
+private:
+    explicit stress_payload(stress_config);
+
+    // Runs a single fiber that spins the given number of times per scheduling
+    // point, until an abort is requested.
+    ss::future<> run_count_fiber(int min_count, int max_count);
+    ss::future<> run_delay_fiber(int min_ms, int max_ms);
+
+    ss::gate _gate;
+    ss::abort_source _as;
+};
+
+stress_payload::stress_payload(stress_config cfg) {
+    if (
+      cfg.max_spins_per_scheduling_point.has_value()
+      && cfg.min_spins_per_scheduling_point.has_value()) {
+        for (size_t i = 0; i < cfg.num_fibers; i++) {
+            ssx::spawn_with_gate(_gate, [cfg, this] {
+                return run_count_fiber(
+                  *cfg.min_spins_per_scheduling_point,
+                  *cfg.max_spins_per_scheduling_point);
+            });
+        }
+    }
+    if (
+      cfg.max_ms_per_scheduling_point.has_value()
+      && cfg.min_ms_per_scheduling_point.has_value()) {
+        for (size_t i = 0; i < cfg.num_fibers; i++) {
+            ssx::spawn_with_gate(_gate, [cfg, this] {
+                return run_delay_fiber(
+                  *cfg.min_ms_per_scheduling_point,
+                  *cfg.max_ms_per_scheduling_point);
+            });
+        }
+    }
+}
+
+ss::future<> stress_payload::run_count_fiber(int min_count, int max_count) {
+    while (!_as.abort_requested()) {
+        int spins_per_scheduling_point = min_count == max_count
+                                           ? min_count
+                                           : random_generators::get_int(
+                                             min_count, max_count);
+        co_await ss::maybe_yield();
+        volatile int spins = 0;
+        while (true) {
+            if (spins == spins_per_scheduling_point) {
+                break;
+            }
+            spins = spins + 1;
+        }
+    }
+}
+
+ss::future<> stress_payload::run_delay_fiber(int min_ms, int max_ms) {
+    while (!_as.abort_requested()) {
+        int ms_per_scheduling_point = min_ms == max_ms
+                                        ? min_ms
+                                        : random_generators::get_int(
+                                          min_ms, max_ms);
+        co_await ss::maybe_yield();
+        const auto stop_time = ss::steady_clock_type::now()
+                               + std::chrono::milliseconds(
+                                 ms_per_scheduling_point);
+        while (true) {
+            if (ss::steady_clock_type::now() >= stop_time) {
+                break;
+            }
+        }
+    }
+}
+
+ss::future<> stress_payload::stop() {
+    _as.request_abort();
+    co_await _gate.close();
+}
+
+stress_fiber_manager::stress_fiber_manager()
+  : _stress(nullptr) {}
+
+stress_fiber_manager::~stress_fiber_manager() {}
+
+bool stress_fiber_manager::start(stress_config cfg) {
+    if (_stress) {
+        return false;
+    }
+    _stress = stress_payload::start(cfg);
+    return true;
+}
+
+ss::future<> stress_fiber_manager::stop() {
+    if (_stress) {
+        co_await _stress->stop();
+        _stress.reset();
+    }
+}

--- a/src/v/finjector/stress_fiber.h
+++ b/src/v/finjector/stress_fiber.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+#include <memory>
+
+struct stress_config {
+    // Number of ticks to increment between each scheduling point.
+    // If set, "delay" variants should not be set.
+    std::optional<int> min_spins_per_scheduling_point;
+    std::optional<int> max_spins_per_scheduling_point;
+
+    // Time in milliseconds to spin for between each scheduling point.
+    // If set, "spins" variants should not be set.
+    std::optional<int> min_ms_per_scheduling_point;
+    std::optional<int> max_ms_per_scheduling_point;
+
+    size_t num_fibers;
+};
+
+class stress_payload;
+
+// Manages a single stress payload.
+class stress_fiber_manager {
+public:
+    explicit stress_fiber_manager();
+    ~stress_fiber_manager();
+
+    // Starts stress fibers with the given config and returns true, or returns
+    // false if the config is invalid or if stress fibers are already running.
+    bool start(stress_config);
+
+    // Stops any existing stress fibers.
+    ss::future<> stop();
+
+private:
+    std::unique_ptr<stress_payload> _stress;
+};

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -47,6 +47,7 @@ v_cc_library(
   DEPS
     Seastar::seastar
     v::cluster
+    v::finjector
     v::syschecks
     v::kafka
     v::pandaproxy_rest

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -23,6 +23,72 @@
             ]
         },
         {
+            "path": "/v1/debug/stress_fiber_start",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Spawns fibers to artificially inflate CPU utilization",
+                    "type": "void",
+                    "nickname": "stress_fiber_start",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "min_spins_per_scheduling_point",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "max_spins_per_scheduling_point",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "min_ms_per_scheduling_point",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "max_ms_per_scheduling_point",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "num_fibers",
+                            "in": "query",
+                            "required": true,
+                            "allowMultiple": false,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "/v1/debug/stress_fiber_stop",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Stops any stress fibers that may be running",
+                    "type": "void",
+                    "nickname": "stress_fiber_stop",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/debug/partition_leaders_table",
             "operations": [
                 {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -49,6 +49,7 @@
 #include "config/endpoint_tls_config.h"
 #include "features/feature_table.h"
 #include "finjector/hbadger.h"
+#include "finjector/stress_fiber.h"
 #include "json/document.h"
 #include "json/schema.h"
 #include "json/stringbuffer.h"
@@ -217,6 +218,7 @@ parse_ntp_from_query_param(const std::unique_ptr<ss::http::request>& req) {
 
 admin_server::admin_server(
   admin_server_cfg cfg,
+  ss::sharded<stress_fiber_manager>& looper,
   ss::sharded<cluster::partition_manager>& pm,
   cluster::controller* controller,
   ss::sharded<cluster::shard_table>& st,
@@ -238,6 +240,7 @@ admin_server::admin_server(
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
+  , _stress_fiber_manager(looper)
   , _partition_manager(pm)
   , _controller(controller)
   , _shard_table(st)
@@ -4057,6 +4060,107 @@ admin_server::get_partition_state_handler(
 }
 
 void admin_server::register_debug_routes() {
+    register_route<user>(
+      ss::httpd::debug_json::stress_fiber_stop,
+      [this](std::unique_ptr<ss::http::request>) {
+          vlog(logger.info, "Stopping stress fiber");
+          return _stress_fiber_manager
+            .invoke_on_all([](auto& stress_mgr) { return stress_mgr.stop(); })
+            .then(
+              [] { return ss::json::json_return_type(ss::json::json_void()); });
+      });
+
+    register_route<user>(
+      ss::httpd::debug_json::stress_fiber_start,
+      [this](std::unique_ptr<ss::http::request> req) {
+          vlog(logger.info, "Requested stress fiber");
+          stress_config cfg;
+          const auto parse_int =
+            [&](const ss::sstring& param, std::optional<int>& val) {
+                if (auto e = req->get_query_param(param); !e.empty()) {
+                    try {
+                        val = boost::lexical_cast<int>(e);
+                    } catch (const boost::bad_lexical_cast&) {
+                        throw ss::httpd::bad_param_exception(fmt::format(
+                          "Invalid parameter '{}' value {{{}}}", param, e));
+                    }
+                } else {
+                    val = std::nullopt;
+                }
+            };
+          parse_int(
+            "min_spins_per_scheduling_point",
+            cfg.min_spins_per_scheduling_point);
+          parse_int(
+            "max_spins_per_scheduling_point",
+            cfg.max_spins_per_scheduling_point);
+          parse_int(
+            "min_ms_per_scheduling_point", cfg.min_ms_per_scheduling_point);
+          parse_int(
+            "max_ms_per_scheduling_point", cfg.max_ms_per_scheduling_point);
+          if (
+            cfg.max_spins_per_scheduling_point.has_value()
+            != cfg.min_spins_per_scheduling_point.has_value()) {
+              throw ss::httpd::bad_param_exception(
+                "Expected 'max_spins_per_scheduling_point' set with "
+                "'min_spins_per_scheduling_point'");
+          }
+          if (
+            cfg.max_ms_per_scheduling_point.has_value()
+            != cfg.min_ms_per_scheduling_point.has_value()) {
+              throw ss::httpd::bad_param_exception(
+                "Expected 'max_ms_per_scheduling_point' set with "
+                "'min_ms_per_scheduling_point'");
+          }
+          // Check that either delay or a spin count is defined.
+          if (
+            cfg.max_spins_per_scheduling_point.has_value()
+            == cfg.max_ms_per_scheduling_point.has_value()) {
+              throw ss::httpd::bad_param_exception(
+                "Expected either spins or delay to be defined");
+          }
+          if (
+            cfg.max_spins_per_scheduling_point.has_value()
+            && cfg.max_spins_per_scheduling_point.value()
+                 < cfg.min_spins_per_scheduling_point.value()) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Invalid parameter 'max_spins_per_scheduling_point' value "
+                "is too low: {} < {}",
+                cfg.max_spins_per_scheduling_point.value(),
+                cfg.min_spins_per_scheduling_point.value()));
+          }
+          if (
+            cfg.max_ms_per_scheduling_point.has_value()
+            && cfg.max_ms_per_scheduling_point.value()
+                 < cfg.min_ms_per_scheduling_point.value()) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Invalid parameter 'max_ms_per_scheduling_point' value "
+                "is too low: {} < {}",
+                cfg.max_ms_per_scheduling_point.value(),
+                cfg.min_ms_per_scheduling_point.value()));
+          }
+          cfg.num_fibers = 1;
+          if (auto e = req->get_query_param("num_fibers"); !e.empty()) {
+              try {
+                  cfg.num_fibers = boost::lexical_cast<int>(e);
+              } catch (const boost::bad_lexical_cast&) {
+                  throw ss::httpd::bad_param_exception(fmt::format(
+                    "Invalid parameter 'num_fibers' value {{{}}}", e));
+              }
+          }
+          return _stress_fiber_manager
+            .invoke_on_all([cfg](auto& stress_mgr) {
+                auto ran = stress_mgr.start(cfg);
+                if (ran) {
+                    vlog(logger.info, "Started stress fiber...");
+                } else {
+                    vlog(logger.info, "Stress fiber already running...");
+                }
+            })
+            .then(
+              [] { return ss::json::json_return_type(ss::json::json_void()); });
+      });
+
     register_route<user>(
       ss::httpd::debug_json::reset_leaders_info,
       [this](std::unique_ptr<ss::http::request>) {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -15,6 +15,7 @@
 #include "cluster/fwd.h"
 #include "cluster/types.h"
 #include "config/endpoint_tls_config.h"
+#include "finjector/stress_fiber.h"
 #include "kafka/server/fwd.h"
 #include "model/metadata.h"
 #include "pandaproxy/rest/fwd.h"
@@ -65,6 +66,7 @@ class admin_server {
 public:
     explicit admin_server(
       admin_server_cfg,
+      ss::sharded<stress_fiber_manager>&,
       ss::sharded<cluster::partition_manager>&,
       cluster::controller*,
       ss::sharded<cluster::shard_table>&,
@@ -514,6 +516,7 @@ private:
 
     ss::httpd::http_server _server;
     admin_server_cfg _cfg;
+    ss::sharded<stress_fiber_manager>& _stress_fiber_manager;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     cluster::controller* _controller;
     ss::sharded<cluster::shard_table>& _shard_table;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -60,6 +60,7 @@
 #include "config/seed_server.h"
 #include "features/feature_table_snapshot.h"
 #include "features/fwd.h"
+#include "finjector/stress_fiber.h"
 #include "kafka/client/configuration.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
 #include "kafka/server/group_manager.h"
@@ -858,6 +859,7 @@ void application::configure_admin_server() {
     construct_service(
       _admin,
       admin_server_cfg_from_global_cfg(sched_groups),
+      std::ref(stress_fiber_manager),
       std::ref(partition_manager),
       controller.get(),
       std::ref(shard_table),
@@ -1699,6 +1701,7 @@ void application::wire_up_bootstrap_services() {
     ss::smp::invoke_on_all([] {
         return storage::internal::chunks().start();
     }).get();
+    construct_service(stress_fiber_manager).get();
     syschecks::systemd_message("Constructing storage services").get();
     construct_single_service_sharded(
       storage_node,

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -24,6 +24,7 @@
 #include "cluster/tx_coordinator_mapper.h"
 #include "config/node_config.h"
 #include "features/fwd.h"
+#include "finjector/stress_fiber.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
 #include "kafka/server/fwd.h"
@@ -95,6 +96,7 @@ public:
 
     smp_groups smp_service_groups;
     scheduling_groups sched_groups;
+    ss::sharded<stress_fiber_manager> stress_fiber_manager;
 
     // Sorted list of services (public members)
     ss::sharded<cloud_storage::cache> shadow_index_cache;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -938,6 +938,35 @@ class Admin:
     def is_node_isolated(self, node):
         return self._request("GET", "debug/is_node_isolated", node=node).json()
 
+    def stress_fiber_start(
+        self,
+        node,
+        num_fibers,
+        min_spins_per_scheduling_point=None,
+        max_spins_per_scheduling_point=None,
+        min_ms_per_scheduling_point=None,
+        max_ms_per_scheduling_point=None,
+    ):
+        p = {"num_fibers": str(num_fibers)}
+        if min_spins_per_scheduling_point is not None:
+            p["min_spins_per_scheduling_point"] = str(
+                min_spins_per_scheduling_point)
+        if max_spins_per_scheduling_point is not None:
+            p["max_spins_per_scheduling_point"] = str(
+                max_spins_per_scheduling_point)
+        if min_ms_per_scheduling_point is not None:
+            p["min_ms_per_scheduling_point"] = str(min_ms_per_scheduling_point)
+        if max_ms_per_scheduling_point is not None:
+            p["max_ms_per_scheduling_point"] = str(max_ms_per_scheduling_point)
+        kwargs = {"params": p}
+        return self._request("PUT",
+                             "debug/stress_fiber_start",
+                             node=node,
+                             **kwargs)
+
+    def stress_fiber_stop(self, node):
+        return self._request("PUT", "debug/stress_fiber_stop", node=node)
+
     def cloud_storage_usage(self) -> int:
         return int(
             self._request(

--- a/tests/rptest/tests/cpu_stress_injection_test.py
+++ b/tests/rptest/tests/cpu_stress_injection_test.py
@@ -1,0 +1,118 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from ducktape.utils.util import wait_until
+
+
+class CpuStressInjectionTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(CpuStressInjectionTest, self).__init__(test_context,
+                                                     num_brokers=1)
+
+    def has_started_stress(self):
+        return self.redpanda.search_log_any("Started stress fiber")
+
+    def has_reactor_stalls(self):
+        return self.redpanda.search_log_any("Reactor stalled for")
+
+    @cluster(num_nodes=1)
+    def test_stress_fibers_ms(self):
+        """
+        Test that time-based stress fibers can reliably spit out reactor
+        stalls.
+        """
+        admin = Admin(self.redpanda)
+        node = self.redpanda.nodes[0]
+        admin.stress_fiber_start(node,
+                                 10,
+                                 min_ms_per_scheduling_point=30,
+                                 max_ms_per_scheduling_point=300)
+
+        try:
+            wait_until(self.has_reactor_stalls, timeout_sec=10, backoff_sec=1)
+            assert self.has_started_stress()
+        finally:
+            admin.stress_fiber_stop(node)
+
+    @cluster(num_nodes=1)
+    def test_stress_fibers_spins(self):
+        """
+        Basic test for count-based stress fibers.
+        """
+        admin = Admin(self.redpanda)
+        node = self.redpanda.nodes[0]
+        admin.stress_fiber_start(node,
+                                 10,
+                                 min_spins_per_scheduling_point=1000,
+                                 max_spins_per_scheduling_point=100000)
+
+        try:
+            # A test that relies on counting some number of cycles is subject
+            # to being flaky in different environments. Instead of checking for
+            # reactor stalls, just look that we started stress fibers.
+            wait_until(self.has_started_stress, timeout_sec=10, backoff_sec=1)
+        finally:
+            admin.stress_fiber_stop(node)
+
+    @cluster(num_nodes=1)
+    def test_misconfigured_stress_fibers(self):
+        """
+        Test that misconfiguring does not result in any started stress fibers.
+        """
+        admin = Admin(self.redpanda)
+        node = self.redpanda.nodes[0]
+        try:
+            admin.stress_fiber_start(node,
+                                     10,
+                                     min_ms_per_scheduling_point=1000,
+                                     max_ms_per_scheduling_point=10)
+            assert False, "Expected failure: require ms min < max"
+        except:
+            pass
+
+        try:
+            admin.stress_fiber_start(node,
+                                     10,
+                                     min_spins_per_scheduling_point=1000,
+                                     max_spins_per_scheduling_point=10)
+            assert False, "Expected failure: require spins min < max"
+        except:
+            pass
+
+        try:
+            admin.stress_fiber_start(node,
+                                     10,
+                                     min_ms_per_scheduling_point=None,
+                                     max_ms_per_scheduling_point=1000)
+            assert False, "Expected failure: require both ms min/max be set"
+        except:
+            pass
+
+        try:
+            admin.stress_fiber_start(node,
+                                     10,
+                                     min_spins_per_scheduling_point=None,
+                                     max_spins_per_scheduling_point=1000)
+            assert False, "Expected failure: require both spins min/max be set"
+        except:
+            pass
+
+        try:
+            admin.stress_fiber_start(node,
+                                     10,
+                                     min_ms_per_scheduling_point=0,
+                                     max_ms_per_scheduling_point=100,
+                                     min_spins_per_scheduling_point=1000,
+                                     max_spins_per_scheduling_point=1000)
+            assert False, "Expected failure: require either spins or ms set"
+        except:
+            pass
+        assert not self.has_started_stress()


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This adds a mechanism for adding artificial stress to Redpanda. A
stress_payload is defined as one or multiple fibers that run in the
background, repeatedly counting up to some bounded random values/delays,
until stopped. This will be exposed via admin endpoint in a subsequent
patch.

It's expected that only one stress payload run at a time. The
public interface (stress_fiber_manager) reflects that.

The public interface exposes configuration by delay or by count. In
practice, I found the former helpful in reliably injecting reactor
stalls, and the latter helpful in having finer grained control over how
many cycles are "wasted".

This PR also plugs into ducktape via the admin endpoint, and adds a ducktape test to cover basic functionality. It is left as future work to plug this into the generic failure injection ducktape framework.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
