### PR TITLE
[test]: add support for google test framework

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -324,3 +324,12 @@ ExternalProject_Add(protobuf
     -Dprotobuf_BUILD_TESTS=OFF
     ${common_cmake_args}
 )
+
+ExternalProject_Add(googletest
+  GIT_REPOSITORY https://github.com/google/googletest
+  GIT_TAG f8d7d77c06936315286eb55f8de22cd23c188571
+  INSTALL_DIR @REDPANDA_DEPS_INSTALL_DIR@
+  CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
+  LIST_SEPARATOR |
+  CMAKE_ARGS ${common_cmake_args}
+)

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -21,7 +21,7 @@ message(STATUS "RP_ENABLE_BENCHMARK_TESTS=${RP_ENABLE_BENCHMARK_TESTS}")
 
 function (rp_test)
   set(options
-    FIXTURE_TEST UNIT_TEST BENCHMARK_TEST)
+    FIXTURE_TEST UNIT_TEST BENCHMARK_TEST GTEST)
   set(oneValueArgs BINARY_NAME TIMEOUT PREPARE_COMMAND POST_COMMAND)
   set(multiValueArgs
     INCLUDES
@@ -117,10 +117,15 @@ function (rp_test)
     endif()
   endif()
 
+  set(gtest_option "")
+  if (RP_TEST_GTEST)
+      set(gtest_option "--gtest")
+  endif()
+
   if(NOT skip_test)
     add_test (
       NAME ${RP_TEST_BINARY_NAME}
-      COMMAND bash -c "${RUNNER} --binary=$<TARGET_FILE:${RP_TEST_BINARY_NAME}> ${prepare_command} ${post_command} ${files_to_copy} ${RP_TEST_ARGS} "
+      COMMAND bash -c "${RUNNER} --binary=$<TARGET_FILE:${RP_TEST_BINARY_NAME}> ${gtest_option} ${prepare_command} ${post_command} ${files_to_copy} ${RP_TEST_ARGS} "
       )
     set_tests_properties(${RP_TEST_BINARY_NAME} PROPERTIES LABELS "${RP_TEST_LABELS}")
     if(RP_TEST_TIMEOUT)

--- a/src/v/test_utils/CMakeLists.txt
+++ b/src/v/test_utils/CMakeLists.txt
@@ -3,4 +3,11 @@ v_cc_library(
   SRCS seastar_testing_main.cc
   DEPS Seastar::seastar_testing v::rprandom)
 
+find_package(GTest)
+
+v_cc_library(
+  NAME gtest_main
+  SRCS gtest_main.cc
+  DEPS Seastar::seastar Seastar::seastar_testing GTest::gtest)
+
 add_subdirectory(tests)

--- a/src/v/test_utils/gtest_main.cc
+++ b/src/v/test_utils/gtest_main.cc
@@ -17,21 +17,21 @@ char** g_argv;
 
 // seastar runner is a singleton that needs to be initialized once
 std::once_flag seastar_runner_init_flag;
-} // namespace
 
-void seastar_test_mixin::init_seastar_test_runner() {
+void init_seastar_test_runner() {
     std::call_once(seastar_runner_init_flag, [] {
         seastar::testing::global_test_runner().start(g_argc, g_argv);
     });
 }
+} // namespace
 
-void seastar_test_mixin::run(std::function<seastar::future<>()> task) {
+void seastar_test::run(std::function<seastar::future<>()> task) {
     // first test to need seastar will initialize it
     init_seastar_test_runner();
     seastar::testing::global_test_runner().run_sync(std::move(task));
 }
 
-void seastar_test_mixin::run_async(std::function<void()> task) {
+void seastar_test::run_async(std::function<void()> task) {
     run([task = std::move(task)]() mutable {
         return seastar::async([task = std::move(task)] { task(); });
     });

--- a/src/v/test_utils/gtest_main.cc
+++ b/src/v/test_utils/gtest_main.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "test_utils/test.h"
+
+namespace {
+// set by main() and consumed by seastar test runner initialization
+int g_argc;
+char** g_argv;
+
+// seastar runner is a singleton that needs to be initialized once
+std::once_flag seastar_runner_init_flag;
+} // namespace
+
+void seastar_test_mixin::init_seastar_test_runner() {
+    std::call_once(seastar_runner_init_flag, [] {
+        seastar::testing::global_test_runner().start(g_argc, g_argv);
+    });
+}
+
+void seastar_test_mixin::run(std::function<seastar::future<>()> task) {
+    // first test to need seastar will initialize it
+    init_seastar_test_runner();
+    seastar::testing::global_test_runner().run_sync(std::move(task));
+}
+
+void seastar_test_mixin::run_async(std::function<void()> task) {
+    run([task = std::move(task)]() mutable {
+        return seastar::async([task = std::move(task)] { task(); });
+    });
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    g_argc = argc;
+    g_argv = argv;
+
+    int ret = RUN_ALL_TESTS();
+
+    int ss_ret = seastar::testing::global_test_runner().finalize();
+    if (ret) {
+        return ret;
+    }
+    return ss_ret;
+}

--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -152,3 +152,25 @@ public:
 
 #define TEST_P_CORO(test_suite_name, test_name)                                \
     TEST_P_SEASTAR_(test_suite_name, test_name, run, seastar::future<>)
+
+/*
+ * Support for coroutine safe assertions
+ */
+#define GTEST_FATAL_FAILURE_CORO_(message)                                     \
+    co_return GTEST_MESSAGE_(message, ::testing::TestPartResult::kFatalFailure)
+#define ASSERT_PRED_FORMAT2_CORO(pred_format, v1, v2)                          \
+    GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_FATAL_FAILURE_CORO_)
+#define GTEST_ASSERT_EQ_CORO(val1, val2)                                       \
+    ASSERT_PRED_FORMAT2_CORO(::testing::internal::EqHelper::Compare, val1, val2)
+
+/*
+ * Coroutine safe assertions
+ */
+#define ASSERT_TRUE_CORO(condition)                                            \
+    GTEST_TEST_BOOLEAN_(                                                       \
+      condition, #condition, false, true, GTEST_FATAL_FAILURE_CORO_)
+#define ASSERT_FALSE_CORO(condition)                                           \
+    GTEST_TEST_BOOLEAN_(                                                       \
+      !(condition), #condition, true, false, GTEST_FATAL_FAILURE_CORO_)
+
+#define ASSERT_EQ_CORO(val1, val2) GTEST_ASSERT_EQ_CORO(val1, val2)

--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -138,8 +138,11 @@ public:
             return 0;                                                          \
         }                                                                      \
         static int gtest_registering_dummy_ GTEST_ATTRIBUTE_UNUSED_;           \
-        GTEST_DISALLOW_COPY_AND_ASSIGN_(                                       \
-          GTEST_TEST_CLASS_NAME_(test_suite_name, test_name));                 \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                     \
+        (GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) const&) = delete;  \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &                   \
+        operator=(GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) const&)   \
+          = delete;                                                            \
     };                                                                         \
     int GTEST_TEST_CLASS_NAME_(                                                \
       test_suite_name, test_name)::gtest_registering_dummy_                    \

--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <seastar/core/thread.hh>
+#include <seastar/testing/test_runner.hh>
+
+#include <gtest/gtest.h>
+
+class seastar_test_mixin {
+public:
+    static void init_seastar_test_runner();
+    static void run(std::function<seastar::future<>()> task);
+    static void run_async(std::function<void()> task);
+};
+
+#define GTEST_TEST_ASYNC_(test_suite_name, test_name, parent_class, parent_id) \
+    static_assert(                                                             \
+      sizeof(GTEST_STRINGIFY_(test_suite_name)) > 1,                           \
+      "test_suite_name must not be empty");                                    \
+    static_assert(                                                             \
+      sizeof(GTEST_STRINGIFY_(test_name)) > 1, "test_name must not be empty"); \
+    class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                   \
+      : public seastar_test_mixin                                              \
+      , public parent_class {                                                  \
+    public:                                                                    \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() = default;        \
+        ~GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() override         \
+          = default;                                                           \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                     \
+        (const GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &) = delete; \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &                   \
+        operator=(const GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &)  \
+          = delete; /* NOLINT */                                               \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                     \
+        (GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &&) noexcept       \
+          = delete;                                                            \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) & operator=(        \
+          GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &&) noexcept      \
+          = delete; /* NOLINT */                                               \
+                                                                               \
+    private:                                                                   \
+        void TestBody() override {                                             \
+            run_async([this] { TestBodyWrapped(); });                          \
+        }                                                                      \
+        void TestBodyWrapped();                                                \
+        static ::testing::TestInfo* const test_info_ GTEST_ATTRIBUTE_UNUSED_;  \
+    };                                                                         \
+                                                                               \
+    ::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(                         \
+      test_suite_name, test_name)::test_info_                                  \
+      = ::testing::internal::MakeAndRegisterTestInfo(                          \
+        #test_suite_name,                                                      \
+        #test_name,                                                            \
+        nullptr,                                                               \
+        nullptr,                                                               \
+        ::testing::internal::CodeLocation(__FILE__, __LINE__),                 \
+        (parent_id),                                                           \
+        ::testing::internal::SuiteApiResolver<                                 \
+          parent_class>::GetSetUpCaseOrSuite(__FILE__, __LINE__),              \
+        ::testing::internal::SuiteApiResolver<                                 \
+          parent_class>::GetTearDownCaseOrSuite(__FILE__, __LINE__),           \
+        new ::testing::internal::TestFactoryImpl<GTEST_TEST_CLASS_NAME_(       \
+          test_suite_name, test_name)>);                                       \
+    void GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)::TestBodyWrapped()
+
+#define TEST_ASYNC(test_suite_name, test_name)                                 \
+    GTEST_TEST_ASYNC_(                                                         \
+      test_suite_name,                                                         \
+      test_name,                                                               \
+      ::testing::Test,                                                         \
+      ::testing::internal::GetTestTypeId())
+
+#define TEST_F_ASYNC(test_fixture, test_name)                                  \
+    GTEST_TEST_ASYNC_(                                                         \
+      test_fixture,                                                            \
+      test_name,                                                               \
+      test_fixture,                                                            \
+      ::testing::internal::GetTypeId<test_fixture>())
+
+#define TEST_P_ASYNC(test_suite_name, test_name)                               \
+    class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                   \
+      : public seastar_test_mixin                                              \
+      , public test_suite_name {                                               \
+    public:                                                                    \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() {}                \
+        void TestBody() override {                                             \
+            run_async([this] { TestBodyWrapped(); });                          \
+        }                                                                      \
+        void TestBodyWrapped();                                                \
+                                                                               \
+    private:                                                                   \
+        static int AddToRegistry() {                                           \
+            ::testing::UnitTest::GetInstance()                                 \
+              ->parameterized_test_registry()                                  \
+              .GetTestSuitePatternHolder<test_suite_name>(                     \
+                GTEST_STRINGIFY_(test_suite_name),                             \
+                ::testing::internal::CodeLocation(__FILE__, __LINE__))         \
+              ->AddTestPattern(                                                \
+                GTEST_STRINGIFY_(test_suite_name),                             \
+                GTEST_STRINGIFY_(test_name),                                   \
+                new ::testing::internal::TestMetaFactory<                      \
+                  GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)>(),       \
+                ::testing::internal::CodeLocation(__FILE__, __LINE__));        \
+            return 0;                                                          \
+        }                                                                      \
+        static int gtest_registering_dummy_ GTEST_ATTRIBUTE_UNUSED_;           \
+        GTEST_DISALLOW_COPY_AND_ASSIGN_(                                       \
+          GTEST_TEST_CLASS_NAME_(test_suite_name, test_name));                 \
+    };                                                                         \
+    int GTEST_TEST_CLASS_NAME_(                                                \
+      test_suite_name, test_name)::gtest_registering_dummy_                    \
+      = GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)::AddToRegistry();   \
+    void GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)::TestBodyWrapped()

--- a/src/v/test_utils/tests/CMakeLists.txt
+++ b/src/v/test_utils/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_test
+  SOURCES gtest_test.cc
+  LIBRARIES v::gtest_main)

--- a/src/v/test_utils/tests/gtest_test.cc
+++ b/src/v/test_utils/tests/gtest_test.cc
@@ -13,14 +13,18 @@
 #include <seastar/core/sleep.hh>
 
 /*
- * TEST_ASYNC() is the Seastar-enabled equivalent of TEST().
+ * TEST_(ASYNC|CORO)() is the Seastar-enabled equivalent of TEST().
  */
 TEST_ASYNC(SeastarTest, Sleep) {
     seastar::sleep(std::chrono::milliseconds(100)).get();
 }
 
+TEST_CORO(SeastarTest, SleepCoro) {
+    co_await seastar::sleep(std::chrono::milliseconds(100));
+}
+
 /*
- * TEST_F_ASYNC() is the Seastar-enabled equivalent of TEST_F()
+ * TEST_F_(ASYNC|CORO)() is the Seastar-enabled equivalent of TEST_F()
  */
 struct MySeastarFixture : public ::testing::Test {
     std::string_view message() const { return "hello"; }
@@ -31,14 +35,22 @@ TEST_F_ASYNC(MySeastarFixture, Sleep) {
     ASSERT_EQ(message(), "hello");
 }
 
+TEST_F_CORO(MySeastarFixture, SleepCoro) {
+    co_await seastar::sleep(std::chrono::milliseconds(100));
+}
+
 /*
- * TEST_P_ASYNC() is the Seastar-enabled equivalent of TEST_P()
+ * TEST_P_(ASYNC|CORO)() is the Seastar-enabled equivalent of TEST_P()
  */
 class MySeastarParamFixture : public ::testing::TestWithParam<int> {};
 
 TEST_P_ASYNC(MySeastarParamFixture, Sleep) {
     seastar::sleep(std::chrono::milliseconds(GetParam() * 10)).get();
     ASSERT_EQ(GetParam() % 11, 0);
+}
+
+TEST_P_CORO(MySeastarParamFixture, SleepCoro) {
+    co_await seastar::sleep(std::chrono::milliseconds(100));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/test_utils/tests/gtest_test.cc
+++ b/src/v/test_utils/tests/gtest_test.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "test_utils/test.h"
+
+#include <seastar/core/sleep.hh>
+
+/*
+ * TEST_ASYNC() is the Seastar-enabled equivalent of TEST().
+ */
+TEST_ASYNC(SeastarTest, Sleep) {
+    seastar::sleep(std::chrono::milliseconds(100)).get();
+}
+
+/*
+ * TEST_F_ASYNC() is the Seastar-enabled equivalent of TEST_F()
+ */
+struct MySeastarFixture : public ::testing::Test {
+    std::string_view message() const { return "hello"; }
+};
+
+TEST_F_ASYNC(MySeastarFixture, Sleep) {
+    seastar::sleep(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(message(), "hello");
+}
+
+/*
+ * TEST_P_ASYNC() is the Seastar-enabled equivalent of TEST_P()
+ */
+class MySeastarParamFixture : public ::testing::TestWithParam<int> {};
+
+TEST_P_ASYNC(MySeastarParamFixture, Sleep) {
+    seastar::sleep(std::chrono::milliseconds(GetParam() * 10)).get();
+    ASSERT_EQ(GetParam() % 11, 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  Divisible, MySeastarParamFixture, testing::Values(11, 22, 33));
+
+/*
+ * Normal test framework macros continues to work.
+ */
+TEST(NotSeastar, T) {}
+
+class NotSeastarFixture : public ::testing::Test {};
+TEST_F(NotSeastarFixture, T) {}
+
+class NotSeastarFixtureParam : public testing::TestWithParam<int> {};
+TEST_P(NotSeastarFixtureParam, T) {}
+
+INSTANTIATE_TEST_SUITE_P(
+  NotSeastarParamTest, NotSeastarFixtureParam, testing::Values(1, 2, 3));

--- a/src/v/test_utils/tests/gtest_test.cc
+++ b/src/v/test_utils/tests/gtest_test.cc
@@ -21,6 +21,7 @@ TEST_ASYNC(SeastarTest, Sleep) {
 
 TEST_CORO(SeastarTest, SleepCoro) {
     co_await seastar::sleep(std::chrono::milliseconds(100));
+    ASSERT_EQ_CORO(100, 100);
 }
 
 /*
@@ -37,6 +38,7 @@ TEST_F_ASYNC(MySeastarFixture, Sleep) {
 
 TEST_F_CORO(MySeastarFixture, SleepCoro) {
     co_await seastar::sleep(std::chrono::milliseconds(100));
+    ASSERT_EQ_CORO(message(), "hello");
 }
 
 /*
@@ -51,6 +53,8 @@ TEST_P_ASYNC(MySeastarParamFixture, Sleep) {
 
 TEST_P_CORO(MySeastarParamFixture, SleepCoro) {
     co_await seastar::sleep(std::chrono::milliseconds(100));
+    ASSERT_TRUE_CORO(true);
+    ASSERT_FALSE_CORO(false);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Adds Google Test and experimental support for Seastar-enabled testing with the framework so that we can take advantage of gtest's nice support for building test fixtures and value parameterized tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
