### PR TITLE
cloud_storage: use  remote index in cloud timequery

### DIFF
--- a/src/v/cloud_storage/read_path_probes.cc
+++ b/src/v/cloud_storage/read_path_probes.cc
@@ -122,6 +122,13 @@ ts_read_path_probe::ts_read_path_probe() {
             "Spillover manifest materialization latency histogram"))
           .aggregate(aggregate_labels),
 
+        sm::make_counter(
+          "chunks_hydrated",
+          [this] { return _chunks_hydrated; },
+          sm::description("Total number of hydrated chunks (some may have been "
+                          "evicted from the cache)"))
+          .aggregate(aggregate_labels),
+
         sm::make_histogram(
           "chunk_hydration_latency",
           [this] {

--- a/src/v/cloud_storage/read_path_probes.h
+++ b/src/v/cloud_storage/read_path_probes.h
@@ -67,6 +67,8 @@ public:
         return _spillover_mat_latency.auto_measure();
     }
 
+    void on_chunks_hydration(size_t num) { _chunks_hydrated += num; }
+
     auto chunk_hydration_latency() {
         return _chunk_hydration_latency.auto_measure();
     }
@@ -84,6 +86,7 @@ private:
     /// Spillover manifest materialization latency
     hist_t _spillover_mat_latency;
 
+    size_t _chunks_hydrated = 0;
     hist_t _chunk_hydration_latency;
 
     ssx::metrics::metric_groups _metrics

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -312,28 +312,32 @@ remote_segment::offset_data_stream(
     vlog(_ctxlog.debug, "remote segment file input stream at offset {}", start);
     ss::gate::holder g(_gate);
     co_await hydrate();
-    offset_index::find_result pos;
+
+    std::optional<offset_index::find_result> indexed_pos;
     std::optional<uint16_t> prefetch_override = std::nullopt;
+
+    // Perform index lookup by timestamp or offset. This reduces the number
+    // of hydrated chunks required to serve the request.
     if (first_timestamp) {
-        // Time queries are linear search from front of the segment.  The
-        // dominant cost of a time query on a remote partition is promoting
-        // the segment into our local cache: once it's here, the cost of
-        // a scan is comparatively small.  For workloads that do many time
-        // queries in close proximity on the same partition, an additional
-        // index could be added here, for hydrated segments.
-        pos = {
-          .rp_offset = _base_rp_offset,
-          .kaf_offset = _base_rp_offset - _base_offset_delta,
-          .file_pos = 0,
-        };
+        // The dominant cost of a time query on a remote partition is promoting
+        // the chunks into our local cache: once they're here, the cost of a
+        // scan is comparatively small.
+
         prefetch_override = 0;
+        indexed_pos = maybe_get_offsets(*first_timestamp);
     } else {
-        pos = maybe_get_offsets(start).value_or(offset_index::find_result{
-          .rp_offset = _base_rp_offset,
-          .kaf_offset = _base_rp_offset - _base_offset_delta,
-          .file_pos = 0,
-        });
+        indexed_pos = maybe_get_offsets(start);
     }
+
+    // If the index lookup failed, scan the entire segement starting from the
+    // first chunk.
+    offset_index::find_result pos = indexed_pos.value_or(
+      offset_index::find_result{
+        .rp_offset = _base_rp_offset,
+        .kaf_offset = _base_rp_offset - _base_offset_delta,
+        .file_pos = 0,
+      });
+
     vlog(
       _ctxlog.debug,
       "Offset data stream start reading at {}, log offset {}, delta {}",
@@ -381,9 +385,31 @@ remote_segment::maybe_get_offsets(kafka::offset kafka_offset) {
     }
     vlog(
       _ctxlog.debug,
-      "Using index to locate {}, the result is rp-offset: {}, kafka-offset: "
+      "Using index to locate Kafka offset {}, the result is rp-offset: {}, "
+      "kafka-offset: "
       "{}, file-pos: {}",
       kafka_offset,
+      pos->rp_offset,
+      pos->kaf_offset,
+      pos->file_pos);
+    return pos;
+}
+
+std::optional<offset_index::find_result>
+remote_segment::maybe_get_offsets(model::timestamp ts) {
+    if (!_index) {
+        return {};
+    }
+    auto pos = _index->find_timestamp(ts);
+    if (!pos) {
+        return {};
+    }
+    vlog(
+      _ctxlog.debug,
+      "Using index to locate timestamp {}, the result is rp-offset: {}, "
+      "kafka-offset: "
+      "{}, file-pos: {}",
+      ts,
       pos->rp_offset,
       pos->kaf_offset,
       pos->file_pos);
@@ -944,6 +970,8 @@ ss::future<> remote_segment::hydrate_chunk(segment_chunk_range range) {
     retry_chain_node rtc{
       cache_hydration_timeout, cache_hydration_backoff, &_rtc};
 
+    const auto chunk_count = range.chunk_count();
+
     const auto end = range.last_offset().value_or(_size - 1);
     auto consumer = split_segment_into_chunk_range_consumer{
       *this, std::move(range)};
@@ -955,6 +983,8 @@ ss::future<> remote_segment::hydrate_chunk(segment_chunk_range range) {
         measurement->cancel();
         throw download_exception{res, _path};
     }
+
+    _ts_probe.on_chunks_hydration(chunk_count);
 }
 
 ss::future<ss::file>

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -192,6 +192,11 @@ private:
     std::optional<offset_index::find_result>
     maybe_get_offsets(kafka::offset kafka_offset);
 
+    /// get a file offset for the corresponding to the timestamp
+    /// if the index is available
+    std::optional<offset_index::find_result>
+      maybe_get_offsets(model::timestamp);
+
     /// Sets the results of the waiters of this segment as the given error.
     void set_waiter_errors(const std::exception_ptr& err);
 

--- a/src/v/cloud_storage/remote_segment_index.cc
+++ b/src/v/cloud_storage/remote_segment_index.cc
@@ -115,73 +115,66 @@ std::
 
 std::optional<offset_index::find_result>
 offset_index::find_rp_offset(model::offset upper_bound) {
-    size_t ix = 0;
-    find_result res{};
-
     auto search_result = maybe_find_offset(upper_bound, _rp_index, _rp_offsets);
 
-    if (std::holds_alternative<std::monostate>(search_result)) {
-        return std::nullopt;
-    } else if (std::holds_alternative<find_result>(search_result)) {
-        return std::get<find_result>(search_result);
-    }
-    auto maybe_ix = std::get<index_value>(search_result);
+    return ss::visit(
+      search_result,
+      [](std::monostate) -> std::optional<find_result> { return std::nullopt; },
+      [](find_result result) -> std::optional<find_result> { return result; },
+      [this](index_value index_result) -> std::optional<find_result> {
+          find_result res{};
 
-    // Invariant: maybe_ix here can't be nullopt
-    ix = maybe_ix.ix;
-    res.rp_offset = model::offset(maybe_ix.value);
+          size_t ix = index_result.ix;
+          res.rp_offset = model::offset(index_result.value);
 
-    decoder_t kaf_dec(
-      _kaf_index.get_initial_value(),
-      _kaf_index.get_row_count(),
-      _kaf_index.copy());
-    auto kaf_offset = _fetch_ix(std::move(kaf_dec), ix);
-    vassert(kaf_offset.has_value(), "Inconsistent index state");
-    res.kaf_offset = kafka::offset(*kaf_offset);
-    foffset_decoder_t file_dec(
-      _file_index.get_initial_value(),
-      _file_index.get_row_count(),
-      _file_index.copy(),
-      delta_delta_t(_min_file_pos_step));
-    auto file_pos = _fetch_ix(std::move(file_dec), ix);
-    res.file_pos = *file_pos;
-    return res;
+          decoder_t kaf_dec(
+            _kaf_index.get_initial_value(),
+            _kaf_index.get_row_count(),
+            _kaf_index.copy());
+          auto kaf_offset = _fetch_ix(std::move(kaf_dec), ix);
+          vassert(kaf_offset.has_value(), "Inconsistent index state");
+          res.kaf_offset = kafka::offset(*kaf_offset);
+          foffset_decoder_t file_dec(
+            _file_index.get_initial_value(),
+            _file_index.get_row_count(),
+            _file_index.copy(),
+            delta_delta_t(_min_file_pos_step));
+          auto file_pos = _fetch_ix(std::move(file_dec), ix);
+          res.file_pos = *file_pos;
+          return res;
+      });
 }
 
 std::optional<offset_index::find_result>
 offset_index::find_kaf_offset(kafka::offset upper_bound) {
-    size_t ix = 0;
-    find_result res{};
-
     auto search_result = maybe_find_offset(
       upper_bound, _kaf_index, _kaf_offsets);
+    return ss::visit(
+      search_result,
+      [](std::monostate) -> std::optional<find_result> { return std::nullopt; },
+      [](find_result result) -> std::optional<find_result> { return result; },
+      [this](index_value index_result) -> std::optional<find_result> {
+          find_result res{};
 
-    if (std::holds_alternative<std::monostate>(search_result)) {
-        return std::nullopt;
-    } else if (std::holds_alternative<find_result>(search_result)) {
-        return std::get<find_result>(search_result);
-    }
-    auto maybe_ix = std::get<index_value>(search_result);
+          size_t ix = index_result.ix;
+          res.kaf_offset = kafka::offset(index_result.value);
 
-    // Invariant: maybe_ix here can't be nullopt
-    ix = maybe_ix.ix;
-    res.kaf_offset = kafka::offset(maybe_ix.value);
-
-    decoder_t rp_dec(
-      _rp_index.get_initial_value(),
-      _rp_index.get_row_count(),
-      _rp_index.copy());
-    auto rp_offset = _fetch_ix(std::move(rp_dec), ix);
-    vassert(rp_offset.has_value(), "Inconsistent index state");
-    res.rp_offset = model::offset(*rp_offset);
-    foffset_decoder_t file_dec(
-      _file_index.get_initial_value(),
-      _file_index.get_row_count(),
-      _file_index.copy(),
-      delta_delta_t(_min_file_pos_step));
-    auto file_pos = _fetch_ix(std::move(file_dec), ix);
-    res.file_pos = *file_pos;
-    return res;
+          decoder_t rp_dec(
+            _rp_index.get_initial_value(),
+            _rp_index.get_row_count(),
+            _rp_index.copy());
+          auto rp_offset = _fetch_ix(std::move(rp_dec), ix);
+          vassert(rp_offset.has_value(), "Inconsistent index state");
+          res.rp_offset = model::offset(*rp_offset);
+          foffset_decoder_t file_dec(
+            _file_index.get_initial_value(),
+            _file_index.get_row_count(),
+            _file_index.copy(),
+            delta_delta_t(_min_file_pos_step));
+          auto file_pos = _fetch_ix(std::move(file_dec), ix);
+          res.file_pos = *file_pos;
+          return res;
+      });
 }
 
 std::optional<offset_index::find_result>
@@ -192,48 +185,44 @@ offset_index::find_timestamp(model::timestamp upper_bound) {
         return std::nullopt;
     }
 
-    size_t ix = 0;
-
     auto search_result = maybe_find_offset(
       upper_bound.value(), _time_index, _time_offsets);
 
-    if (std::holds_alternative<std::monostate>(search_result)) {
-        return std::nullopt;
-    } else if (std::holds_alternative<find_result>(search_result)) {
-        return std::get<find_result>(search_result);
-    }
-    auto maybe_ix = std::get<index_value>(search_result);
+    return ss::visit(
+      search_result,
+      [](std::monostate) -> std::optional<find_result> { return std::nullopt; },
+      [](find_result result) -> std::optional<find_result> { return result; },
+      [this](index_value index_result) -> std::optional<find_result> {
+          size_t ix = index_result.ix;
 
-    // Invariant: maybe_ix here can't be nullopt
-    ix = maybe_ix.ix;
+          // Decode all offset indices to build up the result.
+          decoder_t rp_dec(
+            _rp_index.get_initial_value(),
+            _rp_index.get_row_count(),
+            _rp_index.copy());
+          auto rp_offset = _fetch_ix(std::move(rp_dec), ix);
+          vassert(rp_offset.has_value(), "Inconsistent index state");
 
-    // Decode all offset indices to build up the result.
-    decoder_t rp_dec(
-      _rp_index.get_initial_value(),
-      _rp_index.get_row_count(),
-      _rp_index.copy());
-    auto rp_offset = _fetch_ix(std::move(rp_dec), ix);
-    vassert(rp_offset.has_value(), "Inconsistent index state");
+          decoder_t kaf_dec(
+            _kaf_index.get_initial_value(),
+            _kaf_index.get_row_count(),
+            _kaf_index.copy());
+          auto kaf_offset = _fetch_ix(std::move(kaf_dec), ix);
+          vassert(kaf_offset.has_value(), "Inconsistent index state");
 
-    decoder_t kaf_dec(
-      _kaf_index.get_initial_value(),
-      _kaf_index.get_row_count(),
-      _kaf_index.copy());
-    auto kaf_offset = _fetch_ix(std::move(kaf_dec), ix);
-    vassert(kaf_offset.has_value(), "Inconsistent index state");
+          foffset_decoder_t file_dec(
+            _file_index.get_initial_value(),
+            _file_index.get_row_count(),
+            _file_index.copy(),
+            delta_delta_t(_min_file_pos_step));
+          auto file_pos = _fetch_ix(std::move(file_dec), ix);
+          vassert(file_pos.has_value(), "Inconsistent index state");
 
-    foffset_decoder_t file_dec(
-      _file_index.get_initial_value(),
-      _file_index.get_row_count(),
-      _file_index.copy(),
-      delta_delta_t(_min_file_pos_step));
-    auto file_pos = _fetch_ix(std::move(file_dec), ix);
-    vassert(file_pos.has_value(), "Inconsistent index state");
-
-    return offset_index::find_result{
-      .rp_offset = model::offset(*rp_offset),
-      .kaf_offset = kafka::offset(*kaf_offset),
-      .file_pos = *file_pos};
+          return offset_index::find_result{
+            .rp_offset = model::offset(*rp_offset),
+            .kaf_offset = kafka::offset(*kaf_offset),
+            .file_pos = *file_pos};
+      });
 }
 
 offset_index::coarse_index_t offset_index::build_coarse_index(

--- a/src/v/cloud_storage/remote_segment_index.cc
+++ b/src/v/cloud_storage/remote_segment_index.cc
@@ -184,6 +184,58 @@ offset_index::find_kaf_offset(kafka::offset upper_bound) {
     return res;
 }
 
+std::optional<offset_index::find_result>
+offset_index::find_timestamp(model::timestamp upper_bound) {
+    if (_initial_time == model::timestamp::missing()) {
+        // Bail out early if this is a version 1 index
+        // that does not index timestamps.
+        return std::nullopt;
+    }
+
+    size_t ix = 0;
+
+    auto search_result = maybe_find_offset(
+      upper_bound.value(), _time_index, _time_offsets);
+
+    if (std::holds_alternative<std::monostate>(search_result)) {
+        return std::nullopt;
+    } else if (std::holds_alternative<find_result>(search_result)) {
+        return std::get<find_result>(search_result);
+    }
+    auto maybe_ix = std::get<index_value>(search_result);
+
+    // Invariant: maybe_ix here can't be nullopt
+    ix = maybe_ix.ix;
+
+    // Decode all offset indices to build up the result.
+    decoder_t rp_dec(
+      _rp_index.get_initial_value(),
+      _rp_index.get_row_count(),
+      _rp_index.copy());
+    auto rp_offset = _fetch_ix(std::move(rp_dec), ix);
+    vassert(rp_offset.has_value(), "Inconsistent index state");
+
+    decoder_t kaf_dec(
+      _kaf_index.get_initial_value(),
+      _kaf_index.get_row_count(),
+      _kaf_index.copy());
+    auto kaf_offset = _fetch_ix(std::move(kaf_dec), ix);
+    vassert(kaf_offset.has_value(), "Inconsistent index state");
+
+    foffset_decoder_t file_dec(
+      _file_index.get_initial_value(),
+      _file_index.get_row_count(),
+      _file_index.copy(),
+      delta_delta_t(_min_file_pos_step));
+    auto file_pos = _fetch_ix(std::move(file_dec), ix);
+    vassert(file_pos.has_value(), "Inconsistent index state");
+
+    return offset_index::find_result{
+      .rp_offset = model::offset(*rp_offset),
+      .kaf_offset = kafka::offset(*kaf_offset),
+      .file_pos = *file_pos};
+}
+
 offset_index::coarse_index_t offset_index::build_coarse_index(
   uint64_t step_size, std::string_view index_path) const {
     vlog(

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -87,7 +87,7 @@ public:
 
     /// Find index entry which is strictly lower than the timestamp
     ///
-    /// The returned value has kaf_offset less than upper_bound.
+    /// The returned value has timestamp less than upper_bound.
     /// If all elements are larger than 'upper_bound' nullopt is returned.
     /// If all elements are smaller than 'upper_bound' the last value is
     /// returned.

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -85,6 +85,14 @@ public:
     /// returned.
     std::optional<find_result> find_kaf_offset(kafka::offset upper_bound);
 
+    /// Find index entry which is strictly lower than the timestamp
+    ///
+    /// The returned value has kaf_offset less than upper_bound.
+    /// If all elements are larger than 'upper_bound' nullopt is returned.
+    /// If all elements are smaller than 'upper_bound' the last value is
+    /// returned.
+    std::optional<find_result> find_timestamp(model::timestamp upper_bound);
+
     /// Builds a coarse index mapping kafka offsets to file positions. The step
     /// size is the resolution of the index. So given a step size of 16MiB, the
     /// result contains mappings of kafka offset to file position from the index

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -478,6 +478,8 @@ chunk_start_offset_t segment_chunk_range::first_offset() const {
     return _chunks.begin()->first;
 }
 
+size_t segment_chunk_range::chunk_count() const { return _chunks.size(); }
+
 segment_chunk_range::map_t::iterator segment_chunk_range::begin() {
     return _chunks.begin();
 }

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -181,6 +181,7 @@ public:
 
     std::optional<chunk_start_offset_t> last_offset() const;
     chunk_start_offset_t first_offset() const;
+    size_t chunk_count() const;
 
     map_t::iterator begin();
     map_t::iterator end();

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -14,6 +14,7 @@ import threading
 from logging import Logger
 from typing import Callable
 
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda import RedpandaService, SISettings, make_redpanda_service
@@ -127,6 +128,14 @@ class BaseTimeQuery:
         leader_node = cluster.get_node(
             next(rpk.describe_topic(topic.name)).leader)
 
+        # For when using cloud storage, we expect offsets ahead
+        # of this to still hit raft for their timequeries.
+        is_redpanda = isinstance(cluster, RedpandaService)
+        if is_redpanda:
+            admin = Admin(self.redpanda)
+            status = admin.get_partition_cloud_storage_status(topic.name, 0)
+            local_start_offset = status["local_log_start_offset"]
+
         # Class defining expectations of timequery results to be checked
         class ex:
             def __init__(self, offset, ts=None, expect_read=True):
@@ -136,23 +145,20 @@ class BaseTimeQuery:
                 self.offset = offset
                 self.expect_read = expect_read
 
-        # Selection of interesting cases
-        expectations = [
-            ex(0),  # First message
-            ex(msg_count // 4),  # 25%th message
-            ex(msg_count // 2),  # 50%th message
-            ex(msg_count - 1),  # last message
+        # We will do approx. 10 timequeries within each segment.
+        step = msg_count // total_segments // 10
+
+        expectations = []
+        for o in range(0, msg_count, step):
+            expect_read = o < msg_count
+            expectations.append(ex(o, timestamps[o], expect_read))
+
+        # Add edge cases
+        expectations += [
             ex(0, timestamps[0] - 1000),  # Before the start of the log
             ex(-1, timestamps[msg_count - 1] + 1000,
                False)  # After last message
         ]
-
-        # For when using cloud storage, we expectr offsets ahead
-        # of this to still hit raft for their timequeries.  This is approximate,
-        # but fine as long as the test cases don't tread too near the gap.
-        local_start_offset = msg_count - ((local_retention) / record_size)
-
-        is_redpanda = isinstance(cluster, RedpandaService)
 
         # Remember which offsets we already hit, so that we can
         # make a good guess at whether subsequent hits on the same
@@ -164,7 +170,17 @@ class BaseTimeQuery:
         local_metrics = None
 
         def diff_bytes(old, new):
-            return new > old and new - old < self.log_segment_size
+            # Each timequery will download a maximum of two chunks, but
+            # we make the check extra generous to account for the index
+            # download.
+            return new - old <= self.chunk_size * 5
+
+        def diff_chunks(old, new):
+            # The sampling step for a segment's remote index is 64 KiB and the chunk
+            # size in this the is 128 KiB. Therefore, a timequery should never require
+            # more than two chunks. If the samples were perfectly aligned with the chunks,
+            # we'd only need one chunk, but that's not always the case.
+            return new - old <= 2
 
         for e in expectations:
             ts = e.ts
@@ -201,6 +217,10 @@ class BaseTimeQuery:
                     ("vectorized_cloud_storage_bytes_received_total",
                      diff_bytes)
                 ])
+
+                cloud_metrics.expect([(
+                    "vectorized_cloud_storage_read_path_chunks_hydrated_total",
+                    diff_chunks)])
 
             if is_redpanda and not cloud_storage and not batch_cache and e.expect_read:
                 # Expect to read at most one segment from disk: this validates that
@@ -266,6 +286,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
     # lookup of the proper segment for a time index, as well
     # as the lookup of the offset within that segment.
     log_segment_size = 1024 * 1024
+    chunk_size = 1024 * 128
 
     def setUp(self):
         # Don't start up redpanda yet, because we will need the
@@ -287,7 +308,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
             'log_segment_size_min':
             32 * 1024,
             'cloud_storage_cache_chunk_size':
-            1024 * 128
+            self.chunk_size
         })
 
         if cloud_storage:


### PR DESCRIPTION
This PR updates the timequery read path to skip up to the first
index entry with a timestamp smaller than the searched one. The result
is that timequeries will hydrate/materialize a maximum of two chunks
(two because the chunk boundaries don't always line up with the entries
in the index).

If the index is not present, or was originally created in v1, the search
starts from the first chunk as it did previously.

Fixes #11801

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
* Timequeries (i.e ListOffsets requests) that land in the cloud log now use an index to speed up the search
and reduce the number of hydrated bytes required to serve the query. On average, a time query will have to download 4 times less data (if using the default segment and chunk size)
