### PR TITLE
cloud_storage: Fix timequery

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -988,7 +988,7 @@ remote_partition::timequery(storage::timequery_config cfg) {
         co_return std::nullopt;
     }
 
-    auto start_offset = stm_manifest.get_start_kafka_offset().value();
+    auto start_offset = stm_manifest.full_log_start_kafka_offset().value();
 
     // Synthesize a log_reader_config from our timequery_config
     storage::log_reader_config config(


### PR DESCRIPTION
If the timequery is used the async_manifest_view can chose the spillover manifest or STM manifest incorrectly. If the timestamp is inside the gap between the segments the async_manifest_view is not able to chose STM manifest.

This commit fixes this by changing the timequery logic inside the async_manifest_view. The 'in_stm' function for timequeries are simplified and no longer needs to call partition_manifest.timequery.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix time query behaviour in situation when the timestamp doesn't match any segment