### PR TITLE
cloud_storage: Add compacted segment read-path tests

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1034,16 +1034,16 @@ remote_segment_batch_reader::read_some(
         if (
           _bytes_consumed != 0 && _bytes_consumed == new_bytes_consumed.value()
           && !_config.over_budget) {
-            auto context = fmt_with_ctx(
-              fmt::format,
+            vlog(
+              _ctxlog.error,
               "segment_reader is stuck, segment ntp: {}, _cur_rp_offset: {}, "
               "_bytes_consumed: "
               "{}",
               _seg->get_ntp(),
               _cur_rp_offset,
               _bytes_consumed);
-            throw stuck_reader_exception{
-              _cur_rp_offset, _bytes_consumed, context};
+            _is_unexpected_eof = true;
+            co_return ss::circular_buffer<model::record_batch>{};
         }
         _bytes_consumed = new_bytes_consumed.value();
     }

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -266,7 +266,9 @@ public:
         return _seg->get_base_kafka_offset();
     }
 
-    bool is_eof() const { return _cur_rp_offset > _seg->get_max_rp_offset(); }
+    bool is_eof() const {
+        return _is_unexpected_eof || _cur_rp_offset > _seg->get_max_rp_offset();
+    }
 
     void set_eof() {
         _cur_rp_offset = _seg->get_max_rp_offset() + model::offset{1};
@@ -307,6 +309,8 @@ private:
     size_t _bytes_consumed{0};
     ss::gate _gate;
     bool _stopped{false};
+    /// Set when EOF is reached earlier than expected
+    bool _is_unexpected_eof{false};
 
     /// Units for limiting concurrently-instantiated readers, they belong
     /// to materialized_segments.

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -149,7 +149,7 @@ make_segment(model::offset base, const std::vector<batch_t>& batches) {
           }
           return acc + b.num_records;
       });
-    iobuf segment_bytes = generate_segment(base, batches);
+    auto [segment_bytes, last_offset] = generate_segment(base, batches);
     std::vector<model::record_batch_header> hdr;
     std::vector<iobuf> rec;
     std::vector<uint64_t> off;

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -2543,3 +2543,73 @@ FIXTURE_TEST(
         }
     }
 }
+
+/// This test scans compacted segment support
+FIXTURE_TEST(
+  test_remote_partition_scan_compacted_hole_in_the_middle,
+  cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    batch_t hole = {
+      .num_records = 10,
+      .type = model::record_batch_type::raft_data,
+      .hole = true};
+
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, hole, data, data, data, data, data, data, data, data},
+      {conf, data, conf, data, hole, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, hole, data, data},
+    };
+
+    auto num_holes = 3;
+    auto num_configs = 4;
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+    BOOST_REQUIRE_EQUAL(
+      headers_read.size(), total_batches - num_configs - num_holes);
+}
+
+FIXTURE_TEST(
+  test_remote_partition_scan_compacted_hole_at_the_end, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    batch_t hole = {
+      .num_records = 10,
+      .type = model::record_batch_type::raft_data,
+      .hole = true};
+
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, data, data, data, data, data, data, data, data, hole},
+      {conf, data, conf, data, data, data, data, data, data, hole},
+      {conf, data, data, data, data, data, data, data, data, hole},
+    };
+
+    auto num_holes = 3;
+    auto num_configs = 4;
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+    BOOST_REQUIRE_EQUAL(
+      headers_read.size(), total_batches - num_configs - num_holes);
+}

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -130,7 +130,7 @@ SEASTAR_THREAD_TEST_CASE(test_remote_segment_index_builder) {
         };
         batches.push_back(std::move(batch));
     }
-    auto segment = generate_segment(base_offset, batches);
+    auto [segment, co] = generate_segment(base_offset, batches);
     auto is = make_iobuf_input_stream(std::move(segment));
     offset_index ix(base_offset, kbase_offset, 0, 0);
     auto parser = make_remote_segment_index_builder(


### PR DESCRIPTION
Add two unit-tests. First one checks situation when the compacted segment has a hole in the middle of the segment. The second one has the hole at the end.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none