### PR TITLE
test-infra: add byoc-mock to cdt dependencies.

### DIFF
--- a/tests/docker/cdt_ducktape_deps.sh
+++ b/tests/docker/cdt_ducktape_deps.sh
@@ -21,6 +21,7 @@ REMOTE_FILES_PATH="/tmp" # https://github.com/redpanda-data/vtools/blob/dev/qa/i
 "$REMOTE_FILES_PATH/tests/docker/ducktape-deps/addr2line"
 "$REMOTE_FILES_PATH/tests/docker/ducktape-deps/kafka-streams-examples"
 "$REMOTE_FILES_PATH/tests/docker/ducktape-deps/arroyo"
+"$REMOTE_FILES_PATH/tests/docker/ducktape-deps/byoc-mock"
 
 mkdir -p /opt/redpanda-tests/ /opt/remote /opt/scripts
 pushd "$REMOTE_FILES_PATH"


### PR DESCRIPTION
byoc-mock was introduced in #12456 to ducktape
tests. This commit adds the dependency to CDT.

This PR and vtools/2021 Fixes #12508 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
