### PR TITLE
add missing includes

### DIFF
--- a/src/v/cluster/partition_balancer_state.h
+++ b/src/v/cluster/partition_balancer_state.h
@@ -19,6 +19,7 @@
 #include <seastar/core/sharded.hh>
 
 #include <absl/container/btree_set.h>
+#include <absl/container/flat_hash_set.h>
 
 namespace cluster {
 

--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -18,6 +18,9 @@
 #include "serde/serde.h"
 #include "utils/to_string.h"
 
+#include <absl/container/btree_set.h>
+#include <absl/container/flat_hash_map.h>
+
 namespace cluster {
 
 struct node_disk_space {

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -18,6 +18,8 @@
 
 #include <seastar/core/sstring.hh>
 
+#include <absl/container/flat_hash_map.h>
+
 #include <cstdint>
 
 namespace model {


### PR DESCRIPTION
Adds missing includes required to switch to the new serde version which does not include everything (-> "include what you use").

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

### Bug Fixes

* none

### Features

* none

### Improvements

* prepare for new tag invoke serde
