### PR TITLE
Do not query decommissioned nodes about status

### DIFF
--- a/tests/rptest/tests/node_pool_migration_test.py
+++ b/tests/rptest/tests/node_pool_migration_test.py
@@ -103,11 +103,13 @@ class NodePoolMigrationTest(PreallocNodesTest):
             "Error waiting for all the nodes to report consistent list of brokers in the cluster health and configuration."
         )
 
-    def _wait_for_node_removed(self, node_id):
-        waiter = NodeDecommissionWaiter(self.redpanda,
-                                        node_id,
-                                        self.logger,
-                                        progress_timeout=120)
+    def _wait_for_node_removed(self, node_id, decommissioned_ids):
+        waiter = NodeDecommissionWaiter(
+            self.redpanda,
+            node_id,
+            self.logger,
+            progress_timeout=120,
+            decommissioned_node_ids=decommissioned_ids)
         waiter.wait_for_removal()
         return True
 
@@ -115,8 +117,9 @@ class NodePoolMigrationTest(PreallocNodesTest):
 
         with ThreadPoolExecutor(
                 max_workers=len(decommissioned_ids)) as executor:
-            result = executor.map(lambda id: self._wait_for_node_removed(id),
-                                  decommissioned_ids)
+            result = executor.map(
+                lambda id: self._wait_for_node_removed(id, decommissioned_ids),
+                decommissioned_ids)
 
             return [r for r in result]
 

--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -80,7 +80,12 @@ def generate_random_workload(available_nodes):
 
 
 class NodeDecommissionWaiter():
-    def __init__(self, redpanda, node_id, logger, progress_timeout=30):
+    def __init__(self,
+                 redpanda,
+                 node_id,
+                 logger,
+                 progress_timeout=30,
+                 decommissioned_node_ids=None):
         self.redpanda = redpanda
         self.node_id = node_id
         self.logger = logger
@@ -89,6 +94,9 @@ class NodeDecommissionWaiter():
         self.last_replicas_left = None
         self.last_partitions_bytes_left = None
         self.progress_timeout = progress_timeout
+        self.decommissioned_node_ids = [
+            node_id
+        ] if decommissioned_node_ids == None else decommissioned_node_ids
 
     def _nodes_with_decommission_progress_api(self):
         def has_decommission_progress_api(node):
@@ -127,7 +135,7 @@ class NodeDecommissionWaiter():
     def _not_decommissioned_node(self):
         return random.choice([
             n for n in self._nodes_with_decommission_progress_api()
-            if self.redpanda.node_id(n) != self.node_id
+            if self.redpanda.node_id(n) not in self.decommissioned_node_ids
         ])
 
     def _made_progress(self):


### PR DESCRIPTION
When decommissioning many nodes at the same time a test code should not query any of the decommissioned nodes about the status at they may contain metadata which are not updated. When node is decommissioned and removed from the cluster it stops receiving metadata updates so its view of the cluster state is stale.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none