### PR TITLE
rptest: enable OpenMessagingBenchmark to run against redpanda cloud

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -196,6 +196,13 @@ class OpenMessagingBenchmark(Service):
         node.account.create_file(OpenMessagingBenchmark.WORKLOAD_FILE, conf)
 
     def _create_benchmark_driver_file(self, node):
+        # if testing redpanda cloud, override with default superuser
+        if hasattr(self.redpanda, 'GLOBAL_CLOUD_CLUSTER_CONFIG'):
+            u, p, m = self.redpanda._superuser
+            self.driver['sasl_username'] = u
+            self.driver['sasl_password'] = p
+            self.driver['sasl_mechanism'] = m
+            self.driver['security_protocol'] = 'SASL_SSL'
         self.driver["redpanda_node"] = self.redpanda.nodes[0].account.hostname
         conf = self.render("omb_driver.yaml", **self.driver)
         self.logger.info("Rendered driver config: \n %s", conf)

--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -203,7 +203,11 @@ class OpenMessagingBenchmark(Service):
             self.driver['sasl_password'] = p
             self.driver['sasl_mechanism'] = m
             self.driver['security_protocol'] = 'SASL_SSL'
-        self.driver["redpanda_node"] = self.redpanda.nodes[0].account.hostname
+            self.driver["redpanda_node"] = self.redpanda.brokers().split(
+                ':')[0]
+        else:
+            self.driver["redpanda_node"] = self.redpanda.nodes[
+                0].account.hostname
         conf = self.render("omb_driver.yaml", **self.driver)
         self.logger.info("Rendered driver config: \n %s", conf)
         node.account.create_file(OpenMessagingBenchmark.DRIVER_FILE, conf)

--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -236,7 +236,9 @@ class OpenMessagingBenchmark(Service):
         self.logger.info(
             f"Starting Open Messaging Benchmark with workers: {worker_nodes}")
 
-        rp_node = self.redpanda.nodes[0]
+        rp_node = None
+        if self.redpanda.num_nodes > 0:
+            rp_node = self.redpanda.nodes[0]
         rp_version = "unknown_version"
         try:
             rp_version = self.redpanda.get_version(rp_node)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -868,6 +868,12 @@ class RedpandaServiceBase(Service):
 
         self._skip_if_no_redpanda_log = skip_if_no_redpanda_log
 
+        self._dedicated_nodes = self._context.globals.get(
+            self.DEDICATED_NODE_KEY, False)
+
+        self.logger.info(
+            f"ResourceSettings: dedicated_nodes={self._dedicated_nodes}")
+
     def start_node(self, node, **kwargs):
         pass
 
@@ -1229,6 +1235,17 @@ class RedpandaServiceBase(Service):
                        log_allow_list: list[str | re.Pattern] | None = None):
         pass
 
+    @property
+    def dedicated_nodes(self):
+        """
+        If true, the nodes are dedicated linux servers, e.g. EC2 instances.
+
+        If false, the nodes are containers that share CPUs and memory with
+        one another.
+        :return:
+        """
+        return self._dedicated_nodes
+
 
 class RedpandaServiceK8s(RedpandaServiceBase):
     def __init__(self,
@@ -1430,6 +1447,11 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
         self._cloud_cluster = CloudCluster(self.logger, self._cc_config)
         self._kubectl = None
 
+        self._dedicated_nodes = True
+        self.logger.info(
+            'ResourceSettings: setting dedicated_nodes=True because serving from redpanda cloud'
+        )
+
     def start_node(self, node, **kwargs):
         pass
 
@@ -1537,12 +1559,6 @@ class RedpandaService(RedpandaServiceBase):
         self._raise_on_errors = self._context.globals.get(
             self.RAISE_ON_ERRORS_KEY, True)
 
-        self._dedicated_nodes = self._context.globals.get(
-            self.DEDICATED_NODE_KEY, False)
-
-        self.logger.info(
-            f"ResourceSettings: dedicated_nodes={self._dedicated_nodes}")
-
         self.cloud_storage_client: Optional[S3Client] = None
 
         # enable asan abort / core dumps by default
@@ -1624,17 +1640,6 @@ class RedpandaService(RedpandaServiceBase):
 
     def require_client_auth(self):
         return self._security.require_client_auth
-
-    @property
-    def dedicated_nodes(self):
-        """
-        If true, the nodes are dedicated linux servers, e.g. EC2 instances.
-
-        If false, the nodes are containers that share CPUs and memory with
-        one another.
-        :return:
-        """
-        return self._dedicated_nodes
 
     def get_node_memory_mb(self):
         if self._resource_settings.memory_mb is not None:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1246,6 +1246,12 @@ class RedpandaServiceBase(Service):
         """
         return self._dedicated_nodes
 
+    def get_version(self, node):
+        """
+        Returns the version as a string.
+        """
+        pass
+
 
 class RedpandaServiceK8s(RedpandaServiceBase):
     def __init__(self,
@@ -1494,6 +1500,9 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
     def brokers(self, limit=None, listener: str = "dnslistener") -> str:
         return self._cloud_cluster.get_broker_address()
+
+    def get_version(self, node):
+        return self._cloud_cluster.get_install_pack_version()
 
 
 class RedpandaService(RedpandaServiceBase):

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -466,3 +466,8 @@ class CloudCluster():
         cluster = self.cloudv2._http_get(
             endpoint=f'/api/v1/clusters/{self.config.id}')
         return cluster['status']['listeners']['kafka']['default']['urls'][0]
+
+    def get_install_pack_version(self):
+        cluster = self.cloudv2._http_get(
+            endpoint=f'/api/v1/clusters/{self.config.id}')
+        return cluster['status']['installPackVersion']

--- a/tests/rptest/services/templates/omb_driver.yaml
+++ b/tests/rptest/services/templates/omb_driver.yaml
@@ -9,6 +9,15 @@ topicConfig: |
 commonConfig: |
   bootstrap.servers={{redpanda_node}}:9092
   request.timeout.ms={{request_timeout}}
+  {% if sasl_username and sasl_password %}
+  sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{{sasl_username}}" password="{{sasl_password}}";
+  {% endif %}
+  {% if sasl_mechanism %}
+  sasl.mechanism={{sasl_mechanism}}
+  {% endif %}
+  {% if security_protocol %}
+  security.protocol={{security_protocol}}
+  {% endif %}
 
 producerConfig: |
   enable.idempotence={{enable_idempotence}}

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -10,7 +10,7 @@
 # Tests to run on a Redpanda Cloud cluster.
 cloud:
   included:
-    - tests/rpk_topic_test.py
+    - tests/rpk_topic_test.py::RpkToolTest.test_consume_from_partition
     - tests/services_self_test.py::SimpleSelfTest
     - tests/services_self_test.py::OpenBenchmarkSelfTest
     - scale_tests/high_throughput_test.py::HighThroughputTest2.test_throughput_simple

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -12,4 +12,5 @@ cloud:
   included:
     - tests/rpk_topic_test.py
     - tests/services_self_test.py::SimpleSelfTest
+    - tests/services_self_test.py::OpenBenchmarkSelfTest
     - scale_tests/high_throughput_test.py::HighThroughputTest2.test_throughput_simple


### PR DESCRIPTION
Updates to the ducktape class `OpenMessagingBenchmark` to enable it to run against redpanda cloud by adding SASL and TLS to the driver configuration as well as other small changes. This PR does not change the functionality or expected outcome of existing ducktape tests that use omb.

Also updated `test_suite_cloud.yml` so it runs a test using `OpenMessagingBenchmark`.

This PR also needs PR #12725 to be merged as well.

Example run with redpanda cloud configured in `globals.json`:
```console
bash$ ducktape --debug --globals=/home/ubuntu/redpanda/tests/globals.json --cluster=ducktape.cluster.json.JsonCluster --cluster-file=/home/ubuntu/redpanda/tests/cluster.json --test-runner-timeout=3600000 tests/rptest/tests/services_self_test.py::OpenBenchmarkSelfTest
test_id:    rptest.tests.services_self_test.OpenBenchmarkSelfTest.test_default_omb_configuration.driver=SIMPLE_DRIVER.workload=SIMPLE_WORKLOAD
status:     PASS
run time:   2 minutes 43.724 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
============================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2023-08-11--017
run time:         2 minutes 43.724 seconds
tests run:        1
passed:           1
failed:           0
ignored:          0
opassed:          0
ofailed:          0
============================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
