### PR TITLE
[v23.2.x] Do not compare fsid when checking if reports are equal

### DIFF
--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -60,7 +60,22 @@ void check_reports_the_same(
           lr.topics.cend(),
           rr.topics.cbegin(),
           rr.topics.cend()));
-        BOOST_TEST_REQUIRE(lr.local_state.disks() == rr.local_state.disks());
+        BOOST_TEST_REQUIRE(
+          lr.local_state.disks().size() == rr.local_state.disks().size());
+        for (auto i = 0; i < lr.local_state.disks().size(); ++i) {
+            BOOST_REQUIRE_EQUAL(
+              lr.local_state.disks().at(i).alert,
+              rr.local_state.disks().at(i).alert);
+            BOOST_REQUIRE_EQUAL(
+              lr.local_state.disks().at(i).free,
+              rr.local_state.disks().at(i).free);
+            BOOST_REQUIRE_EQUAL(
+              lr.local_state.disks().at(i).path,
+              rr.local_state.disks().at(i).path);
+            BOOST_REQUIRE_EQUAL(
+              lr.local_state.disks().at(i).total,
+              rr.local_state.disks().at(i).total);
+        }
         BOOST_TEST_REQUIRE(
           lr.local_state.get_disk_alert() == rr.local_state.get_disk_alert());
     }

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -34,10 +34,12 @@ model::offset stm_manager::max_collectible_offset() {
 std::ostream& operator<<(std::ostream& o, const disk& d) {
     fmt::print(
       o,
-      "{{path: {}, free: {}, total: {}}}",
+      "{{path: {}, free: {}, total: {}, alert: {}, fsid: {}}}",
       d.path,
       human::bytes(d.free),
-      human::bytes(d.total));
+      human::bytes(d.total),
+      d.alert,
+      d.fsid);
     return o;
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12630
Fixes: https://github.com/redpanda-data/redpanda/issues/12651,