### PR TITLE
utils: create external process class

### DIFF
--- a/src/v/ssx/CMakeLists.txt
+++ b/src/v/ssx/CMakeLists.txt
@@ -4,6 +4,8 @@ v_cc_library(
   HDRS
     "future-util.h"
     "metrics.h"
+  SRCS
+    process.cc
   DEPS
     Seastar::seastar
   )

--- a/src/v/ssx/process.cc
+++ b/src/v/ssx/process.cc
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/process.h"
+
+#include "ssx/future-util.h"
+#include "vassert.h"
+#include "vlog.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/with_timeout.hh>
+#include <seastar/util/log.hh>
+
+#include <boost/iostreams/device/array.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <fmt/format.h>
+
+#include <sstream>
+#include <string>
+
+namespace ssx {
+
+namespace {
+ss::logger proclog{"process"};
+
+ss::future<> consume_input_stream(
+  ss::input_stream<char> stream, bool is_stdout, ss::abort_source& as) {
+    std::string_view stream_name{is_stdout ? "STDOUT" : "STDERR"};
+
+    std::string line;
+    while (!stream.eof()) {
+        if (as.abort_requested()) {
+            co_return;
+        }
+
+        auto buf = co_await stream.read();
+        if (buf.empty()) {
+            continue;
+        }
+
+        boost::iostreams::stream<boost::iostreams::basic_array_source<char>> ss{
+          buf.begin(), buf.end()};
+        while (!ss.eof()) {
+            std::getline(ss, line);
+            vlog(proclog.trace, "{}: {}", stream_name, line);
+        }
+    }
+}
+
+// Unwraps the result of a Seastar process
+process::exit_status_t
+unwrap_wait_status(ss::experimental::process::wait_status& result) {
+    return ss::visit(
+      result,
+      [](ss::experimental::process::wait_exited exited) {
+          return process::exit_status_t{
+            .exit_int = exited.exit_code, .exit_reason = "exit code"};
+      },
+      [](ss::experimental::process::wait_signaled signaled) {
+          return process::exit_status_t{
+            .exit_int = signaled.terminating_signal,
+            .exit_reason = "exit signal"};
+      });
+}
+} // namespace
+
+process::~process() {
+    vassert(
+      !is_running(),
+      "Processes must exit before destruction: cmd {}",
+      _cmd_str);
+}
+
+ss::future<std::error_code> process::spawn(
+  const std::filesystem::path& cmd, ss::experimental::spawn_parameters params) {
+    gate_guard g{_gate};
+    if (is_running()) {
+        vlog(proclog.error, "A process is already running: cmd {}", _cmd_str);
+        co_return process_errc::running;
+    }
+
+    // Set command string for logging purposes
+    _cmd_str = cmd.string();
+
+    auto p = co_await ss::experimental::spawn_process(cmd, std::move(params));
+    _process.emplace(std::move(p));
+
+    // Capture output async in the background so the broker is not blocked.
+    ssx::background = ssx::spawn_with_gate_then(_gate, [this] {
+        return consume_input_stream(_process->stdout(), true, _as)
+          .then([this] {
+              return consume_input_stream(_process->stderr(), false, _as);
+          })
+          // According to seastar docs, a process that is not wait'd may leave a
+          // zombie behind. So we do that here.
+          .then([this] { return handle_wait(); })
+          .finally([this] { _process.reset(); });
+    });
+
+    co_return process_errc::success;
+}
+
+ss::future<> process::stop() {
+    _as.request_abort();
+    co_await _gate.close();
+}
+
+process::exit_status_t process::exit_status() {
+    return unwrap_wait_status(_wait_status);
+}
+
+ss::future<> process::handle_wait() {
+    vassert(is_running(), "_process not instantiated");
+
+    _wait_status = co_await _process->wait();
+    auto status = exit_status();
+
+    // There is no signal=0, so an exit_int=0 is the success exit code.
+    if (status.exit_int != 0) {
+        vlog(
+          proclog.error,
+          "Process stop fail: cmd {}, {}={}",
+          _cmd_str,
+          status.exit_reason,
+          status.exit_int);
+    } else {
+        vlog(proclog.trace, "Process stop success: cmd {}", _cmd_str);
+    }
+}
+
+ss::future<std::error_code>
+process::terminate(std::chrono::milliseconds timeout) {
+    gate_guard g{_gate};
+    if (!is_running()) {
+        co_return process_errc::does_not_exist;
+    }
+
+    try {
+        _process->terminate();
+    } catch (const std::system_error&) {
+        // The process is already dead
+        co_return process_errc::does_not_exist;
+    }
+
+    auto deadline = ss::lowres_clock::now() + timeout;
+
+    co_return co_await ss::with_timeout(
+      deadline,
+      ss::do_until(
+        [this, deadline] {
+            // The callback (do_until loop) is not auto canceled on timeout,
+            // so exit when the deadline is exceeded.
+            if (ss::lowres_clock::now() > deadline) {
+                return true;
+            }
+
+            return !is_running();
+        },
+        [] { return ss::sleep(std::chrono::milliseconds{5}); }))
+      .then([] {
+          return ss::make_ready_future<process_errc>(process_errc::success);
+      })
+      .handle_exception_type([this](const ss::timed_out_error&) {
+          if (_process.has_value()) {
+              _process->kill();
+          }
+          return ss::make_ready_future<process_errc>(process_errc::success);
+      })
+      .handle_exception_type([](const std::system_error&) {
+          // The process is already dead
+          return ss::make_ready_future<process_errc>(
+            process_errc::does_not_exist);
+      });
+}
+
+} // namespace ssx

--- a/src/v/ssx/process.h
+++ b/src/v/ssx/process.h
@@ -1,0 +1,133 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "utils/gate_guard.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/util/process.hh>
+
+#include <chrono>
+#include <filesystem>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace ssx {
+
+enum class process_errc : int16_t {
+    success = 0, // must be 0
+    does_not_exist,
+    running,
+    non_zero_exit,
+    signaled
+};
+
+struct process_errc_category final : public std::error_category {
+    const char* name() const noexcept final { return "process::errc"; }
+
+    std::string message(int c) const final {
+        switch (static_cast<process_errc>(c)) {
+        case process_errc::success:
+            return "Success";
+        case process_errc::does_not_exist:
+            return "Process does not exist";
+        case process_errc::running:
+            return "Process is already running";
+        case process_errc::non_zero_exit:
+            return "Process exited with non-zero status";
+        case process_errc::signaled:
+            return "Process exited on signal";
+        }
+        return "process::process_errc::unknown";
+    }
+};
+inline const std::error_category& error_category() noexcept {
+    static process_errc_category e;
+    return e;
+}
+inline std::error_code make_error_code(process_errc e) noexcept {
+    return std::error_code(static_cast<int>(e), error_category());
+}
+
+/*
+ * \brief Manages a POSIX fork that runs on one core
+ *
+ *  Seastar supports running external processes via a POSIX fork with
+ * ss::experimental::spawn_process. This class does not spawn two or more forks
+ * within the same instance. The process runs on one core and it is easy to
+ * misuse. Therefore, this wrapper is responsible for:
+ *      1. Starting a process
+ *      2. Killing a process
+ *      3. Waiting for the process to finish
+ *
+ *   Example:
+ *      process p
+ *      p.spawn()
+ *      while p.is_running():
+ *          do_other_work()
+ *      status = p.exit_status()
+ *      log(status.exit_int, status.exit_reason)
+ */
+class process {
+public:
+    // A struct to represent the result of a process
+    struct exit_status_t {
+        int exit_int;
+        ss::sstring exit_reason;
+    };
+
+    process()
+      : _process{std::nullopt}
+      , _wait_status{ss::experimental::process::wait_exited{-1}} {}
+    process(const process&) = delete;
+    ~process();
+
+    // Spawns a posix fork and starts running the command.
+    //
+    // Output from stdout and stderr are logged at TRACE level.
+    ss::future<std::error_code> spawn(
+      const std::filesystem::path& cmd,
+      ss::experimental::spawn_parameters params);
+
+    ss::future<> stop();
+
+    // Terminate a running process
+    //
+    // /param: timeout: Amount of time to wait for the process to respond to
+    // SIGTERM. SIGKILL is sent after timeout. Default 1s.
+    ss::future<std::error_code>
+    terminate(std::chrono::milliseconds timeout = std::chrono::seconds(1));
+
+    // Unwraps the result of a process into an integer for the exit code/signal
+    // and a string describing what caused the exit.
+    exit_status_t exit_status();
+    bool is_running() const { return _process.has_value(); }
+
+private:
+    ss::sstring _cmd_str;
+    std::optional<ss::experimental::process> _process;
+    ss::experimental::process::wait_status _wait_status;
+    ss::gate _gate;
+    ss::abort_source _as;
+
+    // Wait for the running process to finish
+    ss::future<> handle_wait();
+};
+
+} // namespace ssx
+
+namespace std {
+template<>
+struct is_error_code_enum<ssx::process_errc> : true_type {};
+} // namespace std

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -32,3 +32,20 @@ rp_test(
   LIBRARIES Seastar::seastar_perf_testing v::ssx
   LABELS ssx
 )
+
+set(HANDLE_SIGTERM_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/handle-sigterm.sh")
+set(TIMED_LOOP_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/timed-loop.sh")
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME ssx_single_thread
+  SOURCES
+    process_spawn_tests.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main v::ssx
+  ARGS "-- -c 1"
+  LABELS ssx
+  ENV
+    "HANDLE_SIGTERM_SCRIPT=${HANDLE_SIGTERM_SCRIPT}"
+    "TIMED_LOOP_SCRIPT=${TIMED_LOOP_SCRIPT}"
+)

--- a/src/v/ssx/tests/handle-sigterm.sh
+++ b/src/v/ssx/tests/handle-sigterm.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+trap 'echo "sigterm called"' SIGTERM
+
+while true; do
+  :
+done

--- a/src/v/ssx/tests/process_spawn_tests.cc
+++ b/src/v/ssx/tests/process_spawn_tests.cc
@@ -1,0 +1,167 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/node_config.h"
+#include "ssx/process.h"
+#include "test_utils/async.h"
+#include "vassert.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <fmt/format.h>
+
+#include <chrono>
+
+inline ss::logger test_log("test");
+
+std::filesystem::path get_trap_script() {
+    auto trap_script = std::getenv("HANDLE_SIGTERM_SCRIPT");
+    vassert(trap_script, "$HANDLE_SIGTERM_SCRIPT does not exist");
+    BOOST_REQUIRE_MESSAGE(
+      ss::file_exists(trap_script).get0(),
+      std::string(trap_script) + " does not exist");
+    return std::filesystem::path{trap_script};
+}
+
+std::filesystem::path get_timed_loop_script() {
+    auto timed_script = std::getenv("TIMED_LOOP_SCRIPT");
+    vassert(timed_script, "$TIMED_LOOP_SCRIPT does not exist");
+    BOOST_REQUIRE_MESSAGE(
+      ss::file_exists(timed_script).get0(),
+      std::string(timed_script) + " does not exist");
+    return std::filesystem::path{timed_script};
+}
+
+SEASTAR_THREAD_TEST_CASE(process_start) {
+    auto cmd = get_timed_loop_script();
+    int script_runtime_s = 10;
+    std::vector<ss::sstring> argv{
+      cmd.string(), fmt::format("{}", script_runtime_s)};
+    ss::experimental::spawn_parameters params{.argv = argv};
+
+    ssx::process p;
+    BOOST_REQUIRE(!p.is_running());
+
+    auto status = p.exit_status();
+    BOOST_REQUIRE_EQUAL(status.exit_int, -1);
+    BOOST_REQUIRE_EQUAL(status.exit_reason, ss::sstring{"exit code"});
+
+    std::error_code err;
+
+    // Start first run
+    err = p.spawn(cmd, params).get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::success);
+
+    // Try dup run
+    err = p.spawn(cmd, params).get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::running);
+
+    // Wait until process stops
+    tests::cooperative_spin_wait_with_timeout(
+      std::chrono::seconds{script_runtime_s}, [&p] { return !p.is_running(); })
+      .get();
+
+    // The reason for stopping should be success (exit code 0)
+    status = p.exit_status();
+    BOOST_REQUIRE_EQUAL(status.exit_int, 0);
+    BOOST_REQUIRE_EQUAL(status.exit_reason, ss::sstring{"exit code"});
+
+    p.stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(process_stop_sigterm) {
+    auto cmd = get_timed_loop_script();
+    int script_runtime_s = 10;
+    std::vector<ss::sstring> argv{
+      cmd.string(), fmt::format("{}", script_runtime_s)};
+    ss::experimental::spawn_parameters params{.argv = argv};
+
+    ssx::process p;
+    std::error_code err;
+
+    // Try terminate before run
+    test_log.info("Terminating -- expect fail");
+    err = p.terminate().get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::does_not_exist);
+
+    // Run the process
+    test_log.info("Running -- expect success");
+    err = p.spawn(cmd, params).get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::success);
+
+    // Let the script run for a bit
+    using namespace std::chrono_literals;
+    ss::sleep(1s).get();
+
+    // Try terminate
+    test_log.info("Terminating ...");
+    auto fut = p.terminate();
+
+    // Spawn should still report running process
+    err = p.spawn(cmd, params).get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::running);
+
+    // Wait until the process to stops
+    tests::cooperative_spin_wait_with_timeout(3s, [&p] {
+        return !p.is_running();
+    }).get();
+
+    // Terminate should succeed
+    err = fut.get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::success);
+
+    // The reason for stopping should be SIGTERM (signal 15)
+    auto status = p.exit_status();
+    BOOST_REQUIRE_EQUAL(status.exit_int, SIGTERM);
+    BOOST_REQUIRE_EQUAL(status.exit_reason, ss::sstring{"exit signal"});
+
+    p.stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(process_stop_sigkill) {
+    auto cmd = get_trap_script();
+    std::vector<ss::sstring> argv{cmd.string()};
+    ss::experimental::spawn_parameters params{.argv = argv};
+
+    ssx::process p;
+    std::error_code err;
+
+    // Run the process
+    test_log.info("Running -- expect success");
+    err = p.spawn(cmd, params).get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::success);
+
+    // Let the script run for a bit
+    using namespace std::chrono_literals;
+    ss::sleep(1s).get();
+
+    // Try terminate
+    test_log.info("Terminating ...");
+    auto fut = p.terminate();
+
+    // Spawn should still report running process
+    err = p.spawn(cmd, params).get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::running);
+
+    // Wait until the process stops
+    tests::cooperative_spin_wait_with_timeout(3s, [&p] {
+        return !p.is_running();
+    }).get();
+
+    // Terminate should succeed
+    err = fut.get();
+    BOOST_REQUIRE_EQUAL(err, ssx::process_errc::success);
+
+    // The reason for stopping should be SIGKILL (signal 9)
+    auto status = p.exit_status();
+    BOOST_REQUIRE_EQUAL(status.exit_int, SIGKILL);
+    BOOST_REQUIRE_EQUAL(status.exit_reason, ss::sstring{"exit signal"});
+
+    p.stop().get();
+}

--- a/src/v/ssx/tests/timed-loop.sh
+++ b/src/v/ssx/tests/timed-loop.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+TIMEOUT=$1
+echo "Run for $TIMEOUT seconds"
+DEADLINE=$((SECONDS + TIMEOUT))
+
+while [ $SECONDS -lt $DEADLINE ]; do
+  :
+done

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 rp_test(
   UNIT_TEST
   BINARY_NAME utils_single_thread


### PR DESCRIPTION
This is a part of our effort to trigger `rpk debug bundle` via the Admin API https://github.com/redpanda-data/redpanda/issues/8971. The first step is to make use of [Seastar's experimental process](https://docs.seastar.io/master/classseastar_1_1experimental_1_1process.html) to spawn and run bash programs in a posix fork.

Therefore, this PR wraps `ss::experimental::process` into a class that is unit testable so, when devs need a posix fork, the process does not break Redpanda.

Fixes: https://github.com/redpanda-data/redpanda/issues/12753

Changes from force-push `c948847`, `73ac9b8`, `8f8007f`:
- Move files to `ssx`
- Use milliseconds as default for terminate
- Delete the copy constructor
- Assert non-running process in dtor
- Add stop method to close the gate
- Prevent symbol clashed with anon namespace
- Prefer `std::string_view` over `ss::sstring` to reduce copies
- Refactor `consume_input_stream`
- Add an abort source
- Check spawning a process after terminate
- Prefer a struct over `std::pair`
- Add documentation
- Added a script with a timed loop to use in the tests instead of`/usr/bin/sleep`
- Removed `to_process_errc`
- Replace some try/catch with then/handle_exception

Changes from force-push `cbcf8d4`:
- use lowres_clock instead of `steady_clock`
- Move request_abort to the stop method
- Check that the process has value before sending SIGKILL

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
