### PR TITLE
gha: bump quill to 0.4.1

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           mkdir -p "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b "$HOME/.local/bin" v0.2.0
+          curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b "$HOME/.local/bin" v0.4.1
 
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
bump quill from [v0.2.0](https://github.com/anchore/quill/releases/tag/v0.2.0) to [v0.4.1](https://github.com/anchore/quill/releases/tag/v0.4.1)

comparison of changes: https://github.com/anchore/quill/compare/v0.2.0...v0.4.1

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

* none