### PR TITLE
sr: improve startup

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -306,6 +306,10 @@ client::create_topic(kafka::creatable_topic req) {
                   return ss::make_exception_future<create_topics_response>(
                     topic_error(
                       model::topic_view{res.data.topics[0].name}, ec));
+              case error_code::topic_authorization_failed:
+                  return ss::make_exception_future<create_topics_response>(
+                    topic_error(
+                      model::topic_view{res.data.topics[0].name}, ec));
               default:
                   return ss::make_ready_future<create_topics_response>(
                     std::move(res));

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -193,6 +193,36 @@ ss::future<> service::do_start() {
     });
 }
 
+ss::future<> create_acls(cluster::security_frontend& security_fe) {
+    std::vector<security::acl_binding> princpal_acl_binding{
+      security::acl_binding{
+        security::resource_pattern{
+          security::resource_type::topic,
+          model::schema_registry_internal_tp.topic,
+          security::pattern_type::literal},
+        security::acl_entry{
+          principal,
+          security::acl_host::wildcard_host(),
+          security::acl_operation::all,
+          security::acl_permission::allow}}};
+
+    auto err_vec = co_await security_fe.create_acls(princpal_acl_binding, 5s);
+    auto it = std::find_if(err_vec.begin(), err_vec.end(), [](const auto& err) {
+        return err != cluster::errc::success;
+    });
+
+    if (it != err_vec.end()) {
+        vlog(
+          plog.warn,
+          "Failed to create ACLs for {}, err {} - {}",
+          principal,
+          *it,
+          cluster::make_error_code(*it).message());
+    } else {
+        vlog(plog.debug, "Successfully created ACLs for {}", principal);
+    }
+}
+
 ss::future<> service::configure() {
     auto config = co_await pandaproxy::create_client_credentials(
       *_controller,
@@ -207,18 +237,6 @@ ss::future<> service::configure() {
       _ctx.smp_sg, [has_ephemeral_credentials](service& s) {
           s._has_ephemeral_credentials = has_ephemeral_credentials;
       });
-    co_await _controller->get_security_frontend().local().create_acls(
-      {security::acl_binding{
-        security::resource_pattern{
-          security::resource_type::topic,
-          model::schema_registry_internal_tp.topic,
-          security::pattern_type::literal},
-        security::acl_entry{
-          principal,
-          security::acl_host::wildcard_host(),
-          security::acl_operation::all,
-          security::acl_permission::allow}}},
-      5s);
 }
 
 ss::future<> service::mitigate_error(std::exception_ptr eptr) {
@@ -227,17 +245,29 @@ ss::future<> service::mitigate_error(std::exception_ptr eptr) {
         return ss::now();
     }
     vlog(plog.warn, "mitigate_error: {}", eptr);
-    return ss::make_exception_future<>(eptr).handle_exception_type(
-      [this, eptr](kafka::client::broker_error const& ex) {
+    return ss::make_exception_future<>(eptr)
+      .handle_exception_type(
+        [this, eptr](kafka::client::broker_error const& ex) {
+            if (
+              ex.error == kafka::error_code::sasl_authentication_failed
+              && _has_ephemeral_credentials) {
+                return inform(ex.node_id).then([this]() {
+                    // This fully mitigates, don't rethrow.
+                    return _client.local().connect();
+                });
+            }
+
+            // Rethrow unhandled exceptions
+            return ss::make_exception_future<>(eptr);
+        })
+      .handle_exception_type([this,
+                              eptr](kafka::client::topic_error const& ex) {
           if (
-            ex.error == kafka::error_code::sasl_authentication_failed
+            ex.error == kafka::error_code::topic_authorization_failed
             && _has_ephemeral_credentials) {
-              return inform(ex.node_id).then([this]() {
-                  // This fully mitigates, don't rethrow.
-                  return _client.local().connect();
-              });
+              return create_acls(_controller->get_security_frontend().local());
           }
-          // Rethrow unhandled exceptions
+
           return ss::make_exception_future<>(eptr);
       });
 }

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -20,7 +20,6 @@
 #include "seastarx.h"
 #include "utils/request_auth.h"
 
-#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
@@ -72,7 +71,6 @@ private:
     sharded_store& _store;
     ss::sharded<seq_writer>& _writer;
     std::unique_ptr<cluster::controller>& _controller;
-    ss::abort_source _as;
 
     one_shot _ensure_started;
     request_authenticator _auth;


### PR DESCRIPTION
#11563 revealed that SR startup could use some changes. This PR removes the background task that sets authz in a loop. Instead, the SR will set authz during error handling.

This patch also extends SR and PP tests to move the controller leader around startup.

Fixes: https://github.com/redpanda-data/redpanda/issues/13043

Changes from force-push `36f6f6a`:
- Capture the return from `security_frontend::create_acls` in-line
- Loop through the return from `security_frontend::create_acls`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
