### PR TITLE
cloud_storage: Fix race in async_manifest_view_cursor

### DIFF
--- a/tests/rptest/tests/adjacent_segment_merging_test.py
+++ b/tests/rptest/tests/adjacent_segment_merging_test.py
@@ -68,7 +68,7 @@ class AdjacentSegmentMergingTest(RedpandaTest):
         super().tearDown()
 
     @cluster(num_nodes=3)
-    @matrix(acks=[-1, 0, 1], cloud_storage_type=get_cloud_storage_type())
+    @matrix(acks=[-1, 1], cloud_storage_type=get_cloud_storage_type())
     def test_reupload_of_local_segments(self, acks, cloud_storage_type):
         """Test adjacent segment merging using using local data.
         The test starts by uploading large number of very small segments.


### PR DESCRIPTION
The code in the seek method calls async method
'get_materialized_manifest' to get the manifest based on query (offset). Then, after a scheduling point it caches the start offset by querying the STM manifest.

The following sequence of events is possible:
- Initially, there are no spillover manifests;
- 'seek' is calling 'get_materialized_manifest(0)';
- 'get_materialized_manifest' finds STM manifest which at this point starts with offset 0 and returns it.
- Concurrently, spillover happens and the STM manifest gets truncated. The segment with offset 0 gets moved to the spillover manifest.
- The 'seek' method wakes up and caches the start offset of the manifest which is not 0 at this point.
- The client sees the partition that starts from unexpected offset.

This PR fixes this by caching the start offset before the scheduling point.

Also, fix the `adjacent_segment_merger_test.py` CI failure.

Fixes #12612 #8457

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Fix race condition in tiered-storage which could cause a transient read error (missing offset)