### PR TITLE
cluster: Add transform metadata to controller

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -163,6 +163,7 @@ v_cc_library(
     cloud_storage_size_reducer.cc
     topic_recovery_service.cc
     partition_recovery_manager.cc
+    plugin_table.cc
     ../archival/archival_policy.cc
     ../archival/ntp_archiver_service.cc
     ../archival/probe.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -164,6 +164,7 @@ v_cc_library(
     topic_recovery_service.cc
     partition_recovery_manager.cc
     plugin_table.cc
+    plugin_frontend.cc
     ../archival/archival_policy.cc
     ../archival/ntp_archiver_service.cc
     ../archival/probe.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -165,6 +165,7 @@ v_cc_library(
     partition_recovery_manager.cc
     plugin_table.cc
     plugin_frontend.cc
+    plugin_backend.cc
     ../archival/archival_policy.cc
     ../archival/ntp_archiver_service.cc
     ../archival/probe.cc

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -15,6 +15,7 @@
 #include "cluster/types.h"
 #include "model/metadata.h"
 #include "model/record.h"
+#include "model/transform.h"
 #include "reflection/adl.h"
 #include "reflection/async_adl.h"
 #include "security/scram_credential.h"
@@ -126,6 +127,10 @@ static constexpr int8_t feature_update_license_update_cmd_type = 1;
 
 // cluster bootstrap commands
 static constexpr int8_t bootstrap_cluster_cmd_type = 0;
+
+// plugin command types
+static constexpr int8_t transform_update_cmd_type = 0;
+static constexpr int8_t transform_remove_cmd_type = 1;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -328,6 +333,21 @@ using feature_update_license_update_cmd = controller_command<
   int8_t, // unused
   feature_update_license_update_cmd_type,
   model::record_batch_type::feature_update,
+  serde_opts::serde_only>;
+
+// Plugins
+using transform_update_cmd = controller_command<
+  int8_t, // unused
+  model::transform_metadata,
+  transform_update_cmd_type,
+  model::record_batch_type::plugin_update,
+  serde_opts::serde_only>;
+
+using transform_remove_cmd = controller_command<
+  model::transform_name,
+  int8_t, // unused
+  transform_remove_cmd_type,
+  model::record_batch_type::plugin_update,
   serde_opts::serde_only>;
 
 // Cluster bootstrap

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -280,6 +280,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_members_table),
             std::ref(_partition_manager),
             std::ref(_shard_table),
+            ss::sharded_parameter(
+              [this] { return std::ref(_plugin_table.local()); }),
             ss::sharded_parameter([] {
                 return config::shard_local_cfg()
                   .storage_space_alert_free_threshold_percent.bind();

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -36,6 +36,8 @@
 #include "cluster/partition_balancer_state.h"
 #include "cluster/partition_leaders_table.h"
 #include "cluster/partition_manager.h"
+#include "cluster/plugin_backend.h"
+#include "cluster/plugin_frontend.h"
 #include "cluster/raft0_utils.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/security_frontend.h"
@@ -172,6 +174,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_feature_table),
             std::ref(_feature_backend));
       })
+      .then([this] { return _plugin_table.start(); })
+      .then([this] { return _plugin_backend.start_single(&_plugin_table); })
       .then([this] {
           return _config_frontend.start(
             std::ref(_stm),
@@ -232,7 +236,8 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_members_manager),
             std::ref(_config_manager),
             std::ref(_feature_backend),
-            std::ref(_bootstrap_backend));
+            std::ref(_bootstrap_backend),
+            std::ref(_plugin_backend));
       })
       .then([this] {
           return _members_frontend.start(
@@ -279,6 +284,19 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
                 return config::shard_local_cfg()
                   .storage_space_alert_free_threshold_percent.bind();
             }));
+      })
+      .then([this] {
+          return _plugin_frontend.start(
+            _raft0->self().id(),
+            ss::sharded_parameter(
+              [this] { return &_partition_leaders.local(); }),
+            ss::sharded_parameter([this] { return &_plugin_table.local(); }),
+            ss::sharded_parameter([this] { return &_tp_state.local(); }),
+            ss::sharded_parameter([this] {
+                return _stm.local_is_initialized() ? &_stm.local() : nullptr;
+            }),
+            ss::sharded_parameter([this] { return &_connections.local(); }),
+            ss::sharded_parameter([this] { return &_as.local(); }));
       })
       .then([this] {
           return _members_backend.start_single(
@@ -572,6 +590,7 @@ ss::future<> controller::stop() {
           .then([this] { return _api.stop(); })
           .then([this] { return _backend.stop(); })
           .then([this] { return _tp_frontend.stop(); })
+          .then([this] { return _plugin_frontend.stop(); })
           .then([this] { return _ephemeral_credential_frontend.stop(); })
           .then([this] { return _security_frontend.stop(); })
           .then([this] { return _members_frontend.stop(); })
@@ -584,6 +603,8 @@ ss::future<> controller::stop() {
           .then([this] { return _tp_state.stop(); })
           .then([this] { return _members_manager.stop(); })
           .then([this] { return _stm.stop(); })
+          .then([this] { return _plugin_backend.stop(); })
+          .then([this] { return _plugin_table.stop(); })
           .then([this] { return _drain_manager.stop(); })
           .then([this] { return _partition_balancer_state.stop(); })
           .then([this] { return _partition_allocator.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -58,7 +58,9 @@ public:
     ss::sharded<config_manager>& get_config_manager() {
         return _config_manager;
     }
-
+    ss::sharded<plugin_frontend>& get_plugin_frontend() {
+        return _plugin_frontend;
+    }
     ss::sharded<members_table>& get_members_table() { return _members_table; }
     ss::sharded<topic_table>& get_topics_state() { return _tp_state; }
     ss::sharded<partition_leaders_table>& get_partition_leaders() {
@@ -241,6 +243,10 @@ private:
     ss::sharded<node_status_table>& _node_status_table;
     controller_probe _probe;
     ss::sharded<bootstrap_backend> _bootstrap_backend; // single instance
+
+    ss::sharded<plugin_frontend> _plugin_frontend; // instance per core
+    ss::sharded<plugin_table> _plugin_table;       // instance per core
+    ss::sharded<plugin_backend> _plugin_backend;   // single instance
     bool _is_ready = false;
 };
 

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -135,6 +135,16 @@
             "name": "get_partition_state",
             "input_type": "partition_state_request",
             "output_type": "partition_state_reply"
+        },
+        {
+            "name": "upsert_plugin",
+            "input_type": "upsert_plugin_request",
+            "output_type": "upsert_plugin_response"
+        },
+        {
+            "name": "remove_plugin",
+            "input_type": "remove_plugin_request",
+            "output_type": "remove_plugin_response"
         }
     ]
 }

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -170,6 +170,7 @@ ss::future<> controller_snapshot::serde_async_write(iobuf& out) {
     co_await serde::write_async(out, std::move(topics));
     co_await serde::write_async(out, std::move(security));
     co_await serde::write_async(out, std::move(metrics_reporter));
+    co_await serde::write_async(out, std::move(plugins));
 }
 
 ss::future<>
@@ -189,6 +190,11 @@ controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
     metrics_reporter
       = co_await serde::read_async_nested<decltype(metrics_reporter)>(
         in, h._bytes_left_limit);
+
+    if (h._version >= 1) {
+        plugins = co_await serde::read_async_nested<decltype(plugins)>(
+          in, h._bytes_left_limit);
+    }
 
     if (in.bytes_left() > h._bytes_left_limit) {
         in.skip(in.bytes_left() - h._bytes_left_limit);

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -213,12 +213,22 @@ struct metrics_reporter_t
     auto serde_fields() { return std::tie(cluster_info); }
 };
 
+struct plugins_t
+  : public serde::
+      envelope<plugins_t, serde::version<0>, serde::compat_version<0>> {
+    absl::btree_map<model::transform_id, model::transform_metadata> transforms;
+
+    friend bool operator==(const plugins_t&, const plugins_t&) = default;
+
+    auto serde_fields() { return std::tie(transforms); }
+};
+
 } // namespace controller_snapshot_parts
 
 struct controller_snapshot
   : public serde::checksum_envelope<
       controller_snapshot,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     controller_snapshot_parts::bootstrap_t bootstrap;
     controller_snapshot_parts::features_t features;
@@ -227,6 +237,7 @@ struct controller_snapshot
     controller_snapshot_parts::topics_t topics;
     controller_snapshot_parts::security_t security;
     controller_snapshot_parts::metrics_reporter_t metrics_reporter;
+    controller_snapshot_parts::plugins_t plugins;
 
     friend bool
     operator==(const controller_snapshot&, const controller_snapshot&)

--- a/src/v/cluster/controller_stm.cc
+++ b/src/v/cluster/controller_stm.cc
@@ -175,7 +175,9 @@ ss::future<> controller_stm::apply_snapshot(
           std::get<config_manager&>(_state).apply_snapshot(offset, snapshot),
           std::get<topic_updates_dispatcher&>(_state).apply_snapshot(
             offset, snapshot),
+          std::get<plugin_backend&>(_state).apply_snapshot(offset, snapshot),
           std::get<security_manager&>(_state).apply_snapshot(offset, snapshot));
+
     } catch (const seastar::abort_requested_exception&) {
     } catch (const seastar::gate_closed_exception&) {
     } catch (const seastar::broken_semaphore&) {

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -15,6 +15,7 @@
 #include "cluster/config_manager.h"
 #include "cluster/controller_log_limiter.h"
 #include "cluster/feature_backend.h"
+#include "cluster/plugin_backend.h"
 #include "cluster/security_manager.h"
 #include "cluster/topic_updates_dispatcher.h"
 #include "raft/mux_state_machine.h"
@@ -33,7 +34,8 @@ class controller_stm final
       members_manager,
       config_manager,
       feature_backend,
-      bootstrap_backend> {
+      bootstrap_backend,
+      plugin_backend> {
 public:
     template<typename... Args>
     controller_stm(

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -68,6 +68,11 @@ enum class errc : int16_t {
     no_partition_assignments,
     failed_to_create_partition,
     partition_operation_failed,
+    transform_does_not_exist,
+    transform_invalid_update,
+    transform_invalid_create,
+    transform_invalid_source,
+    transform_invalid_environment,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -195,6 +200,17 @@ struct errc_category final : public std::error_category {
         case errc::partition_operation_failed:
             return "Generic failure occurred during partition operation "
                    "execution";
+        case errc::transform_does_not_exist:
+            return "Transform does not exist";
+        case errc::transform_invalid_update:
+            return "Invalid update to transform, topic configuration "
+                   "cannot change";
+        case errc::transform_invalid_source:
+            return "Invalid transform source";
+        case errc::transform_invalid_create:
+            return "Invalid create transform configuration";
+        case errc::transform_invalid_environment:
+            return "Invalid transform environment";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -31,6 +31,7 @@ class partition_manager;
 class shard_table;
 class topics_frontend;
 class topic_table;
+class plugin_table;
 struct topic_table_delta;
 class topic_table_partition_generator;
 class cloud_storage_size_reducer;

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -31,6 +31,7 @@ class partition_manager;
 class shard_table;
 class topics_frontend;
 class topic_table;
+class plugin_frontend;
 class plugin_table;
 struct topic_table_delta;
 class topic_table_partition_generator;

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -33,6 +33,7 @@ class topics_frontend;
 class topic_table;
 class plugin_frontend;
 class plugin_table;
+class plugin_backend;
 struct topic_table_delta;
 class topic_table_partition_generator;
 class cloud_storage_size_reducer;

--- a/src/v/cluster/plugin_backend.cc
+++ b/src/v/cluster/plugin_backend.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "plugin_backend.h"
+
+namespace cluster {
+
+plugin_backend::plugin_backend(ss::sharded<plugin_table>* t)
+  : _table(t) {}
+
+ss::future<> plugin_backend::fill_snapshot(controller_snapshot& snap) const {
+    snap.plugins.transforms = _table->local().all_transforms();
+    return ss::now();
+}
+
+ss::future<>
+plugin_backend::apply_snapshot(model::offset, const controller_snapshot& snap) {
+    return _table->invoke_on_all([&snap](auto& table) {
+        table.reset_transforms(snap.plugins.transforms);
+    });
+}
+
+ss::future<std::error_code>
+plugin_backend::apply_update(model::record_batch b) {
+    auto offset = b.base_offset();
+    auto cmd = co_await cluster::deserialize(std::move(b), accepted_commands);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+    co_await _table->invoke_on_all([&cmd, offset](plugin_table& table) {
+        return ss::visit(
+          cmd,
+          // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+          [&table, offset](transform_update_cmd update) {
+              // For create operations, the first write's offset is the ID
+              auto existing_id = table.find_id_by_name(update.value.name);
+              table.upsert_transform(
+                existing_id.value_or(model::transform_id(offset())),
+                std::move(update.value));
+          },
+          // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+          [&table](const transform_remove_cmd& removal) {
+              table.remove_transform(removal.key);
+          });
+    });
+    co_return errc::success;
+}
+
+} // namespace cluster

--- a/src/v/cluster/plugin_backend.h
+++ b/src/v/cluster/plugin_backend.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/commands.h"
+#include "cluster/controller_snapshot.h"
+#include "cluster/plugin_table.h"
+
+namespace cluster {
+/**
+ * The plugin backend is responsible for dispatching controller updates into the
+ * `plugin` table.
+ */
+class plugin_backend {
+public:
+    explicit plugin_backend(ss::sharded<plugin_table>*);
+
+    ss::future<> fill_snapshot(controller_snapshot&) const;
+    ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
+
+    ss::future<std::error_code> apply_update(model::record_batch);
+    bool is_batch_applicable(const model::record_batch& b) {
+        return b.header().type == model::record_batch_type::plugin_update;
+    }
+
+private:
+    static constexpr auto accepted_commands
+      = make_commands_list<transform_update_cmd, transform_remove_cmd>();
+
+    ss::sharded<plugin_table>* _table;
+};
+} // namespace cluster

--- a/src/v/cluster/plugin_frontend.cc
+++ b/src/v/cluster/plugin_frontend.cc
@@ -1,0 +1,595 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "plugin_frontend.h"
+
+#include "cluster/controller_service.h"
+#include "cluster/controller_stm.h"
+#include "cluster/logger.h"
+#include "model/metadata.h"
+#include "utils/utf8.h"
+
+#include <absl/strings/escaping.h>
+#include <absl/strings/str_join.h>
+
+namespace cluster {
+
+using model::transform_id;
+using model::transform_metadata;
+using model::transform_name;
+using mutation_result = plugin_frontend::mutation_result;
+namespace {
+
+ss::sstring loggable_string(std::string_view s) {
+    constexpr size_t max_log_string_size = 512;
+    if (s.size() > max_log_string_size) {
+        s = s.substr(0, max_log_string_size);
+    }
+    if (is_valid_utf8(s) && !contains_control_character(s)) {
+        return ss::sstring(s);
+    }
+    return absl::CHexEscape(s);
+}
+
+std::vector<ss::sstring>
+loggable_topics(const std::vector<model::topic_namespace>& topics) {
+    std::vector<ss::sstring> sanitized;
+    sanitized.reserve(topics.size());
+    for (const auto& topic : topics) {
+        sanitized.push_back(loggable_string(topic.tp()));
+    }
+    return sanitized;
+}
+
+errc map_errc(std::error_code ec) {
+    if (ec == errc::success) {
+        return errc::success;
+    }
+    if (ec.category() == raft::error_category()) {
+        switch (raft::errc(ec.value())) {
+        case raft::errc::timeout:
+            return errc::timeout;
+        case raft::errc::not_leader:
+            return errc::not_leader_controller;
+        default:
+            return errc::replication_error;
+        }
+    }
+    if (ec.category() == rpc::error_category()) {
+        switch (rpc::errc(ec.value())) {
+        case rpc::errc::client_request_timeout:
+            return errc::timeout;
+        default:
+            return errc::replication_error;
+        }
+    }
+    if (ec.category() == error_category()) {
+        return errc(ec.value());
+    }
+    return errc::replication_error;
+}
+} // namespace
+
+plugin_frontend::plugin_frontend(
+  model::node_id s,
+  partition_leaders_table* l,
+  plugin_table* t,
+  topic_table* tp,
+  controller_stm* c,
+  rpc::connection_cache* r,
+  ss::abort_source* a)
+  : _self(s)
+  , _leaders(l)
+  , _connections(r)
+  , _table(t)
+  , _topics(tp)
+  , _abort_source(a)
+  , _controller(c) {}
+
+ss::future<errc> plugin_frontend::upsert_transform(
+  transform_metadata meta, model::timeout_clock::time_point timeout) {
+    // The ID is looked up later.
+    transform_cmd c{transform_update_cmd{0, std::move(meta)}};
+    mutation_result r = co_await do_mutation(std::move(c), timeout);
+    co_return r.ec;
+}
+
+ss::future<mutation_result> plugin_frontend::remove_transform(
+  transform_name name, model::timeout_clock::time_point timeout) {
+    transform_cmd c{transform_remove_cmd{std::move(name), 0}};
+    return do_mutation(std::move(c), timeout);
+}
+
+ss::future<mutation_result> plugin_frontend::do_mutation(
+  transform_cmd cmd, model::timeout_clock::time_point timeout) {
+    auto cluster_leader = _leaders->get_leader(model::controller_ntp);
+    if (!cluster_leader) {
+        co_return mutation_result{.ec = errc::no_leader_controller};
+    }
+    if (*cluster_leader != _self) {
+        co_return co_await dispatch_mutation_to_remote(
+          *cluster_leader,
+          std::move(cmd),
+          timeout - model::timeout_clock::now());
+    }
+    if (ss::this_shard_id() != controller_stm_shard) {
+        co_return co_await container().invoke_on(
+          controller_stm_shard,
+          // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+          [cmd = std::move(cmd), timeout](auto& service) mutable {
+              return service.do_mutation(std::move(cmd), timeout);
+          });
+    }
+    co_return co_await do_local_mutation(std::move(cmd), timeout);
+}
+
+ss::future<mutation_result> plugin_frontend::dispatch_mutation_to_remote(
+  model::node_id cluster_leader,
+  transform_cmd cmd,
+  model::timeout_clock::duration timeout) {
+    return _connections
+      ->with_node_client<controller_client_protocol>(
+        _self,
+        ss::this_shard_id(),
+        cluster_leader,
+        timeout,
+        [timeout,
+         cmd = std::move(cmd)](controller_client_protocol client) mutable {
+            return ss::visit(
+              std::move(cmd),
+              [client, timeout](transform_update_cmd cmd) mutable {
+                  auto uuid = cmd.value.uuid;
+                  return client
+                    .upsert_plugin(
+                      upsert_plugin_request{
+                        .transform = std::move(cmd.value), .timeout = timeout},
+                      rpc::client_opts(timeout))
+                    .then(&rpc::get_ctx_data<upsert_plugin_response>)
+                    .then([uuid](auto r) {
+                        if (r.has_error()) {
+                            return result<mutation_result>(r.error());
+                        }
+                        return result<mutation_result>(
+                          mutation_result{.uuid = uuid, .ec = r.value().ec});
+                    });
+              },
+              [client, timeout](transform_remove_cmd cmd) mutable {
+                  return client
+                    .remove_plugin(
+                      remove_plugin_request{
+                        .name = std::move(cmd.key), .timeout = timeout},
+                      rpc::client_opts(timeout))
+                    .then(&rpc::get_ctx_data<remove_plugin_response>)
+                    .then([](auto r) {
+                        if (r.has_error()) {
+                            return result<mutation_result>(r.error());
+                        }
+                        return result<mutation_result>(mutation_result{
+                          .uuid = r.value().uuid, .ec = r.value().ec});
+                    });
+              });
+        })
+      .then([](result<mutation_result> r) {
+          if (r.has_error()) {
+              return mutation_result{.ec = map_errc(r.error())};
+          }
+          return r.value();
+      });
+}
+ss::future<mutation_result> plugin_frontend::do_local_mutation(
+  transform_cmd cmd, model::timeout_clock::time_point timeout) {
+    auto u = co_await _mu.get_units();
+    // Make sure we're up to date
+    auto result = co_await _controller->insert_linearizable_barrier(timeout);
+    if (!result) {
+        co_return mutation_result{.ec = errc::not_leader_controller};
+    }
+    auto ec = validate_mutation(cmd);
+    if (ec != errc::success) {
+        co_return mutation_result{.ec = ec};
+    }
+    bool ok = std::visit(
+      [this](const auto& cmd) {
+          using T = std::decay_t<decltype(cmd)>;
+          return _controller->throttle<T>();
+      },
+      cmd);
+    if (!ok) {
+        co_return mutation_result{.ec = errc::throttling_quota_exceeded};
+    }
+    auto uuid = ss::visit(
+      cmd,
+      [](const transform_update_cmd& cmd) { return cmd.value.uuid; },
+      [this](const transform_remove_cmd& cmd) {
+          // This is safe because we've validated the mutation above.
+          return _table->find_by_name(cmd.key)->uuid;
+      });
+    auto b = std::visit(
+      [](auto cmd) { return serde_serialize_cmd(std::move(cmd)); },
+      std::move(cmd));
+    co_return co_await _controller
+      ->replicate_and_wait(std::move(b), timeout, *_abort_source)
+      .then([uuid](std::error_code ec) {
+          return ss::make_ready_future<mutation_result>(
+            mutation_result{.uuid = uuid, .ec = map_errc(ec)});
+      });
+}
+
+errc plugin_frontend::validate_mutation(const transform_cmd& cmd) {
+    validator v(_topics, _table);
+    return v.validate_mutation(cmd);
+}
+
+plugin_frontend::validator::validator(
+  topic_table* topic_table, plugin_table* plugin_table)
+  : _topics(topic_table)
+  , _table(plugin_table) {}
+
+errc plugin_frontend::validator::validate_mutation(const transform_cmd& cmd) {
+    return ss::visit(
+      cmd,
+      [this](const transform_update_cmd& cmd) {
+          // Any mutations are allowed to change environment variables, so we
+          // always need to validate those
+          constexpr static size_t max_key_size = 128;
+          constexpr static size_t max_value_size = 2_KiB;
+          constexpr static size_t max_env_vars = 128;
+          if (cmd.value.environment.size() > max_env_vars) {
+              vlog(
+                clusterlog.info,
+                "deploy of transform {} contained too many environment "
+                "variables {} > {}",
+                cmd.value.name,
+                cmd.value.environment.size(),
+                max_env_vars);
+              return errc::transform_invalid_environment;
+          }
+          for (const auto& [k, v] : cmd.value.environment) {
+              if (k.empty()) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} had an empty environment "
+                    "variable key",
+                    cmd.value.name);
+                  return errc::transform_invalid_environment;
+              }
+              if (k.size() > max_key_size) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} had too large of an "
+                    "environment variable key {}",
+                    cmd.value.name,
+                    k.size(),
+                    max_key_size);
+                  return errc::transform_invalid_environment;
+              }
+              if (!is_valid_utf8(k)) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} had an environment "
+                    "variable key with invalid utf8: {}",
+                    cmd.value.name,
+                    loggable_string(k));
+                  return errc::transform_invalid_environment;
+              }
+              if (contains_control_character(k)) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} had an environment "
+                    "variable key with invalid characters: {}",
+                    cmd.value.name,
+                    loggable_string(k));
+                  return errc::transform_invalid_environment;
+              }
+              if (k.find("=") != ss::sstring::npos) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} contained invalid "
+                    "environment variable key {}",
+                    cmd.value.name,
+                    k);
+                  return errc::transform_invalid_environment;
+              }
+              if (k.find("REDPANDA_") == 0) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} contained reserved "
+                    "environment variable key {}",
+                    cmd.value.name,
+                    k);
+                  return errc::transform_invalid_environment;
+              }
+              if (v.empty()) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} had an empty environment "
+                    "variable value for key {}",
+                    cmd.value.name,
+                    k);
+                  return errc::transform_invalid_environment;
+              }
+              if (v.size() > max_value_size) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} had too large of an "
+                    "environment variable value {} > {}",
+                    cmd.value.name,
+                    v.size(),
+                    max_value_size);
+                  return errc::transform_invalid_environment;
+              }
+              if (!is_valid_utf8(v)) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} had an environment "
+                    "variable value with invalid utf8: {}",
+                    cmd.value.name,
+                    loggable_string(v));
+                  return errc::transform_invalid_environment;
+              }
+              if (contains_control_character(v)) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted deploy of transform {} had an environment "
+                    "variable value with invalid characters: {}",
+                    cmd.value.name,
+                    loggable_string(v));
+                  return errc::transform_invalid_environment;
+              }
+          }
+
+          auto existing = _table->find_by_name(cmd.value.name);
+          if (existing.has_value()) {
+              // update!
+              // Only the offset pointer and environment can change.
+              if (existing->input_topic != cmd.value.input_topic) {
+                  vlog(
+                    clusterlog.info,
+                    "deploy of transform {} attempted to change the input "
+                    "topic from {} to {}",
+                    cmd.value.name,
+                    existing->input_topic,
+                    loggable_string(cmd.value.input_topic.tp()));
+                  return errc::transform_invalid_update;
+              }
+              if (existing->output_topics != cmd.value.output_topics) {
+                  vlog(
+                    clusterlog.info,
+                    "deploy of transform {} attempted to change the output "
+                    "topics from {} to {}",
+                    cmd.value.name,
+                    existing->output_topics,
+                    loggable_topics(cmd.value.output_topics));
+                  return errc::transform_invalid_update;
+              }
+              return errc::success;
+          }
+
+          // create!
+          if (cmd.value.name().empty()) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy a transform without a name");
+              return errc::transform_invalid_create;
+          }
+          constexpr static size_t max_name_size = 128;
+          if (cmd.value.name().size() > max_name_size) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy a transform with too large of a name {} > "
+                "{}",
+                cmd.value.name().size(),
+                max_name_size);
+              return errc::transform_invalid_create;
+          }
+          if (!is_valid_utf8(cmd.value.name())) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy a transform with a non-utf8 name {}",
+                loggable_string(cmd.value.name()));
+              return errc::transform_invalid_create;
+          }
+          if (contains_control_character(cmd.value.name())) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy a transform with an invalid name {}",
+                loggable_string(cmd.value.name()));
+              return errc::transform_invalid_create;
+          }
+          if (cmd.value.input_topic.ns != model::kafka_namespace) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy transform {} to a non-kafka topic {}",
+                cmd.value.name,
+                loggable_string(cmd.value.input_topic.ns()));
+              return errc::transform_invalid_create;
+          }
+          auto input_topic = _topics->get_topic_metadata(cmd.value.input_topic);
+          if (!input_topic) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy transform {} to a non-existant topic {}",
+                cmd.value.name,
+                loggable_string(cmd.value.input_topic.tp()));
+              return errc::topic_not_exists;
+          }
+          const auto& input_config = input_topic->get_configuration();
+          if (input_config.is_internal()) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy transform {} to an internal topic {}",
+                cmd.value.name,
+                loggable_string(cmd.value.input_topic.tp()));
+              return errc::transform_invalid_create;
+          }
+          // TODO: Support input read replicas?
+          if (input_config.is_read_replica()) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy transform {} to an read replica topic {}",
+                cmd.value.name,
+                loggable_string(cmd.value.input_topic.tp()));
+              return errc::transform_invalid_create;
+          }
+          if (cmd.value.output_topics.empty()) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy transform {} without any output topics",
+                loggable_string(cmd.value.name()));
+              return errc::transform_invalid_create;
+          }
+          constexpr static size_t max_output_topics = 1;
+          if (cmd.value.output_topics.size() > max_output_topics) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy transform {} with too many output topics: "
+                "{} > {}",
+                cmd.value.name,
+                cmd.value.output_topics.size(),
+                max_output_topics);
+              return errc::transform_invalid_create;
+          }
+          absl::flat_hash_set<model::topic_namespace> uniq(
+            cmd.value.output_topics.begin(), cmd.value.output_topics.end());
+          if (uniq.size() != cmd.value.output_topics.size()) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy transform {} with duplicate output "
+                "topics {}",
+                cmd.value.name,
+                loggable_topics(cmd.value.output_topics));
+              return errc::transform_invalid_create;
+          }
+          for (const auto& out_name : cmd.value.output_topics) {
+              if (out_name.ns != model::kafka_namespace) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted to deploy transform {} to a non-kafka topic {}",
+                    cmd.value.name,
+                    loggable_string(out_name.ns()));
+                  return errc::transform_invalid_create;
+              }
+              auto output_topic = _topics->get_topic_metadata(out_name);
+              if (!output_topic) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted to deploy transform {} to a non-existant topic "
+                    "{}",
+                    cmd.value.name,
+                    loggable_string(out_name.tp()));
+                  return errc::topic_not_exists;
+              }
+              const auto& output_config = output_topic->get_configuration();
+              if (output_config.is_internal()) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted to deploy transform {} to an internal topic "
+                    "{}",
+                    cmd.value.name,
+                    out_name.tp);
+                  return errc::transform_invalid_create;
+              }
+              if (output_config.is_read_replica()) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted to deploy transform {} to a read replica topic "
+                    "{}",
+                    cmd.value.name,
+                    out_name.tp);
+                  return errc::transform_invalid_create;
+              }
+              if (
+                output_config.partition_count < input_config.partition_count) {
+                  // copartitioning is required
+                  vlog(
+                    clusterlog.info,
+                    "attempted to deploy transform {} without copartitioning "
+                    "{} < {}",
+                    cmd.value.name,
+                    output_config.partition_count,
+                    input_config.partition_count);
+                  return errc::transform_invalid_create;
+              }
+              if (would_cause_cycle(cmd.value.input_topic, out_name)) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted to deploy transform {} that would cause a "
+                    "cycle",
+                    cmd.value.name);
+                  return errc::transform_invalid_create;
+              }
+          }
+
+          return errc::success;
+      },
+      [this](const transform_remove_cmd& cmd) {
+          auto transform = _table->find_by_name(cmd.key);
+          if (!transform) {
+              vlog(
+                clusterlog.info,
+                "attempted to delete a transform that does not exist {}",
+                cmd.key);
+              return errc::transform_does_not_exist;
+          }
+          return errc::success;
+      });
+}
+
+bool plugin_frontend::validator::would_cause_cycle(
+  model::topic_namespace_view input, model::topic_namespace output) {
+    model::topic_namespace_eq eq;
+    // Does output ever lead to input? let's find out via breadth first search.
+    ss::circular_buffer<model::topic_namespace> queue;
+    queue.push_back(std::move(output));
+    // explicitly bound loops to protect against looping forever
+    constexpr int max_iterations = 10000;
+    for (int i = 0; i < max_iterations; ++i) {
+        if (queue.empty()) {
+            return false;
+        }
+        model::topic_namespace current = std::move(queue.front());
+        queue.pop_front();
+        if (eq(input, current)) {
+            return true;
+        }
+        const auto& metas = _table->find_by_input_topic(current);
+        for (const auto& [id, meta] : metas) {
+            for (const auto& output_topic : meta.output_topics) {
+                queue.push_back(output_topic);
+            }
+        }
+    }
+    // we reached our max iterations and gave up
+    return true;
+}
+
+plugin_frontend::notification_id plugin_frontend::register_for_updates(
+  plugin_frontend::notification_callback cb) {
+    return _table->register_for_updates(std::move(cb));
+}
+
+void plugin_frontend::unregister_for_updates(notification_id id) {
+    return _table->unregister_for_updates(id);
+}
+std::optional<transform_metadata>
+plugin_frontend::lookup_transform(transform_id id) const {
+    return _table->find_by_id(id);
+}
+absl::btree_map<transform_id, transform_metadata>
+plugin_frontend::lookup_transforms_by_input_topic(
+  model::topic_namespace_view tp_ns) const {
+    return _table->find_by_input_topic(tp_ns);
+}
+
+absl::btree_map<transform_id, transform_metadata>
+plugin_frontend::all_transforms() const {
+    return _table->all_transforms();
+}
+} // namespace cluster

--- a/src/v/cluster/plugin_frontend.h
+++ b/src/v/cluster/plugin_frontend.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/commands.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/plugin_table.h"
+#include "cluster/topic_table.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timeout_clock.h"
+#include "rpc/connection_cache.h"
+#include "seastarx.h"
+#include "utils/mutex.h"
+
+#include <variant>
+
+#pragma once
+
+namespace cluster {
+
+/**
+ * The plugin frontend takes care of all (WASM) plugin related functionality and
+ * servicing requests from the rest of the cluster.
+ *
+ * Instance per core.
+ */
+class plugin_frontend : public ss::peering_sharded_service<plugin_frontend> {
+private:
+    using transform_cmd
+      = std::variant<transform_update_cmd, transform_remove_cmd>;
+
+public:
+    // The plugin frontend takes the corresponding services for it's core.
+    //
+    // The exception being the controller_stm which is only nonnull for the
+    // service on core 0.
+    plugin_frontend(
+      model::node_id,
+      partition_leaders_table*,
+      plugin_table*,
+      topic_table*,
+      controller_stm*,
+      rpc::connection_cache*,
+      ss::abort_source*);
+
+    using notification_id = plugin_table::notification_id;
+    using notification_callback = plugin_table::notification_callback;
+    struct mutation_result {
+        // The UUID of the modified transform, mostly useful for cleanup
+        // of wasm_binaries.
+        // See transform_metadata::uuid
+        uuid_t uuid;
+        errc ec;
+    };
+
+    // Create or update a transform by name.
+    ss::future<errc> upsert_transform(
+      model::transform_metadata, model::timeout_clock::time_point);
+
+    // Remove a transform by name.
+    ss::future<mutation_result>
+      remove_transform(model::transform_name, model::timeout_clock::time_point);
+
+    // Register for updates going forward.
+    //
+    // This is a core local operation, you can register for updates to the
+    // transforms table. If you want to lookup the transform you can then do
+    // that in the callback.
+    notification_id register_for_updates(notification_callback);
+
+    // Unregister a previously registered notification.
+    void unregister_for_updates(notification_id);
+
+    // Lookup a transform by ID. Useful when paired with registering for
+    // updates.
+    std::optional<model::transform_metadata>
+      lookup_transform(model::transform_id) const;
+
+    // Lookup transforms for input topics.
+    absl::btree_map<model::transform_id, model::transform_metadata>
+      lookup_transforms_by_input_topic(model::topic_namespace_view) const;
+
+    // Get a snapshot of all the transforms that currently exist.
+    absl::btree_map<model::transform_id, model::transform_metadata>
+    all_transforms() const;
+
+private:
+    // Perform a mutation request, check if this node is the cluster leader and
+    // ensuring that the right core is used for local mutations.
+    ss::future<mutation_result>
+      do_mutation(transform_cmd, model::timeout_clock::time_point);
+
+    // If this node is not the leader, dispatch this mutation to `node_id` as
+    // the cluster's leader.
+    ss::future<mutation_result> dispatch_mutation_to_remote(
+      model::node_id, transform_cmd, model::timeout_clock::duration);
+
+    // Performs (and validates) a mutation command to be inserted into the
+    // controller log.
+    //
+    // This must take place on the controller shard on the cluster leader.
+    ss::future<mutation_result>
+      do_local_mutation(transform_cmd, model::timeout_clock::time_point);
+
+    // Ensures that the mutation is valid.
+    //
+    // This must take place on the controller shard on the cluster leader while
+    // holding _mu to ensure consistency.
+    errc validate_mutation(const transform_cmd&);
+
+public:
+    /**
+     * A validator of commands that come through, the validation must happen on
+     * the controller leader, core 0 so that these is a consistent view of the
+     * data in the plugin table.
+     *
+     * Mostly exposed seperately for unit testing.
+     */
+    class validator {
+    public:
+        validator(topic_table*, plugin_table*);
+
+        // Ensures that the mutation is valid.
+        //
+        // NOTE: At the time of writing the topic validation is best effort,
+        // it is possible to race with mutations in the topics_frontend and
+        // topics can be deleted or have partitions added that wouldn't be
+        // valid otherwise.
+        errc validate_mutation(const transform_cmd&);
+
+    private:
+        // Would adding this input->output transform cause a cycle?
+        bool would_cause_cycle(
+          model::topic_namespace_view, model::topic_namespace);
+
+        topic_table* _topics;
+        plugin_table* _table;
+    };
+
+private:
+    // Can only be accessed on the current shard.
+    model::node_id _self;
+    partition_leaders_table* _leaders;
+    rpc::connection_cache* _connections;
+    plugin_table* _table;
+    topic_table* _topics;
+    ss::abort_source* _abort_source;
+
+    // is null if not on shard0
+    controller_stm* _controller;
+    mutex _mu;
+};
+} // namespace cluster

--- a/src/v/cluster/plugin_table.cc
+++ b/src/v/cluster/plugin_table.cc
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "plugin_table.h"
+
+#include "cluster/types.h"
+#include "model/metadata.h"
+#include "model/transform.h"
+#include "vassert.h"
+
+namespace cluster {
+
+using model::transform_id;
+using model::transform_metadata;
+using model::transform_name;
+
+plugin_table::map_t plugin_table::all_transforms() const {
+    map_t all;
+    for (const auto& entry : _underlying) {
+        all.emplace(entry.first, entry.second);
+    }
+    return all;
+}
+
+std::optional<transform_id>
+plugin_table::find_id_by_name(std::string_view name) const {
+    auto it = _name_index.find(name);
+    if (it == _name_index.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::optional<transform_id>
+plugin_table::find_id_by_name(const transform_name& name) const {
+    return find_id_by_name(std::string_view(name()));
+}
+
+std::optional<transform_metadata>
+plugin_table::find_by_name(const transform_name& name) const {
+    return find_by_name(std::string_view(name()));
+}
+
+std::optional<transform_metadata>
+plugin_table::find_by_name(std::string_view name) const {
+    auto id = find_id_by_name(name);
+    if (!id.has_value()) {
+        return std::nullopt;
+    }
+    auto meta = find_by_id(id.value());
+    vassert(
+      meta.has_value(),
+      "inconsistent name index for {} expected id {}",
+      name,
+      id);
+    return meta;
+}
+
+std::optional<transform_metadata>
+plugin_table::find_by_id(transform_id id) const {
+    auto it = _underlying.find(id);
+    if (it == _underlying.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+plugin_table::map_t
+plugin_table::find_by_input_topic(model::topic_namespace_view tn) const {
+    return find_by_topic(_input_topic_index, tn);
+}
+
+plugin_table::map_t
+plugin_table::find_by_output_topic(model::topic_namespace_view tn) const {
+    return find_by_topic(_output_topic_index, tn);
+}
+
+plugin_table::map_t plugin_table::find_by_topic(
+  const topic_index_t& index, model::topic_namespace_view tn) const {
+    auto it = index.find(tn);
+    if (it == index.end()) {
+        return {};
+    }
+    map_t output;
+    for (auto id : it->second) {
+        auto meta = find_by_id(id);
+        vassert(
+          meta.has_value(),
+          "inconsistent topic index for {} expected id {}",
+          tn,
+          id);
+        output.emplace(id, *meta);
+    }
+    return output;
+}
+
+void plugin_table::upsert_transform(transform_id id, transform_metadata meta) {
+    auto it = _name_index.find(std::string_view(meta.name()));
+    if (it != _name_index.end()) {
+        if (it->second != id) {
+            throw std::logic_error(ss::format(
+              "transform meta id={} is attempting to use a name {} which is "
+              "already registered to {}",
+              id,
+              meta.name,
+              it->second));
+        }
+    } else {
+        _name_index.emplace(meta.name, id);
+    }
+    // Topics cannot change over the lifetime of a transform, so we don't need
+    // to worry about updates specially here, additionally duplicates are
+    // allowed, the plugin_frontend asserts that there are no loops in
+    // transforms.
+    _input_topic_index[meta.input_topic].emplace(id);
+
+    for (const auto& output_topic : meta.output_topics) {
+        _output_topic_index[output_topic].emplace(id);
+    }
+    _underlying.insert_or_assign(id, std::move(meta));
+    run_callbacks(id);
+}
+
+void plugin_table::remove_transform(const transform_name& name) {
+    auto name_it = _name_index.find(std::string_view(name()));
+    if (name_it == _name_index.end()) {
+        return;
+    }
+    auto id = name_it->second;
+    auto it = _underlying.find(id);
+    vassert(
+      it != _underlying.end(),
+      "inconsistency: name index index had a record with name: {} id: {}",
+      name,
+      id);
+    const auto& meta = it->second;
+    // Delete input topic index entries
+    [this, &meta, id]() {
+        auto input_it = _input_topic_index.find(meta.input_topic);
+        vassert(
+          input_it != _input_topic_index.end()
+            && input_it->second.erase(id) > 0,
+          "inconsistency: missing transform input index entry: {} id: {}",
+          meta.input_topic,
+          id);
+        if (input_it->second.empty()) {
+            _input_topic_index.erase(input_it);
+        }
+    }();
+    for (const auto& output_topic : it->second.output_topics) {
+        auto output_it = _output_topic_index.find(output_topic);
+        vassert(
+          output_it != _output_topic_index.end()
+            && output_it->second.erase(id) > 0,
+          "inconsistency: missing transform output index entry: {} id: {}",
+          output_topic,
+          id);
+        if (output_it->second.empty()) {
+            _output_topic_index.erase(output_it);
+        }
+    }
+    _name_index.erase(name_it);
+    _underlying.erase(it);
+    run_callbacks(id);
+}
+
+void plugin_table::reset_transforms(plugin_table::map_t snap) {
+    name_index_t snap_name_index;
+    topic_index_t snap_input_index;
+    topic_index_t snap_output_index;
+
+    // Perform a map diff to figure out which transforms need change callbacks
+    // fired.
+    ss::chunked_fifo<transform_id> all_deletes;
+    ss::chunked_fifo<transform_id> all_changed;
+    ss::chunked_fifo<transform_id> all_inserted;
+    for (const auto& [k, v] : _underlying) {
+        auto it = snap.find(k);
+        if (it == snap.end()) {
+            all_deletes.push_back(k);
+        } else if (v != it->second) {
+            all_changed.push_back(k);
+        }
+        // Otherwise unchanged
+    }
+    for (const auto& [k, v] : snap) {
+        if (!_underlying.contains(k)) {
+            all_inserted.push_back(k);
+        }
+        // build the name index
+        auto it = snap_name_index.insert({v.name, k});
+        if (!it.second) {
+            throw std::logic_error(ss::format(
+              "transform meta id={} is attempting to use a name {} which is "
+              "already registered to {}",
+              k,
+              v.name,
+              it.first->first));
+        }
+        // build topic indexes
+        snap_input_index[v.input_topic].emplace(k);
+        for (const auto& output_topic : v.output_topics) {
+            snap_output_index[output_topic].emplace(k);
+        }
+    }
+
+    // Do the actual swap
+    _underlying = std::move(snap);
+    _name_index = std::move(snap_name_index);
+    _input_topic_index = std::move(snap_input_index);
+    _output_topic_index = std::move(snap_output_index);
+
+    for (transform_id deleted : all_deletes) {
+        run_callbacks(deleted);
+    }
+    for (transform_id updated : all_changed) {
+        run_callbacks(updated);
+    }
+    for (transform_id inserted : all_inserted) {
+        run_callbacks(inserted);
+    }
+}
+
+plugin_table::notification_id
+plugin_table::register_for_updates(plugin_table::notification_callback cb) {
+    auto it = _callbacks.insert({++_latest_id, std::move(cb)});
+    vassert(it.second, "invalid duplicate in callbacks");
+    return _latest_id;
+}
+
+void plugin_table::unregister_for_updates(notification_id id) {
+    _callbacks.erase(id);
+}
+
+void plugin_table::run_callbacks(transform_id id) {
+    for (const auto& [_, cb] : _callbacks) {
+        cb(id);
+    }
+}
+
+bool plugin_table::name_less_cmp::operator()(
+  const model::transform_name& lhs, const std::string_view& rhs) const {
+    return lhs() < rhs;
+}
+
+bool plugin_table::name_less_cmp::operator()(
+  const std::string_view& lhs, const model::transform_name& rhs) const {
+    return lhs < rhs();
+}
+
+bool plugin_table::name_less_cmp::operator()(
+  const model::transform_name& lhs, const model::transform_name& rhs) const {
+    return lhs < rhs;
+}
+
+bool plugin_table::topic_map_less_cmp::operator()(
+  const model::topic_namespace& lhs, const model::topic_namespace& rhs) const {
+    return lhs < rhs;
+}
+
+bool plugin_table::topic_map_less_cmp::operator()(
+  const model::topic_namespace_view& lhs,
+  const model::topic_namespace_view& rhs) const {
+    return lhs < rhs;
+}
+
+} // namespace cluster

--- a/src/v/cluster/plugin_table.h
+++ b/src/v/cluster/plugin_table.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/transform.h"
+#include "utils/absl_sstring_hash.h"
+
+#include <absl/container/btree_map.h>
+
+#include <compare>
+
+namespace cluster {
+/**
+ * The plugin table exists on every core and holds the underlying data for all
+ * plugin metadata.
+ */
+class plugin_table {
+    using map_t
+      = absl::btree_map<model::transform_id, model::transform_metadata>;
+
+public:
+    plugin_table() = default;
+    plugin_table(const plugin_table&) = delete;
+    plugin_table& operator=(const plugin_table&) = delete;
+    plugin_table(plugin_table&&) = default;
+    plugin_table& operator=(plugin_table&&) = default;
+    ~plugin_table() = default;
+
+    using notification_id = named_type<size_t, struct plugin_notif_id_tag>;
+    using notification_callback
+      = ss::noncopyable_function<void(model::transform_id)>;
+
+    // Snapshot (copy) of all the transforms
+    map_t all_transforms() const;
+
+    // Lookups
+    std::optional<model::transform_metadata>
+      find_by_name(std::string_view) const;
+    std::optional<model::transform_metadata>
+    find_by_name(const model::transform_name&) const;
+    std::optional<model::transform_id> find_id_by_name(std::string_view) const;
+    std::optional<model::transform_id>
+    find_id_by_name(const model::transform_name&) const;
+    std::optional<model::transform_metadata>
+      find_by_id(model::transform_id) const;
+    // All the transforms that use this topic as input
+    map_t find_by_input_topic(model::topic_namespace_view) const;
+    // All the transforms that output to this topic
+    map_t find_by_output_topic(model::topic_namespace_view) const;
+
+    // Create or update transform metadata.
+    void upsert_transform(model::transform_id id, model::transform_metadata);
+    // remove transform metadata by name.
+    void remove_transform(const model::transform_name&);
+    // reset all transforms to be the following snapshot of the table.
+    // notifications are only fired for the delta of changes.
+    void reset_transforms(map_t);
+
+    notification_id register_for_updates(notification_callback);
+
+    void unregister_for_updates(notification_id);
+
+private:
+    struct name_less_cmp {
+        using is_transparent = void;
+        bool operator()(
+          const model::transform_name&, const model::transform_name&) const;
+        bool
+        operator()(const std::string_view&, const model::transform_name&) const;
+        bool
+        operator()(const model::transform_name&, const std::string_view&) const;
+    };
+    using name_index_t = absl::
+      btree_map<model::transform_name, model::transform_id, name_less_cmp>;
+
+    struct topic_map_less_cmp {
+        using is_transparent = void;
+        bool operator()(
+          const model::topic_namespace&, const model::topic_namespace&) const;
+        bool operator()(
+          const model::topic_namespace_view&,
+          const model::topic_namespace_view&) const;
+    };
+    using topic_index_t = absl::btree_map<
+      model::topic_namespace,
+      absl::flat_hash_set<model::transform_id>,
+      topic_map_less_cmp>;
+
+    void run_callbacks(model::transform_id);
+    map_t
+    find_by_topic(const topic_index_t&, model::topic_namespace_view) const;
+
+    map_t _underlying;
+    name_index_t _name_index;
+    topic_index_t _input_topic_index;
+    topic_index_t _output_topic_index;
+    absl::flat_hash_map<notification_id, notification_callback> _callbacks;
+    notification_id _latest_id{0};
+};
+} // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -28,6 +28,7 @@ public:
       ss::scheduling_group,
       ss::smp_service_group,
       ss::sharded<topics_frontend>&,
+      ss::sharded<plugin_frontend>&,
       ss::sharded<members_manager>&,
       ss::sharded<metadata_cache>&,
       ss::sharded<security_frontend>&,
@@ -118,6 +119,12 @@ public:
     ss::future<partition_state_reply> get_partition_state(
       partition_state_request&&, rpc::streaming_context&) final;
 
+    ss::future<upsert_plugin_response>
+    upsert_plugin(upsert_plugin_request&&, rpc::streaming_context&) final;
+
+    ss::future<remove_plugin_response>
+    remove_plugin(remove_plugin_request&&, rpc::streaming_context&) final;
+
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
     std::
@@ -171,5 +178,6 @@ private:
     ss::sharded<health_monitor_frontend>& _hm_frontend;
     ss::sharded<rpc::connection_cache>& _conn_cache;
     ss::sharded<partition_manager>& _partition_manager;
+    ss::sharded<plugin_frontend>& _plugin_frontend;
 };
 } // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -127,6 +127,7 @@ rp_test(
   BINARY_NAME plugin_test
   SOURCES 
     plugin_table_test.cc
+    plugin_frontend_validation_test.cc
   LIBRARIES 
     v::gtest_main 
     v::cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -120,3 +120,16 @@ rp_test(
   LIBRARIES Seastar::seastar_perf_testing v::seastar_testing_main v::cluster
   LABELS cluster
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME plugin_test
+  SOURCES 
+    plugin_table_test.cc
+  LIBRARIES 
+    v::gtest_main 
+    v::cluster
+  ARGS "-- -c 1"
+  LABELS cluster
+)

--- a/src/v/cluster/tests/plugin_frontend_validation_test.cc
+++ b/src/v/cluster/tests/plugin_frontend_validation_test.cc
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/commands.h"
+#include "cluster/fwd.h"
+#include "cluster/plugin_frontend.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/transform.h"
+#include "raft/types.h"
+#include "utils/uuid.h"
+
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/sstring.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <gtest/gtest.h>
+
+#include <string_view>
+#include <vector>
+
+namespace cluster {
+
+namespace {
+
+using id = model::transform_id;
+using name = model::transform_name;
+using meta = model::transform_metadata;
+
+struct topic_config {
+    int partition_count = 1;
+    bool read_replica = false;
+};
+
+struct transform_config {
+    ss::sstring name;
+    ss::sstring src;
+    std::vector<ss::sstring> sinks;
+    absl::flat_hash_map<ss::sstring, ss::sstring> env;
+};
+
+ss::sstring make_string(size_t size) {
+    ss::sstring str;
+    for (int i = 0; i < size; ++i) {
+        str.append("a", 1);
+    }
+    return str;
+}
+
+absl::flat_hash_map<ss::sstring, ss::sstring> make_env_map(size_t size) {
+    absl::flat_hash_map<ss::sstring, ss::sstring> env;
+    for (int i = 0; i < size; ++i) {
+        env.insert({ss::format("var_{}", i), "bar"});
+    }
+    return env;
+}
+
+class PluginValidationTest : public testing::Test {
+public:
+    model::offset _latest_offset{0};
+    model::transform_id _latest_id{0};
+
+    plugin_table _plugin_table;
+    topic_table _topic_table;
+    plugin_frontend::validator _validator{&_topic_table, &_plugin_table};
+
+    std::error_code
+    create_topic(std::string_view name, topic_config config = {}) {
+        topic_configuration topic_cfg(
+          model::kafka_namespace,
+          model::topic(name),
+          config.partition_count,
+          /*replication_factor=*/1);
+        topic_cfg.properties.read_replica = config.read_replica;
+        std::vector<model::broker_shard> broker_shards;
+        broker_shards.push_back(model::broker_shard{
+          .node_id = model::node_id(1),
+          .shard = 0,
+        });
+        ss::chunked_fifo<partition_assignment> partition_assignments;
+        for (int i = 1; i <= config.partition_count; ++i) {
+            partition_assignments.push_back(partition_assignment(
+              raft::group_id(), model::partition_id(i), broker_shards));
+        }
+        create_topic_cmd cmd(
+          topic_cfg.tp_ns,
+          topic_configuration_assignment(
+            topic_cfg, std::move(partition_assignments)));
+        return _topic_table.apply(std::move(cmd), ++_latest_offset).get();
+    }
+    errc upsert_transform(transform_config config) {
+        std::vector<model::topic_namespace> outputs;
+        outputs.reserve(config.sinks.size());
+        for (const ss::sstring& topic : config.sinks) {
+            outputs.emplace_back(model::kafka_namespace, model::topic(topic));
+        }
+        transform_update_cmd cmd{
+          0,
+          meta{
+            .name = name(config.name),
+            .input_topic = model::topic_namespace(
+              model::kafka_namespace, model::topic(config.src)),
+            .output_topics = outputs,
+            .environment = config.env,
+            .uuid = uuid_t::create(),
+            .source_ptr = ++_latest_offset,
+          }};
+        auto ec = _validator.validate_mutation(cmd);
+        if (ec == errc::success) {
+            auto existing = _plugin_table.find_id_by_name(config.name);
+            auto id = existing.value_or(++_latest_id);
+            _plugin_table.upsert_transform(id, cmd.value);
+        }
+        return ec;
+    }
+    errc delete_transform(std::string_view transform_name) {
+        transform_remove_cmd cmd{name(transform_name), 0};
+        auto ec = _validator.validate_mutation(cmd);
+        if (ec == errc::success) {
+            _plugin_table.remove_transform(cmd.key);
+        }
+        return ec;
+    }
+};
+
+} // namespace
+
+TEST_F(PluginValidationTest, ValidateSuccess) {
+    EXPECT_EQ(create_topic("foo"), errc::success);
+    EXPECT_EQ(create_topic("bar"), errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "qux",
+        .src = "foo",
+        .sinks = {"bar"},
+      }),
+      errc::success);
+}
+
+TEST_F(PluginValidationTest, MissingTopic) {
+    EXPECT_EQ(create_topic("bar"), errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "qux",
+        .src = "foo",
+        .sinks = {"bar"},
+      }),
+      errc::topic_not_exists);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "qux",
+        .src = "bar",
+        .sinks = {"foo"},
+      }),
+      errc::topic_not_exists);
+}
+
+TEST_F(PluginValidationTest, NoCycles) {
+    EXPECT_EQ(create_topic("foo"), errc::success);
+    EXPECT_EQ(create_topic("bar"), errc::success);
+    EXPECT_EQ(create_topic("baz"), errc::success);
+    EXPECT_EQ(create_topic("qux"), errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "x1",
+        .src = "foo",
+        .sinks = {"foo"},
+      }),
+      errc::transform_invalid_create);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "x1",
+        .src = "foo",
+        .sinks = {"bar"},
+      }),
+      errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "x2",
+        .src = "bar",
+        .sinks = {"foo"},
+      }),
+      errc::transform_invalid_create);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "x2",
+        .src = "bar",
+        .sinks = {"baz"},
+      }),
+      errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "x3",
+        .src = "baz",
+        .sinks = {"qux"},
+      }),
+      errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "x4",
+        .src = "foo",
+        .sinks = {"qux"},
+      }),
+      errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "x5",
+        .src = "qux",
+        .sinks = {"foo"},
+      }),
+      errc::transform_invalid_create);
+}
+
+TEST_F(PluginValidationTest, InvalidEnvironment) {
+    EXPECT_EQ(create_topic("foo"), errc::success);
+    EXPECT_EQ(create_topic("bar"), errc::success);
+    auto expect_invalid_env =
+      [this](const absl::flat_hash_map<ss::sstring, ss::sstring>& env) {
+          EXPECT_EQ(
+            upsert_transform({
+              .name = "qux",
+              .src = "foo",
+              .sinks = {"bar"},
+              .env = env,
+            }),
+            errc::transform_invalid_environment)
+            << "environment: " << env;
+      };
+    expect_invalid_env({
+      {"REDPANDA_FOO", "bar"},
+    });
+    expect_invalid_env({
+      // invalid UTF8
+      {"FOO\xc3\x28", "bar"},
+    });
+    expect_invalid_env({
+      // invalid UTF8
+      {"FOO", "bar\xc3\x28"},
+    });
+    expect_invalid_env({
+      // key too big
+      {make_string(1_KiB), "alskdj"},
+    });
+    expect_invalid_env({
+      // value too big
+      {"foo", make_string(3_KiB)},
+    });
+    expect_invalid_env(
+      // too many values
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+      make_env_map(130));
+}
+
+TEST_F(PluginValidationTest, NoReadReplicas) {
+    EXPECT_EQ(create_topic("foo", {.read_replica = true}), errc::success);
+    EXPECT_EQ(create_topic("bar", {.read_replica = true}), errc::success);
+    EXPECT_EQ(create_topic("qux"), errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "no-read-replica",
+        .src = "foo",
+        .sinks = {"qux"},
+      }),
+      errc::transform_invalid_create);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "no-read-replica",
+        .src = "qux",
+        .sinks = {"bar"},
+      }),
+      errc::transform_invalid_create);
+}
+
+TEST_F(PluginValidationTest, MultipleOutputs) {
+    EXPECT_EQ(create_topic("foo"), errc::success);
+    EXPECT_EQ(create_topic("bar"), errc::success);
+    EXPECT_EQ(create_topic("qux"), errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "no-read-replica",
+        .src = "foo",
+        .sinks = {"bar", "qux"},
+      }),
+      errc::transform_invalid_create);
+}
+
+TEST_F(PluginValidationTest, Copartitioned) {
+    EXPECT_EQ(create_topic("foo", {.partition_count = 2}), errc::success);
+    EXPECT_EQ(create_topic("bar", {.partition_count = 4}), errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "missing-output-partitions",
+        .src = "bar",
+        .sinks = {"foo"},
+      }),
+      errc::transform_invalid_create);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "ok-to-have-extra-output-partitions",
+        .src = "foo",
+        .sinks = {"bar"},
+      }),
+      errc::success);
+}
+
+TEST_F(PluginValidationTest, RemoveMustExist) {
+    EXPECT_EQ(delete_transform("bar2foo"), errc::transform_does_not_exist);
+}
+
+TEST_F(PluginValidationTest, DeleteWorks) {
+    EXPECT_EQ(create_topic("foo"), errc::success);
+    EXPECT_EQ(create_topic("bar"), errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "foo2bar",
+        .src = "foo",
+        .sinks = {"bar"},
+      }),
+      errc::success);
+    EXPECT_EQ(delete_transform("foo2bar"), errc::success);
+}
+
+TEST_F(PluginValidationTest, UpdateCannotChangeTopicConfig) {
+    EXPECT_EQ(create_topic("foo"), errc::success);
+    EXPECT_EQ(create_topic("bar"), errc::success);
+    EXPECT_EQ(create_topic("qux"), errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "foo2bar",
+        .src = "foo",
+        .sinks = {"bar"},
+      }),
+      errc::success);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "foo2bar",
+        .src = "bar",
+        .sinks = {"foo"},
+      }),
+      errc::transform_invalid_update);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "foo2bar",
+        .src = "foo",
+        .sinks = {"qux"},
+      }),
+      errc::transform_invalid_update);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "foo2bar",
+        .src = "qux",
+        .sinks = {"bar"},
+      }),
+      errc::transform_invalid_update);
+    EXPECT_EQ(
+      upsert_transform({
+        .name = "foo2bar",
+        .src = "foo",
+        .sinks = {"bar"},
+      }),
+      errc::success);
+}
+
+} // namespace cluster

--- a/src/v/cluster/tests/plugin_table_test.cc
+++ b/src/v/cluster/tests/plugin_table_test.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/plugin_table.h"
+#include "cluster/types.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/transform.h"
+#include "utils/uuid.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+#include <optional>
+#include <stdexcept>
+
+namespace cluster {
+namespace {
+using id = model::transform_id;
+using meta = model::transform_metadata;
+using name = model::transform_name;
+using plugin_map = absl::btree_map<id, meta>;
+
+struct metadata_spec {
+    ss::sstring name;
+    ss::sstring input;
+    std::vector<ss::sstring> output;
+    absl::flat_hash_map<ss::sstring, ss::sstring> env;
+};
+absl::flat_hash_set<id> ids(std::initializer_list<int> ids) {
+    absl::flat_hash_set<id> output;
+    for (int id : ids) {
+        output.emplace(id);
+    }
+    return output;
+}
+
+model::topic_namespace topic(ss::sstring t) {
+    return {model::kafka_namespace, model::topic(t)};
+}
+meta make_meta(const metadata_spec& spec) {
+    std::vector<model::topic_namespace> outputs;
+    outputs.reserve(spec.output.size());
+    for (const auto& name : spec.output) {
+        outputs.emplace_back(topic(name));
+    }
+    return {
+      .name = name(spec.name),
+      .input_topic = topic(spec.input),
+      .output_topics = std::move(outputs),
+      .environment = spec.env,
+    };
+}
+} // namespace
+
+TEST(PluginTable, Mutations) {
+    cluster::plugin_table table;
+
+    auto wheat_millwheel = make_meta(
+      {.name = "millwheel", .input = "wheat", .output = {"flour"}});
+    auto cow = make_meta({.name = "cow", .input = "grass", .output = {"milk"}});
+    auto lawn = make_meta(
+      {.name = "lawn", .input = "water", .output = {"grass", "weeds"}});
+    auto corn_millwheel = make_meta(
+      {.name = "millwheel", .input = "corn", .output = {"cornmeal"}});
+
+    table.upsert_transform(id(1), wheat_millwheel);
+    table.upsert_transform(id(2), cow);
+    table.upsert_transform(id(3), lawn);
+    // Names must be unique
+    EXPECT_THROW(
+      table.upsert_transform(id(4), corn_millwheel), std::logic_error);
+
+    table.upsert_transform(id(1), corn_millwheel);
+
+    plugin_map want{
+      {id(1), corn_millwheel},
+      {id(2), cow},
+      {id(3), lawn},
+    };
+    EXPECT_EQ(table.all_transforms(), want);
+    table.remove_transform(name("cow"));
+    want.erase(id(2));
+    EXPECT_EQ(table.all_transforms(), want);
+    table.reset_transforms(want);
+    EXPECT_EQ(table.all_transforms(), want);
+    want.erase(id(1));
+    auto goat = make_meta(
+      {.name = "goat", .input = "grass", .output = {"milk"}});
+    want.emplace(id(4), goat);
+    table.reset_transforms(want);
+    EXPECT_EQ(table.all_transforms(), want);
+}
+
+TEST(PluginTable, Notifications) {
+    cluster::plugin_table table;
+    absl::flat_hash_set<id> notifications;
+    auto notif_id = table.register_for_updates([&](auto id) {
+        auto [it, inserted] = notifications.emplace(id);
+        // To ensure we don't get duplicate notifications, make sure there are
+        // always imports and we just clear the notifications after assertions
+        EXPECT_TRUE(inserted);
+    });
+    auto miracle = make_meta(
+      {.name = "miracle", .input = "water", .output = {"wine"}});
+    auto optimus_prime = make_meta(
+      {.name = "optimus_prime", .input = "semi", .output = {"hero"}});
+    auto optimus_prime2 = make_meta(
+      {.name = "optimus_prime",
+       .input = "semi",
+       .output = {"hero"},
+       .env = {{"allspark", "enabled"}}});
+    auto parser = make_meta(
+      {.name = "parser", .input = "text", .output = {"ast"}});
+    auto compiler = make_meta(
+      {.name = "compiler", .input = "awesomelang", .output = {"assembly"}});
+
+    table.upsert_transform(id(1), miracle);
+    EXPECT_EQ(notifications, ids({1}));
+    notifications.clear();
+
+    table.upsert_transform(id(2), optimus_prime);
+    EXPECT_EQ(notifications, ids({2}));
+    notifications.clear();
+
+    table.remove_transform(miracle.name);
+    EXPECT_EQ(notifications, ids({1}));
+    notifications.clear();
+
+    table.upsert_transform(id(3), miracle);
+    table.upsert_transform(id(4), parser);
+    EXPECT_EQ(notifications, ids({3, 4}));
+    notifications.clear();
+
+    table.reset_transforms(plugin_map({
+      // changed
+      {id(2), optimus_prime2},
+      // unchanged
+      {id(3), miracle},
+      // removed id(4)
+      // added 5
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+      {id(5), compiler},
+    }));
+    EXPECT_EQ(notifications, ids({2, 4, 5}));
+    notifications.clear();
+
+    table.unregister_for_updates(notif_id);
+    table.remove_transform(miracle.name);
+    EXPECT_TRUE(notifications.empty());
+}
+
+TEST(PluginTable, TopicIndexes) {
+    const static std::optional<meta> missing = std::nullopt;
+    const static std::optional<id> missing_id = std::nullopt;
+    cluster::plugin_table table;
+
+    auto millwheel = make_meta(
+      {.name = "millwheel", .input = "wheat", .output = {"flour"}});
+    table.upsert_transform(id(1), millwheel);
+    auto cow = make_meta({.name = "cow", .input = "grass", .output = {"milk"}});
+    table.upsert_transform(id(2), cow);
+    auto lawn = make_meta(
+      {.name = "lawn", .input = "water", .output = {"grass", "weeds"}});
+    table.upsert_transform(id(3), lawn);
+    auto miller = make_meta(
+      {.name = "miller", .input = "corn", .output = {"flour", "cornmeal"}});
+    table.upsert_transform(id(4), miller);
+    EXPECT_EQ(table.find_by_name("lawn"), std::make_optional(lawn));
+    EXPECT_EQ(table.find_id_by_name("miller"), std::make_optional(id(4)));
+    EXPECT_EQ(table.find_by_name("law"), missing);
+    EXPECT_EQ(table.find_id_by_name("miter"), missing_id);
+    EXPECT_EQ(table.find_by_id(id(2)), std::make_optional(cow));
+    EXPECT_EQ(table.find_by_id(id(99)), missing);
+    EXPECT_EQ(
+      table.find_by_input_topic(topic("grass")), plugin_map({{id(2), cow}}));
+    EXPECT_EQ(
+      table.find_by_output_topic(topic("flour")),
+      plugin_map({{id(1), millwheel}, {id(4), miller}}));
+    EXPECT_EQ(table.find_by_input_topic(topic("waldo")), plugin_map());
+}
+} // namespace cluster

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -52,6 +52,7 @@ public:
       ss::sharded<cluster::members_table>&,
       ss::sharded<partition_manager>&,
       ss::sharded<shard_table>&,
+      plugin_table&,
       config::binding<unsigned>);
 
     ss::future<std::vector<topic_result>> create_topics(
@@ -239,6 +240,7 @@ private:
     ss::sharded<ss::abort_source>& _as;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     ss::sharded<features::feature_table>& _features;
+    plugin_table& _plugin_table;
 
     ss::sharded<cluster::members_table>& _members_table;
     ss::sharded<partition_manager>& _pm;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -20,6 +20,7 @@
 #include "model/namespace.h"
 #include "model/record_batch_types.h"
 #include "model/timeout_clock.h"
+#include "model/transform.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "raft/types.h"
 #include "security/acl.h"
@@ -3924,6 +3925,74 @@ static const ss::sstring archival_stm_snapshot = "archival_metadata.snapshot";
 static const ss::sstring rm_stm_snapshot = "tx.snapshot";
 static const ss::sstring tm_stm_snapshot = "tx.coordinator.snapshot";
 static const ss::sstring id_allocator_snapshot = "id.snapshot";
+
+/**
+ * Create/update a (Wasm) plugin.
+ */
+struct upsert_plugin_request
+  : serde::envelope<
+      upsert_plugin_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    model::transform_metadata transform;
+    model::timeout_clock::duration timeout{};
+
+    friend bool
+    operator==(const upsert_plugin_request&, const upsert_plugin_request&)
+      = default;
+
+    auto serde_fields() { return std::tie(transform, timeout); }
+};
+struct upsert_plugin_response
+  : serde::envelope<
+      upsert_plugin_response,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    errc ec;
+
+    friend bool
+    operator==(const upsert_plugin_response&, const upsert_plugin_response&)
+      = default;
+
+    auto serde_fields() { return std::tie(ec); }
+};
+
+/**
+ * Remove a (Wasm) plugin.
+ */
+struct remove_plugin_request
+  : serde::envelope<
+      remove_plugin_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    model::transform_name name;
+    model::timeout_clock::duration timeout{};
+
+    friend bool
+    operator==(const remove_plugin_request&, const remove_plugin_request&)
+      = default;
+
+    auto serde_fields() { return std::tie(name, timeout); }
+};
+struct remove_plugin_response
+  : serde::envelope<
+      remove_plugin_response,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    uuid_t uuid;
+    errc ec;
+
+    friend bool
+    operator==(const remove_plugin_response&, const remove_plugin_response&)
+      = default;
+
+    auto serde_fields() { return std::tie(uuid, ec); }
+};
 
 } // namespace cluster
 namespace std {

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -85,6 +85,11 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::no_partition_assignments:
     case cluster::errc::failed_to_create_partition:
     case cluster::errc::partition_operation_failed:
+    case cluster::errc::transform_invalid_create:
+    case cluster::errc::transform_invalid_environment:
+    case cluster::errc::transform_does_not_exist:
+    case cluster::errc::transform_invalid_update:
+    case cluster::errc::transform_invalid_source:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -291,6 +291,10 @@ struct topic_namespace_view {
         return H::combine(std::move(h), tp_ns.ns, tp_ns.tp);
     }
 
+    bool operator<(const topic_namespace_view& other) const {
+        return std::make_tuple(ns, tp) < std::make_tuple(other.ns, other.tp);
+    }
+
     const model::ns& ns;
     const model::topic& tp;
 
@@ -320,6 +324,13 @@ struct topic_namespace {
 
     friend bool operator==(const topic_namespace&, const topic_namespace&)
       = default;
+
+    bool operator<(const topic_namespace_view& other) const {
+        return topic_namespace_view(*this) < other;
+    }
+    bool operator<(const topic_namespace& other) const {
+        return *this < topic_namespace_view(other);
+    }
 
     template<typename H>
     friend H AbslHashValue(H h, const topic_namespace& tp_ns) {

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -359,6 +359,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::tx_tm_hosted_trasactions";
     case record_batch_type::prefix_truncate:
         return o << "batch_type::prefix_truncate";
+    case record_batch_type::plugin_update:
+        return o << "batch_type::plugin_update";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -43,7 +43,8 @@ enum class record_batch_type : int8_t {
     version_fence = 23,              // version fence/epoch
     tx_tm_hosted_trasactions = 24,   // tx_tm_hosted_trasactions_batch_type
     prefix_truncate = 25,            // log prefix truncation type
-    MAX = prefix_truncate
+    plugin_update = 26,              // Wasm plugin update
+    MAX = plugin_update
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2212,6 +2212,7 @@ void application::start_runtime_services(
             sched_groups.cluster_sg(),
             smp_service_groups.cluster_smp_sg(),
             std::ref(controller->get_topics_frontend()),
+            std::ref(controller->get_plugin_frontend()),
             std::ref(controller->get_members_manager()),
             std::ref(metadata_cache),
             std::ref(controller->get_security_frontend()),

--- a/src/v/utils/utf8.cc
+++ b/src/v/utils/utf8.cc
@@ -12,3 +12,19 @@
 #include "utils/utf8.h"
 
 thread_local bool permit_unsafe_log_operation::_flag = false;
+
+bool is_valid_utf8(std::string_view s) {
+    bool is_valid = true;
+    class default_utf8_checker {
+    public:
+        explicit default_utf8_checker(bool* is_valid)
+          : _is_valid(is_valid) {}
+
+        void conversion_error() { *_is_valid = false; }
+
+    private:
+        bool* _is_valid;
+    };
+    validate_utf8(s, default_utf8_checker{&is_valid});
+    return is_valid;
+}

--- a/src/v/utils/utf8.h
+++ b/src/v/utils/utf8.h
@@ -119,3 +119,5 @@ inline void validate_utf8(std::string_view s, Thrower&& thrower) {
 inline void validate_utf8(std::string_view s) {
     validate_utf8(s, default_utf8_thrower{});
 }
+
+bool is_valid_utf8(std::string_view s);


### PR DESCRIPTION
This patch set introduces the required metadata we need for Wasm powered data transforms as well as the need controller functionality & RPCs.

A standard set of cluster components are added for plugin related functionality (I'm naming all of this plugin_* in case of non-transform future usages of Wasm will likely slot in here, such as authentication extensions, or maybe I'm being too premature and those will just be another set of components, feel free to chime in your thoughts here).

- `plugin_table`: The per core metadata that we need for Wasm transforms, essentially this is a tuple of name, topics and user specified environment variables.
- `plugin_frontend`: The exposed interface to the rest of the cluster is here, we proxy read events from the `plugin_table` and manage making sure all mutations are ran on core 0 of the controller leader, with validation. Much of the code here is fairly boilerplate with most frontends as far as I can tell, making sure everything runs on the controller's core 0.
- `plugin_backend`: Responsible for dispatching all the controller log commands as updates to every core's `plugin_table`.

Note on the validation, the values there are sort of arbitrary and I have not thought deeply about them. I'm happy to expose those to be cluster config knobs later, but we should probably start with very strict limits. Let me know if you think they should be more strict, right now a single transform's environment variables can be ~272kb with the existing set of limits I've put up.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
