### PR TITLE
Allow followers to catchup with leader to return freshest describeACL responses

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -250,6 +250,7 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
       .then([this] {
           return _security_frontend.start(
             _raft0->self().id(),
+            this,
             std::ref(_stm),
             std::ref(_connections),
             std::ref(_partition_leaders),

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -160,6 +160,10 @@ public:
         });
     }
 
+    ss::future<result<model::offset>> linearizable_barrier() {
+        return _raft0->linearizable_barrier();
+    }
+
     /// Helper for use during cluster join: a join RPC reply may
     /// tip us off about the last applied controller offset of some
     /// other node, and we may wait for that to ensure our controller

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -137,6 +137,11 @@
             "output_type": "partition_state_reply"
         },
         {
+            "name": "get_controller_committed_offset",
+            "input_type": "controller_committed_offset_request",
+            "output_type": "controller_committed_offset_reply"
+        },
+        {
             "name": "upsert_plugin",
             "input_type": "upsert_plugin_request",
             "output_type": "upsert_plugin_response"

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -26,7 +26,8 @@ namespace cluster {
 class security_frontend final {
 public:
     security_frontend(
-      model::node_id,
+      model::node_id self,
+      controller* controller,
       ss::sharded<controller_stm>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
@@ -64,7 +65,13 @@ public:
     static std::optional<user_and_credential>
     get_bootstrap_user_creds_from_env();
 
+    ss::future<std::error_code>
+      wait_until_caughtup_with_leader(model::timeout_clock::duration);
+
 private:
+    ss::future<result<model::offset>>
+      get_leader_committed(model::timeout_clock::duration);
+
     ss::future<std::vector<errc>> do_create_acls(
       std::vector<security::acl_binding>, model::timeout_clock::duration);
 
@@ -83,6 +90,7 @@ private:
       model::timeout_clock::duration);
 
     model::node_id _self;
+    controller* _controller;
     ss::sharded<controller_stm>& _stm;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_leaders_table>& _leaders;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -27,6 +27,7 @@ public:
     service(
       ss::scheduling_group,
       ss::smp_service_group,
+      controller* controller,
       ss::sharded<topics_frontend>&,
       ss::sharded<plugin_frontend>&,
       ss::sharded<members_manager>&,
@@ -119,6 +120,10 @@ public:
     ss::future<partition_state_reply> get_partition_state(
       partition_state_request&&, rpc::streaming_context&) final;
 
+    ss::future<controller_committed_offset_reply>
+    get_controller_committed_offset(
+      controller_committed_offset_request&&, rpc::streaming_context&) final;
+
     ss::future<upsert_plugin_response>
     upsert_plugin(upsert_plugin_request&&, rpc::streaming_context&) final;
 
@@ -165,6 +170,7 @@ private:
     ss::future<partition_state_reply>
       do_get_partition_state(partition_state_request);
 
+    controller* _controller;
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<metadata_cache>& _md_cache;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3909,6 +3909,26 @@ struct metrics_reporter_cluster_info
     auto serde_fields() { return std::tie(uuid, creation_timestamp); }
 };
 
+struct controller_committed_offset_request
+  : serde::envelope<
+      controller_committed_offset_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+};
+
+struct controller_committed_offset_reply
+  : serde::envelope<
+      controller_committed_offset_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    model::offset last_committed;
+    errc result;
+
+    auto serde_fields() { return std::tie(last_committed, result); }
+};
+
 template<typename V>
 std::ostream& operator<<(
   std::ostream& o, const configuration_with_assignment<V>& with_assignment) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2215,6 +2215,7 @@ void application::start_runtime_services(
           runtime_services.push_back(std::make_unique<cluster::service>(
             sched_groups.cluster_sg(),
             smp_service_groups.cluster_smp_sg(),
+            controller.get(),
             std::ref(controller->get_topics_frontend()),
             std::ref(controller->get_plugin_frontend()),
             std::ref(controller->get_members_manager()),

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1040,7 +1040,7 @@ class RpkTool:
             ]
         return flags
 
-    def acl_list(self):
+    def acl_list(self, request_timeout_overhead=None):
         """
         Run `rpk acl list` and return the results.
 
@@ -1056,6 +1056,13 @@ class RpkTool:
             "acl",
             "list",
         ] + self._kafka_conn_settings()
+
+        # How long rpk will wait for a response from the broker, default is 5s
+        if request_timeout_overhead is not None:
+            cmd += [
+                "-X", "globals.request_timeout_overhead=" +
+                f'{str(request_timeout_overhead)}s'
+            ]
 
         output = self._execute(cmd)
 

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import time
+from rptest.services.failure_injector import make_failure_injector, FailureSpec
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool, RpkException
@@ -26,10 +26,12 @@ class RpkACLTest(RedpandaTest):
         security = SecurityConfig()
         security.enable_sasl = True
         security.endpoint_authn_method = 'sasl'
-        super(RpkACLTest, self).__init__(test_ctx,
-                                         security=security,
-                                         *args,
-                                         **kwargs)
+        super(RpkACLTest,
+              self).__init__(test_ctx,
+                             security=security,
+                             extra_rp_conf={'election_timeout_ms': 10000},
+                             *args,
+                             **kwargs)
         self._rpk = RpkTool(redpanda=self.redpanda,
                             username=self.username,
                             password=self.password,
@@ -41,6 +43,42 @@ class RpkACLTest(RedpandaTest):
                        username=self.superuser.username,
                        password=self.superuser.password,
                        sasl_mechanism=self.mechanism)
+
+    @cluster(num_nodes=3)
+    def test_modify_then_query_error(self):
+        """
+        This test ensures that even in cases where multiple nodes may
+        think they are the leader, the freshest data is returned
+        """
+        superclient = self._superclient()
+        superclient.acl_create_allow_cluster(self.superuser.username,
+                                             "describe")
+
+        # Modify an ACL
+        self._rpk.sasl_allow_principal(f'User:{self.username}', ['CREATE'],
+                                       'topic', 'foo', self.superuser.username,
+                                       self.superuser.password,
+                                       self.superuser.algorithm)
+        described = superclient.acl_list()
+        assert 'CREATE' in described, "Failed to modify ACL"
+        assert self.redpanda.search_log_any(
+            ".*Failed waiting on catchup with controller leader.*") is False
+
+        # Network partition the leader away from the rest of the cluster
+        with make_failure_injector(self.redpanda) as fi:
+            fi.inject_failure(
+                FailureSpec(FailureSpec.FAILURE_ISOLATE,
+                            self.redpanda.controller()))
+
+            # Timeout must be larger then hardcoded timeout of 5s within redpanda
+            _ = superclient.acl_list(request_timeout_overhead=30)
+
+            # Of the other remaining nodes, none can be declared a leader before
+            # the election timeout occurs; also the "current" leader is technically
+            # stale so it cannot be sure its returning the freshest data either. In
+            # all cases the log below should be observed on the node handling the req.
+            assert self.redpanda.search_log_any(
+                ".*Failed waiting on catchup with controller leader.*") is True
 
     @cluster(num_nodes=3)
     def test_modify_then_query(self):


### PR DESCRIPTION
This PR attempts to solve the issue of stale describeACLs responses returned when a preceding modification of an ACL was issued shortly before.

This situation currently occurs because all requests that wish to edit ACL state get proxied to the controller, while all requests to query this state may be handled by a follower. Followers will only have the most up to date copy of the current state when their respective controller_stm's catchup with the leaders. Since the system is eventually consistent w.r.t. replicating the controller commands to followers there is no guarantee for a follower to return the freshest result set.

The proposed fix in this PR is to create a new endpoint to allow a follower to query the last applied offset of the controller log from the leader node. Once obtained, the follower then can wait on this offset to be applied within its local controller_stm. When this wait completes, its guaranteed that the follower is up to date with the leader at least at the offset the leader was, at the time the query was initially made. 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Modifications to avoid stale responses returned from DescribeACLs requests
