### PR TITLE
DNM: experiment with streaming chunk read

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -360,7 +360,9 @@ public:
                     if (!result) {
                         vlog(
                           _ctxlog.debug,
-                          "Error while reading from stream '{}'",
+                          "Error while reading from stream {}-{} '{}'",
+                          _reader->base_rp_offset(),
+                          _reader->config(),
                           result.error());
                         co_await set_end_of_stream();
                         throw std::system_error(result.error());

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -968,7 +968,7 @@ ss::future<> remote_segment::hydrate_chunk(
           path_to_start);
         if (eager_stream) {
             eager_stream->get().state
-              = eager_chunk_stream::state::chunk_in_cache;
+              = eager_chunk_stream::stream_state::chunk_in_cache;
             eager_stream->get().stream_available.signal();
         }
         co_return;
@@ -988,7 +988,7 @@ ss::future<> remote_segment::hydrate_chunk(
           if (
             eager_stream.has_value()
             && eager_stream->get().state
-                 == eager_chunk_stream::state::awaiting_hydration) {
+                 == eager_chunk_stream::stream_state::awaiting_hydration) {
               vlog(_ctxlog.trace, "eager stream requested for range {}", range);
               auto [disk_write_str, eager_str] = input_stream_fanout<2>(
                 std::move(stream),

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -968,7 +968,7 @@ ss::future<> remote_segment::hydrate_chunk(
           path_to_start);
         if (eager_stream) {
             eager_stream->get().state
-              = eager_chunk_stream::state::cache_hit_skip_download;
+              = eager_chunk_stream::state::chunk_in_cache;
             eager_stream->get().stream_available.signal();
         }
         co_return;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -946,7 +946,7 @@ ss::future<> remote_segment::hydrate() {
 }
 
 ss::future<> remote_segment::hydrate_chunk(
-  segment_chunk_range range, eager_stream_ref eager_stream) {
+  segment_chunk_range range, eager_stream_ptr eager_stream) {
     const auto start = range.first_offset();
     const auto path_to_start = get_path_to_chunk(start);
 
@@ -967,9 +967,9 @@ ss::future<> remote_segment::hydrate_chunk(
           "cache",
           path_to_start);
         if (eager_stream) {
-            eager_stream->get().state
+            eager_stream->state
               = eager_chunk_stream::stream_state::chunk_in_cache;
-            eager_stream->get().stream_available.signal();
+            eager_stream->stream_available.signal();
         }
         co_return;
     }
@@ -984,10 +984,10 @@ ss::future<> remote_segment::hydrate_chunk(
     auto res = co_await _api.download_segment(
       _bucket,
       _path,
-      [this, &eager_stream, &range, &consumer](auto size, auto stream) {
+      [this, eager_stream, &range, &consumer](auto size, auto stream) {
           if (
-            eager_stream.has_value()
-            && eager_stream->get().state
+            eager_stream
+            && eager_stream->state
                  == eager_chunk_stream::stream_state::awaiting_hydration) {
               vlog(_ctxlog.trace, "eager stream requested for range {}", range);
               auto [disk_write_str, eager_str] = input_stream_fanout<2>(
@@ -997,7 +997,7 @@ ss::future<> remote_segment::hydrate_chunk(
                 {{fmt::format("write_to_disk:{}-{}", _path, range),
                   fmt::format("eager_load:{}-{}", _path, range)}},
                 _path().native());
-              eager_stream->get().set_stream_and_signal(
+              eager_stream->set_stream_and_signal(
                 std::move(eager_str),
                 range.first_offset(),
                 range.last_offset().value_or(_size - 1));

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -987,7 +987,12 @@ ss::future<> remote_segment::hydrate_chunk(
           if (eager_stream.has_value()) {
               vlog(_ctxlog.trace, "eager stream requested for range {}", range);
               auto [disk_write_str, eager_str] = input_stream_fanout<2>(
-                std::move(stream), 10);
+                std::move(stream),
+                10,
+                std::nullopt,
+                {{fmt::format("write_to_disk:{}-{}", _path, range),
+                  fmt::format("eager_load:{}-{}", _path, range)}},
+                _path().native());
               eager_stream->get().set_stream_and_signal(
                 std::move(eager_str),
                 range.first_offset(),

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -395,13 +395,17 @@ public:
 
     bool is_stopped() const { return _stopped; }
 
-    bool is_transient() const { return _is_transient; }
+    bool is_data_source_transient() const { return _is_transient; }
 
-    void mark_transient(bool transient) { _is_transient = transient; }
+    void mark_data_source_transient(bool transient) {
+        _is_transient = transient;
+    }
 
 private:
     friend class single_record_consumer;
     ss::future<std::unique_ptr<storage::continuous_batch_parser>> init_parser();
+
+    ss::future<> reset_state();
 
     size_t produce(model::record_batch batch);
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -139,8 +139,8 @@ public:
     /// Hydrate a part of a segment, identified by the given range. The range
     /// can contain data for multiple contiguous chunks, in which case multiple
     /// files are written to cache.
-    ss::future<> hydrate_chunk(
-      segment_chunk_range range, eager_stream_ref eager_stream = std::nullopt);
+    ss::future<>
+    hydrate_chunk(segment_chunk_range range, eager_stream_ptr eager_stream);
 
     /// Loads the segment chunk file from cache into an open file handle. If the
     /// file is not present in cache, the returned file handle is unopened.

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -111,7 +111,9 @@ bool segment_chunks::downloads_in_progress() const {
 }
 
 ss::future<ss::file> segment_chunks::do_hydrate_and_materialize(
-  chunk_start_offset_t chunk_start, std::optional<uint16_t> prefetch_override) {
+  chunk_start_offset_t chunk_start,
+  std::optional<uint16_t> prefetch_override,
+  eager_stream_ref eager_stream) {
     gate_guard g{_gate};
     vassert(_started, "chunk API is not started");
 
@@ -124,12 +126,14 @@ ss::future<ss::file> segment_chunks::do_hydrate_and_materialize(
     const auto prefetch = prefetch_override.value_or(
       config::shard_local_cfg().cloud_storage_chunk_prefetch);
     co_await _segment.hydrate_chunk(
-      segment_chunk_range{_chunks, prefetch, chunk_start});
+      segment_chunk_range{_chunks, prefetch, chunk_start}, eager_stream);
     co_return co_await _segment.materialize_chunk(chunk_start);
 }
 
 ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
-  chunk_start_offset_t chunk_start, std::optional<uint16_t> prefetch_override) {
+  chunk_start_offset_t chunk_start,
+  std::optional<uint16_t> prefetch_override,
+  eager_stream_ref eager_stream) {
     gate_guard g{_gate};
     vassert(_started, "chunk API is not started");
 
@@ -160,9 +164,22 @@ ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
 
         // Keep retrying if materialization fails.
         bool done = false;
+
+        // If we got this far, we are the first request to download this chunk.
+        // Mark the eager stream as usable (once the hydration finishes). The
+        // path that ends up here has no other points where we yield, so the
+        // caller can now wait on the eager stream safely.
+        if (eager_stream.has_value()) {
+            vlog(
+              _ctxlog.trace,
+              "marking eager stream download start for {}",
+              chunk_start);
+            eager_stream->get().download_skipped = false;
+        }
+
         while (!done) {
             auto handle = co_await do_hydrate_and_materialize(
-              chunk_start, prefetch_override);
+              chunk_start, prefetch_override, eager_stream);
             if (handle) {
                 done = true;
                 chunk.handle = ss::make_lw_shared(std::move(handle));
@@ -484,6 +501,15 @@ segment_chunk_range::map_t::iterator segment_chunk_range::begin() {
 
 segment_chunk_range::map_t::iterator segment_chunk_range::end() {
     return _chunks.end();
+}
+
+std::ostream& operator<<(std::ostream& os, const segment_chunk_range& range) {
+    fmt::print(
+      os,
+      "segment_chunk_range{{start:{}, end:{}}}",
+      range.first_offset(),
+      range.last_offset());
+    return os;
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -174,7 +174,8 @@ ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
               _ctxlog.trace,
               "marking eager stream download start for {}",
               chunk_start);
-            eager_stream->get().download_skipped = false;
+            eager_stream->get().state
+              = eager_chunk_stream::state::awaiting_hydration;
         }
 
         while (!done) {

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -39,19 +39,40 @@ ss::future<cloud_storage::segment_chunk::handle_t> add_waiter_to_chunk(
 
 namespace cloud_storage {
 
+std::ostream&
+operator<<(std::ostream& os, eager_chunk_stream::stream_state state) {
+    switch (state) {
+    case eager_chunk_stream::stream_state::in_wait_queue:
+        fmt::print(os, "in_wait_queue");
+        return os;
+    case eager_chunk_stream::stream_state::awaiting_hydration:
+        fmt::print(os, "awaiting_hydration");
+        return os;
+    case eager_chunk_stream::stream_state::chunk_in_cache:
+        fmt::print(os, "chunk_in_cache");
+        return os;
+    case eager_chunk_stream::stream_state::download_cancelled_timeout:
+        fmt::print(os, "download_cancelled_timeout");
+        return os;
+    case eager_chunk_stream::stream_state::ready:
+        fmt::print(os, "ready");
+        return os;
+    }
+}
+
 ss::future<> eager_chunk_stream::wait_for_stream() {
     using namespace std::chrono_literals;
 
     // If the chunk load operation was put in wait queue, wait for the download
     // to finish. The eager stream cannot be loaded.
-    if (state == state::in_wait_queue) {
+    if (state == stream_state::in_wait_queue) {
         return ss::now();
     }
 
     return stream_available.wait(30s, [this] {
         // Wait for either the stream to be initialized, or if the chunk is
         // already in cache, the eager stream cannot be loaded.
-        return stream.has_value() || state == state::chunk_in_cache;
+        return stream.has_value() || state == stream_state::chunk_in_cache;
     });
 }
 
@@ -63,6 +84,7 @@ void eager_chunk_stream::set_stream_and_signal(
     stream_available.signal();
     first_offset = start;
     last_offset = end;
+    state = stream_state::ready;
 }
 
 void expiry_handler_impl(ss::promise<segment_chunk::handle_t>& pr) {
@@ -201,7 +223,7 @@ ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
               "marking eager stream download start for {}",
               chunk_start);
             eager_stream->get().state
-              = eager_chunk_stream::state::awaiting_hydration;
+              = eager_chunk_stream::stream_state::awaiting_hydration;
         }
 
         while (!done) {

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -161,7 +161,7 @@ bool segment_chunks::downloads_in_progress() const {
 ss::future<ss::file> segment_chunks::do_hydrate_and_materialize(
   chunk_start_offset_t chunk_start,
   std::optional<uint16_t> prefetch_override,
-  eager_stream_ref eager_stream) {
+  eager_stream_ptr eager_stream) {
     gate_guard g{_gate};
     vassert(_started, "chunk API is not started");
 
@@ -181,7 +181,7 @@ ss::future<ss::file> segment_chunks::do_hydrate_and_materialize(
 ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
   chunk_start_offset_t chunk_start,
   std::optional<uint16_t> prefetch_override,
-  eager_stream_ref eager_stream) {
+  eager_stream_ptr eager_stream) {
     gate_guard g{_gate};
     vassert(_started, "chunk API is not started");
 
@@ -217,12 +217,12 @@ ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
         // Mark the eager stream as usable (once the hydration finishes). The
         // path that ends up here has no other points where we yield, so the
         // caller can now wait on the eager stream safely.
-        if (eager_stream.has_value()) {
+        if (eager_stream) {
             vlog(
               _ctxlog.trace,
               "marking eager stream download start for {}",
               chunk_start);
-            eager_stream->get().state
+            eager_stream->state
               = eager_chunk_stream::stream_state::awaiting_hydration;
         }
 

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -39,6 +39,32 @@ ss::future<cloud_storage::segment_chunk::handle_t> add_waiter_to_chunk(
 
 namespace cloud_storage {
 
+ss::future<> eager_chunk_stream::wait_for_stream() {
+    using namespace std::chrono_literals;
+
+    // If the chunk load operation was put in wait queue, wait for the download
+    // to finish. The eager stream cannot be loaded.
+    if (state == state::in_wait_queue) {
+        return ss::now();
+    }
+
+    return stream_available.wait(30s, [this] {
+        // Wait for either the stream to be initialized, or if the chunk is
+        // already in cache, the eager stream cannot be loaded.
+        return stream.has_value() || state == state::chunk_in_cache;
+    });
+}
+
+void eager_chunk_stream::set_stream_and_signal(
+  ss::input_stream<char> s,
+  chunk_start_offset_t start,
+  chunk_start_offset_t end) {
+    stream = std::move(s);
+    stream_available.signal();
+    first_offset = start;
+    last_offset = end;
+}
+
 void expiry_handler_impl(ss::promise<segment_chunk::handle_t>& pr) {
     pr.set_exception(ss::timed_out_error());
 }

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -52,8 +52,7 @@ struct eager_chunk_stream {
 std::ostream&
 operator<<(std::ostream& os, eager_chunk_stream::stream_state state);
 
-using eager_stream_ref
-  = std::optional<std::reference_wrapper<eager_chunk_stream>>;
+using eager_stream_ptr = ss::lw_shared_ptr<eager_chunk_stream>;
 
 class segment_chunks {
 public:
@@ -80,7 +79,7 @@ public:
     ss::future<segment_chunk::handle_t> hydrate_chunk(
       chunk_start_offset_t chunk_start,
       std::optional<uint16_t> prefetch_override = std::nullopt,
-      eager_stream_ref eager_stream = std::nullopt);
+      eager_stream_ptr eager_stream = nullptr);
 
     // For all chunks between first and last, increment the
     // required_by_readers_in_future value by one, and increment the
@@ -113,7 +112,7 @@ private:
     ss::future<ss::file> do_hydrate_and_materialize(
       chunk_start_offset_t chunk_start,
       std::optional<uint16_t> prefetch_override = std::nullopt,
-      eager_stream_ref eager_stream = std::nullopt);
+      eager_stream_ptr eager_stream = nullptr);
 
     // Periodically closes chunk file handles for the space to be reclaimable by
     // cache eviction. The chunks are evicted when they are no longer opened for

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -45,11 +45,12 @@ struct eager_chunk_stream {
     }
 
     ss::future<> wait_for_stream() {
+        using namespace std::chrono_literals;
         if (download_skipped) {
             return ss::now();
         }
         return stream_available.wait(
-          [this] { return stream.has_value() || chunk_in_cache; });
+          30s, [this] { return stream.has_value() || chunk_in_cache; });
     }
 };
 

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -25,11 +25,12 @@ namespace cloud_storage {
 class remote_segment;
 
 struct eager_chunk_stream {
-    enum class state {
+    enum class stream_state {
         in_wait_queue,
         awaiting_hydration,
         chunk_in_cache,
         download_cancelled_timeout,
+        ready,
     };
 
     ss::condition_variable stream_available;
@@ -38,7 +39,7 @@ struct eager_chunk_stream {
     chunk_start_offset_t first_offset;
     chunk_start_offset_t last_offset;
 
-    state state{eager_chunk_stream::state::in_wait_queue};
+    stream_state state{eager_chunk_stream::stream_state::in_wait_queue};
 
     void set_stream_and_signal(
       ss::input_stream<char> s,
@@ -47,6 +48,9 @@ struct eager_chunk_stream {
 
     ss::future<> wait_for_stream();
 };
+
+std::ostream&
+operator<<(std::ostream& os, eager_chunk_stream::stream_state state);
 
 using eager_stream_ref
   = std::optional<std::reference_wrapper<eager_chunk_stream>>;

--- a/src/v/cloud_storage/segment_chunk_data_source.cc
+++ b/src/v/cloud_storage/segment_chunk_data_source.cc
@@ -122,55 +122,56 @@ ss::future<> chunk_data_source_impl::load_chunk_handle(
     }
 }
 
-ss::future<> chunk_data_source_impl::load_stream_for_chunk(
-  chunk_start_offset_t chunk_start) {
-    vlog(_ctxlog.debug, "loading stream for chunk starting at {}", chunk_start);
-
-    if (_download_task) {
-        vlog(_ctxlog.debug, "waiting for pending download: {}", _download_task);
-        co_await wait_for_download();
-    }
-
+ss::future<chunk_data_source_impl::eager_stream_loaded_t>
+chunk_data_source_impl::maybe_load_eager_stream(
+  chunk_start_offset_t chunk_start, eager_stream_ref ecs) {
     std::exception_ptr eptr;
-
-    eager_chunk_stream ecs;
     try {
-        _download_task.emplace(*this, chunk_start, ecs);
-        _download_task->start();
+        if (ecs.has_value()) {
+            _download_task.emplace(*this, chunk_start, ecs);
+            _download_task->start();
 
-        try {
-            co_await ecs.wait_for_stream();
-        } catch (const ss::condition_variable_timed_out&) {
-            // If we timed out, log and continue. The next step will wait for
-            // the chunk download to finish. If the timeout was because of an
-            // abort or shutdown, the next wait will throw. If the timeout was
-            // due to slow client acquisition, the data source will be connected
-            // to the chunk after download.
-            vlog(_ctxlog.info, "timed out while waiting for eager stream");
+            auto& stream_ref = ecs->get();
+            try {
+                co_await stream_ref.wait_for_stream();
+            } catch (const ss::condition_variable_timed_out&) {
+                vlog(_ctxlog.info, "timed out while waiting for eager stream");
+                stream_ref.state = eager_chunk_stream::stream_state::
+                  download_cancelled_timeout;
+            }
 
-            // If the timeout is due to delay in http client acquisition, we
-            // should cancel loading the eager stream, so that when eventually
-            // the client is acquired, we do not initialize the eager stream,
-            // which is not going to be used by this data source. If the eager
-            // stream is initialized and left unused, it will block the download
-            // because the fanout used to initialize the two streams depends on
-            // both streams being steadily consumed from.
-            ecs.state = eager_chunk_stream::state::download_cancelled_timeout;
-        }
-
-        if (ecs.stream.has_value()) {
-            vlog(
-              _ctxlog.trace,
-              "chunk handle load backgrounded for {}",
-              chunk_start);
+            switch (stream_ref.state) {
+            case eager_chunk_stream::stream_state::ready:
+                vassert(
+                  stream_ref.stream.has_value(),
+                  "stream state: {} but stream not loaded for {}",
+                  stream_ref.state,
+                  chunk_start);
+                vlog(
+                  _ctxlog.trace,
+                  "chunk download in background for {}",
+                  chunk_start);
+                co_return eager_stream_loaded_t::yes;
+                break;
+            case eager_chunk_stream::stream_state::awaiting_hydration:
+                vassert(
+                  false,
+                  "invalid state: awaiting_hydration for {}",
+                  chunk_start);
+                break;
+            case eager_chunk_stream::stream_state::in_wait_queue:
+            case eager_chunk_stream::stream_state::chunk_in_cache:
+            case eager_chunk_stream::stream_state::download_cancelled_timeout:
+                vlog(
+                  _ctxlog.trace,
+                  "waiting for chunk download, state: {}",
+                  stream_ref.state);
+                co_await wait_for_download();
+                co_return eager_stream_loaded_t::no;
+            }
         } else {
-            // Either we were put in queue for the chunk, or it was found in
-            // cache
-            vlog(
-              _ctxlog.trace,
-              "eager stream requested but not loaded for {}",
-              chunk_start);
-            co_await wait_for_download();
+            co_await load_chunk_handle(chunk_start);
+            co_return eager_stream_loaded_t::no;
         }
     } catch (...) {
         eptr = std::current_exception();
@@ -184,6 +185,35 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
           eptr);
         co_await maybe_close_stream();
         std::rethrow_exception(eptr);
+    }
+
+    co_return eager_stream_loaded_t::no;
+}
+
+ss::future<> chunk_data_source_impl::load_stream_for_chunk(
+  chunk_start_offset_t chunk_start) {
+    vlog(_ctxlog.debug, "loading stream for chunk starting at {}", chunk_start);
+
+    if (_download_task) {
+        vlog(_ctxlog.debug, "waiting for pending download: {}", _download_task);
+        co_await wait_for_download();
+    }
+
+    // TODO placeholder for config property
+    bool load_eager_stream{true};
+
+    eager_chunk_stream ecs;
+    eager_stream_ref stream_ref = std::nullopt;
+    if (load_eager_stream) {
+        stream_ref = ecs;
+    }
+
+    auto eager_stream_loaded = co_await maybe_load_eager_stream(
+      chunk_start, stream_ref);
+    if (
+      eager_stream_loaded == eager_stream_loaded_t::no
+      && stream_ref.has_value()) {
+        stream_ref.reset();
     }
 
     if (_current_stream) {
@@ -201,8 +231,12 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
         begin = _begin_stream_at;
     }
 
-    auto is_eager_stream_loaded = ecs.stream.has_value();
-    if (is_eager_stream_loaded) {
+    co_await set_current_stream(begin, stream_ref);
+}
+
+ss::future<> chunk_data_source_impl::set_current_stream(
+  uint64_t begin_at, eager_stream_ref ecs) {
+    if (ecs.has_value()) {
         // TODO - this should be flipped if we switch to a disk based stream, or
         // more specifically when we close a transient stream. This change would
         // then need to be communicated back up to the reader so it can be
@@ -216,22 +250,22 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
           "chunk {}, stream ends "
           "at {}",
           _current_chunk_start,
-          begin,
-          ecs.last_offset);
+          begin_at,
+          ecs->get().last_offset);
         _current_stream_t = stream_type::download;
-        _last_download_end = ecs.last_offset;
-        _current_stream = std::move(ecs.stream);
-        co_await skip_stream_to(begin);
+        _last_download_end = ecs->get().last_offset;
+        _current_stream = std::move(ecs->get().stream);
+        co_await skip_stream_to(begin_at);
     } else {
         vlog(
           _ctxlog.trace,
           "creating file stream for chunk starting at {}, begin offset in "
           "chunk {}",
           _current_chunk_start,
-          begin);
+          begin_at);
         _current_stream_t = stream_type::disk;
         _current_stream = ss::make_file_input_stream(
-          *_current_data_file, begin, _stream_options);
+          *_current_data_file, begin_at, _stream_options);
     }
 }
 

--- a/src/v/cloud_storage/segment_chunk_data_source.cc
+++ b/src/v/cloud_storage/segment_chunk_data_source.cc
@@ -153,7 +153,7 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
             // stream is initialized and left unused, it will block the download
             // because the fanout used to initialize the two streams depends on
             // both streams being steadily consumed from.
-            ecs.state = eager_chunk_stream::state::cancelled_timeout;
+            ecs.state = eager_chunk_stream::state::download_cancelled_timeout;
         }
 
         if (ecs.stream.has_value()) {

--- a/src/v/cloud_storage/segment_chunk_data_source.cc
+++ b/src/v/cloud_storage/segment_chunk_data_source.cc
@@ -128,7 +128,7 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
 
     eager_chunk_stream ecs;
     try {
-        auto handle_loaded_f = ssx::spawn_with_gate_then(
+        auto handle_loaded_f = ss::try_with_gate(
           _gate, [this, chunk_start, &ecs] {
               return load_chunk_handle(chunk_start, ecs);
           });
@@ -153,6 +153,11 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
     }
 
     if (eptr) {
+        vlog(
+          _ctxlog.warn,
+          "error during load_stream_for_chunk: {} - {}",
+          chunk_start,
+          eptr);
         co_await maybe_close_stream();
         std::rethrow_exception(eptr);
     }

--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -54,16 +54,16 @@ private:
     // offset.
     ss::future<> load_stream_for_chunk(chunk_start_offset_t chunk_start);
 
-    using eager_stream_loaded_t = ss::bool_class<struct eager_stream_loaded_>;
-    ss::future<eager_stream_loaded_t> maybe_load_eager_stream(
-      chunk_start_offset_t chunk_start, eager_stream_ref ecs);
+    ss::future<eager_stream_ptr>
+    maybe_load_eager_stream(chunk_start_offset_t chunk_start);
 
-    ss::future<> set_current_stream(uint64_t begin_at, eager_stream_ref ecs);
+    ss::future<>
+    set_current_stream(uint64_t begin_at, eager_stream_ptr ecs = nullptr);
 
     ss::future<> maybe_close_stream();
     ss::future<> load_chunk_handle(
       chunk_start_offset_t chunk_start,
-      eager_stream_ref eager_stream = std::nullopt);
+      eager_stream_ptr eager_stream = nullptr);
 
     ss::future<> skip_stream_to(uint64_t begin);
 
@@ -111,14 +111,14 @@ private:
         explicit download_task(
           chunk_data_source_impl& ds,
           chunk_start_offset_t chunk_start,
-          eager_stream_ref ecs);
+          eager_stream_ptr ecs);
         void start();
         ss::future<> finish();
 
     private:
         chunk_data_source_impl& _ds;
         chunk_start_offset_t _chunk_start;
-        eager_stream_ref _ecs;
+        eager_stream_ptr _ecs;
         std::optional<ss::future<>> _download;
     };
 

--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -88,7 +88,6 @@ private:
 
     stream_type _current_stream_t;
     chunk_start_offset_t _last_download_end;
-    bool _is_transient{false};
     std::optional<std::reference_wrapper<remote_segment_batch_reader>>
       _attached_reader;
 };

--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -19,6 +19,8 @@
 
 namespace cloud_storage {
 
+class remote_segment_batch_reader;
+
 class chunk_data_source_impl final : public ss::data_source_impl {
 public:
     chunk_data_source_impl(
@@ -28,7 +30,9 @@ public:
       kafka::offset end,
       int64_t begin_stream_at,
       ss::file_input_stream_options stream_options,
-      std::optional<uint16_t> prefetch_override = std::nullopt);
+      std::optional<uint16_t> prefetch_override = std::nullopt,
+      std::optional<std::reference_wrapper<remote_segment_batch_reader>> reader
+      = std::nullopt);
 
     chunk_data_source_impl(const chunk_data_source_impl&) = delete;
     chunk_data_source_impl& operator=(const chunk_data_source_impl&) = delete;
@@ -41,6 +45,8 @@ public:
 
     ss::future<> close() override;
 
+    bool is_transient() const;
+
 private:
     // Acquires the file handle for the given chunk, then opens a file stream
     // into it. The stream for the first chunk starts at the reader config start
@@ -49,7 +55,11 @@ private:
     ss::future<> load_stream_for_chunk(chunk_start_offset_t chunk_start);
 
     ss::future<> maybe_close_stream();
-    ss::future<> load_chunk_handle(chunk_start_offset_t chunk_start);
+    ss::future<> load_chunk_handle(
+      chunk_start_offset_t chunk_start,
+      eager_stream_ref eager_stream = std::nullopt);
+
+    ss::future<> skip_stream_to(uint64_t begin);
 
     segment_chunks& _chunks;
     remote_segment& _segment;
@@ -70,6 +80,17 @@ private:
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
     std::optional<uint16_t> _prefetch_override;
+
+    enum class stream_type {
+        disk,
+        download,
+    };
+
+    stream_type _current_stream_t;
+    chunk_start_offset_t _last_download_end;
+    bool _is_transient{false};
+    std::optional<std::reference_wrapper<remote_segment_batch_reader>>
+      _attached_reader;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -115,6 +115,14 @@ private:
         void start();
         ss::future<> finish();
 
+        ~download_task();
+
+        download_task(const download_task&) = delete;
+        download_task& operator=(const download_task&) = delete;
+
+        download_task(download_task&&) = delete;
+        download_task&& operator=(download_task&&) = delete;
+
     private:
         chunk_data_source_impl& _ds;
         chunk_start_offset_t _chunk_start;

--- a/src/v/cloud_storage/segment_chunk_data_source.h
+++ b/src/v/cloud_storage/segment_chunk_data_source.h
@@ -54,6 +54,12 @@ private:
     // offset.
     ss::future<> load_stream_for_chunk(chunk_start_offset_t chunk_start);
 
+    using eager_stream_loaded_t = ss::bool_class<struct eager_stream_loaded_>;
+    ss::future<eager_stream_loaded_t> maybe_load_eager_stream(
+      chunk_start_offset_t chunk_start, eager_stream_ref ecs);
+
+    ss::future<> set_current_stream(uint64_t begin_at, eager_stream_ref ecs);
+
     ss::future<> maybe_close_stream();
     ss::future<> load_chunk_handle(
       chunk_start_offset_t chunk_start,

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -88,6 +88,9 @@ ss::future<client::request_response_t> client::make_request(
     ss::sstring target_str(target.data(), target.size());
     prefix_logger ctxlog(http_log, ssx::sformat("[{}]", target_str));
     vlog(ctxlog.trace, "client.make_request {}", header);
+    if (header.count("Range") != 0) {
+        target_str = fmt::format("{}:{}", target_str, header.at("Range"));
+    }
 
     auto req = ss::make_shared<request_stream>(this, std::move(header));
     auto res = ss::make_shared<response_stream>(this, verb, target_str);

--- a/src/v/utils/logger.h
+++ b/src/v/utils/logger.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace fanout {
+inline ss::logger fanout_log("fanout");
+} // namespace fanout


### PR DESCRIPTION
Experiment with streaming chunk read as the chunk is being downloaded. A fanout stream is used which splits the download into two streams, one for writing to disk and one for serving the fetch request.

A spike towards https://github.com/redpanda-data/redpanda/issues/12711

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
