### PR TITLE
co_await mutex hold in conn_quota

### DIFF
--- a/src/v/net/conn_quota.cc
+++ b/src/v/net/conn_quota.cc
@@ -286,7 +286,7 @@ ss::future<> conn_quota::reclaim_to(
   ss::lw_shared_ptr<conn_quota::home_allowance> allowance,
   ss::net::inet_address addr,
   bool one_time) {
-    auto locked = allowance->reclaim_lock.get_units();
+    auto locked = co_await allowance->reclaim_lock.get_units();
     if (allowance->reclaim) {
         // We are already in reclaim mode: remote allowances will
         // not be holding any units belong to us, so don't waste


### PR DESCRIPTION
We need to await acquiring this lock. Found via grep after #12755

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

* none
