### PR TITLE
rpk: load docker host from context in rpk container

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.300
 	github.com/beevik/ntp v1.2.0
-	github.com/cespare/xxhash v1.1.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/docker v24.0.4+incompatible
 	github.com/docker/go-connections v0.4.0
@@ -18,6 +17,7 @@ require (
 	github.com/lestrrat-go/jwx v1.2.26
 	github.com/lorenzosaino/go-sysctl v0.3.1
 	github.com/moby/term v0.5.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc4
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
@@ -89,7 +89,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -52,7 +52,6 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
@@ -64,7 +63,6 @@ github.com/beevik/ntp v1.2.0/go.mod h1:vD6h1um4kzXpqmLTuu0cCLcC+NfvC0IC+ltmEDA8E
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -306,7 +304,6 @@ github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP
 github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=
 github.com/sethgrid/pester v1.2.0 h1:adC9RS29rRUef3rIKWPOuP1Jm3/MmB6ke+OhE5giENI=
 github.com/sethgrid/pester v1.2.0/go.mod h1:hEUINb4RqvDxtoCaU0BNT/HV4ig5kfgOasrf1xcvr0A=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=

--- a/src/go/rpk/pkg/cli/container/common/context.go
+++ b/src/go/rpk/pkg/cli/container/common/context.go
@@ -1,0 +1,114 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/client"
+	"github.com/opencontainers/go-digest"
+)
+
+// clientFromDockerContext reads the current docker context and parse it to
+// obtain the docker host, and creates a client with it.
+func clientFromDockerContext() (*client.Client, error) {
+	currCtx, err := currentContext()
+	if err != nil {
+		return nil, err
+	}
+	host, err := hostFromContext(currCtx.CurrentContext)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewClientWithOpts(client.WithHost(host))
+}
+
+type dockerConfig struct {
+	CurrentContext string `json:"currentContext"`
+}
+
+const (
+	dockerConfigDir   = ".docker"
+	dockerConfigFile  = "config.json"
+	dockerContextDir  = "contexts"
+	dockerContextEnv  = "DOCKER_CONTEXT"
+	dockerEndpoint    = "docker"
+	dockerMetaFile    = "meta.json"
+	dockerMetadataDir = "meta"
+)
+
+// CurrentContext returns the current docker context name based on the docker
+// environment variables or the cli configuration file, in the following
+// order of preference:
+//
+//  1. The "DOCKER_CONTEXT" environment variable.
+//  2. The current context as configured through the in "currentContext"
+//     field in the CLI configuration file ("~/.docker/config.json").
+//
+// It errors if no context is configured. This is matching what the docker CLI
+// does for context handling.
+func currentContext() (*dockerConfig, error) {
+	if curCtx, ok := os.LookupEnv(dockerContextEnv); ok {
+		return &dockerConfig{curCtx}, nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	configPath := filepath.Join(homeDir, dockerConfigDir, dockerConfigFile)
+	file, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find your docker configuration file: %v, please make sure you have Docker installed and running", err)
+	}
+	var cfg dockerConfig
+	err = json.Unmarshal(file, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read your docker config: %v", err)
+	}
+	if cfg.CurrentContext == "" {
+		return nil, fmt.Errorf("unable to get current docker context, please make sure you have Docker installed and running")
+	}
+	return &cfg, nil
+}
+
+type dockerMetadataFile struct {
+	Endpoints map[string]dockerEndpointMeta `json:"Endpoints,omitempty"`
+}
+type dockerEndpointMeta struct {
+	Host string `json:"Host"`
+}
+
+func hostFromContext(context string) (string, error) {
+	// https://github.com/docker/cli/blob/master/cli/context/store/doc.go#L30
+	contextDir := digest.FromString(context).Encoded()
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	metaFilePath := filepath.Join(homeDir, dockerConfigDir, dockerContextDir, dockerMetadataDir, contextDir, dockerMetaFile)
+	file, err := os.ReadFile(metaFilePath)
+	if err != nil {
+		return "", fmt.Errorf("unable to find your docker context file: %v, please make sure you have Docker installed and running", err)
+	}
+	var mFile dockerMetadataFile
+	err = json.Unmarshal(file, &mFile)
+	if err != nil {
+		return "", fmt.Errorf("unable to read your docker metadata file: %v", err)
+	}
+	ep, ok := mFile.Endpoints[dockerEndpoint]
+	if !ok {
+		return "", fmt.Errorf("unable to find docker endpoint in your metadata file: %v", err)
+	}
+	return ep.Host, nil
+}

--- a/src/go/rpk/pkg/cli/generate/app.go
+++ b/src/go/rpk/pkg/cli/generate/app.go
@@ -1,3 +1,12 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package generate
 
 import (


### PR DESCRIPTION
This is a workaround to new docker setups (e.g
docker desktop in Macs) which don't setup the
DOCKER_HOST env variable and does not have the
docker socket in the default location.

The alternative here is to manually parse the
docker endpoint out of the config file and the
docker context. Our current moby client does not
support contexts since this is a concept that is
only used by the CLI and the Desktop apps.

Fixes #12686 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* rpk container improvements: rpk now will search for your docker context if no `DOCKER_HOST` is set when running `rpk container` commands
