### PR TITLE
Skip metrics test on no license

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2199,7 +2199,7 @@ admin_server::put_license_handler(std::unique_ptr<ss::http::request> req) {
     }
 
     try {
-        boost::trim_if(raw_license, boost::is_any_of(" \n"));
+        boost::trim_if(raw_license, boost::is_any_of(" \n\r"));
         auto license = security::make_license(raw_license);
         if (license.is_expired()) {
             throw ss::httpd::bad_request_exception(

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -54,9 +54,9 @@ class MetricsReporterTest(RedpandaTest):
         admin = Admin(self.redpanda)
         license = sample_license()
         if license is None:
-            self.logger.warn(
-                "REDPANDA_SAMPLE_LICENSE env var not found, ignoring license checks."
-            )
+            self.logger.info(
+                "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
+            return
 
         assert admin.put_license(
             license).status_code == 200, "PUT License failed"


### PR DESCRIPTION
We should account for carriage return in the license and the metrics reporter test should skip if the license env var is unset.

Fixes: https://github.com/redpanda-data/redpanda/issues/12719
Fixes: https://github.com/redpanda-data/redpanda/issues/12718

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
