### PR TITLE
rptest: run `rpk` tests against redpanda cloud

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -229,6 +229,11 @@ class RpkTool:
         self._tls_cert = tls_cert
         self._tls_enabled = tls_enabled
 
+        # if testing redpanda cloud, override with default superuser
+        if hasattr(redpanda, 'GLOBAL_CLOUD_API_URL'):
+            self._username, self._password, self._sasl_mechanism = redpanda._superuser
+            self._tls_enabled = True
+
     def create_topic(self, topic, partitions=1, replicas=None, config=None):
         def create_topic():
             try:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1821,6 +1821,7 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
         # set this for use in RedpandaTest
         self._security_config = dict(security_protocol='SASL_SSL',
+                                     sasl_mechanism=superuser.algorithm,
                                      sasl_plain_username=superuser.username,
                                      sasl_plain_password=superuser.password,
                                      enable_tls=True)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1223,6 +1223,10 @@ class RedpandaServiceBase(Service):
         if bad_lines:
             raise BadLogLines(bad_lines)
 
+    def raise_on_crash(self,
+                       log_allow_list: list[str | re.Pattern] | None = None):
+        pass
+
 
 class RedpandaServiceK8s(RedpandaServiceBase):
     def __init__(self,

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -10,5 +10,6 @@
 # Tests to run on a Redpanda Cloud cluster.
 cloud:
   included:
+    - tests/rpk_topic_test.py
     - tests/services_self_test.py::SimpleSelfTest
     - scale_tests/high_throughput_test.py::HighThroughputTest2.test_throughput_simple

--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -29,12 +29,13 @@ class RpkToolTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_create_topic(self):
-        self._rpk.create_topic("topic")
+        topic = 'rp_dt_test_create_topic'
+        self._rpk.create_topic(topic)
 
-        wait_until(lambda: "topic" in self._rpk.list_topics(),
+        wait_until(lambda: topic in self._rpk.list_topics(),
                    timeout_sec=10,
                    backoff_sec=1,
-                   err_msg="Topic never appeared.")
+                   err_msg=f'Topic {topic} never appeared.')
 
     @cluster(num_nodes=1)
     @parametrize(config_type="compression.type")
@@ -44,18 +45,21 @@ class RpkToolTest(RedpandaTest):
     def test_create_topic_with_invalid_config(self, config_type):
         with expect_exception(RpkException,
                               lambda e: "INVALID_CONFIG" in str(e)):
-            out = self._rpk.create_topic("topic", config={config_type: "foo"})
+            out = self._rpk.create_topic(
+                'rp_dt_test_create_topic_with_invalid_config',
+                config={config_type: "foo"})
 
     @cluster(num_nodes=1)
     def test_add_unfeasible_number_of_partitions(self):
+        topic = 'rp_dt_test_add_unfeasible_number_of_partitions'
         with expect_exception(RpkException,
                               lambda e: "INVALID_REQUEST" in str(e)):
-            self._rpk.create_topic("topic")
-            out = self._rpk.add_partitions("topic", 2000000000000)
+            self._rpk.create_topic(topic)
+            out = self._rpk.add_partitions(topic, 2000000000000)
 
     @cluster(num_nodes=4)
     def test_produce(self):
-        topic = 'topic'
+        topic = 'rp_dt_test_produce'
         message = 'message'
         key = 'key'
         h_key = 'h_key'
@@ -80,11 +84,11 @@ class RpkToolTest(RedpandaTest):
         wait_until(cond,
                    timeout_sec=120,
                    backoff_sec=30,
-                   err_msg="Message didn't appear.")
+                   err_msg=f'Message in {topic} never appeared.')
 
     @cluster(num_nodes=4)
     def test_consume_as_group(self):
-        topic = 'topic_group'
+        topic = 'rp_dt_test_consume_as_group'
         message = 'message'
         key = 'key'
         h_key = 'h_key'
@@ -110,11 +114,11 @@ class RpkToolTest(RedpandaTest):
         wait_until(cond,
                    timeout_sec=120,
                    backoff_sec=15,
-                   err_msg="Message didn't appear.")
+                   err_msg=f'Message in {topic} never appeared.')
 
     @cluster(num_nodes=4)
     def test_consume_newest(self):
-        topic = 'topic_newest'
+        topic = 'rp_dt_test_consume_newest'
         message = 'newest message'
         key = 'key'
         h_key = 'h_key'
@@ -140,11 +144,11 @@ class RpkToolTest(RedpandaTest):
         wait_until(cond,
                    timeout_sec=150,
                    backoff_sec=30,
-                   err_msg="Message didn't appear.")
+                   err_msg=f'Message in {topic} never appeared.')
 
     @cluster(num_nodes=4)
     def test_consume_oldest(self):
-        topic = 'topic'
+        topic = 'rp_dt_test_consume_oldest'
 
         n = random.randint(10, 100)
         msgs = {}
@@ -178,11 +182,11 @@ class RpkToolTest(RedpandaTest):
         wait_until(cond,
                    timeout_sec=60,
                    backoff_sec=20,
-                   err_msg="Message didn't appear.")
+                   err_msg=f'Message in {topic} never appeared.')
 
     @cluster(num_nodes=4)
     def test_consume_from_partition(self):
-        topic = 'topic_partition'
+        topic = 'rp_dt_test_consume_from_partition'
 
         n_parts = random.randint(3, 100)
         self._rpk.create_topic(topic, partitions=n_parts)
@@ -233,4 +237,5 @@ class RpkToolTest(RedpandaTest):
             time.sleep(1)
             retries -= 1
 
-        raise ducktape.errors.TimeoutError("Message didn't appear")
+        raise ducktape.errors.TimeoutError(
+            f'Message in {topic} never appeared.')

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -263,19 +263,12 @@ class SimpleSelfTest(Test):
         node_disk_free = self.redpanda.get_node_disk_free()
         assert node_disk_free > 0
 
-        if RedpandaServiceCloud.GLOBAL_CLOUD_API_URL in self.redpanda.context.globals:
-            # just run rpk against redpanda cloud for now since it has tls enabled by default
-            username, password, mechanism = self.redpanda._superuser
-            rpk = RpkTool(self.redpanda,
-                          username=username,
-                          password=password,
-                          sasl_mechanism=mechanism,
-                          tls_enabled=True)
-            topic_name = 'rp_ducktape_test_cloud_topic'
-            self.logger.info(f'creating topic {topic_name}')
-            rpk.create_topic(topic_name)
-            self.logger.info(f'deleting topic {topic_name}')
-            rpk.delete_topic(topic_name)
+        rpk = RpkTool(self.redpanda)
+        topic_name = 'rp_ducktape_test_cloud_topic'
+        self.logger.info(f'creating topic {topic_name}')
+        rpk.create_topic(topic_name)
+        self.logger.info(f'deleting topic {topic_name}')
+        rpk.delete_topic(topic_name)
 
 
 class FailureInjectorSelfTest(Test):


### PR DESCRIPTION
Updates to the redpanda ducktape test helpers `RpkTool` and `RpkConsumer` so they can connect to redpanda cloud. This enables `RpkToolTest`, which does various topic operations, to be able to test redpanda cloud.

Fixes https://github.com/redpanda-data/cloudv2/issues/7909

Output of manual test run against redpanda cloud:
```console
bash$ ducktape --debug --globals=/home/ubuntu/redpanda/tests/globals.json --cluster=ducktape.cluster.json.JsonCluster --cluster-file=/home/ubuntu/redpanda/tests/cluster.json --test-runner-timeout=3600000 tests/rptest/tests/rpk_topic_test.py::RpkToolTest
...
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_consume_as_group
status:     PASS
run time:   25.118 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_consume_from_partition
status:     PASS
run time:   16.124 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_consume_newest
status:     PASS
run time:   37.517 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_consume_oldest
status:     PASS
run time:   56.293 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_produce
status:     PASS
run time:   37.001 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_create_topic
status:     PASS
run time:   6.571 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_add_unfeasible_number_of_partitions
status:     PASS
run time:   6.435 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_create_topic_with_invalid_config.config_type=cleanup.policy
status:     PASS
run time:   5.953 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_create_topic_with_invalid_config.config_type=compaction.strategy
status:     PASS
run time:   5.781 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_create_topic_with_invalid_config.config_type=compression.type
status:     PASS
run time:   6.187 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_create_topic_with_invalid_config.config_type=message.timestamp.type
status:     PASS
run time:   5.920 seconds 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
============================================================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8   
session_id:       2023-08-04--011
run time:         3 minutes 29.055 seconds
tests run:        11
passed:           11
failed:           0
ignored:          0
opassed:          0
ofailed:          0
============================================================================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none