### PR TITLE
[v23.2.x] rpk: show allocation failures in decommission-status

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_broker.go
+++ b/src/go/rpk/pkg/adminapi/api_broker.go
@@ -67,9 +67,10 @@ type DecommissionMovingTo struct {
 }
 
 type DecommissionStatusResponse struct {
-	Finished     bool                     `json:"finished"`
-	ReplicasLeft int                      `json:"replicas_left"`
-	Partitions   []DecommissionPartitions `json:"partitions"`
+	Finished           bool                     `json:"finished"`
+	ReplicasLeft       int                      `json:"replicas_left"`
+	AllocationFailures []string                 `json:"allocation_failures"`
+	Partitions         []DecommissionPartitions `json:"partitions"`
 }
 
 // Brokers queries one of the client's hosts and returns the list of brokers.

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
@@ -22,7 +22,48 @@ func newDecommissionBrokerStatus(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decommission-status [BROKER ID]",
 		Short: "Show the progress of a node decommissioning",
-		Args:  cobra.ExactArgs(1),
+		Long: `Show the progrss of a node decommissioning.
+
+When a node is being decommissioned, this command reports the decommissioning
+progress as follows, where PARTITION-SIZE is in bytes.
+
+$ rpk redpanda admin brokers decommission-status 4
+DECOMMISSION PROGRESS
+=====================
+NAMESPACE-TOPIC              PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE
+kafka/test                   0          3          9             1699470920
+kafka/test                   4          3          0             1614258779
+kafka/test2                  3          3          3             2722706514
+kafka/test2                  4          3          4             2945518089
+kafka_internal/id_allocator  0          3          0             3562
+
+Using --detailed / -d, it additionally prints granular reports.
+
+$ rpk redpanda admin brokers decommission-status 4 -d
+DECOMMISSION PROGRESS
+=====================
+NAMESPACE-TOPIC  PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE  BYTES-MOVED  BYTES-REMAINING
+kafka/test       0          3          13            1731773243      228114727    1503658516
+kafka/test       4          3          1             1645952961      18752660     1627200301
+kafka/test2      3          3          5             2752632301      140975805    2611656496
+kafka/test2      4          3          6             2975443783      181581219    2793862564
+
+If a partition cannot be moved with some reason, the command reports the
+problematic partition in the 'ALLOCATION FAILURES' section and decommission
+never succeeds. Typical scenarios the failure occurs are; there's no node
+that has enough space to allocate a partition or that can satisfy rack
+constraints, etc.
+
+ALLOCATION FAILURES
+==================
+kafka/foo/2
+kafka/test/0
+
+Note that the command reports allocation failed partitions only when
+'partition_autobalancing_mode' is set to 'continuous'. See the current value
+using 'rpk cluster config get partition_autobalancing_mode'.
+`,
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			broker, _ := strconv.Atoi(args[0])
 			p, err := p.LoadVirtualProfile(fs)
@@ -55,7 +96,7 @@ func newDecommissionBrokerStatus(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			if dbs.AllocationFailures != nil {
 				sort.Strings(dbs.AllocationFailures)
-				out.Section("allocation falures")
+				out.Section("allocation failures")
 				for _, f := range dbs.AllocationFailures {
 					fmt.Println(f)
 				}

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
@@ -2,6 +2,8 @@ package brokers
 
 import (
 	"errors"
+	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
@@ -51,6 +53,16 @@ func newDecommissionBrokerStatus(fs afero.Fs, p *config.Params) *cobra.Command {
 				}
 			}
 
+			if dbs.AllocationFailures != nil {
+				sort.Strings(dbs.AllocationFailures)
+				out.Section("allocation falures")
+				for _, f := range dbs.AllocationFailures {
+					fmt.Println(f)
+				}
+				fmt.Println()
+			}
+
+			out.Section("decommission progress")
 			headers := []string{"Namespace-Topic", "Partition", "Moving-to", "Completion-%", "Partition-size"}
 			if detailed {
 				headers = append(headers, "Bytes-moved", "Bytes-remaining")


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12089
Fixes: https://github.com/redpanda-data/redpanda/issues/12884,