### PR TITLE
rpk: attempt to print out Redpanda node's stderr on failure to start

### DIFF
--- a/src/go/rpk/pkg/cli/container/common/client.go
+++ b/src/go/rpk/pkg/cli/container/common/client.go
@@ -62,6 +62,12 @@ type Client interface {
 		options types.ContainerListOptions,
 	) ([]types.Container, error)
 
+	ContainerLogs(
+		ctx context.Context,
+		containerID string,
+		options types.ContainerLogsOptions,
+	) (io.ReadCloser, error)
+
 	ContainerInspect(
 		ctx context.Context,
 		containerID string,


### PR DESCRIPTION
A working example of addressing #13023. It's not covering all possible failure paths and is really for an example of what I'm talking about in the issue.

```
$ ./linux-arm64/rpk container start
Waiting for the cluster to be ready...

Error: unable to dial: dial tcp 127.0.0.1:38135: connect: connection refused
Errors reported from the Docker container:
+ '[' '' = true ']'
+ exec /usr/bin/rpk redpanda start --node-id 0 --kafka-addr internal://0.0.0.0:9092,external://172.24.1.2:9093 --pandaproxy-addr internal://0.0.0.0:8082,external://172.24.1.2:35717 --schema-registry-addr 172.24.1.2:8081 --rpc-addr 172.24.1.2:33145 --advertise-kafka-addr internal://172.24.1.2:9092,external://127.0.0.1:38135 --advertise-pandaproxy-addr internal://172.24.1.2:8082,external://127.0.0.1:35717 --advertise-rpc-addr 172.24.1.2:33145 --mode dev-container
WARNING: This is a setup for development purposes only; in this mode your clusters may run unrealistically fast and data can be corrupted any time your computer shuts down uncleanly.
<libc++abi: terminating due to uncaught exception of type std::runtime_error: Could not setup Async I/O: Resource temporarily unavailable. The most common cause is not enough request capacity in /proc/sys/fs/aio-max-nr. Try increasing that number or reducing the amount of logical CPUs available for your application

Usage:
  rpk container start [flags]

Flags:
  -h, --help           Help for start
      --image string   An arbitrary container image to use (default "vectorized/redpanda:latest")
  -n, --nodes uint     The number of nodes to start (default 1)
      --pull           Force pull the container image used
      --retries uint   The amount of times to check for the cluster before considering it unstable and exiting (default 10)

Global Flags:
      --config string            Redpanda or rpk config file; default search paths are ~/.config/rpk/rpk.yaml, $PWD, and /etc/redpanda/redpanda.yaml
  -X, --config-opt stringArray   Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail
      --profile string           rpk profile to use
  -v, --verbose                  Enable verbose logging

```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* None

