### PR TITLE
tests: Raise the rounding timestamp error threshold for testing

### DIFF
--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -45,8 +45,8 @@ std::chrono::time_point<clock_type, duration> round_to_interval(
       "usage has detected a timestamp '{}' that exceeds the preconfigured "
       "threshold of {}s meaning a clock has fired later or earlier then "
       "expected, this is unexpected behavior and should be investigated.",
-      std::chrono::duration_cast<std::chrono::seconds>(interval),
-      t.time_since_epoch().count());
+      t.time_since_epoch().count(),
+      std::chrono::duration_cast<std::chrono::seconds>(err_threshold));
     return t;
 }
 

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -32,7 +32,7 @@ std::chrono::time_point<clock_type, duration> round_to_interval(
     /// error if this cannot be done within some threshold.
     using namespace std::chrono_literals;
     const auto interval = usage_window_width_interval;
-    const auto err_threshold = interval < 2min ? 1s : 2min;
+    const auto err_threshold = interval < 2min ? 2s : 2min;
     const auto cur_interval_start = t - (t.time_since_epoch() % interval);
     const auto next_interval_start = cur_interval_start + interval;
     if (t - cur_interval_start <= err_threshold) {


### PR DESCRIPTION
There have been some reports of failures in a usage test that is due to a timer being fired a second later then normal. Given some possible discrepancy with rounding and that the error has only been observed in cases where the observed timestamp is 1s over the expected, this patch raises the error threshold for the timer to two seconds. 

Fixes: #12678 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
