### PR TITLE
Fix/cstore hints handling

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -553,23 +553,35 @@ public:
         auto bo = *base_offset_iter;
         auto ix = base_offset_iter.index();
 
-        // escape hatch: disable the use of _hints if their value causes
-        // std::out_of_bound exceptions.
-        auto hint_it
-          = unlikely(
-              config::shard_local_cfg().storage_ignore_cstore_hints.value())
-              ? _hints.end()
-              : _hints.lower_bound(bo);
-        auto hint_threshold = base_offset_iter.get_frame_initial_value();
-        auto hint_initial = hint_it != _hints.end()
-                              ? hint_it->second->at(2).initial
-                              : 0;
-        // The hint can only be applied within the same column_store_frame
-        // instance. If the hint belongs to the previous frame we need to
-        // materialize without optimization.
-        if (
-          hint_it == _hints.end() || hint_it->second == std::nullopt
-          || hint_initial < hint_threshold) {
+        auto maybe_hint = [&]() -> std::optional<hint_vec_t> {
+            // escape hatch: disable the use of _hints if their value causes
+            // std::out_of_bound exceptions.
+            if (unlikely(config::shard_local_cfg()
+                           .storage_ignore_cstore_hints.value())) {
+                return std::nullopt;
+            }
+
+            auto hint_it = _hints.lower_bound(bo);
+            if (hint_it == _hints.end() || hint_it->second == std::nullopt) {
+                return std::nullopt;
+            }
+
+            auto& hint_vec = hint_it->second.value();
+            auto hint_threshold = base_offset_iter.get_frame_initial_value();
+            auto hint_initial
+              = hint_vec.at(static_cast<size_t>(segment_meta_ix::base_offset))
+                  .initial;
+
+            // The hint can only be applied within the same column_store_frame
+            // instance. If the hint belongs to the previous frame we need to
+            // materialize without optimization.
+            if (hint_initial < hint_threshold) {
+                return std::nullopt;
+            }
+            return hint_vec;
+        }();
+
+        if (!maybe_hint) {
             return iterators_t(
               _is_compacted.at_index(ix),
               _size_bytes.at_index(ix),
@@ -586,7 +598,7 @@ public:
               _metadata_size_hint.at_index(ix));
         }
 
-        auto hint = hint_it->second;
+        auto& hint = maybe_hint.value();
         return iterators_t(
           at_with_hint<segment_meta_ix::is_compacted>(_is_compacted, ix, hint),
           at_with_hint<segment_meta_ix::size_bytes>(_size_bytes, ix, hint),

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -25,6 +25,13 @@
 
 namespace cloud_storage {
 
+// each frame contains up to #cstore_max_frame_size elements, compressed with
+// deltafor
+constexpr size_t cstore_max_frame_size = 0x400;
+// every #cstore_sampling_rate element inserted, the byte position in the
+// compressed buffer is recorded to speed up random access
+constexpr size_t cstore_sampling_rate = 8;
+
 template<class value_t, class decoder_t>
 class segment_meta_frame_const_iterator
   : public boost::iterator_facade<
@@ -530,7 +537,7 @@ public:
     /// index lookup operations
     using hint_t = typename frame_t::hint_t;
 
-    static constexpr size_t max_frame_size = 0x400;
+    static constexpr size_t max_frame_size = cstore_max_frame_size;
     using const_iterator
       = segment_meta_column_const_iterator<value_t, delta_alg>;
 

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -43,11 +43,13 @@ public:
       decoder_t decoder,
       const std::array<value_t, buffer_depth>& head,
       uint32_t size,
-      uint32_t pos = 0)
+      uint32_t pos = 0,
+      value_t frame_initial_value = {})
       : _head(head)
       , _decoder(std::move(decoder))
       , _pos(pos)
-      , _size(size) {
+      , _size(size)
+      , _frame_initial(frame_initial_value) {
         if (!_decoder->read(_read_buf)) {
             _read_buf = _head;
         }
@@ -57,6 +59,8 @@ public:
     segment_meta_frame_const_iterator() = default;
 
     uint32_t index() const { return _pos; }
+
+    value_t get_frame_initial_value() const noexcept { return _frame_initial; }
 
 private:
     const value_t& dereference() const {
@@ -90,6 +94,7 @@ private:
     std::optional<decoder_t> _decoder{std::nullopt};
     uint32_t _pos{0};
     uint32_t _size{0};
+    value_t _frame_initial;
 };
 
 struct share_frame_t {};
@@ -219,7 +224,12 @@ public:
           delta_alg_instance);
         decoder.skip(hint);
         auto curr_ix = hint.num_rows * details::FOR_buffer_depth;
-        auto it = const_iterator(std::move(decoder), _head, _size, curr_ix);
+        auto it = const_iterator(
+          std::move(decoder),
+          _head,
+          _size,
+          curr_ix,
+          _tail->get_initial_value());
         std::advance(it, index - curr_ix);
         return it;
     }
@@ -233,6 +243,14 @@ public:
         return sizeof(*this) + _tail.value().mem_use();
     }
 
+    /// Return first element of the frame or nullopt if frame is empty
+    auto get_initial_value() const noexcept {
+        if (_tail.has_value()) {
+            return std::make_optional(_tail->get_initial_value());
+        }
+        return std::nullopt;
+    }
+
     const_iterator begin() const {
         if (_tail.has_value()) {
             decoder_t decoder(
@@ -240,7 +258,8 @@ public:
               _tail->get_row_count(),
               _tail->share(),
               delta_alg_instance);
-            return const_iterator(std::move(decoder), _head, _size);
+            return const_iterator(
+              std::move(decoder), _head, _size, 0, _tail->get_initial_value());
         } else if (_size != 0) {
             // special case, data is only stored in the buffer
             // not in the compressed column
@@ -454,6 +473,10 @@ public:
         // Invariant: _inner_it is never equal to _inner_end
         // unless the iterator points to the end.
         return _inner_it == _inner_end;
+    }
+
+    auto get_frame_initial_value() const noexcept {
+        return _outer_it->get_frame_initial_value();
     }
 
 private:


### PR DESCRIPTION
Fixes hints access in cstore, where a lower_bound will land a base offset in a frame and the related hint in the previous frame. 
a unit test with a reproducer is included.

a simple order of operations for the reproducer is

1. create 2 cstore frames 
2. prefix truncate the first element
  2.1 the first frame will get less elements than max, the second frame being full will cause the creation of a new frame for the next insert
3. insert a new element, creating a new frame
  3.1 this new element will not get a hint, because hint creation is based on cstore size at the moment of append, and the size is not a multiple anymore of sampling rate 

a different design would make hint creation dependant on current frame size, but the solution in this pr is more general

#Fixes https://github.com/redpanda-data/redpanda/issues/12687

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* in some interleaving of appends + prefix_truncate + lower_bound, the wrong internal hint would be accessed