### PR TITLE
schema registry: s/referencedBy/referencedby/g

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -731,7 +731,7 @@
         }
       }
     },
-    "/subjects/{subject}/versions/{version}/referencedBy": {
+    "/subjects/{subject}/versions/{version}/referencedby": {
       "get": {
         "summary": "Retrieve a list of schema ids that reference the subject and version.",
         "operationId": "get_subject_versions_version_referenced_by",

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -372,7 +372,7 @@ class SchemaRegistryEndpoints(RedpandaTest):
             self, subject, version, headers=HTTP_GET_HEADERS, **kwargs):
         return self._request(
             "GET",
-            f"subjects/{subject}/versions/{version}/referencedBy",
+            f"subjects/{subject}/versions/{version}/referencedby",
             headers=headers,
             **kwargs)
 


### PR DESCRIPTION
The schema registry path is defined to be "referencedby". The current implementation of "referencedBy" is a bit of a typo.

This replaces all referencedBy with referencedby in the codebase.

Closes #12729.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Bug Fixes

* fixes the schema registry url `/subjects/{subject}/versions/{version}/referencedBy` to be `.../referencedby`