### PR TITLE
Do not compare fsid when checking if reports are equal

### DIFF
--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -60,7 +60,22 @@ void check_reports_the_same(
           lr.topics.cend(),
           rr.topics.cbegin(),
           rr.topics.cend()));
-        BOOST_TEST_REQUIRE(lr.local_state.disks() == rr.local_state.disks());
+        BOOST_TEST_REQUIRE(
+          lr.local_state.disks().size() == rr.local_state.disks().size());
+        for (auto i = 0; i < lr.local_state.disks().size(); ++i) {
+            BOOST_REQUIRE_EQUAL(
+              lr.local_state.disks().at(i).alert,
+              rr.local_state.disks().at(i).alert);
+            BOOST_REQUIRE_EQUAL(
+              lr.local_state.disks().at(i).free,
+              rr.local_state.disks().at(i).free);
+            BOOST_REQUIRE_EQUAL(
+              lr.local_state.disks().at(i).path,
+              rr.local_state.disks().at(i).path);
+            BOOST_REQUIRE_EQUAL(
+              lr.local_state.disks().at(i).total,
+              rr.local_state.disks().at(i).total);
+        }
         BOOST_TEST_REQUIRE(
           lr.local_state.get_disk_alert() == rr.local_state.get_disk_alert());
     }

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -34,10 +34,12 @@ model::offset stm_manager::max_collectible_offset() {
 std::ostream& operator<<(std::ostream& o, const disk& d) {
     fmt::print(
       o,
-      "{{path: {}, free: {}, total: {}}}",
+      "{{path: {}, free: {}, total: {}, alert: {}, fsid: {}}}",
       d.path,
       human::bytes(d.free),
-      human::bytes(d.total));
+      human::bytes(d.total),
+      d.alert,
+      d.fsid);
     return o;
 }
 


### PR DESCRIPTION
Since `storage::disk::fsid` is not serialized we can not assert that its
value is equal when a data structure is sent over the RPC transport.

Fixes: #12636
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none