### PR TITLE
[v23.2.x] Fix misappropriate use of mutex::get_units in usage based billing

### DIFF
--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -300,7 +300,7 @@ template<typename clock_type>
 ss::future<> usage_aggregator<clock_type>::grab_data(size_t idx) {
     auto gh = _gate.hold();
     try {
-        auto units = _m.get_units();
+        auto units = co_await _m.get_units();
         const auto ts = _buckets[idx].begin;
         /// Grab the data, across this scheduling point we cannot assume things
         /// like _current_window have the same value as before this call, that


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12755
Fixes: https://github.com/redpanda-data/redpanda/issues/12764,