### PR TITLE
Await acquiring the manifest lock

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1019,7 +1019,7 @@ ss::future<> partition::serialize_json_manifest_to_output_stream(
           "{} not configured for cloud storage", _topic_cfg->tp_ns));
     }
 
-    auto lock = _archival_meta_stm->acquire_manifest_lock();
+    auto lock = co_await _archival_meta_stm->acquire_manifest_lock();
 
     // The timeout here is meant to place an upper bound on the amount
     // of time the manifest lock is held for.


### PR DESCRIPTION
This was found via grep after #12755

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
