### PR TITLE
[v23.1.x] storage: fix race between segment.ms and appends

### DIFF
--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "archival/ntp_archiver_service.h"
+#include "cloud_storage/remote_segment.h"
+#include "cluster/partition.h"
+#include "config/configuration.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "storage/disk_log_impl.h"
+
+namespace tests {
+
+class remote_segment_generator {
+public:
+    remote_segment_generator(
+      kafka::client::transport transport, cluster::partition& partition)
+      : _producer(std::move(transport))
+      , _partition(partition) {}
+
+    remote_segment_generator& num_segments(size_t n) {
+        _num_segs = n;
+        return *this;
+    }
+    remote_segment_generator& records_per_batch(size_t r) {
+        _records_per_batch = r;
+        return *this;
+    }
+    remote_segment_generator& batches_per_segment(size_t b) {
+        _batches_per_seg = b;
+        return *this;
+    }
+    kafka_produce_transport& producer() { return _producer; }
+
+    // Produces records, flushing and rolling the local log, and uploading
+    // according to the given parameters. Once the given segments are produced,
+    // the partition manifest is uploaded.
+    //
+    // The produced pattern "key<i>", "val<i>" for Kafka offset i.
+    // Expects to be the only one mutating the underlying partition state.
+    ss::future<int> produce() {
+        co_await _producer.start();
+        auto* log = dynamic_cast<storage::disk_log_impl*>(
+          _partition.log().get_impl());
+        auto& archiver = _partition.archiver().value().get();
+
+        size_t total_records = 0;
+        while (_partition.archival_meta_stm()->manifest().size() < _num_segs) {
+            for (size_t i = 0; i < _batches_per_seg; i++) {
+                std::vector<kv_t> records = kv_t::sequence(
+                  total_records, _records_per_batch);
+                total_records += _records_per_batch;
+                co_await _producer.produce_to_partition(
+                  _partition.ntp().tp.topic,
+                  _partition.ntp().tp.partition,
+                  std::move(records));
+            }
+            co_await log->flush();
+            co_await log->force_roll(ss::default_priority_class());
+            if (
+              config::shard_local_cfg()
+                .cloud_storage_disable_upload_loop_for_tests.value()
+              && !co_await archiver.sync_for_tests()) {
+                co_return -1;
+            }
+            if (
+              (co_await archiver.upload_next_candidates())
+                .non_compacted_upload_result.num_failed
+              > 0) {
+                co_return -1;
+            }
+        }
+        // Upload and flush the manifest to unpin the max collectable offset.
+        if (
+          config::shard_local_cfg()
+            .cloud_storage_disable_upload_loop_for_tests.value()
+          && !co_await archiver.sync_for_tests()) {
+            co_return -1;
+        }
+        auto manifest_res = co_await archiver.upload_manifest("test");
+        if (manifest_res != cloud_storage::upload_result::success) {
+            co_return -1;
+        }
+        co_await archiver.flush_manifest_clean_offset();
+        co_return total_records;
+    }
+
+private:
+    kafka_produce_transport _producer;
+    cluster::partition& _partition;
+    size_t _num_segs{1};
+    size_t _records_per_batch{1};
+    size_t _batches_per_seg{1};
+};
+
+} // namespace tests

--- a/src/v/finjector/CMakeLists.txt
+++ b/src/v/finjector/CMakeLists.txt
@@ -1,6 +1,8 @@
 v_cc_library(
   NAME finjector
-  SRCS hbadger.cc
+  SRCS
+    hbadger.cc
+    stress_fiber.cc
   DEPS
     Seastar::seastar
     absl::flat_hash_map

--- a/src/v/finjector/stress_fiber.cc
+++ b/src/v/finjector/stress_fiber.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "finjector/stress_fiber.h"
+
+#include "random/generators.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/timer.hh>
+
+class stress_payload {
+public:
+    // Starts the stress payload with the given configuration.
+    static std::unique_ptr<stress_payload> start(stress_config cfg) {
+        return std::unique_ptr<stress_payload>(new stress_payload(cfg));
+    }
+
+    // Stops any existing stress fibers.
+    ss::future<> stop();
+
+private:
+    explicit stress_payload(stress_config);
+
+    // Runs a single fiber that spins the given number of times per scheduling
+    // point, until an abort is requested.
+    ss::future<> run_count_fiber(int min_count, int max_count);
+    ss::future<> run_delay_fiber(int min_ms, int max_ms);
+
+    ss::gate _gate;
+    ss::abort_source _as;
+};
+
+stress_payload::stress_payload(stress_config cfg) {
+    if (
+      cfg.max_spins_per_scheduling_point.has_value()
+      && cfg.min_spins_per_scheduling_point.has_value()) {
+        for (size_t i = 0; i < cfg.num_fibers; i++) {
+            ssx::spawn_with_gate(_gate, [cfg, this] {
+                return run_count_fiber(
+                  *cfg.min_spins_per_scheduling_point,
+                  *cfg.max_spins_per_scheduling_point);
+            });
+        }
+    }
+    if (
+      cfg.max_ms_per_scheduling_point.has_value()
+      && cfg.min_ms_per_scheduling_point.has_value()) {
+        for (size_t i = 0; i < cfg.num_fibers; i++) {
+            ssx::spawn_with_gate(_gate, [cfg, this] {
+                return run_delay_fiber(
+                  *cfg.min_ms_per_scheduling_point,
+                  *cfg.max_ms_per_scheduling_point);
+            });
+        }
+    }
+}
+
+ss::future<> stress_payload::run_count_fiber(int min_count, int max_count) {
+    while (!_as.abort_requested()) {
+        int spins_per_scheduling_point = min_count == max_count
+                                           ? min_count
+                                           : random_generators::get_int(
+                                             min_count, max_count);
+        co_await ss::maybe_yield();
+        volatile int spins = 0;
+        while (true) {
+            if (spins == spins_per_scheduling_point) {
+                break;
+            }
+            spins = spins + 1;
+        }
+    }
+}
+
+ss::future<> stress_payload::run_delay_fiber(int min_ms, int max_ms) {
+    while (!_as.abort_requested()) {
+        int ms_per_scheduling_point = min_ms == max_ms
+                                        ? min_ms
+                                        : random_generators::get_int(
+                                          min_ms, max_ms);
+        co_await ss::maybe_yield();
+        const auto stop_time = ss::steady_clock_type::now()
+                               + std::chrono::milliseconds(
+                                 ms_per_scheduling_point);
+        while (true) {
+            if (ss::steady_clock_type::now() >= stop_time) {
+                break;
+            }
+        }
+    }
+}
+
+ss::future<> stress_payload::stop() {
+    _as.request_abort();
+    co_await _gate.close();
+}
+
+stress_fiber_manager::stress_fiber_manager()
+  : _stress(nullptr) {}
+
+stress_fiber_manager::~stress_fiber_manager() {}
+
+bool stress_fiber_manager::start(stress_config cfg) {
+    if (_stress) {
+        return false;
+    }
+    _stress = stress_payload::start(cfg);
+    return true;
+}
+
+ss::future<> stress_fiber_manager::stop() {
+    if (_stress) {
+        co_await _stress->stop();
+        _stress.reset();
+    }
+}

--- a/src/v/finjector/stress_fiber.h
+++ b/src/v/finjector/stress_fiber.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+#include <memory>
+
+struct stress_config {
+    // Number of ticks to increment between each scheduling point.
+    // If set, "delay" variants should not be set.
+    std::optional<int> min_spins_per_scheduling_point;
+    std::optional<int> max_spins_per_scheduling_point;
+
+    // Time in milliseconds to spin for between each scheduling point.
+    // If set, "spins" variants should not be set.
+    std::optional<int> min_ms_per_scheduling_point;
+    std::optional<int> max_ms_per_scheduling_point;
+
+    size_t num_fibers;
+};
+
+class stress_payload;
+
+// Manages a single stress payload.
+class stress_fiber_manager {
+public:
+    explicit stress_fiber_manager();
+    ~stress_fiber_manager();
+
+    // Starts stress fibers with the given config and returns true, or returns
+    // false if the config is invalid or if stress fibers are already running.
+    bool start(stress_config);
+
+    // Stops any existing stress fibers.
+    ss::future<> stop();
+
+private:
+    std::unique_ptr<stress_payload> _stress;
+};

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -15,6 +15,19 @@ rp_test(
 )
 
 
+v_cc_library(
+  NAME
+    kafka_test_utils
+  HDRS
+    "produce_consume_utils.h"
+  SRCS
+    "produce_consume_utils.cc"
+  DEPS
+    v::bytes
+    v::kafka
+    v::storage
+)
+
 set(srcs
   consumer_groups_test.cc
   token_bucket_algorithm_test.cc

--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -121,6 +121,10 @@ ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
           "Processing topic {} from the fetch response",
           topic.name);
         for (auto& partition : topic.partitions) {
+            if (partition.error_code != kafka::error_code::none) {
+                throw std::runtime_error(fmt::format(
+                  "fetch partition error: {}", partition.error_code));
+            }
             vlog(
               test_log.trace,
               "Processing ntp {}/{} from the fetch response",

--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "kafka/server/tests/produce_consume_utils.h"
+
+#include "bytes/iobuf.h"
+#include "kafka/client/transport.h"
+#include "kafka/protocol/produce.h"
+#include "kafka/protocol/schemata/produce_request.h"
+#include "storage/record_batch_builder.h"
+
+namespace tests {
+
+// Produces the given records per partition to the given topic.
+// NOTE: inputs must remain valid for the duration of the call.
+ss::future<kafka_produce_transport::pid_to_offset_map_t>
+kafka_produce_transport::produce(
+  model::topic topic_name,
+  pid_to_kvs_map_t records_per_partition,
+  std::optional<model::timestamp> ts) {
+    kafka::produce_request::topic tp;
+    tp.name = topic_name;
+    tp.partitions = produce_partition_requests(records_per_partition, ts);
+    std::vector<kafka::produce_request::topic> topics;
+    topics.push_back(std::move(tp));
+    kafka::produce_request req(std::nullopt, 1, std::move(topics));
+    req.data.timeout_ms = std::chrono::seconds(10);
+    req.has_idempotent = false;
+    req.has_transactional = false;
+    auto resp = co_await _transport.dispatch(std::move(req));
+
+    pid_to_offset_map_t ret;
+    for (auto& data_resp : resp.data.responses) {
+        for (auto& prt_resp : data_resp.partitions) {
+            if (prt_resp.error_code != kafka::error_code::none) {
+                throw std::runtime_error(fmt::format(
+                  "produce error: {}, message:{}",
+                  prt_resp.error_code,
+                  prt_resp.error_message));
+            }
+            ret.emplace(prt_resp.partition_index, prt_resp.base_offset);
+        }
+    }
+    co_return ret;
+}
+
+std::vector<kafka::partition_produce_data>
+kafka_produce_transport::produce_partition_requests(
+  const pid_to_kvs_map_t& records_per_partition,
+  std::optional<model::timestamp> ts) {
+    std::vector<kafka::partition_produce_data> ret;
+    ret.reserve(records_per_partition.size());
+    for (const auto& [pid, records] : records_per_partition) {
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, model::offset(0));
+        kafka::produce_request::partition partition;
+        for (auto& [k, v] : records) {
+            iobuf key_buf;
+            key_buf.append(k.data(), k.size());
+            iobuf val_buf;
+            val_buf.append(v.data(), v.size());
+            builder.add_raw_kv(std::move(key_buf), std::move(val_buf));
+        }
+        if (ts.has_value()) {
+            builder.set_timestamp(ts.value());
+        }
+        partition.partition_index = pid;
+        partition.records.emplace(std::move(builder).build());
+        ret.emplace_back(std::move(partition));
+    }
+    return ret;
+}
+
+ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
+  model::topic topic_name,
+  std::vector<model::partition_id> pids,
+  model::offset offset_inclusive) {
+    kafka::fetch_request::topic topic;
+    topic.name = topic_name;
+    topic.fetch_partitions.reserve(pids.size());
+    for (const auto& pid : pids) {
+        kafka::fetch_request::partition partition;
+        partition.fetch_offset = offset_inclusive;
+        partition.partition_index = pid;
+        partition.log_start_offset = model::offset(0);
+        partition.max_bytes = 1_MiB;
+        topic.fetch_partitions.emplace_back(std::move(partition));
+    }
+
+    kafka::fetch_request req;
+    req.data.min_bytes = 1;
+    req.data.max_bytes = 10_MiB;
+    req.data.max_wait_ms = 1000ms;
+    req.data.topics.push_back(std::move(topic));
+    auto fetch_resp = co_await _transport.dispatch(
+      std::move(req), kafka::api_version(4));
+    if (fetch_resp.data.error_code != kafka::error_code::none) {
+        throw std::runtime_error(
+          fmt::format("fetch error: {}", fetch_resp.data.error_code));
+    }
+    pid_to_kvs_map_t ret;
+    for (const auto& pid : pids) {
+        ret.emplace(pid, std::vector<kv_t>{});
+    }
+    auto& data = fetch_resp.data;
+    for (auto& topic : data.topics) {
+        for (auto& partition : topic.partitions) {
+            if (!partition.records.has_value()) {
+                continue;
+            }
+            auto batch_adapter = partition.records.value().consume_batch();
+            if (!batch_adapter.batch.has_value()) {
+                continue;
+            }
+            auto records = batch_adapter.batch->copy_records();
+            auto& records_for_partition = ret[partition.partition_index];
+            for (auto& r : records) {
+                iobuf_const_parser key_buf(r.key());
+                iobuf_const_parser val_buf(r.value());
+                records_for_partition.emplace_back(kv_t{
+                  key_buf.read_string(key_buf.bytes_left()),
+                  val_buf.read_string(val_buf.bytes_left())});
+            }
+        }
+    }
+    co_return ret;
+}
+
+} // namespace tests

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -17,7 +17,14 @@
 
 namespace tests {
 
-using kv_t = std::pair<ss::sstring, ss::sstring>;
+struct kv_t {
+    ss::sstring key;
+    ss::sstring val;
+
+    kv_t(ss::sstring k, ss::sstring v)
+      : key(std::move(k))
+      , val(std::move(v)) {}
+};
 using pid_to_kvs_map_t
   = absl::flat_hash_map<model::partition_id, std::vector<kv_t>>;
 

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -24,6 +24,17 @@ struct kv_t {
     kv_t(ss::sstring k, ss::sstring v)
       : key(std::move(k))
       , val(std::move(v)) {}
+
+    static std::vector<kv_t> sequence(size_t start, size_t num_records) {
+        std::vector<kv_t> records;
+        records.reserve(num_records);
+        for (size_t i = 0; i < num_records; i++) {
+            records.emplace_back(
+              ssx::sformat("key{}", start + i),
+              ssx::sformat("val{}", start + i));
+        }
+        return records;
+    }
 };
 using pid_to_kvs_map_t
   = absl::flat_hash_map<model::partition_id, std::vector<kv_t>>;

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "kafka/client/transport.h"
+#include "kafka/protocol/produce.h"
+#include "kafka/protocol/schemata/produce_request.h"
+#include "storage/record_batch_builder.h"
+
+namespace tests {
+
+using kv_t = std::pair<ss::sstring, ss::sstring>;
+using pid_to_kvs_map_t
+  = absl::flat_hash_map<model::partition_id, std::vector<kv_t>>;
+
+// Wrapper around a Kafka transport that encapsulates producing to a node.
+//
+// The primary goal of this class is to allow tests to produce without dealing
+// with the Kafka protocol. To that end, it exposes a protocol-agnostic API.
+class kafka_produce_transport {
+public:
+    using pid_to_offset_map_t
+      = absl::flat_hash_map<model::partition_id, model::offset>;
+
+    explicit kafka_produce_transport(kafka::client::transport&& t)
+      : _transport(std::move(t)) {}
+
+    ss::future<> start() { return _transport.connect(); }
+
+    // Produces the given records per partition to the given topic.
+    ss::future<pid_to_offset_map_t> produce(
+      model::topic topic_name,
+      pid_to_kvs_map_t records_per_partition,
+      std::optional<model::timestamp> ts = std::nullopt);
+
+    // Produces the given records to the given topic partition.
+    ss::future<pid_to_offset_map_t> produce_to_partition(
+      model::topic topic_name,
+      model::partition_id pid,
+      std::vector<kv_t> records,
+      std::optional<model::timestamp> ts = std::nullopt) {
+        pid_to_kvs_map_t m;
+        m.emplace(pid, std::move(records));
+        return produce(std::move(topic_name), std::move(m), ts);
+    }
+
+private:
+    // Convert the given records-per-partition mapping to a set of per-partition
+    // produce requests. Each request, once sent, will correspond to a
+    // replicated Raft batch.
+    // NOTE: input must remain valid for the lifetimes of the returned requests.
+    static std::vector<kafka::partition_produce_data>
+    produce_partition_requests(
+      const pid_to_kvs_map_t& records_per_partition,
+      std::optional<model::timestamp> ts);
+
+    kafka::client::transport _transport;
+};
+
+class kafka_consume_transport {
+public:
+    explicit kafka_consume_transport(kafka::client::transport&& t)
+      : _transport(std::move(t)) {}
+
+    ss::future<> start() { return _transport.connect(); }
+
+    ss::future<pid_to_kvs_map_t> consume(
+      model::topic topic_name,
+      std::vector<model::partition_id> pids,
+      model::offset kafka_offset_inclusive);
+
+    ss::future<std::vector<kv_t>> consume_from_partition(
+      model::topic topic_name,
+      model::partition_id pid,
+      model::offset kafka_offset_inclusive) {
+        auto m = co_await consume(
+          std::move(topic_name), {pid}, kafka_offset_inclusive);
+        if (m.empty()) {
+            throw std::runtime_error(
+              fmt::format("empty fetch {}/{}", topic_name(), pid()));
+        }
+        auto it = m.find(pid);
+        if (it == m.end()) {
+            throw std::runtime_error(fmt::format(
+              "fetch result missing partition {}/{}", topic_name(), pid()));
+        }
+        co_return it->second;
+    }
+
+private:
+    kafka::client::transport _transport;
+};
+
+} // namespace tests

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -46,6 +46,7 @@ v_cc_library(
   DEPS
     Seastar::seastar
     v::cluster
+    v::finjector
     v::syschecks
     v::kafka
     v::coproc

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -23,6 +23,72 @@
             ]
         },
         {
+            "path": "/v1/debug/stress_fiber_start",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Spawns fibers to artificially inflate CPU utilization",
+                    "type": "void",
+                    "nickname": "stress_fiber_start",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "min_spins_per_scheduling_point",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "max_spins_per_scheduling_point",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "min_ms_per_scheduling_point",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "max_ms_per_scheduling_point",
+                            "in": "query",
+                            "required": false,
+                            "allowMultiple": false,
+                            "type": "long"
+                        },
+                        {
+                            "name": "num_fibers",
+                            "in": "query",
+                            "required": true,
+                            "allowMultiple": false,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "/v1/debug/stress_fiber_stop",
+            "operations": [
+                {
+                    "method": "PUT",
+                    "summary": "Stops any stress fibers that may be running",
+                    "type": "void",
+                    "nickname": "stress_fiber_stop",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/debug/partition_leaders_table",
             "operations": [
                 {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "config/endpoint_tls_config.h"
 #include "coproc/partition_manager.h"
+#include "finjector/stress_fiber.h"
 #include "kafka/server/fwd.h"
 #include "model/metadata.h"
 #include "pandaproxy/rest/fwd.h"
@@ -58,6 +59,7 @@ class admin_server {
 public:
     explicit admin_server(
       admin_server_cfg,
+      ss::sharded<stress_fiber_manager>&,
       ss::sharded<cluster::partition_manager>&,
       ss::sharded<coproc::partition_manager>&,
       cluster::controller*,
@@ -433,6 +435,7 @@ private:
 
     ss::http_server _server;
     admin_server_cfg _cfg;
+    ss::sharded<stress_fiber_manager>& _stress_fiber_manager;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<coproc::partition_manager>& _cp_partition_manager;
     cluster::controller* _controller;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -58,6 +58,7 @@
 #include "features/feature_table_snapshot.h"
 #include "features/fwd.h"
 #include "features/migrators.h"
+#include "finjector/stress_fiber.h"
 #include "kafka/client/configuration.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
 #include "kafka/server/fetch_session_cache.h"
@@ -834,6 +835,7 @@ void application::configure_admin_server() {
     construct_service(
       _admin,
       admin_server_cfg_from_global_cfg(sched_groups),
+      std::ref(stress_fiber_manager),
       std::ref(partition_manager),
       std::ref(cp_partition_manager),
       controller.get(),
@@ -1565,6 +1567,7 @@ void application::wire_up_bootstrap_services() {
     ss::smp::invoke_on_all([] {
         return storage::internal::chunks().start();
     }).get();
+    construct_service(stress_fiber_manager).get();
     syschecks::systemd_message("Constructing storage services").get();
     construct_single_service_sharded(storage_node).get();
     construct_single_service_sharded(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -23,6 +23,7 @@
 #include "config/node_config.h"
 #include "coproc/fwd.h"
 #include "features/fwd.h"
+#include "finjector/stress_fiber.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
 #include "kafka/server/fwd.h"
@@ -90,6 +91,7 @@ public:
 
     smp_groups smp_service_groups;
     scheduling_groups sched_groups;
+    ss::sharded<stress_fiber_manager> stress_fiber_manager;
 
     // Sorted list of services (public members)
     ss::sharded<cloud_storage::cache> shadow_index_cache;

--- a/src/v/storage/disk_log_appender.h
+++ b/src/v/storage/disk_log_appender.h
@@ -38,7 +38,7 @@ public:
     ss::future<append_result> end_of_stream() final;
 
 private:
-    bool needs_to_roll_log(model::term_id) const;
+    bool segment_is_appendable(model::term_id) const;
     void release_lock();
     ss::future<ss::stop_iteration>
     append_batch_to_segment(const model::record_batch&);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1115,15 +1115,11 @@ ss::future<> disk_log_impl::force_roll(ss::io_priority_class iopc) {
       });
 }
 
-ss::future<> disk_log_impl::maybe_roll(
+ss::future<> disk_log_impl::maybe_roll_unlocked(
   model::term_id t, model::offset next_offset, ss::io_priority_class iopc) {
-    // This lock will only rarely be contended.  If it is held, then
-    // we must wait for do_housekeeping to complete before proceeding, because
-    // the log might be in a state mid-roll where it has no appender.
-    // We need to take this irrespective of whether we're actually rolling
-    // or not, in order to ensure that writers wait for a background roll
-    // to complete if one is ongoing.
-    auto roll_lock_holder = co_await _segments_rolling_lock.get_units();
+    vassert(
+      !_segments_rolling_lock.ready(),
+      "Must have taken _segments_rolling_lock");
 
     vassert(t >= term(), "Term:{} must be greater than base:{}", t, term());
     if (_segs.empty()) {
@@ -1146,8 +1142,12 @@ ss::future<> disk_log_impl::maybe_roll(
 
 ss::future<> disk_log_impl::apply_segment_ms() {
     auto gate = _compaction_housekeeping_gate.hold();
-    // do_housekeeping races with maybe_roll to use new_segment.
-    // take a lock to prevent problems
+    // Holding the lock blocks writes to the last open segment.
+    // This is required in order to avoid the logic in this function
+    // racing with an inflight append. Contention on this lock should
+    // be very light, since we wouldn't need to enforce segment.ms
+    // if this partition was high throughput (segment would have rolled
+    // naturally).
     auto lock = co_await _segments_rolling_lock.get_units();
 
     if (_segs.empty()) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1144,7 +1144,7 @@ ss::future<> disk_log_impl::maybe_roll(
     }
 }
 
-ss::future<> disk_log_impl::do_housekeeping() {
+ss::future<> disk_log_impl::apply_segment_ms() {
     auto gate = _compaction_housekeeping_gate.hold();
     // do_housekeeping races with maybe_roll to use new_segment.
     // take a lock to prevent problems

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -93,7 +93,8 @@ public:
     get_term_last_offset(model::term_id term) const final;
     std::ostream& print(std::ostream&) const final;
 
-    ss::future<> maybe_roll(
+    // Must be called while _segments_rolling_lock is held.
+    ss::future<> maybe_roll_unlocked(
       model::term_id, model::offset next_offset, ss::io_priority_class);
 
     // roll immediately with the current term. users should prefer the
@@ -110,6 +111,14 @@ public:
     ss::future<> update_configuration(ntp_config::default_overrides) final;
 
     int64_t compaction_backlog() const final;
+
+    std::optional<ssx::semaphore_units> try_segment_roll_lock() {
+        return _segments_rolling_lock.try_get_units();
+    }
+
+    ss::future<ssx::semaphore_units> segment_roll_lock() {
+        return _segments_rolling_lock.get_units();
+    }
 
 private:
     friend class disk_log_appender; // for multi-term appends
@@ -225,6 +234,13 @@ private:
 
     // Mutually exclude operations that will cause segment rolling
     // do_housekeeping and maybe_roll
+    //
+    // This lock will only rarely be contended. If it is held, then we must
+    // wait for housekeeping or truncation to complete before proceeding,
+    // because the log might be in a state mid-roll where it has no appender.
+    // We need to take this irrespective of whether we're actually rolling or
+    // not, in order to ensure that writers wait for a background roll to
+    // complete if one is ongoing.
     mutex _segments_rolling_lock;
 };
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -72,7 +72,7 @@ public:
     ss::future<> truncate(truncate_config) final;
     ss::future<> truncate_prefix(truncate_prefix_config) final;
     ss::future<> compact(compaction_config) final;
-    ss::future<> do_housekeeping() final override;
+    ss::future<> apply_segment_ms() final;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;
     void set_collectible_offset(model::offset) final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -55,7 +55,7 @@ public:
 
         // TODO should compact be merged in this?
         // run housekeeping task, like rolling segments
-        virtual ss::future<> do_housekeeping() = 0;
+        virtual ss::future<> apply_segment_ms() = 0;
 
         virtual ss::future<model::record_batch_reader>
           make_reader(log_reader_config) = 0;
@@ -179,7 +179,7 @@ public:
 
     ss::future<> compact(compaction_config cfg) { return _impl->compact(cfg); }
 
-    ss::future<> housekeeping() { return _impl->do_housekeeping(); }
+    ss::future<> apply_segment_ms() { return _impl->apply_segment_ms(); }
     /**
      * \brief Returns a future that resolves when log eviction is scheduled
      *

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -206,12 +206,19 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         co_return;
     }
 
-    // TODO handle this after compaction?
-    // handle segment.ms sequentially, since compaction is already sequential
-    // when this will be unified with compaction, the whole task could be made
-    // concurrent
+    /*
+     * Apply segment ms will roll the active segment if it is old enough. This
+     * is best done prior to running gc or compaction because it ensures that
+     * an inactive partition eventually makes data in its most recent segment
+     * eligible for these housekeeping processes.
+     *
+     * TODO:
+     *   handle this after compaction? handle segment.ms sequentially, since
+     *   compaction is already sequential when this will be unified with
+     *   compaction, the whole task could be made concurrent
+     */
     for (auto& log_meta : _logs_list) {
-        co_await log_meta.handle.housekeeping();
+        co_await log_meta.handle.apply_segment_ms();
     }
 
     for (auto& log_meta : _logs_list) {

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -163,7 +163,7 @@ struct mem_log_impl final : log::impl {
         return gc(cfg.eviction_time, cfg.max_bytes);
     }
 
-    ss::future<> do_housekeeping() final override { return ss::now(); }
+    ss::future<> apply_segment_ms() final override { return ss::now(); }
     std::ostream& print(std::ostream& o) const final {
         fmt::print(o, "{{mem_log_impl:{}}}", offsets());
         return o;

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -107,3 +107,15 @@ rp_test(
   LABELS storage
 )
 
+set (fixture_srcs
+  storage_e2e_fixture_test.cc)
+
+rp_test(
+  FIXTURE_TEST
+  BINARY_NAME storage_e2e
+  SOURCES ${fixture_srcs}
+  LIBRARIES v::seastar_testing_main v::application v::raft v::config v::kafka_test_utils
+  ARGS "-- -c 1"
+  LABELS storage
+)
+

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -1,0 +1,83 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <vector>
+
+using namespace std::chrono_literals;
+using std::vector;
+
+struct storage_e2e_fixture : public redpanda_thread_fixture {};
+
+namespace {
+
+// Produces to the given fixture's partition for 10 seconds.
+ss::future<> produce_to_fixture(
+  storage_e2e_fixture* fix, model::topic topic_name, int* incomplete) {
+    tests::kafka_produce_transport producer(co_await fix->make_kafka_client());
+    co_await producer.start();
+    const int cardinality = 10;
+    auto now = ss::lowres_clock::now();
+    while (ss::lowres_clock::now() < now + 5s) {
+        for (int i = 0; i < cardinality; i++) {
+            co_await producer.produce_to_partition(
+              topic_name, model::partition_id(0), tests::kv_t::sequence(i, 1));
+        }
+    }
+    *incomplete -= 1;
+}
+} // namespace
+
+FIXTURE_TEST(test_compaction_segment_ms, storage_e2e_fixture) {
+    config::shard_local_cfg().log_segment_ms_min.set_value(
+      std::chrono::duration_cast<std::chrono::milliseconds>(1ms));
+    const auto topic_name = model::topic("tapioca");
+    const auto ntp = model::ntp(model::kafka_namespace, topic_name, 0);
+
+    cluster::topic_properties props;
+    props.retention_duration = tristate<std::chrono::milliseconds>(
+      tristate<std::chrono::milliseconds>{});
+    props.segment_ms = tristate<std::chrono::milliseconds>(1s);
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    stress_config cfg;
+    cfg.min_spins_per_scheduling_point = 100;
+    cfg.max_spins_per_scheduling_point = 10000;
+    cfg.num_fibers = 100;
+    BOOST_REQUIRE(app.stress_fiber_manager.local().start(cfg));
+
+    std::vector<ss::future<>> produces;
+    produces.reserve(5);
+    int incomplete = 5;
+    for (int i = 0; i < 5; i++) {
+        auto fut = produce_to_fixture(this, topic_name, &incomplete);
+        produces.emplace_back(std::move(fut));
+    }
+    auto partition = app.partition_manager.local().get(ntp);
+    auto* log = dynamic_cast<storage::disk_log_impl*>(
+      partition->log().get_impl());
+
+    while (incomplete > 0) {
+        log->apply_segment_ms().get();
+        ss::sleep(500ms).get();
+    }
+
+    for (auto&& p : produces) {
+        std::move(p).get();
+    }
+    app.stress_fiber_manager.local().stop().get();
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Backport of https://github.com/redpanda-data/redpanda/pull/12565
Pulls in:
- a commit to rename do_housekeeping -> apply_segment_ms
- produce_consume_utils to test
- stress fibers to test

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug fixes

* Avoids a race between appends and application of segment.ms that could result in a crash.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
