### PR TITLE
cloud_storage: Force exhaustive trim when fast trim fails

### DIFF
--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -26,6 +26,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <chrono>
+#include <fstream>
 #include <stdexcept>
 
 using namespace cloud_storage;
@@ -465,4 +466,37 @@ FIXTURE_TEST(test_clean_up_on_start_empty, cache_test_fixture) {
     clean_up_at_start().get();
 
     BOOST_CHECK(ss::file_exists(CACHE_DIR.native()).get());
+}
+
+/**
+ * Given a cache dir populated with files which are filtered out by fast trim,
+ * validate that a failing fast trim should be followed up by an exhaustive trim
+ * and clean up the required object count.
+ */
+FIXTURE_TEST(test_exhaustive_trim_runs_after_fast_trim, cache_test_fixture) {
+    std::vector<std::filesystem::path> indices;
+    const auto count_indices = 5;
+    indices.reserve(count_indices);
+
+    for (auto i = 0; i < count_indices; ++i) {
+        indices.emplace_back(CACHE_DIR / fmt::format("{}.index", i, i, i));
+        std::ofstream f{indices.back()};
+        f.flush();
+    }
+
+    BOOST_REQUIRE(
+      std::all_of(indices.cbegin(), indices.cend(), [](const auto& path) {
+          return std::filesystem::exists(path);
+      }));
+
+    // Make cache service scan the disk for objects
+    clean_up_at_start().get();
+
+    // Only allow the access time tracker to remain on disk.
+    trim_cache(std::nullopt, 1);
+
+    BOOST_REQUIRE(
+      std::all_of(indices.cbegin(), indices.cend(), [](const auto& path) {
+          return !std::filesystem::exists(path);
+      }));
 }

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -107,10 +107,16 @@ public:
         return sharded_cache.local().clean_up_at_start();
     }
 
-    void trim_cache() {
+    void trim_cache(
+      std::optional<uint64_t> size_limit_override = std::nullopt,
+      std::optional<size_t> object_limit_override = std::nullopt) {
         sharded_cache
           .invoke_on(
-            ss::shard_id{0}, [](cloud_storage::cache& c) { return c.trim(); })
+            ss::shard_id{0},
+            [&size_limit_override,
+             &object_limit_override](cloud_storage::cache& c) {
+                return c.trim(size_limit_override, object_limit_override);
+            })
           .get();
     }
 };


### PR DESCRIPTION
In the case where the cache dir consists solely of index+tx files, the current code path in fast trim does not remove anything. This should be followed up by an exhaustive trim to free up slots in cache, but due to an adjustment of the objects to delete counter, this ends up not happening.

The change here makes sure that if we have a certain count of objects to delete, and we were not able to delete the count, and there is a set of filtered out files, we proceed to do an exhaustive trim.

FIXES #12980 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
