### PR TITLE
schema_registry: Alias referencedby by referencedBy 

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -731,10 +731,65 @@
         }
       }
     },
-    "/subjects/{subject}/versions/{version}/referencedBy": {
+    "/subjects/{subject}/versions/{version}/referencedby": {
       "get": {
         "summary": "Retrieve a list of schema ids that reference the subject and version.",
         "operationId": "get_subject_versions_version_referenced_by",
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                  "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "422": {
+            "description": "Invalid version",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
+    "/subjects/{subject}/versions/{version}/referencedBy": {
+      "get": {
+        "summary": "Retrieve a list of schema ids that reference the subject and version.",
+        "deprecated": true,
+        "operationId": "get_subject_versions_version_referenced_by_deprecated",
         "parameters": [
           {
             "name": "subject",

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -152,6 +152,11 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       wrap(gate, es, get_subject_versions_version_referenced_by)});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::
+        get_subject_versions_version_referenced_by_deprecated,
+      wrap(gate, es, get_subject_versions_version_referenced_by)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::delete_subject,
       wrap(gate, es, delete_subject)});
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -370,11 +370,18 @@ class SchemaRegistryEndpoints(RedpandaTest):
 
     def _get_subjects_subject_versions_version_referenced_by(
             self, subject, version, headers=HTTP_GET_HEADERS, **kwargs):
-        return self._request(
+        deprecated = self._request(
             "GET",
             f"subjects/{subject}/versions/{version}/referencedBy",
             headers=headers,
             **kwargs)
+        standard = self._request(
+            "GET",
+            f"subjects/{subject}/versions/{version}/referencedby",
+            headers=headers,
+            **kwargs)
+        assert standard.json() == deprecated.json()
+        return standard
 
     def _get_subjects_subject_versions(self,
                                        subject,


### PR DESCRIPTION
`referencedBy` is a typo, but has been around a long time, so replace it with `referencedby`, but keep it as an alias.

Fixes #12729
Closes #12745

## Docs

The reference will need updating
https://docs.redpanda.com/docs/api/pandaproxy-schema-registry/

1. Version has been bumped from `1.0.1` to `1.0.2`.
2. Introduce `GET subjects/{subject}/versions/{version}/referencedby`
3. Deprecate `GET subjects/{subject}/versions/{version}/referencedBy`


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Improvements

* Schema Registry: Introduce `GET subjects/{subject}/versions/{version}/referencedby`
