### PR TITLE
cloud_storage: enforce cloud read path limits strictly

### DIFF
--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -57,11 +57,11 @@ public:
 
     void register_segment(materialized_segment_state& s);
 
-    ssx::semaphore_units get_segment_reader_units();
+    ss::future<segment_reader_units> get_segment_reader_units();
 
     ss::future<ssx::semaphore_units> get_partition_reader_units(size_t);
 
-    ssx::semaphore_units get_segment_units();
+    ss::future<segment_units> get_segment_units();
 
     materialized_manifest_cache& get_materialized_manifest_cache();
 
@@ -93,6 +93,14 @@ private:
     uint64_t get_partition_readers_delayed() {
         return _partition_readers_delayed;
     }
+
+    /// Counts the number of times when get_segment_reader_units() was
+    /// called and had to sleep because no units were immediately available.
+    uint64_t get_segment_readers_delayed() { return _segment_readers_delayed; }
+
+    /// Counts the number of times when get_segment_units() was
+    /// called and had to sleep because no units were immediately available.
+    uint64_t get_segments_delayed() { return _segments_delayed; }
 
     /// Consume from _eviction_list
     ss::future<> run_eviction_loop();
@@ -152,6 +160,8 @@ private:
 
     /// Counter that is exposed via probe object.
     uint64_t _partition_readers_delayed{0};
+    uint64_t _segment_readers_delayed{0};
+    uint64_t _segments_delayed{0};
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/probe.cc
+++ b/src/v/cloud_storage/probe.cc
@@ -203,9 +203,24 @@ remote_probe::remote_probe(
             sm::make_counter(
               "partition_readers_delayed",
               [&ms] { return ms.get_partition_readers_delayed(); },
-              sm::description("How many read requests were delayed due to "
-                              "hitting reader limit.  This indicates cluster "
+              sm::description("How many partition reades were delayed due to "
+                              "hitting reader limit. This indicates cluster "
                               "is saturated with tiered storage reads."))
+              .aggregate({sm::shard_label}),
+            sm::make_counter(
+              "segment_readers_delayed",
+              [&ms] { return ms.get_segment_readers_delayed(); },
+              sm::description("How many segment readers were delayed due to "
+                              "hitting reader limit. This indicates cluster "
+                              "is saturated with tiered storage reads."))
+              .aggregate({sm::shard_label}),
+            sm::make_counter(
+              "segment_materializations_delayed",
+              [&ms] { return ms.get_segments_delayed(); },
+              sm::description(
+                "How many segment materializations were delayed due to "
+                "hitting reader limit. This indicates cluster "
+                "is saturated with tiered storage reads."))
               .aggregate({sm::shard_label}),
             sm::make_counter(
               "segment_index_uploads_total",

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -205,13 +205,15 @@ private:
     borrow_result_t borrow_next_segment_reader(
       const partition_manifest& manifest,
       storage::log_reader_config config,
+      segment_units segment_unit,
+      segment_reader_units segment_reader_unit,
       model::offset hint = {});
 
     /// Materialize new segment
     /// @return iterator that points to newly added segment (always valid
     /// iterator)
-    iterator
-    materialize_segment(const remote_segment_path& path, const segment_meta&);
+    iterator materialize_segment(
+      const remote_segment_path& path, const segment_meta&, segment_units);
 
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;

--- a/src/v/cloud_storage/segment_state.cc
+++ b/src/v/cloud_storage/segment_state.cc
@@ -51,7 +51,8 @@ std::unique_ptr<remote_segment_batch_reader>
 materialized_segment_state::borrow_reader(
   const storage::log_reader_config& cfg,
   retry_chain_logger& ctxlog,
-  partition_probe& probe) {
+  partition_probe& probe,
+  segment_reader_units unit) {
     atime = ss::lowres_clock::now();
     for (auto it = readers.begin(); it != readers.end(); it++) {
         if ((*it)->config().start_offset == cfg.start_offset) {
@@ -68,12 +69,8 @@ materialized_segment_state::borrow_reader(
     }
     vlog(ctxlog.debug, "creating new reader, config: {}", cfg);
 
-    // Obey budget for concurrent readers: call into materialized_segments
-    // to give it an opportunity to free state and make way for us.
-    auto units = parent->materialized().get_segment_reader_units();
-
     return std::make_unique<remote_segment_batch_reader>(
-      segment, cfg, probe, std::move(units));
+      segment, cfg, probe, std::move(unit));
 }
 
 ss::future<> materialized_segment_state::stop() {

--- a/src/v/cloud_storage/segment_state.h
+++ b/src/v/cloud_storage/segment_state.h
@@ -45,7 +45,8 @@ struct materialized_segment_state {
     std::unique_ptr<remote_segment_batch_reader> borrow_reader(
       const storage::log_reader_config& cfg,
       retry_chain_logger& ctxlog,
-      partition_probe& probe);
+      partition_probe& probe,
+      segment_reader_units unit);
 
     ss::future<> stop();
 

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -34,6 +34,13 @@ static constexpr model::cloud_credentials_source config_file{
 
 struct cloud_storage_fixture : s3_imposter_fixture {
     cloud_storage_fixture() {
+        config::shard_local_cfg()
+          .cloud_storage_max_segment_readers_per_shard.reset();
+        config::shard_local_cfg()
+          .cloud_storage_max_partition_readers_per_shard.reset();
+        config::shard_local_cfg()
+          .cloud_storage_max_materialized_segments_per_shard.reset();
+
         tmp_directory.create().get();
         cache
           .start(

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -47,6 +47,11 @@ using local_segment_path
 /// Number of simultaneous connections to S3
 using connection_limit = named_type<size_t, struct archival_connection_limit_t>;
 
+using segment_reader_units
+  = named_type<ssx::semaphore_units, struct segment_reader_units_type>;
+using segment_units
+  = named_type<ssx::semaphore_units, struct segment_units_type>;
+
 /// Version of the segment name format
 enum class segment_name_format : int16_t {
     // Original metadata format, segment name has simple format (same as on


### PR DESCRIPTION
```
There's a number of cluster configs that impose limits on the cloud
storage read path:
* cloud_storage_max_segment_readers
* cloud_storage_max_partition_readers
* cloud_storage_max_materialized_segments_per_shard

Previously, only the partition reader limit was strictly respected.
The number of materialized segments and segment readers was allowed to
overshoot. This is detrimental in the event of a storm of cloud storage
requests since we can't trim fast enough and end up with a significant
amount of memory used by the cloud storage subsystem.

Enforcing these limits, also acts as a rudimentary multi-level
backpressure mechanism for cloud storage reads.

Implementation wise, the gist of this commit is that we separate finding
the metadata for the segment which should service the read, from
reusing/creating the materialized segment and segment reader. We find
the metadata for the segment without introducing scheduling points (such
that the manifest is stable), and then asynchronously grab the required
resources.
```

Fixes #12135

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
* Make enforcement of `cloud_storage_max_segment_readers` and `cloud_storage_max_materialized_segments_per_shard` strict
