### PR TITLE
[v23.2.x] cloud_storage: Fix race in async_manifest_view_cursor

### DIFF
--- a/tests/rptest/tests/adjacent_segment_merging_test.py
+++ b/tests/rptest/tests/adjacent_segment_merging_test.py
@@ -68,7 +68,7 @@ class AdjacentSegmentMergingTest(RedpandaTest):
         super().tearDown()
 
     @cluster(num_nodes=3)
-    @matrix(acks=[-1, 0, 1], cloud_storage_type=get_cloud_storage_type())
+    @matrix(acks=[-1, 1], cloud_storage_type=get_cloud_storage_type())
     def test_reupload_of_local_segments(self, acks, cloud_storage_type):
         """Test adjacent segment merging using using local data.
         The test starts by uploading large number of very small segments.


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12665
Fixes: https://github.com/redpanda-data/redpanda/issues/12702,