### PR TITLE
Alert for messages with timestamp too far from broker time

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -480,6 +480,28 @@ configuration::configuration()
        .visibility = visibility::user},
       model::timestamp_type::create_time,
       {model::timestamp_type::create_time, model::timestamp_type::append_time})
+  , log_message_timestamp_alert_before_ms(
+      *this,
+      "log_message_timestamp_alert_before_ms",
+      "Threshold in milliseconds for alerting on messages with a timestamp "
+      "before the broker's time, meaning they are in the past relative to the "
+      "broker's clock. null to disable this check",
+      {.needs_restart = needs_restart::no,
+       .example = "604800000",
+       .visibility = visibility::tunable},
+      std::nullopt,
+      {.min = 5min})
+  , log_message_timestamp_alert_after_ms(
+      *this,
+      "log_message_timestamp_alert_after_ms",
+      "Threshold in milliseconds for alerting on messages with a timestamp "
+      "after the broker's time, meaning they are in the future relative to the "
+      "broker's clock.",
+      {.needs_restart = needs_restart::no,
+       .example = "3600000",
+       .visibility = visibility::tunable},
+      2h,
+      {.min = 5min})
   , log_compression_type(
       *this,
       "log_compression_type",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -123,6 +123,10 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;
     property<model::cleanup_policy_bitflags> log_cleanup_policy;
     enum_property<model::timestamp_type> log_message_timestamp_type;
+    bounded_property<std::optional<std::chrono::milliseconds>>
+      log_message_timestamp_alert_before_ms;
+    bounded_property<std::chrono::milliseconds>
+      log_message_timestamp_alert_after_ms;
     enum_property<model::compression> log_compression_type;
     property<size_t> fetch_max_bytes;
     property<bool> use_fetch_scheduler_group;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -98,6 +98,9 @@ public:
 
     latency_probe& probe() { return _conn->server().latency_probe(); }
 
+    // used to reach for server_probe::produce_bad_timestamp
+    net::server_probe& server_probe() { return _conn->server().probe(); }
+
     kafka::usage_manager& usage_mgr() const {
         return _conn->server().usage_mgr();
     }

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -108,6 +108,12 @@ void server_probe::setup_metrics(
           sm::description(ssx::sformat(
             "{}: Number of connections are blocked by connection rate", proto)))
           .aggregate(aggregate_labels),
+        sm::make_counter(
+          "produce_bad_create_time",
+          [this] { return _produce_bad_create_time; },
+          sm::description("number of produce requests with timestamps too far "
+                          "in the future or in the past"))
+          .aggregate(aggregate_labels),
       });
 }
 
@@ -144,12 +150,19 @@ std::ostream& operator<<(std::ostream& o, const server_probe& p) {
       << "connects: " << p._connects << ", "
       << "current connections: " << p._connections << ", "
       << "connection close errors: " << p._connection_close_error << ", "
+      << "connections rejected: " << p._connections_rejected << ", "
+      << "requests received: " << p._requests_received << ", "
       << "requests completed: " << p._requests_completed << ", "
+      << "service errors: " << p._service_errors << ", "
       << "received bytes: " << p._in_bytes << ", "
       << "sent bytes: " << p._out_bytes << ", "
       << "corrupted headers: " << p._corrupted_headers << ", "
       << "method not found errors: " << p._method_not_found_errors << ", "
-      << "requests blocked by memory: " << p._requests_blocked_memory << "}";
+      << "requests blocked by memory: " << p._requests_blocked_memory << ", "
+      << "declined new connections: " << p._declined_new_connections << ", "
+      << "connections wait rate: " << p._connections_wait_rate << ", "
+      << "produce bad create time: " << p._produce_bad_create_time << ", "
+      << "}";
     return o;
 }
 

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -60,6 +60,16 @@ public:
 
     void waiting_for_conection_rate() { ++_connections_wait_rate; }
 
+    // metric used to signal a produce request with a timestamp too far into the
+    // future or too far in the past see configuration
+    // log_message_timestamp_alert_after_ms and
+    // log_message_timestamp_alert_before_ms
+    void produce_bad_create_time() { _produce_bad_create_time++; }
+    // for testing
+    auto get_produce_bad_create_time() const {
+        return _produce_bad_create_time;
+    }
+
     void
     setup_metrics(ssx::metrics::metric_groups& mgs, std::string_view proto);
 
@@ -81,6 +91,7 @@ private:
     uint32_t _requests_blocked_memory = 0;
     uint32_t _declined_new_connections = 0;
     uint32_t _connections_wait_rate = 0;
+    uint32_t _produce_bad_create_time = 0;
     friend std::ostream& operator<<(std::ostream& o, const server_probe& p);
 };
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -145,6 +145,8 @@ public:
 
     std::unique_ptr<ssx::thread_worker> thread_worker;
 
+    ss::sharded<kafka::server> _kafka_server;
+
     const std::unique_ptr<pandaproxy::schema_registry::api>& schema_registry() {
         return _schema_registry;
     }
@@ -259,7 +261,6 @@ private:
     ss::sharded<rpc::rpc_server> _rpc;
     ss::sharded<admin_server> _admin;
     ss::sharded<net::conn_quota> _kafka_conn_quotas;
-    ss::sharded<kafka::server> _kafka_server;
     std::unique_ptr<pandaproxy::rest::api> _proxy;
     std::unique_ptr<pandaproxy::schema_registry::api> _schema_registry;
     ss::sharded<storage::compaction_controller> _compaction_controller;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Topics with timestamp.type=CreateTime delegates the producer to set the timestamp for each message.
a timestamp too far into the future is likely a sign of a client bug, while a timestamp into the past can be appropriate for some applications.

This pr introduced two tunable configurations, `log_message_timestamp_alert_before_ms` and `log_message_timestamp_alert_after_ms`, that define the max allowed skew before/after broker_time.

Outside these bounds, a warning is logged, and the metric `vectorized_kafka_rpc_produces_with_timestamps_out_of_bounds` is incremented to alert an observer that some producer is likely buggy.

log_message_timestamp_alert_after_ms defaults to 1 hour into the future
log_message_timestamp_alert_before_ms defaults to millis::max(), to effectively disable this check.

This pr could be backported, but a similar mechanism is already working on the retention side, logging warnings. 

Fixes #12689 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements 

- new tunable configs 
    - log_message_timestamp_alert_before_ms
    - log_message_timestamp_alert_after_ms
- new metric 
    - vectorized_kafka_rpc_produces_with_timestamps_out_of_bounds
- and warning log 
   - [ntp] timestamp too far in the (future|past). broker_time: [broker_time], timestamp: [ts]

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
