### PR TITLE
retest: Implement VPC peering for Cloud Cluster with private network

### DIFF
--- a/tests/rptest/services/provider_clients/__init__.py
+++ b/tests/rptest/services/provider_clients/__init__.py
@@ -2,10 +2,10 @@ from rptest.services.provider_clients.ec2_client import EC2Client
 from rptest.services.provider_clients.gcp_client import GCPClient
 
 
-def make_provider_client(provider, provider_config=None):
+def make_provider_client(provider, logger, provider_config=None):
     _client = None
     if provider == 'AWS':
-        _client = EC2Client(provider_config)
+        _client = EC2Client(provider_config, logger)
     elif provider == 'GCP':
-        _client = GCPClient(provider_config)
+        _client = GCPClient(provider_config, logger)
     return _client

--- a/tests/rptest/services/provider_clients/__init__.py
+++ b/tests/rptest/services/provider_clients/__init__.py
@@ -1,0 +1,11 @@
+from rptest.services.provider_clients.ec2_client import EC2Client
+from rptest.services.provider_clients.gcp_client import GCPClient
+
+
+def make_provider_client(provider, provider_config=None):
+    _client = None
+    if provider == 'AWS':
+        _client = EC2Client(provider_config)
+    elif provider == 'GCP':
+        _client = GCPClient(provider_config)
+    return _client

--- a/tests/rptest/services/provider_clients/__init__.py
+++ b/tests/rptest/services/provider_clients/__init__.py
@@ -2,10 +2,10 @@ from rptest.services.provider_clients.ec2_client import EC2Client
 from rptest.services.provider_clients.gcp_client import GCPClient
 
 
-def make_provider_client(provider, logger, provider_config=None):
+def make_provider_client(provider, logger, region, key, secret):
     _client = None
     if provider == 'AWS':
-        _client = EC2Client(provider_config, logger)
+        _client = EC2Client(region, key, secret, logger)
     elif provider == 'GCP':
-        _client = GCPClient(provider_config, logger)
+        _client = GCPClient(region, key, secret, logger)
     return _client

--- a/tests/rptest/services/provider_clients/ec2_client.py
+++ b/tests/rptest/services/provider_clients/ec2_client.py
@@ -5,6 +5,7 @@ RESPONCE_META_LABEL = "ResponseMetadata"
 VPC_PEERING_LABEL = "VpcPeeringConnection"
 VPC_PEERING_ID_LABEL = "VpcPeeringConnectionId"
 VPCS_PEERING_LABEL = "VpcPeeringConnections"
+VPCS_LABEL = "Vpcs"
 RTBS_LABEL = "RouteTables"
 RTB_ID_LABEL = "RouteTableId"
 
@@ -13,11 +14,17 @@ class EC2Client:
     """
     This almost mimics S3Client from archival.
     """
-    def __init__(self, config, logger, endpoint=None, disable_ssl=True):
+    def __init__(self,
+                 region,
+                 key,
+                 secret,
+                 logger,
+                 endpoint=None,
+                 disable_ssl=True):
 
-        self._region = config['region']
-        self._access_key = config['access_key']
-        self._secret_key = config['secret_key']
+        self._region = region
+        self._access_key = key
+        self._secret_key = secret
         self._endpoint = endpoint
         self._disable_ssl = disable_ssl
         self._cli = self._make_client()
@@ -38,6 +45,53 @@ class EC2Client:
                             aws_secret_access_key=self._secret_key,
                             endpoint_url=self._endpoint,
                             use_ssl=not self._disable_ssl)
+
+    def create_vpc_peering(self, params):
+        """
+        Create VPC peering connection in AWS
+        """
+        _r = self._cli.create_vpc_peering_connection(
+            PeerOwnerId=params.peer_owner_id,
+            PeerVpcId=params.peer_vpc_id,
+            VpcId=params.rp_vpc_id,
+            PeerRegion=params.region,
+        )
+        # TODO: Validate results
+
+        # Return
+        return _r[VPC_PEERING_LABEL][VPC_PEERING_ID_LABEL]
+
+    def get_vpc_by_network_id(self, network_id):
+        """
+        Get VPC from AWS using network id from CloudV2
+        """
+        # Create a filter to search for the vpc
+        _filters = [{"Name": "tag:Name", "Values": [f"network-{network_id}"]}]
+        # Get all available peering connections
+        _resp = self._cli.describe_vpcs(Filters=_filters)
+        _vpcs = _resp[VPCS_LABEL]
+        # Validate connection count
+        if len(_vpcs) < 0:
+            self._log.error(
+                f"No VPC connection found for 'network-{network_id}'")
+            return None
+        elif len(_vpcs) > 1:
+            self._log.warning("Found multiple VPC for "
+                              f"'network-{network_id}'")
+        return _vpcs[0]
+
+    def get_vpc_peering_connection(self, _id):
+        _filters = [{"Name": "vpc-peering-connection-id", "Values": [_id]}]
+        _resp = self._cli.describe_vpc_peering_connections(Filters=_filters)
+        _vpcs = _resp[VPCS_PEERING_LABEL]
+        # Validate connection count
+        if len(_vpcs) < 0:
+            self._log.error(f"No VPC connection found for '{_id}'")
+            return None
+        elif len(_vpcs) > 1:
+            self._log.warning("Found multiple VPC Peerings for "
+                              f"'{_id}'")
+        return _vpcs[0]
 
     def find_vpc_peering_connection(self, state, params):
         """
@@ -96,13 +150,13 @@ class EC2Client:
         # There can be only one such object, no need to validate
         return _r[VPCS_PEERING_LABEL][0]["Status"]["Code"]
 
-    def get_route_table_ids_for_cluster(self, cluster_id):
+    def get_route_table_ids_for_cluster(self, network_id):
         _filters = [{
             "Name": "tag:purpose",
             "Values": ["private"]
         }, {
             "Name": "tag:Name",
-            "Values": [f"network-{cluster_id}"]
+            "Values": [f"network-{network_id}"]
         }]
         _r = self._cli.describe_route_tables(Filters=_filters)
         return [_t[RTB_ID_LABEL] for _t in _r[RTBS_LABEL]]
@@ -116,4 +170,7 @@ class EC2Client:
         _r = self._cli.create_route(RouteTableId=rtb_id,
                                     DestinationCidrBlock=destCidrBlock,
                                     VpcPeeringConnectionId=vpc_peering_id)
+        if not _r['Return']:
+            self._log.warning(f"Failed to create route in '{rtb_id}' "
+                              f"for '{destCidrBlock}'")
         return _r

--- a/tests/rptest/services/provider_clients/ec2_client.py
+++ b/tests/rptest/services/provider_clients/ec2_client.py
@@ -8,6 +8,8 @@ VPCS_PEERING_LABEL = "VpcPeeringConnections"
 VPCS_LABEL = "Vpcs"
 RTBS_LABEL = "RouteTables"
 RTB_ID_LABEL = "RouteTableId"
+AZS_LABEL = "AvailabilityZones"
+AZ_ID_LABEL = "ZoneId"
 
 
 class EC2Client:
@@ -174,3 +176,32 @@ class EC2Client:
             self._log.warning(f"Failed to create route in '{rtb_id}' "
                               f"for '{destCidrBlock}'")
         return _r
+
+    def get_single_zone(self, region):
+        """
+        Get list of available zones based on region
+
+        Sample return value
+        {
+            "AvailabilityZones": [
+                {
+                    "State": "available",
+                    "OptInStatus": "opt-in-not-required",
+                    "Messages": [],
+                    "RegionName": "us-west-2",
+                    "ZoneName": "us-west-2a",
+                    "ZoneId": "usw2-az2",
+                    "GroupName": "us-west-2",
+                    "NetworkBorderGroup": "us-west-2",
+                    "ZoneType": "availability-zone"
+                },
+                ...
+            ]
+        }
+        """
+        # Setup filter for current region just in case
+        # Althrough, by default, only zones from current region will be listed
+        _filters = [{"Name": "region-name", "Values": [region]}]
+        # Call EC2 to get the list
+        _r = self._cli.describe_availability_zones(Filters=_filters)
+        return _r[AZS_LABEL][0][AZ_ID_LABEL]

--- a/tests/rptest/services/provider_clients/ec2_client.py
+++ b/tests/rptest/services/provider_clients/ec2_client.py
@@ -15,10 +15,10 @@ class EC2Client:
         self._endpoint = endpoint
         self._disable_ssl = disable_ssl
         self._cli = self._make_client()
-        self.logger = logger
+        self._log = logger
 
-        logger.debug(f"Created EC2 Client: {self._region}, {endpoint}, "
-                     f"key is set = {self._access_key is not None}")
+        self._log.debug(f"Created EC2 Client: {self._region}, {endpoint},"
+                        f" key is set = {self._access_key is not None}")
 
     def _make_client(self):
         cfg = Config(region_name=self._region,
@@ -32,3 +32,52 @@ class EC2Client:
                             aws_secret_access_key=self._secret_key,
                             endpoint_url=self._endpoint,
                             use_ssl=not self._disable_ssl)
+
+    def find_vpc_peering_connection(self, state, region_id, cidr, rp_vpc_id,
+                                    rp_owner_id, dt_vpc_id, dt_owner_id):
+        """
+        Identifies peering connections by comparing
+        AcceptorVpcInfo and RequestorVpcInfo
+        """
+        # Put all info values to the set
+        _source_info = set([
+            state, region_id, cidr, rp_vpc_id, rp_owner_id, dt_vpc_id,
+            dt_owner_id
+        ])
+        # Get all available peering connections
+        _resp = self._cli.describe_vpc_peering_connections()
+        _ids = []
+        # iterate them to find ours
+        for _pvpc in _resp['VpcPeeringConnections']:
+            # get shortcuts
+            _id = _pvpc['VpcPeeringConnectionId']
+            _r = _pvpc['RequesterVpcInfo']
+            _a = _pvpc['AccepterVpcInfo']
+            # Check that this is our connection
+            # 1. Check that its from same region
+            if _r['Region'] != _a['Region']:
+                continue
+            else:
+                _info = [
+                    _pvpc['Status']['Code'], _r['Region'], _r['CidrBlock'],
+                    _r['OwnerId'], _r['VpcId'], _a['OwnerId'], _a['VpcId']
+                ]
+                if _source_info == _info:
+                    _ids.append(_id)
+        if len(_ids) > 1:
+            self._log.warning("Found multiple peering "
+                              f"connections (cleaning?): {_ids}")
+        elif len(_ids) < 1:
+            self._log.error(
+                f"No peering connections found for given info: {_source_info}")
+
+        self._log.info(f"Using peering connection with id: '{_ids[0]}'")
+        return _ids[0]
+
+    def accept_vpc_peering(self, peering_id, dry_run=False):
+        """
+        Accepts peering
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/accept_vpc_peering_connection.html#
+        """
+        return self._cli.accept_vpc_peering_connection(
+            DryRun=dry_run, VpcPeeringConnectionId=peering_id)

--- a/tests/rptest/services/provider_clients/ec2_client.py
+++ b/tests/rptest/services/provider_clients/ec2_client.py
@@ -1,0 +1,34 @@
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+
+class EC2Client:
+    """
+    This almost mimics S3Client from archival.
+    """
+    def __init__(self, config, logger, endpoint=None, disable_ssl=True):
+
+        self._region = config['region']
+        self._access_key = config['access_key']
+        self._secret_key = config['secret_key']
+        self._endpoint = endpoint
+        self._disable_ssl = disable_ssl
+        self._cli = self._make_client()
+        self.logger = logger
+
+        logger.debug(f"Created EC2 Client: {self._region}, {endpoint}, "
+                     f"key is set = {self._access_key is not None}")
+
+    def _make_client(self):
+        cfg = Config(region_name=self._region,
+                     retries={
+                         'max_attempts': 10,
+                         'mode': 'adaptive'
+                     })
+        return boto3.client('ec2',
+                            config=cfg,
+                            aws_access_key_id=self._access_key,
+                            aws_secret_access_key=self._secret_key,
+                            endpoint_url=self._endpoint,
+                            use_ssl=not self._disable_ssl)

--- a/tests/rptest/services/provider_clients/gcp_client.py
+++ b/tests/rptest/services/provider_clients/gcp_client.py
@@ -36,3 +36,12 @@ class GCPClient:
 
     def create_route(self, rtb_id, destCidrBlock, vpc_peering_id):
         return None
+
+    def get_single_zone(self, region):
+        """
+        Get list of available zones based on region
+        """
+        # TODO: Implement zones list
+        # Hardcoded to us-west2
+        z = {"us-west2": ['us-west2-a', 'us-west2-b', 'us-west2-c']}
+        return z[region][:1]

--- a/tests/rptest/services/provider_clients/gcp_client.py
+++ b/tests/rptest/services/provider_clients/gcp_client.py
@@ -13,6 +13,12 @@ class GCPClient:
     def _make_client(self):
         return None
 
+    def create_vpc_peering(self, params):
+        return None
+
+    def get_vpc_by_network_id(self, network_id):
+        return None
+
     def find_vpc_peering_connection(self, state, params):
         return None
 

--- a/tests/rptest/services/provider_clients/gcp_client.py
+++ b/tests/rptest/services/provider_clients/gcp_client.py
@@ -3,8 +3,30 @@ class GCPClient:
     GCP Client class.
     Should implement function similar to AWS EC2 client
     """
-    def __init__(self) -> None:
+    def __init__(self,
+                 config,
+                 logger,
+                 endpoint=None,
+                 disable_ssl=True) -> None:
         self._cli = self._make_client()
 
     def _make_client(self):
+        return None
+
+    def find_vpc_peering_connection(self, state, params):
+        return None
+
+    def accept_vpc_peering(self, peering_id, dry_run=False):
+        return None
+
+    def get_vpc_peering_status(self, vpc_peering_id):
+        return None
+
+    def get_route_table_ids_for_cluster(self, cluster_id):
+        return None
+
+    def get_route_table_ids_for_vpc(self, vpc_id):
+        return None
+
+    def create_route(self, rtb_id, destCidrBlock, vpc_peering_id):
         return None

--- a/tests/rptest/services/provider_clients/gcp_client.py
+++ b/tests/rptest/services/provider_clients/gcp_client.py
@@ -1,0 +1,10 @@
+class GCPClient:
+    """
+    GCP Client class.
+    Should implement function similar to AWS EC2 client
+    """
+    def __init__(self) -> None:
+        self._cli = self._make_client()
+
+    def _make_client(self):
+        return None

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1415,6 +1415,14 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
         # later to dataclass
         self._cc_config = context.globals.get(self.GLOBAL_CLOUD_CLUSTER_CONFIG,
                                               None)
+        self._provider_config = {
+            "access_key":
+            context.globals.get(SISettings.GLOBAL_S3_ACCESS_KEY, None),
+            "secret_key":
+            context.globals.get(SISettings.GLOBAL_S3_SECRET_KEY, None),
+            "region":
+            context.globals.get(SISettings.GLOBAL_S3_REGION_KEY, None)
+        }
         # log cloud cluster id
         self.logger.debug(f"initial cluster_id: {self._cc_config['id']}")
 
@@ -1451,7 +1459,11 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
         # self._cloud_peer_owner_id = context.globals.get(
         #     self.GLOBAL_CLOUD_PEER_OWNER_ID, None)
 
-        self._cloud_cluster = CloudCluster(self.logger, self._cc_config)
+        self._cloud_cluster = CloudCluster(
+            self.logger,
+            self._cc_config,
+            provider_config=self._provider_config)
+
         self._kubectl = None
 
         self._dedicated_nodes = True

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -124,6 +124,19 @@ class CloudClusterConfig:
     install_pack_ver: str = "latest"
 
 
+@dataclass
+class LiveClusterParams:
+    isAlive: bool = False
+    connection_type: str = 'public'
+    namespace_uuid: str = None
+    name: str = None
+    network_id: str = None
+    install_pack_ver: str = None
+    product_id: str = None
+    region_id: str = None
+    zones: list = []
+
+
 class CloudCluster():
     """
     Operations on a Redpanda Cloud cluster via the swagger API.
@@ -142,27 +155,32 @@ class CloudCluster():
 
 
         :param logger: logging object
-        :param oauth_url: full url of the oauth endpoint to get a token
-        :param oauth_client_id: client id from redpanda cloud ui page for clients
-        :param oauth_client_secret: client secret from redpanda cloud ui page for clients
-        :param oauth_audience: oauth audience
-        :param api_url: url of hostname for swagger api without trailing slash char
-        :param cluster_id: if not empty string, will skip creating a new cluster
-        :param delete_namespace: if False, will skip namespace deletion step after tests are run
+        :param cluster_config: dict object loaded from
+               context.globals["cloud_cluster"]
+        :param delete_namespace: if False, will skip namespace deletion
+               step after tests are run
         """
 
         self._logger = logger
         self._delete_namespace = delete_namespace
         # JSON is serialized directly to dataclass
         self.config = CloudClusterConfig(**cluster_config)
-        # ensure that variables are in uppercase
+        # ensure that variables are in correct case
         self.config.type = self.config.type.upper()
         self.config.provider = self.config.provider.upper()
+        self.config.network = self.config.network.lower()
         # Init API client
         self.cloudv2 = RpCloudApiClient(self.config, logger)
 
-        # unique 8-char identifier to be used when creating names of things for this cluster
+        # Create helper bool variable
+        self.isPublicNetwork = self.config.network == 'public'
+
+        # unique 8-char identifier to be used when creating names of things
+        # for this cluster
         self._unique_id = str(uuid.uuid1())[:8]
+
+        # init live cluster params
+        self.current = LiveClusterParams()
 
     @property
     def cluster_id(self):
@@ -173,7 +191,8 @@ class CloudCluster():
         return self.config.id
 
     def _create_namespace(self):
-        name = f'rp-ducktape-ns-{self._unique_id}'  # e.g. rp-ducktape-ns-3b36f516
+        # format namespace name as 'rp-ducktape-ns-3b36f516
+        name = f'rp-ducktape-ns-{self._unique_id}'
         self._logger.debug(f'creating namespace name {name}')
         body = {'name': name}
         r = self.cloudv2._http_post(endpoint='/api/v1/namespaces', json=body)
@@ -182,18 +201,19 @@ class CloudCluster():
         self.config.namespace = name
         return r['id']
 
-    def _cluster_ready(self, namespace_uuid, name):
-        self._logger.debug(f'checking readiness of cluster {name}')
-        params = {'namespaceUuid': namespace_uuid}
+    def _cluster_ready(self):
+        self._logger.debug('checking readiness of '
+                           f'cluster {self.current.name}')
+        params = {'namespaceUuid': self.current.namespace_uuid}
         clusters = self.cloudv2._http_get(endpoint='/api/v1/clusters',
                                           params=params)
         for c in clusters:
-            if c['name'] == name:
+            if c['name'] == self.current.name:
                 if c['state'] == 'ready':
                     return True
         return False
 
-    def _get_cluster_id_and_network_id(self, namespace_uuid, name):
+    def _get_cluster_id_and_network_id(self):
         """
         Get clusterId and networkId.
 
@@ -202,11 +222,11 @@ class CloudCluster():
         :return: (clusterId, networkId) as tuple of strings or (None, None) if not found
         """
 
-        params = {'namespaceUuid': namespace_uuid}
+        params = {'namespaceUuid': self.current.namespace_uuid}
         clusters = self.cloudv2._http_get(endpoint='/api/v1/clusters',
                                           params=params)
         for c in clusters:
-            if c['name'] == name:
+            if c['name'] == self.current.name:
                 return (c['id'], c['spec']['networkId'])
         return None, None
 
@@ -226,7 +246,7 @@ class CloudCluster():
             return None
         return latest_version
 
-    def _get_region_id(self, cluster_type, provider, region):
+    def _get_region_id(self):
         """Get the region id for a region.
 
         :param cluster_type: cluster type, e.g. 'FMC'
@@ -235,20 +255,15 @@ class CloudCluster():
         :return: id, e.g. 'cckac9vvbr5ofm048jjg'
         """
 
-        params = {'cluster_type': cluster_type}
+        params = {'cluster_type': self.config.type}
         regions = self.cloudv2._http_get(
             endpoint='/api/v1/clusters-resources/regions', params=params)
-        for r in regions[provider]:
-            if r['name'] == region:
+        for r in regions[self.config.provider]:
+            if r['name'] == self.config.region:
                 return r['id']
         return None
 
-    def _get_product_id(self,
-                        config_profile_name,
-                        provider,
-                        cluster_type=None,
-                        region=None,
-                        install_pack_ver=None):
+    def _get_product_id(self, config_profile_name):
         """Get the product id for the first matching config profile name using filter parameters.
 
         :param config_profile_name: config profile name, e.g. 'tier-1-aws'
@@ -260,10 +275,10 @@ class CloudCluster():
         """
 
         params = {
-            'cloud_provider': provider,
-            'cluster_type': cluster_type,
-            'region': region,
-            'install_pack_version': install_pack_ver
+            'cloud_provider': self.config.provider,
+            'cluster_type': self.config.type,
+            'region': self.config.region,
+            'install_pack_version': self.current.install_pack_ver
         }
         products = self.cloudv2._http_get(
             endpoint='/api/v1/clusters-resources/products', params=params)
@@ -271,6 +286,38 @@ class CloudCluster():
             if p['redpandaConfigProfileName'] == config_profile_name:
                 return p['id']
         return None
+
+    def _create_cluster_payload(self):
+        return {
+            "cluster": {
+                "name": self.current.name,
+                "productId": self.current.product_id,
+                "spec": {
+                    "clusterType": self.config.type,
+                    "connectors": {
+                        "enabled": True
+                    },
+                    "installPackVersion": self.current.install_pack_ver,
+                    "isMultiAz": False,
+                    "networkId": "",
+                    "provider": self.config.provider,
+                    "region": self.config.region,
+                    "zones": self.current.zones,
+                }
+            },
+            "connectionType": self.current.connection_type,
+            "namespaceUuid": self.current.namespace_uuid,
+            "network": {
+                "displayName": f"{self.current.connection_type}-network-{self.current.name}",
+                "spec": {
+                    "cidr": "10.1.0.0/16",
+                    "deploymentType": self.config.type,
+                    "installPackVersion": self.current.install_pack_ver,
+                    "provider": self.config.provider,
+                    "regionId": self.current.region_id,
+                }
+            },
+        }
 
     def create(self,
                config_profile_name: str = 'tier-1-aws',
@@ -282,113 +329,57 @@ class CloudCluster():
         """
 
         if self.config.id != '':
-            self._logger.warn(
-                f'will not create cluster; already have cluster_id {self.config.id}'
+            self._logger.warn('will not create cluster; already have '
+                              f'cluster_id {self.config.id}'
             )
             return self.config.id
 
-        namespace_uuid = self._create_namespace()
-        name = f'rp-ducktape-cluster-{self._unique_id}'  # e.g. rp-ducktape-cluster-3b36f516
-        install_pack_ver = self.config.install_pack_ver
-        if install_pack_ver == 'latest':
-            install_pack_ver = self._get_latest_install_pack_ver()
-        # 'FMC'
-        cluster_type = self.config.type
-        # 'AWS'
-        provider = self.config.provider
-        # 'us-west-2'
-        region = self.config.region
-        region_id = self._get_region_id(cluster_type, provider, region)
-        zones = ['usw2-az1']
-        product_id = self._get_product_id(config_profile_name, provider,
-                                          cluster_type, region,
-                                          install_pack_ver)
-        public = True  # TODO get value from globals config setting
-        if public:
-            connection_type = 'public'
-        else:
-            connection_type = 'private'
+        # In order not to have long list of arguments in each internal
+        # functions, use self.current as a data store
+        # Each of the _*_payload functions and _get_* will use it as a source
+        # of data to create proper body for REST request
+        self.current.namespace_uuid = self._create_namespace()
+        # name rp-ducktape-cluster-3b36f516
+        self.current.name = f'rp-ducktape-cluster-{self._unique_id}'
+        self.current.install_pack_ver = self._get_install_pack_ver()
+        self.current.region_id = self._get_region_id()
+        self.current.zones = ['usw2-az1']
+        self.current.product_id = self._get_product_id(config_profile_name)
+        if not self.isPublicNetwork:
+            self.current.connection_type = 'private'
 
-        self._logger.info(f'creating cluster name {name}')
-        body = {
-            "cluster": {
-                "name": name,
-                "productId": product_id,
-                "spec": {
-                    "clusterType": cluster_type,
-                    "connectors": {
-                        "enabled": True
-                    },
-                    "installPackVersion": install_pack_ver,
-                    "isMultiAz": False,
-                    "networkId": "",
-                    "provider": provider,
-                    "region": region,
-                    "zones": zones,
-                }
-            },
-            "connectionType": connection_type,
-            "namespaceUuid": namespace_uuid,
-            "network": {
-                "displayName": f"{connection_type}-network-{name}",
-                "spec": {
-                    "cidr": "10.1.0.0/16",
-                    "deploymentType": cluster_type,
-                    "installPackVersion": install_pack_ver,
-                    "provider": provider,
-                    "regionId": region_id,
-                }
-            },
-        }
-
-        self._logger.debug(f'body: {json.dumps(body)}')
+        # Call Api to create cluster
+        self._logger.info(f'creating cluster name {self.current.name}')
+        _body = self._create_cluster_payload()
+        self._logger.debug(f'body: {json.dumps(_body)}')
 
         r = self.cloudv2._http_post(
-            endpoint='/api/v1/workflows/network-cluster', json=body)
+            endpoint='/api/v1/workflows/network-cluster', json=_body)
 
         self._logger.info(
-            f'waiting for creation of cluster {name} namespaceUuid {r["namespaceUuid"]}, checking every {self.CHECK_BACKOFF_SEC} seconds'
+            f'waiting for creation of cluster {self.current.name} '
+            f'namespaceUuid {r["namespaceUuid"]}, checking every '
+            f'{self.CHECK_BACKOFF_SEC} seconds'
         )
 
         wait_until(
-            lambda: self._cluster_ready(namespace_uuid, name),
+            lambda: self._cluster_ready(),
             timeout_sec=self.CHECK_TIMEOUT_SEC,
             backoff_sec=self.CHECK_BACKOFF_SEC,
-            err_msg=f'Unable to deterimine readiness of cloud cluster {name}')
-        self.config.id, network_id = self._get_cluster_id_and_network_id(
-            namespace_uuid, name)
+            err_msg='Unable to deterimine readiness '
+                    f'of cloud cluster {self.current.name}')
+        self.config.id, self.current.network_id = \
+            self._get_cluster_id_and_network_id()
 
         if superuser is not None:
             self._logger.debug(
-                f'super username: {superuser.username}, algorithm: {superuser.algorithm}'
-            )
+                f'super username: {superuser.username}, '
+                f'algorithm: {superuser.algorithm}')
             self._create_user(superuser)
             self._create_acls(superuser.username)
 
-        if not public:
-            # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
-            # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/owner-id
-            # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/vpc-id
-            network_id = ''  # TODO get network ID from newly-created cluster
-            body = {
-                "networkPeering": {
-                    "displayName": f'peer-{name}',
-                    "spec": {
-                        "provider": "AWS",
-                        "cloudProvider": {
-                            "aws": {
-                                "peerOwnerId": self.config.peer_owner_id,
-                                "peerVpcId": self.config.peer_vpc_id
-                            }
-                        }
-                    }
-                },
-                "namespaceUuid": namespace_uuid
-            }
-            resp = self.cloudv2._http_post(
-                f'/api/v1/networks/{network_id}/network-peerings', json=body)
-            # TODO accept the AWS VPC peering request
-            # TODO create route between vpc and peering connection
+        if not self.isPublicNetwork:
+            self.create_vpc_peering()
 
         return self.config.id
 
@@ -478,3 +469,48 @@ class CloudCluster():
         cluster = self.cloudv2._http_get(
             endpoint=f'/api/v1/clusters/{self.config.id}')
         return cluster['status']['installPackVersion']
+
+    def create_vpc_peering(self):
+        """
+        Create VPC peering for deployed cloud with private network
+
+        Steps:
+        - Get networkID of deployed cloud
+        - Confirm by calling cloudv2 api
+        - Get Deployed Redpanda cluster's VCP
+        - Get VPC of the ducktape client instance
+        - Create initial peering
+            vpc-id <Requester, Redpanda Cluster>
+            peer-vpc-id <Accepter, Ducktape client>
+        - Create routes from Readpanda to Ducktape (10.10.xxx -> 172...)
+        - Create routes to Redpanda from Ducktape (172... -> 10.10.xxx)
+        - Accept
+
+        """
+
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
+        # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/owner-id
+        # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/vpc-id
+
+        network_id = ''  # TODO get network ID from newly-created cluster
+        body = {
+            "networkPeering": {
+                "displayName": f'peer-{self.current.name}',
+                "spec": {
+                    "provider": "AWS",
+                    "cloudProvider": {
+                        "aws": {
+                            "peerOwnerId": self.config.peer_owner_id,
+                            "peerVpcId": self.config.peer_vpc_id
+                        }
+                    }
+                }
+            },
+            "namespaceUuid": self.current.namespace_uuid
+        }
+        resp = self.cloudv2._http_post(
+            f'/api/v1/networks/{network_id}/network-peerings', json=body)
+        # TODO accept the AWS VPC peering request
+        # TODO create route between vpc and peering connection
+        # network_id
+        return

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -109,13 +109,13 @@ class CloudClusterConfig:
     Should be in sync with cloud_cluster subsection in
     vtools/qa/deploy/ansible/roles/ducktape-setup/templates/ducktape_globals.json.j2
     """
-    oauth_url: str
-    oauth_client_id: str
-    oauth_client_secret: str
-    oauth_audience: str
-    api_url: str
-    teleport_auth_server: str
-    teleport_bot_token: str
+    oauth_url: str = ""
+    oauth_client_id: str = ""
+    oauth_client_secret: str = ""
+    oauth_audience: str = ""
+    api_url: str = ""
+    teleport_auth_server: str = ""
+    teleport_bot_token: str = ""
     id: str = ""  # empty string makes it easier to pass thru default value from duck.py
     delete_cluster: bool = True
 
@@ -145,10 +145,12 @@ class LiveClusterParams:
     peer_owner_id: str = None
     rp_vpc_id: str = None
     rp_owner_id: str = None
+    aws_vpc_peering_id: str = None
 
     # Can't use mutables in defaults of dataclass
     # https://docs.python.org/3/library/dataclasses.html#dataclasses.field
     zones: list[str] = field(default_factory=list)
+    aws_vpc_peering: dict = field(default_factory=dict)
 
 
 class CloudCluster():
@@ -313,7 +315,7 @@ class CloudCluster():
             provider: cloud provider filter, e.g. 'AWS'
             cluster_type: cluster type filter, e.g. 'FMC'
             region: region name filter, e.g. 'us-west-2'
-            install_pack_ver: install pack version filter, 
+            install_pack_ver: install pack version filter,
                e.g. '23.2.20230707135118'
 
         :param config_profile_name: config profile name, e.g. 'tier-1-aws'
@@ -586,11 +588,30 @@ class CloudCluster():
                 _meta[item[0]] = item[1]
             return _meta
 
-    def _check_peering_status(self, endpoint, state):
+    def _get_vpc_peering_connection(self, endpoint):
+        """
+        Get VPC peering connection from CloudV2
+        """
         _endpoint = f"{endpoint}/{self.vpc_peering['id']}"
-        _peering = self.cloudv2._http_get(endpoint=_endpoint)
+        return self.cloudv2._http_get(endpoint=_endpoint)
+
+    def _check_peering_status(self, endpoint, state):
+        """
+        Check VPC peering Status on CloudV2 side
+        """
+        _peering = self._get_vpc_peering_connection(endpoint)
         if _peering['state'] == state:
             self.vpc_peering = _peering
+            return True
+        else:
+            return False
+
+    def _check_aws_peering_status(self, _vpc_peering_id, state):
+        """
+        Check VPC Peering connection status on AWS side
+        """
+        _aws_state = self.provider_cli.get_vpc_peering_status(_vpc_peering_id)
+        if _aws_state == state:
             return True
         else:
             return False
@@ -610,31 +631,30 @@ class CloudCluster():
             Create routes from Readpanda to Ducktape (10.10.xxx -> 172...)
             Create routes to Redpanda from Ducktape (172... -> 10.10.xxx)
         5b. Use CloudV2 API to create peering
-
-        6. Accept VPC Peering on AWS side
+        6. Create routes from/to Cloud
+        7. Accept VPC Peering on AWS side
+        8. Ensute Peering is ready/active on both sides
 
         """
 
-        # Network id
+        # 1. Network id
         network_id = self.current.network_id
         _endpoint = f'/api/v1/networks/{network_id}/network-peerings'
-
-        # get CIDR from network
-        # _cidr =
 
         # VPC for the client can be found in metadata
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
         # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/owner-id
         # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/vpc-id
 
-        # Prepare metadata
+        # 4.
         self._ducktape_meta = self._get_ducktape_meta()
         self.current.peer_vpc_id = self._ducktape_meta['vpc-id']
         self.current.peer_owner_id = self._ducktape_meta['owner-id']
+        # 2 and 3.
         # Prepare vpc_id, owner_id and cidrBlock for cloud cluster
         self._prepare_network_vpc_info()
 
-        # Use Cloud API to create peering
+        # 5b. Use Cloud API to create peering
         # Alternatively, Use manual AWS commands to do the same
         _body = self._create_network_peering_payload()
         self._logger.debug(f"body: '{_body}'")
@@ -653,14 +673,51 @@ class CloudCluster():
                    f'of peering {self.current.name}')
 
         # Find id of the correct peering VPC
-        _vpc_id = self.provider_cli.find_vpc_peering_connection(
-            "pending-acceptance", self.current.region_id,
-            self.current.network_cidr, self.current.rp_vpc_id,
-            self.current.rp_owner_id, self.current.peer_vpc_id,
-            self.current.peer_owner_id)
-        # Accept it
-        self.provider_cli.accept_vpc_peering(_vpc_id)
+        self.current.aws_vpc_peering_id = self.provider_cli.find_vpc_peering_connection(
+            "pending-acceptance", self.current)
 
-        # TODO create route between vpc and peering connection
+        # 7. Accept it on AWS
+        self.current.aws_vpc_peering = self.provider_cli.accept_vpc_peering(
+            self.current.aws_vpc_peering_id)
+
+        # 6.
+        # Create routes from CloudV2 to Ducktape (10.10.xxx -> 172...)
+        # aws ec2 describe-route-tables --filter "Name=tag:Name,Values=network-cjah1ecce8edpeoj0li0" "Name=tag:purpose,Values=private" | jq -r '.RouteTables[].RouteTableId' | while read -r route_table_id; do aws ec2 create-route --route-table-id $route_table_id --destination-cidr-block 172.31.0.0/16 --vpc-peering-connection-id pcx-0581b037d9e93593e; done;
+        # !!!! This is handled by CloudV2 and ID count get_rtb results in zero
+        # _rtbs = self.provider_cli.get_route_table_ids_for_cluster(
+        #     self.config.id)
+        # for _rtb_id in _rtbs:
+        #     self.provider_cli.create_route(
+        #         _rtb_id,
+        #         self.current.aws_vpc_peering['AccepterVpcInfo']['CidrBlock'],
+        #         self.current.aws_vpc_peering_id)
+
+        # Create routes from Ducktape to CloudV2
+        # aws ec2 --region us-west-2 create-route --route-table-id rtb-02e89e44cb4da000d --destination-cidr-block 10.10.0.0/16 --vpc-peering-connection-id pcx-0581b037d9e93593e
+        _rtbs = self.provider_cli.get_route_table_ids_for_vpc(
+            self.current.peer_vpc_id)
+        for _rtb_id in _rtbs:
+            self.provider_cli.create_route(
+                _rtb_id,
+                self.current.aws_vpc_peering['RequesterVpcInfo']['CidrBlock'],
+                self.current.aws_vpc_peering_id)
+
+        # 8.
+        # Wait for 'active' on AWS side
+        _state = "active"
+        wait_until(lambda: self._check_aws_peering_status(
+            self.current.aws_vpc_peering_id, _state),
+                   timeout_sec=self.CHECK_TIMEOUT_SEC,
+                   backoff_sec=self.CHECK_BACKOFF_SEC,
+                   err_msg=f'Timeout waiting for {_state} status '
+                   f'of peering {self.current.name}')
+
+        # Wait for 'ready' on CloudV2 side
+        _state = "ready"
+        wait_until(lambda: self._check_peering_status(_endpoint, _state),
+                   timeout_sec=self.CHECK_TIMEOUT_SEC,
+                   backoff_sec=self.CHECK_BACKOFF_SEC,
+                   err_msg=f'Timeout waiting for {_state} status '
+                   f'of peering {self.current.name}')
 
         return

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -9,6 +9,8 @@ from typing import Optional
 
 from ducktape.utils.util import wait_until
 
+from rptest.services.provider_clients import make_provider_client
+
 SaslCredentials = collections.namedtuple("SaslCredentials",
                                          ["username", "password", "algorithm"])
 
@@ -135,6 +137,8 @@ class LiveClusterParams:
     product_id: str = None
     region_id: str = None
     zones: list = []
+    peer_vpc_id: str
+    peer_owner_id: str
 
 
 class CloudCluster():
@@ -148,7 +152,11 @@ class CloudCluster():
     CHECK_TIMEOUT_SEC = 3600
     CHECK_BACKOFF_SEC = 60.0
 
-    def __init__(self, logger, cluster_config, delete_namespace=False):
+    def __init__(self,
+                 logger,
+                 cluster_config,
+                 delete_namespace=False,
+                 provider_config=None):
         """
         Initializes the object, but does not create clusters. Use
         `create` method to create a cluster.
@@ -181,6 +189,15 @@ class CloudCluster():
 
         # init live cluster params
         self.current = LiveClusterParams()
+
+        self.cli = make_provider_client(self.config.provider, provider_config)
+        # Currently we need provider client only for VCP in private networking
+        # Raise exception is client in not implemented yet
+        if self.cli is None and self.config.network != 'public':
+            self._logger.error(
+                f"Current provider is not yet supports private networking ")
+            raise RuntimeError("Private networking is not implemented "
+                               f"for '{self.config.provider}'")
 
     @property
     def cluster_id(self):
@@ -308,7 +325,8 @@ class CloudCluster():
             "connectionType": self.current.connection_type,
             "namespaceUuid": self.current.namespace_uuid,
             "network": {
-                "displayName": f"{self.current.connection_type}-network-{self.current.name}",
+                "displayName":
+                f"{self.current.connection_type}-network-{self.current.name}",
                 "spec": {
                     "cidr": "10.1.0.0/16",
                     "deploymentType": self.config.type,
@@ -330,8 +348,7 @@ class CloudCluster():
 
         if self.config.id != '':
             self._logger.warn('will not create cluster; already have '
-                              f'cluster_id {self.config.id}'
-            )
+                              f'cluster_id {self.config.id}')
             return self.config.id
 
         # In order not to have long list of arguments in each internal
@@ -350,31 +367,29 @@ class CloudCluster():
 
         # Call Api to create cluster
         self._logger.info(f'creating cluster name {self.current.name}')
+        # Prepare cluster payload block
         _body = self._create_cluster_payload()
         self._logger.debug(f'body: {json.dumps(_body)}')
-
+        # Send API request
         r = self.cloudv2._http_post(
             endpoint='/api/v1/workflows/network-cluster', json=_body)
 
         self._logger.info(
             f'waiting for creation of cluster {self.current.name} '
             f'namespaceUuid {r["namespaceUuid"]}, checking every '
-            f'{self.CHECK_BACKOFF_SEC} seconds'
-        )
-
-        wait_until(
-            lambda: self._cluster_ready(),
-            timeout_sec=self.CHECK_TIMEOUT_SEC,
-            backoff_sec=self.CHECK_BACKOFF_SEC,
-            err_msg='Unable to deterimine readiness '
-                    f'of cloud cluster {self.current.name}')
+            f'{self.CHECK_BACKOFF_SEC} seconds')
+        # Poll API and wait for the cluster creation
+        wait_until(lambda: self._cluster_ready(),
+                   timeout_sec=self.CHECK_TIMEOUT_SEC,
+                   backoff_sec=self.CHECK_BACKOFF_SEC,
+                   err_msg='Unable to deterimine readiness '
+                   f'of cloud cluster {self.current.name}')
         self.config.id, self.current.network_id = \
             self._get_cluster_id_and_network_id()
 
         if superuser is not None:
-            self._logger.debug(
-                f'super username: {superuser.username}, '
-                f'algorithm: {superuser.algorithm}')
+            self._logger.debug(f'super username: {superuser.username}, '
+                               f'algorithm: {superuser.algorithm}')
             self._create_user(superuser)
             self._create_acls(superuser.username)
 
@@ -470,47 +485,77 @@ class CloudCluster():
             endpoint=f'/api/v1/clusters/{self.config.id}')
         return cluster['status']['installPackVersion']
 
-    def create_vpc_peering(self):
-        """
-        Create VPC peering for deployed cloud with private network
-
-        Steps:
-        - Get networkID of deployed cloud
-        - Confirm by calling cloudv2 api
-        - Get Deployed Redpanda cluster's VCP
-        - Get VPC of the ducktape client instance
-        - Create initial peering
-            vpc-id <Requester, Redpanda Cluster>
-            peer-vpc-id <Accepter, Ducktape client>
-        - Create routes from Readpanda to Ducktape (10.10.xxx -> 172...)
-        - Create routes to Redpanda from Ducktape (172... -> 10.10.xxx)
-        - Accept
-
-        """
-
-        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
-        # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/owner-id
-        # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/vpc-id
-
-        network_id = ''  # TODO get network ID from newly-created cluster
-        body = {
+    def _create_network_peering_payload(self):
+        return {
             "networkPeering": {
                 "displayName": f'peer-{self.current.name}',
                 "spec": {
                     "provider": "AWS",
                     "cloudProvider": {
                         "aws": {
-                            "peerOwnerId": self.config.peer_owner_id,
-                            "peerVpcId": self.config.peer_vpc_id
+                            "peerOwnerId": self.current.peer_owner_id,
+                            "peerVpcId": self.current.peer_vpc_id
                         }
                     }
                 }
             },
             "namespaceUuid": self.current.namespace_uuid
         }
+
+    def _get_ducktape_meta(self, url):
+        resp = requests.get(url)
+        if not resp:
+            self._logger.error("failed to get metadata from Ducktape node: "
+                               f"'{url}'")
+        return resp.text
+
+    def create_vpc_peering(self):
+        """
+        Create VPC peering for deployed cloud with private network
+
+        Steps:
+        1. Get networkID of deployed cloud
+        2. Confirm by calling cloudv2 api
+        3. Get Deployed Redpanda cluster's VCP
+        4. Get VPC of the ducktape client instance
+        5a. Create initial peering
+            vpc-id <Requester, Redpanda Cluster>
+            peer-vpc-id <Accepter, Ducktape client>
+            Create routes from Readpanda to Ducktape (10.10.xxx -> 172...)
+            Create routes to Redpanda from Ducktape (172... -> 10.10.xxx)
+        5b. Use CloudV2 API to create peering
+
+        6. Accept VPC Peering on AWS side
+
+        """
+
+        # Network id
+        network_id = self.current.network_id
+
+        # get CIDR from network
+        # _cidr =
+
+        # VPC for the client can be found in metadata
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
+        # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/owner-id
+        # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/vpc-id
+
+        _ducktape_client_ip = "0.0.0.0"
+        _baseurl = "http://169.254.169.254/latest/meta-data/network/interfaces/macs/"
+        # Prepare metadata
+        self.current.peer_vpc_id = self._get_ducktape_meta(
+            f"{_baseurl}{_ducktape_client_ip}/vpc-id")
+        self.current.peer_owner_id = self._get_ducktape_meta(
+            f"{_baseurl}{_ducktape_client_ip}/owner-id")
+
+        # Use Cloud API to create peering
+        # Alternatively, Use manual AWS commands to do the same
+        _body = self._create_network_peering_payload()
+        self._logger.debug(f"body: '{_body}'")
         resp = self.cloudv2._http_post(
-            f'/api/v1/networks/{network_id}/network-peerings', json=body)
+            f'/api/v1/networks/{network_id}/network-peerings', json=_body)
+
         # TODO accept the AWS VPC peering request
         # TODO create route between vpc and peering connection
-        # network_id
+
         return

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -253,6 +253,9 @@ class CloudCluster():
             if c['name'] == self.current.name:
                 if c['state'] == 'ready':
                     return True
+                elif c['state'] == 'unknown':
+                    raise RuntimeError("Creation failed (state 'unknown') "
+                                       f"for '{self.config.provider}'")
         return False
 
     def _get_cluster_id_and_network_id(self):
@@ -335,9 +338,12 @@ class CloudCluster():
         for p in products:
             if p['redpandaConfigProfileName'] == config_profile_name:
                 return p['id']
+        self._logger.warning("CloudV2 API returned empty 'product_id' list "
+                             f"for request: '{params}'")
         return None
 
     def _create_cluster_payload(self):
+        _cidr = "10.1.0.0/16" if self.isPublicNetwork else self.config.network
         return {
             "cluster": {
                 "name": self.current.name,
@@ -361,7 +367,7 @@ class CloudCluster():
                 "displayName":
                 f"{self.current.connection_type}-network-{self.current.name}",
                 "spec": {
-                    "cidr": "10.1.0.0/16",
+                    "cidr": _cidr,
                     "deploymentType": self.config.type,
                     "installPackVersion": self.current.install_pack_ver,
                     "provider": self.config.provider,
@@ -394,7 +400,6 @@ class CloudCluster():
         self.current.zones = _c['spec']['zones']
         self.current.network_id = _c['spec']['networkId']
         self.current.network_cidr = _c['spec']['network']['networkCidr']
-
         if self.current.region != self.config.region:
             raise RuntimeError("BYOC Cluster is in different region: "
                                f"'{self.current.region}'. Multi-region "
@@ -436,10 +441,23 @@ class CloudCluster():
         self.current.namespace_uuid = self._create_namespace()
         # name rp-ducktape-cluster-3b36f516
         self.current.name = f'rp-ducktape-cluster-{self._unique_id}'
-        self.current.install_pack_ver = self._get_latest_install_pack_ver()
-        self.current.zones = ['usw2-az1']
-        self.current.product_id = self._get_product_id(config_profile_name)
+        # Install pack handling
+        if self.config.install_pack_ver == 'latest':
+            self.config.install_pack_ver = self._get_latest_install_pack_ver()
+        self.current.install_pack_ver = self.config.install_pack_ver
+        # Multi-zone not supported, so get a single one from the list
+        self.current.region = self.config.region
         self.current.region_id = self._get_region_id()
+        self.current.zones = self.provider_cli.get_single_zone(
+            self.current.region)
+        # Call CloudV2 API to determine Product ID
+        self.current.product_id = self._get_product_id(config_profile_name)
+        if self.current.product_id is None:
+            raise RuntimeError("ProductID failed to be determined for "
+                               f"'{self.config.provider}', "
+                               f"'{self.config.type}', "
+                               f"'{self.config.install_pack_ver}', "
+                               f"'{self.config.region}'")
 
         # Call Api to create cluster
         self._logger.info(f'creating cluster name {self.current.name}')

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -259,6 +259,20 @@ class CloudCluster():
                 return (c['id'], c['spec']['networkId'])
         return None, None
 
+    def _prepare_network_vpc_info(self):
+        """
+        Calls CloudV2 API to get cidr_block, vpc_id
+        and owner_id of created cluster
+
+        """
+        _net = self.cloudv2._http_get(
+            endpoint=f"/api/v1/networks/{self.current.network_id}")
+        _info = _net['status']['created']['providerNetworkDetails'][
+            'cloudProvider'][self.config.provider.lower()]
+        self.current.rp_vpc_id = _info['vpcId']
+        self.current.rp_owner_id = _info['ownerId']
+        self.current.network_cidr = _info['cidrBlock']
+
     def _get_latest_install_pack_ver(self):
         """Get latest certified install pack ver by searching list of avail.
 
@@ -293,13 +307,16 @@ class CloudCluster():
         return None
 
     def _get_product_id(self, config_profile_name):
-        """Get the product id for the first matching config profile name using filter parameters.
+        """Get the product id for the first matching config
+        profile name using filter parameters.
+        Uses self.current as a source of params
+            provider: cloud provider filter, e.g. 'AWS'
+            cluster_type: cluster type filter, e.g. 'FMC'
+            region: region name filter, e.g. 'us-west-2'
+            install_pack_ver: install pack version filter, 
+               e.g. '23.2.20230707135118'
 
         :param config_profile_name: config profile name, e.g. 'tier-1-aws'
-        :param provider: cloud provider filter, e.g. 'AWS'
-        :param cluster_type: cluster type filter, e.g. 'FMC'
-        :param region: region name filter, e.g. 'us-west-2'
-        :param install_pack_ver: install pack version filter, e.g. '23.2.20230707135118'
         :return: productId, e.g. 'chqrd4q37efgkmohsbdg'
         """
 
@@ -370,7 +387,7 @@ class CloudCluster():
         self.current.namespace_uuid = self._create_namespace()
         # name rp-ducktape-cluster-3b36f516
         self.current.name = f'rp-ducktape-cluster-{self._unique_id}'
-        self.current.install_pack_ver = self._get_install_pack_ver()
+        self.current.install_pack_ver = self._get_latest_install_pack_ver()
         self.current.region_id = self._get_region_id()
         self.current.zones = ['usw2-az1']
         self.current.product_id = self._get_product_id(config_profile_name)
@@ -514,12 +531,69 @@ class CloudCluster():
             "namespaceUuid": self.current.namespace_uuid
         }
 
-    def _get_ducktape_meta(self, url):
-        resp = requests.get(url)
-        if not resp:
-            self._logger.error("failed to get metadata from Ducktape node: "
-                               f"'{url}'")
-        return resp.text
+    def _get_ducktape_client_mac_uri(self):
+        """
+        Get MAC address from current interface.
+        Function assumes that there is a single interface on ducktape node
+        """
+        _url = "http://169.254.169.254/latest/meta-data/network/interfaces/macs"
+        resp = requests.get(_url)
+        if not resp.ok:
+            self._logger.error("failed to get MAC for Ducktape node: "
+                               f"'{_url}'")
+            return None
+        else:
+            # Example: '0a:97:f4:40:30:93/'
+            return f"{_url}/{resp.text}"
+
+    def _get_ducktape_meta(self):
+        """
+        Query meta from local node.
+        Source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
+        Available for AWS instance:
+            device-number
+            interface-id
+            ipv4-associations/
+            local-hostname
+            local-ipv4s
+            mac
+            owner-id
+            public-hostname
+            public-ipv4s
+            security-group-ids
+            security-groups
+            subnet-id
+            subnet-ipv4-cidr-block
+            vpc-id
+            vpc-ipv4-cidr-block
+            vpc-ipv4-cidr-blocks
+        """
+        _url = self._get_ducktape_client_mac_uri()
+        resp = requests.get(_url)
+        if not resp.ok:
+            self._logger.error(
+                "failed to get metadata list from Ducktape node: "
+                f"'{_url}'")
+            return None
+        else:
+            # Assume that since first request passed,
+            # There is no need to validate each one.
+            # build dict with meta
+            _keys = resp.text.split()
+            _values = [requests.get(f"{_url}/{key}").text for key in _keys]
+            _meta = {}
+            for item in zip(_keys, _values):
+                _meta[item[0]] = item[1]
+            return _meta
+
+    def _check_peering_status(self, endpoint, state):
+        _endpoint = f"{endpoint}/{self.vpc_peering['id']}"
+        _peering = self.cloudv2._http_get(endpoint=_endpoint)
+        if _peering['state'] == state:
+            self.vpc_peering = _peering
+            return True
+        else:
+            return False
 
     def create_vpc_peering(self):
         """
@@ -543,6 +617,7 @@ class CloudCluster():
 
         # Network id
         network_id = self.current.network_id
+        _endpoint = f'/api/v1/networks/{network_id}/network-peerings'
 
         # get CIDR from network
         # _cidr =
@@ -552,22 +627,40 @@ class CloudCluster():
         # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/owner-id
         # curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ip -br link show eth0 | awk '{print$3}')/vpc-id
 
-        _ducktape_client_ip = "0.0.0.0"
-        _baseurl = "http://169.254.169.254/latest/meta-data/network/interfaces/macs/"
         # Prepare metadata
-        self.current.peer_vpc_id = self._get_ducktape_meta(
-            f"{_baseurl}{_ducktape_client_ip}/vpc-id")
-        self.current.peer_owner_id = self._get_ducktape_meta(
-            f"{_baseurl}{_ducktape_client_ip}/owner-id")
+        self._ducktape_meta = self._get_ducktape_meta()
+        self.current.peer_vpc_id = self._ducktape_meta['vpc-id']
+        self.current.peer_owner_id = self._ducktape_meta['owner-id']
+        # Prepare vpc_id, owner_id and cidrBlock for cloud cluster
+        self._prepare_network_vpc_info()
 
         # Use Cloud API to create peering
         # Alternatively, Use manual AWS commands to do the same
         _body = self._create_network_peering_payload()
         self._logger.debug(f"body: '{_body}'")
-        resp = self.cloudv2._http_post(
-            f'/api/v1/networks/{network_id}/network-peerings', json=_body)
 
-        # TODO accept the AWS VPC peering request
+        # Create peering
+        resp = self.cloudv2._http_post(endpoint=_endpoint, json=_body)
+        self._logger.debug(f"Created VPC peering: '{resp}'")
+        self.vpc_peering = resp
+
+        # Wait for "pending acceptance"
+        _state = "pending acceptance"
+        wait_until(lambda: self._check_peering_status(_endpoint, _state),
+                   timeout_sec=self.CHECK_TIMEOUT_SEC,
+                   backoff_sec=self.CHECK_BACKOFF_SEC,
+                   err_msg=f'Timeout waiting for {_state} status '
+                   f'of peering {self.current.name}')
+
+        # Find id of the correct peering VPC
+        _vpc_id = self.provider_cli.find_vpc_peering_connection(
+            "pending-acceptance", self.current.region_id,
+            self.current.network_cidr, self.current.rp_vpc_id,
+            self.current.rp_owner_id, self.current.peer_vpc_id,
+            self.current.peer_owner_id)
+        # Accept it
+        self.provider_cli.accept_vpc_peering(_vpc_id)
+
         # TODO create route between vpc and peering connection
 
         return

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -4,7 +4,7 @@ import os
 import requests
 import uuid
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from ducktape.utils.util import wait_until
@@ -105,9 +105,9 @@ class RpCloudApiClient(object):
 @dataclass(kw_only=True)
 class CloudClusterConfig:
     """
-    Configuration for the Cloud Cluster.
-    Should be the same as in context.globals['cloud_cluster']
-    Otherwise there will be error for not supplied parameters
+    Configuration of Cloud cluster.
+    Should be in sync with cloud_cluster subsection in
+    vtools/qa/deploy/ansible/roles/ducktape-setup/templates/ducktape_globals.json.j2
     """
     oauth_url: str
     oauth_client_id: str
@@ -128,17 +128,27 @@ class CloudClusterConfig:
 
 @dataclass
 class LiveClusterParams:
+    """
+    Active Cluster params.
+    Should not be used outside of the redpanda_cloud module
+    """
     isAlive: bool = False
     connection_type: str = 'public'
     namespace_uuid: str = None
     name: str = None
     network_id: str = None
+    network_cidr: str = None
     install_pack_ver: str = None
     product_id: str = None
     region_id: str = None
-    zones: list = []
-    peer_vpc_id: str
-    peer_owner_id: str
+    peer_vpc_id: str = None
+    peer_owner_id: str = None
+    rp_vpc_id: str = None
+    rp_owner_id: str = None
+
+    # Can't use mutables in defaults of dataclass
+    # https://docs.python.org/3/library/dataclasses.html#dataclasses.field
+    zones: list[str] = field(default_factory=list)
 
 
 class CloudCluster():
@@ -190,10 +200,11 @@ class CloudCluster():
         # init live cluster params
         self.current = LiveClusterParams()
 
-        self.cli = make_provider_client(self.config.provider, provider_config)
+        self.provider_cli = make_provider_client(
+            self.config.provider, logger, provider_config=provider_config)
         # Currently we need provider client only for VCP in private networking
         # Raise exception is client in not implemented yet
-        if self.cli is None and self.config.network != 'public':
+        if self.provider_cli is None and self.config.network != 'public':
             self._logger.error(
                 f"Current provider is not yet supports private networking ")
             raise RuntimeError("Private networking is not implemented "
@@ -232,11 +243,12 @@ class CloudCluster():
 
     def _get_cluster_id_and_network_id(self):
         """
-        Get clusterId and networkId.
+        Get clusterId.
+        Uses self.current data as a source of needed params:
+        self.current.namespace_uuid: namespaceUuid the cluster is contained in
+        self.current.name: name of the cluster
 
-        :param namespace_uuid: namespaceUuid the cluster is contained in
-        :param name: name of the cluster
-        :return: (clusterId, networkId) as tuple of strings or (None, None) if not found
+        :return: clusterId, networkId as a string or None if not found
         """
 
         params = {'namespaceUuid': self.current.namespace_uuid}
@@ -395,7 +407,7 @@ class CloudCluster():
 
         if not self.isPublicNetwork:
             self.create_vpc_peering()
-
+        self.current.isAlive = True
         return self.config.id
 
     def delete(self):


### PR DESCRIPTION
Create VPC peering for deployed cloud with private network

Steps:
1. Get VPC of the ducktape client instance
2. Detect cloud type and run corresponding workflow: FMC/BYOC

BYOC VPC Peering.
1. Prepare VPC info using boto3/vpc
2. Create peering in AWS or reuse existing one
3. Wait for pending acceptance using AWS if created
4. Accept it if created
5. Create routes
6. Ensure Active on AWS if created

FMC VPC Peering
1. Prepare vpc info using CloudV2
2. Create peering in CloudV2
3. Wait for Pending Acceptance usign CloudV2
4. Accept it
5. Create routes
6. Ensure Ready/Active state on both sides


Prior to implementing, in order not to have long list of arguments in each internal functions, use self.current as a data store. Each of the _*_payload functions and _get_* will use it as a source of data to create proper body for REST request

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none