### PR TITLE
Run all of gtest within a seastar context

### DIFF
--- a/src/v/test_utils/gtest_main.cc
+++ b/src/v/test_utils/gtest_main.cc
@@ -10,39 +10,13 @@
  */
 #include "test_utils/test.h"
 
-namespace {
-// set by main() and consumed by seastar test runner initialization
-int g_argc;
-char** g_argv;
-
-// seastar runner is a singleton that needs to be initialized once
-std::once_flag seastar_runner_init_flag;
-
-void init_seastar_test_runner() {
-    std::call_once(seastar_runner_init_flag, [] {
-        seastar::testing::global_test_runner().start(g_argc, g_argv);
-    });
-}
-} // namespace
-
-void seastar_test::run(std::function<seastar::future<>()> task) {
-    // first test to need seastar will initialize it
-    init_seastar_test_runner();
-    seastar::testing::global_test_runner().run_sync(std::move(task));
-}
-
-void seastar_test::run_async(std::function<void()> task) {
-    run([task = std::move(task)]() mutable {
-        return seastar::async([task = std::move(task)] { task(); });
-    });
-}
-
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
-    g_argc = argc;
-    g_argv = argv;
+    seastar::testing::global_test_runner().start(argc, argv);
 
-    int ret = RUN_ALL_TESTS();
+    int ret = 0;
+    seastar::testing::global_test_runner().run_sync(
+      [&ret] { return seastar::async([&ret] { ret = RUN_ALL_TESTS(); }); });
 
     int ss_ret = seastar::testing::global_test_runner().finalize();
     if (ret) {


### PR DESCRIPTION
This means that if you have class members that connect to seastar
primatives (like ss::lw_shared_ptr) then everything needs to be
constructed on the same seastar thread otherwise assertions get
triggered.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
