### PR TITLE
ducktape: Increase fetch debounce time in ManyPartitionTest

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -307,6 +307,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 # to pad out tiered storage metadata, we don't want them to
                 # get merged together.
                 'cloud_storage_enable_segment_merging': False,
+                'fetch_reads_debounce_timeout': 10,
             },
             # Configure logging the same way a user would when they have
             # very many partitions: set logs with per-partition messages


### PR DESCRIPTION
ManyPartitionTest is one of the cases which is negatively affected by
having the seperate fetch scheduling group (see
https://github.com/redpanda-data/redpanda/commit/6d1223d4e4b0489c0fade40a727b9633d506398a for background).

To work around this and make the test not flaky increase the fetch
debounce timeout. This makes empty fetches less expensive and such
decreases CPU util which allows for leadership balancing to finish in
time.

I think this is better than disabling the extra group as it doesn't
fundamentally change how requests are dispatched.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

