### PR TITLE
[v23.1.x] schema_registry: /referencedby should emit 404 if sub-ver doesn't exist

### DIFF
--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1191,6 +1191,20 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json() == [2]
 
+        # invalid subject should error with 40401
+        result_raw = self._get_subjects_subject_versions_version_referenced_by(
+            "invalid_subject", 1)
+        self.logger.info(result_raw)
+        assert result_raw.status_code == requests.codes.not_found
+        assert result_raw.json()["error_code"] == 40401
+
+        # invalid version should error with 40402
+        result_raw = self._get_subjects_subject_versions_version_referenced_by(
+            "simple", 2)
+        self.logger.info(result_raw)
+        assert result_raw.status_code == requests.codes.not_found
+        assert result_raw.json()["error_code"] == 40402
+
     @cluster(num_nodes=4)
     @parametrize(protocol=SchemaType.AVRO, client_type=SerdeClientType.Python)
     @parametrize(protocol=SchemaType.AVRO, client_type=SerdeClientType.Java)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12956
Fixes: https://github.com/redpanda-data/redpanda/issues/12985,