### PR TITLE
Unify all internal metrics to aggregate by partition and shard

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -48,9 +48,10 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
     auto ns_label = sm::label("namespace");
     auto topic_label = sm::label("topic");
     auto partition_label = sm::label("partition");
-    auto aggregate_labels = config::shard_local_cfg().aggregate_metrics()
-                              ? std::vector<sm::label>{sm::shard_label}
-                              : std::vector<sm::label>{};
+    auto aggregate_labels
+      = config::shard_local_cfg().aggregate_metrics()
+          ? std::vector<sm::label>{sm::shard_label, partition_label}
+          : std::vector<sm::label>{};
 
     const std::vector<sm::label_instance> labels = {
       ns_label(ntp.ns()),

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -3305,9 +3305,10 @@ void rm_stm::setup_metrics() {
     auto ns_label = sm::label("namespace");
     auto topic_label = sm::label("topic");
     auto partition_label = sm::label("partition");
-    auto aggregate_labels = config::shard_local_cfg().aggregate_metrics()
-                              ? std::vector<sm::label>{sm::shard_label}
-                              : std::vector<sm::label>{};
+    auto aggregate_labels
+      = config::shard_local_cfg().aggregate_metrics()
+          ? std::vector<sm::label>{sm::shard_label, partition_label}
+          : std::vector<sm::label>{};
 
     const auto& ntp = _c->ntp();
     const std::vector<sm::label_instance> labels = {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -159,9 +159,11 @@ void consensus::setup_metrics() {
 
     _probe->setup_metrics(_log->config().ntp());
     auto labels = probe::create_metric_labels(_log->config().ntp());
-    auto aggregate_labels = config::shard_local_cfg().aggregate_metrics()
-                              ? std::vector<sm::label>{sm::shard_label}
-                              : std::vector<sm::label>{};
+    auto partition_label = sm::label("partition");
+    auto aggregate_labels
+      = config::shard_local_cfg().aggregate_metrics()
+          ? std::vector<sm::label>{sm::shard_label, partition_label}
+          : std::vector<sm::label>{};
 
     _metrics.add_group(
       prometheus_sanitize::metrics_name("raft"),

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -172,7 +172,7 @@ void probe::setup_metrics(const model::ntp& ntp) {
          [this] { return _compaction_ratio; },
          sm::description("Average segment compaction ratio"),
          labels)
-         .aggregate({sm::shard_label})});
+         .aggregate(aggregate_labels)});
 }
 
 void probe::add_initial_segment(const segment& s) {


### PR DESCRIPTION
There is a lot of inconsistencies with how the `aggregate_metrics` property is treated in various metric probes in the code base. There are some cases in which it's ignored, some cases where only the shard label is aggregated, and some cases where both the shard and partition label is aggregated.

For probes where it is ignored or only used to aggregate the shard label the number of internal metrics that are generated becomes untenable with high partition counts(i.e, 100k+).

This PR unifies the behavior of the `aggregate_metrics` property to always aggregate by the shard and partition label hence avoiding an explosion in metrics with high partition counts. 

Fixes: #12563 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements

* All metrics will now be aggregated by their shard and partition labels when the `aggregate_metrics` cluster property is set to true.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
