### PR TITLE
rptest: fixes to enable tests on redpanda cloud

### DIFF
--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -204,20 +204,11 @@ class HighThroughputTest2(PreallocNodesTest):
             f"Producing {msg_count} messages of {msg_size} B, "
             f"{msg_count*msg_size} B total, target rate {ingress_rate} B/s")
 
-        # if this is a redpanda cloud cluster,
-        # use the default test superuser user/pass
-        security_config = self.redpanda.security_config()
-        username = security_config.get('sasl_plain_username', None)
-        password = security_config.get('sasl_plain_password', None)
-        enable_tls = security_config.get('enable_tls', False)
         producer0 = KgoVerifierProducer(self.test_context,
                                         self.redpanda,
                                         self.topic,
                                         msg_size=msg_size,
-                                        msg_count=msg_count,
-                                        username=username,
-                                        password=password,
-                                        enable_tls=enable_tls)
+                                        msg_count=msg_count)
         producer0.start()
         start = time.time()
 

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -68,6 +68,13 @@ class KgoVerifierService(Service):
         self._password = password
         self._enable_tls = enable_tls
 
+        # if testing redpanda cloud, override with default test super user/pass
+        if hasattr(redpanda, 'GLOBAL_CLOUD_CLUSTER_CONFIG'):
+            security_config = redpanda.security_config()
+            self._username = security_config.get('sasl_plain_username', None)
+            self._password = security_config.get('sasl_plain_password', None)
+            self._enable_tls = security_config.get('enable_tls', False)
+
         for node in self.nodes:
             if not hasattr(node, "kgo_verifier_ports"):
                 node.kgo_verifier_ports = {}

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1523,6 +1523,9 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
     def get_version(self, node):
         return self._cloud_cluster.get_install_pack_version()
 
+    def set_cluster_config(self, values: dict, timeout: int = 300):
+        pass
+
 
 class RedpandaService(RedpandaServiceBase):
     def __init__(self,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1526,6 +1526,9 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
     def set_cluster_config(self, values: dict, timeout: int = 300):
         pass
 
+    def sockets_clear(self, node):
+        True
+
 
 class RedpandaService(RedpandaServiceBase):
     def __init__(self,


### PR DESCRIPTION
various fixes in `KgoVerifierService` and `RedpandaServiceCloud` for getting tests to run on redpanda cloud.

related issue: https://github.com/redpanda-data/cloudv2/issues/8189

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
