### PR TITLE
Add a retry wrapper to the tinygo command

### DIFF
--- a/src/go/transform-sdk/internal/testdata/CMakeLists.txt
+++ b/src/go/transform-sdk/internal/testdata/CMakeLists.txt
@@ -3,23 +3,23 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E env
   ${GO_PROGRAM} env GOROOT
   OUTPUT_VARIABLE GOROOT 
   OUTPUT_STRIP_TRAILING_WHITESPACE)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 function(add_wasm_transform NAME)
   find_program(TINYGO_BIN "tinygo")
-  set(WASM_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.wasm")
-  add_custom_command(OUTPUT ${WASM_OUTPUT}
-                     COMMAND env GOPATH="${GOPATH}" GOROOT="${GOROOT}" 
-                     ${TINYGO_BIN} build -o ${WASM_OUTPUT} -target wasi
-                     "${NAME}/transform.go"
+  set(wasm_output "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.wasm")
+  set(tinygo_cmd ${TINYGO_BIN} build -o ${wasm_output} -target wasi "${NAME}/transform.go")
+  add_custom_command(OUTPUT ${wasm_output}
+                     COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/retry.py
+                     ARGS -- ${CMAKE_COMMAND} -E env GOPATH="${GOPATH}" GOROOT="${GOROOT}" ${tinygo_cmd}
                      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 		     DEPENDS 
                     "${CMAKE_CURRENT_LIST_DIR}/${NAME}/transform.go"
                     # If we update any libraries then we need to rebuild transforms
                     "${CMAKE_CURRENT_LIST_DIR}/go.sum"
-                    "${CMAKE_CURRENT_LIST_DIR}/go.mod"
-                     )
+                    "${CMAKE_CURRENT_LIST_DIR}/go.mod")
   string(REPLACE "-" "_" target_name ${NAME})
-  add_custom_target(wasm_testdata_${target_name} DEPENDS "${WASM_OUTPUT}")
+  add_custom_target(wasm_testdata_${target_name} DEPENDS "${wasm_output}")
 endfunction(add_wasm_transform)
 
 add_wasm_transform(identity) 

--- a/src/go/transform-sdk/internal/testdata/CMakeLists.txt
+++ b/src/go/transform-sdk/internal/testdata/CMakeLists.txt
@@ -11,7 +11,7 @@ function(add_wasm_transform NAME)
   set(tinygo_cmd ${TINYGO_BIN} build -o ${wasm_output} -target wasi "${NAME}/transform.go")
   add_custom_command(OUTPUT ${wasm_output}
                      COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/retry.py
-                     ARGS -- ${CMAKE_COMMAND} -E env GOPATH="${GOPATH}" GOROOT="${GOROOT}" ${tinygo_cmd}
+                     ARGS -- ${CMAKE_COMMAND} -E env PATH="${GOROOT}/bin:$ENV{PATH}" GOPATH="${GOPATH}" GOROOT="${GOROOT}" ${tinygo_cmd}
                      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 		     DEPENDS 
                     "${CMAKE_CURRENT_LIST_DIR}/${NAME}/transform.go"

--- a/src/go/transform-sdk/internal/testdata/retry.py
+++ b/src/go/transform-sdk/internal/testdata/retry.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser(
+    description="retry a command a number of times until it succeeds")
+parser.add_argument('--retries',
+                    type=int,
+                    default=3,
+                    help='number of times to retry the command')
+parser.add_argument('cmd', nargs='+', help='the command to execute')
+args = parser.parse_args()
+
+exitcode = 0
+
+for _ in range(0, args.retries):
+    completed_proc = subprocess.run(args.cmd)
+    exitcode = completed_proc.returncode
+    if exitcode == 0:
+        break
+
+sys.exit(exitcode)


### PR DESCRIPTION
We see tinygo segfaults and in an effort to reduce noise in CI, we
can just retry the build up to 3 times if it fails.

Upstream issue: https://github.com/tinygo-org/tinygo/issues/3874

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
