### PR TITLE
rpk: minor fixes, -X help text and byoc binary lookup path

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/byoc/install.go
+++ b/src/go/rpk/pkg/cli/cloud/byoc/install.go
@@ -79,7 +79,7 @@ func loginAndEnsurePluginVersion(ctx context.Context, fs afero.Fs, cfg *config.C
 		}
 	}
 
-	byoc, pluginExists := plugin.ListPlugins(fs, []string{pluginDir}).Find("byoc")
+	byoc, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find("byoc")
 
 	// If the plugin exists, and we don't want a version check we want to exit
 	// early and avoid calling the Cloud API.

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -604,14 +604,14 @@ globals.dial_timeout=3s
   A duration that rpk will wait for a connection to be established before
   timing out.
 
-globals.request_timeout_overhead=10s
+globals.request_timeout_overhead=5s
   A duration that limits how long rpk waits for responses, *on top* of any
   request-internal timeout. For example, ListOffsets has no Timeout field so
   if request_timeout_overhead is 10s, rpk will wait for 10s for a response.
   However, JoinGroup has a RebalanceTimeoutMillis field, so the 10s is applied
   on top of the rebalance timeout.
 
-globals.retry_timeout=30s
+globals.retry_timeout=11s
   This timeout specifies how long rpk will retry Kafka API requests. This
   timeout is evaluated before any backoff -- if a request fails, we first check
   if the retry timeout has elapsed and if so, we stop retrying. If not, we wait


### PR DESCRIPTION
This includes 2 minor fixes:

[rpk: search for byoc plugins in PATH](https://github.com/redpanda-data/redpanda/commit/624f3de14e8721f3581bb80d41cb952a5fc5fbb3) 

Previously we only searched for the byoc plugin
in the default bin path (~/.local/bin) but a user
can have the plugin installed anywhere in PATH.


[rpk: use current default timeout in -X help text](https://github.com/redpanda-data/redpanda/commit/5113b96c47517c6bed16a18f95badc5ab12d1cc5) 

The old text might confuse someone reading our
docs, rpk timeouts are:
- Dial: 3s
- Overhead: 5s
- Retry: 11s
- Fetch: 5s

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* rpk will now search for a byoc plugin installed in the user's $PATH.
