### PR TITLE
test: check stderr for coordinator error messages

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -639,7 +639,7 @@ class RpkTool:
             try:
                 out = self._run_group(cmd)
             except RpkException as e:
-                if "COORDINATOR_NOT_AVAILABLE" in e.msg:
+                if "COORDINATOR_NOT_AVAILABLE" in e.msg + e.stderr:
                     # Transient, return None to retry
                     return None
                 elif "NOT_COORDINATOR" in e.msg:


### PR DESCRIPTION
Changes to rpk caused the COORDINATOR_NOT_AVAILABLE messages to be printed to stderr (makes sense) instead of stdout. Updated to check for this condition in stderr.

Fixes: #12291

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

