### PR TITLE
Retry balancer tick when topic_table was modified while iterating

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1347,11 +1347,7 @@ const topic_table::underlying_t& topic_table::all_topics_metadata() const {
 
 void topic_table::check_topics_map_stable(model::revision_id start_rev) const {
     if (_topics_map_revision != start_rev) {
-        throw std::runtime_error(fmt::format(
-          "topic table modified, aborting iteration "
-          "(start revision: {}, current revision: {})",
-          start_rev,
-          _topics_map_revision));
+        throw concurrent_modification_error(start_rev, _topics_map_revision);
     }
 }
 

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -96,6 +96,23 @@ public:
     //   * partition::get_revision_id()
     //   * raft::group_configuration::revision_id()
 
+    class concurrent_modification_error final : public std::exception {
+    public:
+        concurrent_modification_error(
+          model::revision_id initial_revision,
+          model::revision_id current_revision)
+          : _msg(ssx::sformat(
+            "Topic table was modified by concurrent fiber. (initial_revision: "
+            "{}, current_revision: {}) ",
+            initial_revision,
+            current_revision)) {}
+
+        const char* what() const noexcept final { return _msg.c_str(); }
+
+    private:
+        ss::sstring _msg;
+    };
+
     class in_progress_update {
     public:
         explicit in_progress_update(


### PR DESCRIPTION
When iterating over topic table in asynchronous loop it may be modified
by another fiber while loop yields in scheduling point. In this case
backend should retry immediately to make progress without delay of
waiting for next tick.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- faster convergence of partition balancer in face of topic operations 