### PR TITLE
tests/kgo-verifier: update to latest SHA

### DIFF
--- a/tests/docker/ducktape-deps/kgo-verifier
+++ b/tests/docker/ducktape-deps/kgo-verifier
@@ -2,6 +2,6 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
 cd /opt/kgo-verifier
-git reset --hard 3508c6e64e1b9ef92dc325a27cd62c16b411f0e4
+git reset --hard e8901aa55c995917044a5665ffdc215db38eee18
 go mod tidy
 make


### PR DESCRIPTION
Franz-go within kgo-verifier needs updating. This PR updates the SHA. For context, see https://redpandadata.slack.com/archives/C044RD18NMV/p1691076044618439?thread_ts=1691071206.358289&cid=C044RD18NMV

Merge https://github.com/redpanda-data/kgo-verifier/pull/39 first, then this PR.

Fixes: https://github.com/redpanda-data/redpanda/issues/12571

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none