### PR TITLE
Migrated scaling up tests to kgo services

### DIFF
--- a/tests/rptest/tests/node_pool_migration_test.py
+++ b/tests/rptest/tests/node_pool_migration_test.py
@@ -190,6 +190,7 @@ class NodePoolMigrationTest(PreallocNodesTest):
             self.msg_size,
             readers=1,
             nodes=self.preallocated_nodes)
+        self.consumer.start(clean=False)
 
     def verify(self):
         self.logger.info(

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -274,6 +274,8 @@ class NodesDecommissioningTest(PreallocNodesTest):
             readers=1,
             nodes=self.preallocated_nodes)
 
+        self.consumer.start(clean=False)
+
     def verify(self):
         self.logger.info(
             f"verifying workload: topic: {self._topic}, with [rate_limit: {self.producer_throughput}, message size: {self.msg_size}, message count: {self.msg_count}]"


### PR DESCRIPTION
Scaling up tests were previously using `VerifiableConsumer/Producer` services to generate the traffic. Those services relay on ducktape engine to analyze standard output and parse events. This is ineffective and as a result python wrapper for verifiable service may lag behind what was actually consumed/produced. To address this issue changed `ScalingUpTest` to use `kgo-verifier`

Fixes: #12826
Fixes: #12813

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none