### PR TITLE
rptest: test max connections to redpanda cloud

### DIFF
--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -47,6 +47,16 @@ class ProducerSwarm(Service):
         self._max_record_size = max_record_size
         self._keys = keys
 
+        if hasattr(redpanda, 'GLOBAL_CLOUD_CLUSTER_CONFIG'):
+            security_config = redpanda.security_config()
+            properties['security.protocol'] = 'SASL_SSL'
+            properties['sasl.mechanism'] = security_config.get(
+                'sasl_mechanism', 'PLAIN')
+            properties['sasl.username'] = security_config.get(
+                'sasl_plain_username', None)
+            properties['sasl.password'] = security_config.get(
+                'sasl_plain_password', None)
+
     def clean_node(self, node):
         self._redpanda.logger.debug(f"{self.__class__.__name__}.clean_node")
         node.account.kill_process(self.EXE, clean_shutdown=False)


### PR DESCRIPTION
WIP

Related issue: https://github.com/redpanda-data/cloudv2/issues/8190

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
