### PR TITLE
kafka: Revert "kafka: Disable use of separate fetch scheduling group"

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -499,7 +499,7 @@ configuration::configuration()
       "use_fetch_scheduler_group",
       "Use a separate scheduler group for fetch processing",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      false)
+      true)
   , metadata_status_wait_timeout_ms(
       *this,
       "metadata_status_wait_timeout_ms",


### PR DESCRIPTION
This reverts commit https://github.com/redpanda-data/redpanda/commit/6d1223d4e4b0489c0fade40a727b9633d506398a.

While the reasoning in above commit for reverting isn't wrong (hard to
reason about and counter cases do exist) from rolling the change
out to cloudv2 it seems the majority of workloads do benefit from having
fetch in a separate scheduling group.

Hence, enable it again by default.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Re-enable separate fetch scheduling group by default. In the majority of cases as seen in cloudv2 it seems to be beneficial.

