### PR TITLE
Add txn coordinator drain api

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -106,6 +106,7 @@ v_cc_library(
     controller.cc
     partition.cc
     partition_probe.cc
+    tx_registry_stm.cc
     id_allocator_stm.cc
     persisted_stm.cc
     tm_stm_cache.cc

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -23,6 +23,7 @@ class log_eviction_stm;
 class tx_registry_frontend;
 class tx_registry_stm;
 class tx_coordinator_mapper;
+struct draining_txs;
 class tm_stm_cache;
 class tm_stm_cache_manager;
 class tx_gateway_frontend;

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -21,6 +21,7 @@ class id_allocator_frontend;
 class rm_partition_frontend;
 class log_eviction_stm;
 class tx_registry_frontend;
+class tx_registry_stm;
 class tx_coordinator_mapper;
 class tm_stm_cache;
 class tm_stm_cache_manager;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -19,6 +19,7 @@
 #include "cluster/partition_probe.h"
 #include "cluster/rm_stm.h"
 #include "cluster/tm_stm.h"
+#include "cluster/tx_registry_stm.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/property.h"
@@ -262,6 +263,10 @@ public:
         return _raft->get_latest_configuration_offset();
     }
 
+    ss::shared_ptr<cluster::tx_registry_stm> tx_registry_stm() {
+        return _tx_registry_stm;
+    }
+
     ss::shared_ptr<cluster::id_allocator_stm> id_allocator_stm() {
         return _id_allocator_stm;
     }
@@ -448,6 +453,7 @@ private:
     consensus_ptr _raft;
     ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
+    ss::shared_ptr<cluster::tx_registry_stm> _tx_registry_stm;
     ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<cluster::tm_stm> _tm_stm;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2269,8 +2269,10 @@ ss::future<tx_errc> rm_stm::do_try_abort_old_tx(model::producer_identity pid) {
         if (tx_data != _log_state.current_txes.end()) {
             tm_partition = tx_data->second.tm_partition;
         }
-        auto r = co_await _tx_gateway_frontend.local().try_abort(
-          tm_partition, pid, *tx_seq, _sync_timeout);
+
+        auto r = co_await _tx_gateway_frontend.local().route_globally(
+          cluster::try_abort_request(
+            tm_partition, pid, tx_seq.value(), _sync_timeout));
         if (r.ec == tx_errc::none) {
             if (r.commited) {
                 vlog(

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ set(srcs
     feature_barrier_test.cc
     tm_stm_tests.cc
     tm_coordinator_mapper_tests.cc
-    tm_tx_hash_ranges_tests.cc
+    tx_hash_ranges_tests.cc
     rm_stm_tests.cc
     rm_stm_compatibility_test.cc
     id_allocator_stm_test.cc

--- a/src/v/cluster/tests/tm_coordinator_mapper_tests.cc
+++ b/src/v/cluster/tests/tm_coordinator_mapper_tests.cc
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0
 
 #include "cluster/tm_stm.h"
-#include "cluster/tm_tx_hash_ranges.h"
 #include "cluster/tx_coordinator_mapper.h"
+#include "cluster/tx_hash_ranges.h"
 
 #include <seastar/testing/thread_test_case.hh>
 

--- a/src/v/cluster/tests/tm_coordinator_mapper_tests.cc
+++ b/src/v/cluster/tests/tm_coordinator_mapper_tests.cc
@@ -16,9 +16,9 @@
 #include <cstdint>
 
 void check_hash_range_distribuiton(int32_t partitions_amount) {
-    cluster::tm_hash_ranges_set hash_ranges{};
+    cluster::tx_hash_ranges_set hash_ranges{};
     for (int i = 0; i < partitions_amount; ++i) {
-        hash_ranges.ranges.push_back(cluster::default_tm_hash_range(
+        hash_ranges.ranges.push_back(cluster::default_hash_range(
           model::partition_id(i), partitions_amount));
     }
     BOOST_REQUIRE_EQUAL(hash_ranges.ranges[0].first, 0);
@@ -65,9 +65,9 @@ void check_get_partition_from_default_distribution(int32_t partitions_amount) {
         cluster::tx_tm_hash_max, partitions_amount),
       model::partition_id(partitions_amount - 1));
 
-    cluster::tm_hash_ranges_set hash_ranges{};
+    cluster::tx_hash_ranges_set hash_ranges{};
     for (int i = 0; i < partitions_amount; ++i) {
-        hash_ranges.ranges.push_back(cluster::default_tm_hash_range(
+        hash_ranges.ranges.push_back(cluster::default_hash_range(
           model::partition_id(i), partitions_amount));
     }
 
@@ -84,7 +84,7 @@ void check_get_partition_from_default_distribution(int32_t partitions_amount) {
 
         BOOST_REQUIRE_EQUAL(
           cluster::get_partition_from_default_distribution(
-            cluster::tm_tx_hash_type(
+            cluster::tx_hash_type(
               (uint64_t(hash_ranges.ranges[i].first)
                + uint64_t(hash_ranges.ranges[i].last))
               / 2),

--- a/src/v/cluster/tests/tm_tx_hash_ranges_tests.cc
+++ b/src/v/cluster/tests/tm_tx_hash_ranges_tests.cc
@@ -16,19 +16,19 @@
 #include <cstdint>
 
 SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
-    cluster::tm_hash_range range_start(0, 100);
-    cluster::tm_hash_range range_middle(101, cluster::tx_tm_hash_max - 100);
-    cluster::tm_hash_range range_end(
+    cluster::tx_hash_range range_start(0, 100);
+    cluster::tx_hash_range range_middle(101, cluster::tx_tm_hash_max - 100);
+    cluster::tx_hash_range range_end(
       cluster::tx_tm_hash_max - 99, cluster::tx_tm_hash_max);
-    cluster::tm_tx_hash_ranges_errc add_res;
+    cluster::tx_hash_ranges_errc add_res;
 
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
     add_res = hosted_transactions_1.add_range(range_start);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_1.add_range(range_middle);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_1.add_range(range_end);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.hash_ranges.ranges[0].first, 0);
     BOOST_REQUIRE_EQUAL(
@@ -37,11 +37,11 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
     add_res = hosted_transactions_2.add_range(range_start);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_2.add_range(range_end);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_2.add_range(range_middle);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.hash_ranges.ranges[0].first, 0);
     BOOST_REQUIRE_EQUAL(
@@ -50,11 +50,11 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
 
     cluster::tm_tx_hosted_transactions hosted_transactions_3{};
     add_res = hosted_transactions_3.add_range(range_end);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_3.add_range(range_middle);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_3.add_range(range_start);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_3.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_3.hash_ranges.ranges[0].first, 0);
     BOOST_REQUIRE_EQUAL(
@@ -63,63 +63,63 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
-    cluster::tm_tx_hash_ranges_errc add_res;
-    cluster::tm_hash_range range_100_200(100, 200);
-    cluster::tm_hash_range range_100_150(100, 150);
-    cluster::tm_hash_range range_150_170(150, 170);
-    cluster::tm_hash_range range_170_200(170, 200);
+    cluster::tx_hash_ranges_errc add_res;
+    cluster::tx_hash_range range_100_200(100, 200);
+    cluster::tx_hash_range range_100_150(100, 150);
+    cluster::tx_hash_range range_150_170(150, 170);
+    cluster::tx_hash_range range_170_200(170, 200);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
     add_res = hosted_transactions_1.add_range(range_100_200);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_1.add_range(range_100_150);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_1.add_range(range_150_170);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_1.add_range(range_170_200);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
     add_res = hosted_transactions_2.add_range(range_100_150);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_2.add_range(range_150_170);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_2.add_range(range_170_200);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_3{};
     add_res = hosted_transactions_3.add_range(range_150_170);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_3.add_range(range_100_150);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_3.add_range(range_170_200);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 }
 
 SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
-    cluster::tm_tx_hash_ranges_errc add_res;
+    cluster::tx_hash_ranges_errc add_res;
 
     kafka::transactional_id tx_id("tx_1");
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
     add_res = hosted_transactions_1.add_range({0, cluster::tx_tm_hash_max});
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     add_res = hosted_transactions_1.include_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::intersection);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
     add_res = hosted_transactions_1.exclude_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE(!hosted_transactions_1.contains(tx_id));
     add_res = hosted_transactions_1.include_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE(hosted_transactions_1.contains(tx_id));
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.included_transactions.size(), 0);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
     add_res = hosted_transactions_2.exclude_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::not_hosted);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::not_hosted);
     add_res = hosted_transactions_2.include_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE(hosted_transactions_2.contains(tx_id));
     add_res = hosted_transactions_2.exclude_transaction(tx_id);
-    BOOST_REQUIRE(add_res == cluster::tm_tx_hash_ranges_errc::success);
+    BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.excluded_transactions.size(), 0);
 }

--- a/src/v/cluster/tests/tm_tx_hash_ranges_tests.cc
+++ b/src/v/cluster/tests/tm_tx_hash_ranges_tests.cc
@@ -23,11 +23,14 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
     cluster::tx_hash_ranges_errc add_res;
 
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
-    add_res = hosted_transactions_1.add_range(range_start);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_1.add_range(range_middle);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_middle);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_1.add_range(range_end);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.hash_ranges.ranges[0].first, 0);
@@ -36,11 +39,14 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       cluster::tx_tm_hash_max);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
-    add_res = hosted_transactions_2.add_range(range_start);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_2.add_range(range_end);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_2.add_range(range_middle);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_middle);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.hash_ranges.ranges[0].first, 0);
@@ -49,11 +55,14 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       cluster::tx_tm_hash_max);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_3{};
-    add_res = hosted_transactions_3.add_range(range_end);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_3.add_range(range_middle);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_middle);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_3.add_range(range_start);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_3.hash_ranges.ranges.size(), 1);
     BOOST_REQUIRE_EQUAL(hosted_transactions_3.hash_ranges.ranges[0].first, 0);
@@ -70,29 +79,39 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
     cluster::tx_hash_range range_170_200(170, 200);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
-    add_res = hosted_transactions_1.add_range(range_100_200);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_100_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_1.add_range(range_100_150);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_1.add_range(range_150_170);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_1.add_range(range_170_200);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
-    add_res = hosted_transactions_2.add_range(range_100_150);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_2.add_range(range_150_170);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_2.add_range(range_170_200);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_2, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_3{};
-    add_res = hosted_transactions_3.add_range(range_150_170);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_3.add_range(range_100_150);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_3.add_range(range_170_200);
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_3, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 }
 
@@ -101,25 +120,35 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
 
     kafka::transactional_id tx_id("tx_1");
     cluster::tm_tx_hosted_transactions hosted_transactions_1{};
-    add_res = hosted_transactions_1.add_range({0, cluster::tx_tm_hash_max});
+    add_res = cluster::hosted_transactions::add_range(
+      hosted_transactions_1, {0, cluster::tx_tm_hash_max});
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    add_res = hosted_transactions_1.include_transaction(tx_id);
+    add_res = cluster::hosted_transactions::include_transaction(
+      hosted_transactions_1, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
-    add_res = hosted_transactions_1.exclude_transaction(tx_id);
+    add_res = cluster::hosted_transactions::exclude_transaction(
+      hosted_transactions_1, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    BOOST_REQUIRE(!hosted_transactions_1.contains(tx_id));
-    add_res = hosted_transactions_1.include_transaction(tx_id);
+    BOOST_REQUIRE(
+      !cluster::hosted_transactions::contains(hosted_transactions_1, tx_id));
+    add_res = cluster::hosted_transactions::include_transaction(
+      hosted_transactions_1, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    BOOST_REQUIRE(hosted_transactions_1.contains(tx_id));
+    BOOST_REQUIRE(
+      cluster::hosted_transactions::contains(hosted_transactions_1, tx_id));
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.included_transactions.size(), 0);
 
     cluster::tm_tx_hosted_transactions hosted_transactions_2{};
-    add_res = hosted_transactions_2.exclude_transaction(tx_id);
+    add_res = cluster::hosted_transactions::exclude_transaction(
+      hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::not_hosted);
-    add_res = hosted_transactions_2.include_transaction(tx_id);
+    add_res = cluster::hosted_transactions::include_transaction(
+      hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
-    BOOST_REQUIRE(hosted_transactions_2.contains(tx_id));
-    add_res = hosted_transactions_2.exclude_transaction(tx_id);
+    BOOST_REQUIRE(
+      cluster::hosted_transactions::contains(hosted_transactions_2, tx_id));
+    add_res = cluster::hosted_transactions::exclude_transaction(
+      hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
     BOOST_REQUIRE_EQUAL(hosted_transactions_2.excluded_transactions.size(), 0);
 }

--- a/src/v/cluster/tests/tx_hash_ranges_tests.cc
+++ b/src/v/cluster/tests/tx_hash_ranges_tests.cc
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "cluster/tm_tx_hash_ranges.h"
+#include "cluster/tm_stm.h"
+#include "cluster/tx_hash_ranges.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
@@ -22,7 +23,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       cluster::tx_tm_hash_max - 99, cluster::tx_tm_hash_max);
     cluster::tx_hash_ranges_errc add_res;
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_1{};
+    cluster::tm_stm::hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -38,7 +39,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       hosted_transactions_1.hash_ranges.ranges[0].last,
       cluster::tx_tm_hash_max);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_2{};
+    cluster::tm_stm::hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_2, range_start);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -54,7 +55,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_union_test) {
       hosted_transactions_2.hash_ranges.ranges[0].last,
       cluster::tx_tm_hash_max);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_3{};
+    cluster::tm_stm::hosted_txs hosted_transactions_3{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_3, range_end);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -78,7 +79,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
     cluster::tx_hash_range range_150_170(150, 170);
     cluster::tx_hash_range range_170_200(170, 200);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_1{};
+    cluster::tm_stm::hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, range_100_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -92,7 +93,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
       hosted_transactions_1, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::intersection);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_2{};
+    cluster::tm_stm::hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_2, range_100_150);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -103,7 +104,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_addition_intersects_test) {
       hosted_transactions_2, range_170_200);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_3{};
+    cluster::tm_stm::hosted_txs hosted_transactions_3{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_3, range_150_170);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -119,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
     cluster::tx_hash_ranges_errc add_res;
 
     kafka::transactional_id tx_id("tx_1");
-    cluster::tm_tx_hosted_transactions hosted_transactions_1{};
+    cluster::tm_stm::hosted_txs hosted_transactions_1{};
     add_res = cluster::hosted_transactions::add_range(
       hosted_transactions_1, {0, cluster::tx_tm_hash_max});
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::success);
@@ -138,7 +139,7 @@ SEASTAR_THREAD_TEST_CASE(hash_ranges_include_exclude_test) {
       cluster::hosted_transactions::contains(hosted_transactions_1, tx_id));
     BOOST_REQUIRE_EQUAL(hosted_transactions_1.included_transactions.size(), 0);
 
-    cluster::tm_tx_hosted_transactions hosted_transactions_2{};
+    cluster::tm_stm::hosted_txs hosted_transactions_2{};
     add_res = cluster::hosted_transactions::exclude_transaction(
       hosted_transactions_2, tx_id);
     BOOST_REQUIRE(add_res == cluster::tx_hash_ranges_errc::not_hosted);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -141,11 +141,11 @@ ss::future<tm_stm::op_status> tm_stm::try_init_hosted_transactions(
     }
 
     model::partition_id partition = get_partition();
-    auto initial_hash_range = default_tm_hash_range(
+    auto initial_hash_range = default_hash_range(
       partition, tx_coordinator_partition_amount);
     tm_tx_hosted_transactions initial_hosted_transactions{};
     auto res = initial_hosted_transactions.add_range(initial_hash_range);
-    if (res == tm_tx_hash_ranges_errc::success) {
+    if (res == tx_hash_ranges_errc::success) {
         initial_hosted_transactions.inited = true;
         co_return co_await update_hosted_transactions(
           term, std::move(initial_hosted_transactions));
@@ -161,7 +161,7 @@ ss::future<tm_stm::op_status> tm_stm::include_hosted_transaction(
     }
     auto new_hosted_tx = _hosted_txes;
     auto res = new_hosted_tx.include_transaction(tx_id);
-    if (res == tm_tx_hash_ranges_errc::success) {
+    if (res == tx_hash_ranges_errc::success) {
         co_return co_await update_hosted_transactions(
           term, std::move(new_hosted_tx));
     } else {
@@ -176,7 +176,7 @@ ss::future<tm_stm::op_status> tm_stm::exclude_hosted_transaction(
     }
     auto new_hosted_tx = _hosted_txes;
     auto res = new_hosted_tx.exclude_transaction(tx_id);
-    if (res == tm_tx_hash_ranges_errc::success) {
+    if (res == tx_hash_ranges_errc::success) {
         co_return co_await update_hosted_transactions(
           term, std::move(new_hosted_tx));
     } else {

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -10,6 +10,7 @@
 #include "cluster/tm_stm.h"
 
 #include "cluster/logger.h"
+#include "cluster/tx_hash_ranges.h"
 #include "cluster/types.h"
 #include "model/record.h"
 #include "raft/errc.h"

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -184,6 +184,20 @@ ss::future<tm_stm::op_status> tm_stm::exclude_hosted_transaction(
     }
 }
 
+ss::future<tm_stm::op_status>
+tm_stm::set_draining_transactions(model::term_id term, draining_txs draining) {
+    if (!_hosted_txes.inited) {
+        co_return op_status::unknown;
+    }
+    auto new_hosted_tx = _hosted_txes;
+    auto error = new_hosted_tx.set_draining(draining);
+    if (error != tx_hash_ranges_errc::success) {
+        co_return op_status::unknown;
+    }
+    co_return co_await update_hosted_transactions(
+      term, std::move(new_hosted_tx));
+}
+
 uint8_t tm_stm::active_snapshot_version() {
     if (_feature_table.local().is_active(
           features::feature::transaction_partitioning)) {

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -144,7 +144,8 @@ ss::future<tm_stm::op_status> tm_stm::try_init_hosted_transactions(
     auto initial_hash_range = default_hash_range(
       partition, tx_coordinator_partition_amount);
     tm_tx_hosted_transactions initial_hosted_transactions{};
-    auto res = initial_hosted_transactions.add_range(initial_hash_range);
+    auto res = hosted_transactions::add_range(
+      initial_hosted_transactions, initial_hash_range);
     if (res == tx_hash_ranges_errc::success) {
         initial_hosted_transactions.inited = true;
         co_return co_await update_hosted_transactions(
@@ -160,7 +161,7 @@ ss::future<tm_stm::op_status> tm_stm::include_hosted_transaction(
         co_return op_status::unknown;
     }
     auto new_hosted_tx = _hosted_txes;
-    auto res = new_hosted_tx.include_transaction(tx_id);
+    auto res = hosted_transactions::include_transaction(new_hosted_tx, tx_id);
     if (res == tx_hash_ranges_errc::success) {
         co_return co_await update_hosted_transactions(
           term, std::move(new_hosted_tx));
@@ -175,7 +176,7 @@ ss::future<tm_stm::op_status> tm_stm::exclude_hosted_transaction(
         co_return op_status::unknown;
     }
     auto new_hosted_tx = _hosted_txes;
-    auto res = new_hosted_tx.exclude_transaction(tx_id);
+    auto res = hosted_transactions::exclude_transaction(new_hosted_tx, tx_id);
     if (res == tx_hash_ranges_errc::success) {
         co_return co_await update_hosted_transactions(
           term, std::move(new_hosted_tx));
@@ -813,7 +814,7 @@ bool tm_stm::hosts(const kafka::transactional_id& tx_id) {
           features::feature::transaction_partitioning)) {
         return true;
     }
-    return _hosted_txes.contains(tx_id);
+    return hosted_transactions::contains(_hosted_txes, tx_id);
 }
 
 ss::future<>

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -136,6 +136,9 @@ ss::future<tm_stm::op_status> tm_stm::try_init_hosted_transactions(
     }
 
     auto units = co_await _cache->write_lock();
+    if (_hosted_txes.inited) {
+        co_return op_status::success;
+    }
 
     model::partition_id partition = get_partition();
     auto initial_hash_range = default_tm_hash_range(

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -10,7 +10,6 @@
 #include "cluster/tm_stm.h"
 
 #include "cluster/logger.h"
-#include "cluster/tm_tx_hash_ranges.h"
 #include "cluster/types.h"
 #include "model/record.h"
 #include "raft/errc.h"
@@ -99,8 +98,7 @@ model::record_batch tm_stm::serialize_tx(tm_transaction tx) {
     return do_serialize_tx(old_tx);
 }
 
-model::record_batch
-tm_stm::serialize_hosted_transactions(tm_tx_hosted_transactions hr) {
+model::record_batch tm_stm::serialize_hosted_transactions(hosted_txs hr) {
     storage::record_batch_builder b(
       model::record_batch_type::tx_tm_hosted_trasactions, model::offset(0));
     b.add_raw_kv(
@@ -143,7 +141,7 @@ ss::future<tm_stm::op_status> tm_stm::try_init_hosted_transactions(
     model::partition_id partition = get_partition();
     auto initial_hash_range = default_hash_range(
       partition, tx_coordinator_partition_amount);
-    tm_tx_hosted_transactions initial_hosted_transactions{};
+    hosted_txs initial_hosted_transactions{};
     auto res = hosted_transactions::add_range(
       initial_hosted_transactions, initial_hash_range);
     if (res == tx_hash_ranges_errc::success) {
@@ -328,14 +326,14 @@ tm_stm::do_sync(model::timeout_clock::duration timeout) {
     co_return _insync_term;
 }
 
-ss::future<tm_stm::op_status> tm_stm::update_hosted_transactions(
-  model::term_id term, tm_tx_hosted_transactions hr) {
+ss::future<tm_stm::op_status>
+tm_stm::update_hosted_transactions(model::term_id term, hosted_txs hr) {
     auto gh = _gate.hold();
     co_return co_await do_update_hosted_transactions(term, std::move(hr));
 }
 
-ss::future<tm_stm::op_status> tm_stm::do_update_hosted_transactions(
-  model::term_id term, tm_tx_hosted_transactions hr) {
+ss::future<tm_stm::op_status>
+tm_stm::do_update_hosted_transactions(model::term_id term, hosted_txs hr) {
     auto batch = serialize_hosted_transactions(std::move(hr));
 
     auto r = co_await replicate_quorum_ack(term, std::move(batch));
@@ -1017,8 +1015,7 @@ ss::future<> tm_stm::apply_hosted_transactions(model::record_batch b) {
       "{}",
       model::record_batch_type::tx_tm_hosted_trasactions,
       key);
-    auto hash_ranges = serde::from_iobuf<tm_tx_hosted_transactions>(
-      rec.release_value());
+    auto hash_ranges = serde::from_iobuf<hosted_txs>(rec.release_value());
     _hosted_txes = hash_ranges;
     return ss::now();
 }

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -387,6 +387,10 @@ tm_stm::do_update_hosted_transactions(model::term_id term, hosted_txs hr) {
     co_return op_status::success;
 }
 
+bool tm_stm::is_transaction_draining(const kafka::transactional_id& tx_id) {
+    return _hosted_txes.is_draining(tx_id);
+}
+
 ss::future<checked<tm_transaction, tm_stm::op_status>>
 tm_stm::update_tx(tm_transaction tx, model::term_id term) {
     return ss::with_gate(

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -201,6 +201,7 @@ public:
       exclude_hosted_transaction(model::term_id, kafka::transactional_id);
     ss::future<tm_stm::op_status>
       set_draining_transactions(model::term_id, draining_txs);
+    draining_txs get_draining_transactions() { return _hosted_txes.draining; }
 
     ss::future<ss::basic_rwlock<>::holder> read_lock() {
         return _cache->read_lock();

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -111,6 +111,14 @@ public:
             draining = std::move(new_draining);
             return tx_hash_ranges_errc::success;
         }
+
+        bool is_draining(const kafka::transactional_id& tx_id) {
+            if (draining.contains(tx_id)) {
+                return true;
+            }
+            auto tx_id_hash = get_tx_id_hash(tx_id);
+            return draining.contains(tx_id_hash);
+        }
     };
 
     struct tm_snapshot_v0 {
@@ -176,6 +184,7 @@ public:
         return r;
     }
     bool hosts(const kafka::transactional_id& tx_id);
+    bool is_transaction_draining(const kafka::transactional_id&);
 
     ss::future<checked<model::term_id, tm_stm::op_status>> barrier();
     ss::future<checked<model::term_id, tm_stm::op_status>>

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -13,7 +13,7 @@
 
 #include "cluster/persisted_stm.h"
 #include "cluster/tm_stm_cache.h"
-#include "cluster/tm_tx_hash_ranges.h"
+#include "cluster/tx_hash_ranges.h"
 #include "config/configuration.h"
 #include "features/feature_table.h"
 #include "kafka/protocol/errors.h"
@@ -62,6 +62,59 @@ public:
         timeout
     };
 
+    struct draining_txs
+      : serde::
+          envelope<draining_txs, serde::version<0>, serde::compat_version<0>> {
+        repartitioning_id id;
+        tx_hash_ranges_set ranges{};
+        absl::btree_set<kafka::transactional_id> transactions{};
+
+        draining_txs() = default;
+
+        draining_txs(
+          repartitioning_id id,
+          tx_hash_ranges_set ranges,
+          absl::btree_set<kafka::transactional_id> txs)
+          : id(id)
+          , ranges(std::move(ranges))
+          , transactions(std::move(txs)) {}
+
+        auto serde_fields() { return std::tie(id, ranges, transactions); }
+    };
+
+    struct hosted_txs
+      : serde::
+          envelope<hosted_txs, serde::version<0>, serde::compat_version<0>> {
+        bool inited{false};
+        tx_hash_ranges_set hash_ranges{};
+        absl::btree_set<kafka::transactional_id> excluded_transactions{};
+        absl::btree_set<kafka::transactional_id> included_transactions{};
+        draining_txs draining{};
+
+        hosted_txs() = default;
+
+        hosted_txs(
+          bool inited,
+          tx_hash_ranges_set hr,
+          absl::btree_set<kafka::transactional_id> et,
+          absl::btree_set<kafka::transactional_id> it,
+          draining_txs dr)
+          : inited(inited)
+          , hash_ranges(std::move(hr))
+          , excluded_transactions(std::move(et))
+          , included_transactions(std::move(it))
+          , draining(std::move(dr)) {}
+
+        auto serde_fields() {
+            return std::tie(
+              inited,
+              hash_ranges,
+              excluded_transactions,
+              included_transactions,
+              draining);
+        }
+    };
+
     struct tm_snapshot_v0 {
         static constexpr uint8_t version = 0;
 
@@ -74,7 +127,7 @@ public:
 
         model::offset offset;
         fragmented_vector<tm_transaction> transactions;
-        tm_tx_hosted_transactions hash_ranges;
+        hosted_txs hash_ranges;
     };
 
     explicit tm_stm(
@@ -220,7 +273,7 @@ private:
       _tx_locks;
     ss::sharded<features::feature_table>& _feature_table;
     ss::lw_shared_ptr<cluster::tm_stm_cache> _cache;
-    tm_tx_hosted_transactions _hosted_txes;
+    hosted_txs _hosted_txes;
 
     ss::future<> apply(model::record_batch b) override;
     ss::future<> apply_hosted_transactions(model::record_batch b);
@@ -233,9 +286,9 @@ private:
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       do_update_tx(tm_transaction, model::term_id);
     ss::future<tm_stm::op_status>
-      update_hosted_transactions(model::term_id, tm_tx_hosted_transactions);
+      update_hosted_transactions(model::term_id, hosted_txs);
     ss::future<tm_stm::op_status>
-      do_update_hosted_transactions(model::term_id, tm_tx_hosted_transactions);
+      do_update_hosted_transactions(model::term_id, hosted_txs);
     ss::future<tm_stm::op_status> do_register_new_producer(
       model::term_id,
       kafka::transactional_id,
@@ -262,8 +315,58 @@ private:
     }
 
     model::record_batch serialize_tx(tm_transaction tx);
-    model::record_batch
-    serialize_hosted_transactions(tm_tx_hosted_transactions hr);
+    model::record_batch serialize_hosted_transactions(hosted_txs hr);
 };
 
 } // namespace cluster
+
+namespace reflection {
+template<>
+struct adl<cluster::tm_stm::draining_txs> {
+    void to(iobuf& out, cluster::tm_stm::draining_txs&& dr) {
+        reflection::serialize(out, dr.id, dr.ranges, dr.transactions);
+    }
+    cluster::tm_stm::draining_txs from(iobuf_parser& in) {
+        auto id = reflection::adl<cluster::repartitioning_id>{}.from(in);
+        auto ranges
+          = reflection::adl<std::vector<cluster::tx_hash_range>>{}.from(in);
+        auto txs = reflection::adl<absl::btree_set<kafka::transactional_id>>{}
+                     .from(in);
+        return {id, std::move(ranges), std::move(txs)};
+    }
+};
+
+template<>
+struct adl<cluster::tm_stm::hosted_txs> {
+    void to(iobuf& out, cluster::tm_stm::hosted_txs&& hr) {
+        reflection::serialize(
+          out,
+          hr.inited,
+          hr.hash_ranges,
+          hr.excluded_transactions,
+          hr.included_transactions,
+          hr.draining);
+    }
+    cluster::tm_stm::hosted_txs from(iobuf_parser& in) {
+        auto inited = reflection::adl<bool>{}.from(in);
+
+        auto hash_ranges_set
+          = reflection::adl<cluster::tx_hash_ranges_set>{}.from(in);
+        auto included_transactions
+          = reflection::adl<absl::btree_set<kafka::transactional_id>>{}.from(
+            in);
+        auto excluded_transactions
+          = reflection::adl<absl::btree_set<kafka::transactional_id>>{}.from(
+            in);
+        auto draining = reflection::adl<cluster::tm_stm::draining_txs>{}.from(
+          in);
+        return {
+          inited,
+          std::move(hash_ranges_set),
+          std::move(included_transactions),
+          std::move(excluded_transactions),
+          std::move(draining)};
+    };
+};
+
+} // namespace reflection

--- a/src/v/cluster/tx_coordinator_mapper.h
+++ b/src/v/cluster/tx_coordinator_mapper.h
@@ -12,7 +12,7 @@
 #pragma once
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_manager.h"
-#include "cluster/tm_tx_hash_ranges.h"
+#include "cluster/tx_hash_ranges.h"
 #include "hashing/murmur.h"
 #include "kafka/protocol/types.h"
 #include "kafka/types.h"

--- a/src/v/cluster/tx_coordinator_mapper.h
+++ b/src/v/cluster/tx_coordinator_mapper.h
@@ -26,8 +26,8 @@
 namespace cluster {
 
 inline model::partition_id get_partition_from_default_distribution(
-  tm_tx_hash_type tx_id_hash, int32_t partitions_amount) {
-    tm_tx_hash_type default_partition_range_size = get_default_range_size(
+  tx_hash_type tx_id_hash, int32_t partitions_amount) {
+    tx_hash_type default_partition_range_size = get_default_range_size(
       partitions_amount);
     int32_t partition = int32_t(tx_id_hash / default_partition_range_size);
 
@@ -74,7 +74,7 @@ public:
         }
         int32_t partitions_amount = cfg->partition_count;
 
-        tm_tx_hash_type tx_id_hash = get_tx_id_hash(tx_id);
+        tx_hash_type tx_id_hash = get_tx_id_hash(tx_id);
         auto partition = get_partition_from_default_distribution(
           tx_id_hash, partitions_amount);
         co_return model::ntp(_tp_ns.ns, _tp_ns.tp, partition);

--- a/src/v/cluster/tx_coordinator_mapper.h
+++ b/src/v/cluster/tx_coordinator_mapper.h
@@ -57,15 +57,12 @@ inline model::partition_id get_partition_from_default_distribution(
 
 class tx_coordinator_mapper {
 public:
-    explicit tx_coordinator_mapper(
-      ss::sharded<cluster::metadata_cache>& md,
-      model::topic_namespace tx_coordinator_topic)
-      : _md(md)
-      , _tp_ns(std::move(tx_coordinator_topic)) {}
+    explicit tx_coordinator_mapper(ss::sharded<cluster::metadata_cache>& md)
+      : _md(md) {}
 
     ss::future<std::optional<model::ntp>>
     ntp_for(kafka::transactional_id tx_id) const {
-        auto cfg = _md.local().get_topic_cfg(_tp_ns);
+        auto cfg = _md.local().get_topic_cfg(model::tx_manager_nt);
         if (!cfg) {
             // Transaction coordinator topic not exist in cache
             // should be catched by caller (find_coordinator)
@@ -77,15 +74,15 @@ public:
         tx_hash_type tx_id_hash = get_tx_id_hash(tx_id);
         auto partition = get_partition_from_default_distribution(
           tx_id_hash, partitions_amount);
-        co_return model::ntp(_tp_ns.ns, _tp_ns.tp, partition);
+        co_return model::ntp(
+          model::tx_manager_nt.ns, model::tx_manager_nt.tp, partition);
     }
 
-    const model::ns& ns() const { return _tp_ns.ns; }
-    const model::topic& topic() const { return _tp_ns.tp; }
+    const model::ns& ns() const { return model::tx_manager_nt.ns; }
+    const model::topic& topic() const { return model::tx_manager_nt.tp; }
 
 private:
     ss::sharded<cluster::metadata_cache>& _md;
-    model::topic_namespace _tp_ns;
 };
 
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -114,4 +114,10 @@ ss::future<find_coordinator_reply> tx_gateway::find_coordinator(
     return _tx_registry_frontend.local().find_coordinator_locally(r.tid);
 }
 
+ss::future<set_draining_transactions_reply>
+tx_gateway::set_draining_transactions(
+  set_draining_transactions_request&& r, rpc::streaming_context&) {
+    co_return co_await _tx_gateway_frontend.local().route_locally(std::move(r));
+}
+
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -44,8 +44,7 @@ tx_gateway::fetch_tx(fetch_tx_request&& request, rpc::streaming_context&) {
 
 ss::future<try_abort_reply>
 tx_gateway::try_abort(try_abort_request&& request, rpc::streaming_context&) {
-    return _tx_gateway_frontend.local().try_abort_locally(
-      request.tm, request.pid, request.tx_seq, request.timeout);
+    return _tx_gateway_frontend.local().route_locally(std::move(request));
 }
 
 ss::future<init_tm_tx_reply>

--- a/src/v/cluster/tx_gateway.h
+++ b/src/v/cluster/tx_gateway.h
@@ -13,6 +13,7 @@
 #include "cluster/fwd.h"
 #include "cluster/rm_group_proxy.h"
 #include "cluster/tx_gateway_service.h"
+#include "cluster/types.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -72,6 +73,9 @@ public:
 
     ss::future<find_coordinator_reply> find_coordinator(
       find_coordinator_request&&, rpc::streaming_context&) override;
+
+    ss::future<set_draining_transactions_reply> set_draining_transactions(
+      set_draining_transactions_request&&, rpc::streaming_context&) override;
 
 private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;

--- a/src/v/cluster/tx_gateway.json
+++ b/src/v/cluster/tx_gateway.json
@@ -64,6 +64,11 @@
             "name": "find_coordinator",
             "input_type": "find_coordinator_request",
             "output_type": "find_coordinator_reply"
+        },
+        {
+            "name": "set_draining_transactions",
+            "input_type": "set_draining_transactions_request",
+            "output_type": "set_draining_transactions_reply"
         }
     ]
 }

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -159,11 +159,116 @@ auto tx_gateway_frontend::with_stm(model::partition_id tm, Func&& func) {
         return func(tx_errc::not_coordinator);
     }
 
-    return ss::with_gate(stm->gate(), [func = std::forward<Func>(func), stm]() {
-        vlog(txlog.trace, "entered tm_stm's gate");
-        return func(stm).finally(
-          [] { vlog(txlog.trace, "leaving tm_stm's gate"); });
-    });
+    return ss::with_gate(
+      stm->gate(), [func = std::forward<Func>(func), stm]() mutable {
+          vlog(txlog.trace, "entered tm_stm's gate");
+          return func(stm).finally(
+            [] { vlog(txlog.trace, "leaving tm_stm's gate"); });
+      });
+}
+
+template<typename T>
+ss::future<typename T::reply>
+tx_gateway_frontend::do_route_globally(model::ntp tx_ntp, T&& request) {
+    if (!_metadata_cache.local().contains(tx_ntp)) {
+        vlog(txlog.warn, "can't find {} in the metadata cache", tx_ntp);
+        co_return typename T::reply(tx_errc::partition_not_exists);
+    }
+
+    auto leader_opt = _leaders.local().get_leader(tx_ntp);
+    if (!leader_opt) {
+        vlog(txlog.warn, "can't find a leader for {}", tx_ntp);
+        co_return typename T::reply(tx_errc::leader_not_found);
+    }
+    auto leader = leader_opt.value();
+
+    auto _self = _controller->self();
+    if (leader == _self) {
+        co_return co_await do_route_locally(tx_ntp, std::move(request));
+    }
+
+    co_return co_await do_dispatch(leader, std::move(request));
+}
+
+template<typename T>
+ss::future<typename T::reply>
+tx_gateway_frontend::do_dispatch(model::node_id target, T&& request) {
+    vlog(
+      txlog.trace,
+      "dispatching name:{}, from:{}, to:{}, request:{}",
+      T::name,
+      request,
+      _controller->self(),
+      target);
+    auto timeout = request.timeout;
+    return _connection_cache.local()
+      .with_node_client<tx_gateway_client_protocol>(
+        _controller->self(),
+        ss::this_shard_id(),
+        target,
+        timeout,
+        [this,
+         request = std::move(request)](tx_gateway_client_protocol cp) mutable {
+            return send(cp, std::move(request));
+        })
+      .then(&rpc::get_ctx_data<typename T::reply>)
+      .then([](result<typename T::reply> r) {
+          if (r.has_error()) {
+              vlog(txlog.warn, "received name:{} error:{}", T::name, r.error());
+              return typename T::reply(tx_errc::unknown_server_error);
+          }
+          auto reply = r.value();
+          vlog(txlog.trace, "received name:{} {}", T::name, reply);
+          return reply;
+      });
+}
+
+template<typename T>
+ss::future<typename T::reply>
+tx_gateway_frontend::do_route_locally(model::ntp tx_ntp, T&& request) {
+    vlog(txlog.trace, "processing name:{} {}", T::name, request);
+
+    auto shard = _shard_table.local().shard_for(tx_ntp);
+
+    if (!shard.has_value()) {
+        vlog(
+          txlog.warn,
+          "sending name:{} {} ec:{}",
+          T::name,
+          request,
+          tx_errc::shard_not_found);
+        co_return typename T::reply(tx_errc::shard_not_found);
+    }
+
+    co_return co_await container().invoke_on(
+      *shard,
+      _ssg,
+      [tm = tx_ntp.tp.partition, request = std::move(request)](
+        tx_gateway_frontend& self) -> ss::future<typename T::reply> {
+          if (self._gate.is_closed()) {
+              return ss::make_ready_future<typename T::reply>(
+                tx_errc::not_coordinator);
+          }
+
+          return ss::with_gate(
+            self._gate, [&self, tm, request = std::move(request)] {
+                return self.with_stm(
+                  tm,
+                  [&self, request = std::move(request)](
+                    checked<ss::shared_ptr<tm_stm>, tx_errc> r) mutable {
+                      if (!r) {
+                          return ss::make_ready_future<typename T::reply>(
+                            r.error());
+                      }
+                      auto stm = r.value();
+                      return self.process_locally(stm, std::move(request))
+                        .then([](typename T::reply r) {
+                            vlog(txlog.trace, "sending name:{} {}", T::name, r);
+                            return r;
+                        });
+                  });
+            });
+      });
 }
 
 static add_paritions_tx_reply make_add_partitions_error_response(

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -680,156 +680,17 @@ ss::future<fetch_tx_reply> tx_gateway_frontend::dispatch_fetch_tx(
       });
 }
 
-ss::future<try_abort_reply> tx_gateway_frontend::try_abort(
-  model::partition_id tm,
-  model::producer_identity pid,
-  model::tx_seq tx_seq,
-  model::timeout_clock::duration timeout) {
-    if (!_metadata_cache.local().contains(model::tx_manager_nt, tm)) {
-        vlog(
-          txlog.warn, "can't find {}/{} partition", model::tx_manager_nt, tm);
-        co_return try_abort_reply{tx_errc::partition_not_exists};
-    }
-    model::ntp tx_ntp(model::tx_manager_nt.ns, model::tx_manager_nt.tp, tm);
-
-    auto leader_opt = _leaders.local().get_leader(tx_ntp);
-
-    auto retries = _metadata_dissemination_retries;
-    auto delay_ms = _metadata_dissemination_retry_delay_ms;
-    auto aborted = false;
-    while (!aborted && !leader_opt && 0 < retries--) {
-        aborted = !co_await sleep_abortable(delay_ms, _as);
-        leader_opt = _leaders.local().get_leader(tx_ntp);
-    }
-
-    if (!leader_opt) {
-        vlog(txlog.warn, "can't find a leader for {}", tx_ntp);
-        co_return try_abort_reply{tx_errc::leader_not_found};
-    }
-
-    auto leader = leader_opt.value();
-    auto _self = _controller->self();
-
-    if (leader == _self) {
-        co_return co_await try_abort_locally(tm, pid, tx_seq, timeout);
-    }
-
-    vlog(
-      txlog.trace,
-      "dispatching name:try_abort, pid:{}, tx_seq:{}, from:{}, to:{}",
-      pid,
-      tx_seq,
-      _self,
-      leader);
-
-    auto reply = co_await dispatch_try_abort(leader, tm, pid, tx_seq, timeout);
-
-    vlog(
-      txlog.trace,
-      "received name:try_abort, pid:{}, tx_seq:{}, ec:{}, committed:{}, "
-      "aborted:{}",
-      pid,
-      tx_seq,
-      reply.ec,
-      reply.commited,
-      reply.aborted);
-
-    co_return reply;
-}
-
-ss::future<try_abort_reply> tx_gateway_frontend::try_abort_locally(
-  model::partition_id tm,
-  model::producer_identity pid,
-  model::tx_seq tx_seq,
-  model::timeout_clock::duration timeout) {
-    vlog(
-      txlog.trace, "processing name:try_abort, pid:{}, tx_seq:{}", pid, tx_seq);
-
-    model::ntp tx_ntp(model::tx_manager_nt.ns, model::tx_manager_nt.tp, tm);
-    auto shard = _shard_table.local().shard_for(tx_ntp);
-
-    if (!shard) {
-        vlog(
-          txlog.trace,
-          "sending name:try_abort, pid:{}, tx_seq:{}, ec:{}",
-          pid,
-          tx_seq,
-          tx_errc::shard_not_found);
-        co_return try_abort_reply{tx_errc::shard_not_found};
-    }
-
-    auto reply = co_await container().invoke_on(
-      shard.value(),
-      _ssg,
-      [pid, tx_seq, timeout, tm](
-        tx_gateway_frontend& self) -> ss::future<try_abort_reply> {
-          return ss::with_gate(
-            self._gate,
-            [pid, tx_seq, timeout, tm, &self]() -> ss::future<try_abort_reply> {
-                return self.with_stm(
-                  tm,
-                  [pid, tx_seq, timeout, &self](
-                    checked<ss::shared_ptr<tm_stm>, tx_errc> r) {
-                      if (r) {
-                          return self.do_try_abort(
-                            r.value(), pid, tx_seq, timeout);
-                      }
-                      return ss::make_ready_future<try_abort_reply>(
-                        try_abort_reply{r.error()});
-                  });
-            });
-      });
-
-    vlog(
-      txlog.trace,
-      "sending name:try_abort, pid:{}, tx_seq:{}, ec:{}, committed:{}, "
-      "aborted:{}",
-      pid,
-      tx_seq,
-      reply.ec,
-      reply.commited,
-      reply.aborted);
-    co_return reply;
-}
-
-ss::future<try_abort_reply> tx_gateway_frontend::dispatch_try_abort(
-  model::node_id leader,
-  model::partition_id tm,
-  model::producer_identity pid,
-  model::tx_seq tx_seq,
-  model::timeout_clock::duration timeout) {
-    return _connection_cache.local()
-      .with_node_client<tx_gateway_client_protocol>(
-        _controller->self(),
-        ss::this_shard_id(),
-        leader,
-        timeout,
-        [tm, pid, tx_seq, timeout](tx_gateway_client_protocol cp) {
-            return cp.try_abort(
-              try_abort_request{tm, pid, tx_seq, timeout},
-              rpc::client_opts(model::timeout_clock::now() + timeout));
-        })
-      .then(&rpc::get_ctx_data<try_abort_reply>)
-      .then([](result<try_abort_reply> r) {
-          if (r.has_error()) {
-              vlog(txlog.warn, "got error {} on remote try abort", r.error());
-              return try_abort_reply{tx_errc::unknown_server_error};
-          }
-
-          return r.value();
-      });
-}
-
-ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
-  ss::shared_ptr<tm_stm> stm,
-  model::producer_identity pid,
-  model::tx_seq tx_seq,
-  model::timeout_clock::duration timeout) {
-    return stm->read_lock().then([this, stm, pid, tx_seq, timeout](
+ss::future<try_abort_reply> tx_gateway_frontend::process_locally(
+  ss::shared_ptr<tm_stm> stm, try_abort_request&& request) {
+    return stm->read_lock().then([this, stm, request = std::move(request)](
                                    ss::basic_rwlock<>::holder unit) {
         return stm->barrier()
-          .then([this, stm, pid, tx_seq, timeout](
+          .then([this, stm, request = std::move(request)](
                   checked<model::term_id, tm_stm::op_status> term_opt) {
+              auto pid = request.pid;
+              auto tx_seq = request.tx_seq;
+              auto timeout = request.timeout;
+
               if (!term_opt.has_value()) {
                   if (term_opt.error() == tm_stm::op_status::not_leader) {
                       return ss::make_ready_future<try_abort_reply>(
@@ -3378,6 +3239,20 @@ ss::future<result<tm_transaction, tx_errc>> tx_gateway_frontend::describe_tx(
     // init_producer_id, add_offsets_to_txn etc
     auto timeout = config::shard_local_cfg().create_topic_timeout_ms();
     co_return co_await get_tx(term, stm, tid, timeout);
+}
+
+ss::future<try_abort_reply>
+tx_gateway_frontend::route_globally(try_abort_request&& r) {
+    auto ntp = model::ntp(
+      model::tx_manager_nt.ns, model::tx_manager_nt.tp, r.tm);
+    return do_route_globally(ntp, std::move(r));
+}
+
+ss::future<try_abort_reply>
+tx_gateway_frontend::route_locally(try_abort_request&& r) {
+    auto ntp = model::ntp(
+      model::tx_manager_nt.ns, model::tx_manager_nt.tp, r.tm);
+    return do_route_locally(ntp, std::move(r));
 }
 
 ss::future<tx_errc> tx_gateway_frontend::delete_partition_from_tx(

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -240,6 +240,15 @@ private:
     template<typename Func>
     auto with_stm(model::partition_id tm, Func&& func);
 
+    template<typename T>
+    ss::future<typename T::reply> do_dispatch(model::node_id, T&&);
+
+    template<typename T>
+    ss::future<typename T::reply> do_route_globally(model::ntp, T&&);
+
+    template<typename T>
+    ss::future<typename T::reply> do_route_locally(model::ntp, T&&);
+
     ss::future<add_paritions_tx_reply> do_add_partition_to_tx(
       ss::shared_ptr<tm_stm>,
       add_paritions_tx_request,

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -70,6 +70,11 @@ public:
     ss::future<try_abort_reply> route_globally(try_abort_request&&);
     ss::future<try_abort_reply> route_locally(try_abort_request&&);
 
+    ss::future<set_draining_transactions_reply>
+    route_globally(set_draining_transactions_request&&);
+    ss::future<set_draining_transactions_reply>
+    route_locally(set_draining_transactions_request&&);
+
     ss::future<tx_errc> delete_partition_from_tx(
       kafka::transactional_id, tm_transaction::tx_partition);
 
@@ -255,9 +260,21 @@ private:
     ss::future<try_abort_reply>
     process_locally(ss::shared_ptr<tm_stm>, try_abort_request&&);
 
+    ss::future<set_draining_transactions_reply> process_locally(
+      ss::shared_ptr<tm_stm>, set_draining_transactions_request&&);
+
     auto send(tx_gateway_client_protocol& cp, try_abort_request&& request) {
         auto timeout = request.timeout;
         return cp.try_abort(
+          std::move(request),
+          rpc::client_opts(model::timeout_clock::now() + timeout));
+    }
+
+    auto send(
+      tx_gateway_client_protocol& cp,
+      set_draining_transactions_request&& request) {
+        auto timeout = request.timeout;
+        return cp.set_draining_transactions(
           std::move(request),
           rpc::client_opts(model::timeout_clock::now() + timeout));
     }

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -66,6 +66,8 @@ public:
     ss::future<return_all_txs_res> get_all_transactions();
     ss::future<result<tm_transaction, tx_errc>>
       describe_tx(kafka::transactional_id);
+    ss::future<result<cluster::draining_txs, tx_errc>>
+    get_draining_txes(model::ntp tx_ntp);
 
     ss::future<try_abort_reply> route_globally(try_abort_request&&);
     ss::future<try_abort_reply> route_locally(try_abort_request&&);
@@ -256,6 +258,8 @@ private:
 
     ss::future<result<tm_transaction, tx_errc>>
       describe_tx(ss::shared_ptr<tm_stm>, kafka::transactional_id);
+    ss::future<result<cluster::draining_txs, tx_errc>>
+      do_get_draining_txes(ss::shared_ptr<tm_stm>);
 
     ss::future<try_abort_reply>
     process_locally(ss::shared_ptr<tm_stm>, try_abort_request&&);

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -193,11 +193,6 @@ private:
     ss::future<tx_errc>
       do_init_hosted_transactions(ss::shared_ptr<cluster::tm_stm>);
 
-    ss::future<cluster::init_tm_tx_reply> dispatch_init_tm_tx(
-      model::node_id,
-      kafka::transactional_id,
-      std::chrono::milliseconds,
-      model::timeout_clock::duration);
     ss::future<cluster::init_tm_tx_reply> init_tm_tx_locally(
       kafka::transactional_id,
       std::chrono::milliseconds,

--- a/src/v/cluster/tx_registry_frontend.cc
+++ b/src/v/cluster/tx_registry_frontend.cc
@@ -25,6 +25,7 @@
 #include "model/namespace.h"
 #include "model/record_batch_reader.h"
 #include "rpc/connection_cache.h"
+#include "utils/gate_guard.h"
 #include "vformat.h"
 
 #include <seastar/core/coroutine.hh>
@@ -267,6 +268,8 @@ tx_registry_frontend::find_coordinator_locally(kafka::transactional_id tid) {
         co_return find_coordinator_reply(
           std::nullopt, std::nullopt, errc::not_leader);
     }
+
+    gate_guard guard{_gate};
 
     co_return co_await container().invoke_on(
       *shard, _ssg, [tid](tx_registry_frontend& self) mutable {

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -22,7 +22,8 @@
 
 namespace cluster {
 
-class tx_registry_frontend {
+class tx_registry_frontend final
+  : public ss::peering_sharded_service<tx_registry_frontend> {
 public:
     tx_registry_frontend(
       ss::smp_service_group,
@@ -50,6 +51,7 @@ public:
 
 private:
     ss::abort_source _as;
+    ss::gate _gate;
     ss::smp_service_group _ssg;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::shard_table>& _shard_table;
@@ -61,6 +63,9 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     int16_t _metadata_dissemination_retries{1};
     std::chrono::milliseconds _metadata_dissemination_retry_delay_ms;
+
+    template<typename Func>
+    auto with_stm(Func&& func);
 
     ss::future<find_coordinator_reply> dispatch_find_coordinator(
       model::node_id, kafka::transactional_id, model::timeout_clock::duration);

--- a/src/v/cluster/tx_registry_frontend.h
+++ b/src/v/cluster/tx_registry_frontend.h
@@ -70,8 +70,8 @@ private:
     ss::future<find_coordinator_reply> dispatch_find_coordinator(
       model::node_id, kafka::transactional_id, model::timeout_clock::duration);
 
-    ss::future<find_coordinator_reply>
-      do_find_coordinator_locally(kafka::transactional_id);
+    ss::future<find_coordinator_reply> do_find_coordinator_locally(
+      ss::shared_ptr<cluster::tx_registry_stm>, kafka::transactional_id);
 
     ss::future<find_coordinator_reply>
       find_coordinator_statically(kafka::transactional_id);

--- a/src/v/cluster/tx_registry_stm.cc
+++ b/src/v/cluster/tx_registry_stm.cc
@@ -22,6 +22,17 @@
 
 namespace cluster {
 
+static model::record_batch
+serialize_mapping(tx_registry_stm::tx_mapping mapping) {
+    storage::record_batch_builder b(
+      model::record_batch_type::tx_registry, model::offset(0));
+    b.add_raw_kv(
+      serde::to_iobuf(
+        static_cast<int32_t>(tx_registry_stm::batch_subtype::tx_mapping)),
+      serde::to_iobuf(mapping));
+    return std::move(b).build();
+}
+
 tx_registry_stm::tx_registry_stm(ss::logger& logger, raft::consensus* c)
   : tx_registry_stm(logger, c, config::shard_local_cfg()) {}
 
@@ -49,6 +60,38 @@ tx_registry_stm::do_sync(model::timeout_clock::duration timeout) {
 }
 
 ss::future<> tx_registry_stm::apply(model::record_batch b) {
+    const auto& hdr = b.header();
+
+    if (hdr.type == model::record_batch_type::tx_registry) {
+        vlog(
+          txlog.trace, "processing tx_registry batch at {}", hdr.base_offset);
+
+        vassert(
+          b.record_count() == 1,
+          "tx_registry batch must contain a single record");
+        auto r = b.copy_records();
+        auto& record = *r.begin();
+        auto key = record.release_key();
+
+        auto subtype = serde::from_iobuf<int32_t>(std::move(key));
+        if (subtype == static_cast<int32_t>(batch_subtype::tx_mapping)) {
+            vlog(
+              txlog.trace,
+              "processing tx_registry/tx_mapping cmd at {}",
+              hdr.base_offset);
+            auto value = record.release_value();
+            _mapping = serde::from_iobuf<tx_mapping>(std::move(value));
+            _initialized = true;
+        } else {
+            vlog(
+              txlog.trace,
+              "unknown tx_registry/{} cmd at {}",
+              subtype,
+              hdr.base_offset);
+            _seen_unknown_batch_subtype = true;
+        }
+    }
+
     _insync_offset = b.last_offset();
 
     _processed++;
@@ -57,6 +100,68 @@ ss::future<> tx_registry_stm::apply(model::record_batch b) {
     }
 
     return ss::now();
+}
+
+ss::future<bool> tx_registry_stm::try_init_mapping(
+  model::term_id term, int32_t partitions_count) {
+    if (_initialized) {
+        co_return true;
+    }
+
+    auto units = co_await write_lock();
+    if (_initialized) {
+        co_return true;
+    }
+
+    tx_mapping mapping;
+    mapping.id = repartitioning_id(0);
+
+    for (int pid = 0; pid < partitions_count; pid++) {
+        model::partition_id partition = model::partition_id(pid);
+        auto initial_hash_range = default_hash_range(
+          partition, partitions_count);
+        hosted_txs initial_hosted_transactions{};
+        auto res = hosted_transactions::add_range(
+          initial_hosted_transactions, initial_hash_range);
+        vassert(
+          res == tx_hash_ranges_errc::success,
+          "default txn hash space must be complete");
+        mapping.mapping[partition] = initial_hosted_transactions;
+    }
+
+    auto batch = serialize_mapping(std::move(mapping));
+    auto r = co_await replicate_quorum_ack(term, std::move(batch));
+    if (!r) {
+        vlog(
+          txlog.info, "got error {} on initing default hash_ranges", r.error());
+        if (_c->is_leader() && _c->term() == term) {
+            co_await _c->step_down(
+              "tx register try_init_mapping repliation error");
+        }
+        co_return false;
+    }
+    auto offset = r.value().last_offset;
+    if (!co_await wait_no_throw(
+          offset, model::timeout_clock::now() + _sync_timeout())) {
+        vlog(
+          txlog.info,
+          "timeout on waiting until {} is applied on updating hash_ranges",
+          offset);
+        if (_c->is_leader() && _c->term() == term) {
+            co_await _c->step_down("tx registry apply timeout");
+        }
+        co_return false;
+    }
+    if (_c->term() != term) {
+        vlog(
+          txlog.info,
+          "lost leadership while waiting until {} is applied on updating hash "
+          "ranges",
+          offset);
+        co_return false;
+    }
+
+    co_return true;
 }
 
 ss::future<> tx_registry_stm::truncate_log_prefix() {

--- a/src/v/cluster/tx_registry_stm.cc
+++ b/src/v/cluster/tx_registry_stm.cc
@@ -1,0 +1,99 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/tx_registry_stm.h"
+
+#include "cluster/logger.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "raft/consensus.h"
+#include "raft/errc.h"
+#include "raft/types.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+namespace cluster {
+
+tx_registry_stm::tx_registry_stm(ss::logger& logger, raft::consensus* c)
+  : tx_registry_stm(logger, c, config::shard_local_cfg()) {}
+
+tx_registry_stm::tx_registry_stm(
+  ss::logger& logger, raft::consensus* c, config::configuration& cfg)
+  : persisted_stm("tx_registry.snapshot", logger, c)
+  , _sync_timeout(cfg.tx_registry_sync_timeout_ms.bind())
+  , _log_capacity(cfg.tx_registry_log_capacity.bind()) {}
+
+ss::future<checked<model::term_id, errc>> tx_registry_stm::sync() {
+    return ss::with_gate(_gate, [this] { return do_sync(_sync_timeout()); });
+}
+
+ss::future<checked<model::term_id, errc>>
+tx_registry_stm::do_sync(model::timeout_clock::duration timeout) {
+    if (!_c->is_leader()) {
+        co_return errc::not_leader;
+    }
+
+    auto ready = co_await persisted_stm::sync(timeout);
+    if (!ready) {
+        co_return errc::generic_tx_error;
+    }
+    co_return _insync_term;
+}
+
+ss::future<> tx_registry_stm::apply(model::record_batch b) {
+    _insync_offset = b.last_offset();
+
+    _processed++;
+    if (_processed > _log_capacity()) {
+        ssx::spawn_with_gate(_gate, [this] { return truncate_log_prefix(); });
+    }
+
+    return ss::now();
+}
+
+ss::future<> tx_registry_stm::truncate_log_prefix() {
+    if (_is_truncating) {
+        return ss::now();
+    }
+    if (_processed <= _log_capacity()) {
+        return ss::now();
+    }
+    _is_truncating = true;
+    return _c->write_snapshot(raft::write_snapshot_cfg(_next_snapshot, iobuf()))
+      .then([this] {
+          _next_snapshot = _insync_offset;
+          _processed = 0;
+      })
+      .finally([this] { _is_truncating = false; });
+}
+
+ss::future<> tx_registry_stm::apply_snapshot(stm_snapshot_header, iobuf&&) {
+    return ss::make_exception_future<>(
+      std::logic_error("tx_registry_stm doesn't support snapshots"));
+}
+
+ss::future<stm_snapshot> tx_registry_stm::take_snapshot() {
+    return ss::make_exception_future<stm_snapshot>(
+      std::logic_error("tx_registry_stm doesn't support snapshots"));
+}
+
+ss::future<> tx_registry_stm::handle_raft_snapshot() {
+    return write_lock().then(
+      [this]([[maybe_unused]] ss::basic_rwlock<>::holder unit) {
+          _next_snapshot = _c->start_offset();
+          _processed = 0;
+          set_next(_next_snapshot);
+          _insync_offset = model::prev_offset(_next_snapshot);
+          return ss::now();
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/tx_registry_stm.cc
+++ b/src/v/cluster/tx_registry_stm.cc
@@ -102,6 +102,20 @@ ss::future<> tx_registry_stm::apply(model::record_batch b) {
     return ss::now();
 }
 
+std::optional<model::partition_id>
+tx_registry_stm::find_hosting_partition(kafka::transactional_id tid) {
+    for (auto& [partition, hosted] : _mapping.mapping) {
+        if (hosted_transactions::contains(hosted, tid)) {
+            return partition;
+        }
+    }
+    vlog(
+      txlog.error,
+      "tx_registry must cover full tx.id space but {} isn't found",
+      tid);
+    return std::nullopt;
+}
+
 ss::future<bool> tx_registry_stm::try_init_mapping(
   model::term_id term, int32_t partitions_count) {
     if (_initialized) {

--- a/src/v/cluster/tx_registry_stm.h
+++ b/src/v/cluster/tx_registry_stm.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "cluster/persisted_stm.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "raft/errc.h"
+#include "raft/logger.h"
+#include "raft/state_machine.h"
+#include "utils/expiring_promise.h"
+#include "utils/mutex.h"
+
+#include <absl/container/flat_hash_map.h>
+
+namespace config {
+struct configuration;
+}
+
+namespace cluster {
+
+class tx_registry_stm final : public persisted_stm<> {
+public:
+    explicit tx_registry_stm(ss::logger&, raft::consensus*);
+
+    explicit tx_registry_stm(
+      ss::logger&, raft::consensus*, config::configuration&);
+
+    ss::gate& gate() { return _gate; }
+
+    ss::future<ss::basic_rwlock<>::holder> read_lock() {
+        return _lock.hold_read_lock();
+    }
+
+    ss::future<ss::basic_rwlock<>::holder> write_lock() {
+        return _lock.hold_write_lock();
+    }
+
+    ss::future<checked<model::term_id, errc>> sync();
+
+private:
+    ss::future<checked<model::term_id, errc>>
+      do_sync(model::timeout_clock::duration);
+
+    ss::future<> apply(model::record_batch) override;
+
+    ss::future<> truncate_log_prefix();
+    ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
+    ss::future<stm_snapshot> take_snapshot() override;
+    ss::future<> handle_raft_snapshot() override;
+
+    config::binding<std::chrono::milliseconds> _sync_timeout;
+    ss::basic_rwlock<> _lock;
+
+    // Unlike the data partitions tx_registry_stm doesn't rely on the eviction
+    // stm and manages log truncations on its own. STM counts the number of
+    // applied commands and when it (`_processed`) surpasses
+    // `_log_capacity` tx_registry_stm trucates the prefix.
+    int64_t _processed{0};
+    config::binding<int16_t> _log_capacity;
+    model::offset _next_snapshot{-1};
+
+    bool _is_truncating{false};
+};
+
+} // namespace cluster

--- a/src/v/cluster/tx_registry_stm.h
+++ b/src/v/cluster/tx_registry_stm.h
@@ -13,8 +13,10 @@
 
 #include "cluster/fwd.h"
 #include "cluster/persisted_stm.h"
+#include "cluster/tx_hash_ranges.h"
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "raft/consensus.h"
 #include "raft/errc.h"
 #include "raft/logger.h"
 #include "raft/state_machine.h"
@@ -22,6 +24,7 @@
 #include "utils/mutex.h"
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_set.h>
 
 namespace config {
 struct configuration;
@@ -31,6 +34,48 @@ namespace cluster {
 
 class tx_registry_stm final : public persisted_stm<> {
 public:
+    enum class batch_subtype : int32_t { tx_mapping = 1 };
+
+    struct hosted_txs
+      : serde::
+          envelope<hosted_txs, serde::version<0>, serde::compat_version<0>> {
+        tx_hash_ranges_set hash_ranges{};
+        absl::node_hash_set<kafka::transactional_id> excluded_transactions{};
+        absl::node_hash_set<kafka::transactional_id> included_transactions{};
+
+        hosted_txs() = default;
+
+        hosted_txs(
+          tx_hash_ranges_set ranges,
+          absl::node_hash_set<kafka::transactional_id> excluded_txs,
+          absl::node_hash_set<kafka::transactional_id> included_txs)
+          : hash_ranges(std::move(ranges))
+          , excluded_transactions(std::move(excluded_txs))
+          , included_transactions(std::move(included_txs)) {}
+
+        auto serde_fields() {
+            return std::tie(
+              hash_ranges, excluded_transactions, included_transactions);
+        }
+    };
+
+    struct tx_mapping
+      : serde::
+          envelope<tx_mapping, serde::version<0>, serde::compat_version<0>> {
+        repartitioning_id id;
+        absl::flat_hash_map<model::partition_id, hosted_txs> mapping;
+
+        tx_mapping() = default;
+
+        tx_mapping(
+          repartitioning_id id,
+          absl::flat_hash_map<model::partition_id, hosted_txs> mapping)
+          : id(id)
+          , mapping(std::move(mapping)) {}
+
+        auto serde_fields() { return std::tie(id, mapping); }
+    };
+
     explicit tx_registry_stm(ss::logger&, raft::consensus*);
 
     explicit tx_registry_stm(
@@ -48,9 +93,27 @@ public:
 
     ss::future<checked<model::term_id, errc>> sync();
 
+    ss::future<bool> try_init_mapping(model::term_id, int32_t);
+
+    bool seen_unknown_batch_subtype() const {
+        return _seen_unknown_batch_subtype;
+    }
+
+    bool is_initialized() const { return _initialized; }
+
+    const tx_mapping& get_mapping() const { return _mapping; }
+
 private:
     ss::future<checked<model::term_id, errc>>
       do_sync(model::timeout_clock::duration);
+
+    ss::future<result<raft::replicate_result>>
+    replicate_quorum_ack(model::term_id term, model::record_batch&& batch) {
+        return _c->replicate(
+          term,
+          model::make_memory_record_batch_reader(std::move(batch)),
+          raft::replicate_options{raft::consistency_level::quorum_ack});
+    }
 
     ss::future<> apply(model::record_batch) override;
 
@@ -69,6 +132,9 @@ private:
     int64_t _processed{0};
     config::binding<int16_t> _log_capacity;
     model::offset _next_snapshot{-1};
+    bool _initialized{false};
+    bool _seen_unknown_batch_subtype{false};
+    tx_mapping _mapping;
 
     bool _is_truncating{false};
 };

--- a/src/v/cluster/tx_registry_stm.h
+++ b/src/v/cluster/tx_registry_stm.h
@@ -95,6 +95,9 @@ public:
 
     ss::future<bool> try_init_mapping(model::term_id, int32_t);
 
+    std::optional<model::partition_id>
+      find_hosting_partition(kafka::transactional_id);
+
     bool seen_unknown_batch_subtype() const {
         return _seen_unknown_batch_subtype;
     }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -105,6 +105,12 @@ std::ostream& operator<<(std::ostream& o, const tx_errc& err) {
     case tx_errc::tx_id_not_found:
         o << "tx_errc::tx_id_not_found";
         break;
+    case tx_errc::tx_hash_range_not_hosted:
+        o << "tx_errc::tx_hash_range_not_hosted";
+        break;
+    case tx_errc::tx_hash_range_not_inited:
+        o << "tx_errc::tx_hash_range_not_inited";
+        break;
     }
     return o;
 }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -992,6 +992,18 @@ std::ostream& operator<<(std::ostream& o, const find_coordinator_reply& r) {
 }
 
 std::ostream&
+operator<<(std::ostream& o, const set_draining_transactions_request& r) {
+    fmt::print(o, "{{ntp: {}}}", r.tm_ntp);
+    return o;
+}
+
+std::ostream&
+operator<<(std::ostream& o, const set_draining_transactions_reply& r) {
+    fmt::print(o, "{{ec {}}}", r.ec);
+    return o;
+}
+
+std::ostream&
 operator<<(std::ostream& o, const configuration_update_request& cr) {
     fmt::print(o, "{{broker: {} target_node: {}}}", cr.node, cr.target_node);
     return o;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -13,6 +13,7 @@
 
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
+#include "cluster/tx_hash_ranges.h"
 #include "kafka/types.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
@@ -1046,6 +1047,66 @@ struct find_coordinator_reply
     operator<<(std::ostream& o, const find_coordinator_reply& r);
 
     auto serde_fields() { return std::tie(coordinator, ntp, ec); }
+};
+
+struct set_draining_transactions_reply
+  : serde::envelope<
+      set_draining_transactions_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    tx_errc ec{};
+
+    set_draining_transactions_reply() noexcept = default;
+
+    set_draining_transactions_reply(tx_errc ec)
+      : ec(ec) {}
+
+    friend bool operator==(
+      const set_draining_transactions_reply&,
+      const set_draining_transactions_reply&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const set_draining_transactions_reply& r);
+
+    auto serde_fields() { return std::tie(ec); }
+};
+
+struct set_draining_transactions_request
+  : serde::envelope<
+      set_draining_transactions_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    using reply = set_draining_transactions_reply;
+    static constexpr const std::string_view name = "set_draining_transactions";
+
+    model::ntp tm_ntp;
+    cluster::draining_txs draining;
+    model::timeout_clock::duration timeout;
+
+    set_draining_transactions_request() noexcept = default;
+
+    set_draining_transactions_request(
+      model::ntp tm_ntp,
+      cluster::draining_txs draining,
+      model::timeout_clock::duration timeout)
+      : tm_ntp(tm_ntp)
+      , draining(std::move(draining))
+      , timeout(timeout) {}
+
+    friend bool operator==(
+      const set_draining_transactions_request&,
+      const set_draining_transactions_request&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const set_draining_transactions_request& r);
+
+    auto serde_fields() { return std::tie(tm_ntp, draining, timeout); }
 };
 
 struct join_node_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -183,35 +183,6 @@ enum class partition_removal_mode : uint8_t {
     global = 1
 };
 
-struct try_abort_request
-  : serde::
-      envelope<try_abort_request, serde::version<0>, serde::compat_version<0>> {
-    model::partition_id tm;
-    model::producer_identity pid;
-    model::tx_seq tx_seq;
-    model::timeout_clock::duration timeout{};
-
-    try_abort_request() noexcept = default;
-
-    try_abort_request(
-      model::partition_id tm,
-      model::producer_identity pid,
-      model::tx_seq tx_seq,
-      model::timeout_clock::duration timeout)
-      : tm(tm)
-      , pid(pid)
-      , tx_seq(tx_seq)
-      , timeout(timeout) {}
-
-    friend bool operator==(const try_abort_request&, const try_abort_request&)
-      = default;
-
-    friend std::ostream&
-    operator<<(std::ostream& o, const try_abort_request& r);
-
-    auto serde_fields() { return std::tie(tm, pid, tx_seq, timeout); }
-};
-
 struct try_abort_reply
   : serde::
       envelope<try_abort_reply, serde::version<0>, serde::compat_version<0>> {
@@ -246,6 +217,38 @@ struct try_abort_reply
     }
 
     auto serde_fields() { return std::tie(commited, aborted, ec); }
+};
+
+struct try_abort_request
+  : serde::
+      envelope<try_abort_request, serde::version<0>, serde::compat_version<0>> {
+    using reply = try_abort_reply;
+    static constexpr const std::string_view name = "try_abort";
+
+    model::partition_id tm;
+    model::producer_identity pid;
+    model::tx_seq tx_seq;
+    model::timeout_clock::duration timeout{};
+
+    try_abort_request() noexcept = default;
+
+    try_abort_request(
+      model::partition_id tm,
+      model::producer_identity pid,
+      model::tx_seq tx_seq,
+      model::timeout_clock::duration timeout)
+      : tm(tm)
+      , pid(pid)
+      , tx_seq(tx_seq)
+      , timeout(timeout) {}
+
+    friend bool operator==(const try_abort_request&, const try_abort_request&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const try_abort_request& r);
+
+    auto serde_fields() { return std::tie(tm, pid, tx_seq, timeout); }
 };
 
 struct init_tm_tx_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -138,7 +138,9 @@ enum class tx_errc {
     invalid_txn_state,
     invalid_producer_epoch,
     tx_not_found,
-    tx_id_not_found
+    tx_id_not_found,
+    tx_hash_range_not_hosted,
+    tx_hash_range_not_inited
 };
 
 std::ostream& operator<<(std::ostream&, const tx_errc&);

--- a/src/v/config/base_property.cc
+++ b/src/v/config/base_property.cc
@@ -56,8 +56,8 @@ std::string_view to_string_view(visibility v) {
 void base_property::assert_live_settable() const {
     vassert(
       _meta.needs_restart == needs_restart::no,
-      "Property must be be marked as "
-      "needs_restart::no");
+      "Property {} must be be marked as needs_restart::no",
+      name());
 }
 
 }; // namespace config

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -428,6 +428,12 @@ configuration::configuration()
       "Time to wait state catch up before rejecting a request",
       {.visibility = visibility::user},
       10s)
+  , tx_registry_sync_timeout_ms(
+      *this,
+      "tx_registry_sync_timeout_ms",
+      "Time to wait state catch up before rejecting a request",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      10s)
   , tm_violation_recovery_policy(*this, "tm_violation_recovery_policy")
   , rm_sync_timeout_ms(
       *this,
@@ -966,11 +972,18 @@ configuration::configuration()
        .visibility = visibility::tunable},
       2,
       {.min = 1})
+  , tx_registry_log_capacity(
+      *this,
+      "tx_registry_log_capacity",
+      "Capacity of the tx_registry log in number of batches. "
+      "Once it reached tx_registry_stm truncates log's prefix.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100)
   , id_allocator_log_capacity(
       *this,
       "id_allocator_log_capacity",
-      "Capacity of the id_allocator log in number of messages. "
-      "Once it reached id_allocator_stm should compact the log.",
+      "Capacity of the id_allocator log in number of batches. "
+      "Once it reached id_allocator_stm truncates log's prefix.",
       {.visibility = visibility::tunable},
       100)
   , id_allocator_batch_size(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -113,6 +113,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> metadata_dissemination_retry_delay_ms;
     property<int16_t> metadata_dissemination_retries;
     property<std::chrono::milliseconds> tm_sync_timeout_ms;
+    property<std::chrono::milliseconds> tx_registry_sync_timeout_ms;
     deprecated_property tm_violation_recovery_policy;
     property<std::chrono::milliseconds> rm_sync_timeout_ms;
     property<std::chrono::milliseconds> find_coordinator_timeout_ms;
@@ -203,6 +204,7 @@ struct configuration final : public config_store {
     property<bool> storage_ignore_cstore_hints;
     bounded_property<int16_t> storage_reserve_min_segments;
 
+    property<int16_t> tx_registry_log_capacity;
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3303,11 +3303,12 @@ group::do_try_abort_old_tx(model::producer_identity pid) {
               "pid {} doesn't exist in current transactions data",
               pid);
         }
-        auto r = co_await _tx_frontend.local().try_abort(
-          tm,
-          pid,
-          tx_seq,
-          config::shard_local_cfg().rm_sync_timeout_ms.value());
+        auto r = co_await _tx_frontend.local().route_globally(
+          cluster::try_abort_request(
+            tm,
+            pid,
+            tx_seq,
+            config::shard_local_cfg().rm_sync_timeout_ms.value()));
         if (r.ec != cluster::tx_errc::none) {
             co_return r.ec;
         }

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -359,6 +359,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::tx_tm_hosted_trasactions";
     case record_batch_type::prefix_truncate:
         return o << "batch_type::prefix_truncate";
+    case record_batch_type::tx_registry:
+        return o << "batch_type::tx_registry";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -43,7 +43,8 @@ enum class record_batch_type : int8_t {
     version_fence = 23,              // version fence/epoch
     tx_tm_hosted_trasactions = 24,   // tx_tm_hosted_trasactions_batch_type
     prefix_truncate = 25,            // log prefix truncation type
-    MAX = prefix_truncate
+    tx_registry = 26,                // tx_registry_batch_type
+    MAX = tx_registry
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/redpanda/admin/api-doc/transaction.json
+++ b/src/v/redpanda/admin/api-doc/transaction.json
@@ -137,6 +137,28 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/transactions/draining_transactions",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get draining transactions by tm partition",
+                    "type": "draining_transactions",
+                    "nickname": "get_draining_transactions",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "tm_partition",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin/api-doc/transaction.json
+++ b/src/v/redpanda/admin/api-doc/transaction.json
@@ -107,6 +107,36 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/transactions/draining_transactions",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Start transactions draining",
+                    "type": "void",
+                    "nickname": "set_draining_transactions",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "tm_partition",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "draining_transactions",
+                            "in": "body",
+                            "required": true,
+                            "schema": {
+                                "type":"draining_transactions"
+                            }
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -305,6 +335,40 @@
                     "description": "Consumer groups for transaction"
                 }
             }
+        },
+        "hash_range": {
+            "id": "hash_range",
+            "description": "Tranactional hash range",
+            "properties": {
+                "from": {
+                    "type": "long"
+                  },
+                "to": {
+                    "type": "long"
+                }
+            }
+        },
+        "draining_transactions": {
+            "id": "draining_transactions",
+            "description": "Draining transactions",
+            "properties": {
+                "repartitioning_id": {
+                    "type": "long"
+                },
+                "transactional_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                "hash_ranges": {
+                    "type": "array",
+                    "items": {
+                      "type": "hash_range"
+                    }
+                }
+            }
         }
+        
     }
 }

--- a/src/v/redpanda/admin/api-doc/transaction.json
+++ b/src/v/redpanda/admin/api-doc/transaction.json
@@ -26,6 +26,21 @@
             ]
         },
         {
+            "path": "/v1/tx_registry",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get tx registry state",
+                    "type": "tx_registry_info",
+                    "nickname": "tx_registry",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/transaction/{transactional_id}/find_coordinator",
             "operations": [
                 {
@@ -95,6 +110,68 @@
         }
     ],
     "models": {
+        "hash_range": {
+            "id": "hash_range",
+            "description": "Hash range",
+            "properties": {
+                "from": {
+                    "type": "long",
+                    "description": "from"
+                },
+                "to": {
+                    "type": "long",
+                    "description": "to"
+                }
+            }
+        },
+        "tx_mapping_entry": {
+            "id": "tx_mapping_entry",
+            "description": "tx_mapping_entry",
+            "properties": {
+                "partition_id": {
+                    "type": "int",
+                    "description": "partition_id"
+                },
+                "excluded_tx_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "excluded_tx_ids"
+                },
+                "included_tx_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "included_tx_ids"
+                },
+                "hash_ranges": {
+                    "type": "array",
+                    "items": {
+                        "type": "hash_range"
+                    },
+                    "description": "hash_ranges"
+                }
+            }
+        },
+        "tx_registry_info": {
+            "id": "tx_registry_info",
+            "description": "tx registry info",
+            "properties": {
+                "version": {
+                    "type": "long",
+                    "description": "repartitioning_id"
+                },
+                "tx_mapping": {
+                    "type": "array",
+                    "items": {
+                        "type": "tx_mapping_entry"
+                    },
+                    "description": "tx_mapping"
+                }
+            }
+        },
         "ntp": {
             "id": "ntp",
             "description": "NTP",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -63,6 +63,8 @@
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "net/dns.h"
+#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/parsing/exceptions.h"
 #include "pandaproxy/rest/api.h"
 #include "pandaproxy/schema_registry/api.h"
 #include "pandaproxy/schema_registry/schema_id_validation.h"
@@ -81,6 +83,7 @@
 #include "redpanda/admin/api-doc/status.json.hh"
 #include "redpanda/admin/api-doc/transaction.json.hh"
 #include "redpanda/admin/api-doc/usage.json.hh"
+#include "redpanda/draining_txes.h"
 #include "resource_mgmt/memory_sampling.h"
 #include "rpc/errc.h"
 #include "security/acl.h"
@@ -1058,6 +1061,10 @@ ss::future<> admin_server::throw_on_error(
             }
             throw ss::httpd::bad_request_exception(error_msg);
         }
+        case cluster::tx_errc::tx_hash_range_not_hosted:
+            throw ss::httpd::bad_request_exception(fmt::format(
+              "Provided hash range is not hosted on one partition. {}",
+              ec.message()));
         case cluster::tx_errc::not_coordinator:
             throw ss::httpd::base_exception(
               fmt::format(
@@ -2776,6 +2783,63 @@ admin_server::mark_transaction_expired_handler(
 }
 
 ss::future<ss::json::json_return_type>
+admin_server::mark_transactions_draining_handler(
+  std::unique_ptr<ss::http::request> req) {
+    if (!config::shard_local_cfg().enable_transactions) {
+        throw ss::httpd::bad_request_exception("Transaction are disabled");
+    }
+
+    auto tx_tm_partition_str = req->get_query_param("tm_partition");
+    if (tx_tm_partition_str.empty()) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("tx_tm_partition_str must be "
+                      "provided in query_params"));
+    }
+    int tx_tm_partition;
+    try {
+        tx_tm_partition = static_cast<int>(std::stoi(tx_tm_partition_str));
+    } catch (...) {
+        throw ss::httpd::bad_param_exception(fmt::format(
+          "Tm partition must be positive integer. Got: {}",
+          tx_tm_partition_str));
+    }
+
+    auto content = co_await ss::util::read_entire_stream_contiguous(
+      *req->content_stream);
+    vlog(
+      logger.info,
+      "mark_transactions_draining_handler request with data: {}",
+      content);
+
+    cluster::draining_txs req_data;
+    try {
+        req_data = pandaproxy::json::rjson_parse(
+          content.c_str(),
+          pandaproxy::json::mark_transactions_draining_request_handler());
+    } catch (pandaproxy::json::parse_error e) {
+        throw ss::httpd::bad_param_exception("Invalid request data");
+    }
+
+    auto tx_ntp = model::ntp(
+      model::tx_manager_nt.ns, model::tx_manager_nt.tp, tx_tm_partition);
+
+    auto& tx_frontend = _partition_manager.local().get_tx_frontend();
+    if (!tx_frontend.local_is_initialized()) {
+        throw ss::httpd::bad_request_exception("Can not get tx_frontend");
+    }
+
+    // we need an upper boundary for happy case cluster wide replication
+    // and create_topic_timeout_ms is a good approximation
+    auto timeout = config::shard_local_cfg().create_topic_timeout_ms();
+    auto r = cluster::set_draining_transactions_request(
+      tx_ntp, req_data, timeout);
+    auto res = co_await tx_frontend.local().route_globally(std::move(r));
+    co_await throw_on_error(*req, res.ec, tx_ntp);
+
+    co_return ss::json::json_void();
+}
+
+ss::future<ss::json::json_return_type>
 admin_server::get_reconfigurations_handler(std::unique_ptr<ss::http::request>) {
     using reconfiguration = ss::httpd::partition_json::reconfiguration;
 
@@ -3715,6 +3779,12 @@ void admin_server::register_transaction_routes() {
       ss::httpd::transaction_json::tx_registry,
       [this](std::unique_ptr<ss::http::request> req) {
           return tx_registry_handler(std::move(req));
+      });
+
+    register_route<user>(
+      ss::httpd::transaction_json::set_draining_transactions,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return mark_transactions_draining_handler(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -427,6 +427,8 @@ private:
       tx_registry_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       find_tx_coordinator_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      mark_transactions_draining_handler(std::unique_ptr<ss::http::request>);
 
     /// Cluster routes
     ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -429,6 +429,8 @@ private:
       find_tx_coordinator_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       mark_transactions_draining_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      get_draining_transactions_handler(std::unique_ptr<ss::http::request>);
 
     /// Cluster routes
     ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -424,6 +424,8 @@ private:
     ss::future<ss::json::json_return_type>
       delete_partition_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
+      tx_registry_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
       find_tx_coordinator_handler(std::unique_ptr<ss::http::request>);
 
     /// Cluster routes

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1445,8 +1445,7 @@ void application::wire_up_redpanda_services(
       .get();
 
     syschecks::systemd_message("Creating tx coordinator mapper").get();
-    construct_service(
-      tx_coordinator_ntp_mapper, std::ref(metadata_cache), model::tx_manager_nt)
+    construct_service(tx_coordinator_ntp_mapper, std::ref(metadata_cache))
       .get();
 
     syschecks::systemd_message("Creating id allocator frontend").get();

--- a/src/v/redpanda/draining_txes.h
+++ b/src/v/redpanda/draining_txes.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/tx_hash_ranges.h"
+#include "json/encodings.h"
+#include "json/types.h"
+#include "kafka/protocol/types.h"
+#include "pandaproxy/json/rjson_parse.h"
+#include "pandaproxy/json/types.h"
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace pandaproxy::json {
+
+template<typename Encoding = ::json::UTF8<>>
+class mark_transactions_draining_request_handler final
+  : public base_handler<Encoding> {
+private:
+    enum class state {
+        empty = 0,
+        repartitioning_id,
+        transactional_ids,
+        hash_ranges,
+        hash_range,
+        from,
+        to,
+    };
+
+    state state = state::empty;
+
+public:
+    using Ch = typename Encoding::Ch;
+    using rjson_parse_result = cluster::draining_txs;
+    rjson_parse_result result;
+
+    bool Int64(int64_t i) {
+        if (state == state::repartitioning_id) {
+            result.id = cluster::repartitioning_id(i);
+            return true;
+        }
+        return false;
+    }
+
+    bool Int(int64_t i) {
+        if (state == state::repartitioning_id) {
+            result.id = cluster::repartitioning_id(i);
+            return true;
+        }
+        return false;
+    }
+
+    bool Uint(unsigned i) {
+        if (state == state::repartitioning_id) {
+            result.id = cluster::repartitioning_id(i);
+            return true;
+        }
+        if (state == state::from) {
+            result.ranges.ranges.back().first = uint32_t(i);
+            state = state::hash_range;
+            return true;
+        }
+        if (state == state::to) {
+            result.ranges.ranges.back().last = uint32_t(i);
+            state = state::hash_range;
+            return true;
+        }
+        return false;
+    }
+
+    bool String(const Ch* str, ::json::SizeType len, bool) {
+        if (state == state::transactional_ids) {
+            result.transactions.insert(
+              kafka::transactional_id(ss::sstring(str, len)));
+            return true;
+        }
+        return false;
+    }
+
+    bool Key(const char* str, ::json::SizeType len, bool) {
+        auto key = std::string_view(str, len);
+        if (state == state::empty && key == "repartitioning_id") {
+            state = state::repartitioning_id;
+            return true;
+        }
+        if (state == state::repartitioning_id && key == "transactional_ids") {
+            state = state::transactional_ids;
+            return true;
+        }
+        if (
+          (state == state::repartitioning_id
+           || state == state::transactional_ids)
+          && key == "hash_ranges") {
+            state = state::hash_ranges;
+            return true;
+        }
+        if (state == state::hash_range) {
+            if (key == "from") {
+                state = state::from;
+            } else if (key == "to") {
+                state = state::to;
+            } else {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    bool StartObject() {
+        if (state == state::empty) {
+            return true;
+        }
+        if (state == state::hash_ranges) {
+            result.ranges.ranges.push_back(cluster::tx_hash_range());
+            state = state::hash_range;
+            return true;
+        }
+        return false;
+    }
+
+    bool EndObject(::json::SizeType size) {
+        if (state == state::hash_range) {
+            state = state::hash_ranges;
+            return size == 2;
+        }
+        if (state == state::hash_ranges || state == state::transactional_ids) {
+            state = state::empty;
+            return true;
+        }
+        return false;
+    }
+
+    bool StartArray() {
+        return state == state::transactional_ids || state == state::hash_ranges;
+    }
+
+    bool EndArray(::json::SizeType) {
+        return state == state::transactional_ids || state == state::hash_ranges;
+    }
+};
+
+} // namespace pandaproxy::json

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -672,6 +672,13 @@ class Admin:
         path = f"transaction/{tid}/find_coordinator"
         return self._request('get', path, node=node).json()
 
+    def get_tx_registry_state(self, node=None):
+        """
+        Get tx_registry state
+        """
+        path = f"tx_registry"
+        return self._request('get', path, node=node).json()
+
     def set_partition_replicas(self,
                                topic,
                                partition,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -679,6 +679,31 @@ class Admin:
         path = f"tx_registry"
         return self._request('get', path, node=node).json()
 
+    def start_tx_draining(self,
+                          tm_partition,
+                          repartitioning_id,
+                          tx_ids,
+                          tx_ranges,
+                          node=None):
+        """
+        Mark tx ids and ranges as draining
+        """
+        path = f"transactions/draining_transactions?tm_partition={tm_partition}"
+        json = dict(repartitioning_id=repartitioning_id,
+                    transactional_ids=tx_ids,
+                    hash_ranges=[{
+                        "from": range[0],
+                        "to": range[1]
+                    } for range in tx_ranges])
+        return self._request('post', path, json=json, node=node)
+
+    def get_draining_transactions(self, tm_partition, node=None):
+        """
+        Get draining transaction for tm_partition
+        """
+        path = f"transactions/draining_transactions?tm_partition={tm_partition}"
+        return self._request('get', path, node=node).json()
+
     def set_partition_replicas(self,
                                topic,
                                partition,


### PR DESCRIPTION
This is a take over of the Roman's PR: https://github.com/redpanda-data/redpanda/pull/10465

----------------

This PR depends on https://github.com/redpanda-data/redpanda/pull/11021, please skip reviewing the commits prior to "txn: tm_stm add draining transactions support"

----------------

Fixes https://github.com/redpanda-data/redpanda/issues/9880

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none