### PR TITLE
tests: miscellaneous improvements for tiered storage C++ tests

### DIFF
--- a/src/v/cloud_storage/tests/manual_fixture.h
+++ b/src/v/cloud_storage/tests/manual_fixture.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/tests/produce_utils.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "model/fundamental.h"
+#include "redpanda/tests/fixture.h"
+#include "storage/disk_log_impl.h"
+
+class cloud_storage_manual_multinode_test_base
+  : public s3_imposter_fixture
+  , public redpanda_thread_fixture
+  , public enable_cloud_storage_fixture {
+public:
+    cloud_storage_manual_multinode_test_base()
+      : redpanda_thread_fixture(
+        redpanda_thread_fixture::init_cloud_storage_tag{},
+        httpd_port_number()) {
+        // No expectations: tests will PUT and GET organically.
+        set_expectations_and_listen({});
+
+        config::shard_local_cfg()
+          .cloud_storage_enable_segment_merging.set_value(false);
+        config::shard_local_cfg()
+          .cloud_storage_disable_upload_loop_for_tests.set_value(true);
+
+        wait_for_controller_leadership().get();
+    }
+
+    std::unique_ptr<redpanda_thread_fixture> start_second_fixture() {
+        return std::make_unique<redpanda_thread_fixture>(
+          model::node_id(2),
+          9092 + 10,
+          33145 + 10,
+          8082 + 10,
+          8081 + 10,
+          std::vector<config::seed_server>{
+            {.addr = net::unresolved_address("127.0.0.1", 33145)}},
+          ssx::sformat("test.second_dir{}", time(0)),
+          app.sched_groups,
+          true,
+          get_s3_config(httpd_port_number()),
+          get_archival_config(),
+          get_cloud_config(httpd_port_number()));
+    }
+};

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -323,7 +323,8 @@ FIXTURE_TEST(
     auto& rr_archiver = rr_partition->archiver()->get();
     rr_archiver.sync_manifest().get();
 
-    tests::kafka_list_offsets_transport rr_lister(make_kafka_client().get());
+    tests::kafka_list_offsets_transport rr_lister(
+      rr_rp->make_kafka_client().get());
     rr_lister.start().get();
     auto rr_hwm = rr_lister
                     .high_watermark_for_partition(

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -226,6 +226,8 @@ public:
 
     model::offset get_last_clean_at() const { return _last_clean_at; };
 
+    model::offset max_collectible_offset() override;
+
 private:
     ss::future<std::error_code> do_add_segments(
       std::vector<cloud_storage::segment_meta>,
@@ -241,7 +243,6 @@ private:
 
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
-    model::offset max_collectible_offset() override;
 
     struct segment;
     struct start_offset;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -597,6 +597,13 @@ configuration::configuration()
       "How often do we trigger background compaction",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       10s)
+  , log_disable_housekeeping_for_tests(
+      *this,
+      "log_disable_housekeeping_for_tests",
+      "Disables the housekeeping loop for local storage. The property exists "
+      "to simplify testing and shouldn't be set in production.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -140,6 +140,7 @@ struct configuration final : public config_store {
     // same as log.retention.ms in kafka
     retention_duration_property delete_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
+    property<bool> log_disable_housekeeping_for_tests;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;

--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -34,7 +34,7 @@ kafka_produce_transport::produce(
     tp.partitions = produce_partition_requests(records_per_partition, ts);
     std::vector<kafka::produce_request::topic> topics;
     topics.push_back(std::move(tp));
-    kafka::produce_request req(std::nullopt, 1, std::move(topics));
+    kafka::produce_request req(std::nullopt, -1, std::move(topics));
     req.data.timeout_ms = std::chrono::seconds(10);
     req.has_idempotent = false;
     req.has_transactional = false;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -97,6 +97,7 @@ public:
       : app(ssx::sformat("redpanda-{}", node_id()))
       , proxy_port(proxy_port)
       , schema_reg_port(schema_reg_port)
+      , kafka_port(kafka_port)
       , data_dir(std::move(base_dir))
       , remove_on_shutdown(remove_on_shutdown)
       , app_signal(std::make_unique<::stop_signal>()) {
@@ -465,7 +466,7 @@ public:
     make_kafka_client(std::optional<ss::sstring> client_id = "test_client") {
         return ss::make_ready_future<kafka::client::transport>(
           net::base_transport::configuration{
-            .server_addr = config::node().kafka_api()[0].address,
+            .server_addr = {"127.0.0.1", kafka_port},
           },
           std::move(client_id));
     }
@@ -707,6 +708,7 @@ public:
     application app;
     uint16_t proxy_port;
     uint16_t schema_reg_port;
+    uint16_t kafka_port;
     std::filesystem::path data_dir;
     ss::sharded<net::server_configuration> configs;
     ss::sharded<kafka::server> proto;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -507,9 +507,11 @@ public:
     ss::future<> add_topic(
       model::topic_namespace_view tp_ns,
       int partitions = 1,
-      std::optional<cluster::topic_properties> props = std::nullopt) {
+      std::optional<cluster::topic_properties> props = std::nullopt,
+      int16_t replication_factor = 1) {
         std::vector<cluster::topic_configuration> cfgs = {
-          cluster::topic_configuration{tp_ns.ns, tp_ns.tp, partitions, 1}};
+          cluster::topic_configuration{
+            tp_ns.ns, tp_ns.tp, partitions, replication_factor}};
         if (props.has_value()) {
             cfgs[0].properties = std::move(props.value());
         }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -167,6 +167,10 @@ ss::future<> log_manager::clean_close(ss::shared_ptr<storage::log> log) {
 }
 
 ss::future<> log_manager::start() {
+    if (unlikely(config::shard_local_cfg()
+                   .log_disable_housekeeping_for_tests.value())) {
+        co_return;
+    }
     ssx::spawn_with_gate(_open_gate, [this] { return housekeeping(); });
     co_return;
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
I intend on writing more tests that use C++ fixtures, and it generally is helpful to have a few things on hand. This PR introduces a few QOL improvements:
- makes archival metadata stm's max collectible offset public
- adds a config to disable the local storage housekeeping loop, for use in tests
- makes the test kafka_produce_transport use acks=-1
- adds the ability to tweak replication factor when adding a topic to a redpanda_thread_fixture
- adds a fixture that spins up two Redpanda applications with tiered storage

These are pulled out of a separate PR https://github.com/redpanda-data/redpanda/pull/12643 that uses these to test tiered storage with mismatched on-disk segment layouts between replicas.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
