### PR TITLE
cluster: include a hash in the metrics reporter

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -269,6 +269,11 @@ metrics_reporter::build_metrics_snapshot() {
           0, metrics_snapshot::max_size_for_rp_env);
     }
 
+    auto license = _feature_table.local().get_license();
+    if (license.has_value()) {
+        snapshot.id_hash = license->checksum;
+    }
+
     co_return snapshot;
 }
 
@@ -522,6 +527,9 @@ void rjson_serialize(
 
     w.Key("redpanda_environment");
     w.String(snapshot.redpanda_environment);
+
+    w.Key("id_hash");
+    w.String(snapshot.id_hash);
 
     w.EndObject();
 }

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -78,6 +78,7 @@ public:
 
         static constexpr int64_t max_size_for_rp_env = 80;
         ss::sstring redpanda_environment;
+        ss::sstring id_hash;
     };
     static constexpr ss::shard_id shard = 0;
 

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -7,11 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import hashlib
 import json
 import random
 
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.utils.rpenv import sample_license
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
@@ -47,6 +49,18 @@ class MetricsReporterTest(RedpandaTest):
         """
         Test that redpanda nodes send well formed messages to the metrics endpoint
         """
+
+        # Load and put a license at start. This is to check the SHA-256 checksum
+        admin = Admin(self.redpanda)
+        license = sample_license()
+        if license is None:
+            self.logger.warn(
+                "REDPANDA_SAMPLE_LICENSE env var not found, ignoring license checks."
+            )
+
+        assert admin.put_license(
+            license).status_code == 200, "PUT License failed"
+
         total_topics = 5
         total_partitions = 0
         for _ in range(0, total_topics):
@@ -80,7 +94,6 @@ class MetricsReporterTest(RedpandaTest):
         def assert_fields_are_the_same(metadata, field):
             assert all(m[field] == metadata[0][field] for m in metadata)
 
-        admin = Admin(self.redpanda)
         features = admin.get_features()
 
         # cluster uuid and create timestamp should stay the same across requests
@@ -123,6 +136,7 @@ class MetricsReporterTest(RedpandaTest):
         wait_until(lambda: len(self.http.requests) > pre_restart_requests,
                    timeout_sec=20,
                    backoff_sec=1)
+        self.redpanda.logger.info("Checking metadata after restart")
         assert_fields_are_the_same(metadata, 'cluster_uuid')
         assert_fields_are_the_same(metadata, 'cluster_created_ts')
 
@@ -133,6 +147,11 @@ class MetricsReporterTest(RedpandaTest):
         assert "metrics_reporter_tick_interval" not in last["config"]
         assert last["config"]["log_message_timestamp_type"] == "CreateTime"
         assert last["redpanda_environment"] == "test"
+
+        raw_id_hash = hashlib.sha256(license.encode()).hexdigest()
+        last_post_restart = metadata.pop()
+        assert last_post_restart["id_hash"] == last["id_hash"]
+        assert last_post_restart["id_hash"] == raw_id_hash
 
 
 class MultiNodeMetricsReporterTest(MetricsReporterTest):


### PR DESCRIPTION
Add an identifiable string to the report: `id_hash`

Changes from force-push `44ee865`:
- Use hashlib to check the returned value from Redpanda

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none