### PR TITLE
cloud_storage: become compatible with storage account where Hierarchical Namespaces are enabled

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -422,8 +422,9 @@ ss::future<> ntp_archiver::upload_topic_manifest() {
         } else {
             _topic_manifest_dirty = false;
         }
-    } catch (const ss::gate_closed_exception& err) {
-    } catch (const ss::abort_requested_exception& err) {
+    } catch (const ss::gate_closed_exception&) {
+    } catch (const ss::broken_named_semaphore&) {
+    } catch (const ss::abort_requested_exception&) {
     } catch (...) {
         vlog(
           _rtclog.warn,
@@ -1068,6 +1069,8 @@ ss::future<cloud_storage::upload_result> ntp_archiver::do_upload_segment(
     } catch (const ss::gate_closed_exception&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const ss::abort_requested_exception&) {
+        response = cloud_storage::upload_result::cancelled;
+    } catch (const ss::broken_named_semaphore&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const std::exception& e) {
         vlog(_rtclog.error, "failed to upload segment {}: {}", path, e);

--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -428,7 +428,7 @@ static constexpr auto required_headers = {
   "If-Modified-Since",
   "If-Match",
   "If-None-Match",
-  "If-UnmodifiedSince",
+  "If-Unmodified-Since",
   "Range"};
 
 result<ss::sstring> signature_abs::get_canonicalized_resource(

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -174,7 +174,7 @@ result<http::client::request_header> abs_request_creator::make_get_blob_request(
     // GET /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format("/{}/{}", name(), key().string());
     const boost::beast::string_view host{_ap().data(), _ap().length()};
@@ -204,7 +204,7 @@ result<http::client::request_header> abs_request_creator::make_put_blob_request(
     // PUT /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     // Content-Length:{payload-size}
     // Content-Type: text/plain
@@ -235,7 +235,7 @@ abs_request_creator::make_get_blob_metadata_request(
     // HEAD /{container-id}/{blob-id}?comp=metadata HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format(
       "/{}/{}?comp=metadata", name(), key().string());
@@ -260,7 +260,7 @@ abs_request_creator::make_delete_blob_request(
     // DELETE /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format("/{}/{}", name(), key().string());
 
@@ -292,7 +292,7 @@ abs_request_creator::make_list_blobs_request(
     // ...&max_results{max_keys}
     // HTTP/1.1 Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     auto target = fmt::format("/{}?restype=container&comp=list", name());
     if (prefix) {
@@ -353,7 +353,7 @@ abs_request_creator::make_delete_file_request(
     // DELETE /{container-id}/{path} HTTP/1.1
     // Host: {storage-account-id}.dfs.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format("/{}/{}", name(), path().string());
 

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -403,16 +403,11 @@ abs_client::abs_client(
     vlog(abs_log.trace, "Created client with config:{}", conf);
 }
 
-ss::future<client_self_configuration_result> abs_client::self_configure() {
-    auto result = co_await get_account_info(5s);
+ss::future<result<client_self_configuration_output, error_outcome>>
+abs_client::self_configure() {
+    auto result = co_await get_account_info(http::default_connect_timeout);
     if (!result) {
-        vlog(
-          abs_log.warn,
-          "Get Account Information request failed: {}. Proceeding without self "
-          "configuration ...",
-          result.error());
-
-        co_return abs_self_configuration_result{.is_hns_enabled = false};
+        co_return result.error();
     } else {
         co_return abs_self_configuration_result{
           .is_hns_enabled = result.value().is_hns_enabled};

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -15,6 +15,7 @@
 #include "cloud_storage_clients/logger.h"
 #include "cloud_storage_clients/util.h"
 #include "cloud_storage_clients/xml_sax_parser.h"
+#include "config/configuration.h"
 #include "vlog.h"
 
 #include <utility>
@@ -191,6 +192,7 @@ abs_request_creator::make_delete_blob_request(
     // x-ms-version:"2021-08-06"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format("/{}/{}", name(), key().string());
+
     const boost::beast::string_view host{_ap().data(), _ap().length()};
 
     http::client::request_header header{};
@@ -262,6 +264,11 @@ abs_client::abs_client(
   : _requestor(conf, std::move(apply_credentials))
   , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
+
+ss::future<client_self_configuration_result> abs_client::self_configure() {
+    // TODO: A future commit will plug in the implementation
+    co_return abs_self_configuration_result{.is_hns_enabled = false};
+}
 
 ss::future<> abs_client::stop() {
     vlog(abs_log.debug, "Stopping ABS client");

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -372,8 +372,19 @@ abs_client::abs_client(
 }
 
 ss::future<client_self_configuration_result> abs_client::self_configure() {
-    // TODO: A future commit will plug in the implementation
-    co_return abs_self_configuration_result{.is_hns_enabled = false};
+    auto result = co_await get_account_info(5s);
+    if (!result) {
+        vlog(
+          abs_log.warn,
+          "Get Account Information request failed: {}. Proceeding without self "
+          "configuration ...",
+          result.error());
+
+        co_return abs_self_configuration_result{.is_hns_enabled = false};
+    } else {
+        co_return abs_self_configuration_result{
+          .is_hns_enabled = result.value().is_hns_enabled};
+    }
 }
 
 ss::future<> abs_client::stop() {

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -245,8 +245,23 @@ private:
     ss::future<storage_account_info>
     do_get_account_info(ss::lowres_clock::duration timeout);
 
+    std::optional<abs_configuration> _data_lake_v2_client_config;
     abs_request_creator _requestor;
     http::client _client;
+
+    // Azure Storage accounts may have enabled Hierarchical Namespaces (HNS),
+    // in which case the container will emulate file system like semantics.
+    // For instance uploading blob "a/b/log.txt", creates two directory blobs
+    // ("a" and "a/b") and one file blob ("a/b/log.txt").
+    //
+    // This changes the semantics of certain Blob Storage REST API requests:
+    // * ListObjects will list both files and directories by default
+    // * DeleteBlob cannot delete directory files
+    //
+    // `_adls_client` connects to the Azure Data Lake Storage V2 REST API
+    // endpoint when HNS is enabled and is used for deletions.
+    std::optional<http::client> _adls_client;
+
     ss::shared_ptr<client_probe> _probe;
 };
 

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -120,7 +120,8 @@ public:
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
-    ss::future<client_self_configuration_result> self_configure() override;
+    ss::future<result<client_self_configuration_output, error_outcome>>
+    self_configure() override;
 
     /// Stop the client
     ss::future<> stop() override;

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -238,7 +238,6 @@ private:
     template<typename T>
     ss::future<result<T, error_outcome>> send_request(
       ss::future<T> request_future,
-      const bucket_name& bucket,
       const object_key& key,
       std::optional<op_type_tag> op_type = std::nullopt);
 

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -65,16 +65,19 @@ public:
     result<http::client::request_header>
     make_delete_blob_request(bucket_name const& name, object_key const& key);
 
+    // clang-format off
     /// \brief Initialize http header for 'List Blobs' request
     ///
     /// \param name of the container
+    /// \param files_only should always be set to true when HNS is enabled and false otherwise
     /// \param prefix prefix of returned blob's names
-    /// \param start_after is always ignored
-    /// \param max_keys is the max number of returned objects
+    /// \param start_after is always ignored \param max_keys is the max number of returned objects
     /// \param delimiter used to group common prefixes
     /// \return initialized and signed http header or error
+    // clang-format on
     result<http::client::request_header> make_list_blobs_request(
       const bucket_name& name,
+      bool files_only,
       std::optional<object_key> prefix,
       std::optional<object_key> start_after,
       std::optional<size_t> max_keys,

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -102,6 +102,8 @@ public:
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
+    ss::future<client_self_configuration_result> self_configure() override;
+
     /// Stop the client
     ss::future<> stop() override;
 

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -80,6 +80,9 @@ public:
       std::optional<size_t> max_keys,
       std::optional<char> delimiter = std::nullopt);
 
+    /// \brief Init http header for 'Get Account Information' request
+    result<http::client::request_header> make_get_account_info_request();
+
 private:
     access_point_uri _ap;
     /// Applies credentials to http requests by adding headers and signing
@@ -187,6 +190,16 @@ public:
       std::vector<object_key> keys,
       ss::lowres_clock::duration timeout) override;
 
+    struct storage_account_info {
+        bool is_hns_enabled{false};
+    };
+
+    /// Send Get Account Information request (used to detect
+    /// if the account has Hierarchical Namespace enabled).
+    /// \param timeout is a timeout of the operation
+    ss::future<result<storage_account_info, error_outcome>>
+    get_account_info(ss::lowres_clock::duration timeout);
+
 private:
     template<typename T>
     ss::future<result<T, error_outcome>> send_request(
@@ -228,6 +241,9 @@ private:
       ss::lowres_clock::duration timeout,
       std::optional<char> delimiter = std::nullopt,
       std::optional<item_filter> collect_item_if = std::nullopt);
+
+    ss::future<storage_account_info>
+    do_get_account_info(ss::lowres_clock::duration timeout);
 
     abs_request_creator _requestor;
     http::client _client;

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -45,6 +45,8 @@ std::istream& operator>>(std::istream& i, abs_error_code& code) {
           .match(
             "ContainerBeingDeleted", abs_error_code::container_being_deleted)
           .match("ContainerNotFound", abs_error_code::container_not_found)
+          .match("DirectoryNotEmpty", abs_error_code::directory_not_empty)
+          .match("PathNotFound", abs_error_code::path_not_found)
           .default_match(abs_error_code::_unknown);
 
     return i;

--- a/src/v/cloud_storage_clients/abs_error.h
+++ b/src/v/cloud_storage_clients/abs_error.h
@@ -38,7 +38,9 @@ enum class abs_error_code {
     blob_being_rehydrated,
     container_being_disabled,
     container_being_deleted,
-    container_not_found
+    container_not_found,
+    directory_not_empty,
+    path_not_found
 };
 
 /// Operators to use with lexical_cast

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -31,6 +31,8 @@ public:
 
     virtual ~client() = default;
 
+    virtual ss::future<client_self_configuration_result> self_configure() = 0;
+
     /// Stop the client
     virtual ss::future<> stop() = 0;
 

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -31,7 +31,8 @@ public:
 
     virtual ~client() = default;
 
-    virtual ss::future<client_self_configuration_result> self_configure() = 0;
+    virtual ss::future<result<client_self_configuration_output, error_outcome>>
+    self_configure() = 0;
 
     /// Stop the client
     virtual ss::future<> stop() = 0;

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -15,6 +15,7 @@
 #include "cloud_storage_clients/client_probe.h"
 #include "utils/gate_guard.h"
 #include "utils/intrusive_list_helpers.h"
+#include "utils/stop_signal.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/sharded.hh>
@@ -31,6 +32,8 @@ enum class client_pool_overdraft_policy {
     /// Client pool should try to borrow connection from another shard
     borrow_if_empty
 };
+
+constexpr ss::shard_id self_config_shard = ss::shard_id{0};
 
 /// Connection pool implementation
 /// All connections share the same configuration
@@ -95,11 +98,15 @@ public:
     /// \param conf is a client configuration
     /// \param policy controls what happens when the pool is empty (wait or try
     ///               to borrow from another shard)
+    /// \param application_abort_source abort source which can be used to stop
+    /// Redpanda gracefully
     client_pool(
       size_t size,
       client_configuration conf,
       client_pool_overdraft_policy policy
-      = client_pool_overdraft_policy::wait_if_empty);
+      = client_pool_overdraft_policy::wait_if_empty,
+      std::optional<std::reference_wrapper<stop_signal>> application_stop_signal
+      = std::nullopt);
 
     ss::future<> stop();
 
@@ -127,9 +134,14 @@ public:
     size_t max_size() const noexcept;
 
 private:
-    ss::future<> client_self_configure();
+    ss::future<>
+    client_self_configure(std::optional<std::reference_wrapper<stop_signal>>
+                            application_stop_signal);
+    ss::future<
+      std::optional<cloud_storage_clients::client_self_configuration_output>>
+    do_client_self_configure(http_client_ptr client);
     ss::future<> accept_self_configure_result(
-      std::optional<client_self_configuration_result> result);
+      std::optional<client_self_configuration_output> result);
 
     void populate_client_pool();
     http_client_ptr make_client() const;

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -127,6 +127,10 @@ public:
     size_t max_size() const noexcept;
 
 private:
+    ss::future<> client_self_configure();
+    ss::future<> accept_self_configure_result(
+      std::optional<client_self_configuration_result> result);
+
     void populate_client_pool();
     http_client_ptr make_client() const;
     void release(http_client_ptr leased);
@@ -158,6 +162,8 @@ private:
     /// enable rotating credentials to all clients.
     ss::lw_shared_ptr<cloud_roles::apply_credentials> _apply_credentials;
     ss::condition_variable _credentials_var;
+
+    ssx::semaphore _self_config_barrier{0, "self_config_barrier"};
 };
 
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -162,6 +162,17 @@ ss::future<abs_configuration> abs_configuration::make_configuration(
     co_return client_cfg;
 }
 
+abs_configuration abs_configuration::make_adls_configuration() const {
+    abs_configuration adls_config{*this};
+
+    const auto endpoint_uri = ssx::sformat("{}.dfs.core.windows.net", storage_account_name());
+    adls_config.tls_sni_hostname = endpoint_uri; 
+    adls_config.uri = access_point_uri{endpoint_uri};
+    adls_config.server_addr = net::unresolved_address{endpoint_uri, default_port};
+
+    return adls_config;
+}
+
 void apply_self_configuration_result(
   client_configuration& cfg, const client_self_configuration_result& res) {
     std::visit(

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -187,7 +187,7 @@ abs_configuration abs_configuration::make_adls_configuration() const {
 }
 
 void apply_self_configuration_result(
-  client_configuration& cfg, const client_self_configuration_result& res) {
+  client_configuration& cfg, const client_self_configuration_output& res) {
     std::visit(
       [&res](auto& cfg) -> void {
           using cfg_type = std::decay_t<decltype(cfg)>;
@@ -239,7 +239,7 @@ std::ostream& operator<<(std::ostream& o, const s3_self_configuration_result&) {
 }
 
 std::ostream&
-operator<<(std::ostream& o, const client_self_configuration_result& r) {
+operator<<(std::ostream& o, const client_self_configuration_output& r) {
     return std::visit(
       [&o](const auto& self_cfg) -> std::ostream& {
           using cfg_type = std::decay_t<decltype(self_cfg)>;

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -78,6 +78,8 @@ struct abs_configuration : common_configuration {
     std::optional<cloud_roles::private_key_str> shared_key;
     bool is_hns_enabled{false};
 
+    abs_configuration make_adls_configuration() const;
+
     static ss::future<abs_configuration> make_configuration(
       const std::optional<cloud_roles::private_key_str>& shared_key,
       const cloud_roles::storage_account& storage_account_name,

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -38,6 +38,8 @@ struct common_configuration : net::base_transport::configuration {
     ss::lowres_clock::duration max_idle_time;
     /// Metrics probe (should be created for every aws account on every shard)
     ss::shared_ptr<client_probe> _probe;
+
+    bool requires_self_configuration{false};
 };
 
 struct s3_configuration : common_configuration {
@@ -74,6 +76,7 @@ struct s3_configuration : common_configuration {
 struct abs_configuration : common_configuration {
     cloud_roles::storage_account storage_account_name;
     std::optional<cloud_roles::private_key_str> shared_key;
+    bool is_hns_enabled{false};
 
     static ss::future<abs_configuration> make_configuration(
       const std::optional<cloud_roles::private_key_str>& shared_key,
@@ -96,6 +99,25 @@ using client_configuration_variant = std::variant<Ts...>;
 
 using client_configuration
   = client_configuration_variant<abs_configuration, s3_configuration>;
+
+std::ostream& operator<<(std::ostream&, const client_configuration&);
+
+struct abs_self_configuration_result {
+    bool is_hns_enabled;
+};
+
+struct s3_self_configuration_result {};
+
+using client_self_configuration_result
+  = std::variant<abs_self_configuration_result, s3_self_configuration_result>;
+
+void apply_self_configuration_result(
+  client_configuration&, const client_self_configuration_result&);
+
+std::ostream& operator<<(std::ostream&, const abs_self_configuration_result&);
+std::ostream& operator<<(std::ostream&, const s3_self_configuration_result&);
+std::ostream&
+operator<<(std::ostream&, const client_self_configuration_result&);
 
 model::cloud_storage_backend infer_backend_from_configuration(
   const client_configuration& client_config,

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -110,16 +110,16 @@ struct abs_self_configuration_result {
 
 struct s3_self_configuration_result {};
 
-using client_self_configuration_result
+using client_self_configuration_output
   = std::variant<abs_self_configuration_result, s3_self_configuration_result>;
 
 void apply_self_configuration_result(
-  client_configuration&, const client_self_configuration_result&);
+  client_configuration&, const client_self_configuration_output&);
 
 std::ostream& operator<<(std::ostream&, const abs_self_configuration_result&);
 std::ostream& operator<<(std::ostream&, const s3_self_configuration_result&);
 std::ostream&
-operator<<(std::ostream&, const client_self_configuration_result&);
+operator<<(std::ostream&, const client_self_configuration_output&);
 
 model::cloud_storage_backend infer_backend_from_configuration(
   const client_configuration& client_config,

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -470,7 +470,8 @@ s3_client::s3_client(
   , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
 
-ss::future<client_self_configuration_result> s3_client::self_configure() {
+ss::future<result<client_self_configuration_output, error_outcome>>
+s3_client::self_configure() {
     vlog(
       s3_log.error,
       "Call to self_configure was made, but the S3 client doesn't require self "

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -470,6 +470,14 @@ s3_client::s3_client(
   , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
 
+ss::future<client_self_configuration_result> s3_client::self_configure() {
+    vlog(
+      s3_log.error,
+      "Call to self_configure was made, but the S3 client doesn't require self "
+      "configuration");
+    co_return s3_self_configuration_result{};
+}
+
 ss::future<> s3_client::stop() { return _client.stop(); }
 
 void s3_client::shutdown() { _client.shutdown(); }

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -126,7 +126,8 @@ public:
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
-    ss::future<client_self_configuration_result> self_configure() override;
+    ss::future<result<client_self_configuration_output, error_outcome>>
+    self_configure() override;
 
     /// Stop the client
     ss::future<> stop() override;

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -126,6 +126,8 @@ public:
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
+    ss::future<client_self_configuration_result> self_configure() override;
+
     /// Stop the client
     ss::future<> stop() override;
     /// Shutdown the underlying connection

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -97,6 +97,7 @@ void cli_opts(boost::program_options::options_description_easy_init opt) {
     opt("port", po::value<uint16_t>(), "alternative port for the api endpoint");
 
     opt("disable-tls", "disable tls for this connection");
+    opt("hns-enabled", "HNS enabled for the storage account");
 }
 
 struct test_conf {
@@ -166,6 +167,9 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
             .disable_tls = m.contains("disable-tls") > 0,
           })
           .get0();
+    if (m.contains("hns-enabled")) {
+        client_cfg.is_hns_enabled = true;
+    }
     vlog(test_log.info, "connecting to {}", client_cfg.server_addr);
     return test_conf{
       .storage_account = storage_acc,

--- a/src/v/cloud_storage_clients/tests/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ rp_test(
     s3_client_test.cc
     xml_sax_parser_test.cc
     exception_test.cc
+    util_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::http v::cloud_storage_clients v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -19,6 +19,7 @@
 #include "net/types.h"
 #include "net/unresolved_address.h"
 #include "seastarx.h"
+#include "test_utils/fixture.h"
 #include "utils/base64.h"
 
 #include <seastar/core/future.hh>
@@ -714,35 +715,42 @@ SEASTAR_TEST_CASE(test_delete_object_retry) {
         server->stop().get();
     });
 }
-/// Http server and client
-struct configured_server_and_client_pool {
+
+class client_pool_fixture {
+public:
+    client_pool_fixture()
+      : s3_conf(transport_configuration())
+      , server(ss::make_shared<ss::httpd::http_server_control>()) {
+        pool
+          .start(
+            2,
+            ss::sharded_parameter([] { return transport_configuration(); }),
+            cloud_storage_clients::client_pool_overdraft_policy::wait_if_empty)
+          .get();
+
+        auto credentials = cloud_roles::aws_credentials{
+          s3_conf.access_key.value(),
+          s3_conf.secret_key.value(),
+          std::nullopt,
+          s3_conf.region};
+
+        pool.local().load_credentials(std::move(credentials));
+
+        server->start().get();
+        server->set_routes(set_routes).get();
+        auto resolved = net::resolve_dns(s3_conf.server_addr).get0();
+        server->listen(resolved).get();
+    }
+
+    ~client_pool_fixture() {
+        pool.stop().get();
+        server->stop().get();
+    }
+
+    cloud_storage_clients::s3_configuration s3_conf;
     ss::shared_ptr<ss::httpd::http_server_control> server;
-    ss::shared_ptr<cloud_storage_clients::client_pool> pool;
+    ss::sharded<cloud_storage_clients::client_pool> pool;
 };
-/// Create server and client connection pool, server is initialized with default
-/// testing paths and listening.
-configured_server_and_client_pool started_pool_and_server(
-  size_t size,
-  cloud_storage_clients::client_pool_overdraft_policy policy,
-  const cloud_storage_clients::s3_configuration& conf) {
-    auto credentials = cloud_roles::aws_credentials{
-      conf.access_key.value(),
-      conf.secret_key.value(),
-      std::nullopt,
-      conf.region};
-    auto client = ss::make_shared<cloud_storage_clients::client_pool>(
-      size, conf, policy);
-    client->load_credentials(std::move(credentials));
-    auto server = ss::make_shared<ss::httpd::http_server_control>();
-    server->start().get();
-    server->set_routes(set_routes).get();
-    auto resolved = net::resolve_dns(conf.server_addr).get0();
-    server->listen(resolved).get();
-    return {
-      .server = server,
-      .pool = client,
-    };
-}
 
 static ss::future<> test_client_pool_payload(
   ss::shared_ptr<ss::httpd::http_server_control> server,
@@ -763,16 +771,13 @@ static ss::future<> test_client_pool_payload(
     BOOST_REQUIRE_EQUAL(actual_payload, expected_payload);
 }
 
-void test_client_pool(
-  cloud_storage_clients::client_pool_overdraft_policy policy) {
-    auto conf = transport_configuration();
-    auto [server, pool] = started_pool_and_server(2, policy, conf);
-
+FIXTURE_TEST(test_client_pool_wait_strategy, client_pool_fixture) {
     ss::abort_source never_abort;
     std::vector<ss::future<>> fut;
     for (size_t i = 0; i < 20; i++) {
         auto f
-          = pool->acquire(never_abort)
+          = pool.local()
+              .acquire(never_abort)
               .then([server = server](
                       cloud_storage_clients::client_pool::client_lease lease) {
                   return test_client_pool_payload(server, std::move(lease));
@@ -780,15 +785,7 @@ void test_client_pool(
         fut.emplace_back(std::move(f));
     }
     ss::when_all_succeed(fut.begin(), fut.end()).get0();
-    BOOST_REQUIRE(pool->size() == 2);
-    server->stop().get();
-}
-
-SEASTAR_TEST_CASE(test_client_pool_wait_strategy) {
-    return ss::async([] {
-        test_client_pool(
-          cloud_storage_clients::client_pool_overdraft_policy::wait_if_empty);
-    });
+    BOOST_REQUIRE(pool.local().size() == 2);
 }
 
 static ss::future<bool> test_client_pool_reconnect_helper(
@@ -817,31 +814,22 @@ static ss::future<bool> test_client_pool_reconnect_helper(
     co_return true;
 }
 
-SEASTAR_TEST_CASE(test_client_pool_reconnect) {
-    return ss::async([] {
-        using namespace std::chrono_literals;
-        auto conf = transport_configuration();
-        auto [server, pool] = started_pool_and_server(
-          2,
-          cloud_storage_clients::client_pool_overdraft_policy::wait_if_empty,
-          conf);
-
-        ss::abort_source never_abort;
-        std::vector<ss::future<bool>> fut;
-        for (size_t i = 0; i < 20; i++) {
-            auto f
-              = pool->acquire(never_abort)
-                  .then(
-                    [server = server](
-                      cloud_storage_clients::client_pool::client_lease lease) {
-                        return test_client_pool_reconnect_helper(
-                          server, std::move(lease));
-                    });
-            fut.emplace_back(std::move(f));
-        }
-        auto result = ss::when_all_succeed(fut.begin(), fut.end()).get0();
-        auto count = std::count(result.begin(), result.end(), true);
-        BOOST_REQUIRE(count == 20);
-        server->stop().get();
-    });
+FIXTURE_TEST(test_client_pool_reconnect, client_pool_fixture) {
+    using namespace std::chrono_literals;
+    ss::abort_source never_abort;
+    std::vector<ss::future<bool>> fut;
+    for (size_t i = 0; i < 20; i++) {
+        auto f = pool.local()
+                   .acquire(never_abort)
+                   .then(
+                     [server = server](
+                       cloud_storage_clients::client_pool::client_lease lease) {
+                         return test_client_pool_reconnect_helper(
+                           server, std::move(lease));
+                     });
+        fut.emplace_back(std::move(f));
+    }
+    auto result = ss::when_all_succeed(fut.begin(), fut.end()).get0();
+    auto count = std::count(result.begin(), result.end(), true);
+    BOOST_REQUIRE(count == 20);
 }

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -1,0 +1,24 @@
+#include "cloud_storage_clients/util.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(test_all_paths_to_file) {
+    using namespace cloud_storage_clients;
+
+    auto result1 = util::all_paths_to_file(object_key{"a/b/c/log.txt"});
+    auto expected1 = std::vector<object_key>{
+      object_key{"a"},
+      object_key{"a/b"},
+      object_key{"a/b/c"},
+      object_key{"a/b/c/log.txt"}};
+    BOOST_REQUIRE_EQUAL(result1, expected1);
+
+    auto result2 = util::all_paths_to_file(object_key{"a/b/c/"});
+    BOOST_REQUIRE_EQUAL(result2, std::vector<object_key>{});
+
+    auto result3 = util::all_paths_to_file(object_key{""});
+    BOOST_REQUIRE_EQUAL(result3, std::vector<object_key>{});
+
+    auto result4 = util::all_paths_to_file(object_key{"foo"});
+    BOOST_REQUIRE_EQUAL(result4, std::vector<object_key>{object_key{"foo"}});
+}

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -197,4 +197,25 @@ void log_buffer_with_rate_limiting(
     vlog(log_with_rate_limit, "{}: {}", msg, sview);
 }
 
+std::vector<object_key> all_paths_to_file(const object_key& path) {
+    if (!path().has_filename()) {
+        return {};
+    }
+
+    std::vector<object_key> paths;
+    std::filesystem::path current_path;
+    for (auto path_iter = path().begin(); path_iter != path().end();
+         ++path_iter) {
+        if (current_path == "") {
+            current_path += *path_iter;
+        } else {
+            current_path /= *path_iter;
+        }
+
+        paths.emplace_back(current_path);
+    }
+
+    return paths;
+}
+
 } // namespace cloud_storage_clients::util

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -47,4 +47,9 @@ void log_buffer_with_rate_limiting(
 
 bool has_abort_or_gate_close_exception(const ss::nested_exception& ex);
 
+/// \brief: Given a file system like path, generate the full list
+/// of valid prefix paths. For instance, if the input is: a/b/log.txt,
+/// return a, a/b, a/b/log.txt
+std::vector<object_key> all_paths_to_file(const object_key& path);
+
 } // namespace cloud_storage_clients::util

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1567,6 +1567,22 @@ configuration::configuration()
        .secret = is_secret::yes},
       std::nullopt,
       &validate_non_empty_string_opt)
+  , cloud_storage_azure_adls_endpoint(
+      *this,
+      "cloud_storage_azure_adls_endpoint",
+      "Azure Data Lake Storage v2 endpoint override. Use when Hierarchical "
+      "Namespaces are enabled on your storage account and you have set up a "
+      "custom endpoint.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt,
+      &validate_non_empty_string_opt)
+  , cloud_storage_azure_adls_port(
+      *this,
+      "cloud_storage_azure_adls_port",
+      "Azure Data Lake Storage v2 port override. Also see "
+      "cloud_storage_azure_adls_endpoint.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -307,6 +307,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;
     property<std::optional<ss::sstring>> cloud_storage_azure_container;
     property<std::optional<ss::sstring>> cloud_storage_azure_shared_key;
+    property<std::optional<ss::sstring>> cloud_storage_azure_adls_endpoint;
+    property<std::optional<uint16_t>> cloud_storage_azure_adls_port;
 
     // Archival upload controller
     property<std::chrono::milliseconds>

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1021,8 +1021,9 @@ make_upload_controller_config(ss::scheduling_group sg) {
 }
 
 // add additional services in here
-void application::wire_up_runtime_services(model::node_id node_id) {
-    wire_up_redpanda_services(node_id);
+void application::wire_up_runtime_services(
+  model::node_id node_id, ::stop_signal& app_signal) {
+    wire_up_redpanda_services(node_id, app_signal);
     if (_proxy_config) {
         construct_single_service(
           _proxy,
@@ -1051,7 +1052,8 @@ void application::wire_up_runtime_services(model::node_id node_id) {
     configure_admin_server();
 }
 
-void application::wire_up_redpanda_services(model::node_id node_id) {
+void application::wire_up_redpanda_services(
+  model::node_id node_id, ::stop_signal& app_signal) {
     ss::smp::invoke_on_all([] {
         resources::available_memory::local().register_metrics();
     }).get();
@@ -1137,7 +1139,18 @@ void application::wire_up_redpanda_services(model::node_id node_id) {
           cloud_configs.local().connection_limit,
           ss::sharded_parameter(
             [&cloud_configs] { return cloud_configs.local().client_config; }),
-          cloud_storage_clients::client_pool_overdraft_policy::borrow_if_empty)
+          cloud_storage_clients::client_pool_overdraft_policy::borrow_if_empty,
+          ss::sharded_parameter(
+            [&app_signal]()
+              -> std::optional<std::reference_wrapper<::stop_signal>> {
+                if (
+                  ss::this_shard_id()
+                  == cloud_storage_clients::self_config_shard) {
+                    return std::ref(app_signal);
+                }
+
+                return std::nullopt;
+            }))
           .get();
         construct_service(
           cloud_storage_api,
@@ -2041,7 +2054,7 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
       node_id,
       storage.local().get_cluster_uuid());
 
-    wire_up_runtime_services(node_id);
+    wire_up_runtime_services(node_id, app_signal);
 
     if (test_mode) {
         // When running inside a unit test fixture, we may fast-forward

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -170,9 +170,10 @@ private:
     void start_bootstrap_services();
 
     // Constructs services across shards meant for Redpanda runtime.
-    void wire_up_runtime_services(model::node_id node_id);
+    void
+    wire_up_runtime_services(model::node_id node_id, ::stop_signal& app_signal);
     void configure_admin_server();
-    void wire_up_redpanda_services(model::node_id);
+    void wire_up_redpanda_services(model::node_id, ::stop_signal& app_signal);
 
     void load_feature_table_snapshot();
 

--- a/src/v/utils/stop_signal.h
+++ b/src/v/utils/stop_signal.h
@@ -40,7 +40,6 @@ public:
 
     ss::abort_source& abort_source() { return _as; };
 
-private:
     void signaled() {
         if (!_as.abort_requested()) {
             _as.request_abort();
@@ -48,6 +47,7 @@ private:
         _cond.broadcast();
     }
 
+private:
     ss::condition_variable _cond;
     ss::abort_source _as;
 };


### PR DESCRIPTION
This PR aims to make Redpanda compatible with Azure storage accounts that have [HNS](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-namespace) enabled.
In brief, when HNS is enabled, each container in the account will mimic file system like semantics.


### Issues and Solutions
This changes semantics for deletions and listing of objects:
1. Deleting a file does not delete the directories. For instance, deleting `a/log.txt` leaves behind the `a` blob.
2. Directories cannot be deleted via the [Blob Service REST API](https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api).
3. Listings include directory blobs by default.

(1) and (2) are solved by using the [Data Lake Storage Gen2 REST API](https://learn.microsoft.com/en-us/rest/api/storageservices/data-lake-storage-gen2) which allows for file-like manipulations. When HNS is enabled 
we issue a ADLSv2 delete request for each valid prefix path of the blob. For instance, to delete `a/b/log.txt` we'll issue the following delete requests sequentially: `a/b/log.txt`, `a/b`, `a`.

(3) The `showonly=files` query param of the [list request](https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs?tabs=azure-ad) is used when HNS is enabled. This preserves the previous semantics.

One important consideration here is that our prefix hashing is not perfect and can have collisions (especially on manifest files). The ADLSv2 deletion request will fail if the directory is not empty, which makes this approach safe at all times.

I looked into a number of alternative approaches that would involve less requests, but none* of them were safe when considering hash collisions (recursive deletes, conditional deletes, leaking aka Azure locks).
* Leases would actually be safe, but implementing them is intrusive

### Auto-detecting HNS
Redpanda will auto-detect if it is running against a storage account where HNS is enabled.
HNS is enabled at storage account creation time, so we make no attempt to detect changes to the storage account.

At start-up Redpanda issues a [request](https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures) to check if the storage account has HNS enabled. This is done before
the client pool can lease any clients. If HNS is enabled, the ABS client will take the steps described in the previous section to maintain the semantics expect by the layers above it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Features
* Redpanda is now compatible with Azure Storage Account that enable Hierarchical Namespaces.
