### PR TITLE
rptest: fix `CloudClusterConfig`

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -114,8 +114,8 @@ class CloudClusterConfig:
     api_url: str
     teleport_auth_server: str
     teleport_bot_token: str
-    id: str = "" # empty string makes it easier to pass thru default value from duck.py
-    delete_cluster: str
+    id: str = ""  # empty string makes it easier to pass thru default value from duck.py
+    delete_cluster: bool = True
 
     region: str = "us-west-2"
     provider: str = "AWS"

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -114,7 +114,7 @@ class CloudClusterConfig:
     api_url: str
     teleport_auth_server: str
     teleport_bot_token: str
-    id: str
+    id: str = "" # empty string makes it easier to pass thru default value from duck.py
     delete_cluster: str
 
     region: str = "us-west-2"

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -169,7 +169,7 @@ class CloudCluster():
         The clusterId of the created cluster.
         """
 
-        return self._cluster_id
+        return self.config.id
 
     def _create_namespace(self):
         name = f'rp-ducktape-ns-{self._unique_id}'  # e.g. rp-ducktape-ns-3b36f516
@@ -387,7 +387,7 @@ class CloudCluster():
             # TODO accept the AWS VPC peering request
             # TODO create route between vpc and peering connection
 
-        return self._cluster_id
+        return self.config.id
 
     def delete(self):
         """


### PR DESCRIPTION
Fix access to `CloudClusterConfig.id` and set default values of config settings.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none