### PR TITLE
K8S: Fix decommission E2E tests

### DIFF
--- a/src/go/k8s/tests/e2e/decommission/07-clean.yaml
+++ b/src/go/k8s/tests/e2e/decommission/07-clean.yaml
@@ -17,3 +17,11 @@ delete:
     kind: PersistentVolumeClaim
     name: datadir-decommission-2
     namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: get-broker-count
+    namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: get-broker-count-again
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/managed-decommission/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/02-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    job-name: get-broker-count
+    job-name: get-broker-count-managed-decom
 status:
   containerStatuses:
     - name: curl

--- a/src/go/k8s/tests/e2e/managed-decommission/02-probe.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/02-probe.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: get-broker-count
+  name: get-broker-count-managed-decom
 spec:
   backoffLimit: 10
   template:

--- a/src/go/k8s/tests/e2e/managed-decommission/03-clean.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/03-clean.yaml
@@ -17,3 +17,7 @@ delete:
     kind: PersistentVolumeClaim
     name: datadir-decommission-2
     namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: get-broker-count-managed-decom
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/managed-decommission/03-clean.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/03-clean.yaml
@@ -13,10 +13,6 @@ delete:
     kind: PersistentVolumeClaim
     name: datadir-decommission-1
     namespace: redpanda-system
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    name: datadir-decommission-2
-    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-broker-count-managed-decom


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## First change

Inside the decommission E2E test there is almost identical test Kubernetes Job.
As the whole kuttle test suite is running inside redpanda-system namespace
there are events when both Kubernetes Jobs runs at the same time.

It ends in the following error in kuttle output.

```
Job.batch "get-broker-count" is invalid: spec.template: Invalid value: core.PodTemplateSpec{ObjectMeta:v1.ObjectMeta{Name:"", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"controller-uid":"468f1776-e429-4e29-8954-1c811a709cf8", "job-name":"get-broker-count"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ZZZ_DeprecatedClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:core.PodSpec{Volumes:[]core.Volume(nil), InitContainers:[]core.Container(nil), Containers:[]core.Container{core.Container{Name:"curl", Image:"apteno/alpine-jq:latest", Command:[]string{"/bin/sh", "-c", "-ex"}, Args:[]string{"url=[http://decommission-0.decommission.$NAMESPACE.svc.cluster.local:9644/v1/brokers\nres=$(curl](http://decommission-0.decommission.%24namespace.svc.cluster.local:9644/v1/brokers/nres=$(curl) --silent -L $url | jq '. | length')\n\nif [[ \"$res\" != \"2\" ]]; then\n  exit 1;\nfi\n"}, WorkingDir:"", Ports:[]core.ContainerPort(nil), EnvFrom:[]core.EnvFromSource(nil), Env:[]core.EnvVar{core.EnvVar{Name:"NAMESPACE", Value:"", ValueFrom:(*core.EnvVarSource)(0xc004d45120)}}, Resources:core.ResourceRequirements{Limits:core.ResourceList(nil), Requests:core.ResourceList(nil)}, VolumeMounts:[]core.VolumeMount(nil), VolumeDevices:[]core.VolumeDevice(nil), LivenessProbe:(*core.Probe)(nil), ReadinessProbe:(*core.Probe)(nil), StartupProbe:(*core.Probe)(nil), Lifecycle:(*core.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"Always", SecurityContext:(*core.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, EphemeralContainers:[]core.EphemeralContainer(nil), RestartPolicy:"Never", TerminationGracePeriodSeconds:(*int64)(0xc00d735578), ActiveDeadlineSeconds:(*int64)(0xc00d7354e8), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"", AutomountServiceAccountToken:(*bool)(nil), NodeName:"", SecurityContext:(*core.PodSecurityContext)(0xc019bf3f00), ImagePullSecrets:[]core.LocalObjectReference(nil), Hostname:"", Subdomain:"", SetHostnameAsFQDN:(*bool)(nil), Affinity:(*core.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]core.Toleration(nil), HostAliases:[]core.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), PreemptionPolicy:(*core.PreemptionPolicy)(nil), DNSConfig:(*core.PodDNSConfig)(nil), ReadinessGates:[]core.PodReadinessGate(nil), RuntimeClassName:(*string)(nil), Overhead:core.ResourceList(nil), EnableServiceLinks:(*bool)(nil), TopologySpreadConstraints:[]core.TopologySpreadConstraint(nil), OS:(*core.PodOS)(nil)}}: field is immutable
```

The most important error is message `field is immutable` at the end. It means
Job should be removed before it can be created.

* https://github.com/redpanda-data/redpanda/blob/7e692551086895a5b4f5a79f34aa3646c59ae857/src/go/k8s/tests/e2e/decommission/02-probe.yaml
* https://github.com/redpanda-data/redpanda/blob/7e692551086895a5b4f5a79f34aa3646c59ae857/src/go/k8s/tests/e2e/managed-decommission/02-probe.yaml

* https://buildkite.com/redpanda/redpanda/builds/34451#0189bf61-64cb-4cea-ad18-04fe5562fe1e/1686-2851
* https://buildkite.com/redpanda/redpanda/builds/34398#0189bd90-44b0-4315-bbf5-e4e14ceece09/1687-2957
* https://buildkite.com/redpanda/redpanda/builds/34379#0189bc8b-606c-4e65-a0fd-e5c5ce3c62cb/1677-2776

## Second change

To clean up all test resources after they are finished Jobs where added to
TestStep delete declaration.

## Third change

The Persistent Volume Claim should be removed by operator in managed
decommisison test case.

* https://buildkite.com/redpanda/redpanda/builds/34393#0189bd75-8061-4d27-b150-5072ae90cd25/1675-2853
* https://buildkite.com/redpanda/redpanda/builds/34422#0189be21-34a9-4d8c-baf4-35566396d961/1694-2737

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
