### PR TITLE
ducktape-deps: bump librdkafka version to v2.0.2

### DIFF
--- a/tests/docker/ducktape-deps/librdkafka
+++ b/tests/docker/ducktape-deps/librdkafka
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 mkdir /opt/librdkafka
-curl -SL "https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
+curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.0.2.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
 cd /opt/librdkafka
 ./configure
 make -j$(nproc)


### PR DESCRIPTION
building the arm64 AMI image (for cdt) fails because the librdkafka version is too old to build confluent-kafka. from the err log:

```
==> redpanda-testing.amazon-ebs.ubuntu:       /tmp/pip-install-pzvhcqco/confluent-
kafka_5e848025e3cf41d8aca322a8e1526b79/src/confluent_kafka/src/confluent_kafka.h:66:2: error:
#error "confluent-kafka-python requires librdkafka v2.0.2 or later.
Install the latest version of librdkafka from the Confluent repositories,
see http://docs.confluent.io/current/installation.html"
```

fixes redpanda-data/devprod#819

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
