### PR TITLE
cluster_health_overview: do not (mis)report leaderless partitions aggressively

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -672,6 +672,7 @@ struct ntp_report {
     size_t size_bytes;
     std::optional<uint8_t> under_replicated_replicas;
     size_t reclaimable_size_bytes;
+    std::chrono::milliseconds ms_since_leadership_status_change;
 };
 
 partition_status to_partition_status(const ntp_report& ntpr) {
@@ -682,7 +683,9 @@ partition_status to_partition_status(const ntp_report& ntpr) {
       .revision_id = ntpr.leader.revision_id,
       .size_bytes = ntpr.size_bytes,
       .under_replicated_replicas = ntpr.under_replicated_replicas,
-      .reclaimable_size_bytes = ntpr.reclaimable_size_bytes};
+      .reclaimable_size_bytes = ntpr.reclaimable_size_bytes,
+      .ms_since_leadership_status_change
+      = ntpr.ms_since_leadership_status_change};
 }
 
 ss::chunked_fifo<ntp_report> collect_shard_local_reports(
@@ -706,6 +709,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 .size_bytes = p.second->size_bytes() + p.second->non_log_disk_size_bytes(),
                 .under_replicated_replicas = p.second->get_under_replicated(),
                 .reclaimable_size_bytes = p.second->reclaimable_local_size_bytes(),
+                .ms_since_leadership_status_change = p.second->ms_since_leadership_status_change(),
               };
           });
     } else {
@@ -721,6 +725,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 .size_bytes = partition->size_bytes() + partition->non_log_disk_size_bytes(),
                 .under_replicated_replicas = partition->get_under_replicated(),
                 .reclaimable_size_bytes = partition->reclaimable_local_size_bytes(),
+                .ms_since_leadership_status_change = partition->ms_since_leadership_status_change(),
                 });
             }
         }

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -140,14 +140,16 @@ std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
     fmt::print(
       o,
       "{{id: {}, term: {}, leader_id: {}, revision_id: {}, size_bytes: {}, "
-      "reclaimable_size_bytes: {}, under_replicated: {}}}",
+      "reclaimable_size_bytes: {}, under_replicated: {} "
+      "ms_since_leadership_status_change: {}}}",
       ps.id,
       ps.term,
       ps.leader_id,
       ps.revision_id,
       ps.size_bytes,
       ps.reclaimable_size_bytes,
-      ps.under_replicated_replicas);
+      ps.under_replicated_replicas,
+      ps.ms_since_leadership_status_change.count());
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -57,8 +57,12 @@ struct node_state
 
 struct partition_status
   : serde::
-      envelope<partition_status, serde::version<2>, serde::compat_version<0>> {
+      envelope<partition_status, serde::version<3>, serde::compat_version<0>> {
     static constexpr size_t invalid_size_bytes = size_t(-1);
+    // max serde serializable duration.
+    static constexpr auto max_duration
+      = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::nanoseconds::max());
 
     model::partition_id id;
     model::term_id term;
@@ -82,6 +86,8 @@ struct partition_status
      */
     std::optional<size_t> reclaimable_size_bytes;
 
+    std::chrono::milliseconds ms_since_leadership_status_change = max_duration;
+
     auto serde_fields() {
         return std::tie(
           id,
@@ -90,7 +96,8 @@ struct partition_status
           revision_id,
           size_bytes,
           under_replicated_replicas,
-          reclaimable_size_bytes);
+          reclaimable_size_bytes,
+          ms_since_leadership_status_change);
     }
 
     friend std::ostream& operator<<(std::ostream&, const partition_status&);

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -254,8 +254,8 @@ public:
         return _raft->get_leader_id();
     }
 
-    std::chrono::milliseconds ms_since_last_leadership_change() const {
-        return _raft->ms_since_last_leadership_change();
+    std::chrono::milliseconds ms_since_leadership_status_change() const {
+        return _raft->ms_since_leadership_status_change();
     }
 
     std::optional<uint8_t> get_under_replicated() const {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -254,6 +254,10 @@ public:
         return _raft->get_leader_id();
     }
 
+    std::chrono::milliseconds ms_since_last_leadership_change() const {
+        return _raft->ms_since_last_leadership_change();
+    }
+
     std::optional<uint8_t> get_under_replicated() const {
         return _raft->get_under_replicated();
     }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2388,7 +2388,16 @@ configuration::configuration()
       "The sample period for the CPU profiler",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       100ms,
-      {.min = 1ms}) {}
+      {.min = 1ms})
+  , leaderless_reporting_threshold_ms(
+      *this,
+      "leaderless_reporting_threshold_ms",
+      "Partitions are not reported as leaderless in health report unless they "
+      "remain leaderless for this duration. This is to avoid (mis)reporting "
+      "transient loss of leadership.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      10s,
+      {.min = 0ms}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -466,6 +466,8 @@ struct configuration final : public config_store {
     // debug controls
     property<bool> cpu_profiler_enabled;
     bounded_property<std::chrono::milliseconds> cpu_profiler_sample_period_ms;
+    bounded_property<std::chrono::milliseconds>
+      leaderless_reporting_threshold_ms;
 
     configuration();
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2848,6 +2848,7 @@ void consensus::update_follower_stats(const group_configuration& cfg) {
 }
 
 void consensus::trigger_leadership_notification() {
+    _last_leadership_update = steady_clock_type::now();
     _probe->leadership_changed();
     vlog(
       _ctxlog.debug,

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -197,7 +197,7 @@ public:
     clock_type::time_point became_leader_at() const {
         return _became_leader_at;
     };
-    std::chrono::milliseconds ms_since_last_leadership_change() const {
+    std::chrono::milliseconds ms_since_leadership_status_change() const {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
           steady_clock_type::now() - _last_leadership_update);
     }


### PR DESCRIPTION
Currently leaderless partitions can be misreported in cluster health overview  endpoint if the backend node health report collection overlaps with a transient loss of leadership (eg during an election / transfer). Node health reports are only updated every 10s by default, so this leaderless partition sticks around for the entire duration. 

This confuses users and downstream tooling that acts on this signal. To avoid this, this PR adds a new configuration "leaderless_reporting_threshold_ms" that controls how long a partition should remain leaderless before it is included in the list of leaderless partitions. Defaults to 10s. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes



<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.
-->

### Improvements

* Leaderless partitions are now reported only if they remain leaderless for at least 10 seconds (configurable via leaderless_reporting_threshold_ms). This is to avoid misreporting transient loss of leadership as leaderless partitions.

