### PR TITLE
kafka: log errored responses at DEBUG instead of TRACE

### DIFF
--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1063,6 +1063,11 @@ class Field:
         type_name, _ = self._redpanda_type()
         return type_name not in WITHOUT_DEFAULT_EQUALITY_OPERATOR
 
+    @property
+    def is_error_code(self):
+        type_name, _ = self._redpanda_type()
+        return type_name == "kafka::error_code"
+
 
 HEADER_TEMPLATE = """
 #pragma once
@@ -1114,6 +1119,9 @@ struct {{ struct.name }} {
 {%- endif %}
 {%- if struct.is_default_comparable %}
     friend bool operator==(const {{ struct.name }}&, const {{ struct.name }}&) = default;
+{%- endif %}
+{%- if op_type == "response" %}
+    bool errored() const;
 {%- endif %}
 {% endmacro %}
 
@@ -1178,6 +1186,8 @@ COMBINED_SOURCE_TEMPLATE = """
 {%- endfor %}
 
 #include "kafka/protocol/wire.h"
+
+#include <algorithm>
 
 #include <fmt/core.h>
 #include <fmt/format.h>
@@ -1444,6 +1454,52 @@ writer.write_tags(std::move({{ tf }}));
 {%- endif %}
 {%- endmacro %}
 
+{% macro render_errored_source(struct) %}
+{%- if op_type == "response" %}
+{%- if not struct.fields %}
+bool {{ struct.name }}::errored() const {
+    return false;
+}
+{%- else %}
+bool {{ struct.name }}::errored() const {
+    bool ret = false;
+    {%- for field in struct.fields %}
+    {%- if field.is_error_code %}
+    if ({{ field.name }} != kafka::error_code::none) {
+        return true;
+    }
+    {%- elif field.is_array and field.type().value_type().is_struct %}
+    {%- if field.nullable() %}
+    if ({{ field.name }}) {
+        ret = std::any_of(
+          {{ field.name }}->begin(),
+          {{ field.name }}->end(),
+          [](auto& item) { return item.errored(); });
+
+        if (ret) {
+            return ret;
+        }
+    }
+
+    {%- else %}
+    ret = std::any_of(
+      {{ field.name }}.begin(),
+      {{ field.name }}.end(),
+      [](auto& item) { return item.errored(); });
+
+    if (ret) {
+        return ret;
+    }
+    {%- endif %}
+    {%- endif %}
+    {%- endfor %}
+
+    return ret;
+}
+{%- endif %}
+{%- endif %}
+{% endmacro %}
+
 namespace kafka {
 
 {%- if struct.fields %}
@@ -1592,6 +1648,7 @@ std::ostream& operator<<(std::ostream& o, const {{ struct.name }}&) {
     return o << "{}";
 }
 {%- endif %}
+{{ render_errored_source(struct) }}
 {% endfor %}
 }
 """

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -185,15 +185,28 @@ public:
               r.data.throttle_time_ms, throttle_delay_ms());
         }
 
-        vlog(
-          klog.trace,
-          "[{}:{}] sending {}:{} for {}, response {}",
-          _conn->client_host(),
-          _conn->client_port(),
-          ResponseType::api_type::key,
-          ResponseType::api_type::name,
-          _header.client_id,
-          r);
+        if (r.data.errored()) {
+            vlog(
+              klog.debug,
+              "[{}:{}] sending {}:{} for {}, response {}",
+              _conn->client_host(),
+              _conn->client_port(),
+              ResponseType::api_type::key,
+              ResponseType::api_type::name,
+              _header.client_id,
+              r);
+        } else {
+            vlog(
+              klog.trace,
+              "[{}:{}] sending {}:{} for {}, response {}",
+              _conn->client_host(),
+              _conn->client_port(),
+              ResponseType::api_type::key,
+              ResponseType::api_type::name,
+              _header.client_id,
+              r);
+        }
+
         /// KIP-511 bumps api_versions_request/response to 3, past the first
         /// supported flex version for this API, and makes an exception
         /// that there will be no tags in the response header.


### PR DESCRIPTION
From slack messages https://redpandadata.slack.com/archives/C04JM4NSZ1S/p1673495659635979?thread_ts=1673489527.731349&cid=C04JM4NSZ1S and https://redpandadata.slack.com/archives/C04JM4NSZ1S/p1673496016609889?thread_ts=1673489527.731349&cid=C04JM4NSZ1S

It looks like debugging would have been quicker if support found `NOT_COORDINATOR` response in the logs earlier.

The ask is to log errored Kafka responses in a way that make it easier to identify them in the logs so the debugging process is easier. Changing the log-level for errored responses is OK but that could also lead to large log volume.

Therefore, this PR adds a method to all Kafka responses that check for an error and it logs errored responses at a limit so they do not flood logging systems.

Fixes #12858

Changes from force-push `942e443`:
- Pass the log message into `do_with`

Changes from force-push `2e32e71`:
- Changed `errored()` to be sychronous
- Remove rate limiting

Changes from force-push `4b631fd`:
- log at debug on errored response, log at trace on successful response

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* The broker now logs errored Kafka API responses at the DEBUG level.
