### PR TITLE
[DRAFT] ssx: Add deadlock detector

### DIFF
--- a/src/v/ssx/CMakeLists.txt
+++ b/src/v/ssx/CMakeLists.txt
@@ -4,6 +4,8 @@ v_cc_library(
   HDRS
     "future-util.h"
     "metrics.h"
+    "this_fiber_id.h"
+    "fiber_local.h"
   DEPS
     Seastar::seastar
   )

--- a/src/v/ssx/deadlock_detector.h
+++ b/src/v/ssx/deadlock_detector.h
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "ssx/fiber_local_storage.h"
+#include "utils/string_switch.h"
+#include "vassert.h"
+#include "vlog.h"
+
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/timed_out_error.hh>
+#include <seastar/util/log.hh>
+
+#include <map>
+#include <stdexcept>
+
+namespace ssx {
+
+inline ss::logger dd_log("deadlock-detector");
+
+class deadlock_detected : public std::runtime_error {
+public:
+    deadlock_detected()
+      : std::runtime_error("deadlock detected") {}
+    explicit deadlock_detected(const char* s)
+      : std::runtime_error(s) {}
+    explicit deadlock_detected(const std::string& s)
+      : std::runtime_error(s) {}
+};
+
+static constexpr uint32_t deadlock_detector_max_depth = 32;
+
+namespace details {
+
+class failstop_monitor {
+public:
+    void
+    report_deadlock(const seastar::sstring& lhs, const seastar::sstring& rhs) {
+        // Crash redpanda and rely on generated backtrace
+        vassert(false, "Deadlock between {} and {} detected", lhs, rhs);
+    }
+    void report_recursion(const seastar::sstring& name) {
+        // The recursion can happen if for instance we're acquiring several
+        // segments in a row.
+        vlog(dd_log.debug, "Recursion on {} detected", name);
+    }
+};
+
+/// Deadlock detector implementation.
+///
+/// \param DeadlockMonitor is an object which is used to report detected
+///        deadlocks. It should be default constructible and implement the
+///        'report' method.
+template<class DeadlockMonitor = failstop_monitor>
+class deadlock_detector {
+    enum class causality {
+        after,
+        before,
+        recursion,
+    };
+    struct transition_row {
+        std::map<seastar::sstring, causality> deps;
+    };
+
+    friend std::ostream& operator<<(std::ostream& s, causality c) {
+        switch (c) {
+        case causality::after:
+            s << "after";
+            break;
+        case causality::before:
+            s << "before";
+            break;
+        case causality::recursion:
+            s << "resursion";
+            break;
+        };
+        return s;
+    }
+
+public:
+    deadlock_detector() = default;
+
+    struct lock_vector {
+        seastar::sstring prev;
+        seastar::sstring curr;
+
+        std::tuple<causality, seastar::sstring, seastar::sstring>
+        get_tuple() const {
+            int cmp = std::strcmp(curr.c_str(), prev.c_str());
+            if (cmp > 0) {
+                return std::make_tuple(causality::after, curr, prev);
+            } else if (cmp < 0) {
+                return std::make_tuple(causality::before, prev, curr);
+            }
+            return std::make_tuple(causality::recursion, curr, curr);
+        }
+    };
+
+    /// Set size limit for the internal data structure.
+    /// The state will be reset when the limit is reached. This means
+    /// fewer detections but also lower memory reqirements.
+    void set_size_limit(size_t size) { _size_limit = size; }
+
+    void on_lock(lock_vector vec) {
+        // The locks in the tuple are sorted by name but the
+        // 'c' variable caputures causality. This is needed to make sure
+        // that two semaphores with the same name will hit the same row
+        // in the '_transitions' table no matter in which order they're
+        // acquired.
+        auto [c, x, y] = vec.get_tuple();
+        if (c == causality::recursion) {
+            _monitor.report_recursion(x);
+        }
+        auto row = _transitions.find(x);
+        if (row == _transitions.end()) {
+            // the row is empty, the sempahore with such name was never used
+            // before
+            auto [it, ok] = _transitions.insert(
+              std::make_pair(x, transition_row{}));
+            vassert(ok, "Row {} is already inserted", x);
+            row = it;
+        }
+        auto transition = row->second.deps.find(y);
+        if (transition == row->second.deps.end()) {
+            // transition was never observed before
+            auto [it, ok] = row->second.deps.insert(std::make_pair(y, c));
+            vassert(ok, "Value for {} is already inserted", y);
+            transition = it;
+            _count++;
+        }
+        if (transition->second != c) {
+            print_row(row, x, y, c);
+            _monitor.report_deadlock(x, y);
+        }
+        // Avoid growing beyond the size limit.
+        maybe_reset();
+    }
+
+    const auto& get_monitor() const { return _monitor; }
+
+    /// This method can be called to free up space to avoid hogging
+    /// too much memory. Also, when the deadlock is detected it is possible
+    /// that the transitions table contains incorrect transition that caused
+    /// deadlock and all subsequent attempts to lock in the right order will
+    /// cause the same deadlock detection. To avoid this we can clear the
+    /// table after the deadlock is detected.
+    void reset() {
+        _transitions.clear();
+        _monitor = DeadlockMonitor();
+        _count = 0;
+    }
+
+    void print_row(
+      std::map<seastar::sstring, transition_row>::const_iterator it,
+      const seastar::sstring& from,
+      const seastar::sstring& to,
+      causality dir) const {
+        vlog(
+          dd_log.info,
+          "Trying to acquire {} {} {}, acquisition history for {}",
+          from,
+          dir,
+          to,
+          from);
+        const transition_row& row = it->second;
+        for (const auto& d : row.deps) {
+            vlog(dd_log.info, "-- Acquired {} {} {}", from, d.second, d.first);
+        }
+    }
+
+private:
+    void maybe_reset() {
+        if (_size_limit > 0 && _count > _size_limit) {
+            reset();
+        }
+    }
+    std::map<seastar::sstring, transition_row> _transitions;
+    DeadlockMonitor _monitor;
+    size_t _count{0};
+    /// Limits thte size of the transitions map, 0 means no limit
+    size_t _size_limit{0};
+};
+
+template<class Monitor>
+class deadlock_detector_waiter_state {
+public:
+    explicit deadlock_detector_waiter_state(seastar::sstring name)
+      : _name(std::move(name))
+      , _fiber_state(std::ref(*this)) {
+        on_lock();
+    }
+    ~deadlock_detector_waiter_state() = default;
+    deadlock_detector_waiter_state(deadlock_detector_waiter_state&&) noexcept
+      = default;
+    deadlock_detector_waiter_state&
+    operator=(deadlock_detector_waiter_state&&) noexcept
+      = default;
+
+    deadlock_detector_waiter_state(const deadlock_detector_waiter_state&)
+      = delete;
+    deadlock_detector_waiter_state&
+    operator=(const deadlock_detector_waiter_state&)
+      = delete;
+
+    const auto& get_monitor() const { return _detector.get_monitor(); }
+
+    static deadlock_detector<Monitor>& get_deadlock_detector() {
+        return _detector;
+    }
+
+    static void set_size_limit(size_t size) { _detector.set_size_limit(size); }
+
+private:
+    void on_lock() const {
+        for (const auto& ref : _fiber_state) {
+            if (&ref.get().get() == this) {
+                continue;
+            }
+            typename deadlock_detector<Monitor>::lock_vector vec{
+              .prev = ref.get().get()._name,
+              .curr = _name,
+            };
+            _detector.on_lock(vec);
+        }
+    }
+
+    using fls_t = fiber_local<
+      struct deadlock_detector_waiter_state_tag,
+      std::reference_wrapper<deadlock_detector_waiter_state<Monitor>>>;
+
+    seastar::sstring _name;
+    fls_t _fiber_state;
+    static thread_local deadlock_detector<Monitor> _detector;
+};
+
+template<class Monitor>
+thread_local deadlock_detector<Monitor>
+  deadlock_detector_waiter_state<Monitor>::_detector;
+
+} // namespace details
+
+} // namespace ssx

--- a/src/v/ssx/fiber_local_storage.h
+++ b/src/v/ssx/fiber_local_storage.h
@@ -7,6 +7,7 @@
 
 #include <boost/iterator/filter_iterator.hpp>
 
+namespace ssx {
 namespace internal {
 
 template<class Tag, class ValueT>
@@ -39,6 +40,7 @@ public:
         _id = other._id;
         _value = std::move(other._value);
         _hook.swap_nodes(other._hook);
+        return *this;
     }
 
     static fiber_local_impl<Tag, ValueT>* get_fiber_local() {
@@ -95,8 +97,6 @@ thread_local typename fiber_local_impl<Tag, ValueT>::intr_list_t
   = intr_list_t();
 
 } // namespace internal
-
-namespace ssx {
 
 /// Fiber local storage instance.
 ///

--- a/src/v/ssx/fiber_local_storage.h
+++ b/src/v/ssx/fiber_local_storage.h
@@ -1,0 +1,206 @@
+#include "seastarx.h"
+#include "ssx/this_fiber_id.h"
+#include "utils/intrusive_list_helpers.h"
+#include "vassert.h"
+
+#include <seastar/core/future.hh>
+
+#include <boost/iterator/filter_iterator.hpp>
+
+namespace internal {
+
+template<class Tag, class ValueT>
+class fiber_local_impl {
+public:
+    ~fiber_local_impl() = default;
+
+    explicit fiber_local_impl(ValueT&& value)
+      : _id(ssx::this_fiber_id())
+      , _value(std::move(value)) {
+        _fifo.push_front(std::ref(*this));
+    }
+
+    fiber_local_impl()
+      : _id(ssx::this_fiber_id())
+      , _value() {
+        _fifo.push_front(std::ref(*this));
+    }
+
+    fiber_local_impl(const fiber_local_impl&) = delete;
+    fiber_local_impl& operator=(const fiber_local_impl&) = delete;
+
+    fiber_local_impl(fiber_local_impl&& other) noexcept
+      : _id(other._id)
+      , _value(std::move(other._value)) {
+        _hook.swap_nodes(other._hook);
+    }
+
+    fiber_local_impl& operator=(fiber_local_impl&& other) noexcept {
+        _id = other._id;
+        _value = std::move(other._value);
+        _hook.swap_nodes(other._hook);
+    }
+
+    static fiber_local_impl<Tag, ValueT>* get_fiber_local() {
+        auto id = ssx::this_fiber_id();
+        auto it = std::find_if(
+          _fifo.begin(),
+          _fifo.end(),
+          [id](const fiber_local_impl<Tag, ValueT>& it) {
+              if (it._id == id) {
+                  return true;
+              }
+              return false;
+          });
+        return it == _fifo.end() ? nullptr : &(*it);
+    }
+
+    template<class T>
+    void set(T&& val) noexcept {
+        _value = std::forward<T>(val);
+    }
+
+    const ValueT& get() const noexcept { return _value; }
+
+    static bool is_current_fiber(const fiber_local_impl<Tag, ValueT>& fls) {
+        auto id = ssx::this_fiber_id();
+        return fls._id == id;
+    }
+
+    auto begin() const {
+        return boost::make_filter_iterator(
+          &is_current_fiber, _fifo.begin(), _fifo.end());
+    }
+
+    auto end() const {
+        return boost::make_filter_iterator(
+          &is_current_fiber, _fifo.end(), _fifo.end());
+    }
+
+private:
+    uint64_t _id;
+    intrusive_list_hook _hook;
+    ValueT _value;
+
+    using intr_list_t
+      = intrusive_list<fiber_local_impl, &fiber_local_impl::_hook>;
+
+    /// Thread local storage for the fiber
+    static thread_local intr_list_t _fifo;
+};
+
+template<class Tag, class ValueT>
+thread_local typename fiber_local_impl<Tag, ValueT>::intr_list_t
+  fiber_local_impl<Tag, ValueT>::_fifo
+  = intr_list_t();
+
+} // namespace internal
+
+namespace ssx {
+
+/// Fiber local storage instance.
+///
+/// This is a container type that can hold object of any
+/// type which becomes available for any code that runs in
+/// the same fiber.
+/// Any fiber_local object with the same tag type will have the same content.
+/// Even if the fiber_local object is recreated the data that it holds will
+/// still be available.
+///
+/// When the fiber_local instance gets destroyed its data is destroyed as well
+/// and no longer available.
+template<class Tag, class ValueT>
+class fiber_local : private internal::fiber_local_impl<Tag, ValueT> {
+public:
+    using base = internal::fiber_local_impl<Tag, ValueT>;
+
+    fiber_local() = default;
+    fiber_local(const fiber_local&) = delete;
+    fiber_local& operator=(const fiber_local&) = delete;
+    fiber_local(fiber_local&&) noexcept = default;
+    fiber_local& operator=(fiber_local&&) noexcept = default;
+    ~fiber_local() = default;
+
+    explicit fiber_local(ValueT&& v)
+      : base(std::move(v)) {}
+
+    /// Get top level FLS value
+    using base::get;
+    /// Update top level FLS value
+    using base::set;
+    /// Enumerate all FLS instances that belong to the current fiber
+    using base::begin;
+    using base::end;
+};
+
+/// Selector for the fiber local storage
+///
+/// The object of this type can be used to fetch data from fiber_local instance.
+/// The fiber_local instance need to be created on the stack of the fiber before
+/// any of the methods of the fiber_local_selector are used.
+///
+/// \code
+/// struct my_tag_type_t;
+/// ss::future<int> async_op() {
+///     fiber_local<my_tag_type_t, int> fiber(1);
+///     return another_async_op().then([] {
+///         fiber_local_selector<my_tag_type_t, int> selector;
+///         return ss::make_ready_future<int>(selector.get());
+///     });
+/// }
+/// \endcode
+template<class Tag, class ValueT>
+class fiber_local_selector {
+    using impl_t = internal::fiber_local_impl<Tag, ValueT>;
+
+    // Try to grab fiber_local instance from TLS.
+    // Terminate on failure.
+    impl_t* get_local_storage() const {
+        auto ptr = impl_t::get_fiber_local();
+        vassert(ptr, "fiber_local doesn't exist for the current fiber");
+        return ptr;
+    }
+    // Try to grab fiber_local instance from TLS.
+    impl_t* maybe_get_local_storage() const {
+        return impl_t::get_fiber_local();
+    }
+
+public:
+    ValueT get() const {
+        auto fls = get_local_storage();
+        return fls->get();
+    }
+
+    std::optional<ValueT> try_get() const {
+        auto fls = maybe_get_local_storage();
+        if (fls) {
+            return fls->get();
+        }
+        return std::nullopt;
+    }
+
+    ValueT operator*() const { return get(); }
+
+    bool has_value() const {
+        auto fls = maybe_get_local_storage();
+        return fls != nullptr;
+    }
+
+    template<class T>
+    void set(T&& value) const {
+        auto fls = get_local_storage();
+        fls->template set<ValueT>(std::forward<T>(value));
+    }
+
+    template<class T>
+    bool try_set(T&& value) const {
+        auto fls = maybe_get_local_storage();
+        if (fls) {
+            fls->template set<ValueT>(std::forward<T>(value));
+            return true;
+        }
+        return false;
+    }
+};
+
+} // namespace ssx

--- a/src/v/ssx/semaphore.h
+++ b/src/v/ssx/semaphore.h
@@ -11,10 +11,15 @@
 
 #pragma once
 
+#include "ssx/deadlock_detector.h"
+
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/timer.hh>
 
 #include <utility>
+
+#define ENABLE_DEADLOCK_DETECTOR
 
 namespace ssx {
 
@@ -28,13 +33,157 @@ class named_semaphore
       basic_semaphore<seastar::named_semaphore_exception_factory, Clock> {
 public:
     named_semaphore(size_t count, seastar::sstring name)
+#ifndef ENABLE_DEADLOCK_DETECTOR
       : seastar::
         basic_semaphore<seastar::named_semaphore_exception_factory, Clock>(
-          count, seastar::named_semaphore_exception_factory{std::move(name)}) {}
+          count, seastar::named_semaphore_exception_factory{std::move(name)})
+#else
+      // We need to keep additional state to enable deadlock detector
+      : seastar::
+        basic_semaphore<seastar::named_semaphore_exception_factory, Clock>(
+          count, seastar::named_semaphore_exception_factory{name})
+      , _name(name)
+#endif
+    {
+    }
+
+#ifdef ENABLE_DEADLOCK_DETECTOR
+    const seastar::sstring& get_name() const noexcept { return _name; }
+
+private:
+    seastar::sstring _name;
+#endif
 };
 
 using semaphore = named_semaphore<>;
 
+template<
+  typename Clock = typename seastar::timer<>::clock,
+  typename Monitor = ssx::details::failstop_monitor>
+class dd_semaphore_units
+  : public seastar::semaphore_units<
+      seastar::named_semaphore_exception_factory> {
+public:
+    dd_semaphore_units() noexcept = default;
+
+    dd_semaphore_units(semaphore& sem, size_t n) noexcept
+      : seastar::semaphore_units<seastar::named_semaphore_exception_factory>(
+        sem, n) {}
+
+    dd_semaphore_units(
+      semaphore& sem,
+      size_t n,
+      details::deadlock_detector_waiter_state<Monitor> state) noexcept
+      : seastar::semaphore_units<seastar::named_semaphore_exception_factory>(
+        sem, n)
+      , _waiter(std::move(state)) {}
+
+    dd_semaphore_units(dd_semaphore_units&& o) noexcept = default;
+
+    dd_semaphore_units& operator=(dd_semaphore_units&& o) noexcept = default;
+
+    dd_semaphore_units(const semaphore_units&) = delete;
+
+    ~dd_semaphore_units() noexcept = default;
+
+private:
+    using waiter_state = details::deadlock_detector_waiter_state<Monitor>;
+    std::optional<waiter_state> _waiter;
+};
+
+#ifndef ENABLE_DEADLOCK_DETECTOR
+
 using semaphore_units = seastar::semaphore_units<semaphore::exception_factory>;
 
+#else
+
+using semaphore_units = dd_semaphore_units<>;
+using dd_waiter_state
+  = details::deadlock_detector_waiter_state<details::failstop_monitor>;
+
+#endif
+
 } // namespace ssx
+
+namespace seastar {
+#ifdef ENABLE_DEADLOCK_DETECTOR
+
+template<
+  typename Clock = typename timer<>::clock,
+  typename Monitor = ssx::details::failstop_monitor>
+future<ssx::dd_semaphore_units<Clock>>
+get_units(ssx::named_semaphore<Clock>& sem, size_t units) noexcept {
+    ssx::dd_waiter_state state(sem.get_name());
+    return sem.wait(units).then([&sem, units, s = std::move(state)]() mutable {
+        return ssx::dd_semaphore_units<Clock>{sem, units, std::move(s)};
+    });
+}
+
+template<
+  typename Clock = typename timer<>::clock,
+  typename Monitor = ssx::details::failstop_monitor>
+future<ssx::dd_semaphore_units<Clock, Monitor>> get_units(
+  ssx::named_semaphore<Clock>& sem,
+  size_t units,
+  typename ssx::named_semaphore<Clock>::time_point timeout) noexcept {
+    ssx::dd_waiter_state state(sem.get_name());
+    return sem.wait(timeout, units)
+      .then([&sem, units, s = std::move(state)]() mutable {
+          return ssx::dd_semaphore_units<Clock, Monitor>{
+            sem, units, std::move(s)};
+      });
+}
+
+template<
+  typename Clock = typename timer<>::clock,
+  typename Monitor = ssx::details::failstop_monitor>
+future<ssx::dd_semaphore_units<Clock, Monitor>> get_units(
+  ssx::named_semaphore<Clock>& sem,
+  size_t units,
+  typename ssx::named_semaphore<Clock>::duration timeout) noexcept {
+    ssx::dd_waiter_state state(sem.get_name());
+    return sem.wait(timeout, units)
+      .then([&sem, units, s = std::move(state)]() mutable {
+          return ssx::dd_semaphore_units<Clock, Monitor>{
+            sem, units, std::move(s)};
+      });
+}
+
+template<
+  typename Clock = typename timer<>::clock,
+  typename Monitor = ssx::details::failstop_monitor>
+future<ssx::dd_semaphore_units<Clock, Monitor>> get_units(
+  ssx::named_semaphore<Clock>& sem, size_t units, abort_source& as) noexcept {
+    ssx::dd_waiter_state state(sem.get_name());
+    return sem.wait(as, units).then(
+      [&sem, units, s = std::move(state)]() mutable {
+          return ssx::dd_semaphore_units<Clock, Monitor>{
+            sem, units, std::move(s)};
+      });
+}
+
+template<
+  typename Clock = typename timer<>::clock,
+  typename Monitor = ssx::details::failstop_monitor>
+std::optional<ssx::dd_semaphore_units<Clock, Monitor>>
+try_get_units(ssx::named_semaphore<Clock>& sem, size_t units) noexcept {
+    // deadlock-detector state is not created because this op can't deadlock
+    if (!sem.try_wait(units)) {
+        return std::nullopt;
+    }
+    return std::make_optional<ssx::dd_semaphore_units<Clock, Monitor>>(
+      sem, units);
+}
+
+template<
+  typename Clock = typename timer<>::clock,
+  typename Monitor = ssx::details::failstop_monitor>
+ssx::dd_semaphore_units<Clock, Monitor>
+consume_units(ssx::named_semaphore<Clock>& sem, size_t units) noexcept {
+    // deadlock-detector state is not created because this op can't deadlock
+    sem.consume(units);
+    return ssx::dd_semaphore_units<Clock>{sem, units};
+}
+
+#endif
+} // namespace seastar

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ rp_test(
     task_local_ptr_test.cc
     this_fiber_id_test.cc
     fiber_local_test.cc
+    deadlock_detector_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::ssx
   LABELS ssx

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ rp_test(
     sleep_abortable_test.cc
     task_local_ptr_test.cc
     this_fiber_id_test.cc
+    fiber_local_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::ssx
   LABELS ssx
@@ -21,6 +22,7 @@ rp_test(
     sformat_bench.cc
     thread_worker_bench.cc
     this_fiber_id_bench.cc
+    fiber_local_bench.cc
   LIBRARIES Seastar::seastar_perf_testing v::ssx
   LABELS ssx
 )

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ rp_test(
     thread_worker.cc
     sleep_abortable_test.cc
     task_local_ptr_test.cc
+    this_fiber_id_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::ssx
   LABELS ssx
@@ -19,6 +20,7 @@ rp_test(
   SOURCES
     sformat_bench.cc
     thread_worker_bench.cc
+    this_fiber_id_bench.cc
   LIBRARIES Seastar::seastar_perf_testing v::ssx
   LABELS ssx
 )

--- a/src/v/ssx/tests/deadlock_detector_test.cc
+++ b/src/v/ssx/tests/deadlock_detector_test.cc
@@ -1,0 +1,195 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "seastarx.h"
+#include "ssx/deadlock_detector.h"
+
+#include <seastar/core/future-util.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <stdexcept>
+
+class tracking_monitor {
+public:
+    void
+    report_deadlock(const seastar::sstring& lhs, const seastar::sstring& rhs) {
+        last_lhs = lhs;
+        last_rhs = rhs;
+        count++;
+    }
+    void report_recursion(const seastar::sstring& lhs) {
+        last_lhs = lhs;
+        count++;
+    }
+    int count{0};
+    ss::sstring last_lhs;
+    ss::sstring last_rhs;
+};
+
+SEASTAR_THREAD_TEST_CASE(deadlock_detector_good) {
+    using namespace ssx::details;
+    deadlock_detector<> detector;
+
+    ss::sstring curr("current");
+    ss::sstring prev("previous");
+
+    deadlock_detector<>::lock_vector vec{
+      .prev = std::ref(prev),
+      .curr = std::ref(curr),
+    };
+    detector.on_lock(vec);
+    detector.on_lock(vec);
+}
+
+SEASTAR_THREAD_TEST_CASE(deadlock_detector_fail) {
+    using namespace ssx::details;
+    deadlock_detector<tracking_monitor> detector;
+
+    ss::sstring curr("current");
+    ss::sstring prev("previous");
+
+    deadlock_detector<tracking_monitor>::lock_vector vec{
+      .prev = std::ref(prev),
+      .curr = std::ref(curr),
+    };
+    deadlock_detector<tracking_monitor>::lock_vector inv{
+      .prev = std::ref(curr),
+      .curr = std::ref(prev),
+    };
+    detector.on_lock(vec);
+    BOOST_REQUIRE(detector.get_monitor().count == 0);
+    detector.on_lock(inv);
+    BOOST_REQUIRE(detector.get_monitor().count == 1);
+}
+
+namespace {
+void reset() {
+    using namespace ssx::details;
+    deadlock_detector_waiter_state<tracking_monitor> accessor("accessor");
+    accessor.get_deadlock_detector().reset();
+}
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(deadlock_detector_waiter_state_good) {
+    using namespace ssx::details;
+    reset();
+
+    ss::sstring curr("current");
+    ss::sstring prev("previous");
+
+    {
+        deadlock_detector_waiter_state<tracking_monitor> st1(prev);
+        deadlock_detector_waiter_state<tracking_monitor> st2(curr);
+
+        BOOST_REQUIRE_EQUAL(st1.get_monitor().count, 0);
+    }
+
+    {
+        deadlock_detector_waiter_state<tracking_monitor> st1(prev);
+        deadlock_detector_waiter_state<tracking_monitor> st2(curr);
+
+        BOOST_REQUIRE_EQUAL(st1.get_monitor().count, 0);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(deadlock_detector_waiter_state_deadlock) {
+    using namespace ssx::details;
+    reset();
+
+    ss::sstring curr("current");
+    ss::sstring prev("previous");
+
+    {
+        deadlock_detector_waiter_state<tracking_monitor> st1(prev);
+        deadlock_detector_waiter_state<tracking_monitor> st2(curr);
+
+        BOOST_REQUIRE_EQUAL(st1.get_monitor().count, 0);
+    }
+
+    {
+        deadlock_detector_waiter_state<tracking_monitor> st1(curr);
+        deadlock_detector_waiter_state<tracking_monitor> st2(prev);
+
+        BOOST_REQUIRE_EQUAL(st1.get_monitor().count, 1);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(deadlock_detector_waiter_state_async_good) {
+    using namespace ssx::details;
+    reset();
+
+    ss::sstring curr("current");
+    ss::sstring prev("previous");
+
+    auto fut1 = ss::yield().then([&] {
+        deadlock_detector_waiter_state<tracking_monitor> st1(prev);
+        deadlock_detector_waiter_state<tracking_monitor> st2(curr);
+    });
+
+    auto fut2 = ss::yield().then([&] {
+        deadlock_detector_waiter_state<tracking_monitor> st1(prev);
+        deadlock_detector_waiter_state<tracking_monitor> st2(curr);
+    });
+
+    ss::when_all_succeed(std::move(fut1), std::move(fut2)).get();
+
+    deadlock_detector_waiter_state<tracking_monitor> st(curr);
+    BOOST_REQUIRE_EQUAL(st.get_monitor().count, 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(deadlock_detector_waiter_state_async_deadlock) {
+    using namespace ssx::details;
+    reset();
+
+    ss::sstring curr("current");
+    ss::sstring prev("previous");
+
+    auto fut1 = ss::yield().then([&] {
+        deadlock_detector_waiter_state<tracking_monitor> st1(prev);
+        deadlock_detector_waiter_state<tracking_monitor> st2(curr);
+    });
+
+    auto fut2 = ss::yield().then([&] {
+        deadlock_detector_waiter_state<tracking_monitor> st1(curr);
+        deadlock_detector_waiter_state<tracking_monitor> st2(prev);
+    });
+
+    ss::when_all_succeed(std::move(fut1), std::move(fut2)).get();
+
+    deadlock_detector_waiter_state<tracking_monitor> st(curr);
+    BOOST_REQUIRE_EQUAL(st.get_monitor().count, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(deadlock_detector_waiter_state_sharded) {
+    // Check that different shards do not interact with each other
+    using namespace ssx::details;
+    reset();
+
+    ss::sstring curr("current");
+    ss::sstring prev("previous");
+
+    auto fut1 = ss::smp::submit_to(0, [=] {
+        deadlock_detector_waiter_state<tracking_monitor> st1(prev);
+        deadlock_detector_waiter_state<tracking_monitor> st2(curr);
+        BOOST_REQUIRE_EQUAL(st2.get_monitor().count, 0);
+    });
+
+    auto fut2 = ss::smp::submit_to(1, [&] {
+        deadlock_detector_waiter_state<tracking_monitor> st1(curr);
+        deadlock_detector_waiter_state<tracking_monitor> st2(prev);
+        BOOST_REQUIRE_EQUAL(st2.get_monitor().count, 0);
+    });
+
+    ss::when_all_succeed(std::move(fut1), std::move(fut2)).get();
+}

--- a/src/v/ssx/tests/fiber_local_bench.cc
+++ b/src/v/ssx/tests/fiber_local_bench.cc
@@ -1,0 +1,70 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/fiber_local_storage.h"
+
+#include <seastar/core/future-util.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/testing/perf_tests.hh>
+
+PERF_TEST(fiber_local, test_fiber_local_x100) {
+    return ss::async([] {
+        ssx::fiber_local<struct tag_type_t, int> fl(42);
+        auto id
+          = ss::yield()
+              .then([] {
+                  return ss::yield().then([] {
+                      return ss::yield().then([] {
+                          ssx::fiber_local_selector<struct tag_type_t, int>
+                            selector;
+                          int x = 0;
+                          perf_tests::start_measuring_time();
+                          for (int i = 0; i < 100; i++) {
+                              x += selector.get();
+                          }
+                          perf_tests::stop_measuring_time();
+                          return ss::make_ready_future<int>(x);
+                      });
+                  });
+              })
+              .get();
+        perf_tests::do_not_optimize(id);
+    });
+}
+
+PERF_TEST(fiber_local, test_fiber_local_slow_x100) {
+    return ss::async([] {
+        // actual fiber_local used by test
+        ssx::fiber_local<struct tag_type_t, int> fl(42);
+        // a bunch of dummy fiber_local instancess to make life harder
+        ssx::fiber_local<struct tag_type_t, int> dummy[1000];
+
+        auto id
+          = ss::yield()
+              .then([] {
+                  return ss::yield().then([] {
+                      return ss::yield().then([] {
+                          ssx::fiber_local_selector<struct tag_type_t, int>
+                            selector;
+                          int x = 0;
+                          perf_tests::start_measuring_time();
+                          for (int i = 0; i < 100; i++) {
+                              x += selector.get();
+                          }
+                          perf_tests::stop_measuring_time();
+                          return ss::make_ready_future<int>(x);
+                      });
+                  });
+              })
+              .get();
+        perf_tests::do_not_optimize(id);
+        perf_tests::do_not_optimize(dummy);
+    });
+}

--- a/src/v/ssx/tests/fiber_local_test.cc
+++ b/src/v/ssx/tests/fiber_local_test.cc
@@ -1,0 +1,117 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "seastarx.h"
+#include "ssx/fiber_local_storage.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <stdexcept>
+
+SEASTAR_THREAD_TEST_CASE(test_fiber_local_iface) {
+    ssx::fiber_local<struct _test_tag_1, int> fls;
+    fls.set(42);
+    auto res = fls.get();
+    BOOST_REQUIRE_EQUAL(res, 42);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fiber_local_nested) {
+    ssx::fiber_local<struct _test_tag_4, int> fls(42);
+    ss::yield()
+      .then([] {
+          ssx::fiber_local_selector<struct _test_tag_4, int> sel;
+          auto res = sel.get();
+          BOOST_REQUIRE_EQUAL(res, 42);
+          return ss::yield().then([] {
+              ssx::fiber_local_selector<struct _test_tag_4, int> sel;
+              auto res = sel.get();
+              BOOST_REQUIRE_EQUAL(res, 42);
+          });
+      })
+      .get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fiber_local_shadowing) {
+    ssx::fiber_local<struct _test_tag_4, int> fls(42);
+    ss::yield()
+      .then([]() -> ss::future<> {
+          ssx::fiber_local_selector<struct _test_tag_4, int> sel;
+          auto res = sel.get();
+          BOOST_REQUIRE_EQUAL(res, 42);
+          co_await ss::yield();
+          res = sel.get();
+          BOOST_REQUIRE_EQUAL(res, 42);
+          {
+              // This should shadow the original fiber_local
+              ssx::fiber_local<struct _test_tag_4, int> fls(24);
+              co_await ss::yield();
+              res = sel.get();
+              BOOST_REQUIRE_EQUAL(res, 24);
+          }
+          res = sel.get();
+          BOOST_REQUIRE_EQUAL(res, 42);
+      })
+      .get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fiber_local_lifetime) {
+    ss::yield()
+      .then([] {
+          ssx::fiber_local<struct _test_tag_5, int> fls(42);
+          ssx::fiber_local_selector<struct _test_tag_5, int> sel;
+          auto res = sel.get();
+          BOOST_REQUIRE_EQUAL(res, 42);
+
+          return ss::yield().then([]() mutable {
+              ssx::fiber_local<struct _test_tag_5, int> fls(32);
+              std::vector<int> expected = {32};
+              std::vector<int> actual;
+              for (auto it = fls.begin(); it != fls.end(); it++) {
+                  actual.push_back(it->get());
+              }
+              BOOST_REQUIRE(expected == actual);
+          });
+      })
+      .get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fiber_local_iter) {
+    ss::yield()
+      .then([] {
+          ssx::fiber_local<struct _test_tag_6, int> fls(42);
+          ssx::fiber_local_selector<_test_tag_6, int> sel;
+          auto res = sel.get();
+          BOOST_REQUIRE_EQUAL(res, 42);
+
+          return ss::yield()
+            .then([]() mutable {
+                ssx::fiber_local<struct _test_tag_6, int> fls(43);
+                ssx::fiber_local_selector<struct _test_tag_6, int> sel;
+                auto res = sel.get();
+                BOOST_REQUIRE_EQUAL(res, 43);
+                return ss::yield().then([outer = std::move(fls)]() mutable {
+                    ssx::fiber_local<struct _test_tag_6, int> fls(44);
+                    std::vector<int> expected = {44, 43, 42};
+                    std::vector<int> actual;
+                    for (auto it = fls.begin(); it != fls.end(); it++) {
+                        actual.push_back(it->get());
+                    }
+                    BOOST_REQUIRE(expected == actual);
+                });
+            })
+            .finally([fls = std::move(fls)] {});
+      })
+      .get();
+}

--- a/src/v/ssx/tests/this_fiber_id_bench.cc
+++ b/src/v/ssx/tests/this_fiber_id_bench.cc
@@ -1,0 +1,71 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/this_fiber_id.h"
+
+#include <seastar/core/future-util.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/testing/perf_tests.hh>
+
+PERF_TEST(fiber_local, test_this_fiber_id_x100) {
+    return ss::yield().then([] {
+        return ss::yield().then([] {
+            return ss::yield().then([] {
+                return ss::yield().then([] {
+                    // Run actual bench
+                    uint64_t id = 0;
+                    perf_tests::start_measuring_time();
+                    // The actual operation is very fast and
+                    // measuring it separately gives big error. To get the
+                    // realistic result we need to time the sequence of 100
+                    // operations.
+                    for (int i = 0; i < 100; i++) {
+                        id += ssx::this_fiber_id();
+                    }
+                    perf_tests::stop_measuring_time();
+                    perf_tests::do_not_optimize(id);
+                    return ss::now();
+                });
+            });
+        });
+    });
+}
+
+PERF_TEST(fiber_local, test_this_fiber_id_deep_x100) {
+    return ss::yield().then([] {
+        return ss::yield().then([] {
+            return ss::yield().then([] {
+                return ss::yield().then([] {
+                    return ss::yield().then([] {
+                        return ss::yield().then([] {
+                            return ss::yield().then([] {
+                                return ss::yield().then([] {
+                                    return ss::yield().then([] {
+                                        return ss::yield().then([] {
+                                            // Run actual bench
+                                            uint64_t id = 0;
+                                            perf_tests::start_measuring_time();
+                                            for (int i = 0; i < 100; i++) {
+                                                id += ssx::this_fiber_id();
+                                            }
+                                            perf_tests::stop_measuring_time();
+                                            perf_tests::do_not_optimize(id);
+                                            return ss::now();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+}

--- a/src/v/ssx/tests/this_fiber_id_test.cc
+++ b/src/v/ssx/tests/this_fiber_id_test.cc
@@ -1,0 +1,60 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "seastarx.h"
+#include "ssx/this_fiber_id.h"
+
+#include <seastar/core/future-util.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <stdexcept>
+
+using ssx::this_fiber_id;
+
+SEASTAR_THREAD_TEST_CASE(test_fiber_id_smoke_test) {
+    auto id = this_fiber_id();
+    BOOST_REQUIRE(id != 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fiber_id_nested) {
+    auto root_id = this_fiber_id();
+    ss::yield()
+      .then([root_id] {
+          auto lvl1 = this_fiber_id();
+          BOOST_REQUIRE_EQUAL(root_id, lvl1);
+          return ss::yield().then([root_id] {
+              auto lvl2 = this_fiber_id();
+              BOOST_REQUIRE_EQUAL(root_id, lvl2);
+          });
+      })
+      .get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fiber_id_background) {
+    auto root_id = this_fiber_id();
+    ss::gate g;
+    (void)ss::with_gate(g, [root_id] {
+        // here the code runs in the same fiber
+        return ss::yield().then([root_id] {
+            // first preemption happense here
+            auto lvl1 = this_fiber_id();
+            BOOST_REQUIRE(root_id != lvl1);
+            return ss::yield().then([root_id, lvl1] {
+                auto lvl2 = this_fiber_id();
+                BOOST_REQUIRE(root_id != lvl2);
+                BOOST_REQUIRE_EQUAL(lvl1, lvl2);
+            });
+        });
+    });
+    g.close().get();
+}

--- a/src/v/ssx/this_fiber_id.h
+++ b/src/v/ssx/this_fiber_id.h
@@ -2,6 +2,7 @@
 #include "vassert.h"
 
 #include <seastar/core/reactor.hh>
+#include <seastar/core/task.hh>
 #include <seastar/core/thread.hh>
 
 namespace ssx {
@@ -12,11 +13,7 @@ namespace ssx {
 /// If one coroutine awaits another one they both will have the same fiber id.
 inline uint64_t this_fiber_id() {
     auto task = ss::engine().current_task();
-    if (task == nullptr) {
-        task = seastar::thread_impl::get()->waiting_task();
-    }
-    vassert(task != nullptr, "this_fiber_id can only be called from coroutine");
-    while (true) {
+    while (task != nullptr) {
         auto child = task->waiting_task();
         if (child == nullptr) {
             break;

--- a/src/v/ssx/this_fiber_id.h
+++ b/src/v/ssx/this_fiber_id.h
@@ -1,0 +1,32 @@
+#include "seastarx.h"
+#include "vassert.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/thread.hh>
+
+namespace ssx {
+
+/// Return unique id of the current fiber
+///
+/// Terminate will be called if the function is called outside of the coroutine.
+/// If one coroutine awaits another one they both will have the same fiber id.
+inline uint64_t this_fiber_id() {
+    auto task = ss::engine().current_task();
+    if (task == nullptr) {
+        task = seastar::thread_impl::get()->waiting_task();
+    }
+    vassert(task != nullptr, "this_fiber_id can only be called from coroutine");
+    while (true) {
+        auto child = task->waiting_task();
+        if (child == nullptr) {
+            break;
+        } else {
+            task = child;
+        }
+    }
+    uint64_t task_id = 0;
+    std::memcpy(&task_id, &task, sizeof(task_id));
+    return task_id;
+}
+
+} // namespace ssx


### PR DESCRIPTION
Implement deadlock detector for `named_semaphore` instances in `ssx`. The `mutex` is also built using the `ssx::named_semaphore` so the deadlock detection naturally extends on mutexes.

The implementation maintains an object for every acquired semaphore units instance. On every fiber these objects are organised into  a linked list that deadlock detector can traverse. On every acquire operation the deadlock detector walks this collection and checks every acquired lock against the new one. If previously, the same pair of semaphores was acquired in the opposite order it triggers an assertion. 

The algorithm uses semaphore names and not the actual semaphore instances. The implementation overrides `get_units` functions and returns `dd_sempahore_units` instance which is derived from `seastar::semaphore_units` but it also has additional state used by the deadlock detector.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* Add deadlock detector.