### PR TITLE
cloud_storage: Remove manifest lock

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -919,7 +919,6 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
       _conf->cloud_storage_initial_backoff,
       &rtc.get());
     retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
-    auto units = co_await _parent.archival_meta_stm()->acquire_manifest_lock();
 
     auto upload_insync_offset = manifest().get_insync_offset();
 

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -340,6 +340,9 @@ public:
     partition_manifest truncate(model::offset starting_rp_offset);
     partition_manifest truncate();
 
+    /// Clone the entire manifest
+    partition_manifest clone() const;
+
     /// \brief Truncate the manifest (remove entries from the manifest)
     ///
     /// \note this works the same way as 'truncate' but the 'archive' size

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -778,7 +778,8 @@ uint64_t remote_partition::cloud_log_size() const {
 
 ss::future<> remote_partition::serialize_json_manifest_to_output_stream(
   ss::output_stream<char>& output) const {
-    return _manifest_view->stm_manifest().serialize_json(output);
+    auto tmp = _manifest_view->stm_manifest().clone();
+    co_await tmp.serialize_json(output);
 }
 
 // returns term last kafka offset

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -735,10 +735,6 @@ ss::future<> archival_metadata_stm::apply(model::record_batch b) {
         co_return;
     }
 
-    // Block manifest serialization during mutation of the
-    // manifest since it's asynchronous.
-    auto units = co_await _manifest_lock.get_units();
-
     b.for_each_record([this, base_offset = b.base_offset()](model::record&& r) {
         auto key = serde::from_iobuf<cmd_key>(r.release_key());
 

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -210,9 +210,6 @@ public:
     command_batch_builder
     batch_start(ss::lowres_clock::time_point deadline, ss::abort_source&);
 
-    /// Acquire the lock that prevents modification of the manifest.
-    auto acquire_manifest_lock() { return _manifest_lock.get_units(); }
-
     enum class state_dirty : uint8_t { dirty, clean };
 
     // If state_dirty::dirty is returned the manifest should be uploaded
@@ -288,7 +285,6 @@ private:
     prefix_logger _logger;
 
     mutex _lock;
-    mutex _manifest_lock;
 
     ss::shared_ptr<cloud_storage::partition_manifest> _manifest;
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1019,8 +1019,6 @@ ss::future<> partition::serialize_json_manifest_to_output_stream(
           "{} not configured for cloud storage", _topic_cfg->tp_ns));
     }
 
-    auto lock = co_await _archival_meta_stm->acquire_manifest_lock();
-
     // The timeout here is meant to place an upper bound on the amount
     // of time the manifest lock is held for.
     co_await ss::with_timeout(


### PR DESCRIPTION
The manifest lock was needed because JSON serialization took long. The manifest might have changed during the process and the result would be invalid. Since we moved to binary format we no longer need to use this lock. The only place where we're using this lock is admin API (the endpoint returns JSON object). To avoid data races there this commit copies the entire manifest before serializing it to JSON. It also removes the lock.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none