### PR TITLE
Eagerly list all files in compute_storage.py

### DIFF
--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -7,7 +7,6 @@ Useful in tests if you want to know what files exist on a node or if they are a 
 from pathlib import Path
 import sys
 import json
-from collections.abc import Iterable
 
 
 def safe_isdir(p: Path) -> bool:
@@ -22,14 +21,14 @@ def safe_isdir(p: Path) -> bool:
         return False
 
 
-def safe_listdir(p: Path) -> Iterable[Path]:
+def safe_listdir(p: Path) -> list[Path]:
     """
     It's valid for directories to be deleted at any time, 
     in that case that the directory is missing, just return
     that there are no files.
     """
     try:
-        return p.iterdir()
+        return [f for f in p.iterdir()]
     except FileNotFoundError:
         return []
 


### PR DESCRIPTION
Listing the segments lazily means that our try..catch wrapper does
nothing.

Fixes errors like seen here: https://ci-artifacts.dev.vectorized.cloud/redpanda/35662/018a299c-8e38-43c8-b545-edb4c4375eb6/vbuild/ducktape/results/2023-08-24--001/TopicDeleteStressTest/stress_test/193/report.txt

Stack trace below:

```
ducktape.cluster.remoteaccount.RemoteCommandError: root@docker-rp-14: Command 'python3 /tmp/compute_storage.py --data-dir=/var/lib/redpanda/data' returned non-zero exit status 1. Remote error message: b'Traceback (most recent call last):\n  File "/tmp/compute_storage.py", line 78, in <module>\n    output = compute_size(data_dir, args.sizes)\n  File "/tmp/compute_storage.py", line 49, in compute_size\n    for segment in safe_listdir(partition):\n  File "/usr/lib/python3.10/pathlib.py", line 1017, in iterdir\n    for name in self._accessor.listdir(self):\nFileNotFoundError: [Errno 2] No such file or directory: \'/var/lib/redpanda/data/kafka/topic-yogwctkfkk/0_28\'\n'
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
