### PR TITLE
Fix observed window drift in usage based billing

### DIFF
--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -188,14 +188,18 @@ void usage_aggregator<clock_type>::rearm_window_timer() {
       std::
         is_same_v<decltype(_usage_window_width_interval), std::chrono::seconds>,
       "Interval is assumed to be in units of seconds");
-    const auto now = clock_type::now();
+    const auto now = timestamp_t::now();
+    const auto now_ts = epoch_time_secs(now);
     /// This modulo trick only works because epoch time is hour aligned
     const auto delta = std::chrono::seconds(
       epoch_time_secs(now) % _usage_window_width_interval.count());
     const auto duration_until_next_close = _usage_window_width_interval - delta;
     vassert(
-      duration_until_next_close >= 0s,
-      "Error correctly detecting last window delta");
+      duration_until_next_close >= 0s
+        && duration_until_next_close <= _usage_window_width_interval,
+      "Error correctly detecting last window delta: {} now: {}",
+      delta.count(),
+      now_ts);
     _close_window_timer.arm(duration_until_next_close);
 }
 

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -193,6 +193,11 @@ void usage_aggregator<clock_type>::rearm_window_timer() {
     /// This modulo trick only works because epoch time is hour aligned
     const auto delta = std::chrono::seconds(
       epoch_time_secs(now) % _usage_window_width_interval.count());
+    vlog(
+      klog.debug,
+      "Usage based billing window_close timer fired, time_now: {} delta: {}",
+      now_ts,
+      delta.count());
     const auto duration_until_next_close = _usage_window_width_interval - delta;
     vassert(
       duration_until_next_close >= 0s

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -347,7 +347,11 @@ void usage_aggregator<clock_type>::close_window() {
         } else {
             vlog(klog.info, "{}", err_str);
         }
-        cur.reset(now_ts);
+        /// Reset the window to the nearest interval
+        const auto true_now = timestamp_t::now();
+        const auto diff_secs = std::chrono::seconds(
+          epoch_time_secs(true_now) % _usage_window_width_interval.count());
+        cur.reset(epoch_time_secs(true_now - diff_secs));
     } else {
         const auto w = _current_window;
         _current_window = (_current_window + 1) % _buckets.size();

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -32,7 +32,7 @@ std::chrono::time_point<clock_type, duration> round_to_interval(
     /// error if this cannot be done within some threshold.
     using namespace std::chrono_literals;
     const auto interval = usage_window_width_interval;
-    const auto err_threshold = interval < 2min ? interval : 2min;
+    const auto err_threshold = interval < 2min ? 1s : 2min;
     const auto cur_interval_start = t - (t.time_since_epoch() % interval);
     const auto next_interval_start = cur_interval_start + interval;
     if (t - cur_interval_start <= err_threshold) {
@@ -43,8 +43,9 @@ std::chrono::time_point<clock_type, duration> round_to_interval(
     vlog(
       klog.error,
       "usage has detected a timestamp '{}' that exceeds the preconfigured "
-      "threshold of 2min meaning a clock has fired later or earlier then "
+      "threshold of {}s meaning a clock has fired later or earlier then "
       "expected, this is unexpected behavior and should be investigated.",
+      std::chrono::duration_cast<std::chrono::seconds>(interval),
       t.time_since_epoch().count());
     return t;
 }

--- a/tests/rptest/tests/usage_test.py
+++ b/tests/rptest/tests/usage_test.py
@@ -7,9 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import re
 import time
 import random
 import operator
+from rptest.services.redpanda import RedpandaService
 from rptest.clients.rpk import RpkTool
 from requests.exceptions import HTTPError
 from rptest.services.cluster import cluster
@@ -26,7 +28,7 @@ from functools import reduce
 from rptest.services.admin import Admin
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
-from rptest.utils.functional import flat_map
+from rptest.utils.functional import flat_map, flatten
 
 
 class UsageWindow:
@@ -111,6 +113,7 @@ class UsageTest(RedpandaTest):
                                           window_interval=3,
                                           disk_write_interval=5)
         super(UsageTest, self).__init__(test_context=test_context,
+                                        log_level='debug',
                                         extra_rp_conf=self._settings)
         self._ctx = test_context
         self._admin = Admin(self.redpanda)
@@ -282,6 +285,41 @@ class UsageTest(RedpandaTest):
         consumer.stop()
         return total_produced
 
+    def _grab_log_lines(self, pattern):
+        def search_log_lines(node):
+            lines = []
+            for line in node.account.ssh_capture(
+                    f"grep \"{pattern}\" {RedpandaService.STDOUT_STDERR_CAPTURE} || true",
+                    timeout_sec=60):
+                lines.append(line.strip())
+            return lines
+
+        return [search_log_lines(node) for node in self.redpanda.nodes]
+
+    def _validate_timer_interval(self):
+        log_lines = self._grab_log_lines("Usage based billing window_close*")
+
+        assert len(log_lines) > 0, "Debug logging not enabled"
+        self.redpanda.logger.debug(f"Log lines: {log_lines}")
+
+        # Remove the first element as it is expected to not be aligned
+        log_lines = flatten([xs[1:] for xs in log_lines])
+
+        regex = re.compile(r".*delta: (?P<delta>\d*)")
+
+        # Parse the value from the log line for lines across all nodes
+        def delta_parse(x):
+            v = regex.match(x)
+            if v is None:
+                raise RuntimeError(f"Unexpected log line: {x}")
+            return int(v[1])
+
+        # Parse the contents to just grab the value of `delta` within the log
+        fire_times = [delta_parse(x) for x in log_lines]
+
+        # Ensure all deltas are 0 meaning there is no skew
+        return all([x == 0 for x in fire_times])
+
     @cluster(num_nodes=3)
     def test_usage_metrics_collection(self):
         # Assert windows are closing
@@ -317,6 +355,9 @@ class UsageTest(RedpandaTest):
 
             prev_usage = usage
             iterations += 1
+
+        # Additional validation to ensure there were no gaps and the timer fired exactly on time
+        assert self._validate_timer_interval()
 
     @cluster(num_nodes=4)
     def test_usage_collection_restart(self):

--- a/tests/rptest/utils/functional.py
+++ b/tests/rptest/utils/functional.py
@@ -18,3 +18,12 @@ def flat_map(fn, input_list):
     each argument in `input_list`.
     """
     return reduce(lambda acc, x: acc + fn(x), input_list, [])
+
+
+def flatten(input_list):
+    """
+    Expects a list of lists
+
+    Returns all lists concatenated into one
+    """
+    return reduce(lambda acc, x: acc + x, input_list)


### PR DESCRIPTION
This patch fixes two bugs observed with usage based billing:
1. The timer would sometimes appear to not fire on the configured interval
2. The correctly detected erraneous windows were not tossed aside from the result set

The root cause of the issues was a method called `rearm_window_timer`, it was erraneously querying `ss::lowres_clock` for wall clock timestamps to use in calculations to determine when to arm the timer so that it will close at exactly the next interval

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in usage based billing where timer doesn't fire at configured interval.
* Fixes a bug in usage based billing where windows with inconstant begin/end timestamps are not tossed from the result set.

