### PR TITLE
Changed api of `shard_table` not to be forced to do two lookups

### DIFF
--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -497,11 +497,7 @@ controller_api::get_node_decommission_progress(
 
 std::optional<ss::shard_id>
 controller_api::shard_for(const raft::group_id& group) const {
-    if (_shard_table.local().contains(group)) {
-        return _shard_table.local().shard_for(group);
-    } else {
-        return std::nullopt;
-    }
+    return _shard_table.local().shard_for(group);
 }
 
 std::optional<ss::shard_id>

--- a/src/v/cluster/shard_table.h
+++ b/src/v/cluster/shard_table.h
@@ -31,11 +31,11 @@ class shard_table final {
     };
 
 public:
-    bool contains(const raft::group_id& group) {
-        return _group_idx.find(group) != _group_idx.end();
-    }
-    ss::shard_id shard_for(const raft::group_id& group) {
-        return _group_idx.find(group)->second.shard;
+    std::optional<ss::shard_id> shard_for(const raft::group_id& group) {
+        if (auto it = _group_idx.find(group); it != _group_idx.end()) {
+            return it->second.shard;
+        }
+        return std::nullopt;
     }
 
     std::optional<model::revision_id> revision_for(const model::ntp& ntp) {

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -289,9 +289,9 @@ struct raft_node {
           });
     }
 
-    ss::shard_id shard_for(raft::group_id) { return ss::shard_id(0); }
-
-    bool contains(raft::group_id) { return true; }
+    std::optional<ss::shard_id> shard_for(raft::group_id) {
+        return ss::shard_id(0);
+    }
 
     ss::future<log_t> read_log() {
         auto max_offset = model::offset(consensus->last_visible_index());


### PR DESCRIPTION
Previously when querying for `shard_id` of a Raft group, caller was forced to use `contains` and `shard_for` methods instead of simply calling shard for. This patch makes the interface more convenient.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none