### PR TITLE
storage: fix race between segment.ms and appends

### DIFF
--- a/src/v/storage/disk_log_appender.h
+++ b/src/v/storage/disk_log_appender.h
@@ -38,7 +38,7 @@ public:
     ss::future<append_result> end_of_stream() final;
 
 private:
-    bool needs_to_roll_log(model::term_id) const;
+    bool segment_is_appendable(model::term_id) const;
     void release_lock();
     ss::future<ss::stop_iteration>
     append_batch_to_segment(const model::record_batch&);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1222,15 +1222,11 @@ ss::future<> disk_log_impl::force_roll(ss::io_priority_class iopc) {
       });
 }
 
-ss::future<> disk_log_impl::maybe_roll(
+ss::future<> disk_log_impl::maybe_roll_unlocked(
   model::term_id t, model::offset next_offset, ss::io_priority_class iopc) {
-    // This lock will only rarely be contended.  If it is held, then
-    // we must wait for do_housekeeping to complete before proceeding, because
-    // the log might be in a state mid-roll where it has no appender.
-    // We need to take this irrespective of whether we're actually rolling
-    // or not, in order to ensure that writers wait for a background roll
-    // to complete if one is ongoing.
-    auto roll_lock_holder = co_await _segments_rolling_lock.get_units();
+    vassert(
+      !_segments_rolling_lock.ready(),
+      "Must have taken _segments_rolling_lock");
 
     vassert(t >= term(), "Term:{} must be greater than base:{}", t, term());
     if (_segs.empty()) {
@@ -1253,8 +1249,12 @@ ss::future<> disk_log_impl::maybe_roll(
 
 ss::future<> disk_log_impl::apply_segment_ms() {
     auto gate = _compaction_housekeeping_gate.hold();
-    // do_housekeeping races with maybe_roll to use new_segment.
-    // take a lock to prevent problems
+    // Holding the lock blocks writes to the last open segment.
+    // This is required in order to avoid the logic in this function
+    // racing with an inflight append. Contention on this lock should
+    // be very light, since we wouldn't need to enforce segment.ms
+    // if this partition was high throughput (segment would have rolled
+    // naturally).
     auto lock = co_await _segments_rolling_lock.get_units();
 
     if (_segs.empty()) {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -94,7 +94,8 @@ public:
     std::optional<model::offset> index_lower_bound(model::offset o) const final;
     std::ostream& print(std::ostream&) const final;
 
-    ss::future<> maybe_roll(
+    // Must be called while _segments_rolling_lock is held.
+    ss::future<> maybe_roll_unlocked(
       model::term_id, model::offset next_offset, ss::io_priority_class);
 
     // roll immediately with the current term. users should prefer the
@@ -134,6 +135,14 @@ public:
     void set_cloud_gc_offset(model::offset);
 
     ss::future<reclaimable_offsets> get_reclaimable_offsets(gc_config cfg);
+
+    std::optional<ssx::semaphore_units> try_segment_roll_lock() {
+        return _segments_rolling_lock.try_get_units();
+    }
+
+    ss::future<ssx::semaphore_units> segment_roll_lock() {
+        return _segments_rolling_lock.get_units();
+    }
 
 private:
     friend class disk_log_appender; // for multi-term appends
@@ -274,6 +283,13 @@ private:
 
     // Mutually exclude operations that will cause segment rolling
     // do_housekeeping and maybe_roll
+    //
+    // This lock will only rarely be contended. If it is held, then we must
+    // wait for housekeeping or truncation to complete before proceeding,
+    // because the log might be in a state mid-roll where it has no appender.
+    // We need to take this irrespective of whether we're actually rolling or
+    // not, in order to ensure that writers wait for a background roll to
+    // complete if one is ongoing.
     mutex _segments_rolling_lock;
 
     std::optional<model::offset> _cloud_gc_offset;

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -108,3 +108,15 @@ rp_test(
   LABELS storage
 )
 
+set (fixture_srcs
+  storage_e2e_fixture_test.cc)
+
+rp_test(
+  FIXTURE_TEST
+  BINARY_NAME storage_e2e
+  SOURCES ${fixture_srcs}
+  LIBRARIES v::seastar_testing_main v::application v::raft v::config v::kafka_test_utils
+  ARGS "-- -c 1"
+  LABELS storage
+)
+

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -1,0 +1,82 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <vector>
+
+using namespace std::chrono_literals;
+using std::vector;
+
+struct storage_e2e_fixture : public redpanda_thread_fixture {};
+
+namespace {
+
+// Produces to the given fixture's partition for 10 seconds.
+ss::future<> produce_to_fixture(
+  storage_e2e_fixture* fix, model::topic topic_name, int* incomplete) {
+    tests::kafka_produce_transport producer(co_await fix->make_kafka_client());
+    co_await producer.start();
+    const int cardinality = 10;
+    auto now = ss::lowres_clock::now();
+    while (ss::lowres_clock::now() < now + 5s) {
+        for (int i = 0; i < cardinality; i++) {
+            co_await producer.produce_to_partition(
+              topic_name, model::partition_id(0), tests::kv_t::sequence(i, 1));
+        }
+    }
+    *incomplete -= 1;
+}
+} // namespace
+
+FIXTURE_TEST(test_compaction_segment_ms, storage_e2e_fixture) {
+    config::shard_local_cfg().log_segment_ms_min.set_value(
+      std::chrono::duration_cast<std::chrono::milliseconds>(1ms));
+    const auto topic_name = model::topic("tapioca");
+    const auto ntp = model::ntp(model::kafka_namespace, topic_name, 0);
+
+    cluster::topic_properties props;
+    props.retention_duration = tristate<std::chrono::milliseconds>(
+      tristate<std::chrono::milliseconds>{});
+    props.segment_ms = tristate<std::chrono::milliseconds>(1s);
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    stress_config cfg;
+    cfg.min_spins_per_scheduling_point = 100;
+    cfg.max_spins_per_scheduling_point = 10000;
+    cfg.num_fibers = 100;
+    BOOST_REQUIRE(app.stress_fiber_manager.local().start(cfg));
+
+    std::vector<ss::future<>> produces;
+    produces.reserve(5);
+    int incomplete = 5;
+    for (int i = 0; i < 5; i++) {
+        auto fut = produce_to_fixture(this, topic_name, &incomplete);
+        produces.emplace_back(std::move(fut));
+    }
+    auto partition = app.partition_manager.local().get(ntp);
+    auto* log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
+
+    while (incomplete > 0) {
+        log->apply_segment_ms().get();
+        ss::sleep(500ms).get();
+    }
+
+    for (auto&& p : produces) {
+        std::move(p).get();
+    }
+    app.stress_fiber_manager.local().stop().get();
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Based on https://github.com/redpanda-data/redpanda/pull/12546 to repro a crash in a test.

H/T to VladLazar for a similar change that inspired this one:
https://github.com/VladLazar/redpanda/commit/682aea582044225132987d23ef80406198526db4
https://github.com/redpanda-data/redpanda/pull/12516

The problem statement:
```
We have seen a couple of races between the application of `segment.ms`
and the normal append path. They had the following pattern in common:
1. application of `segment.ms` begins
2. a call to `segment::append` is interleaved
3. the append finishes first and and advances the dirty offsets, which
the rolling logic in `segment.ms` does not expect
-- or --
4. `segment.ms` releases the current appender while the append is
ongoing, which the append logic does not expect
```

The proposed fix was to introduce a new appender lock to the segment, and
ensure that it is held while appending an while segment.ms rolling. This
addressed problem https://github.com/redpanda-data/redpanda/pull/3, but wasn't sufficient to address https://github.com/redpanda-data/redpanda/pull/4.

The issue with introducing another lock to the segment is that the
unexpected behavior when appending to a segment happens in the context
of an already referenced segment. I.e. the appending fiber may proceed
to reference an appender, only for it to be destructed by the
housekeeping fiber before segment::append() is called, resulting in a
segfault.

This patch extends usage of the existing disk_log_impl::_segments_rolling_lock
to cover the entire duration of append (i.e. not just the underlying
segment::append() call), ensuring that segment.ms rolls and appends are
mutually exclusive.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Avoids a race between appends and application of `segment.ms` that could result in a crash.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
