### PR TITLE
unit tests: make property::set_value accept values convertible to the property T 

### DIFF
--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -215,9 +215,12 @@ public:
       , _bounds(bounds)
       , _example(generate_example()) {}
 
+    using property<T>::set_value;
+
     void set_value(std::any v) override {
         property<T>::update_value(std::any_cast<T>(std::move(v)));
     }
+
     bool set_value(YAML::Node n) override {
         auto val = std::move(n.as<T>());
         return clamp_and_update(val);

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -161,6 +161,14 @@ public:
         update_value(std::any_cast<T>(std::move(v)));
     }
 
+    template<typename U>
+    requires std::constructible_from<T, U>
+    void set_value(U&& v) {
+        // needs to go through virtual inheritance chain, since this class is
+        // not final
+        set_value(std::make_any<T>(std::forward<U>(v)));
+    }
+
     bool set_value(YAML::Node n) override {
         return update_value(std::move(n.as<T>()));
     }
@@ -864,9 +872,14 @@ class retention_duration_property final
   : public property<std::optional<std::chrono::milliseconds>> {
 public:
     using property::property;
+    using property::set_value;
+
     void set_value(std::any v) final {
-        update_value(std::any_cast<std::chrono::milliseconds>(std::move(v)));
+        update_value(
+          std::any_cast<std::optional<std::chrono::milliseconds>>(std::move(v))
+            .value_or(-1ms));
     }
+
     bool set_value(YAML::Node n) final {
         return update_value(n.as<std::chrono::milliseconds>());
     }


### PR DESCRIPTION
Small template helper `property<T>::set_value` to allow passing a value convertible to the property type T. This is primarily useful in unit tests, where otherwise one would be obliged to call set_value with the exact T type or face a runtime exception.

some examples are optional<chrono::milliseconds> property, where it was not possible to write set_value(1h).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none