### PR TITLE
storage: Make segment_appender::_flush_ops a fragmented_vector 

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -421,11 +421,11 @@ ss::future<> segment_appender::process_flush_ops(size_t committed) {
         return ss::now();
     }
 
-    std::vector<flush_op> ops(
+    flush_ops_container ops(
       std::make_move_iterator(flushable),
       std::make_move_iterator(_flush_ops.end()));
 
-    _flush_ops.erase(flushable, _flush_ops.end());
+    _flush_ops.pop_back_n(std::distance(flushable, _flush_ops.end()));
 
     return _out.flush().then([this, committed, ops = std::move(ops)]() mutable {
         _flushed_offset = committed;

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -19,6 +19,8 @@
 #include "ssx/semaphore.h"
 #include "storage/fwd.h"
 #include "storage/segment_appender_chunk.h"
+#include "storage/storage_resources.h"
+#include "utils/fragmented_vector.h"
 #include "utils/intrusive_list_helpers.h"
 
 #include <seastar/core/file.hh>
@@ -155,7 +157,12 @@ private:
         }
     };
 
-    std::vector<flush_op> _flush_ops;
+    // There is one segment_appender per partition replica so we don't want to
+    // allocate too many elements by default and hence limit.
+    // Limit to 16 elements which is about 640 bytes per chunk.
+    using flush_ops_container
+      = fragmented_vector<flush_op, sizeof(flush_op) * 16>;
+    flush_ops_container _flush_ops;
     size_t _flushed_offset{0};
     size_t _stable_offset{0};
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -13,6 +13,7 @@
 #include "vassert.h"
 
 #include <cstddef>
+#include <iterator>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -96,6 +97,17 @@ public:
         return *this;
     }
     ~fragmented_vector() noexcept = default;
+
+    template<typename Iter>
+    requires std::input_iterator<Iter>
+    fragmented_vector(Iter begin, Iter end)
+      : fragmented_vector() {
+        // Improvement: Write a more efficient implementation for
+        // random_access_iterators
+        for (auto it = begin; it != end; ++it) {
+            push_back(*it);
+        }
+    }
 
     fragmented_vector copy() const noexcept { return *this; }
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -179,6 +179,8 @@ public:
 
     const T& front() const { return _frags.front().front(); }
     const T& back() const { return _frags.back().back(); }
+    T& front() { return _frags.front().front(); }
+    T& back() { return _frags.back().back(); }
     bool empty() const noexcept { return _size == 0; }
     size_t size() const noexcept { return _size; }
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -125,10 +125,11 @@ public:
     }
 
     template<class... Args>
-    void emplace_back(Args&&... args) {
+    T& emplace_back(Args&&... args) {
         maybe_add_capacity();
         _frags.back().emplace_back(std::forward<Args>(args)...);
         ++_size;
+        return _frags.back().back();
     }
 
     void pop_back() {

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -129,6 +129,32 @@ public:
         }
     }
 
+    /*
+     * Replacement for `erase(some_it, end())` but more efficient than n
+     * `pop_back()s`
+     */
+    void pop_back_n(size_t n) {
+        vassert(
+          _size >= n, "Cannot pop more than size() elements in container");
+
+        if (_size == n) {
+            clear();
+            return;
+        }
+
+        _size -= n;
+
+        while (n >= _frags.back().size()) {
+            n -= _frags.back().size();
+            _frags.pop_back();
+            _capacity -= elems_per_frag;
+        }
+
+        for (size_t i = 0; i < n; ++i) {
+            _frags.back().pop_back();
+        }
+    }
+
     const T& operator[](size_t index) const {
         vassert(index < _size, "Index out of range {}/{}", index, _size);
         auto& frag = _frags.at(index / elems_per_frag);

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -12,10 +12,12 @@
 #include "serde/serde.h"
 #include "utils/fragmented_vector.h"
 
+#include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <initializer_list>
 #include <limits>
+#include <numeric>
 #include <type_traits>
 #include <vector>
 
@@ -193,7 +195,7 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_test) {
 }
 
 template<typename T = int, size_t S = 8>
-static checker<T, S> make(std::initializer_list<T> in) {
+static checker<T, S> make(std::vector<T> in) {
     checker<T, S> ret;
     for (auto& e : in) {
         ret->push_back(e);
@@ -332,4 +334,28 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_vector_assign) {
 
     v.get() = std::vector{2, 3, 4};
     BOOST_CHECK_EQUAL(v, (make({2, 3, 4})));
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_pop_back_n) {
+    const int elements = 6;
+    for (int i = 0; i <= elements; ++i) {
+        std::vector<int> start_values(elements);
+        std::iota(start_values.begin(), start_values.end(), 0);
+        auto vec = make(start_values);
+
+        vec->pop_back_n(i);
+
+        std::vector<int> expected_values(elements - i);
+        std::iota(expected_values.begin(), expected_values.end(), 0);
+        BOOST_REQUIRE_EQUAL(vec->size(), expected_values.size());
+        BOOST_REQUIRE_EQUAL_COLLECTIONS(
+          vec->begin(),
+          vec->end(),
+          expected_values.begin(),
+          expected_values.end());
+
+        if (elements - i > 0) {
+            BOOST_REQUIRE_EQUAL(vec->back(), expected_values.back());
+        }
+    }
 }

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -359,3 +359,11 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_pop_back_n) {
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_constructor_from_iter_range) {
+    std::vector<int> vals{1, 2, 3};
+
+    fragmented_vector<int, 8> fv(vals.begin(), vals.end());
+
+    test_details::fragmented_vector_accessor::check_consistency(fv);
+}


### PR DESCRIPTION
We are seeing an OOM case where we are trying to allocate 5MB in
`segment_appender::_flush_ops`.

Convert it to a `fragmented_vector` with lower block size. There is one
`segment_appender` per partition replica so we don't want to be too
wasteful.

This required adding a few methods to the `fragmented_vector` to replace `erase` and the iterator constructor.

Not sure I am 100% happy with this:
 - Chunk size is picked a bit out of thin air to keep mem usage low
 - The whole erase + create new vector dance isn't great I guess. Could optimize for the good case where the whole vector is being switched out.

Discarded options are:
 - `ss::chunked_fifo`: Doesn't have `erase`
 - `std::deque`: Has 4k blocks by default on libc++

Fixes https://github.com/redpanda-data/redpanda/issues/12547

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none


