### PR TITLE
dt/docker: bump redpanda-data/openmessaging-benchmark to 8411e4a

### DIFF
--- a/tests/docker/ducktape-deps/omb
+++ b/tests/docker/ducktape-deps/omb
@@ -2,5 +2,5 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git
 cd /opt/openmessaging-benchmark
-git reset --hard 2674d62ca2b6fd7f22536e924c0df8a8fa21350d
+git reset --hard 8411e4a17f9fe190591389bf9b17c515f144a393
 mvn clean package -DskipTests


### PR DESCRIPTION
To bring in changes that work with redpanda cloud. Specifically, need changes from https://github.com/redpanda-data/openmessaging-benchmark/pull/58 so when omb is benchmarking redpanda cloud, it doesn't try to delete the `_schema` topic.

Cannot bump to the [tip of main](https://github.com/redpanda-data/openmessaging-benchmark/tree/7d0251277a3582ffabcffc6c5a44b3af1b7df275) because it would bring in other changes that need adjustment to how omb is deployed. This bump is the simplest, for now. This PR does not change the functionality or expected outcome of existing ducktape tests that use omb.

Comparison of changes this bump brings in: https://github.com/redpanda-data/openmessaging-benchmark/compare/2674d6...8411e4a

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
