### PR TITLE
[v23.2.x] tests: bump timeout for waiting on truncation

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -81,7 +81,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
     partition->log().housekeeping(housekeeping_conf).get();
     // NOTE: the storage layer only initially requests eviction; it relies on
     // Raft to write a snapshot and subsequently truncate.
-    tests::cooperative_spin_wait_with_timeout(3s, [log] {
+    tests::cooperative_spin_wait_with_timeout(10s, [log] {
         return log->segments().size() == 1;
     }).get();
 

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -267,7 +267,7 @@ FIXTURE_TEST(test_delete_from_stm_consume, delete_records_e2e_fixture) {
                    topic_name, model::partition_id(0), model::offset(1), 5s)
                  .get();
     BOOST_CHECK_EQUAL(model::offset(1), lwm);
-    tests::cooperative_spin_wait_with_timeout(3s, [this] {
+    tests::cooperative_spin_wait_with_timeout(10s, [this] {
         return log->segment_count() == 1;
     }).get();
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12495
Fixes: https://github.com/redpanda-data/redpanda/issues/12581,