### PR TITLE
[storage]: storage::log interface self-honesty

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -30,23 +30,7 @@
 
 #include <utility>
 
-namespace {
-
-std::optional<storage::disk_log_impl*>
-get_concrete_log_impl(ss::shared_ptr<storage::log> log) {
-    // NOTE: we need to break encapsulation here to access underlying
-    // implementation because upload policy and archival subsystem needs to
-    // access individual log segments (disk backed).
-    auto plog = dynamic_cast<storage::disk_log_impl*>(log.get());
-    if (plog == nullptr || plog->segment_count() == 0) {
-        return std::nullopt;
-    }
-    return plog;
-}
-
 constexpr size_t compacted_segment_size_multiplier{3};
-
-} // namespace
 
 namespace archival {
 
@@ -128,20 +112,16 @@ archival_policy::lookup_result archival_policy::find_segment(
       "Upload policy for {} invoked, start offset: {}",
       _ntp,
       start_offset);
-    auto maybe_plog = get_concrete_log_impl(std::move(log));
-    if (!maybe_plog) {
+    if (log->segment_count() == 0) {
         vlog(
           archival_log.debug,
-          "Upload policy for {}: can't find candidate, no segments or "
-          "in-memory log",
+          "Upload policy for {}: can't find candidate, no segments",
           _ntp);
         return {};
     }
 
-    auto plog = maybe_plog.value();
-    const auto& set = plog->segments();
-
-    const auto& ntp_conf = plog->config();
+    const auto& set = log->segments();
+    const auto& ntp_conf = log->config();
     auto it = set.lower_bound(start_offset);
     if (it == set.end() || (*it)->finished_self_compaction()) {
         // Skip forward if we hit a gap or compacted segment
@@ -431,8 +411,7 @@ archival_policy::get_next_compacted_segment(
   ss::shared_ptr<storage::log> log,
   const cloud_storage::partition_manifest& manifest,
   ss::lowres_clock::duration segment_lock_duration) {
-    auto plog = get_concrete_log_impl(std::move(log));
-    if (!plog) {
+    if (log->segment_count() == 0) {
         vlog(
           archival_log.warn,
           "Upload policy find next compacted segment: cannot find log for ntp: "
@@ -443,7 +422,7 @@ archival_policy::get_next_compacted_segment(
     segment_collector compacted_segment_collector{
       begin_inclusive,
       manifest,
-      **plog,
+      *log,
       config::shard_local_cfg().compacted_log_segment_size
         * compacted_segment_size_multiplier};
 

--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -414,8 +414,7 @@ archival_policy::get_next_compacted_segment(
     if (log->segment_count() == 0) {
         vlog(
           archival_log.warn,
-          "Upload policy find next compacted segment: cannot find log for ntp: "
-          "{}",
+          "Upload policy find next compacted segment: no segments ntp: {}",
           _ntp);
         co_return upload_candidate_with_locks{upload_candidate{}, {}};
     }

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1904,8 +1904,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
 uint64_t ntp_archiver::estimate_backlog_size() {
     auto last_offset = manifest().size() ? manifest().get_last_offset()
                                          : model::offset(0);
-    auto log_generic = _parent.log();
-    auto log = dynamic_cast<storage::disk_log_impl*>(log_generic.get());
+    auto log = _parent.log();
     uint64_t total_size = std::accumulate(
       std::begin(log->segments()),
       std::end(log->segments()),
@@ -2717,7 +2716,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
     auto units = co_await ss::get_units(_mutex, 1, _as);
     if (run->meta.base_offset >= _parent.raft_start_offset()) {
         auto log_generic = _parent.log();
-        auto& log = dynamic_cast<storage::disk_log_impl&>(*log_generic);
+        auto& log = *log_generic;
         segment_collector collector(
           run->meta.base_offset,
           manifest(),

--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -23,7 +23,7 @@ namespace archival {
 segment_collector::segment_collector(
   model::offset begin_inclusive,
   const cloud_storage::partition_manifest& manifest,
-  const storage::disk_log_impl& log,
+  const storage::log& log,
   size_t max_uploaded_segment_size,
   std::optional<model::offset> end_inclusive)
   : _begin_inclusive(begin_inclusive)

--- a/src/v/archival/segment_reupload.h
+++ b/src/v/archival/segment_reupload.h
@@ -48,7 +48,7 @@ public:
     segment_collector(
       model::offset begin_inclusive,
       const cloud_storage::partition_manifest& manifest,
-      const storage::disk_log_impl& log,
+      const storage::log& log,
       size_t max_uploaded_segment_size,
       std::optional<model::offset> end_inclusive = std::nullopt);
 
@@ -122,7 +122,7 @@ private:
     model::offset _end_inclusive;
 
     const cloud_storage::partition_manifest& _manifest;
-    const storage::disk_log_impl& _log;
+    const storage::log& _log;
     const storage::ntp_config* _ntp_cfg{};
     segment_seq _segments;
     bool _can_replace_manifest_segment{false};

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -175,9 +175,8 @@ struct reupload_fixture : public archiver_fixture {
         init_archiver();
     }
 
-    storage::disk_log_impl* disk_log_impl() {
-        return dynamic_cast<storage::disk_log_impl*>(
-          get_local_storage_api().log_mgr().get(manifest_ntp).get());
+    ss::shared_ptr<storage::log> disk_log_impl() {
+        return get_local_storage_api().log_mgr().get(manifest_ntp);
     }
 
     cloud_storage::partition_manifest

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -79,8 +79,7 @@ static void log_segment(const storage::segment& s) {
 }
 
 static void log_segment_set(storage::log_manager& lm) {
-    auto log = lm.get(manifest_ntp);
-    auto plog = dynamic_cast<const storage::disk_log_impl*>(log.get());
+    auto plog = lm.get(manifest_ntp);
     BOOST_REQUIRE(plog != nullptr);
     const auto& sset = plog->segments();
     for (const auto& s : sset) {
@@ -923,9 +922,7 @@ FIXTURE_TEST(
         as))
       .get0();
 
-    auto plog = dynamic_cast<storage::disk_log_impl*>(log.get());
-
-    auto seg = plog->segments().begin();
+    auto seg = log->segments().begin();
 
     BOOST_REQUIRE((*seg)->finished_self_compaction());
 

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -321,13 +321,13 @@ segment_matcher<Fixture>::list_segments(const model::ntp& ntp) {
     std::vector<ss::lw_shared_ptr<storage::segment>> result;
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-        std::copy_if(
-          log->segments().begin(),
-          log->segments().end(),
-          std::back_inserter(result),
-          [](ss::lw_shared_ptr<storage::segment> seg) {
-              return !seg->has_appender();
-          });
+    std::copy_if(
+      log->segments().begin(),
+      log->segments().end(),
+      std::back_inserter(result),
+      [](ss::lw_shared_ptr<storage::segment> seg) {
+          return !seg->has_appender();
+      });
     return result;
 }
 
@@ -336,13 +336,13 @@ ss::lw_shared_ptr<storage::segment> segment_matcher<Fixture>::get_segment(
   const model::ntp& ntp, const archival::segment_name& name) {
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-        for (const auto& s : log->segments()) {
-            if (
-              !s->has_appender()
-              && boost::ends_with(s->reader().filename(), name())) {
-                return s;
-            }
+    for (const auto& s : log->segments()) {
+        if (
+          !s->has_appender()
+          && boost::ends_with(s->reader().filename(), name())) {
+            return s;
         }
+    }
     return nullptr;
 }
 

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -321,15 +321,13 @@ segment_matcher<Fixture>::list_segments(const model::ntp& ntp) {
     std::vector<ss::lw_shared_ptr<storage::segment>> result;
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.get()); dlog) {
         std::copy_if(
-          dlog->segments().begin(),
-          dlog->segments().end(),
+          log->segments().begin(),
+          log->segments().end(),
           std::back_inserter(result),
           [](ss::lw_shared_ptr<storage::segment> seg) {
               return !seg->has_appender();
           });
-    }
     return result;
 }
 
@@ -338,15 +336,13 @@ ss::lw_shared_ptr<storage::segment> segment_matcher<Fixture>::get_segment(
   const model::ntp& ntp, const archival::segment_name& name) {
     auto log
       = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
-    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log.get()); dlog) {
-        for (const auto& s : dlog->segments()) {
+        for (const auto& s : log->segments()) {
             if (
               !s->has_appender()
               && boost::ends_with(s->reader().filename(), name())) {
                 return s;
             }
         }
-    }
     return nullptr;
 }
 

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -113,7 +113,7 @@ public:
         add_topic({model::kafka_namespace, topic_name}, 1, props).get();
         wait_for_leader(ntp).get();
         partition = app.partition_manager.local().get(ntp).get();
-        log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
+        log = partition->log();
         auto archiver_ref = partition->archiver();
         BOOST_REQUIRE(archiver_ref.has_value());
         archiver = &archiver_ref.value().get();
@@ -134,7 +134,7 @@ public:
     model::topic topic_name;
     model::ntp ntp;
     cluster::partition* partition;
-    storage::disk_log_impl* log;
+    ss::shared_ptr<storage::log> log;
     archival::ntp_archiver* archiver;
 };
 

--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -60,8 +60,7 @@ public:
     // Expects to be the only one mutating the underlying partition state.
     ss::future<int> produce() {
         co_await _producer.start();
-        auto* log = dynamic_cast<storage::disk_log_impl*>(
-          _partition.log().get());
+        auto log = _partition.log();
         auto& archiver = _partition.archiver().value().get();
 
         size_t total_records = 0;

--- a/src/v/cluster/tests/eviction_stm_test.cc
+++ b/src/v/cluster/tests/eviction_stm_test.cc
@@ -66,8 +66,7 @@ FIXTURE_TEST(test_eviction_stm_deadlock, raft_test_fixture) {
     auto leader_raft = gr.get_member(leader_id).consensus;
 
     /// Publish records and open new segments
-    auto* impl = dynamic_cast<storage::disk_log_impl*>(
-      leader_raft->log().get());
+    auto impl = leader_raft->log();
     std::vector<storage::offset_stats> offsets;
     for (auto i = 0; i < 5; ++i) {
         replicate_random_batches(gr, 20).get0();

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -611,7 +611,7 @@ FIXTURE_TEST(test_aborted_transactions, mux_state_machine_fixture) {
 
     auto log = _storage.local().log_mgr().get(_raft->ntp());
     BOOST_REQUIRE(log);
-    auto* disk_log = dynamic_cast<storage::disk_log_impl*>(log.get());
+    auto disk_log = log;
 
     static int64_t pid_counter = 0;
     const auto tx_seq = model::tx_seq(0);

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -47,10 +47,6 @@ using cluster::random_tx_generator;
     log->stm_manager()->add_stm(stm);                                          \
     BOOST_REQUIRE(log);
 
-storage::disk_log_impl* get_disk_log(ss::shared_ptr<storage::log> log) {
-    return dynamic_cast<storage::disk_log_impl*>(log.get());
-}
-
 FIXTURE_TEST(test_tx_compaction_combinations, mux_state_machine_fixture) {
     // This generates very interesting interleaved and non interleaved
     // transaction scopes with single and multi segment transactions. We
@@ -74,7 +70,7 @@ FIXTURE_TEST(test_tx_compaction_combinations, mux_state_machine_fixture) {
                         STM_BOOTSTRAP();
                         vlog(test_logger.info, "Running spec: {}", spec);
                         random_tx_generator{}.run_workload(
-                          spec, _raft->term(), stm, get_disk_log(log));
+                          spec, _raft->term(), stm, log);
                         vlog(test_logger.info, "Finished spec: {}", spec);
                     }
                 }

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -50,7 +50,7 @@ public:
       spec s,
       model::term_id term,
       ss::shared_ptr<cluster::rm_stm> stm,
-      storage::disk_log_impl* log) {
+      ss::shared_ptr<storage::log> log) {
         // ---- Step 1: Generate random transaction ops.
         // As we generate random txns, we populate them in a priority queue that
         // orders them by their associated weight, which controls the sequence
@@ -173,7 +173,7 @@ private:
     struct tx_op_ctx {
         ss::shared_ptr<linear_int_kv_batch_generator> _data_gen;
         ss::shared_ptr<rm_stm> _stm;
-        storage::disk_log_impl* _log;
+        ss::shared_ptr<storage::log> _log;
         model::producer_identity _pid;
         model::term_id _term;
     };

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -663,7 +663,7 @@ FIXTURE_TEST(test_basic_delete_around_batch, prod_consume_fixture) {
     const model::partition_id pid(0);
     const model::ntp ntp(tp_ns.ns, tp_ns.tp, pid);
     auto partition = app.partition_manager.local().get(ntp);
-    auto* log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
+    auto log = partition->log();
 
     tests::kafka_produce_transport producer(make_kafka_client().get());
     producer.start().get();

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -272,7 +272,7 @@ eviction_policy::collect_reclaimable_offsets() {
     fragmented_vector<partition> res;
     co_await ss::max_concurrent_for_each(
       partitions.begin(), partitions.end(), 20, [&res, cfg](const auto& p) {
-          auto log = dynamic_cast<storage::disk_log_impl*>(p->log().get());
+          auto log = p->log();
           return log->get_reclaimable_offsets(cfg)
             .then([&res, group = p->group()](auto offsets) {
                 res.push_back({
@@ -330,7 +330,7 @@ ss::future<size_t> eviction_policy::install_schedule(shard_partitions shard) {
                 continue;
             }
 
-            auto log = dynamic_cast<storage::disk_log_impl*>(p->log().get());
+            auto log = p->log();
             log->set_cloud_gc_offset(partition.decision.value());
             ++decisions;
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -99,7 +99,7 @@ public:
 
     ss::future<> force_roll(ss::io_priority_class) override;
 
-    probe& get_probe() { return *_probe; }
+    probe& get_probe() override { return *_probe; }
     model::term_id term() const;
     segment_set& segments() override { return _segs; }
     const segment_set& segments() const override { return _segs; }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -97,9 +97,7 @@ public:
     ss::future<> maybe_roll(
       model::term_id, model::offset next_offset, ss::io_priority_class);
 
-    // roll immediately with the current term. users should prefer the
-    // maybe_call interface which enforces sizing policies.
-    ss::future<> force_roll(ss::io_priority_class);
+    ss::future<> force_roll(ss::io_priority_class) override;
 
     probe& get_probe() { return *_probe; }
     model::term_id term() const;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -104,7 +104,7 @@ public:
     probe& get_probe() { return *_probe; }
     model::term_id term() const;
     segment_set& segments() { return _segs; }
-    const segment_set& segments() const { return _segs; }
+    const segment_set& segments() const override { return _segs; }
     size_t bytes_left_before_roll() const;
 
     size_t size_bytes() const override { return _probe->partition_size(); }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -103,7 +103,7 @@ public:
 
     probe& get_probe() { return *_probe; }
     model::term_id term() const;
-    segment_set& segments() { return _segs; }
+    segment_set& segments() override { return _segs; }
     const segment_set& segments() const override { return _segs; }
     size_t bytes_left_before_roll() const;
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -113,7 +113,7 @@ public:
 
     int64_t compaction_backlog() const final;
 
-    ss::future<usage_report> disk_usage(gc_config);
+    ss::future<usage_report> disk_usage(gc_config) override;
 
     /*
      * Interface for disk space management (see resource_mgmt/storage.cc).
@@ -131,9 +131,10 @@ public:
      */
     auto& gate() { return _compaction_housekeeping_gate; }
     fragmented_vector<ss::lw_shared_ptr<segment>> cloud_gc_eligible_segments();
-    void set_cloud_gc_offset(model::offset);
+    void set_cloud_gc_offset(model::offset) override;
 
-    ss::future<reclaimable_offsets> get_reclaimable_offsets(gc_config cfg);
+    ss::future<reclaimable_offsets>
+    get_reclaimable_offsets(gc_config cfg) override;
 
 private:
     friend class disk_log_appender; // for multi-term appends

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -137,6 +137,9 @@ public:
     virtual const segment_set& segments() const = 0;
     virtual segment_set& segments() = 0;
 
+    // roll immediately with the current term.
+    virtual ss::future<> force_roll(ss::io_priority_class) = 0;
+
 private:
     ntp_config _config;
 

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -135,6 +135,7 @@ public:
     virtual void set_cloud_gc_offset(model::offset) = 0;
 
     virtual const segment_set& segments() const = 0;
+    virtual segment_set& segments() = 0;
 
 private:
     ntp_config _config;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -28,6 +28,8 @@
 
 namespace storage {
 
+class segment_set;
+
 class log {
 public:
     explicit log(ntp_config cfg) noexcept
@@ -131,6 +133,8 @@ public:
     virtual ss::future<reclaimable_offsets>
     get_reclaimable_offsets(gc_config cfg) = 0;
     virtual void set_cloud_gc_offset(model::offset) = 0;
+
+    virtual const segment_set& segments() const = 0;
 
 private:
     ntp_config _config;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -29,6 +29,7 @@
 namespace storage {
 
 class segment_set;
+class probe;
 
 class log {
 public:
@@ -139,6 +140,8 @@ public:
 
     // roll immediately with the current term.
     virtual ss::future<> force_roll(ss::io_priority_class) = 0;
+
+    virtual probe& get_probe() = 0;
 
 private:
     ntp_config _config;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -127,6 +127,11 @@ public:
 
     virtual int64_t compaction_backlog() const = 0;
 
+    virtual ss::future<usage_report> disk_usage(gc_config) = 0;
+    virtual ss::future<reclaimable_offsets>
+    get_reclaimable_offsets(gc_config cfg) = 0;
+    virtual void set_cloud_gc_offset(model::offset) = 0;
+
 private:
     ntp_config _config;
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -341,8 +341,7 @@ ss::future<> log_manager::housekeeping_loop() {
                 }
 
                 auto ntp = log_meta.handle->config().ntp();
-                auto log = dynamic_cast<disk_log_impl*>(log_meta.handle.get());
-                auto usage = co_await log->disk_usage(
+                auto usage = co_await log_meta.handle->disk_usage(
                   gc_config(collection_threshold(), _config.retention_bytes()));
 
                 /*
@@ -763,8 +762,7 @@ ss::future<usage_report> log_manager::disk_usage() {
     co_return co_await ss::map_reduce(
       logs.begin(),
       logs.end(),
-      [this, collection_threshold](ss::shared_ptr<log> l) {
-          auto log = dynamic_cast<disk_log_impl*>(l.get());
+      [this, collection_threshold](ss::shared_ptr<log> log) {
           return log->disk_usage(
             gc_config(collection_threshold, _config.retention_bytes()));
       },

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -474,7 +474,7 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
       [&rec_mgr]() mutable { rec_mgr.stop().get0(); });
     auto rec_log
       = rec_mgr.manage(storage::ntp_config(ntp, cfg.base_dir)).get0();
-    auto& impl = dynamic_cast<disk_log_impl&>(*rec_log);
+    auto& impl = *rec_log;
 
     BOOST_REQUIRE_EQUAL(impl.segment_count(), 3);
 
@@ -549,10 +549,8 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     f1.get0();
     f2.get0();
 
-    auto& impl = dynamic_cast<storage::disk_log_impl&>(*log);
-
     BOOST_REQUIRE_EQUAL(
-      (*impl.segments().begin())->offsets().base_offset,
+      (*log->segments().begin())->offsets().base_offset,
       log->offsets().start_offset);
 }
 
@@ -679,7 +677,7 @@ FIXTURE_TEST(test_index_max_timestamp_update, storage_test_fixture) {
         model::offset{20}, ss::default_priority_class()))
       .get();
 
-    auto& impl = dynamic_cast<storage::disk_log_impl&>(*log);
+    auto& impl = *log;
 
     // The maximum timestamp in the index should be the maximum
     // timestamp of the batch preceeding the batch where the truncation

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -50,10 +50,6 @@
 #include <optional>
 #include <vector>
 
-storage::disk_log_impl* get_disk_log(ss::shared_ptr<storage::log> log) {
-    return dynamic_cast<storage::disk_log_impl*>(log.get());
-}
-
 void validate_offsets(
   model::offset base,
   const std::vector<model::record_batch_header>& write_headers,
@@ -71,7 +67,7 @@ void validate_offsets(
 }
 
 void compact_and_prefix_truncate(
-  storage::disk_log_impl& log, storage::housekeeping_config cfg) {
+  storage::log& log, storage::housekeeping_config cfg) {
     ss::abort_source as;
     auto eviction_future = log.monitor_eviction(as);
 
@@ -473,7 +469,7 @@ FIXTURE_TEST(
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     append_batch_with_no_max_ts(log, model::term_id(0), model::timestamp(100));
     append_batch_with_no_max_ts(log, model::term_id(0), model::timestamp(110));
@@ -507,7 +503,7 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // 1. segment timestamps from 100 to 110
     append_custom_timestamp_batches(
@@ -591,7 +587,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
     auto headers = append_random_batches(log, 10);
     log->flush().get0();
     auto all_batches = read_and_validate_all_batches(log);
@@ -1266,7 +1262,7 @@ FIXTURE_TEST(check_max_segment_size, storage_test_fixture) {
     auto ntp = model::ntp("default", "test", 0);
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 0);
 
@@ -1320,7 +1316,7 @@ FIXTURE_TEST(check_max_segment_size_limits, storage_test_fixture) {
         auto ntp = model::ntp("default", "test", 0);
         storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
         auto log = mgr.manage(std::move(ntp_cfg)).get0();
-        auto disk_log = get_disk_log(log);
+        auto disk_log = log;
 
         BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 0);
 
@@ -1386,7 +1382,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
       ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov));
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
 
-    auto sz_initial = get_disk_log(log)->get_probe().partition_size();
+    auto sz_initial = log->get_probe().partition_size();
     info("sz_initial={}", sz_initial);
     BOOST_REQUIRE_EQUAL(sz_initial, 0);
 
@@ -1403,7 +1399,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
 
     // Read back and validate content of log pre-compaction.
     BOOST_REQUIRE_EQUAL(
-      get_disk_log(log)->get_probe().partition_size(),
+      log->get_probe().partition_size(),
       input_batch_count * batch_size);
     BOOST_REQUIRE_EQUAL(
       read_and_validate_all_batches(log).size(), input_batch_count);
@@ -1422,9 +1418,9 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     // Compact 10 times, with a configuration calling for 60kiB max log size.
     // This results in prefix truncating at offset 50.
     for (int i = 0; i < 10; ++i) {
-        compact_and_prefix_truncate(*get_disk_log(log), ccfg);
+        compact_and_prefix_truncate(*log, ccfg);
     }
-    get_disk_log(log)->get_probe().partition_size();
+    log->get_probe().partition_size();
 
     as.request_abort();
     auto lstats_after = log->offsets();
@@ -1441,14 +1437,14 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
           return sum + b.size_bytes();
       });
 
-    auto& segments = get_disk_log(log)->segments();
+    auto& segments = log->segments();
     // One historic segment (all historic batches compacted down to 1), plus
     // one active segment.
     BOOST_REQUIRE_EQUAL(segments.size(), 2);
 
     // The log-scope reported size must be equal to the sum of the batch sizes
     auto expected_size = total_batch_size;
-    auto actual_size = get_disk_log(log)->get_probe().partition_size();
+    auto actual_size = log->get_probe().partition_size();
     info("expected_size={}, actual_size={}", expected_size, actual_size);
     BOOST_REQUIRE_EQUAL(actual_size, expected_size);
 };
@@ -1476,7 +1472,7 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
     }
     std::vector<size_t> sizes;
     for (auto& l : logs) {
-        auto& segs = get_disk_log(l)->segments();
+        auto& segs = l->segments();
         sizes.push_back((*segs.begin())->size_bytes());
     }
     BOOST_REQUIRE_EQUAL(
@@ -1509,7 +1505,7 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
                  .get0();
 
     // build some segments
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
     append_single_record_batch(log, 20, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     append_single_record_batch(log, 30, model::term_id(1));
@@ -1577,7 +1573,7 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
                  .get0();
 
     // build some segments
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
     append_single_record_batch(log, 20, model::term_id(1));
     append_single_record_batch(log, 30, model::term_id(2));
     disk_log->force_roll(ss::default_priority_class()).get();
@@ -1642,7 +1638,7 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
                      overrides)))
                  .get0();
 
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // add a segment with random keys until a certain size
     auto add_segment = [&log, disk_log](size_t size, model::term_id term) {
@@ -1720,7 +1716,7 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
                      overrides)))
                  .get0();
 
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
     append_single_record_batch(log, 20, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     append_single_record_batch(log, 30, model::term_id(2));
@@ -1844,7 +1840,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
                      overrides)))
                  .get0();
 
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // add a segment with random keys until a certain size
     auto add_segment = [&log, disk_log](size_t size, model::term_id term) {
@@ -1925,7 +1921,7 @@ FIXTURE_TEST(not_compacted_log_backlog, storage_test_fixture) {
                      overrides)))
                  .get0();
 
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // add a segment with random keys until a certain size
     auto add_segment = [&log, disk_log](size_t size, model::term_id term) {
@@ -2127,7 +2123,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
                      overrides)))
                  .get0();
 
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // add a segment, some of the record keys in batches are random and some of
     // them are the same to generate offset gaps after compaction
@@ -2281,7 +2277,7 @@ FIXTURE_TEST(test_querying_term_last_offset, storage_test_fixture) {
     // append some batches in term 1
     append_random_batches(log, 10, model::term_id(1));
     {
-        auto disk_log = get_disk_log(log);
+        auto disk_log = log;
         // force segment roll
         disk_log->force_roll(ss::default_priority_class()).get();
     }
@@ -2380,7 +2376,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
                      overrides)))
                  .get0();
 
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // the same key but three different batch types
     write_batch(log, "key_1", 1, model::record_batch_type::raft_data);
@@ -2838,7 +2834,7 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
       mgr.config().base_dir,
       std::make_unique<storage::ntp_config::default_overrides>(overrides));
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // (1) append some random data, with limited number of distinct keys, so
     // compaction can make progress.
@@ -2905,7 +2901,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
       mgr.config().base_dir,
       std::make_unique<storage::ntp_config::default_overrides>(overrides));
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // (1) append some random data, with limited number of distinct keys, so
     // compaction can make progress.
@@ -2956,7 +2952,7 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
       mgr.config().base_dir,
       std::make_unique<storage::ntp_config::default_overrides>(overrides));
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // Append some linear kv ints
     int num_appends = 5;
@@ -3019,7 +3015,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
       mgr.config().base_dir,
       std::make_unique<storage::ntp_config::default_overrides>(overrides));
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     auto append_batch =
       [](ss::shared_ptr<storage::log> log, model::term_id term) {
@@ -3305,7 +3301,7 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
         for (int i = 0; i < batch_cnt; ++i) {
             append_exactly(log, 1, batch_size).get();
         }
-        auto disk_log = get_disk_log(log);
+        auto disk_log = log;
 
         BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 11);
 
@@ -3451,7 +3447,7 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
     produce.get();
     read.get();
     truncate.get();
-    auto disk_log = get_disk_log(log);
+    auto disk_log = log;
 
     // at the end of this test there must be no batch parse errors
     BOOST_REQUIRE_EQUAL(disk_log->get_probe().get_batch_parse_errors(), 0);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1399,8 +1399,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
 
     // Read back and validate content of log pre-compaction.
     BOOST_REQUIRE_EQUAL(
-      log->get_probe().partition_size(),
-      input_batch_count * batch_size);
+      log->get_probe().partition_size(), input_batch_count * batch_size);
     BOOST_REQUIRE_EQUAL(
       read_and_validate_all_batches(log).size(), input_batch_count);
     auto lstats_before = log->offsets();


### PR DESCRIPTION
We've been hiding behind `dynamic_cast` instead of being honest with ourselves about the unpleasant parts of the log interface. This PR changes that by surfacing the external interfaces to storage::log (it's really not so bad). In any case, the disk_log_builder is now the only remaining user of `dynamic_cast<disk_log_impl>` as it uses a bunch of low-level interfaces.

This change is important as we look towards evolving the local log implementation--we need to be able to clearly see the interface we are trying to support.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

