### PR TITLE
set k8s/tests label automatically

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,9 @@
 area/k8s:
 - src/go/k8s/**/*
 
+k8s/tests:
+- src/go/k8s/**/*
+
 area/build:
 - cmake/**/*
 - .github/**/*


### PR DESCRIPTION
Use labeler to set the `k8s/tests` label for operator PRs

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

