### PR TITLE
Clear Raft & Partition metrics after they are stopped

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -593,6 +593,7 @@ ss::future<> partition::stop() {
           clusterlog.debug, "Stopping tm_stm on partition: {}", partition_ntp);
         co_await _tm_stm->stop();
     }
+    _probe.clear_metrics();
     vlog(clusterlog.debug, "Stopped partition {}", partition_ntp);
 }
 

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -28,9 +28,13 @@ replicated_partition_probe::replicated_partition_probe(
 }
 
 void replicated_partition_probe::reconfigure_metrics() {
+    clear_metrics();
+    setup_metrics(_partition.ntp());
+}
+
+void replicated_partition_probe::clear_metrics() {
     _metrics.clear();
     _public_metrics.clear();
-    setup_metrics(_partition.ntp());
 }
 
 void replicated_partition_probe::setup_metrics(const model::ntp& ntp) {

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -31,6 +31,7 @@ public:
         virtual void add_bytes_fetched(uint64_t) = 0;
         virtual void add_schema_id_validation_failed() = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
+        virtual void clear_metrics() = 0;
         virtual ~impl() noexcept = default;
     };
 
@@ -60,6 +61,8 @@ public:
         _impl->add_schema_id_validation_failed();
     }
 
+    void clear_metrics() { _impl->clear_metrics(); }
+
 private:
     std::unique_ptr<impl> _impl;
 };
@@ -76,6 +79,8 @@ public:
     void add_schema_id_validation_failed() final {
         ++_schema_id_validation_records_failed;
     };
+
+    void clear_metrics() final;
 
 private:
     void reconfigure_metrics();

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -277,6 +277,11 @@ ss::future<> consensus::stop() {
         co_await _snapshot_writer->close();
         _snapshot_writer.reset();
     }
+    /**
+     * Clear metrics after consensus instance is stopped.
+     */
+    _metrics.clear();
+    _probe->clear();
 }
 
 consensus::success_reply consensus::update_follower_index(

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -59,6 +59,11 @@ public:
     void full_heartbeat() { ++_full_heartbeat_requests; }
     void lw_heartbeat() { ++_lw_heartbeat_requests; }
 
+    void clear() {
+        _metrics.clear();
+        _public_metrics.clear();
+    }
+
 private:
     uint64_t _vote_requests = 0;
     uint64_t _append_requests = 0;


### PR DESCRIPTION
  By default `ss::metircs_group` uses RAII to unregister metrics. In case of the
  consensus object the metrics should be cleared right after the instance
  is stopped. The lifecycle of an object may be prolongated in Kafka
  protocol handlers. By clearing metrics we prevent old stopped but still
  present object from interfering with the newly created one.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes: #11344 
Fixes: #12699 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixed rare but possible deadlock that might lead to Redpanda crash when moving partitions back and forth between nodes.
