### PR TITLE
Introduce transform::processor

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -99,6 +99,7 @@ add_subdirectory(rp_util)
 add_subdirectory(resource_mgmt)
 add_subdirectory(migrations)
 add_subdirectory(wasm)
+add_subdirectory(transform)
 
 option(ENABLE_GIT_VERSION "Build with Git metadata" OFF)
 

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -1,0 +1,17 @@
+v_cc_library(
+  NAME transform
+  HDRS
+    probe.h
+    logger.h
+    transform_processor.h
+    io.h
+  SRCS
+    probe.cc
+    logger.cc
+    transform_processor.cc
+  DEPS
+    v::wasm
+    v::model
+)
+
+add_subdirectory(tests)

--- a/src/v/transform/fwd.h
+++ b/src/v/transform/fwd.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace transform {
+class processor;
+class probe;
+} // namespace transform

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/transform.h"
+
+namespace transform {
+namespace detail {
+
+/**
+ * A factory for sources and sinks.
+ *
+ * Use sink::factory or source::factory instead.
+ */
+template<typename T>
+class factory {
+public:
+    factory() = default;
+    factory(const factory&) = delete;
+    factory& operator=(const factory&) = delete;
+    factory(factory&&) = delete;
+    factory& operator=(factory&&) = delete;
+    virtual ~factory() = default;
+
+    virtual std::optional<std::unique_ptr<T>> create(model::ntp) = 0;
+};
+} // namespace detail
+
+/**
+ * The output sink for Wasm transforms.
+ */
+class sink {
+public:
+    sink() = default;
+    sink(const sink&) = delete;
+    sink& operator=(const sink&) = delete;
+    sink(sink&&) = delete;
+    sink& operator=(sink&&) = delete;
+    virtual ~sink() = default;
+
+    virtual ss::future<> write(ss::chunked_fifo<model::record_batch>) = 0;
+
+    using factory = detail::factory<sink>;
+};
+
+/**
+ * The input source for Wasm transforms.
+ */
+class source {
+public:
+    source() = default;
+    source(const source&) = delete;
+    source& operator=(const source&) = delete;
+    source(source&&) = delete;
+    source& operator=(source&&) = delete;
+    virtual ~source() = default;
+
+    virtual ss::future<model::offset> load_latest_offset() = 0;
+    virtual ss::future<model::record_batch_reader>
+    read_batch(model::offset, ss::abort_source*) = 0;
+
+    using factory = detail::factory<source>;
+};
+} // namespace transform

--- a/src/v/transform/logger.cc
+++ b/src/v/transform/logger.cc
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/logger.h"
+
+namespace transform {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
+ss::logger tlog("transform");
+} // namespace transform

--- a/src/v/transform/logger.h
+++ b/src/v/transform/logger.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace transform {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern ss::logger tlog;
+} // namespace transform

--- a/src/v/transform/probe.cc
+++ b/src/v/transform/probe.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/probe.h"
+
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace transform {
+
+void probe::setup_metrics(ss::sstring transform_name) {
+    wasm::transform_probe::setup_metrics(transform_name);
+    namespace sm = ss::metrics;
+
+    auto name_label = sm::label("function_name");
+    const std::vector<sm::label_instance> labels = {
+      name_label(std::move(transform_name)),
+    };
+    _public_metrics.add_group(
+      prometheus_sanitize::metrics_name("transform"),
+      {
+        sm::make_counter(
+          "processor_read_bytes",
+          [this] { return _read_bytes; },
+          sm::description(
+            "A counter for all the bytes that has been input to a transform"),
+          labels)
+          .aggregate({ss::metrics::shard_label}),
+        sm::make_counter(
+          "processor_write_bytes",
+          [this] { return _write_bytes; },
+          sm::description("A counter for all the bytes that has been output "
+                          "from a transform"),
+          labels)
+          .aggregate({ss::metrics::shard_label}),
+      });
+}
+void probe::increment_write_bytes(uint64_t bytes) { _write_bytes += bytes; }
+void probe::increment_read_bytes(uint64_t bytes) { _read_bytes += bytes; }
+} // namespace transform

--- a/src/v/transform/probe.h
+++ b/src/v/transform/probe.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "wasm/probe.h"
+
+#include <functional>
+
+namespace transform {
+
+/** A per transform probe. */
+class probe : public wasm::transform_probe {
+public:
+    void setup_metrics(ss::sstring transform_name);
+
+    void increment_read_bytes(uint64_t bytes);
+    void increment_write_bytes(uint64_t bytes);
+
+private:
+    uint64_t _read_bytes = 0;
+    uint64_t _write_bytes = 0;
+};
+
+} // namespace transform

--- a/src/v/transform/tests/CMakeLists.txt
+++ b/src/v/transform/tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+v_cc_library(
+  NAME
+    transform_test_fixture
+  HDRS 
+    test_fixture.h
+  SRCS 
+    test_fixture.cc
+  DEPS
+    v::transform
+    Seastar::seastar
+    v::model_test_utils
+    v::gtest_main
+  )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME
+    transform_processor
+  SOURCES
+    transform_processor_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::transform_test_fixture
+  ARGS "-- -c 1"
+  LABELS transform
+)

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/tests/test_fixture.h"
+
+#include <seastar/core/abort_source.hh>
+
+#include <gtest/gtest.h>
+
+#include <exception>
+
+namespace transform::testing {
+ss::future<> fake_sink::write(ss::chunked_fifo<model::record_batch> batches) {
+    for (auto& batch : batches) {
+        co_await _batches.push_eventually(std::move(batch));
+    }
+}
+ss::future<model::record_batch> fake_sink::read() {
+    return _batches.pop_eventually();
+}
+ss::future<model::offset> fake_source::load_latest_offset() {
+    co_return _latest_offset;
+}
+ss::future<model::record_batch_reader>
+fake_source::read_batch(model::offset offset, ss::abort_source* as) {
+    EXPECT_EQ(offset, _latest_offset);
+    if (!_batches.empty()) {
+        model::record_batch_reader::data_t batches;
+        while (!_batches.empty()) {
+            batches.push_back(_batches.pop());
+        }
+        _latest_offset = model::next_offset(batches.back().last_offset());
+        co_return model::make_memory_record_batch_reader(std::move(batches));
+    }
+    auto sub = as->subscribe(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+      [this](const std::optional<std::exception_ptr>& ex) noexcept {
+          _batches.abort(ex.value_or(
+            std::make_exception_ptr(ss::abort_requested_exception())));
+      });
+    if (!sub) {
+        _batches.abort(
+          std::make_exception_ptr(ss::abort_requested_exception()));
+    }
+    auto batch = co_await _batches.pop_eventually();
+    _latest_offset = model::next_offset(batch.last_offset());
+    sub->unlink();
+    co_return model::make_memory_record_batch_reader(std::move(batch));
+}
+ss::future<> fake_source::push_batch(model::record_batch batch) {
+    co_await _batches.push_eventually(std::move(batch));
+}
+std::string_view fake_wasm_engine::function_name() const {
+    return my_metadata.name();
+}
+uint64_t fake_wasm_engine::memory_usage_size_bytes() const {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    return 64_KiB;
+};
+ss::future<> fake_wasm_engine::start() { return ss::now(); }
+ss::future<> fake_wasm_engine::initialize() { return ss::now(); }
+ss::future<> fake_wasm_engine::stop() { return ss::now(); }
+} // namespace transform::testing

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/tests/randoms.h"
+#include "model/transform.h"
+#include "transform/io.h"
+#include "units.h"
+#include "utils/notification_list.h"
+#include "wasm/api.h"
+#include "wasm/probe.h"
+
+namespace transform::testing {
+
+constexpr model::transform_id my_transform_id{42};
+// NOLINTBEGIN(cert-err58-cpp)
+static const model::ntp my_ntp = model::random_ntp();
+static const model::transform_metadata my_metadata{
+  .name = model::transform_name("xform"),
+  .input_topic = model::topic_namespace(my_ntp.ns, my_ntp.tp.topic),
+  .output_topics = {model::random_topic_namespace()},
+  .environment = {{"FOO", "bar"}},
+  .uuid = uuid_t::create(),
+  .source_ptr = model::offset(9)};
+// NOLINTEND(cert-err58-cpp)
+
+class fake_wasm_engine : public wasm::engine {
+public:
+    ss::future<model::record_batch>
+    transform(model::record_batch batch, wasm::transform_probe*) override {
+        co_return batch;
+    }
+
+    ss::future<> start() override;
+    ss::future<> initialize() override;
+    ss::future<> stop() override;
+
+    std::string_view function_name() const override;
+    uint64_t memory_usage_size_bytes() const override;
+};
+
+class fake_source : public source {
+    static constexpr size_t max_queue_size = 64;
+
+public:
+    explicit fake_source(model::offset initial_offset)
+      : _batches(max_queue_size)
+      , _latest_offset(initial_offset) {}
+
+    ss::future<model::offset> load_latest_offset() override;
+    ss::future<model::record_batch_reader>
+    read_batch(model::offset offset, ss::abort_source* as) override;
+
+    ss::future<> push_batch(model::record_batch batch);
+
+private:
+    ss::queue<model::record_batch> _batches;
+    model::offset _latest_offset;
+};
+
+class fake_sink : public sink {
+    static constexpr size_t max_queue_size = 64;
+
+public:
+    ss::future<> write(ss::chunked_fifo<model::record_batch> batches) override;
+
+    ss::future<model::record_batch> read();
+
+private:
+    ss::queue<model::record_batch> _batches{max_queue_size};
+};
+
+} // namespace transform::testing

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "model/tests/randoms.h"
+#include "model/transform.h"
+#include "transform/tests/test_fixture.h"
+#include "transform/transform_processor.h"
+
+#include <gtest/gtest.h>
+
+namespace transform {
+namespace {
+class ProcessorTestFixture : public ::testing::Test {
+public:
+    void SetUp() override {
+        std::unique_ptr<wasm::engine> engine
+          = std::make_unique<testing::fake_wasm_engine>();
+        auto src = std::make_unique<testing::fake_source>(_offset);
+        _src = src.get();
+        auto sink = std::make_unique<testing::fake_sink>();
+        std::vector<std::unique_ptr<transform::sink>> sinks;
+        _sinks.push_back(sink.get());
+        sinks.push_back(std::move(sink));
+        _p = std::make_unique<transform::processor>(
+          testing::my_transform_id,
+          testing::my_ntp,
+          testing::my_metadata,
+          std::move(engine),
+          [this](
+            model::transform_id,
+            const model::ntp&,
+            const model::transform_metadata&) { ++_error_count; },
+          std::move(src),
+          std::move(sinks),
+          &_probe);
+        _p->start().get();
+    }
+    void TearDown() override { _p->stop().get(); }
+
+    model::record_batch make_tiny_batch() {
+        return model::test::make_random_batch(model::test::record_batch_spec{
+          .offset = _offset++, .allow_compression = false, .count = 1});
+    }
+    void push_batch(model::record_batch batch) {
+        _src->push_batch(std::move(batch)).get();
+    }
+    model::record_batch read_batch() { return _sinks[0]->read().get(); }
+    uint64_t error_count() const { return _error_count; }
+
+private:
+    static constexpr model::offset start_offset = model::offset(9);
+
+    model::offset _offset = start_offset;
+    std::unique_ptr<transform::processor> _p;
+    testing::fake_source* _src;
+    std::vector<testing::fake_sink*> _sinks;
+    uint64_t _error_count = 0;
+    probe _probe;
+};
+} // namespace
+
+TEST_F(ProcessorTestFixture, ProcessOne) {
+    auto batch = make_tiny_batch();
+    push_batch(batch.share());
+    auto returned = read_batch();
+    EXPECT_EQ(batch, returned);
+    EXPECT_EQ(error_count(), 0);
+}
+
+TEST_F(ProcessorTestFixture, ProcessMany) {
+    std::vector<model::record_batch> batches;
+    constexpr int num_batches = 32;
+    std::generate_n(std::back_inserter(batches), num_batches, [this] {
+        return make_tiny_batch();
+    });
+    for (auto& b : batches) {
+        push_batch(b.share());
+    }
+    for (auto& b : batches) {
+        auto returned = read_batch();
+        EXPECT_EQ(b, returned);
+    }
+    EXPECT_EQ(error_count(), 0);
+}
+} // namespace transform

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "transform/transform_processor.h"
+
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "model/timeout_clock.h"
+#include "random/simple_time_jitter.h"
+#include "transform/logger.h"
+#include "wasm/api.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/core/sleep.hh>
+
+#include <optional>
+
+namespace transform {
+
+processor::processor(
+  model::transform_id id,
+  model::ntp ntp,
+  model::transform_metadata meta,
+  std::unique_ptr<wasm::engine> engine,
+  error_callback cb,
+  std::unique_ptr<source> source,
+  std::vector<std::unique_ptr<sink>> sinks,
+  probe* p)
+  : _id(id)
+  , _ntp(std::move(ntp))
+  , _meta(std::move(meta))
+  , _engine(std::move(engine))
+  , _source(std::move(source))
+  , _sinks(std::move(sinks))
+  , _error_callback(std::move(cb))
+  , _probe(p)
+  , _task(ss::now())
+  , _logger(tlog, ss::format("{}/{}", meta.name(), _ntp.tp.partition)) {
+    vassert(
+      _sinks.size() == 1,
+      "expected only a single sink, got: {}",
+      _sinks.size());
+}
+
+ss::future<> processor::start() {
+    try {
+        co_await _engine->start();
+        co_await _engine->initialize();
+    } catch (const std::exception& ex) {
+        vlog(_logger.warn, "error starting processor engine: {}", ex);
+        _error_callback(_id, _ntp, _meta);
+    }
+    _task = run_transform_loop();
+}
+
+ss::future<> processor::stop() {
+    _as.request_abort();
+    co_await std::exchange(_task, ss::now());
+    co_await _engine->stop();
+}
+
+ss::future<> processor::run_transform_loop() {
+    try {
+        co_await do_run_transform_loop();
+    } catch (const ss::abort_requested_exception&) {
+        // do nothing, we wanted to stop.
+    } catch (...) {
+        vlog(
+          _logger.warn,
+          "error running processor: {}",
+          std::current_exception());
+        _error_callback(_id, _ntp, _meta);
+    }
+}
+ss::future<> processor::do_run_transform_loop() {
+    auto offset = co_await _source->load_latest_offset();
+    vlog(_logger.trace, "starting at offset {}", offset);
+    // TODO(rockwood): Optimize this loop, we should not wait for the transform
+    // or for writing before attempting to read more data.
+    while (!_as.abort_requested()) {
+        auto reader = co_await _source->read_batch(offset, &_as);
+        auto batches = co_await model::consume_reader_to_memory(
+          std::move(reader), model::no_timeout);
+        if (batches.empty()) {
+            vlog(
+              _logger.trace,
+              "received no results, sleeping before polling at offset {}",
+              offset);
+            constexpr auto fallback_poll_interval = std::chrono::seconds(1);
+            simple_time_jitter<ss::lowres_clock> jitter(fallback_poll_interval);
+            try {
+                co_await ss::sleep_abortable<ss::lowres_clock>(
+                  jitter.next_duration(), _as);
+            } catch (const ss::sleep_aborted&) {
+                // do nothing, the next iteration of the loop will exit
+            }
+            continue;
+        }
+        offset = model::next_offset(batches.back().last_offset());
+        vlog(_logger.trace, "consumed upto offset {}", offset);
+        ss::chunked_fifo<model::record_batch> transformed_batches;
+        transformed_batches.reserve(batches.size());
+        for (auto& batch : batches) {
+            _probe->increment_read_bytes(batch.size_bytes());
+            auto transformed = co_await _engine->transform(
+              std::move(batch), _probe);
+            _probe->increment_write_bytes(transformed.size_bytes());
+            transformed_batches.push_back(std::move(transformed));
+        }
+        co_await _sinks[0]->write(std::move(transformed_batches));
+    }
+}
+
+model::transform_id processor::id() const { return _id; }
+const model::ntp& processor::ntp() const { return _ntp; }
+} // namespace transform

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/transform.h"
+#include "seastarx.h"
+#include "transform/io.h"
+#include "transform/probe.h"
+#include "utils/prefix_logger.h"
+#include "wasm/fwd.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+namespace transform {
+
+/**
+ * A processor is the driver of a transform for a single partition.
+ *
+ * At it's heart it's a fiber that reads->transforms->writes batches
+ * from an input ntp to an output ntp.
+ */
+class processor {
+public:
+    using error_callback = ss::noncopyable_function<void(
+      model::transform_id, model::ntp, model::transform_metadata)>;
+
+    processor(
+      model::transform_id,
+      model::ntp,
+      model::transform_metadata,
+      std::unique_ptr<wasm::engine>,
+      error_callback,
+      std::unique_ptr<source>,
+      std::vector<std::unique_ptr<sink>>,
+      probe*);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    model::transform_id id() const;
+    const model::ntp& ntp() const;
+
+private:
+    ss::future<> run_transform_loop();
+    ss::future<> do_run_transform_loop();
+    ss::future<> transform_batches(model::record_batch_reader::data_t);
+
+    model::transform_id _id;
+    model::ntp _ntp;
+    model::transform_metadata _meta;
+    std::unique_ptr<wasm::engine> _engine;
+    std::unique_ptr<source> _source;
+    std::vector<std::unique_ptr<sink>> _sinks;
+    error_callback _error_callback;
+    probe* _probe;
+
+    ss::abort_source _as;
+    ss::future<> _task;
+    prefix_logger _logger;
+};
+} // namespace transform


### PR DESCRIPTION
This processor is the driver for a single instance of a wasm runtime.

Essentially at it's core the processor is a fiber that
read->transform->writes a partition.

There are optimizations to do to improve pipelining of the processor,
but I figured it would be better to start with the simplest thing
possible and have future changes for the optimizations.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
