### PR TITLE
Fix misappropriate use of mutex::get_units in usage based billing

### DIFF
--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -300,7 +300,7 @@ template<typename clock_type>
 ss::future<> usage_aggregator<clock_type>::grab_data(size_t idx) {
     auto gh = _gate.hold();
     try {
-        auto units = _m.get_units();
+        auto units = co_await _m.get_units();
         const auto ts = _buckets[idx].begin;
         /// Grab the data, across this scheduling point we cannot assume things
         /// like _current_window have the same value as before this call, that


### PR DESCRIPTION
This bug was first observed as a CI issue reporting an unhandled exceptional future. This seemed strange as there are exception handlers surrounding the few call sites where a mutex is used within UBB, and they contain a catch clause for std exception.

The cause of a bug is a call to `mutex.get_units()` without a preceeding `co_await` in the context of a coroutine. This means the mutex is not being used properly and in the event it contains an exception it will not be caught by the handler because the value returned by `get_units()` is a future not the unwrapped value.

Fixes: #12733

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in usage framework that where unhandled exceptions may be observed