### PR TITLE
[v23.2.x] c/leader_balancer: use node_hash_map to store leader information

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer_random.h
+++ b/src/v/cluster/scheduling/leader_balancer_random.h
@@ -19,7 +19,9 @@
 #include "utils/fragmented_vector.h"
 #include "vassert.h"
 
+#include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 #include <cmath>
 #include <cstddef>
@@ -95,7 +97,7 @@ private:
         raft::group_id group_id;
         model::broker_shard broker_shard;
     };
-    absl::flat_hash_map<raft::group_id, model::broker_shard> _current_leaders;
+    absl::node_hash_map<raft::group_id, model::broker_shard> _current_leaders;
 
     using replicas_t = fragmented_vector<replica>;
     replicas_t _replicas;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12905
