### PR TITLE
rpk: support `--format help` to print the shape(ish) of json/yaml output

### DIFF
--- a/src/go/rpk/pkg/cli/acl/user/create.go
+++ b/src/go/rpk/pkg/cli/acl/user/create.go
@@ -52,6 +52,9 @@ acl help text for more info.
 		Args: cobra.MaximumNArgs(1), // when the deprecated user flag is removed, change this to cobra.ExactArgs(1)
 		Run: func(cmd *cobra.Command, args []string) {
 			f := p.Formatter
+			if h, ok := f.Help(credentials{}); ok {
+				out.Exit(h)
+			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 

--- a/src/go/rpk/pkg/cli/acl/user/delete.go
+++ b/src/go/rpk/pkg/cli/acl/user/delete.go
@@ -32,6 +32,9 @@ delete any ACLs that may exist for this user.
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			f := p.Formatter
+			if h, ok := f.Help(credentials{}); ok {
+				out.Exit(h)
+			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 

--- a/src/go/rpk/pkg/cli/acl/user/list.go
+++ b/src/go/rpk/pkg/cli/acl/user/list.go
@@ -24,6 +24,9 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short:   "List SASL users",
 		Run: func(cmd *cobra.Command, _ []string) {
 			f := p.Formatter
+			if h, ok := f.Help([]string{}); ok {
+				out.Exit(h)
+			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 

--- a/src/go/rpk/pkg/config/format.go
+++ b/src/go/rpk/pkg/config/format.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -11,6 +13,7 @@ import (
 // OutFormatter is the output formatter for rpk.
 type OutFormatter struct {
 	Kind string
+	t    reflect.Type
 }
 
 var marshallerMap = map[string]func(any) ([]byte, error){
@@ -22,7 +25,12 @@ var marshallerMap = map[string]func(any) ([]byte, error){
 // formatted string, along with a boolean flag indicating if the 'kind' is plain
 // text (short) or wide text.
 func (f *OutFormatter) Format(data any) (isShort, isLong bool, s string, err error) { // TODO add isWide
+	if f.t != nil && reflect.TypeOf(data) != f.t {
+		return false, false, "", fmt.Errorf("--help format type %s does not match serialize type %s, please open a bug report against rpk with the command you are running", f.t, reflect.TypeOf(data))
+	}
 	switch strings.ToLower(f.Kind) {
+	case "help":
+		return false, false, "", errors.New("--help should have been handled already, please open a bug report against rpk with the command you are running")
 	case "json", "yaml":
 		marshaller := marshallerMap[f.Kind]
 		b, err := marshaller(data)
@@ -40,5 +48,130 @@ func (f *OutFormatter) Format(data any) (isShort, isLong bool, s string, err err
 }
 
 func (*OutFormatter) SupportedFormats() []string {
-	return []string{"json", "yaml", "text", "wide"}
+	return []string{"json", "yaml", "text", "wide", "help"}
+}
+
+func (f *OutFormatter) Help(t any) (string, bool) {
+	if f.Kind != "help" {
+		return "", false
+	}
+	f.t = reflect.TypeOf(t)
+	s, err := formatType(t, false)
+	if err != nil {
+		panic(err)
+	}
+	return s, true
+}
+
+func formatType(t any, includeTypeName bool) (string, error) {
+	types := make(map[reflect.Type]struct{})
+
+	sb := new(strings.Builder)
+	var walk func(reflect.Type) error
+	var nested int
+	spaces := func() string { return strings.Repeat("  ", nested) }
+	walk = func(typ reflect.Type) error {
+		switch typ.Kind() {
+		default:
+			// complex64, complex128, chan, func, interface, map, unsafepointer
+			return fmt.Errorf("unsupported type %s at %s", typ.Kind(), sb.String())
+
+		case reflect.Bool, reflect.String,
+			reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+			reflect.Float32, reflect.Float64:
+			fmt.Fprintf(sb, "%s", typ.Name()) // primitive types always need the type in the output
+			return nil
+
+		case reflect.Pointer:
+			fmt.Fprintf(sb, "*")
+			return walk(typ.Elem())
+
+		case reflect.Slice, reflect.Array:
+			fmt.Fprintf(sb, "[]")
+			return walk(typ.Elem())
+
+		case reflect.Struct:
+			// rest of this function
+		}
+
+		if includeTypeName {
+			fmt.Fprintf(sb, "%s", typ.Name())
+		}
+
+		fmt.Fprintf(sb, "{\n")
+		defer fmt.Fprintf(sb, spaces()+"}")
+
+		_, seen := types[typ]
+		if seen {
+			fmt.Fprintf(sb, spaces()+"CYCLE")
+			return nil // a cycle is fine, all types known in this cycle so far are valid
+		}
+		types[typ] = struct{}{}
+		defer delete(types, typ)
+
+		nested++
+		defer func() { nested-- }()
+		for i := 0; i < typ.NumField(); i++ {
+			sf := typ.Field(i)
+			if !sf.IsExported() {
+				continue
+			}
+			ytag := sf.Tag.Get("yaml")
+			jtag := sf.Tag.Get("json")
+			if ytag == "-" {
+				if jtag != "-" {
+					return fmt.Errorf("field %s.%s at %s has yaml:- but json:%q", typ.Name(), sf.Name, sb.String(), jtag)
+				}
+				continue
+			}
+			if ytag == "" {
+				return fmt.Errorf("field %s.%s at %s is missing a yaml tag", typ.Name(), sf.Name, sb.String())
+			}
+			if jtag == "" {
+				return fmt.Errorf("field %s.%s at %s is missing a json tag", typ.Name(), sf.Name, sb.String())
+			}
+			if jtag != ytag {
+				return fmt.Errorf("field %s.%s at %s has different json:%q and yaml:%q tags", typ.Name(), sf.Name, sb.String(), jtag, ytag)
+			}
+
+			split := strings.Split(jtag, ",")
+			name := split[0]
+			var extra string
+			if len(split) > 1 {
+				extra = "," + split[1]
+			}
+			fmt.Fprintf(sb, "%s%s: ", spaces(), name)
+			addr := sf.Type
+			typ := sf.Type
+			if addr.Kind() != reflect.Ptr {
+				addr = reflect.PointerTo(addr)
+			}
+			for typ.Kind() == reflect.Ptr {
+				typ = typ.Elem()
+			}
+
+			_, hasUnmarshalText := addr.MethodByName("UnmarshalText")
+			if hasUnmarshalText {
+				fnt, ok := addr.MethodByName("YamlTypeNameForTest")
+				if !ok {
+					return fmt.Errorf("field %s.%s at %s has UnmarshalText no YamlTypeNameForTest", typ.Name(), sf.Name, sb.String())
+				}
+				if fnt.Type.NumIn() != 1 || fnt.Type.NumOut() != 1 || fnt.Type.Out(0).Kind() != reflect.String {
+					return fmt.Errorf("field %s.%s at %s YamlTypeNameForTest: wrong signature", typ.Name(), sf.Name, sb.String())
+				}
+				name := reflect.New(typ).MethodByName("YamlTypeNameForTest").Call(nil)[0].String()
+				fmt.Fprintf(sb, "%s", name)
+			} else {
+				if err := walk(sf.Type); err != nil {
+					return err
+				}
+			}
+			fmt.Fprintf(sb, "%s\n", extra)
+		}
+		return nil
+	}
+
+	err := walk(reflect.TypeOf(t))
+	return sb.String(), err
 }

--- a/src/go/rpk/pkg/config/redpanda_yaml.go
+++ b/src/go/rpk/pkg/config/redpanda_yaml.go
@@ -123,9 +123,9 @@ type (
 	// BACKCOMPAT 23-05-01: The CA used to be "truststore_file" in yaml; we
 	// deserialize truststore_file AND ca_file. See weak.go.
 	TLS struct {
-		KeyFile        string `yaml:"key_file,omitempty" json:"key_file"`
-		CertFile       string `yaml:"cert_file,omitempty" json:"cert_file"`
-		TruststoreFile string `yaml:"ca_file,omitempty" json:"ca_file"`
+		KeyFile        string `yaml:"key_file,omitempty" json:"key_file,omitempty"`
+		CertFile       string `yaml:"cert_file,omitempty" json:"cert_file,omitempty"`
+		TruststoreFile string `yaml:"ca_file,omitempty" json:"ca_file,omitempty"`
 	}
 
 	ServerTLS struct {
@@ -174,14 +174,14 @@ type (
 	}
 
 	RpkKafkaAPI struct {
-		Brokers []string `yaml:"brokers,omitempty" json:"brokers"`
-		TLS     *TLS     `yaml:"tls,omitempty" json:"tls"`
+		Brokers []string `yaml:"brokers,omitempty" json:"brokers,omitempty"`
+		TLS     *TLS     `yaml:"tls,omitempty" json:"tls,omitempty"`
 		SASL    *SASL    `yaml:"sasl,omitempty" json:"sasl,omitempty"`
 	}
 
 	RpkAdminAPI struct {
-		Addresses []string `yaml:"addresses,omitempty" json:"addresses"`
-		TLS       *TLS     `yaml:"tls,omitempty" json:"tls"`
+		Addresses []string `yaml:"addresses,omitempty" json:"addresses,omitempty"`
+		TLS       *TLS     `yaml:"tls,omitempty" json:"tls,omitempty"`
 	}
 
 	SASL struct {

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -84,55 +84,55 @@ type (
 		// If we read a config with a newer version, we exit with a
 		// message saying "we don't know how to parse this, please
 		// upgrade rpk".
-		Version int `yaml:"version"`
+		Version int `json:"version" yaml:"version"`
 
-		Globals RpkGlobals `yaml:"globals,omitempty"`
+		Globals RpkGlobals `json:"globals,omitempty" yaml:"globals,omitempty"`
 
-		CurrentProfile   string         `yaml:"current_profile"`
-		CurrentCloudAuth string         `yaml:"current_cloud_auth"`
-		Profiles         []RpkProfile   `yaml:"profiles,omitempty"`
-		CloudAuths       []RpkCloudAuth `yaml:"cloud_auth,omitempty"`
+		CurrentProfile   string         `json:"current_profile" yaml:"current_profile"`
+		CurrentCloudAuth string         `json:"current_cloud_auth" yaml:"current_cloud_auth"`
+		Profiles         []RpkProfile   `json:"profiles,omitempty" yaml:"profiles,omitempty"`
+		CloudAuths       []RpkCloudAuth `json:"cloud_auth,omitempty" yaml:"cloud_auth,omitempty"`
 	}
 
 	RpkGlobals struct {
 		// Prompt is the prompt to use for all profiles, unless the
 		// profile itself overrides it.
-		Prompt string `yaml:"prompt"`
+		Prompt string `json:"prompt" yaml:"prompt"`
 
 		// NoDefaultCluster disables localhost:{9092,9644} as a default
 		// profile when no other is selected.
-		NoDefaultCluster bool `yaml:"no_default_cluster"`
+		NoDefaultCluster bool `json:"no_default_cluster" yaml:"no_default_cluster"`
 
 		// DialTimeout is how long we allow for initiating a connection
 		// to brokers for the Admin API and Kafka API.
-		DialTimeout Duration `yaml:"dial_timeout"`
+		DialTimeout Duration `json:"dial_timeout" yaml:"dial_timeout"`
 
 		// RequestTimeoutOverhead, for Kafka API requests, how long do
 		// we give the request on top of any request's timeout field.
-		RequestTimeoutOverhead Duration `yaml:"request_timeout_overhead"`
+		RequestTimeoutOverhead Duration `json:"request_timeout_overhead" yaml:"request_timeout_overhead"`
 
 		// RetryTimeout allows us to retry requests. If see we need to
 		// retry before the retry timeout has elapsed, we do -- even if
 		// backing off after we know to retry pushes us past the
 		// timeout.
-		RetryTimeout Duration `yaml:"retry_timeout"`
+		RetryTimeout Duration `json:"retry_timeout" yaml:"retry_timeout"`
 
 		// FetchMaxWait is how long we give the broker to respond to
 		// fetch requests.
-		FetchMaxWait Duration `yaml:"fetch_max_wait"`
+		FetchMaxWait Duration `json:"fetch_max_wait" yaml:"fetch_max_wait"`
 
 		// KafkaProtocolReqClientID is the client ID to use for the Kafka API.
-		KafkaProtocolReqClientID string `yaml:"kafka_protocol_request_client_id"`
+		KafkaProtocolReqClientID string `json:"kafka_protocol_request_client_id" yaml:"kafka_protocol_request_client_id"`
 	}
 
 	RpkProfile struct {
-		Name         string           `yaml:"name"`
-		Description  string           `yaml:"description,omitempty"`
-		Prompt       string           `yaml:"prompt,omitempty"`
-		FromCloud    bool             `yaml:"from_cloud,omitempty"`
-		CloudCluster *RpkCloudCluster `yaml:"cloud_cluster,omitempty"`
-		KafkaAPI     RpkKafkaAPI      `yaml:"kafka_api,omitempty"`
-		AdminAPI     RpkAdminAPI      `yaml:"admin_api,omitempty"`
+		Name         string           `json:"name" yaml:"name"`
+		Description  string           `json:"description,omitempty" yaml:"description,omitempty"`
+		Prompt       string           `json:"prompt,omitempty" yaml:"prompt,omitempty"`
+		FromCloud    bool             `json:"from_cloud,omitempty" yaml:"from_cloud,omitempty"`
+		CloudCluster *RpkCloudCluster `json:"cloud_cluster,omitempty" yaml:"cloud_cluster,omitempty"`
+		KafkaAPI     RpkKafkaAPI      `json:"kafka_api,omitempty" yaml:"kafka_api,omitempty"`
+		AdminAPI     RpkAdminAPI      `json:"admin_api,omitempty" yaml:"admin_api,omitempty"`
 
 		// We stash the config struct itself so that we can provide
 		// the logger / dev overrides.
@@ -140,18 +140,18 @@ type (
 	}
 
 	RpkCloudCluster struct {
-		Namespace string `yaml:"namespace"`
-		Cluster   string `yaml:"cluster"`
-		Auth      string `yaml:"auth"`
+		Namespace string `json:"namespace" yaml:"namespace"`
+		Cluster   string `json:"cluster" yaml:"cluster"`
+		Auth      string `json:"auth" yaml:"auth"`
 	}
 
 	RpkCloudAuth struct {
-		Name         string `yaml:"name"`
-		Description  string `yaml:"description,omitempty"`
-		AuthToken    string `yaml:"auth_token,omitempty"`
-		RefreshToken string `yaml:"refresh_token,omitempty"`
-		ClientID     string `yaml:"client_id,omitempty"`
-		ClientSecret string `yaml:"client_secret,omitempty"`
+		Name         string `json:"name" yaml:"name"`
+		Description  string `json:"description,omitempty" yaml:"description,omitempty"`
+		AuthToken    string `json:"auth_token,omitempty" yaml:"auth_token,omitempty"`
+		RefreshToken string `json:"refresh_token,omitempty" yaml:"refresh_token,omitempty"`
+		ClientID     string `json:"client_id,omitempty" yaml:"client_id,omitempty"`
+		ClientSecret string `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
 	}
 
 	Duration struct{ time.Duration }


### PR DESCRIPTION
Potential future improvements could include documentation on the
shape(ish) output, but simply knowing the shape can be quite beneficial.

We also will error hard (panic) if our own code uses different types for
`--format help` vs. `--format json/yaml`

Also adds support for `--format help` to the acl user commands that currently support `--format`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none