### PR TITLE
[v23.2.x] kafka: Revert "kafka: Disable use of separate fetch scheduling group"

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -499,7 +499,7 @@ configuration::configuration()
       "use_fetch_scheduler_group",
       "Use a separate scheduler group for fetch processing",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      false)
+      true)
   , metadata_status_wait_timeout_ms(
       *this,
       "metadata_status_wait_timeout_ms",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12559
