### PR TITLE
Fix segmentation fault in `tx_gateway_frontend::expire_old_txs`

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -3046,47 +3046,50 @@ void tx_gateway_frontend::expire_old_txs() {
               model::tx_manager_nt);
             return ss::now();
         }
+
         return ss::do_for_each(
           ntp_meta->get_assignments(), [this](partition_assignment pa) {
               auto tx_ntp = model::ntp(
                 model::tx_manager_nt.ns, model::tx_manager_nt.tp, pa.id);
 
-              auto shard = _shard_table.local().shard_for(tx_ntp);
-
-              if (shard == std::nullopt) {
+              return expire_old_txs(tx_ntp).finally([this] {
                   // TODO: Create per shard timer
                   // https://github.com/redpanda-data/redpanda/issues/9606
+                  // to consider: most likely it's ok to re-arm the timer
+                  // only once out of the do_for_each
                   rearm_expire_timer();
-                  return ss::now();
-              }
-
-              return container()
-                .invoke_on(
-                  *shard,
-                  _ssg,
-                  [tm = pa.id](tx_gateway_frontend& self) -> ss::future<void> {
-                      return ss::with_gate(
-                        self._gate, [tm, &self]() -> ss::future<void> {
-                            return self.with_stm(
-                              tm,
-                              [&self](
-                                checked<ss::shared_ptr<tm_stm>, tx_errc> r) {
-                                  if (!r) {
-                                      return ss::now();
-                                  }
-                                  auto stm = r.value();
-                                  return stm->read_lock().then(
-                                    [&self,
-                                     stm](ss::basic_rwlock<>::holder unit) {
-                                        return self.expire_old_txs(stm).finally(
-                                          [u = std::move(unit)] {});
-                                    });
-                              });
-                        });
-                  })
-                .finally([this] { rearm_expire_timer(); });
+              });
           });
     });
+}
+
+ss::future<> tx_gateway_frontend::expire_old_txs(model::ntp tx_ntp) {
+    auto shard = _shard_table.local().shard_for(tx_ntp);
+
+    if (!shard) {
+        return ss::now();
+    }
+
+    return container().invoke_on(
+      *shard,
+      _ssg,
+      [tm = tx_ntp.tp.partition](
+        tx_gateway_frontend& self) -> ss::future<void> {
+          return ss::with_gate(self._gate, [tm, &self]() -> ss::future<void> {
+              return self.with_stm(
+                tm, [&self](checked<ss::shared_ptr<tm_stm>, tx_errc> r) {
+                    if (!r) {
+                        return ss::now();
+                    }
+                    auto stm = r.value();
+                    return stm->read_lock().then(
+                      [&self, stm](ss::basic_rwlock<>::holder unit) {
+                          return self.expire_old_txs(stm).finally(
+                            [u = std::move(unit)] {});
+                      });
+                });
+          });
+      });
 }
 
 ss::future<> tx_gateway_frontend::expire_old_txs(ss::shared_ptr<tm_stm> stm) {

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -266,6 +266,7 @@ private:
       describe_tx(ss::shared_ptr<tm_stm>, kafka::transactional_id);
 
     void expire_old_txs();
+    ss::future<> expire_old_txs(model::ntp);
     ss::future<> expire_old_txs(ss::shared_ptr<tm_stm>);
     ss::future<> expire_old_tx(ss::shared_ptr<tm_stm>, kafka::transactional_id);
     ss::future<> do_expire_old_tx(


### PR DESCRIPTION
`ntp_meta->get_assignments()` returns a reference to a collection and `expire_old_txs` iterates it asynchronously so there is a chance of the collection being modified out of `expire_old_txs` leading to the iterator invalidation and the crash. Fixing the problem by making a copy before iterating.
    
Fixes #12503

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none