### PR TITLE
schema_registry: Check compatibility iff the schema is a new version

### DIFF
--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -91,12 +91,20 @@ struct handler_adaptor : ss::httpd::handler_base {
             set_reply_unavailable(*rp.rep);
             rp.mime_type = _exceptional_mime_type;
         } else {
+            auto method = rq.req->_method;
+            auto url = rq.req->_url;
             try {
                 rp = co_await _handler(std::move(rq), std::move(rp));
             } catch (...) {
+                auto ex = std::current_exception();
+                vlog(
+                  plog.warn,
+                  "Request: {} {} failed: {}",
+                  method,
+                  url,
+                  std::current_exception());
                 rp = server::reply_t{
-                  exception_reply(std::current_exception()),
-                  _exceptional_mime_type};
+                  exception_reply(ex), _exceptional_mime_type};
             }
         }
         set_mime_type(*rp.rep, rp.mime_type);

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -75,7 +75,9 @@ HTTP_POST_HEADERS = {
 }
 
 schema1_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
-schema2_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"string","default":"foo"}]}'
+# Schema 2 is only backwards compatible
+schema2_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":["null","string"]},{"name":"f2","type":"string","default":"foo"}]}'
+# Schema 3 is not backwards compatible
 schema3_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"string"}]}'
 invalid_avro = '{"type":"notatype","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 
@@ -1521,6 +1523,8 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 "schema_ids": [],
                 "subject_versions": []
             }
+
+        self._set_config(data=json.dumps({"compatibility": "NONE"}))
 
         self.logger.debug("Register and check schemas before restart")
         for subject in subjects:


### PR DESCRIPTION
If a subject already has a version of the schema, don't perform compatibility checks

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Bug Fixes

* Schema Registry: Check compatibility iff the schema is a new version for the subject
