### PR TITLE
kafka: Tag connection aborts with abort type

### DIFF
--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -152,6 +152,7 @@ public:
             conn->shutdown_input();
         }
         co_await _wait_input_shutdown.get_future();
+        co_await _as.request_abort_ex(ssx::connection_aborted_exception{});
         co_await _as.stop();
     }
 

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -11,6 +11,7 @@
 
 #include "net/exceptions.h"
 #include "rpc/service.h"
+#include "ssx/abort_source.h"
 
 #include <seastar/core/future.hh>
 
@@ -89,6 +90,10 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
             return fmt::format("invalid request: {}", e.what());
         }
         return "invalid request";
+    } catch (const ssx::connection_aborted_exception&) {
+        return "connection aborted";
+    } catch (const ssx::shutdown_requested_exception&) {
+        return "shutdown requested";
     } catch (const ss::nested_exception& e) {
         if (auto err = is_disconnect_exception(e.inner)) {
             return err;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -84,6 +84,7 @@
 #include "redpanda/admin_server.h"
 #include "resource_mgmt/io_priority.h"
 #include "resource_mgmt/memory_sampling.h"
+#include "ssx/abort_source.h"
 #include "ssx/thread_worker.h"
 #include "storage/backlog_controller.h"
 #include "storage/chunk_cache.h"
@@ -1707,7 +1708,11 @@ application::set_proxy_client_config(ss::sstring name, std::any val) {
 }
 
 void application::trigger_abort_source() {
-    _as.invoke_on_all([](auto& local_as) { local_as.request_abort(); }).get();
+    _as
+      .invoke_on_all([](auto& local_as) {
+          local_as.request_abort_ex(ssx::shutdown_requested_exception{});
+      })
+      .get();
 }
 
 void application::wire_up_bootstrap_services() {

--- a/src/v/ssx/abort_source.h
+++ b/src/v/ssx/abort_source.h
@@ -73,4 +73,7 @@ private:
     std::optional<ss::abort_source::subscription> _sub;
 };
 
+struct shutdown_requested_exception : ss::abort_requested_exception {};
+struct connection_aborted_exception : ss::abort_requested_exception {};
+
 } // namespace ssx


### PR DESCRIPTION
This allows us to differentiate the reason for an abort and also avoid
"expected" error logs.

Fixes https://github.com/redpanda-data/redpanda/issues/12722
Fixes https://github.com/redpanda-data/redpanda/issues/12723

Co-Authored-By: Ben Pope <ben@redpanda.com>

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes


* none
