### PR TITLE
tests: fix path for rpk byoc-mock

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -183,7 +183,7 @@ RUN /k8s && \
 
 FROM golang as byoc-mock
 
-COPY --chown=0:0 --chmod=0755 tests/go/byoc-mock /opt/redpanda-tests/byoc-mock
+COPY --chown=0:0 --chmod=0755 tests/go/byoc-mock /opt/redpanda-tests/go/byoc-mock
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/byoc-mock /
 RUN /byoc-mock && rm /byoc-mock
 
@@ -262,7 +262,7 @@ COPY --from=k8s /usr/local/bin/kubectl /usr/local/bin/helm /usr/local/bin/
 COPY --from=kaf /usr/local/bin/kaf /usr/local/bin/
 COPY --from=kcl /usr/local/bin/kcl /usr/local/bin/
 COPY --from=kgo-verifier /opt/kgo-verifier /opt/kgo-verifier
-COPY --from=byoc-mock /opt/redpanda-tests/byoc-mock/.rpk.managed-byoc /root/.local/bin/.rpk.managed-byoc
+COPY --from=byoc-mock /opt/redpanda-tests/go/byoc-mock/.rpk.managed-byoc /root/.local/bin/.rpk.managed-byoc
 
 RUN ldconfig
 

--- a/tests/docker/ducktape-deps/byoc-mock
+++ b/tests/docker/ducktape-deps/byoc-mock
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-cd /opt/redpanda-tests/byoc-mock
+cd /opt/redpanda-tests/go/byoc-mock
 go mod tidy
 go build -o .rpk.managed-byoc


### PR DESCRIPTION
This path mismatch triggers an error in cdt, first this commits deals with that and another PR will
add this dependency to vtools.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
