### PR TITLE
[v22.3.x] c/create_topics: improvements to create_topic workflow #12531

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -482,6 +482,11 @@ errc topics_frontend::validate_topic_configuration(
 ss::future<topic_result> topics_frontend::do_create_topic(
   custom_assignable_topic_configuration assignable_config,
   model::timeout_clock::time_point timeout) {
+    if (_topics.local().contains(assignable_config.cfg.tp_ns)) {
+        co_return topic_result(
+          assignable_config.cfg.tp_ns, errc::topic_already_exists);
+    }
+
     auto validation_err = validate_topic_configuration(assignable_config);
 
     if (validation_err != errc::success) {

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -94,14 +94,9 @@ ss::future<std::vector<topic_result>> topics_frontend::create_topics(
     vlog(clusterlog.info, "Create topics {}", topics);
     // make sure that STM is up to date (i.e. we have the most recent state
     // available) before allocating topics
-    return _stm
-      .invoke_on(
-        controller_stm_shard,
-        [timeout](controller_stm& stm) {
-            return stm.quorum_write_empty_batch(timeout);
-        })
+    return stm_linearizable_barrier(timeout)
       .then([this, topics = std::move(topics), timeout](
-              result<raft::replicate_result> result) mutable {
+              result<model::offset> result) mutable {
           if (!result) {
               return ss::make_ready_future<std::vector<topic_result>>(
                 create_topic_results(topics, errc::not_leader_controller));
@@ -189,10 +184,7 @@ ss::future<std::vector<topic_result>> topics_frontend::update_topic_properties(
     // current node is a leader, just replicate
     if (cluster_leader == _self) {
         // replicate empty batch to make sure leader local state is up to date.
-        auto result = co_await _stm.invoke_on(
-          controller_stm_shard, [timeout](controller_stm& stm) {
-              return stm.quorum_write_empty_batch(timeout);
-          });
+        auto result = co_await stm_linearizable_barrier(timeout);
         if (!result) {
             co_return create_topic_results(updates, map_errc(result.error()));
         }

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -183,7 +183,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
           .get0();
     };
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(get_next_partition_revision_id().get());
+    auto ntp = make_data();
 
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {

--- a/src/v/kafka/server/tests/list_offsets_test.cc
+++ b/src/v/kafka/server/tests/list_offsets_test.cc
@@ -29,7 +29,7 @@ FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
     // Synthetic default timestamp for produced data
     auto base_ts = model::timestamp{10000};
 
-    auto ntp = make_data(get_next_partition_revision_id().get(), base_ts);
+    auto ntp = make_data(base_ts);
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(
@@ -72,7 +72,7 @@ FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
 
 FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(get_next_partition_revision_id().get());
+    auto ntp = make_data();
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(
@@ -107,7 +107,7 @@ FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
 
 FIXTURE_TEST(list_offsets_latest, redpanda_thread_fixture) {
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(get_next_partition_revision_id().get());
+    auto ntp = make_data();
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(
@@ -146,7 +146,7 @@ FIXTURE_TEST(list_offsets_not_found, redpanda_thread_fixture) {
     auto base_ts = model::timestamp{100000};
     auto future_ts = model::timestamp{9999999};
 
-    auto ntp = make_data(get_next_partition_revision_id().get(), base_ts);
+    auto ntp = make_data(base_ts);
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -516,44 +516,86 @@ public:
         auto ntp = model::controller_ntp;
         auto shard = app.shard_table.local().shard_for(ntp);
         assert(shard);
+        // flush any in flight changes for a consistent committed_offset.
+        app.partition_manager
+          .invoke_on(
+            *shard,
+            [ntp](cluster::partition_manager& mgr) {
+                auto partition = mgr.get(ntp);
+                assert(partition);
+                return partition->linearizable_barrier();
+            })
+          .get();
         return app.partition_manager.invoke_on(
           *shard, [ntp](cluster::partition_manager& mgr) -> model::revision_id {
               auto partition = mgr.get(ntp);
               assert(partition);
-              return model::revision_id{partition->last_stable_offset()}
-                     + model::revision_id{1};
+              return model::revision_id{partition->committed_offset()}
+                     + model::offset{1};
           });
     }
 
-    model::ntp make_data(
-      model::revision_id rev,
-      std::optional<model::timestamp> base_ts = std::nullopt) {
+    model::ntp
+    make_data(std::optional<model::timestamp> base_ts = std::nullopt) {
         auto topic_name = ssx::sformat("my_topic_{}", 0);
         model::ntp ntp(
           model::kafka_namespace,
           model::topic(topic_name),
           model::partition_id(0));
 
-        storage::ntp_config ntp_cfg(
-          ntp, config::node().data_directory().as_sstring(), nullptr, rev);
+        const auto& topic_table = app.controller->get_topics_state().local();
+        model::topic_namespace tp_ns{model::kafka_namespace, ntp.tp.topic};
+        model::topic_namespace_view tp_ns_view(ntp);
+        while (true) {
+            if (topic_table.contains(tp_ns_view)) {
+                delete_topic(tp_ns).get();
+            }
 
-        storage::disk_log_builder builder(make_default_config());
-        using namespace storage; // NOLINT
+            // Here we first request a potential revision from the controller
+            // and create an ntp structure on the disk. The expectation is that
+            // when the topic is eventually created, the segments are recovered
+            // at bootstrap and we have the exact data in the structure we
+            // populated.
 
-        builder | start(std::move(ntp_cfg)) | add_segment(model::offset(0))
-          | add_random_batches(
-            model::offset(0),
-            20,
-            maybe_compress_batches::yes,
-            log_append_config{
-              .should_fsync = log_append_config::fsync::yes,
-              .io_priority = ss::default_priority_class(),
-              .timeout = model::no_timeout},
-            disk_log_builder::should_flush_after::yes,
-            base_ts)
-          | stop();
+            // This is inherently racy because there could be other controller
+            // updates between the time we request a revision and create a
+            // table. That invalidates the revision as the topic is created with
+            // a newer revision and the desired segements are not recovered from
+            // disk. This loop mitigates this problem by deleting and recreating
+            // the topic if there is a revision mismatch.
 
-        add_topic(model::topic_namespace_view(ntp)).get();
+            // Get a potential revision for ntp.
+            auto rev = get_next_partition_revision_id().get();
+
+            storage::ntp_config ntp_cfg(
+              ntp, config::node().data_directory().as_sstring(), nullptr, rev);
+
+            storage::disk_log_builder builder(make_default_config());
+            using namespace storage; // NOLINT
+
+            builder | start(std::move(ntp_cfg)) | add_segment(model::offset(0))
+              | add_random_batches(
+                model::offset(0),
+                20,
+                maybe_compress_batches::yes,
+                log_append_config{
+                  .should_fsync = log_append_config::fsync::yes,
+                  .io_priority = ss::default_priority_class(),
+                  .timeout = model::no_timeout},
+                disk_log_builder::should_flush_after::yes,
+                base_ts)
+              | stop();
+
+            add_topic(tp_ns_view).get();
+            // validate if version matches
+            const auto& topic_meta = topic_table.get_topic_metadata(tp_ns_view);
+            assert(topic_meta);
+            // Check if the topic revision matches the desired revision, if not
+            // delete and recreate the topic.
+            if (topic_meta->get_revision() == rev) {
+                break;
+            }
+        }
 
         return ntp;
     }

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -16,7 +16,7 @@ from rptest.clients.default import DefaultClient
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
-from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.producer_swarm import ProducerSwarm
 from rptest.services.redpanda import ResourceSettings, SISettings
@@ -30,6 +30,7 @@ from ducktape.utils.util import wait_until
 from ducktape.mark import matrix, parametrize
 
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.offline_log_viewer import OfflineLogViewer
 
 
 class Workload():
@@ -218,6 +219,43 @@ class CreateTopicsTest(RedpandaTest):
 
             cfgs = rpk.describe_topic_configs(topic=name)
             assert str(cfgs[p][0]) == str(property_value)
+
+    @cluster(num_nodes=3)
+    def test_no_log_bloat_when_recreating_existing_topics(self):
+        rpk = RpkTool(self.redpanda)
+        topic = "test"
+        rpk.create_topic(topic=topic)
+
+        for _ in range(0, 10):
+            try:
+                rpk.create_topic(topic=topic)
+                assert False, f"No exception receating existing topic: {topic}"
+            except RpkException as e:
+                if "TOPIC_ALREADY_EXISTS" not in e.msg:
+                    raise e
+
+        def create_topic_commands():
+            cmds = []
+            for node in self.redpanda.started_nodes():
+                log_viewer = OfflineLogViewer(self.redpanda)
+                records = log_viewer.read_controller(node=node)
+
+                def is_create_topic_cmd(r):
+                    return "type" in r.keys() and r["type"] == "topic_management_cmd" and\
+                        r["data"]["type"] == 0
+
+                create_topic_cmds = list(filter(is_create_topic_cmd, records))
+                self.redpanda.logger.debug(
+                    f"Node {node.account.hostname}, controller records: {records}"
+                )
+                cmds.append(len(create_topic_cmds) == 1)
+            return all(cmds)
+
+        self.redpanda.wait_until(
+            create_topic_commands,
+            timeout_sec=30,
+            backoff_sec=3,
+            err_msg="Timed out waiting for single create_topic command")
 
 
 class CreateSITopicsTest(RedpandaTest):


### PR DESCRIPTION
Changes the following

* Replaces empty checkpoint batch with linearizable barrier. Latter works without appending any batches to the log
* When recreating an existing topic, checks the topic table cache first before replicating to the log

Both these problems were contributing to log bloat, especially when a client tries to recreate existing topics.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
