### PR TITLE
[storage]: add local retention reclaimable to partition health report

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -11,8 +11,10 @@
 #include "archival/ntp_archiver_service.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/spillover_manifest.h"
+#include "cloud_storage/tests/manual_fixture.h"
 #include "cloud_storage/tests/produce_utils.h"
 #include "cloud_storage/tests/s3_imposter.h"
+#include "cluster/health_monitor_frontend.h"
 #include "config/configuration.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
@@ -463,4 +465,120 @@ FIXTURE_TEST(test_consume_during_spillover, cloud_storage_manual_e2e_test) {
         BOOST_CHECK(check.get());
     }
     cleanup.cancel();
+}
+
+FIXTURE_TEST(
+  reclaimable_reported_in_health_report,
+  cloud_storage_manual_multinode_test_base) {
+    config::shard_local_cfg().retention_local_trim_interval.set_value(
+      std::chrono::milliseconds(2000));
+
+    // start a second fixutre and wait for stable setup
+    auto fx2 = start_second_fixture();
+    tests::cooperative_spin_wait_with_timeout(3s, [this] {
+        return app.controller->get_members_table().local().node_ids().size()
+               == 2;
+    }).get();
+
+    // test topic
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    props.segment_size = 64_KiB;
+    props.retention_local_target_bytes = tristate<size_t>(1);
+    add_topic({model::kafka_namespace, topic_name}, 1, props, 2).get();
+
+    // figuring out the leader is useful for constructing the producer. the
+    // follower is just the "other" node.
+    redpanda_thread_fixture* fx_l = nullptr;
+    boost_require_eventually(10s, [&] {
+        cluster::partition* prt_a
+          = app.partition_manager.local().get(ntp).get();
+        cluster::partition* prt_b
+          = fx2->app.partition_manager.local().get(ntp).get();
+        if (!prt_a || !prt_b) {
+            return false;
+        }
+        if (prt_a->is_leader()) {
+            fx_l = this;
+            return true;
+        }
+        if (prt_b->is_leader()) {
+            fx_l = fx2.get();
+            return true;
+        }
+        return false;
+    });
+
+    auto prt_l = fx_l->app.partition_manager.local().get(ntp);
+
+    kafka_produce_transport producer(fx_l->make_kafka_client().get());
+    producer.start().get();
+
+    auto get_reclaimable = [&]() -> std::optional<std::vector<size_t>> {
+        auto report = app.controller->get_health_monitor()
+                        .local()
+                        .get_cluster_health(
+                          cluster::cluster_report_filter{},
+                          cluster::force_refresh::yes,
+                          model::timeout_clock::now() + std::chrono::seconds(2))
+                        .get();
+        if (report.has_value()) {
+            std::vector<size_t> sizes;
+            for (auto& node_report : report.value().node_reports) {
+                for (auto& topic : node_report.topics) {
+                    if (
+                      topic.tp_ns
+                      != model::topic_namespace_view(
+                        model::kafka_namespace, topic_name)) {
+                        continue;
+                    }
+                    for (auto partition : topic.partitions) {
+                        sizes.push_back(
+                          partition.reclaimable_size_bytes.value_or(0));
+                    }
+                }
+            }
+            if (!sizes.empty()) {
+                return sizes;
+            }
+        }
+        return std::nullopt;
+    };
+
+    for (int j = 0; j < 20; j++) {
+        for (int i = 0; i < 200; i++) {
+            producer
+              .produce_to_partition(
+                topic_name,
+                model::partition_id(0),
+                tests::kv_t::sequence(0, 200))
+              .get();
+        }
+
+        // drive the uploading
+        auto& archiver = prt_l->archiver()->get();
+        archiver.sync_for_tests().get();
+        archiver.upload_next_candidates().get();
+
+        // not for synchronization... just to give the system time to propogate
+        // all the state changes are are happening so that this overall loop
+        // doesn't spin to completion too fast.
+        ss::sleep(std::chrono::seconds(2)).get();
+
+        auto sizes = get_reclaimable();
+        if (sizes.has_value()) {
+            BOOST_REQUIRE(!sizes->empty());
+            if (std::all_of(sizes->begin(), sizes->end(), [](size_t s) {
+                    return s > 0;
+                })) {
+                return; // test success
+            }
+        }
+    }
+
+    // health report never reported non-zero reclaimable sizes. bummer!
+    BOOST_REQUIRE(false);
 }

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -671,6 +671,7 @@ struct ntp_report {
     ntp_leader leader;
     size_t size_bytes;
     std::optional<uint8_t> under_replicated_replicas;
+    size_t reclaimable_size_bytes;
 };
 
 partition_status to_partition_status(const ntp_report& ntpr) {
@@ -680,7 +681,8 @@ partition_status to_partition_status(const ntp_report& ntpr) {
       .leader_id = ntpr.leader.leader_id,
       .revision_id = ntpr.leader.revision_id,
       .size_bytes = ntpr.size_bytes,
-      .under_replicated_replicas = ntpr.under_replicated_replicas};
+      .under_replicated_replicas = ntpr.under_replicated_replicas,
+      .reclaimable_size_bytes = ntpr.reclaimable_size_bytes};
 }
 
 ss::chunked_fifo<ntp_report> collect_shard_local_reports(
@@ -703,6 +705,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 },
                 .size_bytes = p.second->size_bytes() + p.second->non_log_disk_size_bytes(),
                 .under_replicated_replicas = p.second->get_under_replicated(),
+                .reclaimable_size_bytes = p.second->reclaimable_local_size_bytes(),
               };
           });
     } else {
@@ -717,6 +720,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 },
                 .size_bytes = partition->size_bytes() + partition->non_log_disk_size_bytes(),
                 .under_replicated_replicas = partition->get_under_replicated(),
+                .reclaimable_size_bytes = partition->reclaimable_local_size_bytes(),
                 });
             }
         }

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -715,7 +715,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                   .leader_id = partition->get_leader_id(),
                   .revision_id = partition->get_revision_id(),
                 },
-                .size_bytes = partition->size_bytes(),
+                .size_bytes = partition->size_bytes() + partition->non_log_disk_size_bytes(),
                 .under_replicated_replicas = partition->get_under_replicated(),
                 });
             }

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -140,12 +140,13 @@ std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
     fmt::print(
       o,
       "{{id: {}, term: {}, leader_id: {}, revision_id: {}, size_bytes: {}, "
-      "under_replicated: {}}}",
+      "reclaimable_size_bytes: {}, under_replicated: {}}}",
       ps.id,
       ps.term,
       ps.leader_id,
       ps.revision_id,
       ps.size_bytes,
+      ps.reclaimable_size_bytes,
       ps.under_replicated_replicas);
     return o;
 }

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -58,22 +58,6 @@ struct node_state
 struct partition_status
   : serde::
       envelope<partition_status, serde::version<1>, serde::compat_version<0>> {
-    /**
-     * We increase a version here 'backward' since incorrect assertion would
-     * cause older redpanda versions to crash.
-     *
-     * Version: -1: added revision_id field
-     * Version: -2: added size_bytes field
-     *
-     * Same versioning should also be supported in get_node_health_request
-     */
-
-    static constexpr int8_t initial_version = 0;
-    static constexpr int8_t revision_id_version = -1;
-    static constexpr int8_t size_bytes_version = -2;
-
-    static constexpr int8_t current_version = size_bytes_version;
-
     static constexpr size_t invalid_size_bytes = size_t(-1);
 
     model::partition_id id;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -275,6 +275,10 @@ public:
 
     size_t size_bytes() const { return _raft->log()->size_bytes(); }
 
+    size_t reclaimable_local_size_bytes() const {
+        return _raft->log()->reclaimable_local_size_bytes();
+    }
+
     uint64_t non_log_disk_size_bytes() const;
 
     ss::future<> update_configuration(topic_properties);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2113,6 +2113,11 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
       .local_retention = lcl.total(),
     };
 
+    /*
+     * cache this for access by the health
+     */
+    _reclaimable_local_size_bytes = reclaim.local_retention;
+
     co_return std::make_pair(usage, reclaim);
 }
 
@@ -2585,6 +2590,25 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
     }
 
     co_return res;
+}
+
+size_t disk_log_impl::reclaimable_local_size_bytes() const {
+    /*
+     * circumstances/configuration under which this log will be trimming back to
+     * local retention size may change. catch these before reporting potentially
+     * stale information.
+     */
+    if (!is_cloud_retention_active()) {
+        return 0;
+    }
+    if (config().is_read_replica_mode_enabled()) {
+        // https://github.com/redpanda-data/redpanda/issues/11936
+        return 0;
+    }
+    if (deletion_exempt(config().ntp())) {
+        return 0;
+    }
+    return _reclaimable_local_size_bytes;
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -140,6 +140,8 @@ public:
         return _segments_rolling_lock.get_units();
     }
 
+    size_t reclaimable_local_size_bytes() const override;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
@@ -289,6 +291,7 @@ private:
     mutex _segments_rolling_lock;
 
     std::optional<model::offset> _cloud_gc_offset;
+    size_t _reclaimable_local_size_bytes{0};
 };
 
 } // namespace storage

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -143,6 +143,12 @@ public:
 
     virtual probe& get_probe() = 0;
 
+    /*
+     * estimate amount of data beyond local retention. zero will be returned in
+     * cases where this is not applicable, such as the log not being TS-enabled.
+     */
+    virtual size_t reclaimable_local_size_bytes() const = 0;
+
 private:
     ntp_config _config;
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -749,14 +749,7 @@ ss::future<usage_report> log_manager::disk_usage() {
      * TODO: this will be factored out to make the sharing of settings easier to
      * maintain.
      */
-    model::timestamp collection_threshold;
-    if (!_config.delete_retention()) {
-        collection_threshold = model::timestamp(0);
-    } else {
-        collection_threshold = model::timestamp(
-          model::timestamp::now().value()
-          - _config.delete_retention()->count());
-    }
+    auto cfg = default_gc_config();
 
     fragmented_vector<ss::shared_ptr<log>> logs;
     for (auto& it : _logs) {
@@ -766,10 +759,7 @@ ss::future<usage_report> log_manager::disk_usage() {
     co_return co_await ss::map_reduce(
       logs.begin(),
       logs.end(),
-      [this, collection_threshold](ss::shared_ptr<log> log) {
-          return log->disk_usage(
-            gc_config(collection_threshold, _config.retention_bytes()));
-      },
+      [cfg](ss::shared_ptr<log> log) { return log->disk_usage(cfg); },
       usage_report{},
       [](usage_report acc, usage_report update) { return acc + update; });
 }
@@ -795,6 +785,18 @@ void log_manager::handle_disk_notification(storage::disk_space_alert alert) {
 void log_manager::trigger_gc() {
     _gc_triggered = true;
     _housekeeping_sem.signal();
+}
+
+gc_config log_manager::default_gc_config() const {
+    model::timestamp collection_threshold;
+    if (!_config.delete_retention()) {
+        collection_threshold = model::timestamp(0);
+    } else {
+        collection_threshold = model::timestamp(
+          model::timestamp::now().value()
+          - _config.delete_retention()->count());
+    }
+    return {collection_threshold, _config.retention_bytes()};
 }
 
 } // namespace storage

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -236,6 +236,8 @@ public:
      */
     void trigger_gc();
 
+    gc_config default_gc_config() const;
+
 private:
     using logs_type
       = absl::flat_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;


### PR DESCRIPTION
The partition balancer needs to know how much of a partition's size is easily reclaimable. That is, the amount of data that has grown best-effort above local retention threshold. This will be used to adjust the balancer's view of how much free space is available on a node.

Note: this is needs to be backported, but we should wait until we've accumulated changes and tests related to updates of the partition balancer as well. These are being track in https://github.com/redpanda-data/core-internal/issues/719

Fixes: https://github.com/redpanda-data/core-internal/issues/725

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

