### PR TITLE
Avoid kreq gen build all

### DIFF
--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -74,8 +74,8 @@ function (rp_test)
     ${RP_TEST_BINARY_NAME} "${RP_TEST_SOURCES}")
   target_link_libraries(
     ${RP_TEST_BINARY_NAME} PUBLIC "${RP_TEST_LIBRARIES}")
-  if(${BUILD_DEPENDENCIES})
-    add_dependencies(${RP_TEST_BINARY_NAME} ${BUILD_DEPENDENCIES})
+  if (RP_TEST_BUILD_DEPENDENCIES)
+    add_dependencies(${RP_TEST_BINARY_NAME} ${RP_TEST_BUILD_DEPENDENCIES})
   endif()
 
   foreach(i ${RP_TEST_INCLUDES})

--- a/src/go/kreq-gen/CMakeLists.txt
+++ b/src/go/kreq-gen/CMakeLists.txt
@@ -2,14 +2,14 @@ set(GOPATH ${CMAKE_CURRENT_BINARY_DIR})
 
 function(add_go_dependency NAME MAIN_SRC)
   get_filename_component(MAIN_SRC_ABS ${MAIN_SRC} ABSOLUTE)
-  add_custom_target(${NAME})
-  add_custom_command(TARGET ${NAME}
+  string(REPLACE "-" "_" target_name ${NAME})
+  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}"
                     COMMAND env GOPATH=${GOPATH} ${CMAKE_GO_BINARY} build
                     -modcacherw -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}"
                     ${CMAKE_GO_FLAGS} ${MAIN_SRC}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-                    DEPENDS ${MAIN_SRC_ABS})
-  add_custom_target(${NAME}_all ALL DEPENDS ${NAME})
+                    DEPENDS "${CMAKE_CURRENT_LIST_DIR}/${MAIN_SRC}")
+  add_custom_target(${target_name} DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${NAME}")
   install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${NAME} DESTINATION bin)
 endfunction(add_go_dependency)
 

--- a/src/v/kafka/protocol/tests/CMakeLists.txt
+++ b/src/v/kafka/protocol/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ rp_test(
     kafka
     kafka_protocol
   BUILD_DEPENDENCIES
-    kafka-request-generator
+    kafka_request_generator
   ENV
     "GENERATOR_BIN=${KAFKA_REQUEST_GENERATOR}"
 )


### PR DESCRIPTION
avoid rebuilding kreq-generator when the tree is clean.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

