### PR TITLE
Add proper exception handler to around eviction_stm's call to replicate

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -291,6 +291,12 @@ ss::future<log_eviction_stm::offset_result> log_eviction_stm::replicate_command(
         }
     } catch (const ss::timed_out_error&) {
         result = errc::timeout;
+    } catch (...) {
+        vlog(
+          _log.warn,
+          "Replicating prefix_truncate failed with exception: {}",
+          std::current_exception());
+        result = errc::replication_error;
     }
 
     if (!result) {

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -301,7 +301,7 @@ ss::future<log_eviction_stm::offset_result> log_eviction_stm::replicate_command(
 
     if (!result) {
         vlog(
-          _log.info,
+          _log.warn,
           "Failed to replicate prefix_truncate command, reason: {}",
           result.error());
         co_return result.error();


### PR DESCRIPTION
The issue is observed as a bad log line error within a delete-records test. A higher level exception handler in the delete records request handling logic caught an exception and logged it at error level making the test fail.

Looking into the cause of the issue, it was observed that within `log_eviction_stm::truncate` there's a call to `consensus::replicate` that does not catch exceptions, which may occur. Note that this is not a severe issue because the code eventually catches the exception and returns the proper error code to the client in its current state.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none